### PR TITLE
UI polish: timeline toolbar, T=timeline / Cmd+E split, marker clipping, app icon

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1076,7 +1076,7 @@ Each region is drawn as a rounded coloured rectangle. Audio regions show a wavef
 
 ### Splitting
 
-Position the playhead and press **T** to split the selected region at the playhead. Or right-click and choose **Split**.
+Position the playhead and press **Cmd/Ctrl+E** to split the selected region at the playhead. Or right-click and choose **Split**. (**T** shows / hides the timeline.)
 
 ### Duplicating
 
@@ -1169,7 +1169,7 @@ You **cannot** edit individual samples. There is no pencil tool, no zoom-to-samp
 The top is a row of icon buttons:
 
 - **Undo / Redo** (also **Cmd+Z** and **Cmd+Shift+Z**).
-- **Split** at the edit cursor (also **S**).
+- **Split** at the edit cursor (also **Cmd/Ctrl+E**).
 - **Normalize** (peak-aligns the region to 0 dB by adjusting its gain).
 - **Properties** (file path, sample rate, channel count, length).
 - **Zoom out / Zoom in / Zoom fit** (also **−**, **+**, **0**).
@@ -1742,7 +1742,7 @@ Shortcuts use **Cmd** on macOS and **Ctrl** on Linux and Windows unless noted.
 | **Cmd+V**                   | Paste at playhead                      |
 | **Cmd+D**                   | Duplicate selected region              |
 | **Delete** / **Backspace**  | Delete selected region                 |
-| **T**                       | Split selected region at playhead      |
+| **Cmd+E**                   | Split selected region at playhead      |
 | **Cmd+←**                   | Nudge selected region one beat earlier |
 | **Cmd+→**                   | Nudge selected region one beat later   |
 | **Cmd+Shift+←**             | Nudge by one bar (earlier)             |
@@ -1785,11 +1785,12 @@ Shortcuts use **Cmd** on macOS and **Ctrl** on Linux and Windows unless noted.
 
 ## Timeline
 
-| Shortcut              | Action             |
-| --------------------- | ------------------ |
-| **=** / **+**         | Zoom in            |
-| **−**                 | Zoom out           |
-| **0**                 | Zoom fit           |
+| Shortcut              | Action                            |
+| --------------------- | --------------------------------- |
+| **T**                 | Show / hide timeline (tape strip) |
+| **=** / **+**         | Zoom in                           |
+| **−**                 | Zoom out                          |
+| **0**                 | Zoom fit                          |
 | **Cmd+wheel**         | Zoom around cursor |
 | **Shift+wheel**       | Horizontal scroll  |
 | **Middle-mouse drag** | Pan                |
@@ -1798,7 +1799,7 @@ Shortcuts use **Cmd** on macOS and **Ctrl** on Linux and Windows unless noted.
 
 | Shortcut              | Action                                             |
 | --------------------- | -------------------------------------------------- |
-| **S** / **Cmd+E**     | Split at edit cursor                               |
+| **Cmd+E**             | Split at edit cursor                               |
 | **G**                 | Grab (move / select) edit mode (used inside the region / piano-roll editors) |
 | **Cmd+]** / **Cmd+[** | Next / previous region                             |
 | **Esc**               | Close modal                                        |
@@ -1885,7 +1886,7 @@ Each aux return lane can be sent to its own physical output pair (see the aux la
 
 1. Record three or four passes into the same region, each fully containing the last. Each pass pushes the previous one into the take history.
 2. In the audio region editor, cycle through takes (**Alt+T** / **Alt+Shift+T**) and listen to each.
-3. Pick the best phrases by splitting (**S** or **T**) at the breaths, choosing the best take per phrase, and using fades to mask the joins.
+3. Pick the best phrases by splitting (**Cmd/Ctrl+E**) at the breaths, choosing the best take per phrase, and using fades to mask the joins.
 
 \newpage
 

--- a/packaging/audio.dusk.studio.desktop
+++ b/packaging/audio.dusk.studio.desktop
@@ -7,6 +7,6 @@ Exec=DuskStudio %f
 Icon=DuskStudio
 Terminal=false
 Categories=AudioVideo;Audio;Recorder;Music;
-StartupWMClass=DuskStudio
+StartupWMClass=Dusk Studio
 Keywords=DAW;recording;mixer;multitrack;portastudio;
 MimeType=application/x-dusk-studio-session;

--- a/src/ui/AudioRegionEditor.cpp
+++ b/src/ui/AudioRegionEditor.cpp
@@ -2625,12 +2625,12 @@ bool AudioRegionEditor::keyPressed (const juce::KeyPress& k)
         }
     }
 
