### PR TITLE
Fix/timeline controls narrow display

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -31,8 +31,20 @@ concurrency:
 
 jobs:
   release:
-    name: Build + package tarball (GCC Release, Ubuntu 22.04, amd64)
-    runs-on: ubuntu-22.04
+    name: Build + package tarball (${{ matrix.label }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      # Don't cancel the working amd64 build if arm64 fails to compile; a broken
+      # Pi build should show red on its own, not block the x86_64 release.
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-22.04
+            label: GCC Release, Ubuntu 22.04, amd64
+          - arch: aarch64
+            runner: ubuntu-22.04-arm
+            label: GCC Release, Ubuntu 22.04, arm64 (Raspberry Pi)
     env:
       RELEASES_REPO: dusk-audio/dusk-studio-releases
 
@@ -119,7 +131,7 @@ jobs:
         run: |
           if [ -z "${PATREON_REFRESH_TOKEN}" ] || [ -z "${PATREON_ACCESS_TOKEN}" ] \
              || [ -z "${PATREON_CLIENT_ID}" ] || [ -z "${PATREON_CLIENT_SECRET}" ]; then
-            echo "Patreon secrets not fully configured - shipping the committed supporters list."
+            echo "::warning::Patreon secrets not configured - shipping the committed supporters list (may be stale)."
             exit 0
           fi
           umask 077
@@ -130,7 +142,13 @@ jobs:
           # json.dump escapes any special characters in the secrets; a raw heredoc
           # would corrupt the JSON on a quote/backslash in a token.
           python3 -c 'import json, os, sys; json.dump({"access_token": os.environ["PATREON_ACCESS_TOKEN"], "refresh_token": os.environ["PATREON_REFRESH_TOKEN"], "client_id": os.environ["PATREON_CLIENT_ID"], "client_secret": os.environ["PATREON_CLIENT_SECRET"]}, open(sys.argv[1], "w"))' "${cfg}"
-          python3 scripts/update-patrons.py || echo "update-patrons.py failed - shipping the committed list."
+          # Secrets are configured, so this release must ship the live list.
+          # Fail loud instead of falling back to the committed (possibly stale)
+          # list. A blocked release beats a silently wrong one.
+          if ! python3 scripts/update-patrons.py; then
+            echo "::error::Patreon refresh failed despite configured secrets - refusing to ship a stale supporters list. Check the token/API and re-run."
+            exit 1
+          fi
 
       - name: Configure (Release)
         run: |
@@ -156,8 +174,9 @@ jobs:
           ctest --test-dir build-tests --output-on-failure
 
       - name: Package portable tarball
-        # scripts/package-tarball.sh emits dusk-studio-<version>-Linux-x86_64.tar.xz
-        # at the repo root: a portable program directory (run ./DuskStudio/DuskStudio
+        # scripts/package-tarball.sh emits dusk-studio-<version>-Linux-<arch>.tar.xz
+        # at the repo root (arch from uname -m, so the arm runner produces the
+        # aarch64 tarball): a portable program directory (run ./DuskStudio/DuskStudio
         # in place) plus install.sh for optional menu / PATH / session-file-type
         # integration. Needs ImageMagick (icon downscale).
         run: BUILD_DIR=build-linux scripts/package-tarball.sh
@@ -165,7 +184,8 @@ jobs:
       - name: Checksums
         run: |
           set -euo pipefail
-          sha256sum dusk-studio-*-Linux-x86_64.tar.xz | tee SHA256SUMS.linux
+          sha256sum dusk-studio-*-Linux-${{ matrix.arch }}.tar.xz \
+            | tee "SHA256SUMS.linux-${{ matrix.arch }}"
 
       - name: Publish tarball to the PRIVATE releases repo
         # Only on a real v* tag — dispatch runs are build validation.
@@ -175,22 +195,27 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
-          NOTES="Unsigned Linux x86_64 tarball: extract, then run ./DuskStudio/DuskStudio (or ./install.sh for a menu entry, PATH launcher, and session-file association)."
+          ARCH="${{ matrix.arch }}"
+          NOTES="Unsigned Linux tarball: extract, then run ./DuskStudio/DuskStudio (or ./install.sh for a menu entry, PATH launcher, and session-file association). The aarch64 build targets 64-bit Raspberry Pi OS (Pi 3/4/5)."
 
           shopt -s nullglob
-          ASSETS=( dusk-studio-*-Linux-x86_64.tar.xz SHA256SUMS.linux )
+          ASSETS=( dusk-studio-*-Linux-${ARCH}.tar.xz "SHA256SUMS.linux-${ARCH}" )
           if [[ ${#ASSETS[@]} -eq 0 ]]; then
-            echo "::error::no Linux artifacts produced — packaging step failed" >&2
+            echo "::error::no Linux ${ARCH} artifacts produced, packaging step failed" >&2
             exit 1
           fi
 
+          # The amd64 + arm64 matrix jobs publish to the SAME tag in parallel, so
+          # the release may be absent when we look yet created by the sibling a
+          # moment later. Create best-effort (tolerate the race), then always
+          # upload our arch's assets with --clobber. Asset names carry the arch,
+          # so the two jobs never overwrite each other's tarballs.
           if ! gh release view "$TAG" --repo "$RELEASES_REPO" >/dev/null 2>&1; then
             gh release create "$TAG" \
               --repo "$RELEASES_REPO" \
               --title "Dusk Studio $TAG" \
               --notes "$NOTES" \
-              "${ASSETS[@]}"
-          else
-            gh release upload "$TAG" --repo "$RELEASES_REPO" --clobber "${ASSETS[@]}"
+              || echo "release create raced with the sibling arch job; uploading instead."
           fi
-          echo "Published ${#ASSETS[@]} asset(s) to ${RELEASES_REPO} @ ${TAG}"
+          gh release upload "$TAG" --repo "$RELEASES_REPO" --clobber "${ASSETS[@]}"
+          echo "Published ${#ASSETS[@]} ${ARCH} asset(s) to ${RELEASES_REPO} @ ${TAG}"

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -199,11 +199,15 @@ jobs:
           NOTES="Unsigned Linux tarball: extract, then run ./DuskStudio/DuskStudio (or ./install.sh for a menu entry, PATH launcher, and session-file association). The aarch64 build targets 64-bit Raspberry Pi OS (Pi 3/4/5)."
 
           shopt -s nullglob
-          ASSETS=( dusk-studio-*-Linux-${ARCH}.tar.xz "SHA256SUMS.linux-${ARCH}" )
-          if [[ ${#ASSETS[@]} -eq 0 ]]; then
-            echo "::error::no Linux ${ARCH} artifacts produced, packaging step failed" >&2
+          # Validate the TARBALL glob alone - a combined array would always carry
+          # the SHA256SUMS literal, so its length is never zero even if the
+          # packaging step produced no tarball.
+          TARBALLS=( dusk-studio-*-Linux-${ARCH}.tar.xz )
+          if [[ ${#TARBALLS[@]} -eq 0 ]]; then
+            echo "::error::no Linux ${ARCH} tarball produced, packaging step failed" >&2
             exit 1
           fi
+          ASSETS=( "${TARBALLS[@]}" "SHA256SUMS.linux-${ARCH}" )
 
           # The amd64 + arm64 matrix jobs publish to the SAME tag in parallel, so
           # the release may be absent when we look yet created by the sibling a

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -97,7 +97,7 @@ jobs:
         run: |
           if [ -z "${PATREON_REFRESH_TOKEN}" ] || [ -z "${PATREON_ACCESS_TOKEN}" ] \
              || [ -z "${PATREON_CLIENT_ID}" ] || [ -z "${PATREON_CLIENT_SECRET}" ]; then
-            echo "Patreon secrets not fully configured - shipping the committed supporters list."
+            echo "::warning::Patreon secrets not configured - shipping the committed supporters list (may be stale)."
             exit 0
           fi
           umask 077
@@ -108,7 +108,13 @@ jobs:
           # json.dump escapes any special characters in the secrets; a raw heredoc
           # would corrupt the JSON on a quote/backslash in a token.
           python3 -c 'import json, os, sys; json.dump({"access_token": os.environ["PATREON_ACCESS_TOKEN"], "refresh_token": os.environ["PATREON_REFRESH_TOKEN"], "client_id": os.environ["PATREON_CLIENT_ID"], "client_secret": os.environ["PATREON_CLIENT_SECRET"]}, open(sys.argv[1], "w"))' "${cfg}"
-          python3 scripts/update-patrons.py || echo "update-patrons.py failed - shipping the committed list."
+          # Secrets are configured, so this release must ship the live list.
+          # Fail loud instead of falling back to the committed (possibly stale)
+          # list. A blocked release beats a silently wrong one.
+          if ! python3 scripts/update-patrons.py; then
+            echo "::error::Patreon refresh failed despite configured secrets - refusing to ship a stale supporters list. Check the token/API and re-run."
+            exit 1
+          fi
 
       - name: Configure (Release)
         run: |

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           if [ -z "${PATREON_REFRESH_TOKEN}" ] || [ -z "${PATREON_ACCESS_TOKEN}" ] \
              || [ -z "${PATREON_CLIENT_ID}" ] || [ -z "${PATREON_CLIENT_SECRET}" ]; then
-            echo "Patreon secrets not fully configured - shipping the committed supporters list."
+            echo "::warning::Patreon secrets not configured - shipping the committed supporters list (may be stale)."
             exit 0
           fi
           umask 077
@@ -101,7 +101,13 @@ jobs:
           # json.dump escapes any special characters in the secrets; a raw heredoc
           # would corrupt the JSON on a quote/backslash in a token.
           python3 -c 'import json, os, sys; json.dump({"access_token": os.environ["PATREON_ACCESS_TOKEN"], "refresh_token": os.environ["PATREON_REFRESH_TOKEN"], "client_id": os.environ["PATREON_CLIENT_ID"], "client_secret": os.environ["PATREON_CLIENT_SECRET"]}, open(sys.argv[1], "w"))' "${cfg}"
-          python3 scripts/update-patrons.py || echo "update-patrons.py failed - shipping the committed list."
+          # Secrets are configured, so this release must ship the live list.
+          # Fail loud instead of falling back to the committed (possibly stale)
+          # list. A blocked release beats a silently wrong one.
+          if ! python3 scripts/update-patrons.py; then
+            echo "::error::Patreon refresh failed despite configured secrets - refusing to ship a stale supporters list. Check the token/API and re-run."
+            exit 1
+          fi
 
       - name: Fetch Steinberg ASIO SDK
         shell: bash

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -24,7 +24,11 @@ concurrency:
 
 jobs:
   tests:
-    name: Catch2 tests (MSVC x64 Release, Windows 2022)
+    # Runner-agnostic name on purpose: the required-status-check context in the
+    # branch ruleset matches this string, so it must NOT carry the runner image
+    # version. Re-pinning runs-on below (when an image is retired) then never
+    # renames the check and silently breaks the gate.
+    name: Catch2 tests (MSVC x64 Release, Windows)
     # Pinned to windows-2022: windows-latest migrated to windows-2025, whose
     # image no longer resolves the "Visual Studio 17 2022" CMake generator.
     runs-on: windows-2022

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -388,11 +388,11 @@ Windows SmartScreen treats every new MSI hash as untrusted on first download; re
 
 ### Verifying your download
 
-Every release ships with a `SHA256SUMS.{linux,macos,windows}` file. To verify:
+Every release ships a `SHA256SUMS` file per platform. Linux is split by architecture: `SHA256SUMS.linux-x86_64` (PC) and `SHA256SUMS.linux-aarch64` (64-bit Raspberry Pi), alongside `SHA256SUMS.macos` and `SHA256SUMS.windows`. To verify:
 
 ```bash
 # Linux + macOS
-shasum -a 256 -c SHA256SUMS.linux         # or .macos
+shasum -a 256 -c SHA256SUMS.linux-x86_64    # or -aarch64 (Raspberry Pi), or SHA256SUMS.macos
 ```
 
 ```pwsh

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -172,9 +172,9 @@ This chapter is a visual reference. Every numbered callout on the figures below 
 | 14  | Clock display    | Bars.Beats.Ticks or mm:ss.mmm; right-click to flip.                              |
 | 15  | Tuner            | Opens the chromatic tuner against the selected input.                            |
 | 16  | TIMELINE / TAPE   | Same as the tape strip toggle below the bar.                                     |
-| 17  | − / + / Fit      | Timeline zoom out / in / fit-to-window (shown in the header when the timeline is expanded). |
+| 17  | − / + / Fit      | Timeline zoom out / in / fit-to-window (in the timeline toolbar above the tape strip, shown when the timeline is expanded). |
 
-In compact mode (window narrower than 1850 px) labels shorten; `SNAP` becomes `S`, `TIMELINE` becomes `▾`, and the time-format toggle hides — right-click the clock display to flip format instead.
+In compact mode (window narrower than 1850 px) labels shorten: `TIMELINE` becomes `▾` and the time-format toggle hides; right-click the clock display to flip format instead.
 
 ## The channel strip — MIXING stage
 
@@ -452,6 +452,7 @@ A single button opens the **MIDI Bindings** panel, which lists every CC-to-contr
 
 - **UI scale**: a global zoom factor for the entire interface. Restart Dusk Studio after changing this for best results.
 - **Expand tape strip by default**: show the tape strip on every session open.
+- **Follow playhead by default**: start the timeline and the audio / MIDI editors with Chase engaged, so the view scrolls to keep the playhead in sight during playback. Per-machine; takes effect on next launch.
 - **Scan plugins on startup**: re-run the plugin scanner every time Dusk Studio launches. Off by default; large plugin collections take 10–30 seconds to scan.
 
 ### Advanced
@@ -476,7 +477,7 @@ The window is structured as a stack of horizontal bands.
 ├───────────────────────────────────────────────────────┤
 │  1-8   9-16                                           │  Bank selector
 ├───────────────────────────────────────────────────────┤
-│ ◀◀  ▶  ▶▶  ●  ⟳  ◉   CLK ♩=120 4/4 00:01:23  SNAP ⊕⊖│  Transport bar
+│ ◀◀  ▶  ▶▶  ●  ⟳  ◉   CLK ♩=120 4/4 00:01:23         │  Transport bar
 ├───────────────────────────────────────────────────────┤
 │  ▾ TIMELINE                                            │  Tape strip toggle
 ├───────────────────────────────────────────────────────┤
@@ -524,12 +525,13 @@ From left to right:
 - **Tuner**. Opens a chromatic tuner that listens to the selected input.
 - **▾ TIMELINE / ▴ TAPE**. Collapses or expands the tape strip below the console.
 
-On the right end of the transport bar:
+When the timeline is expanded, a toolbar row sits directly above the tape strip:
 
-- **Snap**. Global grid snap toggle in the header (with a resolution button beside it). When on, region drags, trims, pastes, marker / loop / punch / tempo moves snap to the chosen grid resolution.
+- **Snap**. Global grid snap toggle, with a resolution button beside it. When on, region drags, trims, pastes, marker / loop / punch / tempo moves snap to the chosen grid resolution.
 - **−** / **+** / **Fit**. Timeline zoom out, in, and fit-to-window.
+- **Chase**. When on, the timeline scrolls during playback to keep the playhead in view. Its launch default is set by **Follow playhead by default** in Settings.
 
-In compact mode (window narrower than 1850 pixels), labels shorten: `SNAP` becomes `S`, `TIMELINE` becomes `▾`, and the time-format toggle hides — right-click the clock display to flip format instead.
+In compact mode (window narrower than 1850 pixels), `TIMELINE` becomes `▾` and the time-format toggle hides; right-click the clock display to flip format instead.
 
 \newpage
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -144,8 +144,8 @@ This chapter is a visual reference. Every numbered callout on the figures below 
 | #   | Name              | Description                                                                                                                       |
 | --- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | 1   | Menu bar          | `File` and `Settings` menus only. No tabs, no hidden submenus.                                                                    |
-| 2   | Stage selector    | Four buttons: **RECORDING**, **MIXING**, **MASTERING**, **AUX** (keys 1–4). Picks which view fills the console area.                  |
-| 3   | Bank selector     | `1-8`, `9-16`, `17-24`. Only visible when the window is too narrow to show all 24 channel strips at once.                         |
+| 2   | Stage selector    | Four buttons: **RECORDING**, **MIXING**, **MASTERING**, **AUX** (Ctrl+1 to Ctrl+4). Picks which view fills the console area.          |
+| 3   | Bank selector     | The visible channel bank (e.g. `1-6`, `7-12`, ...), switched with the plain number keys 1 to 4. Only visible when the window is too narrow to show all channel strips at once. |
 | 4   | Transport bar     | Play, record, loop, punch, BPM, time signature, clock, tuner. See the next figure for the inventory.                              |
 | 5   | Tape strip toggle | `▾ TIMELINE` / `▴ TAPE`. Collapses or expands the timeline view below the bar.                                                     |
 | 6   | Console view      | Holds 24 channel strips, 4 buses, and the master strip. Replaced by the aux lane or mastering chain when those stages are active. |
@@ -500,7 +500,7 @@ Only one stage is visible at a time, but the same engine drives all four. Switch
 - **MASTERING** swaps the console view for the mastering chain, including a file picker for loading a finished mix.
 - **AUX** swaps the console view for the four aux return lanes, with a full-width view of each lane's plugin chain.
 
-Press **1 / 2 / 3 / 4** to jump straight to RECORDING / MIXING / MASTERING / AUX. The bank selector has its own keys — **Cmd/Ctrl+1 / 2 / 3** — so a plain digit changes stage and a modified digit changes bank. Hovering any tab or bank button shows its shortcut, and **?** opens a full keyboard-shortcut list (also under **Settings → Keyboard Shortcuts**).
+Press **Cmd/Ctrl+1 / 2 / 3 / 4** to jump straight to RECORDING / MIXING / MASTERING / AUX. The channel banks have the plain number keys **1 / 2 / 3 / 4**, so a modified digit changes stage and a plain digit changes bank. Hovering any tab or bank button shows its shortcut, and **?** opens a full keyboard-shortcut list (also under **Settings → Keyboard Shortcuts**).
 
 Switching into or out of MASTERING force-stops the transport. The mix engine and the mastering engine cannot run at the same time.
 
@@ -1775,6 +1775,13 @@ Shortcuts use **Cmd** on macOS and **Ctrl** on Linux and Windows unless noted.
 | **A**    | Toggle ARM on selected track  |
 | **S**    | Toggle SOLO on selected track |
 | **X**    | Toggle MUTE on selected track |
+
+## Stages & banks
+
+| Shortcut             | Action                                  |
+| -------------------- | --------------------------------------- |
+| **Cmd+1 … Cmd+4**    | Recording / Mixing / Mastering / Aux    |
+| **1 … 4**            | Select channel bank 1 to 4              |
 
 ## Timeline
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -144,7 +144,7 @@ This chapter is a visual reference. Every numbered callout on the figures below 
 | #   | Name              | Description                                                                                                                       |
 | --- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | 1   | Menu bar          | `File` and `Settings` menus only. No tabs, no hidden submenus.                                                                    |
-| 2   | Stage selector    | Four buttons: **RECORDING**, **MIXING**, **MASTERING**, **AUX** (Ctrl+1 to Ctrl+4). Picks which view fills the console area.          |
+| 2   | Stage selector    | Four buttons: **RECORDING**, **MIXING**, **MASTERING**, **AUX** (Cmd/Ctrl+1 to 4). Picks which view fills the console area.            |
 | 3   | Bank selector     | The visible channel bank (e.g. `1-6`, `7-12`, ...), switched with the plain number keys 1 to 4. Only visible when the window is too narrow to show all channel strips at once. |
 | 4   | Transport bar     | Play, record, loop, punch, BPM, time signature, clock, tuner. See the next figure for the inventory.                              |
 | 5   | Tape strip toggle | `▾ TIMELINE` / `▴ TAPE`. Collapses or expands the timeline view below the bar.                                                     |

--- a/src/engine/BounceEngine.cpp
+++ b/src/engine/BounceEngine.cpp
@@ -301,7 +301,7 @@ void BounceEngine::run()
     {
         succeeded = false;
         const juce::ScopedLock lock (lastErrorLock);
-        lastError = "Cancelled";
+        lastError = kCancelledError;
     }
 
     writer.reset();  // flush + close
@@ -522,7 +522,7 @@ bool BounceEngine::runStemsMode()
     if (cancelRequested.load (std::memory_order_relaxed))
     {
         const juce::ScopedLock lock (lastErrorLock);
-        lastError = "Cancelled";
+        lastError = kCancelledError;
         succeeded = false;
     }
     return succeeded;

--- a/src/engine/BounceEngine.h
+++ b/src/engine/BounceEngine.h
@@ -36,6 +36,11 @@ public:
     // a clear error). The caller picks the matching file extension.
     enum class Format { Wav, Mp3 };
 
+    // lastError value set when a render is cancelled. Shared so the dialog can
+    // tell a user cancel from a real failure without a string literal that
+    // silently drifts out of sync with run().
+    static constexpr const char* kCancelledError = "Cancelled";
+
     // <dir>/<base>_<NN>_<safe>.wav. Empty / default ("5") track names
     // fall back to "track" so the user doesn't open 24 files called
     // mix_05_5.wav. Inline so the unit test links without dragging in

--- a/src/ui/AppConfig.cpp
+++ b/src/ui/AppConfig.cpp
@@ -8,6 +8,7 @@ namespace
 constexpr const char* kKeyUiScale            = "ui_scale";
 constexpr const char* kKeyScanOnStartup      = "scan_plugins_on_startup";
 constexpr const char* kKeyTapeStripExpanded  = "tape_strip_expanded_default";
+constexpr const char* kKeyFollowPlayhead     = "follow_playhead_default";
 constexpr const char* kKeyStopBehavior       = "stop_behavior";
 constexpr const char* kKeyVkbCentreNote      = "vkb_centre_note";
 constexpr const char* kKeyMulticoreMode      = "multicore_dsp_mode";
@@ -110,6 +111,19 @@ bool getTapeStripExpandedDefault()
 void setTapeStripExpandedDefault (bool expanded)
 {
     writeKey (kKeyTapeStripExpanded, expanded ? "1" : "0");
+}
+
+bool getFollowPlayheadDefault()
+{
+    const auto raw = readKey (kKeyFollowPlayhead);
+    if (raw.isEmpty()) return false;   // default off — view stays put unless asked
+    return raw == "1" || raw.equalsIgnoreCase ("true")
+        || raw.equalsIgnoreCase ("yes");
+}
+
+void setFollowPlayheadDefault (bool follow)
+{
+    writeKey (kKeyFollowPlayhead, follow ? "1" : "0");
 }
 
 StopBehavior getStopBehavior()

--- a/src/ui/AppConfig.h
+++ b/src/ui/AppConfig.h
@@ -37,6 +37,13 @@ void setScanPluginsOnStartup (bool scan);
 bool getTapeStripExpandedDefault();
 void setTapeStripExpandedDefault (bool expanded);
 
+// Follow the playhead by default on app launch: when true, the timeline
+// (and the audio / MIDI editors) start with Chase engaged so the view
+// scrolls to keep the playhead in sight during playback. Default false.
+// Persisted per-machine.
+bool getFollowPlayheadDefault();
+void setFollowPlayheadDefault (bool follow);
+
 // Tape-head behaviour on Stop. Mirrors the equivalent option in Pro Tools
 // (Operation > Transport > "Audio During Fast Forward / Rewind") and
 // Logic (Preferences > Recording > "Stop returns to playback start").

--- a/src/ui/AudioRegionEditor.cpp
+++ b/src/ui/AudioRegionEditor.cpp
@@ -547,6 +547,7 @@ void AudioRegionEditor::paint (juce::Graphics& g)
 
     paintRuler         (g, rulerArea);
     paintWaveform      (g, waveArea);
+    paintBarGrid       (g, waveArea);
     paintFadeEnvelopes (g, waveArea);
     paintLoopPunchBrackets (g, rulerArea, waveArea);
 
@@ -727,23 +728,60 @@ void AudioRegionEditor::paintRuler (juce::Graphics& g, juce::Rectangle<int> area
 
         if (sr > 0.0)
         {
+            const juce::int64 ticksPerBeat = kMidiTicksPerQuarter;
             const auto startTick = session.samplesToTicks (anchorTimelineStart, sr);
             const auto endTick   = session.samplesToTicks (anchorEndTimeline,   sr);
             const int firstBar = (int) (startTick / ticksPerBar);
             const int lastBar  = (int) (endTick   / ticksPerBar) + 1;
 
+            // Beat / sub-beat tick density follows the zoom: beats appear once a
+            // beat is wide enough to read, sub-beats once they are wider still.
+            const float bpm = session.tempoBpm.load (std::memory_order_relaxed);
+            const double pxPerBeat = bpm > 0.0f
+                ? (double) pixelsPerSample * (sr * 60.0 / (double) bpm) : 0.0;
+            const bool showBeats = pxPerBeat >= 9.0;
+            const int  subdiv    = pxPerBeat >= 80.0 ? 4 : (pxPerBeat >= 36.0 ? 2 : 1);
+            const int  beatTop   = area.getBottom() - (int) (area.getHeight() * 0.45);
+            const int  subTop    = area.getBottom() - (int) (area.getHeight() * 0.28);
+
+            const auto drawTick = [&] (juce::int64 tick, int top, juce::Colour c)
+            {
+                const auto timeline = session.ticksToSamples (tick, sr);
+                if (timeline < anchorTimelineStart || timeline > anchorEndTimeline) return;
+                const int x = xForTimelineSample (timeline, area);
+                if (x < area.getX() || x > area.getRight()) return;
+                g.setColour (c);
+                g.drawVerticalLine (x, (float) top, (float) area.getBottom());
+            };
+
             for (int bar = firstBar; bar <= lastBar; ++bar)
             {
-                const auto barTimeline = session.ticksToSamples ((juce::int64) bar * ticksPerBar, sr);
-                if (barTimeline < anchorTimelineStart || barTimeline > anchorEndTimeline) continue;
-                const int x = xForTimelineSample (barTimeline, area);
-                if (x < area.getX() || x > area.getRight()) continue;
-                g.setColour (kBarLine);
-                g.drawVerticalLine (x, (float) area.getY(), (float) area.getBottom());
-                g.setColour (kHeaderText);
-                g.drawText (juce::String (bar + 1),
-                             juce::Rectangle<int> (x + 3, area.getY(), 40, area.getHeight()),
-                             juce::Justification::centredLeft, false);
+                const juce::int64 barTick = (juce::int64) bar * ticksPerBar;
+                const auto barTimeline = session.ticksToSamples (barTick, sr);
+                if (barTimeline >= anchorTimelineStart && barTimeline <= anchorEndTimeline)
+                {
+                    const int x = xForTimelineSample (barTimeline, area);
+                    if (x >= area.getX() && x <= area.getRight())
+                    {
+                        g.setColour (kBarLine);
+                        g.drawVerticalLine (x, (float) area.getY(), (float) area.getBottom());
+                        g.setColour (kHeaderText);
+                        g.drawText (juce::String (bar + 1),
+                                     juce::Rectangle<int> (x + 3, area.getY(), 40, area.getHeight()),
+                                     juce::Justification::centredLeft, false);
+                    }
+                }
+                if (! showBeats) continue;
+                for (int beat = 0; beat < beatsPerBar; ++beat)
+                {
+                    if (beat > 0)
+                        drawTick (barTick + (juce::int64) beat * ticksPerBeat,
+                                   beatTop, kBarLine.withAlpha (0.55f));
+                    for (int s = 1; s < subdiv; ++s)
+                        drawTick (barTick + (juce::int64) beat * ticksPerBeat
+                                      + (juce::int64) s * ticksPerBeat / subdiv,
+                                   subTop, kBarLine.withAlpha (0.30f));
+                }
             }
         }
     }
@@ -776,6 +814,49 @@ void AudioRegionEditor::paintRuler (juce::Graphics& g, juce::Rectangle<int> area
             g.drawText (juce::String::formatted ("%d:%02d", mins, secs),
                          juce::Rectangle<int> (x + 3, area.getY(), 60, area.getHeight()),
                          juce::Justification::centredLeft, false);
+        }
+    }
+}
+
+void AudioRegionEditor::paintBarGrid (juce::Graphics& g, juce::Rectangle<int> area)
+{
+    // Faint bar / beat lines over the waveform so edits read against the grid.
+    // Bars-mode only; the time ruler has no musical grid to mirror.
+    const auto* r = region();
+    if (r == nullptr || r->lengthInSamples <= 0) return;
+    if ((TimeDisplayMode) session.timeDisplayMode.load (std::memory_order_relaxed)
+          != TimeDisplayMode::Bars) return;
+
+    const double sr = juce::jmax (1.0,
+        loadedFileSampleRate > 0.0 ? loadedFileSampleRate
+                                    : engine.getCurrentSampleRate());
+    const float bpm = session.tempoBpm.load (std::memory_order_relaxed);
+    if (bpm <= 0.0f) return;
+    const double pxPerBeat = (double) pixelsPerSample * (sr * 60.0 / (double) bpm);
+    if (pxPerBeat < 6.0) return;   // too dense to be anything but noise
+
+    const int beatsPerBar = juce::jmax (1, session.beatsPerBar.load (std::memory_order_relaxed));
+    const juce::int64 ticksPerBeat = kMidiTicksPerQuarter;
+    const juce::int64 ticksPerBar  = (juce::int64) beatsPerBar * ticksPerBeat;
+    const juce::int64 anchorEndTimeline = anchorTimelineStart + anchorTimelineLength;
+    const auto startTick = session.samplesToTicks (anchorTimelineStart, sr);
+    const auto endTick   = session.samplesToTicks (anchorEndTimeline,   sr);
+    const int firstBar = (int) (startTick / ticksPerBar);
+    const int lastBar  = (int) (endTick   / ticksPerBar) + 1;
+
+    juce::Graphics::ScopedSaveState saved (g);
+    g.reduceClipRegion (area);
+    for (int bar = firstBar; bar <= lastBar; ++bar)
+    {
+        const juce::int64 barTick = (juce::int64) bar * ticksPerBar;
+        for (int beat = 0; beat < beatsPerBar; ++beat)
+        {
+            const auto timeline = session.ticksToSamples (barTick + (juce::int64) beat * ticksPerBeat, sr);
+            if (timeline < anchorTimelineStart || timeline > anchorEndTimeline) continue;
+            const int x = xForTimelineSample (timeline, area);
+            if (x < area.getX() || x > area.getRight()) continue;
+            g.setColour (kBarLine.withAlpha (beat == 0 ? 0.28f : 0.12f));
+            g.drawVerticalLine (x, (float) area.getY(), (float) area.getBottom());
         }
     }
 }

--- a/src/ui/AudioRegionEditor.cpp
+++ b/src/ui/AudioRegionEditor.cpp
@@ -1,4 +1,5 @@
 #include "AudioRegionEditor.h"
+#include "AppConfig.h"
 #include "DuskAlerts.h"
 #include "DuskContextMenu.h"
 #include "EditCursors.h"
@@ -68,8 +69,9 @@ AudioRegionEditor::AudioRegionEditor (Session& s, AudioEngine& e, int t, int r)
 
     // Chase: when on AND transport is playing AND the playhead leaves the
     // visible window, scroll the view forward so the playhead stays in
-    // sight. Stateless toggle - off by default.
+    // sight. Initial state follows the per-machine Follow-playhead setting.
     chaseToggle.setClickingTogglesState (true);
+    chaseToggle.setToggleState (appconfig::getFollowPlayheadDefault(), juce::dontSendNotification);
     chaseToggle.setColour (juce::TextButton::buttonColourId,   juce::Colour (0xff222226));
     chaseToggle.setColour (juce::TextButton::buttonOnColourId, juce::Colour (0xff406030));
     chaseToggle.setColour (juce::TextButton::textColourOffId,  juce::Colour (0xff909094));

--- a/src/ui/AudioRegionEditor.cpp
+++ b/src/ui/AudioRegionEditor.cpp
@@ -729,8 +729,18 @@ void AudioRegionEditor::paintRuler (juce::Graphics& g, juce::Rectangle<int> area
         if (sr > 0.0)
         {
             const juce::int64 ticksPerBeat = kMidiTicksPerQuarter;
-            const auto startTick = session.samplesToTicks (anchorTimelineStart, sr);
-            const auto endTick   = session.samplesToTicks (anchorEndTimeline,   sr);
+            // Limit bar/beat generation to the clipped (visible) span: during
+            // playback the repaint clip is just the playhead column, so walking
+            // every bar in a long zoomed-in track is wasted work. Pad the window
+            // so a bar line just off-screen whose number label spills into view
+            // still draws; the per-tick x-clipping below keeps visuals exact.
+            const auto clip     = area.getIntersection (g.getClipBounds());
+            const auto winStart = juce::jmax (anchorTimelineStart,
+                                              timelineSampleForX (clip.getX()     - 48, area));
+            const auto winEnd   = juce::jmin (anchorEndTimeline,
+                                              timelineSampleForX (clip.getRight() + 48, area));
+            const auto startTick = session.samplesToTicks (winStart, sr);
+            const auto endTick   = session.samplesToTicks (winEnd,   sr);
             const int firstBar = (int) (startTick / ticksPerBar);
             const int lastBar  = (int) (endTick   / ticksPerBar) + 1;
 

--- a/src/ui/AudioRegionEditor.h
+++ b/src/ui/AudioRegionEditor.h
@@ -299,6 +299,7 @@ private:
     void changeListenerCallback (juce::ChangeBroadcaster*) override;
 
     void paintRuler         (juce::Graphics&, juce::Rectangle<int> area);
+    void paintBarGrid       (juce::Graphics&, juce::Rectangle<int> waveArea);
     void paintWaveform      (juce::Graphics&, juce::Rectangle<int> area);
     void paintFadeEnvelopes (juce::Graphics&, juce::Rectangle<int> area);
     // Loop (green) + punch (red) brackets over the ruler + waveform, read

--- a/src/ui/AudioSettingsPanel.cpp
+++ b/src/ui/AudioSettingsPanel.cpp
@@ -381,6 +381,18 @@ AudioSettingsPanel::AudioSettingsPanel (juce::AudioDeviceManager& dm,
     };
     addAndMakeVisible (tapeStripExpandedToggle);
 
+    followPlayheadToggle.setToggleState (appconfig::getFollowPlayheadDefault(),
+                                           juce::dontSendNotification);
+    followPlayheadToggle.setTooltip (
+        "When on, the timeline and editors start with Chase engaged, scrolling "
+        "to keep the playhead in view during playback. Saved per-machine; takes "
+        "effect on next launch.");
+    followPlayheadToggle.onClick = [this]
+    {
+        appconfig::setFollowPlayheadDefault (followPlayheadToggle.getToggleState());
+    };
+    addAndMakeVisible (followPlayheadToggle);
+
     stopBehaviorLabel.setJustificationType (juce::Justification::centredRight);
     addAndMakeVisible (stopBehaviorLabel);
     stopBehaviorCombo.addItem ("Stay where it is (pause)",      1);
@@ -522,6 +534,11 @@ void AudioSettingsPanel::resized()
         auto row = takeStdRow();
         row.removeFromLeft (kLabelW);
         tapeStripExpandedToggle.setBounds (row.reduced (4, 2));
+    }
+    {
+        auto row = takeStdRow();
+        row.removeFromLeft (kLabelW);
+        followPlayheadToggle.setBounds (row.reduced (4, 2));
     }
     {
         auto row = takeStdRow();

--- a/src/ui/AudioSettingsPanel.h
+++ b/src/ui/AudioSettingsPanel.h
@@ -122,6 +122,7 @@ private:
     juce::Label generalSectionLabel       { {}, "General" };
     juce::Label advancedSectionLabel      { {}, "Advanced" };
     juce::ToggleButton tapeStripExpandedToggle { "Expand tape strip by default" };
+    juce::ToggleButton followPlayheadToggle    { "Follow playhead by default" };
     juce::Label        stopBehaviorLabel       { {}, "Playhead on Stop:" };
     juce::ComboBox     stopBehaviorCombo;
 

--- a/src/ui/BounceDialog.cpp
+++ b/src/ui/BounceDialog.cpp
@@ -74,10 +74,13 @@ BounceDialog::~BounceDialog()
     stopTimer();
     if (bounceEngine != nullptr && bounceEngine->isRendering())
     {
-        // Defensive: should not happen because closeDialog() blocks until the
-        // worker exits before letting the user dismiss, but if the dialog is
-        // torn down some other way (app shutdown) we still want to stop the
-        // worker cleanly before its destructor runs.
+        // Defensive: shouldn't happen during normal use because the Close
+        // button stays hidden while a render is in flight, so the user can't
+        // dismiss us mid-bounce - closeDialog() just requests cancel() and
+        // returns, keeping the message loop free for the worker's teardown
+        // (which re-attaches the audio device). But if the dialog is torn down
+        // some other way (app shutdown) we still stop the worker cleanly before
+        // its destructor runs.
         bounceEngine->cancel();
     }
     bounceEngine.reset();
@@ -123,46 +126,57 @@ void BounceDialog::timerCallback()
         }
     }
 
-    if (! bounceEngine->isRendering() && ! finished)
-    {
-        finished = true;
-        const auto err = bounceEngine->getLastError();
-        succeeded = err.isEmpty();
+    finalizeIfStopped();
+}
 
-        if (succeeded)
+// Drive the dialog into its finished state once the worker stops. The `finished`
+// flag latches this so it runs exactly once - whether the 20 Hz timer notices
+// the stop first, or a Cancel click lands in the gap between the worker stopping
+// and the next tick (the button is still visible then). Calling it from both
+// paths guarantees `succeeded` is computed before closeDialog() decides whether
+// to fire onSuccessfulFinish, so a just-completed render isn't lost.
+void BounceDialog::finalizeIfStopped()
+{
+    if (bounceEngine == nullptr || finished || bounceEngine->isRendering())
+        return;
+
+    finished = true;
+    const auto err = bounceEngine->getLastError();
+    succeeded = err.isEmpty();
+
+    if (succeeded)
+    {
+        titleLabel.setText ("Bounce complete", juce::dontSendNotification);
+        if (renderMode == BounceEngine::Mode::Stems)
         {
-            titleLabel.setText ("Bounce complete", juce::dontSendNotification);
-            if (renderMode == BounceEngine::Mode::Stems)
-            {
-                const int total = bounceEngine->getTotalStemsToRender();
-                statusLabel.setText ("Wrote " + juce::String (total) + " stem"
-                                      + juce::String (total == 1 ? "" : "s")
-                                      + " to " + outputFile.getParentDirectory().getFullPathName(),
-                                      juce::dontSendNotification);
-            }
-            else
-            {
-                statusLabel.setText ("Wrote " + outputFile.getFullPathName(),
-                                      juce::dontSendNotification);
-            }
-            progressValue = 1.0;
-            progressBar.repaint();
-        }
-        else if (err == "Cancelled")
-        {
-            titleLabel.setText ("Bounce cancelled", juce::dontSendNotification);
-            statusLabel.setText ("No file was written.", juce::dontSendNotification);
+            const int total = bounceEngine->getTotalStemsToRender();
+            statusLabel.setText ("Wrote " + juce::String (total) + " stem"
+                                  + juce::String (total == 1 ? "" : "s")
+                                  + " to " + outputFile.getParentDirectory().getFullPathName(),
+                                  juce::dontSendNotification);
         }
         else
         {
-            titleLabel.setText ("Bounce failed", juce::dontSendNotification);
-            statusLabel.setText (err, juce::dontSendNotification);
+            statusLabel.setText ("Wrote " + outputFile.getFullPathName(),
+                                  juce::dontSendNotification);
         }
-
-        cancelButton.setVisible (false);
-        closeButton.setVisible (true);
-        stopTimer();
+        progressValue = 1.0;
+        progressBar.repaint();
     }
+    else if (err == BounceEngine::kCancelledError)
+    {
+        titleLabel.setText ("Bounce cancelled", juce::dontSendNotification);
+        statusLabel.setText ("No file was written.", juce::dontSendNotification);
+    }
+    else
+    {
+        titleLabel.setText ("Bounce failed", juce::dontSendNotification);
+        statusLabel.setText (err, juce::dontSendNotification);
+    }
+
+    cancelButton.setVisible (false);
+    closeButton.setVisible (true);
+    stopTimer();
 }
 
 void BounceDialog::closeDialog()
@@ -180,6 +194,11 @@ void BounceDialog::closeDialog()
         bounceEngine->cancel();
         return;
     }
+
+    // The worker may have stopped between timer ticks with the Cancel button
+    // still up; finalize now so `succeeded` reflects the real outcome before we
+    // decide whether to fire onSuccessfulFinish.
+    finalizeIfStopped();
 
     if (succeeded && onSuccessfulFinish)
         onSuccessfulFinish (outputFile);

--- a/src/ui/BounceDialog.cpp
+++ b/src/ui/BounceDialog.cpp
@@ -43,19 +43,8 @@ BounceDialog::BounceDialog (AudioEngine& e,
     styleButton (cancelButton);
     styleButton (closeButton);
     closeButton.setVisible (false);  // shown after the render finishes
-    cancelButton.onClick = [this]
-    {
-        if (bounceEngine != nullptr && bounceEngine->isRendering())
-        {
-            statusLabel.setText ("Cancelling...", juce::dontSendNotification);
-            bounceEngine->cancel();
-        }
-        else
-        {
-            closeDialog();
-        }
-    };
-    closeButton.onClick = [this] { closeDialog(); };
+    cancelButton.onClick = [this] { closeDialog(); };
+    closeButton.onClick  = [this] { closeDialog(); };
     addAndMakeVisible (cancelButton);
     addAndMakeVisible (closeButton);
 
@@ -159,6 +148,11 @@ void BounceDialog::timerCallback()
             progressValue = 1.0;
             progressBar.repaint();
         }
+        else if (err == "Cancelled")
+        {
+            titleLabel.setText ("Bounce cancelled", juce::dontSendNotification);
+            statusLabel.setText ("No file was written.", juce::dontSendNotification);
+        }
         else
         {
             titleLabel.setText ("Bounce failed", juce::dontSendNotification);
@@ -173,29 +167,28 @@ void BounceDialog::timerCallback()
 
 void BounceDialog::closeDialog()
 {
-    // If the user hits Cancel and immediately closes, the worker may still be
-    // unwinding. Wait for it before returning so the engine is back on the
-    // device by the time the dialog is gone.
+    // Still rendering (Cancel pressed before the bounce finished): request a
+    // cancel and return. The 20 Hz timer flips the dialog to its finished
+    // state once the worker actually stops, then the Close button appears.
+    // We must NOT block the message thread waiting here - the worker's
+    // teardown re-attaches the audio device and needs the loop to keep
+    // turning, so a blocking wait deadlocks it (and freezes the UI).
     if (bounceEngine != nullptr && bounceEngine->isRendering())
     {
+        statusLabel.setText ("Cancelling...", juce::dontSendNotification);
+        cancelButton.setEnabled (false);
         bounceEngine->cancel();
-        // Pump the message loop briefly so the worker can publish its final
-        // state. We can't block the message thread outright - the worker
-        // re-attaches the engine via the device manager, which doesn't need
-        // the message thread, but Timer callbacks scheduled on this dialog
-        // would otherwise pile up.
-        const auto deadline = juce::Time::getMillisecondCounter() + 5000;
-        while (bounceEngine->isRendering()
-               && juce::Time::getMillisecondCounter() < deadline)
-        {
-            juce::Thread::sleep (20);
-        }
+        return;
     }
 
     if (succeeded && onSuccessfulFinish)
         onSuccessfulFinish (outputFile);
 
-    if (auto* parent = findParentComponentOfClass<juce::DialogWindow>())
+    // Embedded modal: the host closes us. Fall back to exitModalState for the
+    // rare DialogWindow host.
+    if (onRequestClose)
+        onRequestClose();
+    else if (auto* parent = findParentComponentOfClass<juce::DialogWindow>())
         parent->exitModalState (succeeded ? 1 : 0);
 }
 } // namespace duskstudio

--- a/src/ui/BounceDialog.h
+++ b/src/ui/BounceDialog.h
@@ -15,9 +15,12 @@ class Session;
 // marshalled to the message thread via SafePointer + MessageManager::callAsync
 // so the panel can update its progress bar / status label safely.
 //
-// Lifetime: launched from MainComponent's "Bounce..." button. The bounce
-// runs to completion or cancellation before the dialog is dismissed; closing
-// the dialog while a render is in flight requests a cancel and waits.
+// Lifetime: launched from MainComponent's "Bounce..." button. Closing the
+// dialog while a render is in flight requests a cancel and returns immediately;
+// the 20 Hz timer flips the dialog to its finished state once the worker
+// actually stops (the close never blocks the message thread - the worker's
+// teardown re-attaches the audio device and needs the loop to keep turning).
+// The host wires onRequestClose to dismiss the embedded modal.
 class BounceDialog final : public juce::Component,
                             private juce::Timer
 {
@@ -37,7 +40,14 @@ public:
     // Fired once when the dialog is dismissed AFTER a successful render.
     // Not fired on cancel or failure. Caller can use it to chain post-bounce
     // workflow (e.g. Mixdown → switch to Mastering with the new file loaded).
+    // Defer any heavy work (stage switches, etc.) via callAsync - this fires
+    // from inside the close-button callback.
     std::function<void(juce::File)> onSuccessfulFinish;
+
+    // Fired to dismiss the dialog. The host (which owns the EmbeddedModal)
+    // wires this to its modal.close(). Without it the embedded dialog has no
+    // way to close itself (exitModalState only works for a real DialogWindow).
+    std::function<void()> onRequestClose;
 
 private:
     void timerCallback() override;

--- a/src/ui/BounceDialog.h
+++ b/src/ui/BounceDialog.h
@@ -51,6 +51,7 @@ public:
 
 private:
     void timerCallback() override;
+    void finalizeIfStopped();
     void closeDialog();
 
     AudioEngine& engine;

--- a/src/ui/DuskStudioLookAndFeel.h
+++ b/src/ui/DuskStudioLookAndFeel.h
@@ -70,6 +70,15 @@ public:
         return juce::Font (juce::FontOptions (18.5f));
     }
 
+    // The menu-row band that tooltips live in, and the stage-tab block they
+    // must NOT cover. MainComponent::resized() keeps these current; both are
+    // in MainComponent-local coords (the space getTooltipBounds returns).
+    void setTooltipPlacement (juce::Rectangle<int> row, juce::Rectangle<int> avoid) noexcept
+    {
+        tooltipRow_   = row;
+        tooltipAvoid_ = avoid;
+    }
+
     // Anchor in the top menu-bar row (same row as File/Settings) so
     // tooltips never overlap the control they describe. JUCE's default
     // cursor-follow kept landing over UI the user was about to click.
@@ -86,12 +95,36 @@ public:
         const juce::Font font { juce::FontOptions (kFontPx) };
         const auto flat = tipText.replaceCharacter ('\n', ' ');
         const int textW = (int) std::ceil (font.getStringWidthFloat (flat)) + 32;   // +padding (must match drawTooltip's natural width)
-        const int textH = (int) std::ceil (kFontPx) + 10;
-        // Top menu bar row is ~28 px tall; centre the tooltip
-        // vertically in that band.
+        const int h     = (int) std::ceil (kFontPx) + 10;
+
+        if (! tooltipRow_.isEmpty())
+        {
+            // Place inside the menu-row band, dodging the centred stage tabs:
+            // a centred tip would always sit on top of them. Prefer the side
+            // gap that fits the natural width (left/status gap first), else the
+            // wider side, clamping width so the tip never overlaps the tabs.
+            const int y = tooltipRow_.getY() + juce::jmax (0, (tooltipRow_.getHeight() - h) / 2);
+            constexpr int gap = 12;
+            int w = juce::jmin (textW, tooltipRow_.getWidth());
+            int x = tooltipRow_.getCentreX() - w / 2;
+
+            if (! tooltipAvoid_.isEmpty()
+                  && juce::Rectangle<int> (x, y, w, h).intersects (tooltipAvoid_))
+            {
+                const int leftRoom  = juce::jmax (0, tooltipAvoid_.getX() - gap - tooltipRow_.getX());
+                const int rightRoom = juce::jmax (0, tooltipRow_.getRight() - (tooltipAvoid_.getRight() + gap));
+                if (w <= leftRoom)              { x = tooltipRow_.getX(); }
+                else if (w <= rightRoom)        { x = tooltipAvoid_.getRight() + gap; }
+                else if (leftRoom >= rightRoom) { w = leftRoom;  x = tooltipRow_.getX(); }
+                else                            { w = rightRoom; x = tooltipRow_.getRight() - w; }
+            }
+            return juce::Rectangle<int> (x, y, juce::jmax (0, w), h).constrainedWithin (tooltipRow_);
+        }
+
+        // Fallback before the first layout pass sets a placement: centre the
+        // tip in a top band the height of the original menu row.
         constexpr int kMenuRowH = 28;
         const int w = juce::jmin (textW, juce::jmax (60, parentArea.getWidth() - 16));
-        const int h = textH;
         const int x = parentArea.getCentreX() - w / 2;
         const int y = parentArea.getY() + juce::jmax (0, (kMenuRowH - h) / 2);
         return juce::Rectangle<int> (x, y, w, h).constrainedWithin (parentArea);
@@ -372,6 +405,10 @@ public:
         g.setColour (juce::Colour (0x80000000));
         g.drawEllipse (tipX - tipR, tipY - tipR, tipR * 2.0f, tipR * 2.0f, 0.5f);
     }
+
+private:
+    juce::Rectangle<int> tooltipRow_;     // menu-row band tooltips live in
+    juce::Rectangle<int> tooltipAvoid_;   // stage-tab block they must not cover
 };
 
 // 4K band/section palette. Names also drive the track colour-picker labels.

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -1402,7 +1402,6 @@ void MainComponent::resized()
     // Rebuild bank-button row to match the current numBanks. Buttons
     // sit inline immediately right of the centered stage block.
     syncBankButtons (needsBanking ? numBanks : 0);
-    int lastBankRight = stageX + stageBlockW;   // fallback when no banks
     if (needsBanking && consoleView != nullptr)
     {
         const int bankY = rowBounds.getY() + (rowBounds.getHeight() - kBankBtnH) / 2;
@@ -1421,14 +1420,14 @@ void MainComponent::resized()
             btn->setToggleState (i == activeBank, juce::dontSendNotification);
             bankX += kBankBtnW + kBankBtnGap;
         }
-        lastBankRight = bankX - kBankBtnGap;
     }
 
-    // SNAP + zoom cluster pinned in the gap between the rightmost bank
-    // tab and the tuner button (transport bar right edge - kBtnDia(36)
-    // - right padding). Hidden when there's no TapeStrip context (e.g.
-    // user in AUX/Mastering fullscreen views — strip controls don't
-    // apply there).
+    // SNAP + grid + zoom (- / + / Fit) cluster. It only acts on the timeline,
+    // so it is positioned in the tape strip ruler's top-right corner (in the
+    // tapeStrip->setBounds block below), NOT the transport row. Keeping it off
+    // the transport row means a narrow window can no longer make it overlap the
+    // BPM / tuner controls. Shown only with the timeline open and not in a
+    // fullscreen stage (AUX/Mastering), where the zoom buttons have no subject.
     constexpr int kHdrZoomBtnW = 30;
     constexpr int kHdrFitW     = 36;
     constexpr int kHdrSnapW    = 48;
@@ -1437,10 +1436,6 @@ void MainComponent::resized()
     constexpr int kHdrBtnH     = 24;
     constexpr int kHdrClusterW = kHdrSnapW + kHdrSnapResW + kHdrZoomBtnW * 2 + kHdrFitW
                                + kHdrBtnGap * 4;
-    // Only show when TapeStrip is actually expanded — when it's
-    // collapsed or the user is in a fullscreen stage (AUX/Mastering),
-    // the zoom buttons have no on-screen subject so they don't belong in
-    // the header. (Snap moved onto the edit-tools strip above the timeline.)
     const bool hdrClusterVisible = ! inFullscreenView
                                   && tapeStrip != nullptr
                                   && tapeStripExpanded;
@@ -1449,27 +1444,6 @@ void MainComponent::resized()
     hdrZoomFitBtn.setVisible (hdrClusterVisible);
     hdrSnapBtn   .setVisible (hdrClusterVisible);
     hdrSnapResBtn.setVisible (hdrClusterVisible);
-    if (hdrClusterVisible)
-    {
-        // Real tuner X (parent-local on transportBar = parent-local on
-        // our row, since transportBar.setBounds(rowBounds) puts them
-        // in the same coord space). The previous heuristic
-        // (rowBounds.getRight() - 56) was ~320 px off — tuner sits
-        // BEFORE the right-anchored BPM / tap / time-sig / tape cluster.
-        const int tunerLeftInBar = transportBar != nullptr ? transportBar->getTunerLeftX() : rowBounds.getWidth() - 56;
-        const int tunerLeft = rowBounds.getX() + tunerLeftInBar;
-        const int leftEdge  = lastBankRight + 16;
-        const int rightEdge = tunerLeft - 16;
-        const int gapW      = juce::jmax (0, rightEdge - leftEdge);
-        const int clusterX  = leftEdge + juce::jmax (0, (gapW - kHdrClusterW) / 2);
-        const int clusterY  = rowBounds.getY() + (rowBounds.getHeight() - kHdrBtnH) / 2;
-        int x = clusterX;
-        hdrSnapBtn   .setBounds (x, clusterY, kHdrSnapW,    kHdrBtnH); x += kHdrSnapW    + kHdrBtnGap;
-        hdrSnapResBtn.setBounds (x, clusterY, kHdrSnapResW, kHdrBtnH); x += kHdrSnapResW + kHdrBtnGap;
-        hdrZoomOutBtn.setBounds (x, clusterY, kHdrZoomBtnW, kHdrBtnH); x += kHdrZoomBtnW + kHdrBtnGap;
-        hdrZoomInBtn .setBounds (x, clusterY, kHdrZoomBtnW, kHdrBtnH); x += kHdrZoomBtnW + kHdrBtnGap;
-        hdrZoomFitBtn.setBounds (x, clusterY, kHdrFitW,    kHdrBtnH);
-    }
 
     area.removeFromTop (4);
 
@@ -1497,6 +1471,27 @@ void MainComponent::resized()
             const int wanted = tapeStrip->naturalHeight();
             const int cap    = juce::jmax (120, area.getHeight() / 2);
             tapeStrip->setBounds (area.removeFromTop (juce::jmin (wanted, cap)));
+
+            // Place the snap / grid / zoom cluster in the ruler's top-right
+            // corner, above the timeline it controls. The buttons were added
+            // before the tape strip (which paints over them), so lift them
+            // to front so they show in the ruler band.
+            if (hdrClusterVisible)
+            {
+                const auto slot = tapeStrip->headerControlSlot (kHdrClusterW)
+                                    + tapeStrip->getPosition();
+                int x = slot.getX();
+                const int cy = slot.getY();
+                hdrSnapBtn   .setBounds (x, cy, kHdrSnapW,    kHdrBtnH); x += kHdrSnapW    + kHdrBtnGap;
+                hdrSnapResBtn.setBounds (x, cy, kHdrSnapResW, kHdrBtnH); x += kHdrSnapResW + kHdrBtnGap;
+                hdrZoomOutBtn.setBounds (x, cy, kHdrZoomBtnW, kHdrBtnH); x += kHdrZoomBtnW + kHdrBtnGap;
+                hdrZoomInBtn .setBounds (x, cy, kHdrZoomBtnW, kHdrBtnH); x += kHdrZoomBtnW + kHdrBtnGap;
+                hdrZoomFitBtn.setBounds (x, cy, kHdrFitW,     kHdrBtnH);
+                hdrSnapBtn   .toFront (false); hdrSnapResBtn.toFront (false);
+                hdrZoomOutBtn.toFront (false); hdrZoomInBtn .toFront (false);
+                hdrZoomFitBtn.toFront (false);
+            }
+
             area.removeFromTop (4);
         }
 

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -419,6 +419,21 @@ MainComponent::MainComponent()
     hdrSnapResBtn.onClick = [this] { showSnapResolutionMenu(); };
     addAndMakeVisible (hdrSnapBtn);
     addAndMakeVisible (hdrSnapResBtn);
+
+    // Chase toggle - green when on, matching the audio / MIDI editors.
+    hdrChaseBtn.setClickingTogglesState (true);
+    hdrChaseBtn.setColour (juce::TextButton::buttonColourId,   juce::Colour (0xff262630));
+    hdrChaseBtn.setColour (juce::TextButton::buttonOnColourId, juce::Colour (0xff406030));
+    hdrChaseBtn.setColour (juce::TextButton::textColourOffId,  juce::Colour (0xffd0d0d4));
+    hdrChaseBtn.setColour (juce::TextButton::textColourOnId,   juce::Colours::white);
+    hdrChaseBtn.setMouseClickGrabsKeyboardFocus (false);
+    hdrChaseBtn.setToggleState (appconfig::getFollowPlayheadDefault(), juce::dontSendNotification);
+    hdrChaseBtn.setTooltip ("Scroll the timeline to follow the playhead during playback");
+    hdrChaseBtn.onClick = [this]
+    {
+        if (tapeStrip != nullptr) tapeStrip->setChaseEnabled (hdrChaseBtn.getToggleState());
+    };
+    addAndMakeVisible (hdrChaseBtn);
     refreshSnapUi();
 
     // Bank-button row is rebuilt by syncBankButtons() each layout pass
@@ -448,6 +463,7 @@ MainComponent::MainComponent()
     tapeStripExpanded = appconfig::getTapeStripExpandedDefault();
     tapeStrip = std::make_unique<TapeStrip> (session, engine);
     tapeStrip->setVisible (tapeStripExpanded);
+    tapeStrip->setChaseEnabled (appconfig::getFollowPlayheadDefault());
     tapeStrip->onMidiRegionDoubleClicked  = [this] (int t, int r) { openPianoRoll   (t, r); };
     tapeStrip->onAudioRegionDoubleClicked = [this] (int t, int r) { openAudioEditor (t, r); };
     tapeStrip->onFilesDropped = [this] (juce::Array<juce::File> files,
@@ -1385,6 +1401,13 @@ void MainComponent::resized()
         // Help text in the gap between the menu bar and the tabs.
         const int statusW = juce::jmax (0, stageX - 12 - menuLeftPad);
         statusLabel.setBounds (menuLeftPad, menuRow.getY(), statusW, menuRow.getHeight());
+
+        // Parameter tooltips live in this same band; keep them off the tabs.
+        lookAndFeel.setTooltipPlacement (
+            juce::Rectangle<int> (menuLeftPad, menuRow.getY(),
+                                    juce::jmax (0, menuRightPad - menuLeftPad),
+                                    menuRow.getHeight()),
+            juce::Rectangle<int> (stageX, menuRow.getY(), stageBlockW, menuRow.getHeight()));
     }
 
     // Bank buttons centered in the TRANSPORT row (the stage selector vacated it),
@@ -1416,20 +1439,18 @@ void MainComponent::resized()
         }
     }
 
-    // SNAP + grid + zoom (- / + / Fit) cluster. It only acts on the timeline,
-    // so it is positioned in the tape strip ruler's top-right corner (in the
-    // tapeStrip->setBounds block below), NOT the transport row. Keeping it off
-    // the transport row means a narrow window can no longer make it overlap the
-    // BPM / tuner controls. Shown only with the timeline open and not in a
-    // fullscreen stage (AUX/Mastering), where the zoom buttons have no subject.
+    // SNAP + zoom (- / + / Fit) + Chase cluster. These only act on the
+    // timeline, so they live in a dedicated thin toolbar row directly above
+    // the tape strip (carved in the tapeStrip block below), NOT the transport
+    // row. Shown only with the timeline open and not in a fullscreen stage
+    // (AUX/Mastering), where they have no subject.
     constexpr int kHdrZoomBtnW = 30;
     constexpr int kHdrFitW     = 36;
     constexpr int kHdrSnapW    = 48;
     constexpr int kHdrSnapResW = 78;
+    constexpr int kHdrChaseW   = 56;
     constexpr int kHdrBtnGap   = 4;
     constexpr int kHdrBtnH     = 24;
-    constexpr int kHdrClusterW = kHdrSnapW + kHdrSnapResW + kHdrZoomBtnW * 2 + kHdrFitW
-                               + kHdrBtnGap * 4;
     const bool hdrClusterVisible = ! inFullscreenView
                                   && tapeStrip != nullptr
                                   && tapeStripExpanded;
@@ -1438,6 +1459,7 @@ void MainComponent::resized()
     hdrZoomFitBtn.setVisible (hdrClusterVisible);
     hdrSnapBtn   .setVisible (hdrClusterVisible);
     hdrSnapResBtn.setVisible (hdrClusterVisible);
+    hdrChaseBtn  .setVisible (hdrClusterVisible);
 
     area.removeFromTop (4);
 
@@ -1458,6 +1480,23 @@ void MainComponent::resized()
                     ConsoleView::rangeForBankAtWidth (bank, area.getWidth());
                 tapeStrip->setConsoleVisibleRange (first1 - 1, last1 - first1 + 1);
             }
+            // Dedicated timeline-toolbar row directly above the tape strip.
+            // Left-aligned [Snap | res | - | + | Fit | Chase]. Its own row, so
+            // no overlapping sibling and no toFront needed.
+            if (hdrClusterVisible)
+            {
+                constexpr int kTimelineToolbarH = 28;
+                const auto bar = area.removeFromTop (kTimelineToolbarH);
+                int x = bar.getX();
+                const int cy = bar.getY() + (bar.getHeight() - kHdrBtnH) / 2;
+                hdrSnapBtn   .setBounds (x, cy, kHdrSnapW,    kHdrBtnH); x += kHdrSnapW    + kHdrBtnGap;
+                hdrSnapResBtn.setBounds (x, cy, kHdrSnapResW, kHdrBtnH); x += kHdrSnapResW + kHdrBtnGap;
+                hdrZoomOutBtn.setBounds (x, cy, kHdrZoomBtnW, kHdrBtnH); x += kHdrZoomBtnW + kHdrBtnGap;
+                hdrZoomInBtn .setBounds (x, cy, kHdrZoomBtnW, kHdrBtnH); x += kHdrZoomBtnW + kHdrBtnGap;
+                hdrZoomFitBtn.setBounds (x, cy, kHdrFitW,     kHdrBtnH); x += kHdrFitW     + kHdrBtnGap;
+                hdrChaseBtn  .setBounds (x, cy, kHdrChaseW,   kHdrBtnH);
+            }
+
             // Cap the strip at ~half the available height so vertical
             // zoom (taller rows) can't swallow the console - past the cap
             // the rows scroll inside the strip. Console keeps a usable
@@ -1465,26 +1504,6 @@ void MainComponent::resized()
             const int wanted = tapeStrip->naturalHeight();
             const int cap    = juce::jmax (120, area.getHeight() / 2);
             tapeStrip->setBounds (area.removeFromTop (juce::jmin (wanted, cap)));
-
-            // Place the snap / grid / zoom cluster in the ruler's top-right
-            // corner, above the timeline it controls. The buttons were added
-            // before the tape strip (which paints over them), so lift them
-            // to front so they show in the ruler band.
-            if (hdrClusterVisible)
-            {
-                const auto slot = tapeStrip->headerControlSlot (kHdrClusterW)
-                                    + tapeStrip->getPosition();
-                int x = slot.getX();
-                const int cy = slot.getY();
-                hdrSnapBtn   .setBounds (x, cy, kHdrSnapW,    kHdrBtnH); x += kHdrSnapW    + kHdrBtnGap;
-                hdrSnapResBtn.setBounds (x, cy, kHdrSnapResW, kHdrBtnH); x += kHdrSnapResW + kHdrBtnGap;
-                hdrZoomOutBtn.setBounds (x, cy, kHdrZoomBtnW, kHdrBtnH); x += kHdrZoomBtnW + kHdrBtnGap;
-                hdrZoomInBtn .setBounds (x, cy, kHdrZoomBtnW, kHdrBtnH); x += kHdrZoomBtnW + kHdrBtnGap;
-                hdrZoomFitBtn.setBounds (x, cy, kHdrFitW,     kHdrBtnH);
-                hdrSnapBtn   .toFront (false); hdrSnapResBtn.toFront (false);
-                hdrZoomOutBtn.toFront (false); hdrZoomInBtn .toFront (false);
-                hdrZoomFitBtn.toFront (false);
-            }
 
             area.removeFromTop (4);
         }

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -352,10 +352,16 @@ MainComponent::MainComponent()
     styleStageButton (mixingStageBtn,    juce::Colour (0xff5a8ad0));   // mix-desk blue
     styleStageButton (auxStageBtn,       juce::Colour (0xff6e5ad0));   // aux indigo-violet
     styleStageButton (masteringStageBtn, juce::Colour (0xff8a5ad0));   // mastering purple
-    recordingStageBtn.setTooltip ("Recording stage - press Ctrl+1");
-    mixingStageBtn   .setTooltip ("Mixing stage - press Ctrl+2");
-    masteringStageBtn.setTooltip ("Mastering stage - press Ctrl+3");
-    auxStageBtn      .setTooltip ("Aux send / return stage - press Ctrl+4");
+    // isCommandDown() is Cmd on macOS, Ctrl elsewhere - keep the hint in sync.
+   #if JUCE_MAC
+    const juce::String modKey = "Cmd";
+   #else
+    const juce::String modKey = "Ctrl";
+   #endif
+    recordingStageBtn.setTooltip ("Recording stage - press " + modKey + "+1");
+    mixingStageBtn   .setTooltip ("Mixing stage - press " + modKey + "+2");
+    masteringStageBtn.setTooltip ("Mastering stage - press " + modKey + "+3");
+    auxStageBtn      .setTooltip ("Aux send / return stage - press " + modKey + "+4");
     recordingStageBtn.setConnectedEdges (juce::Button::ConnectedOnRight);
     mixingStageBtn   .setConnectedEdges (juce::Button::ConnectedOnLeft | juce::Button::ConnectedOnRight);
     masteringStageBtn.setConnectedEdges (juce::Button::ConnectedOnLeft | juce::Button::ConnectedOnRight);

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -1725,20 +1725,25 @@ void MainComponent::doMixdown()
                                                    engine.getDeviceManager(), target);
     panel->setSize (520, 200);
 
-    // Hand off to Mastering once the bounce finishes successfully. The
-    // dialog fires this on its message-thread "Close" path, well after the
-    // worker has restored engine state, so the stage flip is safe.
+    // Close the modal, then hand off to Mastering once the bounce finishes
+    // successfully. The handoff is deferred so the heavy stage swap does not
+    // run re-entrantly from inside the dialog's close-button callback.
     juce::Component::SafePointer<MainComponent> safeThis (this);
+    panel->onRequestClose = [safeThis] { if (safeThis != nullptr) safeThis->mixdownModal.close(); };
     panel->onSuccessfulFinish = [safeThis] (juce::File rendered)
     {
-        if (safeThis == nullptr) return;
-        safeThis->mixdownModal.close();
-        safeThis->switchToStage (AudioEngine::Stage::Mastering);
-        if (safeThis->masteringView != nullptr)
-            safeThis->masteringView->loadFile (rendered);
+        juce::MessageManager::callAsync ([safeThis, rendered]
+        {
+            if (safeThis == nullptr) return;
+            safeThis->switchToStage (AudioEngine::Stage::Mastering);
+            if (safeThis->masteringView != nullptr)
+                safeThis->masteringView->loadFile (rendered);
+        });
     };
 
-    mixdownModal.show (*this, std::move (panel));
+    // A render in progress must not be dismissed by a stray click / Escape -
+    // only the dialog's own Cancel / Close buttons drive teardown.
+    mixdownModal.show (*this, std::move (panel), {}, false, false);
 }
 
 void MainComponent::launchStartupDialog()
@@ -2829,7 +2834,9 @@ void MainComponent::openBounceDialog()
                                                        engine.getDeviceManager(), outFile,
                                                        BounceEngine::Mode::MasterMix, fmt);
         panel->setSize (520, 200);
-        bounceModal.show (*this, std::move (panel));
+        juce::Component::SafePointer<MainComponent> safeThis (this);
+        panel->onRequestClose = [safeThis] { if (safeThis != nullptr) safeThis->bounceModal.close(); };
+        bounceModal.show (*this, std::move (panel), {}, false, false);
     });
 }
 
@@ -2884,7 +2891,9 @@ void MainComponent::openBounceStemsDialog()
                                                            engine.getDeviceManager(), outFile,
                                                            BounceEngine::Mode::Stems);
             panel->setSize (520, 200);
-            bounceModal.show (*this, std::move (panel));
+            juce::Component::SafePointer<MainComponent> safeThis (this);
+            panel->onRequestClose = [safeThis] { if (safeThis != nullptr) safeThis->bounceModal.close(); };
+            bounceModal.show (*this, std::move (panel), {}, false, false);
         };
 
         if (conflicts.isEmpty())

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -352,10 +352,10 @@ MainComponent::MainComponent()
     styleStageButton (mixingStageBtn,    juce::Colour (0xff5a8ad0));   // mix-desk blue
     styleStageButton (auxStageBtn,       juce::Colour (0xff6e5ad0));   // aux indigo-violet
     styleStageButton (masteringStageBtn, juce::Colour (0xff8a5ad0));   // mastering purple
-    recordingStageBtn.setTooltip ("Recording stage - press 1");
-    mixingStageBtn   .setTooltip ("Mixing stage - press 2");
-    masteringStageBtn.setTooltip ("Mastering stage - press 3");
-    auxStageBtn      .setTooltip ("Aux send / return stage - press 4");
+    recordingStageBtn.setTooltip ("Recording stage - press Ctrl+1");
+    mixingStageBtn   .setTooltip ("Mixing stage - press Ctrl+2");
+    masteringStageBtn.setTooltip ("Mastering stage - press Ctrl+3");
+    auxStageBtn      .setTooltip ("Aux send / return stage - press Ctrl+4");
     recordingStageBtn.setConnectedEdges (juce::Button::ConnectedOnRight);
     mixingStageBtn   .setConnectedEdges (juce::Button::ConnectedOnLeft | juce::Button::ConnectedOnRight);
     masteringStageBtn.setConnectedEdges (juce::Button::ConnectedOnLeft | juce::Button::ConnectedOnRight);
@@ -790,27 +790,23 @@ bool MainComponent::keyPressed (const juce::KeyPress& key)
         return true;
     }
 
-    // ── Bank switching: Cmd/Ctrl + 1/2/3 selects banks 1-8 / 9-16 / 17-24.
-    // Maps to ConsoleView::setBank which also publishes the active bank
-    // to the audio thread so bank-relative MIDI bindings retarget.
-    if (cmd && ! shift && consoleView != nullptr)
+    // ── Bank switching: plain 1/2/3/4 select the visible channel bank. Maps to
+    // ConsoleView::setBank which also publishes the active bank to the audio
+    // thread so bank-relative MIDI bindings retarget. Out-of-range digits (more
+    // banks than the window currently shows) fall through unhandled.
+    if (noMods && consoleView != nullptr)
     {
-        const int bankIndex = (code == '1') ? 0
-                            : (code == '2') ? 1
-                            : (code == '3') ? 2
-                                            : -1;
-        if (bankIndex >= 0)
+        const int bankIndex = (code >= '1' && code <= '4') ? (code - '1') : -1;
+        if (bankIndex >= 0 && bankIndex < consoleView->numBanks())
         {
-            consoleView->setBank (juce::jlimit (0,
-                                                  juce::jmax (0, consoleView->numBanks() - 1),
-                                                  bankIndex));
+            consoleView->setBank (bankIndex);
             return true;
         }
     }
 
-    // ── Stage switching: plain 1/2/3/4 select Recording / Mixing / Mastering /
-    // Aux. Cmd/Ctrl + digit is bank switching (above), so these stay unmodified.
-    if (noMods)
+    // ── Stage switching: Cmd/Ctrl + 1/2/3/4 select Recording / Mixing /
+    // Mastering / Aux. Plain digits are bank switching (above).
+    if (cmd && ! shift)
     {
         switch (code)
         {
@@ -1229,12 +1225,10 @@ void MainComponent::syncBankButtons (int desiredCount)
         {
             if (consoleView != nullptr) consoleView->setBank (idx);
         };
-        // Banks 1-3 are reachable via Cmd/Ctrl + 1/2/3 (see keyPressed).
+        // Banks 1-4 are reachable via the plain number keys 1/2/3/4 (see keyPressed).
         juce::String hint;
-        if (idx < 3)
-            hint = "  (" + juce::KeyPress ('1' + idx,
-                                             juce::ModifierKeys (juce::ModifierKeys::commandModifier), 0)
-                               .getTextDescriptionWithIcons() + ")";
+        if (idx < 4)
+            hint = "  (press " + juce::String (idx + 1) + ")";
         btn->setTooltip ("Channel bank " + juce::String (idx + 1) + hint);
         addAndMakeVisible (btn.get());
         bankButtons.push_back (std::move (btn));

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -1297,16 +1297,15 @@ void MainComponent::resized()
 
     auto area = getLocalBounds().reduced (8);
 
-    // Slim menu-bar row at the very top. The menu bar grows to fit its
-    // top-level menu names (~80 px); status text + system meters share
-    // the rest of the row to its right.
-    auto top = area.removeFromTop (22);
-    menuBar.setBounds (top.removeFromLeft (200));
-    top.removeFromLeft (8);
+    // Top menu row. Grown to host the centered stage selector (RECORDING /
+    // MIXING / MASTERING / AUX). File / Settings menu on the left, system meters
+    // on the right; the stage selector and the session status text are placed
+    // below, once the stage-tab width is known.
+    constexpr int kMenuRowH = 32;
+    const auto menuRow = area.removeFromTop (kMenuRowH);
+    menuBar.setBounds (menuRow.withWidth (200));
     if (systemStatusBar != nullptr)
-        systemStatusBar->setBounds (top.removeFromRight (300));
-    top.removeFromRight (8);
-    statusLabel.setBounds (top);
+        systemStatusBar->setBounds (menuRow.withTrimmedLeft (menuRow.getWidth() - 300));
     area.removeFromTop (4);
 
     const auto curStage = engine.getStage();
@@ -1338,7 +1337,6 @@ void MainComponent::resized()
     }
 
     constexpr int kStageBtnH = 28;
-    const int stageY = rowBounds.getY() + (rowBounds.getHeight() - kStageBtnH) / 2;
 
     // Banking decision: ConsoleView reports how many channel strips fit
     // alongside the always-anchored bus + master column at min width.
@@ -1366,46 +1364,42 @@ void MainComponent::resized()
     constexpr int kBankBtnGap = 6;
     constexpr int kBankBtnH  = 26;
 
-    // Center the stages + banks group within the row. Transport sits on
-    // the LEFT (TransportBar own widgets); BPM cluster sits on the RIGHT.
-    // The centered group reads: STAGES (4 tabs) [+ BANK 1..N buttons
-    // when 16 strips need banking].
-    constexpr int kStageToBankGap = 12;
-    const int bankClusterW = needsBanking
-                                ? (kStageToBankGap
-                                     + numBanks * kBankBtnW
-                                     + (numBanks - 1) * kBankBtnGap)
-                                : 0;
-    const int groupW       = stageBlockW + bankClusterW;
-    int stageX             = rowBounds.getX() + (rowBounds.getWidth() - groupW) / 2;
-
-    // Pure window-width centering walks over the transport bar's clock /
-    // timecode label at wide widths (the transport cluster is left-anchored,
-    // the stage tabs centre on the FULL row). Clamp the centred group so
-    // its left edge sits at least `kStageClockGap` past the clock's right
-    // edge — matches the gap conventions used elsewhere in this row.
-    if (transportBar != nullptr)
+    // Stage selector lives in the TOP menu row, centered between the File /
+    // Settings menu and the system meters. The session status text fills the
+    // gap to its left. (stageW / stageBlockW were computed above with the
+    // transport metrics so the tabs follow the same compact breakpoint.)
     {
-        constexpr int kStageClockGap = 12;
-        const int clockRight = rowBounds.getX() + transportBar->getClockRightX();
-        stageX = juce::jmax (stageX, clockRight + kStageClockGap);
+        const int menuStageY   = menuRow.getY() + (menuRow.getHeight() - kStageBtnH) / 2;
+        const int menuLeftPad  = menuRow.getX() + 200 + 12;            // past File / Settings
+        const int menuRightPad = menuRow.getRight()
+                                   - (systemStatusBar != nullptr ? 300 + 12 : 0);
+        int stageX = menuRow.getX() + (menuRow.getWidth() - stageBlockW) / 2;
+        stageX = juce::jlimit (menuLeftPad,
+                                 juce::jmax (menuLeftPad, menuRightPad - stageBlockW),
+                                 stageX);
+        recordingStageBtn.setBounds (stageX,              menuStageY, stageW, kStageBtnH);
+        mixingStageBtn   .setBounds (stageX + stageW,     menuStageY, stageW, kStageBtnH);
+        masteringStageBtn.setBounds (stageX + 2 * stageW, menuStageY, stageW, kStageBtnH);
+        auxStageBtn      .setBounds (stageX + 3 * stageW, menuStageY, stageW, kStageBtnH);
+
+        // Help text in the gap between the menu bar and the tabs.
+        const int statusW = juce::jmax (0, stageX - 12 - menuLeftPad);
+        statusLabel.setBounds (menuLeftPad, menuRow.getY(), statusW, menuRow.getHeight());
     }
 
-    recordingStageBtn.setBounds (stageX,                stageY, stageW, kStageBtnH);
-    mixingStageBtn   .setBounds (stageX + stageW,       stageY, stageW, kStageBtnH);
-    masteringStageBtn.setBounds (stageX + 2 * stageW,   stageY, stageW, kStageBtnH);
-    auxStageBtn      .setBounds (stageX + 3 * stageW,   stageY, stageW, kStageBtnH);
-    // Z-order is correct by construction: transportBar is added BEFORE
-    // the stage tabs + bank buttons in the ctor, so the overlays sit on
-    // top of the transport bar's painted background naturally.
-
-    // Rebuild bank-button row to match the current numBanks. Buttons
-    // sit inline immediately right of the centered stage block.
+    // Bank buttons centered in the TRANSPORT row (the stage selector vacated it),
+    // clamped past the clock so they never overlap it.
     syncBankButtons (needsBanking ? numBanks : 0);
     if (needsBanking && consoleView != nullptr)
     {
+        const int bankClusterW = numBanks * kBankBtnW + (numBanks - 1) * kBankBtnGap;
+        int bankX = rowBounds.getX() + (rowBounds.getWidth() - bankClusterW) / 2;
+        if (transportBar != nullptr)
+        {
+            const int clockRight = rowBounds.getX() + transportBar->getClockRightX();
+            bankX = juce::jmax (bankX, clockRight + 12);
+        }
         const int bankY = rowBounds.getY() + (rowBounds.getHeight() - kBankBtnH) / 2;
-        int bankX = stageX + stageBlockW + kStageToBankGap;
         const int activeBank = consoleView->getBank();
         for (int i = 0; i < (int) bankButtons.size(); ++i)
         {

--- a/src/ui/MainComponent.h
+++ b/src/ui/MainComponent.h
@@ -226,6 +226,9 @@ private:
     // region / marker / loop / tempo drag on.
     juce::TextButton hdrSnapBtn    { "Snap" };
     juce::TextButton hdrSnapResBtn { {}     };
+    // Chase: scroll the tape strip to keep the playhead in view during
+    // playback. Live toggle; its launch default comes from AppConfig.
+    juce::TextButton hdrChaseBtn   { "Chase" };
     void showSnapResolutionMenu();
     void refreshSnapUi();
 

--- a/src/ui/MasteringView.cpp
+++ b/src/ui/MasteringView.cpp
@@ -764,7 +764,9 @@ void MasteringView::doExport()
                                                        engine.getDeviceManager(), target,
                                                        BounceEngine::Mode::MasteringChain, fmt);
         panel->setSize (520, 200);
-        exportModal.show (*this, std::move (panel));
+        juce::Component::SafePointer<MasteringView> safeThis (this);
+        panel->onRequestClose = [safeThis] { if (safeThis != nullptr) safeThis->exportModal.close(); };
+        exportModal.show (*this, std::move (panel), {}, false, false);
     });
 }
 } // namespace duskstudio

--- a/src/ui/PianoRollComponent.cpp
+++ b/src/ui/PianoRollComponent.cpp
@@ -1,4 +1,5 @@
 #include "PianoRollComponent.h"
+#include "AppConfig.h"
 #include "DuskContextMenu.h"
 #include "EditCursors.h"
 #include "EditModeToolbar.h"
@@ -425,9 +426,11 @@ PianoRollComponent::PianoRollComponent (Session& s, AudioEngine& e, int t, int r
     toggleCcButton.setTooltip ("Show / hide CC lane");
     toggleCcButton.onClick = [this] { toggleCcLane(); };
 
-    // Chase toggle - auto-scroll the grid to follow the transport
-    // playhead when it leaves the visible window. Off by default.
+    // Chase toggle - auto-scroll the grid to follow the transport playhead
+    // when it leaves the visible window. Initial state follows the per-machine
+    // Follow-playhead setting.
     chaseToggle.setClickingTogglesState (true);
+    chaseToggle.setToggleState (appconfig::getFollowPlayheadDefault(), juce::dontSendNotification);
     chaseToggle.setColour (juce::TextButton::buttonColourId,   juce::Colour (0xff222226));
     chaseToggle.setColour (juce::TextButton::buttonOnColourId, juce::Colour (0xff406030));
     chaseToggle.setColour (juce::TextButton::textColourOffId,  juce::Colour (0xff909094));

--- a/src/ui/PianoRollComponent.cpp
+++ b/src/ui/PianoRollComponent.cpp
@@ -1041,30 +1041,44 @@ void PianoRollComponent::paintBeatRuler (juce::Graphics& g, juce::Rectangle<int>
     if (mode == TimeDisplayMode::Bars)
     {
         const float pxPerBeat = (float) ticksPerBeat * pixelsPerTick;
-        const bool showSubBeats = pxPerBeat >= 40.0f;
+        const bool showBeatTicks = pxPerBeat >= 9.0f;   // beat tick marks
+        const bool showSubBeats  = pxPerBeat >= 40.0f;  // beat-number labels
+        const int  beatTop = area.getBottom() - (int) (area.getHeight() * 0.45f);
         for (int bar = 0; bar <= totalBars; ++bar)
         {
-            const int bx = xForTick ((juce::int64) bar * ticksPerBar);
+            const juce::int64 barTick = (juce::int64) bar * ticksPerBar;
+            const int bx = xForTick (barTick);
             if (bx >= kKeyboardWidth && bx <= area.getRight())
             {
+                g.setColour (kBarLine);
+                g.drawVerticalLine (bx, (float) area.getY(), (float) area.getBottom());
+                g.setColour (kHeaderText);
+                g.setFont (juce::Font (juce::FontOptions (12.5f, juce::Font::bold)));
                 g.drawText (juce::String (bar + 1), bx + 3, area.getY(),
                              48, area.getHeight(), juce::Justification::centredLeft, false);
+            }
+            if (showBeatTicks)
+            {
+                g.setColour (kBeatLine.withAlpha (0.7f));
+                for (int beat = 1; beat < beatsPerBar; ++beat)
+                {
+                    const int bbx = xForTick (barTick + (juce::int64) beat * ticksPerBeat);
+                    if (bbx < kKeyboardWidth || bbx > area.getRight()) continue;
+                    g.drawVerticalLine (bbx, (float) beatTop, (float) area.getBottom());
+                }
             }
             if (! showSubBeats) continue;
             g.setFont (juce::Font (juce::FontOptions (10.5f, juce::Font::plain)));
             g.setColour (kHeaderText.withAlpha (0.65f));
             for (int beat = 1; beat < beatsPerBar; ++beat)
             {
-                const int bbx = xForTick ((juce::int64) bar * ticksPerBar
-                                              + (juce::int64) beat * ticksPerBeat);
+                const int bbx = xForTick (barTick + (juce::int64) beat * ticksPerBeat);
                 if (bbx < kKeyboardWidth || bbx > area.getRight()) continue;
                 g.drawText (juce::String (bar + 1) + "." + juce::String (beat + 1),
                              bbx + 3, area.getY(),
                              48, area.getHeight(),
                              juce::Justification::centredLeft, false);
             }
-            g.setFont (juce::Font (juce::FontOptions (12.5f, juce::Font::bold)));
-            g.setColour (kHeaderText);
         }
     }
     else

--- a/src/ui/ShortcutsPanel.h
+++ b/src/ui/ShortcutsPanel.h
@@ -29,10 +29,10 @@ public:
 
         sections = {
             { "Stages", {
-                { "1", "Recording" }, { "2", "Mixing" },
-                { "3", "Mastering" }, { "4", "Aux" } } },
+                { mod ('1'), "Recording" }, { mod ('2'), "Mixing" },
+                { mod ('3'), "Mastering" }, { mod ('4'), "Aux" } } },
             { "Channel banks", {
-                { mod ('1'), "Bank 1" }, { mod ('2'), "Bank 2" }, { mod ('3'), "Bank 3" } } },
+                { "1", "Bank 1" }, { "2", "Bank 2" }, { "3", "Bank 3" }, { "4", "Bank 4" } } },
             { "Transport", {
                 { "Space", "Play / Stop" }, { "R", "Record" },
                 { "Home", "Playhead to start" }, { ".", "Stop + rewind to start" } } },

--- a/src/ui/TapeStrip.cpp
+++ b/src/ui/TapeStrip.cpp
@@ -864,7 +864,7 @@ void TapeStrip::updatePlayheadBand()
     // (only possible when zoomed in past fit-to-window), re-anchor the scroll so
     // it lands at the left quarter, then full-repaint - the whole strip shifted,
     // so the thin-band optimisation below would be wrong.
-    if (chaseEnabled_ && engine.getTransport().isPlaying())
+    if (chaseEnabled && engine.getTransport().isPlaying())
     {
         const double sr = engine.getCurrentSampleRate();
         const double px = pixelsPerSecond();

--- a/src/ui/TapeStrip.cpp
+++ b/src/ui/TapeStrip.cpp
@@ -389,6 +389,17 @@ juce::Rectangle<int> TapeStrip::tracksColumnBounds() const noexcept
                                   juce::jmax (0, getHeight() - kRulerH));
 }
 
+juce::Rectangle<int> TapeStrip::headerControlSlot (int clampWidth) const noexcept
+{
+    const auto ruler = rulerBounds();
+    constexpr int pad   = 8;
+    constexpr int slotH = 24;
+    const int w = juce::jmin (clampWidth, juce::jmax (0, ruler.getWidth() - pad));
+    const int x = ruler.getRight() - pad - w;   // right-anchored; x stays >= ruler.getX()
+    const int y = ruler.getY() + (ruler.getHeight() - slotH) / 2;
+    return juce::Rectangle<int> (x, y, w, slotH);
+}
+
 void TapeStrip::refreshLabelColumnWidth()
 {
     // Measure every row's drawn text (name, or the 1-based number fallback) in

--- a/src/ui/TapeStrip.cpp
+++ b/src/ui/TapeStrip.cpp
@@ -389,17 +389,6 @@ juce::Rectangle<int> TapeStrip::tracksColumnBounds() const noexcept
                                   juce::jmax (0, getHeight() - kRulerH));
 }
 
-juce::Rectangle<int> TapeStrip::headerControlSlot (int clampWidth) const noexcept
-{
-    const auto ruler = rulerBounds();
-    constexpr int pad   = 8;
-    constexpr int slotH = 24;
-    const int w = juce::jmin (clampWidth, juce::jmax (0, ruler.getWidth() - pad));
-    const int x = ruler.getRight() - pad - w;   // right-anchored; x stays >= ruler.getX()
-    const int y = ruler.getY() + (ruler.getHeight() - slotH) / 2;
-    return juce::Rectangle<int> (x, y, w, slotH);
-}
-
 void TapeStrip::refreshLabelColumnWidth()
 {
     // Measure every row's drawn text (name, or the 1-based number fallback) in
@@ -870,6 +859,29 @@ void TapeStrip::updatePlayheadBand()
 
     const auto now = engine.getTransport().getPlayhead();
     if (now == lastPlayhead) return;
+
+    // Chase: when on and playing, if the playhead has run off the tracks column
+    // (only possible when zoomed in past fit-to-window), re-anchor the scroll so
+    // it lands at the left quarter, then full-repaint - the whole strip shifted,
+    // so the thin-band optimisation below would be wrong.
+    if (chaseEnabled_ && engine.getTransport().isPlaying())
+    {
+        const double sr = engine.getCurrentSampleRate();
+        const double px = pixelsPerSecond();
+        const auto  col = tracksColumnBounds();
+        if (sr > 0.0 && px > 0.0 && col.getWidth() > 0)
+        {
+            const int phX = xForSample (now);
+            if (phX < col.getX() || phX > col.getRight())
+            {
+                const juce::int64 viewSamples = (juce::int64) std::llround ((double) col.getWidth() / px * sr);
+                scrollSamples = juce::jmax<juce::int64> (0, now - viewSamples / 4);
+                lastPlayhead  = now;
+                repaint();
+                return;
+            }
+        }
+    }
 
     const int oldX = xForSample (lastPlayhead < 0 ? 0 : lastPlayhead);
     const int newX = xForSample (now);

--- a/src/ui/TapeStrip.h
+++ b/src/ui/TapeStrip.h
@@ -48,6 +48,13 @@ public:
 
     // Rows = armed ∪ has-content (or every track when SHOW ALL is on).
     int naturalHeight() const noexcept;
+
+    // Right-aligned slot in the ruler band for the host's snap/zoom header
+    // controls, in this strip's own coords. Width is clampWidth clamped to the
+    // ruler's free width; the slot never crosses the label column. The host
+    // positions its buttons inside (slot + getPosition()) so they sit in the
+    // ruler's top-right corner instead of the crowded transport row.
+    juce::Rectangle<int> headerControlSlot (int clampWidth) const noexcept;
     // Upper bound for layout code that needs an estimate before any
     // TapeStrip instance exists.
     static int maxNaturalHeight() noexcept;

--- a/src/ui/TapeStrip.h
+++ b/src/ui/TapeStrip.h
@@ -127,7 +127,7 @@ public:
 
     // Follow the playhead: when on, the strip scrolls during playback so the
     // playhead stays in view (no-op at fit-to-window zoom, where it always is).
-    void setChaseEnabled (bool enabled) noexcept { chaseEnabled_ = enabled; }
+    void setChaseEnabled (bool enabled) noexcept { chaseEnabled = enabled; }
 
     // Explicit refresh for the session-load path. The strip otherwise relies on
     // indirect side effects (setConsoleVisibleRange / setBounds / the 30 Hz
@@ -246,7 +246,7 @@ private:
     // zoom clamp it so the visible window stays inside content.
     juce::int64 scrollSamples = 0;
 
-    bool chaseEnabled_ = false;
+    bool chaseEnabled = false;
 
     // Bold-text LookAndFeel for the SHOW ALL pill (TextButton has no setFont).
     // Declared before showAllToggle so the button is destroyed first.

--- a/src/ui/TapeStrip.h
+++ b/src/ui/TapeStrip.h
@@ -49,12 +49,6 @@ public:
     // Rows = armed ∪ has-content (or every track when SHOW ALL is on).
     int naturalHeight() const noexcept;
 
-    // Right-aligned slot in the ruler band for the host's snap/zoom header
-    // controls, in this strip's own coords. Width is clampWidth clamped to the
-    // ruler's free width; the slot never crosses the label column. The host
-    // positions its buttons inside (slot + getPosition()) so they sit in the
-    // ruler's top-right corner instead of the crowded transport row.
-    juce::Rectangle<int> headerControlSlot (int clampWidth) const noexcept;
     // Upper bound for layout code that needs an estimate before any
     // TapeStrip instance exists.
     static int maxNaturalHeight() noexcept;
@@ -130,6 +124,10 @@ public:
     // the cursor stays put.
     void zoomByFactor (float factor, int anchorX = -1);
     void zoomFit() noexcept;
+
+    // Follow the playhead: when on, the strip scrolls during playback so the
+    // playhead stays in view (no-op at fit-to-window zoom, where it always is).
+    void setChaseEnabled (bool enabled) noexcept { chaseEnabled_ = enabled; }
 
     // Explicit refresh for the session-load path. The strip otherwise relies on
     // indirect side effects (setConsoleVisibleRange / setBounds / the 30 Hz
@@ -247,6 +245,8 @@ private:
     // Leftmost visible sample when zoomed. 0 when factor == 1. Wheel +
     // zoom clamp it so the visible window stays inside content.
     juce::int64 scrollSamples = 0;
+
+    bool chaseEnabled_ = false;
 
     // Bold-text LookAndFeel for the SHOW ALL pill (TextButton has no setFont).
     // Declared before showAllToggle so the button is destroyed first.

--- a/src/ui/TransportBar.cpp
+++ b/src/ui/TransportBar.cpp
@@ -1021,15 +1021,6 @@ void TransportBar::resized()
 {
     auto area = getLocalBounds().reduced (8, 6);
 
-   #if JUCE_MAC
-    int macTitlePad = 78;
-    if (auto* top = getTopLevelComponent())
-        if (auto* peer = top->getPeer())
-            if (peer->isFullScreen() || peer->isKioskMode())
-                macTitlePad = 0;
-    area.removeFromLeft (macTitlePad);
-   #endif
-
     constexpr int kBtnDia = 36;
     constexpr int kBtnGap = 4;
     auto buttons = area.removeFromLeft (kBtnDia * 8 + kBtnGap * 7);

--- a/src/ui/TransportBar.cpp
+++ b/src/ui/TransportBar.cpp
@@ -1073,7 +1073,7 @@ void TransportBar::resized()
         sectionLabel.setBounds (area.removeFromLeft (juce::jmin (textW, maxW)).reduced (0, 4));
     }
 
-    tapeToggle.setBounds (area.removeFromRight (compact ? 32 : 84).reduced (1));
+    tapeToggle.setBounds (area.removeFromRight (compact ? 48 : 84).reduced (1));
     area.removeFromRight (12);
 
     countInToggle.setBounds (area.removeFromRight (compact ? 34 : 44).reduced (1, 4));
@@ -1170,9 +1170,11 @@ void TransportBar::syncCompactLabels (bool compact)
     const bool tapeExpanded = tapeToggle.getToggleState();
     if (compact)
     {
+        // Keep a short "TL" tag beside the chevron so the control still reads
+        // as the TIMELINE toggle - a bare chevron is too cryptic on its own.
         tapeToggle .setButtonText (tapeExpanded
-            ? juce::CharPointer_UTF8 ("\xe2\x96\xbe")    // "▾"
-            : juce::CharPointer_UTF8 ("\xe2\x96\xb8")); // "▸"
+            ? juce::CharPointer_UTF8 ("\xe2\x96\xbe TL")    // "▾ TL"
+            : juce::CharPointer_UTF8 ("\xe2\x96\xb8 TL")); // "▸ TL"
     }
     else
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Follow playhead by default” (per-machine) with persistent Chase toggle, affecting app launch behavior.
  * Added a Bars-mode bar/beat grid overlay in the audio editor.

* **Improvements**
  * Updated stage/bank keyboard shortcuts and related shortcut labels/tooltips.
  * Refreshed timeline/transport toolbar layout and compact-mode TIMELINE labeling.
  * Improved dialog closing behavior with safe, non-blocking cancellation and proper close requests.

* **Bug Fixes / Release Workflow**
  * Improved release packaging for per-architecture artifacts.
  * Tightened Patreon refresh handling: when configured, update failures now fail the release.

* **Documentation**
  * Updated MANUAL shortcut and per-architecture SHA256 checksum verification instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->