### PR TITLE
Feature/0.12.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ project(DuskStudio VERSION ${DUSKSTUDIO_VERSION} LANGUAGES C CXX)
 # Native CLAP host (src/engine/clap/ + the X11 editor) is POSIX + X11 — Linux only.
 # Default ON for Linux, OFF elsewhere; can be forced off on Linux for testing the
 # gated (DUSKSTUDIO_HAS_NATIVE_CLAP) build path with -DDUSKSTUDIO_NATIVE_CLAP=OFF.
-if(UNIX AND NOT APPLE)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     option(DUSKSTUDIO_NATIVE_CLAP "Build the native CLAP plugin host (Linux/X11 only)" ON)
 else()
     set(DUSKSTUDIO_NATIVE_CLAP OFF)

--- a/docs/native-vst3-lv2-host-plan.md
+++ b/docs/native-vst3-lv2-host-plan.md
@@ -1,0 +1,188 @@
+# Native VST3 + LV2 plugin host — implementation plan
+
+Status: **planning / awaiting approval to start Phase F1.** Authored 2026-07-01.
+
+## Why
+
+JUCE's VST3/LV2 hosting on Linux relies on `juce::XEmbedComponent` + an
+out-of-process child whose X11 editor window is reparented under Wayland via
+XEmbed. That path is the last major JUCE/Wayland liability after the CallOutBox,
+menu, cursor, keystate, and file-dialog work already landed. The native CLAP
+host (`src/engine/clap/`) proved the pattern — a native C/C++-SDK host with a
+directly-embedded X11 editor is far more stable on Mutter/XWayland than JUCE's
+XEmbed. This plan extends that to VST3 and LV2.
+
+## Decisions (locked 2026-07-01)
+
+1. **Both formats, in parallel**, shared foundation first.
+2. **Accept GPLv3 for the whole binary.** See "License" — DuskStudio is *already*
+   GPL-3.0-or-later, so this is a docs/metadata bump + a no-bundling rule, not a
+   relicense.
+3. **Native-hosted plugin params are automatable** (VST3 + LV2 + retrofit CLAP) —
+   captured into Session automation lanes and played back.
+4. **Generalize ports now** — mono / stereo / multi-out / sidechain /
+   instrument+MIDI, not stereo-only like the CLAP host.
+
+## License (verified clean)
+
+`LICENSE` is GPL-3.0-or-later; JUCE is already consumed under its GPL arm (no
+`JUCE_DISPLAY_SPLASH_SCREEN` / commercial define set); `LICENSES.txt:20` already
+declares JUCE GPL-used-here; `CMakeLists.txt` sets
+`CPACK_RPM_PACKAGE_LICENSE=GPL-3.0-or-later`. Vendoring the Steinberg VST3 SDK
+under its GPLv3 arm and adding lilv/suil/lv2 (ISC) is therefore clean. Action
+items are documentation + one invariant:
+
+- Add VST3 SDK (GPL-3.0 arm) + lilv/suil/lv2 (ISC) to `LICENSES.txt`.
+- **Hard invariant: ship ZERO third-party plugins in any distribution.** Bundling
+  even a demo proprietary plugin voids GPL compliance for the whole binary.
+- Dusk-owned VST3 SDK mirror + immutable tag (analog to
+  `dusk-audio/JUCE-wayland` `dusk-wayland-v1`) — the plugdata-JUCE GC precedent
+  makes a mirror mandatory for reproducible release CI, not optional.
+
+## Architecture
+
+A shared, host-agnostic layer under `src/engine/hosting/` that all three native
+formats implement, so the audio-thread call sites and the automation/session code
+never branch per format:
+
+- **`PortLayout.h`** — negotiated shape produced once at load (message thread):
+  audio/event buses tagged Main/Aux/Sidechain, channel counts, `isInstrument`,
+  main/sidechain/event bus indices. Single source of truth; replaces
+  `ClapInstance`'s two `inCh/outCh` ints.
+- **`PortBuffers.h`** — the one audio-thread process argument replacing
+  `(inL,inR,outL,outR,n)`: main/sidechain/multi-out audio pointers (into
+  pre-sized scratch), a host-neutral MIDI event view/sink
+  (`{sampleOffset,status,d1,d2}`), transport view. Nothing allocated on the RT
+  thread.
+- **`INativeInstance.h`** — abstract base every instance implements. Message
+  thread: `create` / `negotiateLayout` / `activate` / `deactivate` /
+  `saveState`/`loadState` / param enumeration / `getLatencySamples`. Audio
+  thread: `void processBlock(const PortBuffers&) noexcept`.
+- **`InsertAdapter.h/.cpp`** — reconciles an arbitrary `PortLayout` to the
+  mixer's **fixed stereo-in/stereo-out insert contract**. Owns pre-sized scratch;
+  the ONE place the "an insert is stereo" invariant lives. Fold rules: 1-in →
+  average L,R to mono feed; mono-out → broadcast to L,R (generalizes the current
+  `ChannelStrip.cpp:~719` averaging); multi-out insert → take main-out ch 0/1,
+  drop aux buses; sidechain fed from the tap or pre-sized silence (never null).
+- **`NativeInsertSlot`** (generalized from `NativeClapSlot`) — format-agnostic
+  slot holding `unique_ptr<INativeInstance>` behind the lock-free `ready` flag;
+  `leakForShutdown`; "at most one host per slot" enforced here.
+- Automation: **`NativePluginParams.h`** (format-neutral `NativeParamInfo`
+  {stableId,name,min/max/default,isStepped,...}) + **`PluginAutomationBridge`**
+  (id-keyed lane container parallel to the fixed `AutomationParam` enum array).
+
+Then per-format instances plug in: `Vst3Instance` (IComponent/IAudioProcessor/
+IEditController, `setBusArrangements`/`activateBus`/`getBusInfo`, event input bus
+for MIDI, `IParameterChanges` for automation) and `Lv2Instance` (lilv port
+classification: audio/CV/control/atom-midi/morph). CLAP is retrofit onto the same
+interfaces so `processStereo` disappears.
+
+## Corrections folded in (from adversarial review)
+
+- **`evaluateLane` is enum-closed** (`Session.cpp:314` → `denormalizeAutomation`
+  switch + `isContinuousParam`). It **cannot** serve plugin params as-is. Split
+  into `evaluateLaneNormalized(pts, t, bool continuous) -> float01` (interpolate/
+  step core, no enum) + keep the enum wrapper for the fixed mixer params. Plugin
+  lanes call the core with `continuous = !NativeParamInfo.isStepped`, then
+  denormalize via the plugin's own range. (Phase F3.)
+- **Single host per slot.** Replace the current parallel `nativeClapPath` field
+  with one `enum {none,juce,clap,vst3,lv2}` + one path per slot (migrate the
+  existing `nativeClapPath`). No four parallel optional path fields. (Phase F4.)
+- **Plugin latency (PDC) is entirely absent today** — CLAP host never queries
+  `clap_plugin_latency`; `ChannelStrip.cpp:610` already excludes insert-plugin
+  tracks from silent-skip for this reason. Query latency at `activate()` via
+  `INativeInstance::getLatencySamples`, feed the PDC aggregator, handle
+  `latencyChanged` (VST3 `restartComponent kLatencyChanged` / CLAP
+  `latency.changed` / LV2 latency port) on the message thread under the process
+  gate. (Phase X1.)
+- **AtomicSnapshot RT hazard**: lazy `push_back` of a new `PluginParamLane` while
+  the audio thread iterates the vector is a data race. Pre-size the lane vector at
+  `prepare()` (mark entries active) or wrap the vector in `AtomicSnapshot`; never
+  raw-append under a concurrent RT reader. (Phase A1.)
+- **Sidechain source index is a prerequisite, not "open"** — the RT sidechain tap
+  needs a per-slot source index in Session; design it in the same increment as the
+  tap. (Phase F7 + a Session field.)
+- **Instrument-source + MIDI-out are first-class branches**, not afterthoughts:
+  an instrument insert makes the plugin output *the strip's source* (bypass the
+  pre/post crossfade blend, `ChannelStrip.cpp:~875`); a `MidiEventSink` with no
+  consumer is a dead field until a MIDI-out destination is designed (deferred,
+  stated).
+- **Editor is a hard dependency for WRITE-capture automation** — gestures are
+  captured from the plugin's own editor (`beginEdit`/`performEdit`/`endEdit`). Until
+  the VST3/LV2 editors land, automation for those formats is READ-only. Stated
+  explicitly, not assumed delivered.
+- Fix stale `ClapInstance.h:62` "out may not alias in" comment — the in-place
+  `processStereo(L,R,L,R)` call at `ChannelStrip.cpp:903` is safe only because of
+  copy-in/copy-out scratch discipline; preserve that discipline in `processBlock`.
+
+## Deferred (explicit non-goals for the first cut)
+
+- Sample-accurate automation + MIDI event timing (all events at sampleOffset 0,
+  matching current CLAP).
+- Preset/program browsing (VST3 `IUnitInfo` program lists, LV2 `pset:Preset`) —
+  session state-blob persistence works; factory-preset UI is a later axis.
+- MIDI-out consumers (arpeggiator/note-FX routing).
+- Multi-out "plugin as a bus/track source" (adapter drop-aux rule assumes insert).
+- Cross-platform: VST3 native host is Linux-gated like CLAP for the first cut
+  (macOS/Windows keep JUCE).
+
+## Phase DAG
+
+Every phase is ≤5 files, independently buildable, with its own verification. `F`
+= shared foundation, `V` = VST3, `L` = LV2, `A` = automation, `X` = cross-cutting,
+`S` = scan, `E` = editor UI, `Z` = cutover. Live-Wayland sign-off = no offline
+test possible (launching on live Wayland crashes; harness can't drive a real
+editor).
+
+| id | phase | files | verification | dependsOn |
+|----|-------|-------|--------------|-----------|
+| F1 | `PortLayout.h` + `PortBuffers.h` + `INativeInstance.h` (interfaces) | 3 | Catch2: construct/read a PortLayout | — |
+| F2 | `InsertAdapter.h/.cpp` fold rules + scratch sizing | 2 | Catch2: mono→stereo broadcast, stereo passthrough, multi-out drop-aux, silence sidechain | F1 |
+| F3 | `evaluateLane` split → normalized core + enum wrapper (`Session.h/.cpp`) | 2 | Catch2: existing automation tests pass + normalized-core test | — |
+| F4 | single-host-per-slot enum+path model + migration (`Session.h`, `SessionSerializer.cpp`) | 2 | Catch2: round-trip + `nativeClapPath` migration | — |
+| F5 | retrofit `ClapInstance` onto `INativeInstance` (drop 2in/2out reject, PortLayout, `processBlock`) | 2 | A/B null-test vs current CLAP + Catch2 | F1,F2 |
+| F6 | generalize `NativeClapSlot` → `NativeInsertSlot` (`unique_ptr<INativeInstance>`, one-host invariant) | 2 | Catch2: ready/bypass/leak + exclusivity | F5 |
+| F7 | wire `ChannelStrip` + `AuxLaneStrip` call sites to `processInsert(PortBuffers)` (+ instrument-source branch, sidechain tap + Session source field) | 3 | A/B null-test CLAP unchanged; crossfade+instrument branch | F6 |
+| X1 | plugin latency query + PDC aggregation + `latencyChanged` handling | 3 | Catch2: reported latency == measured delay | F6 |
+| V1 | GPL/build: VST3 SDK submodule (Dusk mirror) + CMake gate + `LICENSES.txt` + `linux-release.yml` + `CLAUDE.md` | 5 | clean configure+build of host subset under `-Werror` | — |
+| V2 | `Vst3Bundle` (dlopen module, `GetPluginFactory`, enumerate) | 2 | Catch2: load/enumerate a known `.vst3` | V1 |
+| V3 | `Vst3HostContext` (IHostApplication/IComponentHandler/IPlugFrame/IRunLoop + fd/timer registry) | 2 | Catch2: IRunLoop **dispatches** (pipe fd → onFDIsSet; timer cadence) | V1 |
+| V4 | `Vst3Instance` offline audio (bus negotiation → PortLayout, `processBlock`) | 2 | Catch2: silence-in/out, mono/stereo/sidechain layouts | F1,F2,V2,V3 |
+| V5 | `Vst3Instance` dual-stream state (length-prefixed component+controller, restore order, atomic-park) | 1 | Catch2: round-trip incl controller-only change | V4 |
+| V6 | `Vst3Editor` X11 embed + editor-test harness (`setFrame` before `attached`, `resizeView` honored, ContentScale) | 3 | live-Wayland sign-off | V4 |
+| L1 | lilv/suil/lv2 pkg-config + `Lv2World`/`Lv2Bundle` + CMake gate | 3 | Catch2: world-load + resolve plugin URI | — |
+| L2 | `Lv2Instance` offline audio (port classification, connect_port, atom-midi, `processBlock`) | 2 | Catch2: silence + port classification | F1,F2,L1 |
+| L3 | `Lv2Instance` state + rate-change reinstantiate contract | 1 | Catch2: state survives simulated rate change | L2 |
+| L4 | `Lv2Editor` suil X11 embed + harness | 3 | live-Wayland sign-off | L2 |
+| A1 | `NativePluginParams.h` + `NativePluginHost` iface + `PluginAutomationBridge` (pre-sized/AtomicSnapshot lanes, release/acquire id→slot cache) | 3 | Catch2: arm/disarm no-RT-hazard, id stability | F3,F4 |
+| A2 | Session `PluginAutomation` storage + serializer (id hex + normalized points, re-bind by stableId) | 2 | Catch2: round-trip re-bind | A1,F4 |
+| A3 | CLAP `clap_host_params` retrofit (extension, 2nd audio-thread SPSC ring, editor-edit ring drain) | 3 | Catch2: param push/capture | A1,F5 |
+| A4 | AudioEngine READ playback pass (armed plugin lanes → `evaluateLaneNormalized` → denormalize → RT ring) | 1 | Catch2: playback pushes value | A1,A3,F3 |
+| A5 | CLAP WRITE capture wiring (editor gestures → touched/live → `captureWritePoint`, WRITE-only discrete) | 2 | live-Wayland sign-off (CLAP editor exists) | A3,A4 |
+| A6 | VST3 automation (`IComponentHandler` begin/perform/endEdit capture + `IParameterChanges` playback) | 2 | live-Wayland sign-off | A4,V6 |
+| A7 | LV2 automation (control-port capture + playback, endEdit quiesce heuristic) | 2 | live-Wayland sign-off | A4,L4 |
+| S1 | extend `PluginScanProtocol` + scan child for native VST3/LV2 + skip-list cache | 3 | Catch2 protocol + crashy-plugin-doesn't-kill-app | V2,L1 |
+| S2 | picker routing (`scanVst3`/`scanLv2` → PluginDescription `VST3-Native`/`LV2-Native`, `onPickNative` by format) | 3 | descriptor routing test | S1,F6 |
+| E1 | `Vst3PluginEditorComponent` + wire into ChannelStrip modal + aux inline | 3 | live-Wayland sign-off | V6 |
+| E2 | `Lv2PluginEditorComponent` + wire | 3 | live-Wayland sign-off | L4 |
+| Z1 | keep JUCE fallback; route by format-name at load; optionally hide JUCE-format rows when native healthy | 3 | manual: both hosts coexist in picker | S2,F7,E1,E2 |
+
+## Critical path
+
+`F1 → F2 → F5 → F6 → F7` unlocks the DSP spine. VST3 (`V1→V2/V3→V4→V6→E1→A6`) and
+LV2 (`L1→L2→L4→E2→A7`) run in parallel off the foundation. Automation core
+(`F3,F4→A1→A2/A3→A4`) lands against CLAP first (A5), then grafts onto each format
+once its editor exists. `V1` (GPL/build) and `L1` (deps) have no deps and can
+start immediately alongside `F1`.
+
+## Verification discipline
+
+- DSP/session/engine phases: `cmake --build build-tests` + `ctest` must pass, plus
+  an A/B null-test where a CLAP path is being generalized (target ~1e-6, per
+  existing multicore A/B harness).
+- Editor phases: live-Wayland sign-off only — the harness cannot drive a real
+  plugin editor and launching on live Wayland crashes. Use the
+  `DUSKSTUDIO_*_EDITOR_TEST` harness clones under Xvfb for construction/no-crash,
+  Marc for the interactive pass.
+- Each phase is its own reviewed commit; pause for approval between phases per
+  CLAUDE.md.