-    // Split: 'S' or Cmd+E. With a range active, splits at BOTH
-    // boundaries (3 regions). Without a range, splits at the edit
-    // cursor (existing single-cut behaviour from splitAtCursor()).
     const auto ch = k.getTextCharacter();
-    const bool isSplit = (ch == 's' || ch == 'S')
-                          || (cmdOrCtrl && (k.getKeyCode() == 'E' || k.getKeyCode() == 'e'));
+
+    // Split: Cmd/Ctrl+E (uniform with the tape strip + MIDI editor). With a
+    // range active, splits at BOTH boundaries (3 regions). Without a range,
+    // splits at the edit cursor (existing single-cut from splitAtCursor()).
+    const bool isSplit = cmdOrCtrl && (k.getKeyCode() == 'E' || k.getKeyCode() == 'e');
     if (isSplit)
     {
         auto* r = region();

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -1481,13 +1481,16 @@ void MainComponent::resized()
                 tapeStrip->setConsoleVisibleRange (first1 - 1, last1 - first1 + 1);
             }
             // Dedicated timeline-toolbar row directly above the tape strip.
-            // Left-aligned [Snap | res | - | + | Fit | Chase]. Its own row, so
-            // no overlapping sibling and no toFront needed.
+            // Right-aligned [Snap | res | - | + | Fit | Chase] - view controls
+            // sit over the timeline they act on (and clear of the left-edge
+            // track-label column). Its own row, so no toFront needed.
             if (hdrClusterVisible)
             {
                 constexpr int kTimelineToolbarH = 28;
                 const auto bar = area.removeFromTop (kTimelineToolbarH);
-                int x = bar.getX();
+                const int clusterW = kHdrSnapW + kHdrSnapResW + kHdrZoomBtnW * 2
+                                   + kHdrFitW + kHdrChaseW + kHdrBtnGap * 5;
+                int x = bar.getRight() - clusterW - 8;
                 const int cy = bar.getY() + (bar.getHeight() - kHdrBtnH) / 2;
                 hdrSnapBtn   .setBounds (x, cy, kHdrSnapW,    kHdrBtnH); x += kHdrSnapW    + kHdrBtnGap;
                 hdrSnapResBtn.setBounds (x, cy, kHdrSnapResW, kHdrBtnH); x += kHdrSnapResW + kHdrBtnGap;

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -844,11 +844,12 @@ bool MainComponent::keyPressed (const juce::KeyPress& key)
         return true;
     }
 
