### PR TITLE
chore(release): unify cross-platform asset naming + SHA256SUMS.linux

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -116,16 +116,29 @@ jobs:
       - name: Package AppImage
         # scripts/package-appimage.sh expects BUILD_DIR=build-linux, ImageMagick
         # (downscales the icon), and linuxdeploy on PATH. Emits
-        # DuskStudio-<version>-x86_64.AppImage + .sha256 at the repo root.
+        # dusk-studio-<version>-Linux-x86_64.AppImage at the repo root.
         run: BUILD_DIR=build-linux scripts/package-appimage.sh
 
       - name: Stage raw executable
         # Ship the bare ELF too, for users who'd rather run the binary
-        # directly than via the AppImage wrapper. (No .deb / .rpm yet.)
+        # directly than via the AppImage wrapper. (No .deb / .rpm yet.) Name
+        # mirrors the cross-platform scheme: dusk-studio-<version>-Linux-x86_64.
         run: |
           set -euo pipefail
-          cp build-linux/DuskStudio_artefacts/Release/DuskStudio ./DuskStudio-x86_64
-          sha256sum DuskStudio-x86_64 | tee DuskStudio-x86_64.sha256
+          VERSION="$(tr -d '[:space:]' < VERSION)"
+          EXE="dusk-studio-${VERSION}-Linux-x86_64"
+          cp build-linux/DuskStudio_artefacts/Release/DuskStudio "./${EXE}"
+
+      - name: Checksums
+        # One combined SHA256SUMS.linux over both Linux artifacts, mirroring
+        # SHA256SUMS.macos / SHA256SUMS.windows (the per-file .sha256 form is
+        # gone for parity). The two globs match the AppImage and the bare ELF
+        # respectively - the ELF glob has no trailing wildcard so it can't also
+        # catch the .AppImage.
+        run: |
+          set -euo pipefail
+          sha256sum dusk-studio-*-Linux-x86_64.AppImage dusk-studio-*-Linux-x86_64 \
+            | tee SHA256SUMS.linux
 
       - name: Publish AppImage + executable to the PRIVATE releases repo
         # Only on a real v* tag — dispatch runs are build validation.
@@ -138,7 +151,7 @@ jobs:
           NOTES="Unsigned Linux x86_64: AppImage (chmod +x and run) + bare executable."
 
           shopt -s nullglob
-          ASSETS=( *.AppImage *.AppImage.sha256 DuskStudio-x86_64 DuskStudio-x86_64.sha256 )
+          ASSETS=( *.AppImage dusk-studio-*-Linux-x86_64 SHA256SUMS.linux )
           if [[ ${#ASSETS[@]} -eq 0 ]]; then
             echo "::error::no Linux artifacts produced — packaging step failed" >&2
             exit 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -990,11 +990,14 @@ set(CPACK_DMG_FORMAT                "UDZO")
 set(CPACK_DMG_VOLUME_NAME           "Dusk Studio ${DUSKSTUDIO_VERSION}")
 
 # Package filename platform suffix. CPack defaults to the kernel name
-# ("Darwin") on macOS - rename to a user-facing, arch-explicit "macOS-arm64"
-# (the build is Apple-Silicon-only; it won't run on Intel Macs). Mirrors the
-# arch-suffixed win64 / x86_64 the Windows + Linux artifacts already carry.
+# ("Darwin") on macOS and "win64" on Windows - override both to a user-facing,
+# OS-and-arch-explicit suffix so every platform shares one scheme:
+# dusk-studio-<version>-<OS>-<arch>.<ext> (macOS-arm64 / Windows-x64 /
+# Linux-x86_64). macOS is Apple-Silicon-only (won't run on Intel Macs).
 if(APPLE)
     set(CPACK_SYSTEM_NAME "macOS-arm64")
+elseif(WIN32)
+    set(CPACK_SYSTEM_NAME "Windows-x64")
 endif()
 
 include(CPack)

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -328,14 +328,14 @@ The source on GitHub is GPL-3.0; anyone who prefers to skip the warning can buil
 
 ### Linux (AppImage)
 
-1. Download `DuskStudio-x86_64.AppImage` (or `-aarch64` on Raspberry Pi / ARM64 Linux) from the Patreon post or the private releases repo.
+1. Download `dusk-studio-<version>-Linux-x86_64.AppImage` from the Patreon post or the private releases repo.
 2. Open a terminal in the download folder and mark it executable:
    ```bash
-   chmod +x DuskStudio-x86_64.AppImage
+   chmod +x dusk-studio-*-Linux-x86_64.AppImage
    ```
 3. Double-click to launch, or run it from the terminal:
    ```bash
-   ./DuskStudio-x86_64.AppImage
+   ./dusk-studio-*-Linux-x86_64.AppImage
    ```
 
 No signing dance. Linux desktops trust AppImages by default.

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -54,7 +54,7 @@ linuxdeploy --appdir AppDir \
             --output appimage
 ```
 
-Output: `DuskStudio-<version>-x86_64.AppImage` ready to upload to Patreon.
+Output: `dusk-studio-<version>-Linux-x86_64.AppImage` ready to upload to Patreon.
 
 ## Patreon delivery checklist
 

--- a/scripts/package-appimage.sh
+++ b/scripts/package-appimage.sh
@@ -12,7 +12,7 @@
 #     already-prepared icon.
 #
 # Output:
-#   DuskStudio-<version>-x86_64.AppImage in the repo root.
+#   dusk-studio-<version>-Linux-x86_64.AppImage in the repo root.
 
 set -euo pipefail
 
@@ -64,7 +64,7 @@ else
     cp "$ICON_SRC" "$ICON_256"
 fi
 
-OUTPUT="DuskStudio-${VERSION}-x86_64.AppImage"
+OUTPUT="dusk-studio-${VERSION}-Linux-x86_64.AppImage"
 export OUTPUT
 # linuxdeploy derives the AppImage's root icon name from the basename of
 # --icon-file; the .desktop file's Icon= field must match. Copy the
@@ -85,4 +85,3 @@ linuxdeploy --appdir AppDir \
 
 echo
 echo "Built: $OUTPUT"
-sha256sum "$OUTPUT" | tee "$OUTPUT.sha256"

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -49,6 +49,6 @@ popd >/dev/null
 # Move output to repo root for predictable downstream paths.
 shopt -s nullglob
 case "$FORMAT" in
-    deb) for f in "$BUILD_DIR"/*.deb; do mv "$f" .; echo "Built: $(basename "$f")"; sha256sum "$(basename "$f")" >> SHA256SUMS; done ;;
-    rpm) for f in "$BUILD_DIR"/*.rpm; do mv "$f" .; echo "Built: $(basename "$f")"; sha256sum "$(basename "$f")" >> SHA256SUMS; done ;;
+    deb) for f in "$BUILD_DIR"/*.deb; do mv "$f" .; echo "Built: $(basename "$f")"; sha256sum "$(basename "$f")" >> SHA256SUMS.linux; done ;;
+    rpm) for f in "$BUILD_DIR"/*.rpm; do mv "$f" .; echo "Built: $(basename "$f")"; sha256sum "$(basename "$f")" >> SHA256SUMS.linux; done ;;
 esac


### PR DESCRIPTION
Names every release artifact `dusk-studio-<version>-<OS>-<arch>` (Windows `win64`→`Windows-x64`; Linux AppImage + bare exe gain `Linux` + version). Combined `SHA256SUMS.linux` for parity with macos/windows. Docs updated. Packaging/CI/docs only — app binary unaffected.