### PR TITLE
fix(docs/pdf): define \pandocbounded before renewing it

### DIFF
--- a/docs/build-pdf.sh
+++ b/docs/build-pdf.sh
@@ -71,7 +71,14 @@ cat > "${HEADER}" <<'TEX'
 % caption - which then collides with the centred footer page number). Width
 % bound (\linewidth) is unchanged. Mirrors pandoc 3.x's definition, only the
 % height reference shrinks.
+%
+% \providecommand first so \renewcommand always has a target: pandoc only
+% emits \pandocbounded for sized images from ~3.1.7 on, so on a runner with
+% an older pandoc the macro is undefined and a bare \renewcommand errors out
+% ("Command \pandocbounded undefined"). The provide is a no-op when pandoc
+% already defined it; the renew then installs the height-capped version.
 \makeatletter
+\providecommand*\pandocbounded[1]{#1}%
 \renewcommand*\pandocbounded[1]{%
   \sbox\pandoc@box{#1}%
   \Gscale@div\@tempa{0.82\textheight}{\dimexpr\ht\pandoc@box+\dp\pandoc@box\relax}%


### PR DESCRIPTION
Manual PDF release job fails with `LaTeX Error: Command \pandocbounded undefined` when the runner's pandoc predates the `\pandocbounded` macro. `\providecommand` an identity stub before the existing `\renewcommand` so the height-cap override applies on any pandoc version. Docs/CI only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced PDF build process compatibility with older tool versions by adding a fallback mechanism to prevent script failures during document generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->