-    // ── TIMELINE toggle: Cmd/Ctrl + \ shows / hides the tape strip.
-    // Mirrors the TransportBar's TIMELINE button so the user can flip
-    // the arrangement view without mousing. Backslash is otherwise
-    // unbound; \\ is what Reaper / Pro Tools use for similar toggles.
-    if (cmd && ! shift && key.getTextCharacter() == '\\')
+    // ── TIMELINE toggle: T (or Cmd/Ctrl + \) shows / hides the tape strip.
+    // Mirrors the TransportBar's TIMELINE button so the user can flip the
+    // arrangement view without mousing. Plain T is the mnemonic ("Timeline");
+    // \\ is the Reaper / Pro Tools-style alias. (Alt+T is take cycling below.)
+    if ((code == 'T' && noMods)
+        || (cmd && ! shift && key.getTextCharacter() == '\\'))
     {
         setTimelineVisible (! tapeStripExpanded);
         return true;
@@ -923,13 +924,11 @@ bool MainComponent::keyPressed (const juce::KeyPress& key)
         {
             if (tapeStrip->deleteSelectedRegion()) return true;
         }
-        // 'T' (no modifiers) splits the selected region at the
-        // playhead - razor-tool equivalent without needing a tool
-        // mode. No-op when no region is selected or the playhead is
-        // outside it. Mnemonic: "Trim / spliT". 'B' (Reaper-style
-        // razor) is taken by Bounce; Cmd+T (Logic-style) was rejected
-        // for consistency with Dusk Studio's other no-mod transport hotkeys.
-        if (code == 'T' && noMods)
+        // Cmd/Ctrl+E splits the selected region at the playhead - razor
+        // without a tool mode. Pro Tools / Ableton convention, uniform with
+        // the audio + MIDI editors. No-op when nothing is selected or the
+        // playhead is outside the region. (Plain T is the timeline toggle.)
+        if (code == 'E' && cmd && ! shift)
         {
             if (tapeStrip->splitSelectedAtPlayhead()) return true;
         }

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -1376,7 +1376,12 @@ void MainComponent::resized()
     // (now centered) transport cluster at the OS minimum window width.
     const int stageW = transportCompact ? 92 : 110;
     const int stageBlockW = stageW * 4;
-    const int  kBankBtnW   = transportCompact ? 70 : 100;
+    // Compact the banks to the short "1-6" pills (not "BANK 1 (1-6)") when the
+    // window is narrow OR the tape strip is open - the latter frees room for
+    // the timeline toolbar that sits to the banks' right.
+    const bool banksCompact = transportCompact
+                            || (tapeStripExpanded && ! inFullscreenView);
+    const int  kBankBtnW   = banksCompact ? 70 : 100;
     constexpr int kBankBtnGap = 6;
     constexpr int kBankBtnH  = 26;
 
@@ -1410,9 +1415,23 @@ void MainComponent::resized()
             juce::Rectangle<int> (stageX, menuRow.getY(), stageBlockW, menuRow.getHeight()));
     }
 
-    // Bank buttons centered in the TRANSPORT row (the stage selector vacated it),
-    // clamped past the clock so they never overlap it.
+    // Transport-row overlays: bank buttons (centered, clamped past the clock)
+    // and, when the tape strip is open, the timeline toolbar immediately to
+    // their right. The stage selector vacated this row (now in the menu row).
+    constexpr int kHdrZoomBtnW = 30;
+    constexpr int kHdrFitW     = 36;
+    constexpr int kHdrSnapW    = 48;
+    constexpr int kHdrSnapResW = 78;
+    constexpr int kHdrChaseW   = 56;
+    constexpr int kHdrBtnGap   = 4;
+    constexpr int kHdrBtnH     = 24;
+
     syncBankButtons (needsBanking ? numBanks : 0);
+    const int bankY = rowBounds.getY() + (rowBounds.getHeight() - kBankBtnH) / 2;
+    // Where the timeline toolbar starts: just past the banks, or past the clock
+    // when no banks are shown.
+    int banksRightX = rowBounds.getX()
+                    + (transportBar != nullptr ? transportBar->getClockRightX() : 0) + 12;
     if (needsBanking && consoleView != nullptr)
     {
         const int bankClusterW = numBanks * kBankBtnW + (numBanks - 1) * kBankBtnGap;
@@ -1422,13 +1441,12 @@ void MainComponent::resized()
             const int clockRight = rowBounds.getX() + transportBar->getClockRightX();
             bankX = juce::jmax (bankX, clockRight + 12);
         }