--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -1004,7 +1004,12 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
         clapEditorTestWindow->setUsingNativeTitleBar (true);
         clapEditorTestWindow->setContentOwned (comp.release(), true);
         clapEditorTestWindow->centreWithSize (w, h);
-        clapEditorTestWindow->setVisible (true);
+        clapEditorTestWindow->setVisible (true);   // creates the peer → consumes the X11 latch
+        // Match MainWindow's native-window setup: release the X11 latch now the peer
+        // exists, and install the non-fatal X error handler so a dying CLAP editor
+        // window can't core-dump this harness.
+        duskstudio::platform::clearPreferX11ForNativeWindow();
+        duskstudio::platform::installNonFatalXErrorHandler();
         return;   // standalone — skip the normal engine + main-window startup
     }
 #endif // DUSKSTUDIO_HAS_NATIVE_CLAP

--- a/src/dsp/AuxLaneStrip.cpp
+++ b/src/dsp/AuxLaneStrip.cpp
@@ -83,8 +83,9 @@ bool AuxLaneStrip::loadNativeClap (int slotIdx, const juce::File& path, std::str
     if (preparedSampleRate <= 0.0 || preparedBlockSize <= 0)
     { errorOut = "aux lane not prepared"; return false; }
     const bool ok = nativeClapSlots[(size_t) slotIdx].load (path, preparedSampleRate, preparedBlockSize, errorOut);
-    if (ok)
-        nativeReloadFailed[(size_t) slotIdx].store (false, std::memory_order_relaxed);   // recovered
+    // User-initiated load always ends any "failed restore" state (see ChannelStrip::
+    // loadNativeClap) — clear regardless of outcome so the flag stays caller-independent.
+    nativeReloadFailed[(size_t) slotIdx].store (false, std::memory_order_relaxed);
     return ok;
 }
 