-        const int bankY = rowBounds.getY() + (rowBounds.getHeight() - kBankBtnH) / 2;
         const int activeBank = consoleView->getBank();
         for (int i = 0; i < (int) bankButtons.size(); ++i)
         {
             auto* btn = bankButtons[(size_t) i].get();
             const auto range = ConsoleView::rangeForBankAtWidth (i, consoleTargetWidth);
-            btn->setButtonText (transportCompact
+            btn->setButtonText (banksCompact
                                   ? (juce::String (range.first) + "-" + juce::String (range.second))
                                   : (juce::String ("BANK ") + juce::String (i + 1) + "  ("
                                        + juce::String (range.first) + "-"
@@ -1437,29 +1455,40 @@ void MainComponent::resized()
             btn->setToggleState (i == activeBank, juce::dontSendNotification);
             bankX += kBankBtnW + kBankBtnGap;
         }
+        banksRightX = bankX;
     }
 
-    // SNAP + zoom (- / + / Fit) + Chase cluster. These only act on the
-    // timeline, so they live in a dedicated thin toolbar row directly above
-    // the tape strip (carved in the tapeStrip block below), NOT the transport
-    // row. Shown only with the timeline open and not in a fullscreen stage
-    // (AUX/Mastering), where they have no subject.
-    constexpr int kHdrZoomBtnW = 30;
-    constexpr int kHdrFitW     = 36;
-    constexpr int kHdrSnapW    = 48;
-    constexpr int kHdrSnapResW = 78;
-    constexpr int kHdrChaseW   = 56;
-    constexpr int kHdrBtnGap   = 4;
-    constexpr int kHdrBtnH     = 24;
-    const bool hdrClusterVisible = ! inFullscreenView
-                                  && tapeStrip != nullptr
-                                  && tapeStripExpanded;
-    hdrZoomOutBtn.setVisible (hdrClusterVisible);
-    hdrZoomInBtn .setVisible (hdrClusterVisible);
-    hdrZoomFitBtn.setVisible (hdrClusterVisible);
-    hdrSnapBtn   .setVisible (hdrClusterVisible);
-    hdrSnapResBtn.setVisible (hdrClusterVisible);
-    hdrChaseBtn  .setVisible (hdrClusterVisible);
+    // Timeline toolbar (Snap / res / - / + / Fit / Chase) only acts on the
+    // timeline, so it appears only when the tape strip is open - inline to the
+    // right of the banks, clamped left of the transport bar's BPM / tuner
+    // cluster. Hidden when there isn't room (no fallback row).
+    const int kHdrClusterW = kHdrSnapW + kHdrSnapResW + kHdrZoomBtnW * 2
+                           + kHdrFitW + kHdrChaseW + kHdrBtnGap * 5;
+    const int toolbarX = banksRightX + 8;
+    const int toolbarMaxRight = rowBounds.getX()
+                              + (transportBar != nullptr ? transportBar->getTunerLeftX()
+                                                          : rowBounds.getWidth()) - 12;
+    const bool toolbarVisible = ! inFullscreenView
+                              && tapeStrip != nullptr
+                              && tapeStripExpanded
+                              && (toolbarX + kHdrClusterW <= toolbarMaxRight);
+    hdrZoomOutBtn.setVisible (toolbarVisible);
+    hdrZoomInBtn .setVisible (toolbarVisible);
+    hdrZoomFitBtn.setVisible (toolbarVisible);
+    hdrSnapBtn   .setVisible (toolbarVisible);
+    hdrSnapResBtn.setVisible (toolbarVisible);
+    hdrChaseBtn  .setVisible (toolbarVisible);
+    if (toolbarVisible)
+    {
+        int x = toolbarX;
+        const int cy = rowBounds.getY() + (rowBounds.getHeight() - kHdrBtnH) / 2;
+        hdrSnapBtn   .setBounds (x, cy, kHdrSnapW,    kHdrBtnH); x += kHdrSnapW    + kHdrBtnGap;
+        hdrSnapResBtn.setBounds (x, cy, kHdrSnapResW, kHdrBtnH); x += kHdrSnapResW + kHdrBtnGap;
+        hdrZoomOutBtn.setBounds (x, cy, kHdrZoomBtnW, kHdrBtnH); x += kHdrZoomBtnW + kHdrBtnGap;
+        hdrZoomInBtn .setBounds (x, cy, kHdrZoomBtnW, kHdrBtnH); x += kHdrZoomBtnW + kHdrBtnGap;
+        hdrZoomFitBtn.setBounds (x, cy, kHdrFitW,     kHdrBtnH); x += kHdrFitW     + kHdrBtnGap;
+        hdrChaseBtn  .setBounds (x, cy, kHdrChaseW,   kHdrBtnH);
+    }
 
     area.removeFromTop (4);
 
@@ -1480,26 +1509,6 @@ void MainComponent::resized()
                     ConsoleView::rangeForBankAtWidth (bank, area.getWidth());
                 tapeStrip->setConsoleVisibleRange (first1 - 1, last1 - first1 + 1);
             }
-            // Dedicated timeline-toolbar row directly above the tape strip.
-            // Right-aligned [Snap | res | - | + | Fit | Chase] - view controls
-            // sit over the timeline they act on (and clear of the left-edge
-            // track-label column). Its own row, so no toFront needed.
-            if (hdrClusterVisible)
-            {
-                constexpr int kTimelineToolbarH = 28;
-                const auto bar = area.removeFromTop (kTimelineToolbarH);
-                const int clusterW = kHdrSnapW + kHdrSnapResW + kHdrZoomBtnW * 2
-                                   + kHdrFitW + kHdrChaseW + kHdrBtnGap * 5;
-                int x = bar.getRight() - clusterW - 8;
-                const int cy = bar.getY() + (bar.getHeight() - kHdrBtnH) / 2;
-                hdrSnapBtn   .setBounds (x, cy, kHdrSnapW,    kHdrBtnH); x += kHdrSnapW    + kHdrBtnGap;
-                hdrSnapResBtn.setBounds (x, cy, kHdrSnapResW, kHdrBtnH); x += kHdrSnapResW + kHdrBtnGap;
-                hdrZoomOutBtn.setBounds (x, cy, kHdrZoomBtnW, kHdrBtnH); x += kHdrZoomBtnW + kHdrBtnGap;
-                hdrZoomInBtn .setBounds (x, cy, kHdrZoomBtnW, kHdrBtnH); x += kHdrZoomBtnW + kHdrBtnGap;
-                hdrZoomFitBtn.setBounds (x, cy, kHdrFitW,     kHdrBtnH); x += kHdrFitW     + kHdrBtnGap;
-                hdrChaseBtn  .setBounds (x, cy, kHdrChaseW,   kHdrBtnH);
-            }
-
             // Cap the strip at ~half the available height so vertical
             // zoom (taller rows) can't swallow the console - past the cap
             // the rows scroll inside the strip. Console keeps a usable

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -1376,12 +1376,7 @@ void MainComponent::resized()
     // (now centered) transport cluster at the OS minimum window width.
     const int stageW = transportCompact ? 92 : 110;
     const int stageBlockW = stageW * 4;
-    // Compact the banks to the short "1-6" pills (not "BANK 1 (1-6)") when the
-    // window is narrow OR the tape strip is open - the latter frees room for
-    // the timeline toolbar that sits to the banks' right.
-    const bool banksCompact = transportCompact
-                            || (tapeStripExpanded && ! inFullscreenView);
-    const int  kBankBtnW   = banksCompact ? 70 : 100;
+    const int  kBankBtnW   = transportCompact ? 70 : 100;
     constexpr int kBankBtnGap = 6;
     constexpr int kBankBtnH  = 26;
 
@@ -1389,6 +1384,9 @@ void MainComponent::resized()
     // Settings menu and the system meters. The session status text fills the
     // gap to its left. (stageW / stageBlockW were computed above with the
     // transport metrics so the tabs follow the same compact breakpoint.)
+    // stageCentreX is reused below to centre the bank / toolbar group directly
+    // under the stage selector.
+    int stageCentreX = rowBounds.getCentreX();
     {
         const int menuStageY   = menuRow.getY() + (menuRow.getHeight() - kStageBtnH) / 2;
         const int menuLeftPad  = menuRow.getX() + 200 + 12;            // past File / Settings
@@ -1398,6 +1396,7 @@ void MainComponent::resized()
         stageX = juce::jlimit (menuLeftPad,
                                  juce::jmax (menuLeftPad, menuRightPad - stageBlockW),
                                  stageX);
+        stageCentreX = stageX + stageBlockW / 2;
         recordingStageBtn.setBounds (stageX,              menuStageY, stageW, kStageBtnH);
         mixingStageBtn   .setBounds (stageX + stageW,     menuStageY, stageW, kStageBtnH);
         masteringStageBtn.setBounds (stageX + 2 * stageW, menuStageY, stageW, kStageBtnH);
@@ -1415,9 +1414,10 @@ void MainComponent::resized()
             juce::Rectangle<int> (stageX, menuRow.getY(), stageBlockW, menuRow.getHeight()));
     }
 
-    // Transport-row overlays: bank buttons (centered, clamped past the clock)
-    // and, when the tape strip is open, the timeline toolbar immediately to
-    // their right. The stage selector vacated this row (now in the menu row).
+    // Transport-row overlays: the bank buttons and, when the tape strip is
+    // open, the timeline toolbar to their right - centred together as one group
+    // directly under the stage selector above. The stage selector vacated this
+    // row (it lives in the menu row now).
     constexpr int kHdrZoomBtnW = 30;
     constexpr int kHdrFitW     = 36;
     constexpr int kHdrSnapW    = 48;
@@ -1425,28 +1425,49 @@ void MainComponent::resized()
     constexpr int kHdrChaseW   = 56;
     constexpr int kHdrBtnGap   = 4;
     constexpr int kHdrBtnH     = 24;
+    const int kHdrClusterW = kHdrSnapW + kHdrSnapResW + kHdrZoomBtnW * 2
+                           + kHdrFitW + kHdrChaseW + kHdrBtnGap * 5;
+    constexpr int kBankToolbarGap = 16;
 
     syncBankButtons (needsBanking ? numBanks : 0);
     const int bankY = rowBounds.getY() + (rowBounds.getHeight() - kBankBtnH) / 2;
-    // Where the timeline toolbar starts: just past the banks, or past the clock
-    // when no banks are shown.
-    int banksRightX = rowBounds.getX()
-                    + (transportBar != nullptr ? transportBar->getClockRightX() : 0) + 12;
+    const int bankClusterW = needsBanking
+                           ? (numBanks * kBankBtnW + (numBanks - 1) * kBankBtnGap) : 0;
+
+    const int clockRight = rowBounds.getX()
+                         + (transportBar != nullptr ? transportBar->getClockRightX() : 0);
+    const int tunerLeft  = rowBounds.getX()
+                         + (transportBar != nullptr ? transportBar->getTunerLeftX()
+                                                      : rowBounds.getWidth());
+
+    // The toolbar joins the group only with the tape strip open AND when the
+    // combined group still fits between the clock and the BPM / tuner cluster.
+    const bool wantToolbar = ! inFullscreenView && tapeStrip != nullptr && tapeStripExpanded;
+    int  groupW = bankClusterW;
+    bool toolbarVisible = false;
+    if (wantToolbar)
+    {
+        const int combinedW = bankClusterW + (needsBanking ? kBankToolbarGap : 0) + kHdrClusterW;
+        const int gX = juce::jmax (clockRight + 12, stageCentreX - combinedW / 2);
+        if (gX + combinedW <= tunerLeft - 12)
+        {
+            toolbarVisible = true;
+            groupW = combinedW;
+        }
+    }
+
+    // Centre the group under the stage selector, clamped past the clock.
+    const int groupX = juce::jmax (clockRight + 12, stageCentreX - groupW / 2);
+
     if (needsBanking && consoleView != nullptr)
     {
-        const int bankClusterW = numBanks * kBankBtnW + (numBanks - 1) * kBankBtnGap;
-        int bankX = rowBounds.getX() + (rowBounds.getWidth() - bankClusterW) / 2;
-        if (transportBar != nullptr)
-        {
-            const int clockRight = rowBounds.getX() + transportBar->getClockRightX();
-            bankX = juce::jmax (bankX, clockRight + 12);
-        }
+        int bankX = groupX;
         const int activeBank = consoleView->getBank();
         for (int i = 0; i < (int) bankButtons.size(); ++i)
         {
             auto* btn = bankButtons[(size_t) i].get();
             const auto range = ConsoleView::rangeForBankAtWidth (i, consoleTargetWidth);
-            btn->setButtonText (banksCompact
+            btn->setButtonText (transportCompact
                                   ? (juce::String (range.first) + "-" + juce::String (range.second))
                                   : (juce::String ("BANK ") + juce::String (i + 1) + "  ("
                                        + juce::String (range.first) + "-"
@@ -1455,23 +1476,8 @@ void MainComponent::resized()
             btn->setToggleState (i == activeBank, juce::dontSendNotification);
             bankX += kBankBtnW + kBankBtnGap;
         }
-        banksRightX = bankX;
     }
 
-    // Timeline toolbar (Snap / res / - / + / Fit / Chase) only acts on the
-    // timeline, so it appears only when the tape strip is open - inline to the
-    // right of the banks, clamped left of the transport bar's BPM / tuner
-    // cluster. Hidden when there isn't room (no fallback row).
-    const int kHdrClusterW = kHdrSnapW + kHdrSnapResW + kHdrZoomBtnW * 2
-                           + kHdrFitW + kHdrChaseW + kHdrBtnGap * 5;
-    const int toolbarX = banksRightX + 8;
-    const int toolbarMaxRight = rowBounds.getX()
-                              + (transportBar != nullptr ? transportBar->getTunerLeftX()
-                                                          : rowBounds.getWidth()) - 12;
-    const bool toolbarVisible = ! inFullscreenView
-                              && tapeStrip != nullptr
-                              && tapeStripExpanded
-                              && (toolbarX + kHdrClusterW <= toolbarMaxRight);
     hdrZoomOutBtn.setVisible (toolbarVisible);
     hdrZoomInBtn .setVisible (toolbarVisible);
     hdrZoomFitBtn.setVisible (toolbarVisible);
@@ -1480,7 +1486,7 @@ void MainComponent::resized()
     hdrChaseBtn  .setVisible (toolbarVisible);
     if (toolbarVisible)
     {
-        int x = toolbarX;
+        int x = groupX + bankClusterW + (needsBanking ? kBankToolbarGap : 0);
         const int cy = rowBounds.getY() + (rowBounds.getHeight() - kHdrBtnH) / 2;
         hdrSnapBtn   .setBounds (x, cy, kHdrSnapW,    kHdrBtnH); x += kHdrSnapW    + kHdrBtnGap;
         hdrSnapResBtn.setBounds (x, cy, kHdrSnapResW, kHdrBtnH); x += kHdrSnapResW + kHdrBtnGap;

--- a/src/ui/PianoRollComponent.cpp
+++ b/src/ui/PianoRollComponent.cpp
@@ -3114,6 +3114,13 @@ bool PianoRollComponent::keyPressed (const juce::KeyPress& k)
             repaint();
             return true;
         }
+        // Split at the edit cursor: Cmd/Ctrl+E, uniform with the tape strip +
+        // audio editor.
+        if (cmdOrCtrl && (k.getKeyCode() == 'E' || k.getKeyCode() == 'e'))
+        {
+            splitSelectedAtCursor();
+            return true;
+        }
         // Loop / punch points against the edit cursor. Bare [ / ] set the loop
         // in/out; Shift+[ / Shift+] set the punch in/out; bare P toggles punch.
         // Mirrors the audio region editor, but the roll works in ticks so the

--- a/src/ui/ShortcutsPanel.h
+++ b/src/ui/ShortcutsPanel.h
@@ -45,7 +45,8 @@ public:
                 { "A", "Arm" }, { "S", "Solo" }, { "X", "Mute" } } },
             { "Tools & view", {
                 { "G", "Grab / move edit mode" }, { "C", "Metronome on / off" },
-                { "K", "Virtual MIDI keyboard" }, { mod ('\\'), "Show / hide timeline" },
+                { "K", "Virtual MIDI keyboard" }, { "T", "Show / hide timeline" },
+                { mod ('E'), "Split region at playhead / cursor" },
                 { "F11", "Fullscreen" }, { alt + "T", "Cycle take (Shift = back)" },
                 { "?", "This shortcut list" } } },
             { "Zoom", {

--- a/src/ui/TapeStrip.cpp
+++ b/src/ui/TapeStrip.cpp
@@ -768,13 +768,14 @@ void TapeStrip::resized()
     // SHOW ALL toggle (which is pinned to that column's width).
     refreshLabelColumnWidth();
 
-    // SHOW ALL toggle pinned to the right edge of the label column at
-    // the top — lives in unused real estate above the row labels, fits
-    // in the kRulerH band so it doesn't compete with the time ruler.
+    // SHOW ALL toggle over the label column - centred in the kRulerH band
+    // (horizontally in the column, vertically in the band), in unused real
+    // estate above the row labels where it doesn't compete with the ruler.
     constexpr int kShowAllH = 14;
     constexpr int kShowAllInset = 8;   // a touch narrower than the full column
     const int allW = juce::jmax (24, labelColW - 2 * kShowAllInset);
-    showAllToggle.setBounds ((labelColW - allW) / 2, 2, allW, kShowAllH);
+    const int allY = (kRulerH - kShowAllH) / 2;
+    showAllToggle.setBounds ((labelColW - allW) / 2, allY, allW, kShowAllH);
     inheritCursorOnDescendants (*this);
 }
 

--- a/src/ui/TapeStrip.cpp
+++ b/src/ui/TapeStrip.cpp
@@ -3764,6 +3764,11 @@ void TapeStrip::paint (juce::Graphics& g)
     // boundary is still readable on top.
     {
         g.setFont (juce::Font (juce::FontOptions (10.5f, juce::Font::bold)));
+        // Clip to the timeline so a marker scrolled just off the left edge
+        // (flag is left-anchored at its position) can't paint its pill or
+        // guideline over the track-name column.
+        juce::Graphics::ScopedSaveState markerClip (g);
+        g.reduceClipRegion (col.getX(), 0, getWidth() - col.getX(), getHeight());
         for (const auto& marker : session.getMarkers())
         {
             const int x = xForSample (marker.timelineSamples);


### PR DESCRIPTION
Post-0.11.0 UI polish + two fixes, batched.

## Tape strip / transport row
- Markers are clipped to the timeline so one scrolled just off the left edge no longer paints its pill / guideline over the track-name column.
- The timeline toolbar (Snap / res / − / + / Fit / Chase) moved out of a dedicated row into the transport row, centered together with the banks as one group directly under the stage selector. Verbose `BANK 1 (1-6)` labels are kept; the toolbar shows only when the tape strip is open and there's room before the BPM / tuner cluster.
- SHOW ALL pill centered in the ruler band.

## Shortcuts
- `T` now shows / hides the timeline (tape strip); `Cmd/Ctrl+\` kept as an alias.
- `Cmd/Ctrl+E` is the universal split (tape strip, audio editor, piano roll) — the Pro Tools / Ableton convention. Drops plain-`T` split and the audio editor's `S` split (which clashed with solo / scale elsewhere).
- Untouched: `Alt+T` take cycling, `S` solo, `X` mute, `A` arm.
- In-app Shortcuts panel + MANUAL updated.

## Packaging
- `StartupWMClass` corrected to `Dusk Studio` (the real WM_CLASS JUCE emits) so GNOME / other compositors link the window to the desktop entry and show the app icon instead of a generic one.

Build clean (zero new warnings); headless launch + screenshots verified the layout. Keyboard bindings couldn't be confirmed headlessly (Xvfb has no WM) — verified by inspection against the existing handlers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clear shortcut for splitting regions/edits with **Cmd/Ctrl+E** across the app.
  * **T** now toggles the timeline visibility.

* **Bug Fixes**
  * Improved marker rendering so it no longer overlaps the track-name area when scrolled.
  * Refined layout spacing for toolbar and transport controls in the timeline area.

* **Documentation**
  * Updated the user manual and shortcut reference to match the latest keyboard shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->