--- a/src/dsp/ChannelStrip.cpp
+++ b/src/dsp/ChannelStrip.cpp
@@ -93,16 +93,20 @@ void ChannelStrip::prepare (double sampleRate, int blockSize, int oversamplingFa
     {
         // Re-activate in place — a full reload would destroy the instance the editor's
         // GUI is attached to (plugin->destroy with a live GUI aborts u-he plugins) and
-        // reset the plugin's parameters.
+        // reset the plugin's parameters. Track failure so the save path keeps the
+        // persisted path instead of mistaking a failed re-activate for a user removal.
         std::string err;
-        nativeClapSlot.reactivate (preparedSampleRate, preparedBlockSize, err);
+        const bool ok = nativeClapSlot.reactivate (preparedSampleRate, preparedBlockSize, err);
+        nativeReloadFailed.store (! ok, std::memory_order_relaxed);
     }
     else if (pendingClapPath.isNotEmpty())
     {
         const juce::File p (pendingClapPath);
         std::string err;
-        if (nativeClapSlot.load (p, preparedSampleRate, preparedBlockSize, err) && ! pendingClapState.empty())
+        const bool ok = nativeClapSlot.load (p, preparedSampleRate, preparedBlockSize, err);
+        if (ok && ! pendingClapState.empty())
             nativeClapSlot.loadState (pendingClapState);
+        nativeReloadFailed.store (! ok, std::memory_order_relaxed);
         pendingClapPath.clear();
         pendingClapState.clear();
     }
@@ -435,12 +439,18 @@ bool ChannelStrip::loadNativeClap (const juce::File& path, std::string& errorOut
 {
     if (preparedSampleRate <= 0.0 || preparedBlockSize <= 0)
     { errorOut = "channel strip not prepared"; return false; }
-    return nativeClapSlot.load (path, preparedSampleRate, preparedBlockSize, errorOut);
+    const bool ok = nativeClapSlot.load (path, preparedSampleRate, preparedBlockSize, errorOut);
+    // A user-initiated load is not a restore, so it always ends any "failed restore"
+    // state — whether it succeeds (recovered) or fails (caller clears the persisted
+    // refs). Clearing unconditionally keeps the flag's meaning independent of the caller.
+    nativeReloadFailed.store (false, std::memory_order_relaxed);
+    return ok;
 }
 
 void ChannelStrip::unloadNativeClap() noexcept
 {
     nativeClapSlot.unload();
+    nativeReloadFailed.store (false, std::memory_order_relaxed);   // slot reset — clear stale failure
     pendingClapPath.clear();
     pendingClapState.clear();
 }

--- a/src/dsp/ChannelStrip.h
+++ b/src/dsp/ChannelStrip.h
@@ -67,9 +67,13 @@ public:
     const clap::NativeClapSlot& getNativeClapSlot() const noexcept { return nativeClapSlot; }
     // Session restore before the engine is prepared: stash {path,state}; prepare() loads it.
     void setPendingNativeClap (const juce::File& path, std::vector<uint8_t> state) noexcept;
+    // True when the last prepare()-time reactivate / pending-restore load failed. Lets
+    // the save path tell "failed restore" (keep the persisted path) from "user removed".
+    bool nativeClapReloadFailed() const noexcept { return nativeReloadFailed.load (std::memory_order_relaxed); }
 #else
     bool isNativeClapLoaded() const noexcept { return false; }
     void unloadNativeClap() noexcept {}
+    bool nativeClapReloadFailed() const noexcept { return false; }
 #endif
 
     // Hardware vs plugin insert: one runs per block, chosen by
@@ -173,6 +177,7 @@ private:
     PluginSlot pluginSlot;
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
     clap::NativeClapSlot nativeClapSlot;   // native CLAP alternative to pluginSlot
+    std::atomic<bool>    nativeReloadFailed { false };   // prepare()-time reactivate/restore failed
 #endif
     HardwareInsertSlot hardwareSlot;
 

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -481,9 +481,14 @@ bool AudioEngine::freezePrepare (int trackIndex, juce::File& outFile, juce::int6
     lenSamples = contentEnd + (juce::int64) (sr * kFreezeTailSeconds);
 
     auto audioDir = session.getAudioDirectory();
-    if (! audioDir.createDirectory())
+    if (audioDir.createDirectory().failed())
         { lastFreezeError = "Could not create audio directory"; return false; }
-    outFile = audioDir.getChildFile (
+    // Freeze WAVs live in a dedicated subdir so they can never overwrite (and later be
+    // deleted by unfreezeTrack) a user file that happens to share the freeze name.
+    auto freezeDir = audioDir.getChildFile ("freeze");
+    if (freezeDir.createDirectory().failed())
+        { lastFreezeError = "Could not create freeze directory"; return false; }
+    outFile = freezeDir.getChildFile (
         "freeze_track" + juce::String (trackIndex + 1).paddedLeft ('0', 2) + ".wav");
     return true;
 }
@@ -554,7 +559,13 @@ void AudioEngine::unfreezeTrack (int trackIndex)
     // freeze WAV (or any other freeze_track*.wav) by accident.
     const auto expectedName = "freeze_track"
                             + juce::String (trackIndex + 1).paddedLeft ('0', 2) + ".wav";
-    const bool engineOwned = wav.getParentDirectory() == session.getAudioDirectory()
+    const auto audioDir  = session.getAudioDirectory();
+    const auto freezeDir = audioDir.getChildFile ("freeze");
+    const auto parent    = wav.getParentDirectory();
+    // Current freezes live in <audio>/freeze/; older sessions wrote straight into
+    // <audio>/. Accept either parent so both round-trip, but still require the exact
+    // per-track name so a corrupt path can't delete an unrelated file.
+    const bool engineOwned = (parent == freezeDir || parent == audioDir)
                           && wav.getFileName() == expectedName;
     if (engineOwned && wav.existsAsFile())
         wav.deleteFile();
@@ -1285,8 +1296,13 @@ void AudioEngine::publishPluginStateForSave (bool audioCallbackDetached)
             else
                 track.nativeClapStateBase64.clear();
         }
-        else
+        else if (! strip.nativeClapReloadFailed())
         {
+            // Slot genuinely empty (user removed it, or never had one) — drop the
+            // persisted refs. When a restore FAILED (e.g. the .clap was missing this
+            // launch) the slot is also empty, but we keep the path/state so the
+            // reference survives to reconnect on a future launch — mirrors how an
+            // offline JUCE plugin preserves its descXml.
             track.nativeClapPath.clear();
             track.nativeClapStateBase64.clear();
         }
@@ -1314,8 +1330,11 @@ void AudioEngine::publishPluginStateForSave (bool audioCallbackDetached)
                 else
                     lane.nativeClapStateBase64[(size_t) s].clear();
             }
-            else
+            else if (! strip.nativeClapReloadFailed (s))
             {
+                // See the track block above: keep the persisted refs when a restore
+                // failed (path preserved to reconnect later); clear only a genuinely
+                // empty / user-removed slot.
                 lane.nativeClapPath[(size_t) s].clear();
                 lane.nativeClapStateBase64[(size_t) s].clear();
             }
@@ -3309,7 +3328,9 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
         // defaulting to false — the user must explicitly click IN to
         // open the live-input → master path. Disk playback always passes
         // (independent of IN).
-        const bool monitorPasses = willReadFromDisk ? true : monitorEnabled;
+        // A frozen track plays its baked WAV only — never live input. When stopped it
+        // stays silent instead of monitoring the device through a frozen (bypassed) strip.
+        const bool monitorPasses = willReadFromDisk ? true : (monitorEnabled && ! isFrozen);
 
         // SIP-style bus solo (matches Pro Tools / Logic / Cubase): when any
         // bus is soloed, a track is audible ONLY if it feeds a soloed bus.
@@ -3380,7 +3401,7 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
                                           numSamples);
             monoIn = playbackScratch[(size_t) t].data();
         }
-        else if (deviceInput != nullptr && (armed || monitorEnabled))
+        else if (deviceInput != nullptr && (armed || monitorEnabled) && ! isFrozen)
         {
             monoIn = deviceInput;
         }

--- a/src/engine/PluginManager.cpp
+++ b/src/engine/PluginManager.cpp
@@ -150,6 +150,9 @@ PluginManager::PluginManager()
    #endif
 
     loadCache();
+#if DUSKSTUDIO_HAS_NATIVE_CLAP
+    loadClapCache();   // restore native CLAP descriptions so the picker has them at launch
+#endif
 }
 
 PluginManager::~PluginManager() = default;
@@ -368,8 +371,49 @@ void PluginManager::scanClapPlugins()
         d.isInstrument     = s.desc.isInstrument();
         clapDescriptions.add (d);
     }
+    saveClapCache();   // persist so the picker has CLAP at next launch without a re-scan
 #endif
 }
+
+#if DUSKSTUDIO_HAS_NATIVE_CLAP
+juce::File PluginManager::getClapCacheFile() const
+{
+    const auto base = getCacheFile();
+    return base == juce::File() ? juce::File() : base.getSiblingFile ("clap-cache.xml");
+}
+
+void PluginManager::loadClapCache()
+{
+    const auto file = getClapCacheFile();
+    if (file == juce::File() || ! file.existsAsFile())
+        return;
+
+    if (auto xml = juce::parseXML (file))
+    {
+        clapDescriptions.clearQuick();
+        for (auto* child : xml->getChildIterator())
+        {
+            juce::PluginDescription d;
+            // Drop entries whose .clap bundle is gone since the cache was written, so
+            // the picker never offers a removed plugin until the next rescan rebuilds it.
+            if (d.loadFromXml (*child) && juce::File (d.fileOrIdentifier).exists())
+                clapDescriptions.add (d);
+        }
+    }
+}
+
+void PluginManager::saveClapCache() const
+{
+    const auto file = getClapCacheFile();
+    if (file == juce::File())
+        return;
+
+    juce::XmlElement root ("CLAP_PLUGINS");
+    for (const auto& d : clapDescriptions)
+        root.addChildElement (d.createXml().release());
+    root.writeTo (file);
+}
+#endif
 
 juce::Array<juce::PluginDescription> PluginManager::getClapEffectDescriptions() const
 {

--- a/src/engine/PluginManager.h
+++ b/src/engine/PluginManager.h
@@ -98,6 +98,14 @@ private:
 
     void loadCache();
     void saveCache() const;
+
+    // Native CLAP descriptions persist in their own sidecar cache (knownPluginList is
+    // JUCE-formats only). Loaded at construction, rewritten after each scanClapPlugins.
+#if DUSKSTUDIO_HAS_NATIVE_CLAP
+    juce::File getClapCacheFile() const;
+    void loadClapCache();
+    void saveClapCache() const;
+#endif
 };
 
 inline juce::String PluginManager::getHostExecutablePath() const

--- a/src/engine/clap/ClapHost.cpp
+++ b/src/engine/clap/ClapHost.cpp
@@ -1,6 +1,7 @@
 #include "ClapHost.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdio>
 #include <cstring>
 
@@ -192,7 +193,16 @@ void ClapHost::pumpGui (double elapsedMs)
             for (auto& t : timers)
             {
                 t.accumMs += elapsedMs;
-                if (t.accumMs >= (double) t.periodMs) { t.accumMs = 0.0; due.push_back (t.id); }
+                // Keep the sub-period remainder instead of zeroing, so a UI stall that
+                // overshoots doesn't drop time and the timer stays on-rate. fmod (not a
+                // single subtract) also BOUNDS the accumulator: a timer whose period is
+                // shorter than the pump interval would otherwise grow accumMs without
+                // limit. Fire at most once per pump — no catch-up storm.
+                if (t.accumMs >= (double) t.periodMs)
+                {
+                    t.accumMs = std::fmod (t.accumMs, (double) t.periodMs);
+                    due.push_back (t.id);
+                }
             }
             for (const auto id : due)
             {

--- a/src/session/RegionEditActions.cpp
+++ b/src/session/RegionEditActions.cpp
@@ -816,6 +816,7 @@ bool RecordCommitAction::perform()
     for (const auto& d : diffs)
     {
         if (d.trackIndex < 0 || d.trackIndex >= Session::kNumTracks) continue;
+        if (frozenLocked (session, d.trackIndex)) continue;   // frozen track is edit-locked
         session.track (d.trackIndex).regions = d.audioAfter;
         session.track (d.trackIndex).midiRegions.mutate (
             [&d] (std::vector<MidiRegion>& mregs) { mregs = d.midiAfter; });
@@ -829,6 +830,7 @@ bool RecordCommitAction::undo()
     for (const auto& d : diffs)
     {
         if (d.trackIndex < 0 || d.trackIndex >= Session::kNumTracks) continue;
+        if (frozenLocked (session, d.trackIndex)) continue;   // frozen track is edit-locked
         session.track (d.trackIndex).regions = d.audioBefore;
         session.track (d.trackIndex).midiRegions.mutate (
             [&d] (std::vector<MidiRegion>& mregs) { mregs = d.midiBefore; });

--- a/src/session/SessionSerializer.cpp
+++ b/src/session/SessionSerializer.cpp
@@ -1,5 +1,7 @@
 #include "SessionSerializer.h"
 #include <juce_audio_devices/juce_audio_devices.h>
+#include <cmath>
+#include <limits>
 
 #if JUCE_LINUX || JUCE_MAC
  #include <fcntl.h>
@@ -32,8 +34,12 @@ constexpr int kFormatVersion = 3;
 // default is kept instead. Mirrors the master Pultec EQ's loadMasterFloat.
 inline void storeFiniteFloat (std::atomic<float>& dst, const juce::var& src) noexcept
 {
-    const float v = (float) (double) src;
-    if (std::isfinite (v)) dst.store (v);
+    // Range-check the ORIGINAL double before narrowing: casting an out-of-float-range
+    // double to float is UB, so reject non-finite / oversized values up front rather
+    // than relying on the post-cast isfinite catching an inf the narrowing produced.
+    const double d = (double) src;
+    if (std::isfinite (d) && std::abs (d) <= (double) std::numeric_limits<float>::max())
+        dst.store ((float) d);
 }
 
 // Parse one automation point from JSON, hardening every field against a

--- a/src/ui/AudioRegionEditor.cpp
+++ b/src/ui/AudioRegionEditor.cpp
@@ -2816,6 +2816,12 @@ bool AudioRegionEditor::keyPressed (const juce::KeyPress& k)
         // nuke the entire region on a Ctrl+X the user meant as a no-op range cut.
         if (rangeActive) return true;
 
+        // Whole-region cut path: a locked region / frozen track is edit-locked
+        // everywhere else (cutRange, the Delete handler) — consume the key as a no-op
+        // rather than clipboarding + deleting content the user can't edit.
+        if (r->locked || session.track (trackIdx).frozen.load (std::memory_order_relaxed))
+            return true;
+
         // Whole-region cut. Editor closes (its anchor region is gone).
         clip.region      = *r;
         clip.sourceTrack = trackIdx;

--- a/src/ui/AuxLaneComponent.cpp
+++ b/src/ui/AuxLaneComponent.cpp
@@ -900,9 +900,16 @@ void AuxLaneComponent::loadNativeClapForSlot (int slotIdx, const juce::File& cla
         std::fprintf (stderr, "[aux clap] load failed: %s\n", err.c_str());
         showDuskAlert (*this, "Couldn't load CLAP plugin",
                        clapFile.getFileNameWithoutExtension() + ":\n" + juce::String (err));
+        // Slot is empty now — drop any persisted refs (incl. a previous plugin's state
+        // blob) so a save doesn't carry a stale path/state for a slot the user sees empty.
+        lane.nativeClapPath[(size_t) slotIdx].clear();
+        lane.nativeClapStateBase64[(size_t) slotIdx].clear();
         return;
     }
     lane.nativeClapPath[(size_t) slotIdx] = clapFile.getFullPathName();
+    // Fresh plugin: don't inherit the previous slot occupant's state blob. The next
+    // save re-captures this plugin's real state.
+    lane.nativeClapStateBase64[(size_t) slotIdx].clear();
     refreshSlotControls (slotIdx);
     rebuildSlots();
 }

--- a/src/ui/BusComponent.h
+++ b/src/ui/BusComponent.h
@@ -121,11 +121,11 @@ private:
     // share one visual grammar.
     juce::Rectangle<int> eqArea;
     juce::Rectangle<int> compArea;
-    // Compact-mode placeholder buttons. Hidden when compactMode=false;
-    // visible (and the section knobs hidden) when true. Decorative —
-    // click does nothing (tooltip explains the TIMELINE toggle owns the
-    // expand/collapse). Mirrors ChannelStripComponent's eqCompactButton
-    // / compCompactButton grammar.
+    // Compact-mode section pills. Hidden when compactMode=false; visible (and the
+    // section knobs hidden) when true. Left-click toggles the EQ / COMP enable state;
+    // right-click opens the matching editor popup (openEqEditorPopup / openCompEditorPopup)
+    // so the user can tweak without expanding the strip. Mirrors ChannelStripComponent's
+    // eqCompactButton / compCompactButton grammar.
     SectionPillButton eqCompactButton  { "EQ"   };
     SectionPillButton compCompactButton { "COMP" };
     // Compact-mode popups: clicking the placeholder button shows a

--- a/src/ui/ChannelEqEditor.cpp
+++ b/src/ui/ChannelEqEditor.cpp
@@ -266,8 +266,9 @@ ChannelEqEditor::ChannelEqEditor (Track& t) : track (t)
 
     // Tight fit to resized()'s layout: header 24 + gap 8 + HPF 80 + gap 4
     // + rows[ HF 84 + HM 160 + LM 160 + LF 84, each + 4 gap = 504 ] = 620 inner,
-    // + outer reduced(12) padding 24 = 644. The bell rows are full-height now
-    // that the Q block matches the gain/freq block (kQBlockH == kKnobBlockH).
+    // + outer reduced(12) padding 24 = 644, + 4 px bottom breathing room = 648. The
+    // bell rows are full-height now that the Q block matches the gain/freq block
+    // (kQBlockH == kKnobBlockH).
     setSize (380, 648);
 }
 

--- a/src/ui/ChannelEqEditor.h
+++ b/src/ui/ChannelEqEditor.h
@@ -9,7 +9,7 @@ namespace duskstudio
 {
 // Overlay editor for a channel's 4-band EQ. Constructed each time the user
 // clicks the strip's "EQ" button - controls bind to the same atomics on the
-// Track, so values persist across open/close. Designed for juce::CallOutBox.
+// Track, so values persist across open/close. Hosted in an EmbeddedModal.
 class ChannelEqEditor final : public juce::Component
 {
 public:

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -1265,7 +1265,7 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
     refreshInputSelectorVisibility();
 
     // I/O config button. Replaces the inline mode/input/midi rows; opens a
-    // CallOutBox populated with those widgets when clicked. Saves ~60 px
+    // modal populated with those widgets when clicked. Saves ~60 px
     // vertical per strip without losing access to any setting.
     ioConfigButton.setColour (juce::TextButton::buttonColourId,  juce::Colour (0xff222226));
     ioConfigButton.setColour (juce::TextButton::textColourOffId, juce::Colour (0xffa0a8b8));
@@ -1509,16 +1509,13 @@ ChannelStripComponent::~ChannelStripComponent()
     // window is closing), force-delete it so its content (which references
     // `track`) doesn't outlive us. Same SafePointer pattern as the audio
     // settings dialog in MainComponent.
-    // CallOutBoxes auto-clean themselves when their content is deleted, but
-    // we dismiss any in-flight box so it disappears immediately rather than
-    // lingering through the next message-loop tick.
-    if (auto* eq   = activeEqBox.getComponent())   eq->dismiss();
-    if (auto* cmp  = activeCompBox.getComponent()) cmp->dismiss();
-    if (auto* aux  = activeAuxBox.getComponent())  aux->dismiss();
-    // I/O popup holds references to this strip's modeSelector / inputSelector
-    // children — must dismiss before the strip dies so the CallOutBox + its
-    // re-parented controls tear down cleanly.
-    if (auto* io   = activeIoBox.getComponent())   io->dismiss();
+    eqEditorModal.close();
+    compEditorModal.close();
+    auxEditorModal.close();
+    // I/O popup re-parents this strip's modeSelector / inputSelector children,
+    // so it must close LAST — before those combo members destruct — so its
+    // deferred body teardown doesn't outlive the controls it borrowed.
+    ioConfigModal.close();
     // Drop the cached editor BEFORE the strip's PluginSlot destructs,
     // since the editor's destructor calls editorBeingDeleted on its
     // owning AudioProcessor. dropPluginEditor() also closes the modal.
@@ -2461,6 +2458,9 @@ void ChannelStripComponent::loadNativeClapForChannel (const juce::File& clapFile
     }
 
     track.nativeClapPath = clapFile.getFullPathName();
+    // Fresh bundle: don't reuse the previous plugin's state blob. The next save
+    // re-captures this plugin's real state.
+    track.nativeClapStateBase64 = {};
     refreshPluginSlotButton();
     openPluginEditor();
 }
@@ -2472,27 +2472,6 @@ namespace
 // (+ MIDI activity LED) into a single column. When the popup closes the
 // widgets become orphans; ChannelStripComponent retains ownership and
 // state lives on Track atoms, so reopening the popup just re-parents.
-// CallOutBox subclass that ignores dismissal attempts while a nested
-// JUCE PopupMenu (e.g. a child ComboBox's dropdown) is the topmost
-// modal. The stock CallOutBox dismisses on any input outside its own
-// screen bounds — and the native ComboBox popup renders OUTSIDE those
-// bounds, so clicking Mono/Stereo/MIDI items in the IO popup's combo
-// otherwise closes the whole IO modal before the selection lands.
-class StickyCallOutBox : public juce::CallOutBox
-{
-public:
-    StickyCallOutBox (juce::Component& content,
-                       juce::Rectangle<int> areaToPointTo,
-                       juce::Component* parent)
-        : juce::CallOutBox (content, areaToPointTo, parent) {}
-
-    void inputAttemptWhenModal() override
-    {
-        if (juce::Component::getCurrentlyModalComponent() != this) return;
-        juce::CallOutBox::inputAttemptWhenModal();
-    }
-};
-
 class IoConfigPopup : public juce::Component
 {
 public:
@@ -2568,7 +2547,7 @@ private:
 
 void ChannelStripComponent::openIoConfigPopup()
 {
-    if (auto* existing = activeIoBox.getComponent()) { existing->dismiss(); return; }
+    if (ioConfigModal.isOpen()) { ioConfigModal.close(); return; }
 
     auto panel = std::make_unique<IoConfigPopup> (modeSelector, inputSelector, inputSelectorR,
                                                    midiInputSelector, midiChannelSelector,
@@ -2579,37 +2558,14 @@ void ChannelStripComponent::openIoConfigPopup()
 
     auto* topLevel = getTopLevelComponent();
     if (topLevel == nullptr) topLevel = this;
-    const auto anchor = topLevel->getLocalArea (this, ioConfigButton.getBounds());
 
-    // Replicate juce::CallOutBox::launchAsynchronously, but with the
-    // StickyCallOutBox subclass that holds itself open while a child
-    // ComboBox's native PopupMenu is the topmost modal.
-    auto* box = new StickyCallOutBox (*panel, anchor, topLevel);
-    box->setDismissalMouseClicksAreAlwaysConsumed (false);
-    box->setVisible (true);
-    box->enterModalState (true,
-        juce::ModalCallbackFunction::create (
-            [owned = std::move (panel)] (int) mutable
-            {
-                owned.reset();
-                // Return keyboard focus to the main view on dismiss. Without
-                // this the CallOutBox's modal exit leaves focus orphaned (on
-                // XWayland the focus traverser doesn't drill back into the
-                // content component), so Space / transport keys die until the
-                // user clicks the canvas. Mirrors EmbeddedModal::close().
-                if (auto* mc = EmbeddedModal::focusRestoreTarget().getComponent())
-                {
-                    mc->grabKeyboardFocus();
-                    juce::Component::SafePointer<juce::Component> safe (mc);
-                    juce::MessageManager::callAsync ([safe]() mutable
-                    {
-                        if (auto* c = safe.getComponent()) c->grabKeyboardFocus();
-                    });
-                }
-            }),
-        /*deleteWhenDismissed*/ true);
-    attachTransportKeyForwarder (*box);
-    activeIoBox = box;
+    // The panel borrows this strip's live combo children; owning show() adds
+    // them as its children and close() releases them back (re-parented on the
+    // next open). The DuskComboBox dropdowns render as nested in-window modals,
+    // so no CallOutBox-style "sticky while a native popup is up" guard is needed.
+    ioConfigModal.show (*topLevel, std::move (panel),
+                        /*onDismiss*/ {}, /*dismissOnClickOutside*/ true,
+                        /*dismissOnEscape*/ true, kEditorDimAlpha);
 }
 
 void ChannelStripComponent::refreshAuxSendLabel (int auxIdx)
@@ -2783,76 +2739,40 @@ void ChannelStripComponent::refreshIoConfigButton()
 
 void ChannelStripComponent::openEqEditorPopup()
 {
-    // Toggle: clicking EQ while EQ is up dismisses it. With CallOutBox the
-    // click that lands on the button while the box is open is consumed by
-    // the box's dismissal handler (setDismissalMouseClicksAreAlwaysConsumed
-    // below), so we never actually re-enter this function on the second
-    // click - the box dismisses itself and the button never sees the click.
-    // This branch handles programmatic toggle calls (e.g. keyboard shortcut).
-    if (auto* existing = activeEqBox.getComponent())
-    {
-        existing->dismiss();
-        return;
-    }
+    if (eqEditorModal.isOpen()) { eqEditorModal.close(); return; }
 
-    // Mutual exclusion: close the COMP popup if it's open.
-    if (auto* otherBox = activeCompBox.getComponent())
-        otherBox->dismiss();
+    // Mutual exclusion — one processing editor at a time.
+    if (compEditorModal.isOpen()) compEditorModal.close();
+    if (auxEditorModal.isOpen())  auxEditorModal.close();
 
     auto panel = std::make_unique<ChannelEqEditor> (track);
     panel->setSize (380, 648);   // match ChannelEqEditor's intrinsic height (full bell rows)
 
     auto* topLevel = getTopLevelComponent();
     if (topLevel == nullptr) topLevel = this;
-    const auto anchor = topLevel->getLocalArea (this, eqCompactButton.getBounds());
 
-    attachDimOverlay();
-    auto& box = juce::CallOutBox::launchAsynchronously (
-        std::move (panel), anchor, topLevel);
-    box.setDismissalMouseClicksAreAlwaysConsumed (true);
-    attachTransportKeyForwarder (box);
-    // Force the popup to fire from the RIGHT side of the button by
-    // restricting the available fit-area to the strip's right edge onward.
-    // Without this, JUCE's CallOutBox picks whichever side has the most
-    // space, which can drop below the button when the strip is centred.
-    {
-        const auto rightFit = topLevel->getLocalBounds()
-                                  .withTrimmedLeft (anchor.getRight());
-        box.updatePosition (anchor, rightFit);
-    }
-    activeEqBox = &box;
+    eqEditorModal.show (*topLevel, std::move (panel),
+                        /*onDismiss*/ {}, /*dismissOnClickOutside*/ true,
+                        /*dismissOnEscape*/ true, kEditorDimAlpha);
 }
 
 void ChannelStripComponent::openCompEditorPopup()
 {
-    if (auto* existing = activeCompBox.getComponent())
-    {
-        existing->dismiss();
-        return;
-    }
-    if (auto* otherBox = activeEqBox.getComponent())
-        otherBox->dismiss();
+    if (compEditorModal.isOpen()) { compEditorModal.close(); return; }
 
+    if (eqEditorModal.isOpen())  eqEditorModal.close();
+    if (auxEditorModal.isOpen()) auxEditorModal.close();
+
+    // ChannelCompEditor sizes itself in its ctor (uniform height across all
+    // comp modes — see refreshLabelsForMode), so it's fully sized before show().
     auto panel = std::make_unique<ChannelCompEditor> (track);
-    // Editor sets its own size based on the active comp mode (Opto is
-    // shorter than FET/VCA). The CallOutBox follows via childBoundsChanged.
 
     auto* topLevel = getTopLevelComponent();
     if (topLevel == nullptr) topLevel = this;
-    const auto anchor = topLevel->getLocalArea (this, compCompactButton.getBounds());
 
-    attachDimOverlay();
-    auto& box = juce::CallOutBox::launchAsynchronously (
-        std::move (panel), anchor, topLevel);
-    box.setDismissalMouseClicksAreAlwaysConsumed (true);
-    attachTransportKeyForwarder (box);
-    // Force right-side placement (same logic as the EQ popup).
-    {
-        const auto rightFit = topLevel->getLocalBounds()
-                                  .withTrimmedLeft (anchor.getRight());
-        box.updatePosition (anchor, rightFit);
-    }
-    activeCompBox = &box;
+    compEditorModal.show (*topLevel, std::move (panel),
+                          /*onDismiss*/ {}, /*dismissOnClickOutside*/ true,
+                          /*dismissOnEscape*/ true, kEditorDimAlpha);
 }
 
 namespace
@@ -3063,55 +2983,20 @@ private:
 
 void ChannelStripComponent::openAuxEditorPopup()
 {
-    if (auto* existing = activeAuxBox.getComponent())
-    {
-        existing->dismiss();
-        return;
-    }
-    // Mutual exclusion with the EQ / COMP popups.
-    if (auto* otherBox = activeEqBox.getComponent())   otherBox->dismiss();
-    if (auto* otherBox = activeCompBox.getComponent()) otherBox->dismiss();
+    if (auxEditorModal.isOpen()) { auxEditorModal.close(); return; }
 
+    if (eqEditorModal.isOpen())   eqEditorModal.close();
+    if (compEditorModal.isOpen()) compEditorModal.close();
+
+    // AuxSendsCompactPanel sizes itself in its ctor (setSize 260x130).
     auto panel = std::make_unique<AuxSendsCompactPanel> (track, session);
 
     auto* topLevel = getTopLevelComponent();
     if (topLevel == nullptr) topLevel = this;
-    const auto anchor = topLevel->getLocalArea (this, auxCompactButton.getBounds());
 
-    attachDimOverlay();
-    auto& box = juce::CallOutBox::launchAsynchronously (
-        std::move (panel), anchor, topLevel);
-    box.setDismissalMouseClicksAreAlwaysConsumed (true);
-    attachTransportKeyForwarder (box);
-    {
-        const auto rightFit = topLevel->getLocalBounds()
-                                  .withTrimmedLeft (anchor.getRight());
-        box.updatePosition (anchor, rightFit);
-    }
-    activeAuxBox = &box;
-}
-
-void ChannelStripComponent::attachDimOverlay()
-{
-    if (activeDimOverlay != nullptr) return;
-
-    auto* topLevel = getTopLevelComponent();
-    if (topLevel == nullptr) return;
-
-    // Lighter editor dim — the compact COMP/EQ/AUX callouts are processing
-    // editors; keep the strip meters behind readable while auditioning.
-    activeDimOverlay = std::make_unique<DimOverlay> (kEditorDimAlpha);
-    activeDimOverlay->setBounds (topLevel->getLocalBounds());
-    activeDimOverlay->onClick = [this]
-    {
-        if (auto* eq  = activeEqBox.getComponent())   eq->dismiss();
-        if (auto* cmp = activeCompBox.getComponent()) cmp->dismiss();
-        if (auto* aux = activeAuxBox.getComponent())  aux->dismiss();
-    };
-    topLevel->addAndMakeVisible (activeDimOverlay.get());
-    // CallOutBox::launchAsynchronously adds the box to the desktop / top
-    // level after this call returns; since it's added later, it ends up
-    // above the dim in z-order — exactly what we want.
+    auxEditorModal.show (*topLevel, std::move (panel),
+                         /*onDismiss*/ {}, /*dismissOnClickOutside*/ true,
+                         /*dismissOnEscape*/ true, kEditorDimAlpha);
 }
 
 int ChannelStripComponent::groupMasterIndex() const noexcept
@@ -3122,27 +3007,6 @@ int ChannelStripComponent::groupMasterIndex() const noexcept
         if (session.track (t).strip.faderGroupId.load (std::memory_order_relaxed) == gid)
             return t;
     return -1;
-}
-
-void ChannelStripComponent::detachDimOverlay()
-{
-    activeDimOverlay.reset();
-
-    // The compact COMP/EQ/AUX callouts just closed (only reached once all three
-    // SafePointers are null - see timerCallback). CallOutBox modal exit leaves
-    // keyboard focus orphaned on XWayland, so Space/transport keys die until the
-    // user clicks the UI. Return focus to the main view, same as
-    // openIoConfigPopup's dismissal path. Sync grab + a deferred one because the
-    // box's own teardown can re-steal focus after we return.
-    if (auto* target = EmbeddedModal::focusRestoreTarget().getComponent())
-    {
-        target->grabKeyboardFocus();
-        juce::Component::SafePointer<juce::Component> safe (target);
-        juce::MessageManager::callAsync ([safe]() mutable
-        {
-            if (auto* c = safe.getComponent()) c->grabKeyboardFocus();
-        });
-    }
 }
 
 void ChannelStripComponent::refreshFaderValueLabel()
@@ -3202,16 +3066,6 @@ void ChannelStripComponent::timerCallback()
         const auto& laneName = session.auxLane (i).name;
         if (! lbl.isBeingEdited() && lbl.getText (false) != laneName)
             lbl.setText (laneName, juce::dontSendNotification);
-    }
-
-    // Tear down the dim overlay once all popups have closed. Polling at
-    // 30 Hz is cheaper than wiring a ComponentListener on each CallOutBox.
-    if (activeDimOverlay != nullptr
-        && activeEqBox.getComponent() == nullptr
-        && activeCompBox.getComponent() == nullptr
-        && activeAuxBox.getComponent() == nullptr)
-    {
-        detachDimOverlay();
     }
 
     // MIDI activity LED. Read-and-clear the engine's flag each tick — a
@@ -4142,26 +3996,21 @@ void ChannelStripComponent::onTrackModeChanged()
     refreshPluginSlotButton();
     refreshIoConfigButton();
     refreshPrintButtonForMode();
-    // If the I/O popup is open it needs to grow / shrink (rows differ
-    // per mode: 2 for audio, 4 for MIDI). Setting the content's size
-    // triggers CallOutBox's auto-reflow — it repositions itself to
-    // accommodate the new content height. Walking the box's children
-    // and calling resized() alone is insufficient: that re-runs layout
-    // within the existing bounds, so the MIDI rows render outside the
-    // popup's visible area and the user only sees the mode dropdown.
-    //
-    // Also call resized() unconditionally after setSize: mono ↔ stereo
-    // both use rows == 2 so the height doesn't change, setSize becomes
-    // a no-op, and IoConfigPopup::resized() wouldn't fire — the inner
-    // layout (full-width mono input vs L/R halves) would stay frozen
-    // on whichever mode the popup was opened with.
-    if (auto* box = activeIoBox.getComponent())
+    // If the I/O popup is open it needs to grow / shrink (rows differ per
+    // mode: 2 for audio, 4 for MIDI), then re-centre — EmbeddedModal centres
+    // only at show() time, so a plain setSize would leave the grown MIDI panel
+    // anchored off-centre with its extra rows clipped. resized() runs
+    // unconditionally after setSize because mono ↔ stereo both use rows == 2
+    // (no height change → setSize no-ops), yet the inner layout still differs
+    // (full-width mono input vs L/R halves) and must re-lay-out.
+    if (ioConfigModal.isOpen())
     {
-        if (auto* content = box->getChildComponent (0))
+        if (auto* body = ioConfigModal.getBody())
         {
             const int rows = (mode == 2) ? 4 : 2;
-            content->setSize (240, 8 + rows * 24 + (rows - 1) * 6 + 8);
-            content->resized();
+            body->setSize (240, 8 + rows * 24 + (rows - 1) * 6 + 8);
+            body->resized();
+            ioConfigModal.recenterBody();
         }
     }
     // Resize so the layout reflects the new mode (extra dropdown for stereo,

--- a/src/ui/ChannelStripComponent.h
+++ b/src/ui/ChannelStripComponent.h
@@ -251,7 +251,8 @@ private:
     // pre-fader bool from the session atoms and pushes the formatted
     // text into auxKnobLabels[auxIdx].
     void refreshAuxSendLabel (int auxIdx);
-    juce::Component::SafePointer<juce::CallOutBox> activeIoBox;
+    // I/O config popup (mode + input routing) hosted as a centred EmbeddedModal.
+    EmbeddedModal ioConfigModal;
     // Repainted by the 30 Hz timer when engine sets track.midiActivity
     // (clear-on-read).
     struct MidiActivityLed : juce::Component
@@ -361,19 +362,17 @@ private:
     SectionPillButton eqCompactButton   { "EQ" };
     SectionPillButton compCompactButton { "COMP" };
     juce::TextButton  auxCompactButton  { "AUX" };
-    juce::Component::SafePointer<juce::CallOutBox> activeEqBox;
-    juce::Component::SafePointer<juce::CallOutBox> activeCompBox;
-    juce::Component::SafePointer<juce::CallOutBox> activeAuxBox;
+    // EQ / COMP / AUX compact editors, each a centred EmbeddedModal (dim
+    // backdrop, Esc / click-outside dismiss, transport-key forwarding, focus
+    // restore all handled internally). Mutually exclusive — opening one closes
+    // the others.
+    EmbeddedModal eqEditorModal;
+    EmbeddedModal compEditorModal;
+    EmbeddedModal auxEditorModal;
     void openEqEditorPopup();
     void openCompEditorPopup();
     void openAuxEditorPopup();
     void setAuxSectionVisible (bool visible);
-
-    // Translucent shade on the top-level while either popup is open.
-    // Removed by timerCallback once both are gone.
-    std::unique_ptr<class DimOverlay> activeDimOverlay;
-    void attachDimOverlay();
-    void detachDimOverlay();
 
     void setEqSectionVisible (bool visible);
     void setCompSectionVisible (bool visible);

--- a/src/ui/EmbeddedModal.h
+++ b/src/ui/EmbeddedModal.h
@@ -318,6 +318,21 @@ public:
                                               topLeftInParent.y - kBackdropMargin);
     }
 
+    // Re-centre the body (and its backdrop) on the host after the caller has
+    // resized it while the modal is open. show() centres once at open time; a
+    // body that grows/shrinks in place (e.g. the I/O popup gaining MIDI rows)
+    // must call this or it stays anchored at its old top-left, off-centre.
+    void recenterBody()
+    {
+        auto* body = getBody();
+        if (body == nullptr || host == nullptr) return;
+        const auto bounds = host->getLocalBounds();
+        const auto bodyBounds = bounds.withSizeKeepingCentre (
+            juce::jmin (juce::jmax (1, body->getWidth()),  bounds.getWidth()  - 16),
+            juce::jmin (juce::jmax (1, body->getHeight()), bounds.getHeight() - 16));
+        repositionBody (bodyBounds.getTopLeft());
+    }
+
 private:
     bool keyPressed (const juce::KeyPress& k, juce::Component*) override
     {

--- a/src/ui/FreezeDialog.cpp
+++ b/src/ui/FreezeDialog.cpp
@@ -57,9 +57,9 @@ FreezeDialog::FreezeDialog (AudioEngine& e, Session& s,
 
     titleLabel.setText ("Freezing " + session.track (trackIndex).name + "...",
                          juce::dontSendNotification);
-    const bool isMidi = session.track (trackIndex).mode.load (std::memory_order_relaxed)
-                          == (int) Track::Mode::Midi;
-    statusLabel.setText (isMidi
+    isMidiTrack = session.track (trackIndex).mode.load (std::memory_order_relaxed)
+                    == (int) Track::Mode::Midi;
+    statusLabel.setText (isMidiTrack
                              ? "Rendering instrument + insert + EQ + comp to audio..."
                              : "Rendering insert + EQ + comp to audio...",
                          juce::dontSendNotification);
@@ -139,7 +139,9 @@ void FreezeDialog::finalizeIfStopped()
             committed = true;
         }
         titleLabel.setText ("Track frozen", juce::dontSendNotification);
-        statusLabel.setText ("Instrument bypassed — playing from rendered audio.",
+        statusLabel.setText (isMidiTrack
+                                 ? "Instrument bypassed — playing from rendered audio."
+                                 : "Insert + EQ + comp bypassed — playing from rendered audio.",
                              juce::dontSendNotification);
         progressValue = 1.0;
         progressBar.repaint();

--- a/src/ui/FreezeDialog.h
+++ b/src/ui/FreezeDialog.h
@@ -45,13 +45,17 @@ private:
 
     std::unique_ptr<BounceEngine> bounceEngine;
 
+    // progressValue is declared BEFORE progressBar: the ctor constructs progressBar
+    // with a reference to it, so it must already be alive at that point.
+    double progressValue = 0.0;   // bound to ProgressBar
+
     juce::Label       titleLabel;
     juce::Label       statusLabel;
     juce::ProgressBar progressBar;
     juce::TextButton  cancelButton { "Cancel" };
     juce::TextButton  closeButton  { "Close" };
 
-    double progressValue = 0.0;   // bound to ProgressBar
+    bool   isMidiTrack = false;   // cached in ctor — picks the audio vs instrument message
     bool   finished  = false;
     bool   succeeded = false;
     bool   committed = false;     // commitFreeze runs exactly once

--- a/src/ui/PluginPickerHelpers.cpp
+++ b/src/ui/PluginPickerHelpers.cpp
@@ -646,18 +646,19 @@ public:
 
         constexpr int kBigBtnH = 44;
         constexpr int kGap     = 8;
-        if (hwVisible)
-        {
-            hwBtn.setBounds (area.removeFromTop (kBigBtnH));
-            area.removeFromTop (kGap);
-        }
+        pluginBtn.setBounds (area.removeFromTop (kBigBtnH));
+        area.removeFromTop (kGap);
         if (sfVisible)
         {
             sfBtn.setBounds (area.removeFromTop (kBigBtnH));
             area.removeFromTop (kGap);
         }
-        pluginBtn.setBounds (area.removeFromTop (kBigBtnH));
-        area.removeFromTop (14);
+        if (hwVisible)
+        {
+            hwBtn.setBounds (area.removeFromTop (kBigBtnH));
+            area.removeFromTop (kGap);
+        }
+        area.removeFromTop (14 - kGap);
 
         // Cancel pinned to the bottom, slightly narrower so it reads as
         // secondary action vs the three big choice buttons above.

--- a/src/ui/PluginPickerHelpers.h
+++ b/src/ui/PluginPickerHelpers.h
@@ -49,8 +49,9 @@ enum class PluginKind { Effects, Instruments };
 // hardware inserts).
 // `onPickNativeClap`, when set, MERGES native-CLAP plugins (PluginManager's CLAP
 // scan) into the list tagged "(CLAP)" and routes a CLAP selection here (the .clap
-// bundle path) instead of the JUCE loader — used by surfaces with a native CLAP host
-// (aux lanes). Unset → no CLAP rows (e.g. channel strips, which host via JUCE only).
+// bundle path) instead of the JUCE loader. Used by every surface with a native CLAP
+// host — aux lanes AND channel-strip effect slots — which expose CLAP rows alongside
+// their JUCE-hosted VST3/LV2/AU. Unset → no CLAP rows (surfaces without a native host).
 void openPickerMenu (PluginSlot& slot,
                       juce::Component& target,
                       std::unique_ptr<juce::FileChooser>& chooserOwner,

--- a/src/ui/PluginPickerPanel.cpp
+++ b/src/ui/PluginPickerPanel.cpp
@@ -10,39 +10,77 @@ namespace duskstudio
 class PluginPickerPanel::ListBody final : public juce::Component
 {
 public:
+    enum class Group { Manufacturer, Type };
+
     ListBody (juce::Array<juce::PluginDescription> descs,
               std::function<void (const juce::PluginDescription&)> picker)
-        : onPick (std::move (picker))
+        : rawDescs (std::move (descs)), onPick (std::move (picker))
     {
+        rebuild();
+    }
+
+    void setGroup (Group g)
+    {
+        if (g == group) return;
+        group = g;
+        rebuild();
+    }
+
+    // Header key a description sorts/groups under, per current group mode.
+    static juce::String groupKeyFor (const juce::PluginDescription& d, Group g)
+    {
+        if (g == Group::Manufacturer)
+            return d.manufacturerName.isEmpty() ? juce::String ("(unknown)")
+                                                : d.manufacturerName;
+
+        // Type: the plugin category, reduced to its most specific token
+        // ("Fx|EQ" -> "EQ"). Falls back to instrument/effect when the
+        // scanned description carries no category (e.g. native CLAP).
+        auto cat = d.category.trim();
+        if (cat.containsChar ('|'))
+            cat = cat.fromLastOccurrenceOf ("|", false, false).trim();
+        if (cat.isNotEmpty())
+            return cat;
+        return d.isInstrument ? juce::String ("Instrument") : juce::String ("Effect");
+    }
+
+    void rebuild()
+    {
+        auto descs = rawDescs;
+        const auto g = group;
         std::sort (descs.begin(), descs.end(),
-            [] (const juce::PluginDescription& a, const juce::PluginDescription& b)
+            [g] (const juce::PluginDescription& a, const juce::PluginDescription& b)
             {
-                if (a.manufacturerName != b.manufacturerName)
-                    return a.manufacturerName.compareIgnoreCase (b.manufacturerName) < 0;
+                const auto ka = groupKeyFor (a, g);
+                const auto kb = groupKeyFor (b, g);
+                if (ka != kb) return ka.compareIgnoreCase (kb) < 0;
                 return a.name.compareIgnoreCase (b.name) < 0;
             });
 
-        juce::String currentManu;
+        allEntries.clear();
+        juce::String currentKey;
+        bool first = true;
         for (int i = 0; i < descs.size(); ++i)
         {
             const auto& d = descs.getReference (i);
-            const auto manu = d.manufacturerName.isEmpty() ? juce::String ("(unknown)")
-                                                            : d.manufacturerName;
-            if (manu != currentManu)
+            const auto key = groupKeyFor (d, g);
+            if (first || key != currentKey)
             {
-                allEntries.push_back ({ true, manu, {} });
-                currentManu = manu;
+                allEntries.push_back ({ true, key, {} });
+                currentKey = key;
+                first = false;
             }
             juce::String label = d.name;
             if (d.pluginFormatName.isNotEmpty())
                 label += "  (" + d.pluginFormatName + ")";
             allEntries.push_back ({ false, label, d });
         }
-        applyFilter ({});
+        applyFilter (currentFilter);
     }
 
     void applyFilter (const juce::String& needle)
     {
+        currentFilter = needle;
         visibleEntries.clear();
         if (needle.isEmpty())
         {
@@ -216,6 +254,9 @@ private:
         g.fillRect (x + 1, thumbY, kScrollbarW - 2, thumbH);
     }
 
+    juce::Array<juce::PluginDescription> rawDescs;
+    Group group = Group::Manufacturer;
+    juce::String currentFilter;
     std::vector<Entry> allEntries;
     std::vector<Entry> visibleEntries;
     std::function<void (const juce::PluginDescription&)> onPick;
@@ -258,6 +299,18 @@ PluginPickerPanel::PluginPickerPanel (juce::Array<juce::PluginDescription> descr
     styleBtn (browseBtn);
     styleBtn (hwInsertBtn);
     styleBtn (soundfontBtn);
+    styleBtn (groupBtn);
+
+    groupBtn.setTooltip ("Toggle plugin list grouping between manufacturer and type.");
+    groupBtn.onClick = [this]
+    {
+        groupByType = ! groupByType;
+        groupBtn.setButtonText (groupByType ? "Group: Type" : "Group: Maker");
+        if (listBody != nullptr)
+            listBody->setGroup (groupByType ? ListBody::Group::Type
+                                            : ListBody::Group::Manufacturer);
+    };
+    addAndMakeVisible (groupBtn);
 
     cancelBtn.onClick     = [this] { if (callbacks_.onCancel)         callbacks_.onCancel(); };
     scanBtn.onClick       = [this] { if (callbacks_.onScan)           callbacks_.onScan(); };
@@ -305,6 +358,8 @@ void PluginPickerPanel::resized()
     area.removeFromTop (6);
 
     auto filterRow = area.removeFromTop (kFilterH);
+    groupBtn.setBounds (filterRow.removeFromRight (110));
+    filterRow.removeFromRight (6);
     filterEditor.setBounds (filterRow);
     area.removeFromTop (8);
 

--- a/src/ui/PluginPickerPanel.h
+++ b/src/ui/PluginPickerPanel.h
@@ -53,6 +53,7 @@ private:
 
     juce::Label titleLabel;
     juce::TextEditor filterEditor;
+    juce::TextButton groupBtn       { "Group: Maker" };
     juce::TextButton cancelBtn      { "Close" };
     juce::TextButton scanBtn        { "Scan plugins" };
     juce::TextButton browseBtn      { "Browse file..." };
@@ -60,6 +61,7 @@ private:
     juce::TextButton soundfontBtn   { "Load Soundfont" };
 
     std::unique_ptr<ListBody> listBody;
+    bool groupByType { false };
 
     static constexpr int kPad      = 10;
     static constexpr int kTitleH   = 28;

--- a/src/ui/TransportBar.cpp
+++ b/src/ui/TransportBar.cpp
@@ -315,13 +315,13 @@ TransportBar::TransportBar (AudioEngine& engineRef) : engine (engineRef)
 
     // REW / FFWD - dual-action.
     //   Brief press (< kHoldThresholdMs):
-    //     Stopped -> REW = goto zero, FFWD = goto last record point.
-    //     Rolling -> REW = jump to prev marker, FFWD = jump to next marker.
+    //     REW = jump to prev marker, FFWD = jump to next marker.
+    //     Stopped with no markers falls back to goto zero / goto last record point.
     //   Held: 10x scrub via the timer (drives the playhead while button down).
-    rewButton.setTooltip  ("Rewind: hold = 10x scrub. Tap = prev marker (rolling) "
-                            "or jump to zero (stopped).");
-    ffwdButton.setTooltip ("Forward: hold = 10x scrub. Tap = next marker (rolling) "
-                            "or jump to last record point (stopped).");
+    rewButton.setTooltip  ("Rewind. Hold to scrub back at 10x. Tap for previous marker "
+                            "(jumps to zero when stopped with no markers).");
+    ffwdButton.setTooltip ("Forward. Hold to scrub forward at 10x. Tap for next marker "
+                            "(jumps to last record point when stopped with no markers).");
 
     rewButton.onStateChange = [this]
     {
@@ -332,14 +332,13 @@ TransportBar::TransportBar (AudioEngine& engineRef) : engine (engineRef)
         }
         else if (rewPressedAtMs != 0)
         {
-            const auto held = juce::Time::currentTimeMillis() - rewPressedAtMs;
             rewPressedAtMs = 0;
-            if (rewIsScrubbing) { rewIsScrubbing = false; }
-            else if (held < kHoldThresholdMs)
-            {
-                if (engine.getTransport().isStopped()) engine.jumpToZero();
-                else                                    engine.jumpToPrevMarker();
-            }
+            if (rewIsScrubbing)
+                rewIsScrubbing = false;   // was a hold-scrub, not a tap
+            else if (engine.getTransport().isStopped() && engine.getSession().getMarkers().empty())
+                engine.jumpToZero();
+            else
+                engine.jumpToPrevMarker();
         }
     };
 
@@ -352,14 +351,13 @@ TransportBar::TransportBar (AudioEngine& engineRef) : engine (engineRef)
         }
         else if (ffwdPressedAtMs != 0)
         {
-            const auto held = juce::Time::currentTimeMillis() - ffwdPressedAtMs;
             ffwdPressedAtMs = 0;
-            if (ffwdIsScrubbing) { ffwdIsScrubbing = false; }
-            else if (held < kHoldThresholdMs)
-            {
-                if (engine.getTransport().isStopped()) engine.jumpToLastRecordPoint();
-                else                                    engine.jumpToNextMarker();
-            }
+            if (ffwdIsScrubbing)
+                ffwdIsScrubbing = false;   // was a hold-scrub, not a tap
+            else if (engine.getTransport().isStopped() && engine.getSession().getMarkers().empty())
+                engine.jumpToLastRecordPoint();
+            else
+                engine.jumpToNextMarker();
         }
     };
 

--- a/src/ui/TransportBar.h
+++ b/src/ui/TransportBar.h
@@ -109,7 +109,9 @@ private:
 
     // < threshold = brief press (marker jump / stop modifier on mouse-up).
     // >= threshold = hold (scrub timer drives playhead until release).
-    static constexpr int kHoldThresholdMs   = 180;
+    // Kept well above natural single-click duration (~100-300 ms) so a
+    // deliberate tap is never misread as a scrub-hold and swallowed.
+    static constexpr int kHoldThresholdMs   = 400;
     static constexpr float kScrubMultiplier = 10.0f;
     juce::int64 rewPressedAtMs  = 0;
     juce::int64 ffwdPressedAtMs = 0;

--- a/src/ui/VirtualKeyboardComponent.cpp
+++ b/src/ui/VirtualKeyboardComponent.cpp
@@ -170,7 +170,11 @@ bool VirtualKeyboardComponent::keyPressed (const juce::KeyPress& k)
     //     sounding old note, then Note On the new one.
     if (held[(size_t) code].note >= 0)
     {
-        if (held[(size_t) code].silentScans > 0)
+        // Retrigger only on CONFIRMED release evidence — the key must have read
+        // not-down for at least kReleaseScans-1 consecutive scans. A lone silentScans
+        // increment (one stale read) coinciding with an auto-repeat keyPressed must NOT
+        // fire a spurious Note Off / Note On on a note that's really still held.
+        if (held[(size_t) code].silentScans >= kReleaseScans - 1)
         {
             sendNoteOff (held[(size_t) code].note, held[(size_t) code].channel);
             held[(size_t) code] = { note, channel };

--- a/src/ui/VirtualKeyboardComponent.h
+++ b/src/ui/VirtualKeyboardComponent.h
@@ -98,10 +98,12 @@ private:
         // Note Off fires once it reaches kReleaseScans (see debounce note above).
         int silentScans { 0 };
     };
-    // ~66 ms at the 30 Hz scan rate. With XQueryKeymap ground truth a single
-    // scan would do; this just absorbs a one-off stale read while keeping
-    // release latency imperceptible.
-    static constexpr int kReleaseScans = 2;
+    // ~100 ms at the 30 Hz scan rate. With XQueryKeymap ground truth a single
+    // scan would do; the extra scans absorb a one-off stale read while keeping
+    // release latency imperceptible — and leave a window (silentScans in
+    // [kReleaseScans-1, kReleaseScans)) where a fast re-press can retrigger on
+    // CONFIRMED release evidence rather than a lone stale increment.
+    static constexpr int kReleaseScans = 3;
     std::array<HeldNote, 128> held {};
 
     // Single slot for the note currently being mouse-pressed (separate

--- a/tests/clap_instance_process.cpp
+++ b/tests/clap_instance_process.cpp
@@ -34,7 +34,9 @@ TEST_CASE ("ClapInstance loads + processes a real CLAP plugin", "[clap][instance
     // Single-plugin fixture (e.g. DuskVerb), so front() is deterministic.
     REQUIRE (inst.create (bundle, bundle.plugins().front().id, err));
     REQUIRE (inst.activate (48000.0, 512, err));
-    REQUIRE (inst.outputChannels() >= 1);
+    // create() rejects anything but stereo-in/stereo-out, so a plugin that reaches here
+    // is 2/2 — assert it before driving the stereo processStereo assertions below.
+    REQUIRE (inst.outputChannels() == 2);
 
     constexpr int kBlock = 512;
     constexpr int kBlocks = 40;   // drive enough blocks for any tail to settle


### PR DESCRIPTION
Removing chunks of JUCE incrementally that affect Wayland and UI updates. Adding CLAP support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native CLAP plugin support on Linux, including plugin scanning, loading, and editor embedding.
  * Added track freeze workflows with freeze/unfreeze dialogs and preserved frozen audio playback.
  * Added a collapsed mini-timeline view, richer VU meter styling, and improved plugin picker grouping.

* **Bug Fixes**
  * Improved session recovery, import handling, tooltip wrapping, and transport/marker behavior.
  * Fixed limiter lookahead/latency handling, pitch detection accuracy, MIDI clock timing, and SMPTE hour wrapping.
  * Improved freeze, record, and edit safeguards for frozen tracks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->