### PR TITLE
Native LV2 host: full mixer integration (de-JUCE for Wayland)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,15 +26,11 @@ Single canonical build dir on both OSes: `build/` (app) and `build-tests/` (Catc
 | OS    | App build | Tests build      | JUCE source                              | Plugins source                 |
 |-------|-----------|------------------|------------------------------------------|--------------------------------|
 | macOS | `build/`  | `build-tests/`   | `../JUCE` (upstream)                     | `../plugins` (any branch)      |
-| Linux | `build/`  | `build-tests/`   | `../JUCE-wayland` (plugdata-team fork)   | `../plugins-main` (worktree)   |
+| Linux | `build/`  | `build-tests/`   | `../JUCE-wayland` (plugdata-team fork)   | `../plugins` (single checkout, main) |
 
 CMake auto-detects:
 - **JUCE** — on Linux it prefers `../JUCE-wayland` if present, falls back to `../JUCE`. The wayland fork has 5 local commits Dusk Studio depends on (XEmbed mapping, X11-on-Wayland fix, peer-creation latch — see [memory](../../.claude/projects/-home-marc-projects-Dusk Studio/memory/linux_juce_wayland_pin.md)) and a divergent `addDefaultFormatsToManager` free function.
-- **Plugins** — prefers `../plugins-main` over `../plugins`. The `plugins-main` directory is a git worktree pinned to the plugins repo's `main` branch so feature-branch work in `../plugins/` doesn't break Dusk Studio's expected donor API. Set up once on Linux:
-  ```bash
-  cd ../plugins && git worktree add ../plugins-main main
-  ```
-  Mac dev typically stays on `main` of `../plugins` and skips the worktree.
+- **Plugins** — the donor is a single checkout at `../plugins`, kept on `main` as its resting state (the stable donor API). Auto-detected from the sibling `../plugins` directory; override with `-DDUSK_PLUGINS_PATH=/path/to/plugins`. If `../plugins` is ever on a feature branch when you build, you build against *that* branch — check it out to `main` first if you need the released donor API. (The former `../plugins-main` worktree was removed; the repo is consolidated to one directory. Do NOT run `git worktree add ../plugins-main main` — `main` is already checked out at `../plugins` and git will refuse it.)
 
 The upstream-vs-fork `addDefaultFormats` API split is hidden behind [src/engine/JuceCompat.h](src/engine/JuceCompat.h) — call `duskstudio::juce_compat::addDefaultFormats(fm)` and the `#if defined(__linux__)` lives in one place. Don't sprinkle new platform `#ifdef`s into call sites.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -536,9 +536,11 @@ endif()
 if(DUSKSTUDIO_NATIVE_LV2)
     target_sources(DuskStudio PRIVATE
         src/engine/lv2/Lv2Bundle.cpp
+        src/engine/lv2/Lv2Editor.cpp
         src/engine/lv2/Lv2Instance.cpp
         src/engine/lv2/Lv2Scanner.cpp
-        src/engine/lv2/NativeLv2Slot.cpp)
+        src/engine/lv2/NativeLv2Slot.cpp
+        src/ui/Lv2PluginEditorComponent.cpp)
     target_link_libraries(DuskStudio PRIVATE PkgConfig::LILV PkgConfig::SUIL PkgConfig::LV2)
     target_compile_definitions(DuskStudio PRIVATE DUSKSTUDIO_HAS_NATIVE_LV2=1)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,27 @@ else()
     set(DUSKSTUDIO_NATIVE_CLAP OFF)
 endif()
 
+# Native LV2 host (src/engine/lv2/) via lilv + suil (both ISC). Linux-only, ON when
+# the dev libraries are present (like the optional LAME dep); OFF otherwise. The
+# pkg_check_modules IMPORTED_TARGETs (PkgConfig::LILV etc.) are linked further down.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        # GLOBAL so the imported targets are visible in the tests/ subdirectory too.
+        pkg_check_modules(LILV IMPORTED_TARGET GLOBAL lilv-0)
+        pkg_check_modules(SUIL IMPORTED_TARGET GLOBAL suil-0)
+        pkg_check_modules(LV2  IMPORTED_TARGET GLOBAL lv2)
+    endif()
+    if(LILV_FOUND AND SUIL_FOUND AND LV2_FOUND)
+        option(DUSKSTUDIO_NATIVE_LV2 "Build the native LV2 plugin host (Linux, needs lilv/suil)" ON)
+    else()
+        set(DUSKSTUDIO_NATIVE_LV2 OFF)
+        message(STATUS "Native LV2 host: lilv/suil/lv2 not all found - disabled")
+    endif()
+else()
+    set(DUSKSTUDIO_NATIVE_LV2 OFF)
+endif()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -256,16 +277,12 @@ endif()
 #
 # Resolution priority:
 #   1. -DDUSK_PLUGINS_PATH (explicit override)
-#   2. sibling ../plugins-main — a permanent worktree pinned to plugins-`main`.
-#      Use this when the working ../plugins checkout is on a feature branch
-#      that may not have the donor API Dusk Studio expects. Create with:
-#          cd ../plugins && git worktree add ../plugins-main main
-#   3. sibling ../plugins (the usual checkout)
+#   2. sibling ../plugins — the single donor checkout, kept on main as its resting
+#      state (the stable donor API). If ../plugins is on a feature branch, you build
+#      against that branch. (The former ../plugins-main worktree was removed; the
+#      plugins repo is consolidated to one directory.)
 if(DEFINED DUSK_PLUGINS_PATH)
     message(STATUS "Using Dusk plugins from: ${DUSK_PLUGINS_PATH}")
-elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../plugins-main/plugins/shared")
-    set(DUSK_PLUGINS_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../plugins-main")
-    message(STATUS "Using Dusk plugins from sibling worktree (plugins-main): ${DUSK_PLUGINS_PATH}")
 elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../plugins/plugins/shared")
     set(DUSK_PLUGINS_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../plugins")
     message(STATUS "Using Dusk plugins from sibling directory: ${DUSK_PLUGINS_PATH}")
@@ -494,12 +511,16 @@ if(UNIX AND NOT APPLE)
     target_compile_definitions(DuskStudio PRIVATE DUSKSTUDIO_HAS_ALSA=1)
 endif()
 
+# Shared native-host layer (format-agnostic) — compiled whenever any native host
+# is on, so it isn't double-added by the per-format blocks below.
+if(DUSKSTUDIO_NATIVE_CLAP OR DUSKSTUDIO_NATIVE_LV2)
+    target_sources(DuskStudio PRIVATE src/engine/hosting/InsertAdapter.cpp)
+endif()
+
 # Native CLAP host — POSIX (dlopen/poll) + X11 editor embed. Gated by DUSKSTUDIO_NATIVE_CLAP
 # (ON for Linux). DUSKSTUDIO_HAS_NATIVE_CLAP guards every #if in the source.
 if(DUSKSTUDIO_NATIVE_CLAP)
     target_sources(DuskStudio PRIVATE
-        # Shared native-host layer (format-agnostic); CLAP is its first consumer.
-        src/engine/hosting/InsertAdapter.cpp
         src/engine/clap/ClapBundle.cpp
         src/engine/clap/ClapHost.cpp
         src/engine/clap/ClapInstance.cpp
@@ -508,6 +529,15 @@ if(DUSKSTUDIO_NATIVE_CLAP)
         src/engine/clap/ClapScanner.cpp
         src/ui/ClapPluginEditorComponent.cpp)
     target_compile_definitions(DuskStudio PRIVATE DUSKSTUDIO_HAS_NATIVE_CLAP=1)
+endif()
+
+# Native LV2 host — lilv (discovery/instantiation) + suil (UI embed), both ISC.
+# Gated by DUSKSTUDIO_NATIVE_LV2 (ON on Linux when the dev libs are present).
+if(DUSKSTUDIO_NATIVE_LV2)
+    target_sources(DuskStudio PRIVATE
+        src/engine/lv2/Lv2Bundle.cpp)
+    target_link_libraries(DuskStudio PRIVATE PkgConfig::LILV PkgConfig::SUIL PkgConfig::LV2)
+    target_compile_definitions(DuskStudio PRIVATE DUSKSTUDIO_HAS_NATIVE_LV2=1)
 endif()
 
 # Optional MP3 bounce via libmp3lame (LAME). Detected at configure time on every

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -537,6 +537,7 @@ if(DUSKSTUDIO_NATIVE_LV2)
     target_sources(DuskStudio PRIVATE
         src/engine/lv2/Lv2Bundle.cpp
         src/engine/lv2/Lv2Instance.cpp
+        src/engine/lv2/Lv2Scanner.cpp
         src/engine/lv2/NativeLv2Slot.cpp)
     target_link_libraries(DuskStudio PRIVATE PkgConfig::LILV PkgConfig::SUIL PkgConfig::LV2)
     target_compile_definitions(DuskStudio PRIVATE DUSKSTUDIO_HAS_NATIVE_LV2=1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -536,7 +536,8 @@ endif()
 if(DUSKSTUDIO_NATIVE_LV2)
     target_sources(DuskStudio PRIVATE
         src/engine/lv2/Lv2Bundle.cpp
-        src/engine/lv2/Lv2Instance.cpp)
+        src/engine/lv2/Lv2Instance.cpp
+        src/engine/lv2/NativeLv2Slot.cpp)
     target_link_libraries(DuskStudio PRIVATE PkgConfig::LILV PkgConfig::SUIL PkgConfig::LV2)
     target_compile_definitions(DuskStudio PRIVATE DUSKSTUDIO_HAS_NATIVE_LV2=1)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,7 +535,8 @@ endif()
 # Gated by DUSKSTUDIO_NATIVE_LV2 (ON on Linux when the dev libs are present).
 if(DUSKSTUDIO_NATIVE_LV2)
     target_sources(DuskStudio PRIVATE
-        src/engine/lv2/Lv2Bundle.cpp)
+        src/engine/lv2/Lv2Bundle.cpp
+        src/engine/lv2/Lv2Instance.cpp)
     target_link_libraries(DuskStudio PRIVATE PkgConfig::LILV PkgConfig::SUIL PkgConfig::LV2)
     target_compile_definitions(DuskStudio PRIVATE DUSKSTUDIO_HAS_NATIVE_LV2=1)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,6 +498,8 @@ endif()
 # (ON for Linux). DUSKSTUDIO_HAS_NATIVE_CLAP guards every #if in the source.
 if(DUSKSTUDIO_NATIVE_CLAP)
     target_sources(DuskStudio PRIVATE
+        # Shared native-host layer (format-agnostic); CLAP is its first consumer.
+        src/engine/hosting/InsertAdapter.cpp
         src/engine/clap/ClapBundle.cpp
         src/engine/clap/ClapHost.cpp
         src/engine/clap/ClapInstance.cpp

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -30,7 +30,7 @@ Dusk Studio includes:
 - Four mix buses, each with a 3-band EQ and console-style bus compressor.
 - A master bus with tape saturation, a tube program EQ, bus compressor, and mono-sum check.
 - A dedicated mastering stage with 5-band digital EQ, multiband compressor, brick-wall limiter, and BS.1770 loudness metering.
-- VST3, LV2, and AU plugin hosting, with optional out-of-process sandboxing for crash isolation.
+- VST3, LV2, AU, and CLAP plugin hosting, with optional out-of-process sandboxing for crash isolation. On Linux, CLAP and LV2 effects run through Dusk Studio's own native hosts.
 - External hardware insert per channel and per aux, with automatic latency measurement.
 - A multi-sampler that plays `.sfz` files and `.sf2` SoundFonts on MIDI tracks, both through the built-in sfizz engine (SF2 files are converted to SFZ on load — no external synth required).
 - MIDI Clock and MIDI Time Code chase and emit.
@@ -1375,11 +1375,12 @@ A few rules:
 Dusk Studio scans and hosts:
 
 - **VST3** on Linux, macOS, and Windows.
-- **LV2** on Linux.
+- **LV2** on Linux. Effects load through Dusk Studio's own native LV2 host (rows tagged **LV2-Native**); LV2 instruments load through the standard host.
+- **CLAP** on Linux, through the native host. Effects only.
 - **AU** on macOS only.
 - **Native multi-sampler** (`.sfz` and `.sf2` files, both via the built-in sfizz engine — SF2 is converted to SFZ on load) on all platforms.
 
-There is no VST2 support.
+There is no VST2 support. See *Native plugin hosting (Linux)* below for what the native hosts change.
 
 ## Scanning
 
@@ -1391,6 +1392,8 @@ Plugin scan results are cached in:
 - macOS: `~/Library/Application Support/Dusk Studio/plugin-cache.xml`
 - Windows: `%APPDATA%\Dusk Studio\plugin-cache.xml`
 
+On Linux the native hosts keep their own sidecar caches next to it (`clap-cache.xml`, `lv2-native-cache.xml`), rebuilt by the same **Scan plugins** button. The native LV2 scan reads only the bundles' manifests — it never loads the plugin binary, so a broken bundle cannot crash the scan; it is simply skipped (or reported when you try to load it).
+
 To re-scan on every launch, enable **Settings → General → Scan plugins on startup**. The startup scan runs in the background behind a progress window (it shows the plugin currently being scanned and a progress bar), so the app stays responsive instead of appearing to hang while a large collection is scanned.
 
 ## Loading a plugin
@@ -1399,8 +1402,10 @@ In the **plugin picker** modal:
 
 - Use the filter field at the top to narrow by name.
 - The list is grouped by manufacturer. Click a manufacturer to expand or collapse.
-- Each row shows the plugin name and its format (VST3 / LV2 / AU).
+- Each row shows the plugin name and its format (VST3 / LV2 / AU / CLAP / LV2-Native).
 - Click a row to load and dismiss.
+
+On Linux, effect slots list LV2 plugins as **LV2-Native** rows — the same plugins, hosted by Dusk Studio's native LV2 host instead of the standard one. Each plugin appears once; there is no duplicate plain-LV2 row.
 
 The picker filters by intent: only effect plugins appear when you're loading onto a channel insert or aux lane; only instruments appear when you're loading onto a MIDI track.
 
@@ -1416,6 +1421,20 @@ At the bottom of the picker are alternative buttons:
 Click the loaded plugin's slot to open its editor. The editor appears as a centred modal with a dimmed backdrop; press **Esc** or click outside to dismiss. There is no user option to detach it into a floating window.
 
 This holds on all platforms, including the macOS out-of-process sandbox. Rather than reparenting the sandbox child's native window into the main window (cross-process NSView embedding, which Dusk Studio deliberately does not use), macOS hosts the editor **in-process** against a lightweight "shell" instance of the plugin while the plugin's DSP keeps running in the sandbox child; knob moves are mirrored between the shell editor and the running child in both directions. If the plugin cannot be instantiated in-process for editing (its file has moved, or it refuses a second instance), the editor falls back to a floating window owned by the sandbox child — that fallback window is not dimmed by other modals and is closed from its own controls.
+
+## Native plugin hosting (Linux)
+
+On Linux, CLAP plugins and LV2 effects are hosted by Dusk Studio's own plugin hosts rather than the standard hosting layer. This exists for one reason: plugin editor windows embedded through the standard layer are the biggest source of UI breakage on Wayland desktops. The native hosts own the editor embedding directly and sidestep that class of problem.
+
+In practice the differences are small:
+
+- Rows tagged **CLAP** or **LV2-Native** in the picker load through the native hosts; everything else about picking, replacing, and removing is identical.
+- Editors open the same way (centred modal on channel slots, inline on aux lanes) and their settings persist in the session like any other plugin.
+- Native-hosted plugins always run in-process; the OOP sandbox does not apply to them. Scanning is still crash-safe — CLAP discovery is isolated and native LV2 discovery never executes plugin code.
+- Insert latency reported by a native-hosted plugin feeds plugin delay compensation like any other insert.
+- A slot holds one plugin regardless of host: loading a CLAP, an LV2-Native, or a standard-host plugin into the same slot replaces whatever was there.
+
+One caveat: a plugin's saved state does not transfer between hosting layers. If a session carried a plugin under the standard LV2 host and you load the same plugin as LV2-Native (or vice versa), it starts from its defaults — set it up once and save.
 
 ## Out-of-process sandboxing
 
@@ -2072,7 +2091,7 @@ Two variants:
 ### Missing plugins
 
 - **When**: Session load found plugin references that can't be instantiated on this machine.
-- **Text**: "These plugins from the saved session could not be loaded and were left empty: [per-plugin: location — plugin name]. Check that the plugins are still installed for the right format (VST3 / LV2 / AU) and that this binary can find them, then reload the session."
+- **Text**: "These plugins from the saved session could not be loaded and were left empty: [per-plugin: location — plugin name]. Check that the plugins are still installed for the right format (VST3 / LV2 / AU / CLAP) and that this binary can find them, then reload the session."
 - **Buttons**: OK.
 - **Action**: Install the missing plugins (or the right plugin format) and reload the session. Saved state for offline plugins is preserved on disk; it round-trips through the next save.
 

--- a/docs/lv2-dsp-integration-handoff.md
+++ b/docs/lv2-dsp-integration-handoff.md
@@ -1,0 +1,64 @@
+# Task: wire the native LV2 host into the mixer DSP (make LV2 plugins loadable in-app)
+
+You are working in **DuskStudio** (`/home/marc/projects/DuskStudio`, branch `feature/juce-removals-wayland`). Read `CLAUDE.md` first — its Agent Directives, audio-thread rules, and DSP-lifecycle conventions are binding.
+
+## What already exists (don't rebuild)
+
+A native LV2 host is fully built and tested at the **audio-instance level**, mirroring the existing native CLAP host:
+
+- **Shared foundation** `src/engine/hosting/`: `INativeInstance` (host-agnostic contract), `PortLayout`, `PortBuffers`, `InsertAdapter` (folds a plugin's real bus layout onto the mixer's stereo insert).
+- **LV2** `src/engine/lv2/`: `Lv2Bundle`, `Lv2Instance` (implements `INativeInstance` via lilv), **`NativeLv2Slot`** — a per-insert slot that is a **direct mirror of `src/engine/clap/NativeClapSlot`** (same public API: `load`/`unload`/`reactivate`/`leakForShutdown`/`isLoaded`/`getPath`/`setBypassed`/`saveState`/`loadState`/`processStereo`/`getInstance`). It routes audio through the `InsertAdapter`.
+- Validated against real effects via `DUSKSTUDIO_TEST_LV2=/path/to/bundle.lv2` (e.g. `~/.lv2/Universal Compressor.lv2`, `/usr/local/lib/ardour9/LV2/a-comp.lv2`).
+
+**`NativeLv2Slot` is done and proven.** Your job is to plug it into the mixer so a user can actually load an LV2 plugin into a channel/aux insert, persist it, and edit it.
+
+## The pattern to mirror: native CLAP integration
+
+Everywhere the codebase already does native CLAP, add a parallel native LV2 path. Find every touch point:
+
+```
+grep -rn 'nativeClapSlot\|NativeClapSlot\|loadNativeClap\|isNativeClapLoaded\|pendingClap\|scanClapPlugins\|onPickNativeClap\|nativeClapPath\|DUSKSTUDIO_HAS_NATIVE_CLAP' src/
+```
+
+Mirror each for LV2 (`nativeLv2Slot`, `loadNativeLv2`, `isNativeLv2Loaded`, `pendingLv2Path`, `scanLv2Plugins`, `onPickNativeLv2`, `nativeLv2Path`, gate `DUSKSTUDIO_HAS_NATIVE_LV2`). The CLAP code compiles under `#if DUSKSTUDIO_HAS_NATIVE_CLAP` with `#else` stubs — do the same with `DUSKSTUDIO_HAS_NATIVE_LV2` (already defined by CMake on Linux when lilv/suil are present).
+
+## Steps (each its own small commit; verify + pause between phases per CLAUDE.md)
+
+### 1. ChannelStrip DSP integration (`src/dsp/ChannelStrip.{h,cpp}`)
+Mirror the CLAP surface exactly:
+- Header: `#include "../engine/lv2/NativeLv2Slot.h"` (gated), a `lv2::NativeLv2Slot nativeLv2Slot` member, `pendingLv2Path`/`pendingLv2State`, and the API (`loadNativeLv2`/`unloadNativeLv2`/`isNativeLv2Loaded`/`getNativeLv2Slot`/`setPendingNativeLv2`) with `#else` stubs.
+- `.cpp`: mirror `prepare()`'s reactivate/pending-restore block, `loadNativeClap`/`unloadNativeClap`/`setPendingNativeClap`.
+- **Audio-thread call sites** (find them: `grep -n 'nativeClapSlot.processStereo' src/dsp/ChannelStrip.cpp` — mono + stereo insert branches). Add an `else if (isNativeLv2Loaded()) nativeLv2Slot.processStereo(...)` branch alongside the CLAP one. **RT rules apply — no alloc, no lock, no logging on this path.**
+
+### 2. One-host-per-slot invariant (NEW — the CLAP-only code never needed this)
+An insert slot must hold **at most one** of {JUCE `pluginSlot`, `nativeClapSlot`, `nativeLv2Slot`}. Enforce at load time: `loadNativeLv2` unloads CLAP + the JUCE slot; `loadNativeClap` (edit it) unloads LV2 + JUCE; loading a JUCE plugin unloads both native slots. The audio-thread if/else chain must be provably exclusive (only one `isXLoaded()` true). Session currently notes `nativeClapPath` is "mutually exclusive with the JUCE plugin" (see `Session.h`) — extend that to three-way. Consider one enum `{none,juce,clap,lv2}` + one path per slot rather than parallel optional fields, if it's a clean refactor; otherwise parallel fields + strict unload-others is acceptable for this pass.
+
+### 3. AuxLaneStrip (`src/dsp/AuxLaneStrip.{h,cpp}`)
+Same as ChannelStrip but the **array** form — aux lanes have `nativeClapSlots[sIdx]` (`kMaxLanePlugins`). Add `nativeLv2Slots[]` and the branch inside the crossfade gate (`grep -n 'nativeClapSlots' src/dsp/AuxLaneStrip.cpp`).
+
+### 4. Session persistence (`src/session/Session.h`, `src/session/SessionSerializer.cpp`, `src/engine/AudioEngine.cpp`)
+Add `nativeLv2Path` + `nativeLv2StateBase64` (track + aux), always-present so non-Linux sessions round-trip. Mirror `nativeClapPath` serialization. In `AudioEngine`, mirror the CLAP branch of `consumePluginStateAfterLoad` (load fenced by `suspendProcessing()`/`resumeProcessing()` when prepared, else `setPendingNativeLv2`), the save side, and `leakAllPluginInstancesForShutdown` (call `nativeLv2Slot.leakForShutdown()` too). **`Lv2Instance::saveState/loadState` currently return false (state not wired)** — so session persistence stores the path only for now; that's fine, note it.
+
+### 5. Picker routing (`src/engine/PluginManager.{h,cpp}`, `src/ui/PluginPickerHelpers.*`)
+Add `Lv2Scanner` (mirror `src/engine/clap/ClapScanner` — walk `LV2_PATH` + `~/.lv2` via a shared `LilvWorld`, filter to audio effects, emit `juce::PluginDescription` with `pluginFormatName == "LV2-Native"` into an `lv2-native-cache.xml`). Route a picked LV2-Native row to `loadNativeLv2` (mirror `onPickNativeClap`). **Use the existing sandboxed scan child if practical (crashy plugin shouldn't kill the app on first scan); at minimum note if you don't.**
+
+### 6. Editor (`src/ui/Lv2PluginEditorComponent.*`) — the Wayland-risk part, do last
+Mirror `src/ui/ClapPluginEditorComponent` + `src/engine/clap/ClapEditor`, but embed via **suil** (`suil_instance_new` into an unmapped X11 host window, reparent `suil_instance_get_widget`). This is where the actual JUCE-escape payoff lands, and the riskiest — read the CLAP editor's X11 embed sequence carefully (unmapped-until-reveal, XMapWindow host before reparent) and the `PlatformWindowing` `preferX11ForNextNativeWindow` / non-fatal-X-error-handler shims. Requires `suil` (already found via pkg-config).
+
+## Gotchas already handled in `Lv2Instance` (don't undo)
+- JUCE/DPF-wrapped LV2 plugins hard-require **urid-map + options(min/max/nominal block + sampleRate) + boundedBlockLength**; Ardour's minimal plugins don't. The feature set is built in `Lv2Instance::assembleFeatures`.
+- **Output atom ports** need `atom->size` re-advertised before every `run()` (done).
+- Every LV2 port (audio/control/atom/**CV/unknown**) must be connected before `run()` or it's UB.
+- Bundle URIs must end in `/`.
+
+## Verification (mandatory before claiming done)
+- `cmake --build build -j$(nproc)` — zero new warnings.
+- `cmake --build build-tests --target dusk-studio-tests -j$(nproc) && ctest --test-dir build-tests --output-on-failure` — all pass. Add a slot/DSP test where feasible.
+- **NEVER launch the binary on live Wayland** (it crashes) — run the self-test under Xvfb: `Xvfb :99 -screen 0 1920x1200x24 & env -u WAYLAND_DISPLAY DISPLAY=:99 DUSKSTUDIO_RUN_SELFTEST=1 timeout 90 ./build/DuskStudio_artefacts/Release/DuskStudio`.
+- Prove an LV2 loads + processes in a strip (a targeted test or the self-test with a real bundle).
+- Donor path: builds use `-DDUSK_PLUGINS_PATH=/home/marc/projects/plugins` (do NOT recreate `../plugins-main`).
+
+## Constraints
+- Small, reviewable commits (one per step). **Do not push; do not `git commit --amend` others' commits.** No `Co-Authored-By` trailers.
+- Audio-thread code: no allocation, no locks, no logging (see CLAUDE.md "Audio thread rules").
+- Load/unload is message-thread and must be fenced by the engine process gate (see how `AudioEngine` does it for CLAP).

--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -3,6 +3,10 @@
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
   #include "ui/ClapPluginEditorComponent.h"   // Linux-only native CLAP editor test
 #endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+  #include "engine/lv2/NativeLv2Slot.h"       // Linux-only native LV2 editor test
+  #include "ui/Lv2PluginEditorComponent.h"
+#endif
 #include "ui/ConsoleView.h"
 #include "ui/MainComponent.h"
 #include "ui/WindowState.h"
@@ -919,6 +923,14 @@ static juce::File sessionPathFromCommandLine (const juce::String& commandLine)
     return firstExisting;
 }
 
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+struct DuskStudioApp::Lv2EditorTest
+{
+    duskstudio::lv2::NativeLv2Slot slot;
+    std::unique_ptr<juce::DocumentWindow> window;   // declared last → destroyed first
+};
+#endif
+
 void DuskStudioApp::initialise (const juce::String& commandLine)
 {
     // --version: print app + JUCE versions + platform string and exit
@@ -1013,6 +1025,49 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
         return;   // standalone — skip the normal engine + main-window startup
     }
 #endif // DUSKSTUDIO_HAS_NATIVE_CLAP
+
+    // DUSKSTUDIO_LV2_EDITOR_TEST=/path/to.lv2 — same standalone live-verification
+    // for the native LV2 (suil) editor embed. Close the window to quit.
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    if (const char* path = std::getenv ("DUSKSTUDIO_LV2_EDITOR_TEST"); path != nullptr && *path)
+    {
+        duskstudio::platform::preferX11ForNextNativeWindow();   // editor host needs an X11 peer
+        lv2EditorTest = std::make_unique<Lv2EditorTest>();
+        std::string err;
+        if (! lv2EditorTest->slot.load (juce::File (juce::String (path)), 48000.0, 1024, err))
+        {
+            std::fprintf (stderr, "[lv2 editor test] load failed: %s\n", err.c_str());
+            quit();
+            return;
+        }
+        auto comp = std::make_unique<duskstudio::Lv2PluginEditorComponent>();
+        juce::String jerr;
+        auto* inst = lv2EditorTest->slot.getInstance();
+        if (inst == nullptr || ! comp->attach (*inst, jerr))
+        {
+            std::fprintf (stderr, "[lv2 editor test] attach failed: %s\n", jerr.toRawUTF8());
+            quit();
+            return;
+        }
+        const int w = juce::jmax (200, comp->getWidth());
+        const int h = juce::jmax (200, comp->getHeight());
+        struct TestWindow final : juce::DocumentWindow
+        {
+            using juce::DocumentWindow::DocumentWindow;
+            void closeButtonPressed() override
+            { juce::JUCEApplication::getInstance()->systemRequestedQuit(); }
+        };
+        lv2EditorTest->window = std::make_unique<TestWindow> (
+            "Dusk — LV2 editor test", juce::Colours::black, juce::DocumentWindow::allButtons);
+        lv2EditorTest->window->setUsingNativeTitleBar (true);
+        lv2EditorTest->window->setContentOwned (comp.release(), true);
+        lv2EditorTest->window->centreWithSize (w, h);
+        lv2EditorTest->window->setVisible (true);   // creates the peer → consumes the X11 latch
+        duskstudio::platform::clearPreferX11ForNativeWindow();
+        duskstudio::platform::installNonFatalXErrorHandler();
+        return;
+    }
+#endif // DUSKSTUDIO_HAS_NATIVE_LV2
 
     // DUSKSTUDIO_REPLACE_TEST=A.vst3:B.vst3 — exercises the Replace plugin...
     // swap pattern under live processing. Loads A, runs audio, swaps to
@@ -1289,6 +1344,9 @@ void DuskStudioApp::shutdown()
 
     mainWindow.reset();
     clapEditorTestWindow.reset();   // dev CLAP-editor test path: release its component deterministically
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    lv2EditorTest.reset();          // dev LV2-editor test path: window first, then its slot
+#endif
 
     // Tear down the FileLogger installed by crash_handler::install so
     // JUCE's leak detector doesn't complain at exit. The crash callback

--- a/src/DuskStudioApp.h
+++ b/src/DuskStudioApp.h
@@ -24,5 +24,11 @@ private:
     std::unique_ptr<MainWindow> mainWindow;
     // DUSKSTUDIO_CLAP_EDITOR_TEST standalone window (native CLAP editor embed).
     std::unique_ptr<juce::DocumentWindow> clapEditorTestWindow;
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    // DUSKSTUDIO_LV2_EDITOR_TEST twins — the slot owns the instance the editor
+    // attaches to, so it must outlive the window.
+    struct Lv2EditorTest;
+    std::unique_ptr<Lv2EditorTest> lv2EditorTest;
+#endif
 };
 } // namespace duskstudio

--- a/src/dsp/AuxLaneStrip.cpp
+++ b/src/dsp/AuxLaneStrip.cpp
@@ -52,15 +52,19 @@ void AuxLaneStrip::prepare (double sampleRate, int blockSize)
             const bool ok = nls.reactivate (preparedSampleRate, preparedBlockSize, err);
             lv2ReloadFailed[(size_t) s].store (! ok, std::memory_order_relaxed);
         }
-        else if (pendingLv2Path[(size_t) s].isNotEmpty()
-                 && ! isNativeClapLoaded (s))   // both pendings set (corrupt session): CLAP wins
+        else if (pendingLv2Path[(size_t) s].isNotEmpty())
         {
-            const juce::File p (pendingLv2Path[(size_t) s]);
-            std::string err;
-            const bool ok = nls.load (p, preparedSampleRate, preparedBlockSize, err);
-            if (ok && ! pendingLv2State[(size_t) s].empty())
-                nls.loadState (pendingLv2State[(size_t) s]);
-            lv2ReloadFailed[(size_t) s].store (! ok, std::memory_order_relaxed);
+            if (! isNativeClapLoaded (s))   // both pendings set (corrupt session): CLAP wins
+            {
+                const juce::File p (pendingLv2Path[(size_t) s]);
+                std::string err;
+                const bool ok = nls.load (p, preparedSampleRate, preparedBlockSize, err);
+                if (ok && ! pendingLv2State[(size_t) s].empty())
+                    nls.loadState (pendingLv2State[(size_t) s]);
+                lv2ReloadFailed[(size_t) s].store (! ok, std::memory_order_relaxed);
+            }
+            // Consumed either way — a CLAP-suppressed pending must not replay on a
+            // later prepare() once the CLAP is unloaded.
             pendingLv2Path[(size_t) s].clear();
             pendingLv2State[(size_t) s].clear();
         }

--- a/src/dsp/AuxLaneStrip.cpp
+++ b/src/dsp/AuxLaneStrip.cpp
@@ -42,6 +42,30 @@ void AuxLaneStrip::prepare (double sampleRate, int blockSize)
         }
     }
 #endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    for (int s = 0; s < kMaxPlugins; ++s)
+    {
+        auto& nls = nativeLv2Slots[(size_t) s];
+        if (nls.isLoaded())
+        {
+            std::string err;
+            const bool ok = nls.reactivate (preparedSampleRate, preparedBlockSize, err);
+            lv2ReloadFailed[(size_t) s].store (! ok, std::memory_order_relaxed);
+        }
+        else if (pendingLv2Path[(size_t) s].isNotEmpty()
+                 && ! isNativeClapLoaded (s))   // both pendings set (corrupt session): CLAP wins
+        {
+            const juce::File p (pendingLv2Path[(size_t) s]);
+            std::string err;
+            const bool ok = nls.load (p, preparedSampleRate, preparedBlockSize, err);
+            if (ok && ! pendingLv2State[(size_t) s].empty())
+                nls.loadState (pendingLv2State[(size_t) s]);
+            lv2ReloadFailed[(size_t) s].store (! ok, std::memory_order_relaxed);
+            pendingLv2Path[(size_t) s].clear();
+            pendingLv2State[(size_t) s].clear();
+        }
+    }
+#endif
 
     constexpr double rampSeconds = 0.020;
     returnGain.reset (sampleRate, rampSeconds);
@@ -82,6 +106,11 @@ bool AuxLaneStrip::loadNativeClap (int slotIdx, const juce::File& path, std::str
     jassert (slotIdx >= 0 && slotIdx < kMaxPlugins);
     if (preparedSampleRate <= 0.0 || preparedBlockSize <= 0)
     { errorOut = "aux lane not prepared"; return false; }
+    // One host per slot: evict the other native format and any JUCE plugin so the
+    // audio chain (CLAP → LV2 → JUCE) never sees two loaded. Callers fence the
+    // audio thread around this call.
+    unloadNativeLv2 (slotIdx);
+    slots[(size_t) slotIdx].unload();
     const bool ok = nativeClapSlots[(size_t) slotIdx].load (path, preparedSampleRate, preparedBlockSize, errorOut);
     // User-initiated load always ends any "failed restore" state (see ChannelStrip::
     // loadNativeClap) — clear regardless of outcome so the flag stays caller-independent.
@@ -104,6 +133,38 @@ void AuxLaneStrip::setPendingNativeClap (int slotIdx, const juce::File& path,
     jassert (slotIdx >= 0 && slotIdx < kMaxPlugins);
     pendingClapPath[(size_t) slotIdx]  = path.getFullPathName();
     pendingClapState[(size_t) slotIdx] = std::move (state);
+}
+#endif
+
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+bool AuxLaneStrip::loadNativeLv2 (int slotIdx, const juce::File& path, std::string& errorOut)
+{
+    jassert (slotIdx >= 0 && slotIdx < kMaxPlugins);
+    if (preparedSampleRate <= 0.0 || preparedBlockSize <= 0)
+    { errorOut = "aux lane not prepared"; return false; }
+    // One host per slot — see loadNativeClap.
+    unloadNativeClap (slotIdx);
+    slots[(size_t) slotIdx].unload();
+    const bool ok = nativeLv2Slots[(size_t) slotIdx].load (path, preparedSampleRate, preparedBlockSize, errorOut);
+    lv2ReloadFailed[(size_t) slotIdx].store (false, std::memory_order_relaxed);
+    return ok;
+}
+
+void AuxLaneStrip::unloadNativeLv2 (int slotIdx) noexcept
+{
+    jassert (slotIdx >= 0 && slotIdx < kMaxPlugins);
+    nativeLv2Slots[(size_t) slotIdx].unload();
+    lv2ReloadFailed[(size_t) slotIdx].store (false, std::memory_order_relaxed);
+    pendingLv2Path[(size_t) slotIdx].clear();
+    pendingLv2State[(size_t) slotIdx].clear();
+}
+
+void AuxLaneStrip::setPendingNativeLv2 (int slotIdx, const juce::File& path,
+                                         std::vector<uint8_t> state) noexcept
+{
+    jassert (slotIdx >= 0 && slotIdx < kMaxPlugins);
+    pendingLv2Path[(size_t) slotIdx]  = path.getFullPathName();
+    pendingLv2State[(size_t) slotIdx] = std::move (state);
 }
 #endif
 
@@ -204,6 +265,11 @@ void AuxLaneStrip::processStereoBlock (float* L, float* R, int numSamples,
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
             if (nativeClapSlots[sIdx].isLoaded())
                 nativeClapSlots[sIdx].processStereo (L, R, L, R, numSamples);
+            else
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+            if (nativeLv2Slots[sIdx].isLoaded())
+                nativeLv2Slots[sIdx].processStereo (L, R, L, R, numSamples);
             else
 #endif
                 slots[sIdx].processStereoBlock (L, R, numSamples, pluginMidiScratch);

--- a/src/dsp/AuxLaneStrip.h
+++ b/src/dsp/AuxLaneStrip.h
@@ -79,6 +79,8 @@ public:
     // True when a sample-rate re-prepare reload of a loaded native CLAP failed (the
     // slot is now empty). The UI reads this to report which lane lost its plugin.
     bool nativeClapReloadFailed (int slotIdx) const noexcept { jassert (slotIdx >= 0 && slotIdx < kMaxPlugins); return nativeReloadFailed[(size_t) slotIdx].load (std::memory_order_relaxed); }
+    // See ChannelStrip::markNativeClapRestoreFailed — re-marks a failed engine restore.
+    void markNativeClapRestoreFailed (int slotIdx) noexcept { jassert (slotIdx >= 0 && slotIdx < kMaxPlugins); nativeReloadFailed[(size_t) slotIdx].store (true, std::memory_order_relaxed); }
 #else
     bool isNativeClapLoaded (int) const noexcept { return false; }
     void unloadNativeClap (int) noexcept {}
@@ -94,6 +96,7 @@ public:
     const lv2::NativeLv2Slot& getNativeLv2Slot (int idx) const noexcept { jassert (idx >= 0 && idx < kMaxPlugins); return nativeLv2Slots[(size_t) idx]; }
     void setPendingNativeLv2 (int slotIdx, const juce::File& path, std::vector<uint8_t> state) noexcept;
     bool nativeLv2ReloadFailed (int slotIdx) const noexcept { jassert (slotIdx >= 0 && slotIdx < kMaxPlugins); return lv2ReloadFailed[(size_t) slotIdx].load (std::memory_order_relaxed); }
+    void markNativeLv2RestoreFailed (int slotIdx) noexcept { jassert (slotIdx >= 0 && slotIdx < kMaxPlugins); lv2ReloadFailed[(size_t) slotIdx].store (true, std::memory_order_relaxed); }
 #else
     bool isNativeLv2Loaded (int) const noexcept { return false; }
     void unloadNativeLv2 (int) noexcept {}

--- a/src/dsp/AuxLaneStrip.h
+++ b/src/dsp/AuxLaneStrip.h
@@ -8,6 +8,9 @@
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
   #include "../engine/clap/NativeClapSlot.h"   // Linux-only native CLAP host
 #endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+  #include "../engine/lv2/NativeLv2Slot.h"     // Linux-only native LV2 host
+#endif
 #include "HardwareInsertSlot.h"
 
 namespace duskstudio
@@ -82,6 +85,21 @@ public:
     bool nativeClapReloadFailed (int) const noexcept { return false; }
 #endif
 
+    // Native LV2 host path — same contract as the CLAP block above.
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    bool loadNativeLv2   (int slotIdx, const juce::File& path, std::string& errorOut);
+    void unloadNativeLv2 (int slotIdx) noexcept;
+    bool isNativeLv2Loaded (int slotIdx) const noexcept { jassert (slotIdx >= 0 && slotIdx < kMaxPlugins); return nativeLv2Slots[(size_t) slotIdx].isLoaded(); }
+    lv2::NativeLv2Slot&       getNativeLv2Slot (int idx)       noexcept { jassert (idx >= 0 && idx < kMaxPlugins); return nativeLv2Slots[(size_t) idx]; }
+    const lv2::NativeLv2Slot& getNativeLv2Slot (int idx) const noexcept { jassert (idx >= 0 && idx < kMaxPlugins); return nativeLv2Slots[(size_t) idx]; }
+    void setPendingNativeLv2 (int slotIdx, const juce::File& path, std::vector<uint8_t> state) noexcept;
+    bool nativeLv2ReloadFailed (int slotIdx) const noexcept { jassert (slotIdx >= 0 && slotIdx < kMaxPlugins); return lv2ReloadFailed[(size_t) slotIdx].load (std::memory_order_relaxed); }
+#else
+    bool isNativeLv2Loaded (int) const noexcept { return false; }
+    void unloadNativeLv2 (int) noexcept {}
+    bool nativeLv2ReloadFailed (int) const noexcept { return false; }
+#endif
+
     enum InsertMode : int { kInsertEmpty = 0, kInsertPlugin = 1, kInsertHardware = 2 };
 
     std::array<std::atomic<int>, kMaxPlugins> insertMode {};
@@ -108,6 +126,12 @@ private:
     // Pending session-restore load, consummated by prepare() (see setPendingNativeClap).
     std::array<juce::String,           kMaxPlugins> pendingClapPath;
     std::array<std::vector<uint8_t>,   kMaxPlugins> pendingClapState;
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    std::array<lv2::NativeLv2Slot,   kMaxPlugins> nativeLv2Slots;
+    std::array<std::atomic<bool>,    kMaxPlugins> lv2ReloadFailed {};
+    std::array<juce::String,         kMaxPlugins> pendingLv2Path;
+    std::array<std::vector<uint8_t>, kMaxPlugins> pendingLv2State;
 #endif
 
     // Stashed in prepare so loadNativeClap (and re-prepare across a sample-rate

--- a/src/dsp/ChannelStrip.cpp
+++ b/src/dsp/ChannelStrip.cpp
@@ -111,6 +111,25 @@ void ChannelStrip::prepare (double sampleRate, int blockSize, int oversamplingFa
         pendingClapState.clear();
     }
 #endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    if (nativeLv2Slot.isLoaded())
+    {
+        std::string err;
+        const bool ok = nativeLv2Slot.reactivate (preparedSampleRate, preparedBlockSize, err);
+        lv2ReloadFailed.store (! ok, std::memory_order_relaxed);
+    }
+    else if (pendingLv2Path.isNotEmpty())
+    {
+        const juce::File p (pendingLv2Path);
+        std::string err;
+        const bool ok = nativeLv2Slot.load (p, preparedSampleRate, preparedBlockSize, err);
+        if (ok && ! pendingLv2State.empty())
+            nativeLv2Slot.loadState (pendingLv2State);
+        lv2ReloadFailed.store (! ok, std::memory_order_relaxed);
+        pendingLv2Path.clear();
+        pendingLv2State.clear();
+    }
+#endif
 
     // Oversampling: build a Dusk Studio-side wrapper around (EQ + Comp) when the
     // user picks 2× / 4× in Audio Settings. The donor's BritishEQ console
@@ -462,6 +481,32 @@ void ChannelStrip::setPendingNativeClap (const juce::File& path, std::vector<uin
 }
 #endif
 
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+bool ChannelStrip::loadNativeLv2 (const juce::File& path, std::string& errorOut)
+{
+    if (preparedSampleRate <= 0.0 || preparedBlockSize <= 0)
+    { errorOut = "channel strip not prepared"; return false; }
+    const bool ok = nativeLv2Slot.load (path, preparedSampleRate, preparedBlockSize, errorOut);
+    // A user-initiated load always ends any "failed restore" state (see loadNativeClap).
+    lv2ReloadFailed.store (false, std::memory_order_relaxed);
+    return ok;
+}
+
+void ChannelStrip::unloadNativeLv2() noexcept
+{
+    nativeLv2Slot.unload();
+    lv2ReloadFailed.store (false, std::memory_order_relaxed);
+    pendingLv2Path.clear();
+    pendingLv2State.clear();
+}
+
+void ChannelStrip::setPendingNativeLv2 (const juce::File& path, std::vector<uint8_t> state) noexcept
+{
+    pendingLv2Path  = path.getFullPathName();
+    pendingLv2State = std::move (state);
+}
+#endif
+
 void ChannelStrip::relatchPdcIfDrained (float blockPeakAbs, int numSamples) noexcept
 {
     // Track how long the signal feeding the delay has been silent. We only
@@ -727,6 +772,19 @@ void ChannelStrip::processAndAccumulate (const float* inL,
             }
             else
 #endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+            if (nativeLv2Slot.isLoaded())
+            {
+                // Same stereo-only mono fold as the CLAP branch above.
+                std::memcpy (insertScratchR.data(), tempMono.data(), sizeof (float) * (size_t) numSamples);
+                nativeLv2Slot.processStereo (tempMono.data(), insertScratchR.data(),
+                                             tempMono.data(), insertScratchR.data(), numSamples);
+                for (int i = 0; i < numSamples; ++i)
+                    tempMono[(size_t) i] = 0.5f
+                        * (tempMono[(size_t) i] + insertScratchR[(size_t) i]);
+            }
+            else
+#endif
             {
                 pluginMidiScratch.clear();
                 pluginSlot.processMonoBlock (tempMono.data(), numSamples, pluginMidiScratch);
@@ -904,6 +962,11 @@ void ChannelStrip::processAndAccumulate (const float* inL,
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
                 if (nativeClapSlot.isLoaded())
                     nativeClapSlot.processStereo (L, R, L, R, numSamples);
+                else
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+                if (nativeLv2Slot.isLoaded())
+                    nativeLv2Slot.processStereo (L, R, L, R, numSamples);
                 else
 #endif
                 {

--- a/src/dsp/ChannelStrip.cpp
+++ b/src/dsp/ChannelStrip.cpp
@@ -118,15 +118,19 @@ void ChannelStrip::prepare (double sampleRate, int blockSize, int oversamplingFa
         const bool ok = nativeLv2Slot.reactivate (preparedSampleRate, preparedBlockSize, err);
         lv2ReloadFailed.store (! ok, std::memory_order_relaxed);
     }
-    else if (pendingLv2Path.isNotEmpty()
-             && ! isNativeClapLoaded())   // both pendings set (corrupt session): CLAP wins
+    else if (pendingLv2Path.isNotEmpty())
     {
-        const juce::File p (pendingLv2Path);
-        std::string err;
-        const bool ok = nativeLv2Slot.load (p, preparedSampleRate, preparedBlockSize, err);
-        if (ok && ! pendingLv2State.empty())
-            nativeLv2Slot.loadState (pendingLv2State);
-        lv2ReloadFailed.store (! ok, std::memory_order_relaxed);
+        if (! isNativeClapLoaded())   // both pendings set (corrupt session): CLAP wins
+        {
+            const juce::File p (pendingLv2Path);
+            std::string err;
+            const bool ok = nativeLv2Slot.load (p, preparedSampleRate, preparedBlockSize, err);
+            if (ok && ! pendingLv2State.empty())
+                nativeLv2Slot.loadState (pendingLv2State);
+            lv2ReloadFailed.store (! ok, std::memory_order_relaxed);
+        }
+        // Consumed either way — a CLAP-suppressed pending must not replay on a
+        // later prepare() once the CLAP is unloaded.
         pendingLv2Path.clear();
         pendingLv2State.clear();
     }

--- a/src/dsp/ChannelStrip.cpp
+++ b/src/dsp/ChannelStrip.cpp
@@ -118,7 +118,8 @@ void ChannelStrip::prepare (double sampleRate, int blockSize, int oversamplingFa
         const bool ok = nativeLv2Slot.reactivate (preparedSampleRate, preparedBlockSize, err);
         lv2ReloadFailed.store (! ok, std::memory_order_relaxed);
     }
-    else if (pendingLv2Path.isNotEmpty())
+    else if (pendingLv2Path.isNotEmpty()
+             && ! isNativeClapLoaded())   // both pendings set (corrupt session): CLAP wins
     {
         const juce::File p (pendingLv2Path);
         std::string err;
@@ -458,6 +459,11 @@ bool ChannelStrip::loadNativeClap (const juce::File& path, std::string& errorOut
 {
     if (preparedSampleRate <= 0.0 || preparedBlockSize <= 0)
     { errorOut = "channel strip not prepared"; return false; }
+    // One host per insert: evict the other native format and any JUCE plugin so
+    // the audio-thread chain (CLAP → LV2 → JUCE) can never see two loaded at once.
+    // Callers fence the audio thread around this call.
+    unloadNativeLv2();
+    pluginSlot.unload();
     const bool ok = nativeClapSlot.load (path, preparedSampleRate, preparedBlockSize, errorOut);
     // A user-initiated load is not a restore, so it always ends any "failed restore"
     // state — whether it succeeds (recovered) or fails (caller clears the persisted
@@ -486,6 +492,9 @@ bool ChannelStrip::loadNativeLv2 (const juce::File& path, std::string& errorOut)
 {
     if (preparedSampleRate <= 0.0 || preparedBlockSize <= 0)
     { errorOut = "channel strip not prepared"; return false; }
+    // One host per insert — see loadNativeClap.
+    unloadNativeClap();
+    pluginSlot.unload();
     const bool ok = nativeLv2Slot.load (path, preparedSampleRate, preparedBlockSize, errorOut);
     // A user-initiated load always ends any "failed restore" state (see loadNativeClap).
     lv2ReloadFailed.store (false, std::memory_order_relaxed);

--- a/src/dsp/ChannelStrip.h
+++ b/src/dsp/ChannelStrip.h
@@ -10,6 +10,9 @@
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
   #include "../engine/clap/NativeClapSlot.h"   // Linux-only native CLAP host
 #endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+  #include "../engine/lv2/NativeLv2Slot.h"     // Linux-only native LV2 host
+#endif
 #include "HardwareInsertSlot.h"
 
 #if DUSKSTUDIO_HAS_DUSK_DSP
@@ -74,6 +77,21 @@ public:
     bool isNativeClapLoaded() const noexcept { return false; }
     void unloadNativeClap() noexcept {}
     bool nativeClapReloadFailed() const noexcept { return false; }
+#endif
+
+    // Native LV2 host path — same contract as the CLAP block above.
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    bool loadNativeLv2   (const juce::File& path, std::string& errorOut);
+    void unloadNativeLv2() noexcept;
+    bool isNativeLv2Loaded() const noexcept { return nativeLv2Slot.isLoaded(); }
+    lv2::NativeLv2Slot&       getNativeLv2Slot()       noexcept { return nativeLv2Slot; }
+    const lv2::NativeLv2Slot& getNativeLv2Slot() const noexcept { return nativeLv2Slot; }
+    void setPendingNativeLv2 (const juce::File& path, std::vector<uint8_t> state) noexcept;
+    bool nativeLv2ReloadFailed() const noexcept { return lv2ReloadFailed.load (std::memory_order_relaxed); }
+#else
+    bool isNativeLv2Loaded() const noexcept { return false; }
+    void unloadNativeLv2() noexcept {}
+    bool nativeLv2ReloadFailed() const noexcept { return false; }
 #endif
 
     // Hardware vs plugin insert: one runs per block, chosen by
@@ -179,6 +197,10 @@ private:
     clap::NativeClapSlot nativeClapSlot;   // native CLAP alternative to pluginSlot
     std::atomic<bool>    nativeReloadFailed { false };   // prepare()-time reactivate/restore failed
 #endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    lv2::NativeLv2Slot nativeLv2Slot;      // native LV2 alternative to pluginSlot
+    std::atomic<bool>  lv2ReloadFailed { false };
+#endif
     HardwareInsertSlot hardwareSlot;
 
     // Stashed in prepare() so loadNativeClap / pending-restore can (re)activate at spec.
@@ -187,6 +209,10 @@ private:
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
     juce::String         pendingClapPath;    // session-restore load consummated by prepare()
     std::vector<uint8_t> pendingClapState;
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    juce::String         pendingLv2Path;
+    std::vector<uint8_t> pendingLv2State;
 #endif
 
     // activeInsertMode = what we're currently running; insertMode = what

--- a/src/dsp/ChannelStrip.h
+++ b/src/dsp/ChannelStrip.h
@@ -73,6 +73,9 @@ public:
     // True when the last prepare()-time reactivate / pending-restore load failed. Lets
     // the save path tell "failed restore" (keep the persisted path) from "user removed".
     bool nativeClapReloadFailed() const noexcept { return nativeReloadFailed.load (std::memory_order_relaxed); }
+    // Engine session-restore failure: loadNativeClap clears the flag (it treats every
+    // call as user-initiated), so a failed RESTORE must re-mark it to keep the refs.
+    void markNativeClapRestoreFailed() noexcept { nativeReloadFailed.store (true, std::memory_order_relaxed); }
 #else
     bool isNativeClapLoaded() const noexcept { return false; }
     void unloadNativeClap() noexcept {}
@@ -88,6 +91,7 @@ public:
     const lv2::NativeLv2Slot& getNativeLv2Slot() const noexcept { return nativeLv2Slot; }
     void setPendingNativeLv2 (const juce::File& path, std::vector<uint8_t> state) noexcept;
     bool nativeLv2ReloadFailed() const noexcept { return lv2ReloadFailed.load (std::memory_order_relaxed); }
+    void markNativeLv2RestoreFailed() noexcept { lv2ReloadFailed.store (true, std::memory_order_relaxed); }
 #else
     bool isNativeLv2Loaded() const noexcept { return false; }
     void unloadNativeLv2() noexcept {}

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -1307,6 +1307,24 @@ void AudioEngine::publishPluginStateForSave (bool audioCallbackDetached)
             track.nativeClapStateBase64.clear();
         }
 #endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+        if (strip.isNativeLv2Loaded())
+        {
+            track.nativeLv2Path = strip.getNativeLv2Slot().getPath();
+            std::vector<uint8_t> blob;
+            // Lv2Instance state persistence isn't wired yet (saveState returns
+            // false) — the path alone restores the plugin at its defaults.
+            if (strip.getNativeLv2Slot().saveState (blob) && ! blob.empty())
+                track.nativeLv2StateBase64 = juce::Base64::toBase64 (blob.data(), blob.size());
+            else
+                track.nativeLv2StateBase64.clear();
+        }
+        else if (! strip.nativeLv2ReloadFailed())
+        {
+            track.nativeLv2Path.clear();
+            track.nativeLv2StateBase64.clear();
+        }
+#endif
     }
     for (int a = 0; a < Session::kNumAuxLanes; ++a)
     {
@@ -1337,6 +1355,22 @@ void AudioEngine::publishPluginStateForSave (bool audioCallbackDetached)
                 // empty / user-removed slot.
                 lane.nativeClapPath[(size_t) s].clear();
                 lane.nativeClapStateBase64[(size_t) s].clear();
+            }
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+            if (strip.isNativeLv2Loaded (s))
+            {
+                lane.nativeLv2Path[(size_t) s] = strip.getNativeLv2Slot (s).getPath();
+                std::vector<uint8_t> blob;
+                if (strip.getNativeLv2Slot (s).saveState (blob) && ! blob.empty())
+                    lane.nativeLv2StateBase64[(size_t) s] = juce::Base64::toBase64 (blob.data(), blob.size());
+                else
+                    lane.nativeLv2StateBase64[(size_t) s].clear();
+            }
+            else if (! strip.nativeLv2ReloadFailed (s))
+            {
+                lane.nativeLv2Path[(size_t) s].clear();
+                lane.nativeLv2StateBase64[(size_t) s].clear();
             }
 #endif
         }
@@ -1375,6 +1409,9 @@ void AudioEngine::leakAllPluginInstancesForShutdown()
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
         strip.getNativeClapSlot().leakForShutdown();   // u-he hangs in destroy/dlclose
 #endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+        strip.getNativeLv2Slot().leakForShutdown();
+#endif
     }
     for (auto& laneStrip : auxLaneStrips)
         for (int s = 0; s < AuxLaneParams::kMaxLanePlugins; ++s)
@@ -1382,6 +1419,9 @@ void AudioEngine::leakAllPluginInstancesForShutdown()
             laneStrip.getPluginSlot (s).leakInstanceForShutdown();
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
             laneStrip.getNativeClapSlot (s).leakForShutdown();   // u-he hangs in destroy/dlclose
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+            laneStrip.getNativeLv2Slot (s).leakForShutdown();
 #endif
         }
 }
@@ -1469,23 +1509,67 @@ void AudioEngine::consumePluginStateAfterLoad()
             }
             else
             {
+                // Not prepared → no live audio; safe to clear a carried-over LV2
+                // unfenced (the prepared path's loadNativeClap evicts it itself).
+                strip.unloadNativeLv2();
                 strip.setPendingNativeClap (clapFile, std::move (blob));
             }
             continue;
         }
 #endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+        if (track.nativeLv2Path.isNotEmpty())
+        {
+            slot.unload();
+            strip.insertMode.store (ChannelStrip::kInsertPlugin, std::memory_order_release);
 
-        // No native CLAP in this session for this strip — tear down any native
+            std::vector<uint8_t> blob;
+            if (const auto& st = track.nativeLv2StateBase64; st.isNotEmpty())
+            {
+                juce::MemoryBlock mb;
+                if (mb.fromBase64Encoding (st) && mb.getSize() > 0)
+                    blob.assign (static_cast<const uint8_t*> (mb.getData()),
+                                 static_cast<const uint8_t*> (mb.getData()) + mb.getSize());
+            }
+
+            const juce::File lv2File (track.nativeLv2Path);
+            if (strip.isPrepared())
+            {
+                suspendProcessing();
+                std::string err;
+                const bool ok = strip.loadNativeLv2 (lv2File, err);
+                if (ok && ! blob.empty())
+                    strip.getNativeLv2Slot().loadState (blob);
+                resumeProcessing();
+                if (! ok)
+                    lastPluginLoadFailures.push_back ({
+                        "Track " + juce::String (t + 1),
+                        lv2File.getFileNameWithoutExtension() });
+            }
+            else
+            {
+                strip.unloadNativeClap();   // see the CLAP pending branch above
+                strip.setPendingNativeLv2 (lv2File, std::move (blob));
+            }
+            continue;
+        }
+#endif
+
+        // No native host in this session for this strip — tear down any native
         // instance carried over from the previously-loaded session before the JUCE
         // restore below (unload destroys the instance, so fence it when live).
-        if (strip.isNativeClapLoaded())
+        if (strip.isNativeClapLoaded() || strip.isNativeLv2Loaded())
         {
             suspendProcessing();
             strip.unloadNativeClap();
+            strip.unloadNativeLv2();
             resumeProcessing();
         }
         else
+        {
             strip.unloadNativeClap();   // no live instance: just clears any stale pending
+            strip.unloadNativeLv2();
+        }
 
         if (track.pluginDescriptionXml.isEmpty())
         {
@@ -1557,22 +1641,65 @@ void AudioEngine::consumePluginStateAfterLoad()
                 }
                 else
                 {
+                    // Not prepared → no live audio; clear a carried-over LV2 unfenced.
+                    strip.unloadNativeLv2 (s);
                     strip.setPendingNativeClap (s, clapFile, std::move (blob));
                 }
                 continue;   // native handled — skip the JUCE restore for this slot
             }
 #endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+            if (lane.nativeLv2Path[(size_t) s].isNotEmpty())
+            {
+                slot.unload();
+                strip.insertMode[(size_t) s].store (AuxLaneStrip::kInsertPlugin, std::memory_order_release);
 
-            // No native CLAP for this slot — tear down any instance carried over from
+                std::vector<uint8_t> blob;
+                if (const auto& st = lane.nativeLv2StateBase64[(size_t) s]; st.isNotEmpty())
+                {
+                    juce::MemoryBlock mb;
+                    if (mb.fromBase64Encoding (st) && mb.getSize() > 0)
+                        blob.assign (static_cast<const uint8_t*> (mb.getData()),
+                                     static_cast<const uint8_t*> (mb.getData()) + mb.getSize());
+                }
+
+                const juce::File lv2File (lane.nativeLv2Path[(size_t) s]);
+                if (strip.isPrepared())
+                {
+                    suspendProcessing();   // load is not RT-safe; fence the audio thread
+                    std::string err;
+                    const bool ok = strip.loadNativeLv2 (s, lv2File, err);
+                    if (ok && ! blob.empty())
+                        strip.getNativeLv2Slot (s).loadState (blob);
+                    resumeProcessing();
+                    if (! ok)
+                        lastPluginLoadFailures.push_back ({
+                            "Aux " + juce::String (a + 1) + " slot " + juce::String (s + 1),
+                            lv2File.getFileNameWithoutExtension() });
+                }
+                else
+                {
+                    strip.unloadNativeClap (s);   // see the CLAP pending branch above
+                    strip.setPendingNativeLv2 (s, lv2File, std::move (blob));
+                }
+                continue;   // native handled — skip the JUCE restore for this slot
+            }
+#endif
+
+            // No native host for this slot — tear down any instance carried over from
             // the previous session before the JUCE restore (fence when live).
-            if (strip.isNativeClapLoaded (s))
+            if (strip.isNativeClapLoaded (s) || strip.isNativeLv2Loaded (s))
             {
                 suspendProcessing();
                 strip.unloadNativeClap (s);
+                strip.unloadNativeLv2 (s);
                 resumeProcessing();
             }
             else
+            {
                 strip.unloadNativeClap (s);   // clears any stale pending restore
+                strip.unloadNativeLv2 (s);
+            }
 
             const auto& descXml = lane.pluginDescriptionXml[(size_t) s];
             if (descXml.isEmpty())

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -435,7 +435,21 @@ void AudioEngine::recomputePdc() noexcept
         {
             const int mode = strip.insertMode.load (std::memory_order_relaxed);
             if (mode == ChannelStrip::kInsertPlugin)
+            {
                 lat = strip.getPluginSlot().getLatencySamples();
+                // A native insert replaces the JUCE slot (which then reports 0),
+                // so its latency must feed PDC instead.
+#if DUSKSTUDIO_HAS_NATIVE_CLAP
+                if (strip.isNativeClapLoaded())
+                    if (auto* inst = strip.getNativeClapSlot().getInstance())
+                        lat = inst->getLatencySamples();
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+                if (strip.isNativeLv2Loaded())
+                    if (auto* inst = strip.getNativeLv2Slot().getInstance())
+                        lat = inst->getLatencySamples();
+#endif
+            }
             else if (mode == ChannelStrip::kInsertHardware)
                 lat = strip.getHardwareInsertSlot().getLatencySamples();
         }
@@ -1313,11 +1327,10 @@ void AudioEngine::publishPluginStateForSave (bool audioCallbackDetached)
             track.nativeLv2Path = strip.getNativeLv2Slot().getPath();
             std::vector<uint8_t> blob;
             // Lv2Instance state persistence isn't wired yet (saveState returns
-            // false) — the path alone restores the plugin at its defaults.
+            // false) — keep whatever blob the session already carries rather than
+            // wiping it on every save round-trip.
             if (strip.getNativeLv2Slot().saveState (blob) && ! blob.empty())
                 track.nativeLv2StateBase64 = juce::Base64::toBase64 (blob.data(), blob.size());
-            else
-                track.nativeLv2StateBase64.clear();
         }
         else if (! strip.nativeLv2ReloadFailed())
         {
@@ -1362,10 +1375,10 @@ void AudioEngine::publishPluginStateForSave (bool audioCallbackDetached)
             {
                 lane.nativeLv2Path[(size_t) s] = strip.getNativeLv2Slot (s).getPath();
                 std::vector<uint8_t> blob;
+                // See the track block above: preserve the carried blob until LV2
+                // state serialization is wired.
                 if (strip.getNativeLv2Slot (s).saveState (blob) && ! blob.empty())
                     lane.nativeLv2StateBase64[(size_t) s] = juce::Base64::toBase64 (blob.data(), blob.size());
-                else
-                    lane.nativeLv2StateBase64[(size_t) s].clear();
             }
             else if (! strip.nativeLv2ReloadFailed (s))
             {
@@ -1503,9 +1516,14 @@ void AudioEngine::consumePluginStateAfterLoad()
                     strip.getNativeClapSlot().loadState (blob);
                 resumeProcessing();
                 if (! ok)
+                {
+                    // A failed RESTORE is not a user removal — mark it so the save
+                    // path keeps the persisted refs (loadNativeClap cleared the flag).
+                    strip.markNativeClapRestoreFailed();
                     lastPluginLoadFailures.push_back ({
                         "Track " + juce::String (t + 1),
                         clapFile.getFileNameWithoutExtension() });
+                }
             }
             else
             {
@@ -1542,9 +1560,12 @@ void AudioEngine::consumePluginStateAfterLoad()
                     strip.getNativeLv2Slot().loadState (blob);
                 resumeProcessing();
                 if (! ok)
+                {
+                    strip.markNativeLv2RestoreFailed();   // keep refs — see the CLAP twin
                     lastPluginLoadFailures.push_back ({
                         "Track " + juce::String (t + 1),
                         lv2File.getFileNameWithoutExtension() });
+                }
             }
             else
             {
@@ -1635,9 +1656,12 @@ void AudioEngine::consumePluginStateAfterLoad()
                         strip.getNativeClapSlot (s).loadState (blob);
                     resumeProcessing();
                     if (! ok)
+                    {
+                        strip.markNativeClapRestoreFailed (s);   // keep refs — restore, not removal
                         lastPluginLoadFailures.push_back ({
                             "Aux " + juce::String (a + 1) + " slot " + juce::String (s + 1),
                             clapFile.getFileNameWithoutExtension() });
+                    }
                 }
                 else
                 {
@@ -1673,9 +1697,12 @@ void AudioEngine::consumePluginStateAfterLoad()
                         strip.getNativeLv2Slot (s).loadState (blob);
                     resumeProcessing();
                     if (! ok)
+                    {
+                        strip.markNativeLv2RestoreFailed (s);   // keep refs — restore, not removal
                         lastPluginLoadFailures.push_back ({
                             "Aux " + juce::String (a + 1) + " slot " + juce::String (s + 1),
                             lv2File.getFileNameWithoutExtension() });
+                    }
                 }
                 else
                 {

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -1326,9 +1326,8 @@ void AudioEngine::publishPluginStateForSave (bool audioCallbackDetached)
         {
             track.nativeLv2Path = strip.getNativeLv2Slot().getPath();
             std::vector<uint8_t> blob;
-            // Lv2Instance state persistence isn't wired yet (saveState returns
-            // false) — keep whatever blob the session already carries rather than
-            // wiping it on every save round-trip.
+            // Preserve the carried blob when a plugin can't serialize (no state
+            // extension / save failure) — don't wipe it on a save round-trip.
             if (strip.getNativeLv2Slot().saveState (blob) && ! blob.empty())
                 track.nativeLv2StateBase64 = juce::Base64::toBase64 (blob.data(), blob.size());
         }
@@ -1375,8 +1374,8 @@ void AudioEngine::publishPluginStateForSave (bool audioCallbackDetached)
             {
                 lane.nativeLv2Path[(size_t) s] = strip.getNativeLv2Slot (s).getPath();
                 std::vector<uint8_t> blob;
-                // See the track block above: preserve the carried blob until LV2
-                // state serialization is wired.
+                // See the track block above: preserve the carried blob when the
+                // plugin can't serialize.
                 if (strip.getNativeLv2Slot (s).saveState (blob) && ! blob.empty())
                     lane.nativeLv2StateBase64[(size_t) s] = juce::Base64::toBase64 (blob.data(), blob.size());
             }

--- a/src/engine/FileImporter.cpp
+++ b/src/engine/FileImporter.cpp
@@ -21,8 +21,10 @@ juce::String makeImportedFilename (int trackIndex, const juce::String& extension
     const auto stamp = juce::String::formatted ("%04d%02d%02d-%02d%02d%02d",
                                                   now.getYear(), now.getMonth() + 1, now.getDayOfMonth(),
                                                   now.getHours(), now.getMinutes(), now.getSeconds());
-    return juce::String::formatted ("import_track%02d_%s", trackIndex + 1, stamp.toRawUTF8())
-             + extension;
+    // No %s through String::formatted: MSVC's wide printf reads a char* as
+    // wchar_t* and garbles the name into invalid filename characters.
+    return "import_track" + juce::String (trackIndex + 1).paddedLeft ('0', 2)
+             + "_" + stamp + extension;
 }
 
 // Channel-conform `src` into `dst` (dst is pre-sized to (targetChannels,

--- a/src/engine/PluginManager.cpp
+++ b/src/engine/PluginManager.cpp
@@ -367,9 +367,12 @@ int PluginManager::scanInstalledPlugins (
 
 void PluginManager::scanClapPlugins()
 {
-    clapDescriptions.clearQuick();
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
-    for (const auto& s : clap::ClapScanner::scan())
+    // Discover OUTSIDE the lock (dlopens every bundle — slow), swap in under it.
+    const auto scanned = clap::ClapScanner::scan();
+    const juce::ScopedLock sl (nativeDescriptionsLock);
+    clapDescriptions.clearQuick();
+    for (const auto& s : scanned)
     {
         juce::PluginDescription d;
         d.name             = juce::String (juce::CharPointer_UTF8 (s.desc.name.c_str()));
@@ -381,6 +384,9 @@ void PluginManager::scanClapPlugins()
         clapDescriptions.add (d);
     }
     saveClapCache();   // persist so the picker has CLAP at next launch without a re-scan
+#else
+    const juce::ScopedLock sl (nativeDescriptionsLock);
+    clapDescriptions.clearQuick();
 #endif
 }
 
@@ -426,6 +432,7 @@ void PluginManager::saveClapCache() const
 
 juce::Array<juce::PluginDescription> PluginManager::getClapEffectDescriptions() const
 {
+    const juce::ScopedLock sl (nativeDescriptionsLock);
     juce::Array<juce::PluginDescription> effects;
     for (const auto& d : clapDescriptions)
         if (! d.isInstrument)
@@ -435,9 +442,11 @@ juce::Array<juce::PluginDescription> PluginManager::getClapEffectDescriptions() 
 
 void PluginManager::scanLv2Plugins()
 {
-    lv2Descriptions.clearQuick();
 #if DUSKSTUDIO_HAS_NATIVE_LV2
-    for (const auto& s : lv2::Lv2Scanner::scan())
+    const auto scanned = lv2::Lv2Scanner::scan();   // manifest parse outside the lock
+    const juce::ScopedLock sl (nativeDescriptionsLock);
+    lv2Descriptions.clearQuick();
+    for (const auto& s : scanned)
     {
         // Only audio effects for now — the native LV2 host is an insert host;
         // instruments and MIDI utilities stay with the JUCE LV2 format.
@@ -451,6 +460,9 @@ void PluginManager::scanLv2Plugins()
         lv2Descriptions.add (d);
     }
     saveLv2Cache();   // persist so the picker has LV2 at next launch without a re-scan
+#else
+    const juce::ScopedLock sl (nativeDescriptionsLock);
+    lv2Descriptions.clearQuick();
 #endif
 }
 
@@ -495,6 +507,7 @@ void PluginManager::saveLv2Cache() const
 
 juce::Array<juce::PluginDescription> PluginManager::getLv2EffectDescriptions() const
 {
+    const juce::ScopedLock sl (nativeDescriptionsLock);
     return lv2Descriptions;   // scan already filtered to audio effects
 }
 

--- a/src/engine/PluginManager.cpp
+++ b/src/engine/PluginManager.cpp
@@ -10,6 +10,9 @@
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
   #include "clap/ClapScanner.h"   // Linux-only native CLAP discovery
 #endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+  #include "lv2/Lv2Scanner.h"     // Linux-only native LV2 discovery
+#endif
 
 #include <map>
 
@@ -152,6 +155,9 @@ PluginManager::PluginManager()
     loadCache();
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
     loadClapCache();   // restore native CLAP descriptions so the picker has them at launch
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    loadLv2Cache();
 #endif
 }
 
@@ -352,7 +358,10 @@ int PluginManager::scanInstalledPlugins (
     if (added > 0 || pruned > 0 || blacklistGrew) saveCache();
 
     if (! aborting)
+    {
         scanClapPlugins();   // CLAP isn't a juce format — scan it alongside the JUCE pass
+        scanLv2Plugins();    // native-LV2 rows are separate from JUCE's LV2 format
+    }
     return added;
 }
 
@@ -422,6 +431,71 @@ juce::Array<juce::PluginDescription> PluginManager::getClapEffectDescriptions() 
         if (! d.isInstrument)
             effects.add (d);
     return effects;
+}
+
+void PluginManager::scanLv2Plugins()
+{
+    lv2Descriptions.clearQuick();
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    for (const auto& s : lv2::Lv2Scanner::scan())
+    {
+        // Only audio effects for now — the native LV2 host is an insert host;
+        // instruments and MIDI utilities stay with the JUCE LV2 format.
+        if (s.desc.audioInputs <= 0 || s.desc.audioOutputs <= 0)
+            continue;
+        juce::PluginDescription d;
+        d.name             = juce::String (juce::CharPointer_UTF8 (s.desc.name.c_str()));
+        d.pluginFormatName = "LV2-Native";
+        d.fileOrIdentifier = s.bundlePath;
+        d.isInstrument     = false;
+        lv2Descriptions.add (d);
+    }
+    saveLv2Cache();   // persist so the picker has LV2 at next launch without a re-scan
+#endif
+}
+
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+juce::File PluginManager::getLv2CacheFile() const
+{
+    const auto base = getCacheFile();
+    return base == juce::File() ? juce::File() : base.getSiblingFile ("lv2-native-cache.xml");
+}
+
+void PluginManager::loadLv2Cache()
+{
+    const auto file = getLv2CacheFile();
+    if (file == juce::File() || ! file.existsAsFile())
+        return;
+
+    if (auto xml = juce::parseXML (file))
+    {
+        lv2Descriptions.clearQuick();
+        for (auto* child : xml->getChildIterator())
+        {
+            juce::PluginDescription d;
+            // Drop entries whose bundle directory is gone since the cache was written.
+            if (d.loadFromXml (*child) && juce::File (d.fileOrIdentifier).isDirectory())
+                lv2Descriptions.add (d);
+        }
+    }
+}
+
+void PluginManager::saveLv2Cache() const
+{
+    const auto file = getLv2CacheFile();
+    if (file == juce::File())
+        return;
+
+    juce::XmlElement root ("LV2_NATIVE_PLUGINS");
+    for (const auto& d : lv2Descriptions)
+        root.addChildElement (d.createXml().release());
+    root.writeTo (file);
+}
+#endif
+
+juce::Array<juce::PluginDescription> PluginManager::getLv2EffectDescriptions() const
+{
+    return lv2Descriptions;   // scan already filtered to audio effects
 }
 
 juce::Array<juce::PluginDescription> PluginManager::getInstrumentDescriptions() const

--- a/src/engine/PluginManager.cpp
+++ b/src/engine/PluginManager.cpp
@@ -369,24 +369,25 @@ void PluginManager::scanClapPlugins()
 {
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
     // Discover OUTSIDE the lock (dlopens every bundle — slow), swap in under it.
+    // The cache write also stays outside so a picker open on the message thread
+    // can't stall behind this thread's file I/O.
     const auto scanned = clap::ClapScanner::scan();
-    const juce::ScopedLock sl (nativeDescriptionsLock);
-    clapDescriptions.clearQuick();
-    for (const auto& s : scanned)
     {
-        juce::PluginDescription d;
-        d.name             = juce::String (juce::CharPointer_UTF8 (s.desc.name.c_str()));
-        d.manufacturerName = juce::String (juce::CharPointer_UTF8 (s.desc.vendor.c_str()));
-        d.version          = juce::String (juce::CharPointer_UTF8 (s.desc.version.c_str()));
-        d.pluginFormatName = "CLAP";
-        d.fileOrIdentifier = s.bundlePath;
-        d.isInstrument     = s.desc.isInstrument();
-        clapDescriptions.add (d);
+        const juce::ScopedLock sl (nativeDescriptionsLock);
+        clapDescriptions.clearQuick();
+        for (const auto& s : scanned)
+        {
+            juce::PluginDescription d;
+            d.name             = juce::String (juce::CharPointer_UTF8 (s.desc.name.c_str()));
+            d.manufacturerName = juce::String (juce::CharPointer_UTF8 (s.desc.vendor.c_str()));
+            d.version          = juce::String (juce::CharPointer_UTF8 (s.desc.version.c_str()));
+            d.pluginFormatName = "CLAP";
+            d.fileOrIdentifier = s.bundlePath;
+            d.isInstrument     = s.desc.isInstrument();
+            clapDescriptions.add (d);
+        }
     }
     saveClapCache();   // persist so the picker has CLAP at next launch without a re-scan
-#else
-    const juce::ScopedLock sl (nativeDescriptionsLock);
-    clapDescriptions.clearQuick();
 #endif
 }
 
@@ -423,8 +424,15 @@ void PluginManager::saveClapCache() const
     if (file == juce::File())
         return;
 
+    // Snapshot under the lock; serialize + write with it released so the picker
+    // can't stall behind the file I/O.
+    juce::Array<juce::PluginDescription> snapshot;
+    {
+        const juce::ScopedLock sl (nativeDescriptionsLock);
+        snapshot = clapDescriptions;
+    }
     juce::XmlElement root ("CLAP_PLUGINS");
-    for (const auto& d : clapDescriptions)
+    for (const auto& d : snapshot)
         root.addChildElement (d.createXml().release());
     root.writeTo (file);
 }
@@ -444,25 +452,24 @@ void PluginManager::scanLv2Plugins()
 {
 #if DUSKSTUDIO_HAS_NATIVE_LV2
     const auto scanned = lv2::Lv2Scanner::scan();   // manifest parse outside the lock
-    const juce::ScopedLock sl (nativeDescriptionsLock);
-    lv2Descriptions.clearQuick();
-    for (const auto& s : scanned)
     {
-        // Only audio effects for now — the native LV2 host is an insert host;
-        // instruments and MIDI utilities stay with the JUCE LV2 format.
-        if (s.desc.audioInputs <= 0 || s.desc.audioOutputs <= 0)
-            continue;
-        juce::PluginDescription d;
-        d.name             = juce::String (juce::CharPointer_UTF8 (s.desc.name.c_str()));
-        d.pluginFormatName = "LV2-Native";
-        d.fileOrIdentifier = s.bundlePath;
-        d.isInstrument     = false;
-        lv2Descriptions.add (d);
+        const juce::ScopedLock sl (nativeDescriptionsLock);
+        lv2Descriptions.clearQuick();
+        for (const auto& s : scanned)
+        {
+            // Only audio effects for now — the native LV2 host is an insert host;
+            // instruments and MIDI utilities stay with the JUCE LV2 format.
+            if (s.desc.audioInputs <= 0 || s.desc.audioOutputs <= 0)
+                continue;
+            juce::PluginDescription d;
+            d.name             = juce::String (juce::CharPointer_UTF8 (s.desc.name.c_str()));
+            d.pluginFormatName = "LV2-Native";
+            d.fileOrIdentifier = s.bundlePath;
+            d.isInstrument     = false;
+            lv2Descriptions.add (d);
+        }
     }
     saveLv2Cache();   // persist so the picker has LV2 at next launch without a re-scan
-#else
-    const juce::ScopedLock sl (nativeDescriptionsLock);
-    lv2Descriptions.clearQuick();
 #endif
 }
 
@@ -498,8 +505,13 @@ void PluginManager::saveLv2Cache() const
     if (file == juce::File())
         return;
 
+    juce::Array<juce::PluginDescription> snapshot;
+    {
+        const juce::ScopedLock sl (nativeDescriptionsLock);
+        snapshot = lv2Descriptions;
+    }
     juce::XmlElement root ("LV2_NATIVE_PLUGINS");
-    for (const auto& d : lv2Descriptions)
+    for (const auto& d : snapshot)
         root.addChildElement (d.createXml().release());
     root.writeTo (file);
 }

--- a/src/engine/PluginManager.h
+++ b/src/engine/PluginManager.h
@@ -43,6 +43,12 @@ public:
     // via scanInstalledPlugins; result cached in memory for the session.
     void scanClapPlugins();
 
+    // Native-LV2 plugins, scanned separately from JUCE's LV2 format (which stays as
+    // the fallback host). pluginFormatName "LV2-Native", fileOrIdentifier = the .lv2
+    // bundle directory. Audio effects only; discovery is manifest-only via lilv.
+    juce::Array<juce::PluginDescription> getLv2EffectDescriptions() const;
+    void scanLv2Plugins();
+
     // Synchronous instantiation. May take 100s of ms. Returns nullptr on
     // failure and sets errorMessage. Caller runs prepareToPlay before
     // processing audio. Success adds the description to knownPluginList.
@@ -94,6 +100,7 @@ private:
     juce::AudioPluginFormatManager formatManager;
     juce::KnownPluginList          knownPluginList;
     juce::Array<juce::PluginDescription> clapDescriptions;   // native CLAP (scanned separately)
+    juce::Array<juce::PluginDescription> lv2Descriptions;    // native LV2 (scanned separately)
     bool                           oopEnabled { false };
 
     void loadCache();
@@ -105,6 +112,11 @@ private:
     juce::File getClapCacheFile() const;
     void loadClapCache();
     void saveClapCache() const;
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    juce::File getLv2CacheFile() const;
+    void loadLv2Cache();
+    void saveLv2Cache() const;
 #endif
 };
 

--- a/src/engine/PluginManager.h
+++ b/src/engine/PluginManager.h
@@ -99,6 +99,10 @@ public:
 private:
     juce::AudioPluginFormatManager formatManager;
     juce::KnownPluginList          knownPluginList;
+    // Native-format descriptions. scanInstalledPlugins runs on a background
+    // thread (PluginScanModal) and repopulates these while the message thread
+    // may be reading them for the picker — every access goes through this lock.
+    mutable juce::CriticalSection nativeDescriptionsLock;
     juce::Array<juce::PluginDescription> clapDescriptions;   // native CLAP (scanned separately)
     juce::Array<juce::PluginDescription> lv2Descriptions;    // native LV2 (scanned separately)
     bool                           oopEnabled { false };

--- a/src/engine/RecordManager.cpp
+++ b/src/engine/RecordManager.cpp
@@ -116,8 +116,11 @@ bool RecordManager::startRecording (double sampleRate, juce::int64 startSample)
             continue;
         }
 
-        auto trackName = juce::String::formatted ("track%02d_%s.wav", t + 1,
-                                                   stamp.toRawUTF8());
+        // No %s through String::formatted: MSVC's wide printf reads a char* as
+        // wchar_t* and garbles the name into invalid filename characters — the
+        // writer then fails to open and the take is silently dropped.
+        auto trackName = "track" + juce::String (t + 1).paddedLeft ('0', 2)
+                           + "_" + stamp + ".wav";
         // The stamp has one-second resolution: a stop + re-arm within the
         // same second would collide with the just-committed take, and
         // deleting here would destroy the WAV its region references.

--- a/src/engine/clap/ClapInstance.cpp
+++ b/src/engine/clap/ClapInstance.cpp
@@ -70,9 +70,9 @@ bool ClapInstance::create (const ClapBundle& bundle, const std::string& pluginId
         if (ap->count (plugin, false) > 0 && ap->get (plugin, 0, false, &info)) outCh = (int) info.channel_count;
     }
 
-    // processStereo drives a single stereo in + stereo out port. Reject anything
-    // else for now (the aux path is stereo); the reject relaxes when the call
-    // sites move to processBlock + InsertAdapter (F6/F7).
+    // Reject anything but stereo-in / stereo-out for now. The generalized
+    // processBlock + InsertAdapter path handles other layouts, but the DSP call
+    // sites still assume stereo, so gate non-stereo plugins out here until they migrate.
     if (inCh != 2 || outCh != 2)
     {
         errorOut = "plugin is not stereo-in/stereo-out (got "

--- a/src/engine/clap/ClapInstance.cpp
+++ b/src/engine/clap/ClapInstance.cpp
@@ -60,7 +60,7 @@ bool ClapInstance::create (const ClapBundle& bundle, const std::string& pluginId
 
     // Channel counts of the first audio port in / out (the aux path is stereo;
     // a full port-config negotiation comes with the multi-port increment).
-    inCh = outCh = 0;
+    int inCh = 0, outCh = 0;
     if (const auto* ap = static_cast<const clap_plugin_audio_ports_t*> (
             plugin->get_extension (plugin, CLAP_EXT_AUDIO_PORTS));
         ap != nullptr && ap->count != nullptr && ap->get != nullptr)
@@ -71,7 +71,8 @@ bool ClapInstance::create (const ClapBundle& bundle, const std::string& pluginId
     }
 
     // processStereo drives a single stereo in + stereo out port. Reject anything
-    // else for now (the aux path is stereo); multi-port support is a later step.
+    // else for now (the aux path is stereo); the reject relaxes when the call
+    // sites move to processBlock + InsertAdapter (F6/F7).
     if (inCh != 2 || outCh != 2)
     {
         errorOut = "plugin is not stereo-in/stereo-out (got "
@@ -80,6 +81,23 @@ bool ClapInstance::create (const ClapBundle& bundle, const std::string& pluginId
         plugin = nullptr;
         owningBundle = nullptr;
         return false;
+    }
+
+    // Record the negotiated shape for INativeInstance consumers (the InsertAdapter
+    // reads it to fold the stereo insert onto the plugin's real channel counts).
+    layout = {};
+    {
+        hosting::BusInfo in;
+        in.kind = hosting::BusInfo::Kind::Audio; in.dir = hosting::BusInfo::Direction::Input;
+        in.role = hosting::BusInfo::Role::Main;  in.channelCount = inCh;  in.active = true; in.name = "Input";
+        layout.inputs.push_back (in);
+        layout.mainInIndex = 0;
+
+        hosting::BusInfo out;
+        out.kind = hosting::BusInfo::Kind::Audio; out.dir = hosting::BusInfo::Direction::Output;
+        out.role = hosting::BusInfo::Role::Main;  out.channelCount = outCh; out.active = true; out.name = "Output";
+        layout.outputs.push_back (out);
+        layout.mainOutIndex = 0;
     }
 
     // Snapshot the parameter list for automation / display. [main-thread]
@@ -124,6 +142,18 @@ bool ClapInstance::activate (double sampleRate, int maxBlock, std::string& error
     if (plugin->activate == nullptr
         || ! plugin->activate (plugin, sampleRate, 1, (uint32_t) maxFrames))
     { errorOut = "activate() failed"; return false; }
+
+    // Plugin latency is valid post-activate; cache it for PDC. Size the CLAP
+    // buffer pointer arrays to the negotiated channel counts so processBlock
+    // just points them at the caller's scratch each block (no RT alloc).
+    latencySamples = 0;
+    if (const auto* lat = static_cast<const clap_plugin_latency_t*> (
+            plugin->get_extension (plugin, CLAP_EXT_LATENCY));
+        lat != nullptr && lat->get != nullptr)
+        latencySamples = (int) lat->get (plugin);
+
+    clapInData .assign ((size_t) layout.mainInChannels(),  nullptr);
+    clapOutData.assign ((size_t) layout.mainOutChannels(), nullptr);
 
     startFailed = false;   // a fresh activation may try start_processing again
     active = true;
@@ -238,6 +268,35 @@ void ClapInstance::setParamValue (clap_id id, double value) noexcept
     ringWrite.store (next, std::memory_order_release);
 }
 
+void ClapInstance::drainParamRing() noexcept
+{
+    // Drain queued parameter changes into this block's CLAP event list (audio thread
+    // = single consumer). All at time 0 — sample-accurate automation is a later step.
+    eventCount = 0;
+    uint32_t r = ringRead.load (std::memory_order_relaxed);
+    const uint32_t w   = ringWrite.load (std::memory_order_acquire);
+    const uint32_t cap = (uint32_t) eventScratch.size();
+    while (r != w && eventCount < cap)
+    {
+        const ParamChange pc = paramRing[(size_t) r];
+        auto& ev = eventScratch[(size_t) eventCount++];
+        ev.header.size     = sizeof (clap_event_param_value_t);
+        ev.header.time     = 0;
+        ev.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+        ev.header.type     = CLAP_EVENT_PARAM_VALUE;
+        ev.header.flags    = 0;
+        ev.param_id        = pc.id;
+        ev.cookie          = pc.cookie;
+        ev.note_id         = -1;
+        ev.port_index      = -1;
+        ev.channel         = -1;
+        ev.key             = -1;
+        ev.value           = pc.value;
+        r = (r + 1u) % (uint32_t) kParamRingCap;
+    }
+    ringRead.store (r, std::memory_order_release);
+}
+
 void ClapInstance::processStereo (const float* inL, const float* inR,
                                   float* outL, float* outR, int numFrames) noexcept
 {
@@ -275,33 +334,7 @@ void ClapInstance::processStereo (const float* inL, const float* inR,
         processing = true;
     }
 
-    // Drain queued parameter changes into this block's CLAP event list (audio thread
-    // = single consumer). All at time 0 — sample-accurate automation is a later step.
-    eventCount = 0;
-    {
-        uint32_t r = ringRead.load (std::memory_order_relaxed);
-        const uint32_t w   = ringWrite.load (std::memory_order_acquire);
-        const uint32_t cap = (uint32_t) eventScratch.size();
-        while (r != w && eventCount < cap)
-        {
-            const ParamChange pc = paramRing[(size_t) r];
-            auto& ev = eventScratch[(size_t) eventCount++];
-            ev.header.size     = sizeof (clap_event_param_value_t);
-            ev.header.time     = 0;
-            ev.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
-            ev.header.type     = CLAP_EVENT_PARAM_VALUE;
-            ev.header.flags    = 0;
-            ev.param_id        = pc.id;
-            ev.cookie          = pc.cookie;
-            ev.note_id         = -1;
-            ev.port_index      = -1;
-            ev.channel         = -1;
-            ev.key             = -1;
-            ev.value           = pc.value;
-            r = (r + 1u) % (uint32_t) kParamRingCap;
-        }
-        ringRead.store (r, std::memory_order_release);
-    }
+    drainParamRing();
 
     const auto n = (size_t) numFrames;
     std::memcpy (inScratchL.data(), inL, sizeof (float) * n);
@@ -338,5 +371,77 @@ void ClapInstance::processStereo (const float* inL, const float* inR,
 
     std::memcpy (outL, outScratchL.data(), sizeof (float) * n);
     std::memcpy (outR, outScratchR.data(), sizeof (float) * n);
+}
+
+void ClapInstance::processBlock (const hosting::PortBuffers& io) noexcept
+{
+    const int numFrames = io.numFrames;
+
+    auto clearOutputs = [&]
+    {
+        if (io.mainOut == nullptr || numFrames <= 0) return;
+        for (int c = 0; c < io.mainOutChannels; ++c)
+            if (io.mainOut[c] != nullptr)
+                std::memset (io.mainOut[c], 0, sizeof (float) * (size_t) numFrames);
+    };
+
+    if (! active || plugin == nullptr || plugin->process == nullptr
+        || numFrames <= 0 || numFrames > maxFrames
+        || io.mainOut == nullptr || io.mainOutChannels <= 0)
+    {
+        clearOutputs();
+        return;
+    }
+
+    if (startFailed)   // plugin already refused to start — stay silent
+    {
+        clearOutputs();
+        return;
+    }
+
+    if (! processing)
+    {
+        hostObj.setAudioThread (std::this_thread::get_id());
+        if (plugin->start_processing != nullptr && ! plugin->start_processing (plugin))
+        {
+            startFailed = true;
+            clearOutputs();
+            return;
+        }
+        processing = true;
+    }
+
+    drainParamRing();
+
+    // Point the CLAP audio buffers straight at the caller's pre-sized scratch — the
+    // plugin writes its output there, no instance-owned copy. Clamp to the channel
+    // counts negotiated at activate() so a mismatched block can't over-index; a null
+    // mainIn (instrument-style caller) processes as zero input ports.
+    const int nin  = io.mainIn != nullptr ? std::min (io.mainInChannels, (int) clapInData.size()) : 0;
+    const int nout = std::min (io.mainOutChannels, (int) clapOutData.size());
+    for (int c = 0; c < nin;  ++c) clapInData [(size_t) c] = io.mainIn[c];
+    for (int c = 0; c < nout; ++c) clapOutData[(size_t) c] = io.mainOut[c];
+
+    clap_audio_buffer_t inBuf {};
+    inBuf.data32        = clapInData.data();
+    inBuf.channel_count = (uint32_t) nin;
+
+    clap_audio_buffer_t outBuf {};
+    outBuf.data32        = clapOutData.data();
+    outBuf.channel_count = (uint32_t) nout;
+
+    clap_process_t p {};
+    p.steady_time         = -1;          // free-running
+    p.frames_count        = (uint32_t) numFrames;
+    p.transport           = nullptr;
+    p.audio_inputs        = nin > 0 ? &inBuf : nullptr;
+    p.audio_inputs_count  = nin > 0 ? 1u : 0u;
+    p.audio_outputs       = &outBuf;
+    p.audio_outputs_count = 1u;
+    p.in_events           = &inEvents;
+    p.out_events          = &emptyOut;
+
+    if (plugin->process (plugin, &p) == CLAP_PROCESS_ERROR)
+        clearOutputs();
 }
 } // namespace duskstudio::clap

--- a/src/engine/clap/ClapInstance.h
+++ b/src/engine/clap/ClapInstance.h
@@ -23,9 +23,9 @@ class ClapBundle;
 // path. Parameters are enumerated at create(); changes are queued (message thread,
 // single producer) and consumed as CLAP events by the next process() block.
 //
-// Implements the host-agnostic INativeInstance so a NativeInsertSlot can drive
-// CLAP, VST3 and LV2 through one pointer. processStereo() is the legacy stereo
-// entry, kept as the A/B reference until the call sites move to processBlock.
+// Implements the host-agnostic INativeInstance so one plugin slot can drive
+// CLAP, VST3 and LV2 through a single pointer. processStereo() is the legacy
+// stereo entry, retained as the reference for verifying processBlock's output.
 class ClapInstance : public hosting::INativeInstance
 {
 public:
@@ -77,8 +77,8 @@ public:
     int getLatencySamples() const noexcept override { return latencySamples; }
 
     // Audio thread. Legacy stereo entry — inL/inR → outL/outR through the plugin.
-    // Kept as the A/B reference for processBlock until the call sites migrate; the
-    // NativeInsertSlot + DSP call sites move to processBlock in a following phase.
+    // Superseded by processBlock (the slot routes production audio through that);
+    // retained as the reference implementation for the processBlock equivalence test.
     void processStereo (const float* inL, const float* inR,
                         float* outL, float* outR, int numFrames) noexcept;
 

--- a/src/engine/clap/ClapInstance.h
+++ b/src/engine/clap/ClapInstance.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ClapHost.h"
+#include "../hosting/INativeInstance.h"
 
 #include <clap/events.h>
 
@@ -16,12 +17,16 @@ namespace duskstudio::clap
 class ClapBundle;
 
 // One CLAP plugin instance: create from a factory + plugin id, activate at a
-// fixed sample rate / max block, and process stereo audio through it. Manages the
+// fixed sample rate / max block, and process audio through it. Manages the
 // full lifecycle (init → activate → start_processing → process → stop_processing
-// → deactivate → destroy). Setup is message-thread; processStereo is the audio
+// → deactivate → destroy). Setup is message-thread; processBlock is the audio
 // path. Parameters are enumerated at create(); changes are queued (message thread,
 // single producer) and consumed as CLAP events by the next process() block.
-class ClapInstance
+//
+// Implements the host-agnostic INativeInstance so a NativeInsertSlot can drive
+// CLAP, VST3 and LV2 through one pointer. processStereo() is the legacy stereo
+// entry, kept as the A/B reference until the call sites move to processBlock.
+class ClapInstance : public hosting::INativeInstance
 {
 public:
     // One plugin parameter (snapshot of clap_param_info at create()).
@@ -46,20 +51,34 @@ public:
     // False (+ errorOut) on failure.
     bool create (const ClapBundle& bundle, const std::string& pluginId, std::string& errorOut);
 
+    // The negotiated bus/port shape, populated at create(). [INativeInstance]
+    const hosting::PortLayout& portLayout() const noexcept override { return layout; }
+
     // Activate at the given config (sizes the process scratch; no later RT alloc).
-    bool activate (double sampleRate, int maxBlock, std::string& errorOut);
-    void deactivate();
+    bool activate (double sampleRate, int maxBlock, std::string& errorOut) override;
+    void deactivate() override;
 
     // Re-activate the SAME plugin at a new sample-rate / block-size (device-rate or
     // oversampling-factor change). Deactivate → activate without destroying the plugin,
     // so an open editor's GUI and the plugin's parameter state both survive. Caller
     // must fence the audio thread (engine process gate) around the call.
-    bool reactivate (double sampleRate, int maxBlock, std::string& errorOut);
+    bool reactivate (double sampleRate, int maxBlock, std::string& errorOut) override;
 
-    // Audio thread. Process `numFrames` (<= maxBlock) of stereo through the plugin:
-    // inL/inR → outL/outR. A null inR is treated as mono (duplicated). out may not
-    // alias in. Starts processing lazily on the first call. No-op if not active or
-    // numFrames is out of range.
+    bool isActive() const noexcept override { return active; }
+
+    // Audio thread. Bus-aware process entry [INativeInstance]: reads io.mainIn,
+    // writes io.mainOut (pointers into the caller's pre-sized scratch — the plugin
+    // writes CLAP output directly there, no instance-owned copy). Starts processing
+    // lazily on the first call. No-op if not active or io.numFrames is out of range.
+    void processBlock (const hosting::PortBuffers& io) noexcept override;
+
+    // Plugin-reported latency in samples at the active config (CLAP_EXT_LATENCY);
+    // 0 until activate() or if the plugin has no latency extension. [INativeInstance]
+    int getLatencySamples() const noexcept override { return latencySamples; }
+
+    // Audio thread. Legacy stereo entry — inL/inR → outL/outR through the plugin.
+    // Kept as the A/B reference for processBlock until the call sites migrate; the
+    // NativeInsertSlot + DSP call sites move to processBlock in a following phase.
     void processStereo (const float* inL, const float* inR,
                         float* outL, float* outR, int numFrames) noexcept;
 
@@ -67,8 +86,8 @@ public:
     // extension. saveState REPLACES `out` with the plugin's blob (clears it first);
     // loadState feeds `in` back. False if the plugin has no state extension or the
     // call fails. Used for session persistence of a native CLAP.
-    bool saveState (std::vector<uint8_t>& out) const;
-    bool loadState (const std::vector<uint8_t>& in);
+    bool saveState (std::vector<uint8_t>& out) const override;
+    bool loadState (const std::vector<uint8_t>& in) override;
 
     // Parameters (message thread). Enumerated once at create().
     int               paramCount() const noexcept { return (int) params.size(); }
@@ -84,9 +103,8 @@ public:
     void setParamValue (clap_id id, double value) noexcept;
 
     bool isCreated()      const noexcept { return plugin != nullptr; }
-    bool isActive()       const noexcept { return active; }
-    int  inputChannels()  const noexcept { return inCh; }
-    int  outputChannels() const noexcept { return outCh; }
+    int  inputChannels()  const noexcept { return layout.mainInChannels(); }
+    int  outputChannels() const noexcept { return layout.mainOutChannels(); }
 
     // For the editor: the live plugin + the host that owns its callback/pump state.
     const ::clap_plugin* getPlugin() const noexcept { return plugin; }
@@ -99,12 +117,20 @@ private:
     bool active     = false;
     bool processing = false;
     bool startFailed = false;   // plugin refused start_processing — stay asleep, don't retry every block
-    int  inCh = 0, outCh = 0;
     int  maxFrames = 0;
 
+    hosting::PortLayout layout;   // negotiated at create()
+    int latencySamples = 0;       // cached at activate() from CLAP_EXT_LATENCY
+
     // Separate input + output scratch so we never assume the plugin supports
-    // in-place processing. Sized in activate().
+    // in-place processing. Sized in activate(). Used by the legacy processStereo.
     std::vector<float> inScratchL, inScratchR, outScratchL, outScratchR;
+
+    // Per-channel pointer arrays the CLAP process buffers point at. processBlock
+    // fills these from PortBuffers each block (pointers into the caller's scratch),
+    // so the plugin writes its output straight there — no instance-owned audio copy.
+    // Sized in activate() to the negotiated channel counts.
+    std::vector<float*> clapInData, clapOutData;
 
     // Output event list handed to every process() call. We accept and ignore the
     // plugin's outgoing events for now (try_push returns true). Member, not a
@@ -124,6 +150,10 @@ private:
     std::vector<clap_event_param_value_t> eventScratch;   // sized in activate(), never RT-grown
     uint32_t             eventCount = 0;
     clap_input_events_t  inEvents {};
+
+    // Audio thread. Refills eventScratch[0..eventCount) from the param ring; shared
+    // by processStereo and processBlock.
+    void drainParamRing() noexcept;
 
     const clap_plugin_params_t* paramsExt = nullptr;
     std::vector<ParamInfo>      params;

--- a/src/engine/clap/NativeClapSlot.cpp
+++ b/src/engine/clap/NativeClapSlot.cpp
@@ -26,6 +26,7 @@ bool NativeClapSlot::load (const juce::File& path, double sampleRate, int maxBlo
     // `ready` pairs with this release so it never sees a half-built instance.
     bundle     = std::move (b);
     instance   = std::move (inst);
+    adapter.prepare (instance->portLayout(), maxBlock);   // size the fold scratch
     loadedPath = path.getFullPathName();
     ready.store (true, std::memory_order_release);
     return true;
@@ -36,7 +37,9 @@ bool NativeClapSlot::reactivate (double sampleRate, int maxBlock, std::string& e
     if (instance == nullptr) { errorOut = "no instance"; return false; }
     // `ready`/`instance` are unchanged across the call; the audio thread (fenced by the
     // engine gate) sees active==false mid-swap and no-ops, then resumes after activate.
-    return instance->reactivate (sampleRate, maxBlock, errorOut);
+    if (! instance->reactivate (sampleRate, maxBlock, errorOut)) return false;
+    adapter.prepare (instance->portLayout(), maxBlock);   // block size may have changed
+    return true;
 }
 
 void NativeClapSlot::unload()
@@ -68,33 +71,49 @@ bool NativeClapSlot::loadState (const std::vector<uint8_t>& in)
 void NativeClapSlot::processStereo (const float* inL, const float* inR,
                                     float* outL, float* outR, int numFrames) noexcept
 {
-    if (! ready.load (std::memory_order_acquire) || instance == nullptr)
+    auto clearOutputs = [&]
     {
-        if (numFrames > 0)
-        {
-            if (outL != nullptr) std::memset (outL, 0, sizeof (float) * (size_t) numFrames);
-            if (outR != nullptr) std::memset (outR, 0, sizeof (float) * (size_t) numFrames);
-        }
+        if (numFrames <= 0) return;
+        const size_t n = sizeof (float) * (size_t) numFrames;
+        if (outL != nullptr) std::memset (outL, 0, n);
+        if (outR != nullptr) std::memset (outR, 0, n);
+    };
+
+    // Clear when empty or momentarily inactive (mid-reactivate, fenced by the
+    // engine gate) — matches the pre-adapter behaviour of a no-op silent pass.
+    if (! ready.load (std::memory_order_acquire) || instance == nullptr
+        || ! instance->isActive() || inL == nullptr)
+    {
+        clearOutputs();
         return;
     }
+
+    if (numFrames <= 0) return;
+    const size_t n = sizeof (float) * (size_t) numFrames;
+
     if (bypassed.load (std::memory_order_relaxed))
     {
         // Passthrough — copy in→out (a no-op when called in-place).
-        if (numFrames > 0)
-        {
-            if (inL == nullptr)
-            {
-                if (outL != nullptr) std::memset (outL, 0, sizeof (float) * (size_t) numFrames);
-                if (outR != nullptr) std::memset (outR, 0, sizeof (float) * (size_t) numFrames);
-                return;
-            }
-            const size_t n = sizeof (float) * (size_t) numFrames;
-            if (outL != nullptr && outL != inL) std::memcpy (outL, inL, n);
-            const float* r = (inR != nullptr) ? inR : inL;
-            if (outR != nullptr && outR != r)   std::memcpy (outR, r, n);
-        }
+        if (outL != nullptr && outL != inL) std::memcpy (outL, inL, n);
+        const float* r = (inR != nullptr) ? inR : inL;
+        if (outR != nullptr && outR != r)   std::memcpy (outR, r, n);
         return;
     }
-    instance->processStereo (inL, inR, outL, outR, numFrames);
+
+    // The adapter needs both output buffers to process in place; a missing one is
+    // the same silent no-op the pre-adapter path gave it.
+    if (outL == nullptr || outR == nullptr)
+    {
+        clearOutputs();
+        return;
+    }
+
+    // The InsertAdapter processes in place, so stage the input into the output
+    // buffers first (a no-op for the in-place call sites where out == in).
+    if (outL != inL) std::memcpy (outL, inL, n);
+    const float* r = (inR != nullptr) ? inR : inL;
+    if (outR != r)  std::memcpy (outR, r, n);
+
+    adapter.process (*instance, outL, outR, numFrames);
 }
 } // namespace duskstudio::clap

--- a/src/engine/clap/NativeClapSlot.h
+++ b/src/engine/clap/NativeClapSlot.h
@@ -2,6 +2,7 @@
 
 #include "ClapBundle.h"
 #include "ClapInstance.h"
+#include "../hosting/InsertAdapter.h"
 
 #include <juce_core/juce_core.h>
 
@@ -65,8 +66,9 @@ public:
     void setParamValue (clap_id id, double value)
         { if (instance != nullptr) instance->setParamValue (id, value); }
 
-    // Audio thread: process stereo through the plugin; clears the outputs + returns
-    // when no plugin is loaded.
+    // Audio thread: process stereo through the plugin, via the InsertAdapter →
+    // INativeInstance::processBlock (the generalized host path). Clears the outputs
+    // + returns when no plugin is loaded; passes audio through when bypassed.
     void processStereo (const float* inL, const float* inR,
                         float* outL, float* outR, int numFrames) noexcept;
 
@@ -79,6 +81,9 @@ private:
     // vtable, which lives in the bundle's .so) must tear down before the .so unloads.
     std::unique_ptr<ClapBundle>   bundle;
     std::unique_ptr<ClapInstance> instance;
+    // Folds the mixer's stereo insert onto the plugin's negotiated layout. Prepared
+    // on load / reactivate; owns its own scratch (no plugin refs, teardown order-free).
+    hosting::InsertAdapter        adapter;
     std::atomic<bool> ready    { false };
     std::atomic<bool> bypassed { false };
     juce::String      loadedPath;

--- a/src/engine/hosting/INativeInstance.h
+++ b/src/engine/hosting/INativeInstance.h
@@ -9,7 +9,7 @@
 
 namespace duskstudio::hosting
 {
-// The format-agnostic contract a NativeInsertSlot drives, generalising the
+// The format-agnostic contract a plugin slot drives, generalising the
 // lifecycle ClapInstance already implements so VST3 / LV2 / CLAP instances are
 // interchangeable behind one pointer. Construction stays concrete (each format's
 // create() takes its own bundle + id / URI); this interface begins once the

--- a/src/engine/hosting/INativeInstance.h
+++ b/src/engine/hosting/INativeInstance.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "PortBuffers.h"
+#include "PortLayout.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace duskstudio::hosting
+{
+// The format-agnostic contract a NativeInsertSlot drives, generalising the
+// lifecycle ClapInstance already implements so VST3 / LV2 / CLAP instances are
+// interchangeable behind one pointer. Construction stays concrete (each format's
+// create() takes its own bundle + id / URI); this interface begins once the
+// plugin exists. Parameter enumeration + automation are added by a later phase
+// (they pull in NativeParamInfo); this base is the audio + lifecycle + state
+// contract that the DSP spine needs first.
+//
+// Threading, matching the CLAP host: activate / deactivate / reactivate /
+// saveState / loadState are message-thread; processBlock is the sole audio-thread
+// entry. The slot fences load/unload with the engine process gate.
+class INativeInstance
+{
+public:
+    virtual ~INativeInstance() = default;
+
+    // The negotiated bus/port shape. Valid after the concrete create(); stable
+    // until deactivate(). Message-thread read — the audio thread uses the slot's
+    // cached copy, not this vtable.
+    virtual const PortLayout& portLayout() const noexcept = 0;
+
+    // Message thread. Size every process-scratch buffer here; no RT allocation
+    // afterwards. False (+ errorOut) on failure.
+    virtual bool activate (double sampleRate, int maxBlockFrames, std::string& errorOut) = 0;
+    virtual void deactivate() = 0;
+
+    // Re-activate the SAME instance at a new sample-rate / block-size (device-rate
+    // or oversampling change) without destroying it, so an open editor survives.
+    // The caller fences the audio thread. LV2 re-instantiates internally (state
+    // saved + restored) because lilv fixes the rate at instantiate.
+    virtual bool reactivate (double sampleRate, int maxBlockFrames, std::string& errorOut) = 0;
+
+    virtual bool isActive() const noexcept = 0;
+
+    // Audio thread. Process one block. Every buffer in `io` is pre-sized; no
+    // allocation or locking here. No-op if inactive or io.numFrames is out of range.
+    virtual void processBlock (const PortBuffers& io) noexcept = 0;
+
+    // Message thread. Opaque state blob for session persistence. saveState
+    // REPLACES out. Formats with more than one state stream (VST3 component +
+    // controller) pack them length-prefixed into this single blob.
+    virtual bool saveState (std::vector<uint8_t>& out) const = 0;
+    virtual bool loadState (const std::vector<uint8_t>& in) = 0;
+
+    // Plugin-reported processing latency in samples at the active config; 0 until
+    // activate(). Fed into the engine's plugin-delay-compensation aggregator.
+    virtual int getLatencySamples() const noexcept = 0;
+};
+} // namespace duskstudio::hosting

--- a/src/engine/hosting/InsertAdapter.cpp
+++ b/src/engine/hosting/InsertAdapter.cpp
@@ -1,0 +1,116 @@
+#include "InsertAdapter.h"
+
+#include <cstring>
+
+namespace duskstudio::hosting
+{
+void InsertAdapter::repoint()
+{
+    inPtrs.resize ((size_t) inChans);
+    for (int c = 0; c < inChans; ++c)
+        inPtrs[(size_t) c] = inStore.data() + (size_t) c * (size_t) maxFrames;
+
+    outPtrs.resize ((size_t) outChans);
+    for (int c = 0; c < outChans; ++c)
+        outPtrs[(size_t) c] = outStore.data() + (size_t) c * (size_t) maxFrames;
+
+    scPtrs.resize ((size_t) scChans);
+    for (int c = 0; c < scChans; ++c)
+        scPtrs[(size_t) c] = scStore.data() + (size_t) c * (size_t) maxFrames;
+}
+
+void InsertAdapter::prepare (const PortLayout& layout, int maxBlockFrames)
+{
+    maxFrames = juce::jmax (0, maxBlockFrames);
+    inChans  = layout.mainInChannels();
+    outChans = layout.mainOutChannels();
+    scChans  = layout.hasSidechain()
+                 ? layout.inputs[(size_t) layout.sidechainInIndex].channelCount
+                 : 0;
+
+    inStore .assign ((size_t) inChans  * (size_t) maxFrames, 0.0f);
+    outStore.assign ((size_t) outChans * (size_t) maxFrames, 0.0f);
+    scStore .assign ((size_t) scChans  * (size_t) maxFrames, 0.0f);
+    repoint();
+}
+
+void InsertAdapter::process (INativeInstance& inst,
+                             float* L, float* R, int numFrames,
+                             const float* sidechainL,
+                             const float* sidechainR,
+                             const juce::MidiBuffer* midiIn,
+                             const juce::AudioPlayHead::PositionInfo* transport) noexcept
+{
+    if (! inst.isActive() || numFrames <= 0 || numFrames > maxFrames)
+        return;   // dry passthrough — leave L/R untouched
+
+    const auto n = (size_t) numFrames;
+
+    // ── INPUT FOLD: stereo L/R → the plugin's main-in channel count ──
+    if (inChans == 1)
+    {
+        // Sum to mono so a mono plugin hears both sides.
+        float* d = inStore.data();
+        for (int i = 0; i < numFrames; ++i)
+            d[i] = 0.5f * (L[i] + R[i]);
+    }
+    else if (inChans >= 2)
+    {
+        std::memcpy (inPtrs[0], L, n * sizeof (float));
+        std::memcpy (inPtrs[1], R, n * sizeof (float));
+        for (int c = 2; c < inChans; ++c)   // extra main-in channels (rare) get silence
+            juce::FloatVectorOperations::clear (inPtrs[(size_t) c], numFrames);
+    }
+    // inChans == 0 → instrument: no audio input to build.
+
+    // ── SIDECHAIN: fill the bus from the tap, or silence (never null) ──
+    if (scChans >= 1)
+    {
+        if (sidechainL != nullptr) std::memcpy (scPtrs[0], sidechainL, n * sizeof (float));
+        else                       juce::FloatVectorOperations::clear (scPtrs[0], numFrames);
+
+        if (scChans >= 2)
+        {
+            const float* r = sidechainR != nullptr ? sidechainR : sidechainL;   // mono source → dup
+            if (r != nullptr) std::memcpy (scPtrs[1], r, n * sizeof (float));
+            else              juce::FloatVectorOperations::clear (scPtrs[1], numFrames);
+
+            for (int c = 2; c < scChans; ++c)
+                juce::FloatVectorOperations::clear (scPtrs[(size_t) c], numFrames);
+        }
+    }
+
+    // Clear the output scratch so any main-out channel the plugin leaves
+    // unwritten reads as silence, not last block's data.
+    for (int c = 0; c < outChans; ++c)
+        juce::FloatVectorOperations::clear (outPtrs[(size_t) c], numFrames);
+
+    PortBuffers io;
+    io.mainIn              = inChans  > 0 ? inPtrs.data() : nullptr;
+    io.mainInChannels      = inChans;
+    io.mainOut             = outChans > 0 ? outPtrs.data() : nullptr;
+    io.mainOutChannels     = outChans;
+    io.sidechainIn         = scChans  > 0 ? scPtrs.data() : nullptr;
+    io.sidechainInChannels = scChans;
+    io.numFrames           = numFrames;
+    io.midiIn              = midiIn;
+    io.transport           = transport;
+
+    inst.processBlock (io);
+
+    // ── OUTPUT FOLD: the plugin's main-out → stereo L/R ──
+    if (outChans == 1)
+    {
+        const float* s = outPtrs[0];   // broadcast mono to both sides
+        std::memcpy (L, s, n * sizeof (float));
+        std::memcpy (R, s, n * sizeof (float));
+    }
+    else if (outChans >= 2)
+    {
+        std::memcpy (L, outPtrs[0], n * sizeof (float));
+        std::memcpy (R, outPtrs[1], n * sizeof (float));
+        // main-out channels >= 2 (multi-out) are dropped: an insert is stereo.
+    }
+    // outChans == 0 → nothing to fold; L/R pass through unchanged.
+}
+} // namespace duskstudio::hosting

--- a/src/engine/hosting/InsertAdapter.h
+++ b/src/engine/hosting/InsertAdapter.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "INativeInstance.h"
+#include "PortBuffers.h"
+#include "PortLayout.h"
+
+#include <vector>
+
+namespace duskstudio::hosting
+{
+// Reconciles a plugin's arbitrary negotiated PortLayout to the mixer's fixed
+// stereo-in / stereo-out insert contract. This is the ONE place the "an insert
+// is stereo" invariant lives:
+//
+//   * mono plugin  → the stereo feed is summed to a mono input, and the mono
+//                    output is broadcast back to L and R;
+//   * stereo plugin→ straight L/R through;
+//   * multi-out    → only main-out channels 0/1 reach the mixer; aux output
+//                    buses are dropped (an insert has nowhere to send them);
+//   * sidechain    → fed from the tap when routed, otherwise pre-sized silence
+//                    (never a null pointer — plugins may dereference it);
+//   * instrument   → no audio input; the plugin's output IS the signal.
+//
+// Owns every process-scratch buffer, sized once in prepare(); process() runs on
+// the audio thread and allocates nothing.
+class InsertAdapter
+{
+public:
+    // Message thread. Size scratch for `layout` at `maxBlockFrames`. Idempotent —
+    // safe to call again when the layout or block size changes.
+    void prepare (const PortLayout& layout, int maxBlockFrames);
+
+    // Audio thread. Run `inst` as a stereo insert over L/R in place. sidechainL/R
+    // feed the plugin's sidechain bus when it has one (null → silence). midiIn /
+    // transport are forwarded for instrument / tempo-synced plugins (null ok).
+    // Leaves L/R untouched (dry passthrough) if `inst` is inactive or numFrames
+    // exceeds the prepared maximum.
+    void process (INativeInstance& inst,
+                  float* L, float* R, int numFrames,
+                  const float* sidechainL = nullptr,
+                  const float* sidechainR = nullptr,
+                  const juce::MidiBuffer* midiIn = nullptr,
+                  const juce::AudioPlayHead::PositionInfo* transport = nullptr) noexcept;
+
+    int inputChannels()     const noexcept { return inChans; }
+    int outputChannels()    const noexcept { return outChans; }
+    int sidechainChannels() const noexcept { return scChans; }
+
+private:
+    void repoint();   // rebuild the per-channel pointer arrays into the stores
+
+    int maxFrames = 0;
+    int inChans = 0, outChans = 0, scChans = 0;
+
+    // Contiguous per-channel scratch; the pointer arrays below index into these.
+    // Kept mutable (float*) so we can fill them; float** converts implicitly to
+    // PortBuffers' const float* const* for the input / sidechain buses.
+    std::vector<float>  inStore, outStore, scStore;
+    std::vector<float*> inPtrs, outPtrs, scPtrs;
+};
+} // namespace duskstudio::hosting

--- a/src/engine/hosting/PortBuffers.h
+++ b/src/engine/hosting/PortBuffers.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>   // MidiBuffer, AudioPlayHead::PositionInfo
+
+namespace duskstudio::hosting
+{
+// The single audio-thread argument to INativeInstance::processBlock, replacing
+// the CLAP host's fixed (inL, inR, outL, outR, numFrames). Every pointer refers
+// to storage the caller/instance sized ahead of time — NOTHING here is allocated
+// or locked on the audio thread. Channel arrays are `float* const*` (an array of
+// per-channel pointers), so mono / stereo / multi-out all use one shape.
+//
+// juce::MidiBuffer and AudioPlayHead::PositionInfo are the engine's existing
+// currency for MIDI and transport; each host translates them into its own format
+// (VST3 Event, LV2 atom-midi, CLAP note events) internally.
+struct PortBuffers
+{
+    // Main audio I/O. The audio arrays are mutable (float* const*) because
+    // in-place-capable hosts — CLAP's clap_audio_buffer.data32, VST3's
+    // ProcessData — hand the plugin writable input buffers; the InsertAdapter
+    // owns and refills that storage each block, so a plugin scribbling on its
+    // input is harmless. The const is on the array, not the samples.
+    float* const* mainIn          = nullptr;
+    int           mainInChannels  = 0;
+    float* const* mainOut         = nullptr;
+    int           mainOutChannels = 0;
+
+    // Optional sidechain input. When a slot could take a sidechain but none is
+    // routed, the InsertAdapter feeds pre-sized silence rather than a null
+    // pointer — some plugins dereference their sidechain unconditionally.
+    float* const* sidechainIn         = nullptr;
+    int           sidechainInChannels = 0;
+
+    int numFrames = 0;
+
+    // Optional MIDI. midiIn drives instrument / MIDI-effect inserts; midiOut
+    // collects a plugin's emitted MIDI (null until a destination is wired).
+    const juce::MidiBuffer* midiIn  = nullptr;
+    juce::MidiBuffer*       midiOut = nullptr;
+
+    // Optional transport for tempo-synced plugins (null = not supplied).
+    const juce::AudioPlayHead::PositionInfo* transport = nullptr;
+};
+} // namespace duskstudio::hosting

--- a/src/engine/hosting/PortLayout.h
+++ b/src/engine/hosting/PortLayout.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace duskstudio::hosting
+{
+// The negotiated bus/port shape of a native plugin instance, produced ONCE at
+// load on the message thread and stable until the instance deactivates. This is
+// the single host-agnostic description that VST3 (setBusArrangements / getBusInfo),
+// LV2 (lilv port classification) and CLAP (audio_ports) all populate, so the
+// InsertAdapter and the audio-thread call sites never branch per format. It
+// replaces the two bare inCh/outCh ints the CLAP host carried.
+//
+// Message-thread only: the audio thread reads a cached copy held by the slot,
+// never walks this vector.
+struct BusInfo
+{
+    enum class Kind      { Audio, Event };
+    enum class Direction { Input, Output };
+    enum class Role      { Main, Aux, Sidechain };
+
+    Kind      kind        = Kind::Audio;
+    Direction dir         = Direction::Input;
+    Role      role        = Role::Main;
+    int       channelCount = 0;      // audio channels; 0 for event buses
+    bool      active       = false;  // did we activate / connect this bus?
+    bool      carriesMidi  = false;  // event bus that carries note / MIDI data
+    std::string name;
+};
+
+struct PortLayout
+{
+    std::vector<BusInfo> inputs;
+    std::vector<BusInfo> outputs;
+
+    // Indices into inputs / outputs, or -1 when absent. The main audio buses are
+    // what the mixer insert feeds; sidechain + event buses are optional.
+    int  mainInIndex      = -1;
+    int  mainOutIndex     = -1;
+    int  sidechainInIndex = -1;
+    int  eventInIndex     = -1;
+    int  eventOutIndex    = -1;
+
+    // MIDI-in + audio-out with no main audio input: the plugin IS the source
+    // (see the instrument branch in ChannelStrip), not an in-line processor.
+    bool isInstrument = false;
+
+    int  mainInChannels() const noexcept
+        { return mainInIndex  >= 0 ? inputs [(size_t) mainInIndex ].channelCount : 0; }
+    int  mainOutChannels() const noexcept
+        { return mainOutIndex >= 0 ? outputs[(size_t) mainOutIndex].channelCount : 0; }
+    bool hasSidechain() const noexcept { return sidechainInIndex >= 0; }
+    bool acceptsMidi()  const noexcept { return eventInIndex     >= 0; }
+    bool emitsMidi()    const noexcept { return eventOutIndex    >= 0; }
+};
+} // namespace duskstudio::hosting

--- a/src/engine/lv2/Lv2Bundle.cpp
+++ b/src/engine/lv2/Lv2Bundle.cpp
@@ -28,44 +28,10 @@ bool Lv2Bundle::load (const std::string& path, std::string& errorOut)
     lilv_world_load_bundle (world, bundleUri);
     lilv_node_free (bundleUri);
 
-    LilvNode* audioClass  = lilv_new_uri (world, LILV_URI_AUDIO_PORT);
-    LilvNode* inputClass  = lilv_new_uri (world, LILV_URI_INPUT_PORT);
-    LilvNode* atomClass   = lilv_new_uri (world, LILV_URI_ATOM_PORT);
-
     descriptors.clear();
     const LilvPlugins* allPlugins = lilv_world_get_all_plugins (world);
     LILV_FOREACH (plugins, it, allPlugins)
-    {
-        const LilvPlugin* p = lilv_plugins_get (allPlugins, it);
-
-        PluginDesc d;
-        d.uri = lilv_node_as_uri (lilv_plugin_get_uri (p));
-        if (LilvNode* nameNode = lilv_plugin_get_name (p))
-        {
-            d.name = lilv_node_as_string (nameNode);
-            lilv_node_free (nameNode);
-        }
-
-        int atomInputs = 0;
-        const uint32_t numPorts = lilv_plugin_get_num_ports (p);
-        for (uint32_t i = 0; i < numPorts; ++i)
-        {
-            const LilvPort* port = lilv_plugin_get_port_by_index (p, i);
-            const bool isInput = lilv_port_is_a (p, port, inputClass);
-            if (lilv_port_is_a (p, port, audioClass))
-                (isInput ? d.audioInputs : d.audioOutputs) += 1;
-            else if (isInput && lilv_port_is_a (p, port, atomClass))
-                ++atomInputs;
-        }
-        // Instrument: takes MIDI/atom in, produces audio, but has no audio input.
-        d.isInstrument = (d.audioInputs == 0 && atomInputs > 0 && d.audioOutputs > 0);
-
-        descriptors.push_back (std::move (d));
-    }
-
-    lilv_node_free (audioClass);
-    lilv_node_free (inputClass);
-    lilv_node_free (atomClass);
+        descriptors.push_back (describePlugin (world, lilv_plugins_get (allPlugins, it)));
 
     if (descriptors.empty())
     { errorOut = "no plugins advertised by bundle: " + path; lilv_world_free (world); return false; }
@@ -84,6 +50,43 @@ void Lv2Bundle::unload()
     }
     descriptors.clear();
     bundlePath.clear();
+}
+
+PluginDesc Lv2Bundle::describePlugin (void* worldHandle, const void* pluginHandle)
+{
+    auto* world = static_cast<LilvWorld*> (worldHandle);
+    const auto* p = static_cast<const LilvPlugin*> (pluginHandle);
+
+    LilvNode* audioClass = lilv_new_uri (world, LILV_URI_AUDIO_PORT);
+    LilvNode* inputClass = lilv_new_uri (world, LILV_URI_INPUT_PORT);
+    LilvNode* atomClass  = lilv_new_uri (world, LILV_URI_ATOM_PORT);
+
+    PluginDesc d;
+    d.uri = lilv_node_as_uri (lilv_plugin_get_uri (p));
+    if (LilvNode* nameNode = lilv_plugin_get_name (p))
+    {
+        d.name = lilv_node_as_string (nameNode);
+        lilv_node_free (nameNode);
+    }
+
+    int atomInputs = 0;
+    const uint32_t numPorts = lilv_plugin_get_num_ports (p);
+    for (uint32_t i = 0; i < numPorts; ++i)
+    {
+        const LilvPort* port = lilv_plugin_get_port_by_index (p, i);
+        const bool isInput = lilv_port_is_a (p, port, inputClass);
+        if (lilv_port_is_a (p, port, audioClass))
+            (isInput ? d.audioInputs : d.audioOutputs) += 1;
+        else if (isInput && lilv_port_is_a (p, port, atomClass))
+            ++atomInputs;
+    }
+    // Instrument: takes MIDI/atom in, produces audio, but has no audio input.
+    d.isInstrument = (d.audioInputs == 0 && atomInputs > 0 && d.audioOutputs > 0);
+
+    lilv_node_free (audioClass);
+    lilv_node_free (inputClass);
+    lilv_node_free (atomClass);
+    return d;
 }
 
 const void* Lv2Bundle::pluginByUri (const std::string& uri) const

--- a/src/engine/lv2/Lv2Bundle.cpp
+++ b/src/engine/lv2/Lv2Bundle.cpp
@@ -1,0 +1,99 @@
+#include "Lv2Bundle.h"
+
+#include <lilv/lilv.h>
+
+#include <cstdint>
+
+namespace duskstudio::lv2
+{
+Lv2Bundle::~Lv2Bundle() { unload(); }
+
+bool Lv2Bundle::load (const std::string& path, std::string& errorOut)
+{
+    unload();
+
+    LilvWorld* world = lilv_world_new();
+    if (world == nullptr) { errorOut = "lilv_world_new failed"; return false; }
+
+    // A bundle URI must end in '/', or lilv resolves the manifest's relative
+    // includes (dsp.ttl, ui.ttl) against the PARENT directory and silently loses
+    // the port/DSP metadata. Normalise the trailing slash before making the URI.
+    std::string dir = path;
+    if (! dir.empty() && dir.back() != '/') dir += '/';
+
+    // Load only this bundle, not the whole LV2_PATH — fast and side-effect-free.
+    LilvNode* bundleUri = lilv_new_file_uri (world, nullptr, dir.c_str());
+    if (bundleUri == nullptr)
+    { errorOut = "invalid bundle path: " + path; lilv_world_free (world); return false; }
+    lilv_world_load_bundle (world, bundleUri);
+    lilv_node_free (bundleUri);
+
+    LilvNode* audioClass  = lilv_new_uri (world, LILV_URI_AUDIO_PORT);
+    LilvNode* inputClass  = lilv_new_uri (world, LILV_URI_INPUT_PORT);
+    LilvNode* atomClass   = lilv_new_uri (world, LILV_URI_ATOM_PORT);
+
+    descriptors.clear();
+    const LilvPlugins* allPlugins = lilv_world_get_all_plugins (world);
+    LILV_FOREACH (plugins, it, allPlugins)
+    {
+        const LilvPlugin* p = lilv_plugins_get (allPlugins, it);
+
+        PluginDesc d;
+        d.uri = lilv_node_as_uri (lilv_plugin_get_uri (p));
+        if (LilvNode* nameNode = lilv_plugin_get_name (p))
+        {
+            d.name = lilv_node_as_string (nameNode);
+            lilv_node_free (nameNode);
+        }
+
+        int atomInputs = 0;
+        const uint32_t numPorts = lilv_plugin_get_num_ports (p);
+        for (uint32_t i = 0; i < numPorts; ++i)
+        {
+            const LilvPort* port = lilv_plugin_get_port_by_index (p, i);
+            const bool isInput = lilv_port_is_a (p, port, inputClass);
+            if (lilv_port_is_a (p, port, audioClass))
+                (isInput ? d.audioInputs : d.audioOutputs) += 1;
+            else if (isInput && lilv_port_is_a (p, port, atomClass))
+                ++atomInputs;
+        }
+        // Instrument: takes MIDI/atom in, produces audio, but has no audio input.
+        d.isInstrument = (d.audioInputs == 0 && atomInputs > 0 && d.audioOutputs > 0);
+
+        descriptors.push_back (std::move (d));
+    }
+
+    lilv_node_free (audioClass);
+    lilv_node_free (inputClass);
+    lilv_node_free (atomClass);
+
+    if (descriptors.empty())
+    { errorOut = "no plugins advertised by bundle: " + path; lilv_world_free (world); return false; }
+
+    worldHandle = world;
+    bundlePath  = path;
+    return true;
+}
+
+void Lv2Bundle::unload()
+{
+    if (worldHandle != nullptr)
+    {
+        lilv_world_free (static_cast<LilvWorld*> (worldHandle));
+        worldHandle = nullptr;
+    }
+    descriptors.clear();
+    bundlePath.clear();
+}
+
+const void* Lv2Bundle::pluginByUri (const std::string& uri) const
+{
+    if (worldHandle == nullptr) return nullptr;
+    auto* world = static_cast<LilvWorld*> (worldHandle);
+    const LilvPlugins* allPlugins = lilv_world_get_all_plugins (world);
+    LilvNode* uriNode = lilv_new_uri (world, uri.c_str());
+    const LilvPlugin* p = lilv_plugins_get_by_uri (allPlugins, uriNode);
+    lilv_node_free (uriNode);
+    return p;
+}
+} // namespace duskstudio::lv2

--- a/src/engine/lv2/Lv2Bundle.h
+++ b/src/engine/lv2/Lv2Bundle.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace duskstudio::lv2
+{
+// One plugin advertised by an LV2 bundle's manifest.
+struct PluginDesc
+{
+    std::string uri;    // the stable plugin URI — the id persisted in sessions
+    std::string name;
+    int  audioInputs  = 0;
+    int  audioOutputs = 0;
+    bool isInstrument = false;   // atom/MIDI input, no audio input, has audio output
+};
+
+// Owns a private LilvWorld, loads a single .lv2 bundle directory into it, and
+// enumerates the plugins that bundle advertises (URI, name, audio-port counts).
+// RAII: lilv_world_free on destruction. Message thread only — not real-time safe.
+//
+// LV2's analog of ClapBundle. lilv types stay out of this header (opaque void*
+// handles); the instance layer includes lilv and casts. This stage only loads +
+// enumerates; instance / process / editor land in later increments.
+class Lv2Bundle
+{
+public:
+    Lv2Bundle() = default;
+    ~Lv2Bundle();
+    Lv2Bundle (const Lv2Bundle&)            = delete;
+    Lv2Bundle& operator= (const Lv2Bundle&) = delete;
+
+    // Load the .lv2 bundle directory at `bundlePath`. False (+ errorOut) on failure;
+    // the bundle is left unloaded. A successful load leaves the world alive.
+    bool load (const std::string& bundlePath, std::string& errorOut);
+    void unload();
+
+    bool isLoaded() const noexcept { return worldHandle != nullptr; }
+
+    const std::vector<PluginDesc>& plugins() const noexcept { return descriptors; }
+    const std::string&             getPath() const noexcept { return bundlePath; }
+
+    // Opaque accessors for the instance layer (keeps lilv out of this header):
+    // world() is a LilvWorld*, pluginByUri() a const LilvPlugin* (null if absent).
+    void*       world() const noexcept { return worldHandle; }
+    const void* pluginByUri (const std::string& uri) const;
+
+private:
+    void* worldHandle = nullptr;   // LilvWorld*
+    std::vector<PluginDesc> descriptors;
+    std::string bundlePath;
+};
+} // namespace duskstudio::lv2

--- a/src/engine/lv2/Lv2Bundle.h
+++ b/src/engine/lv2/Lv2Bundle.h
@@ -45,6 +45,12 @@ public:
     void*       world() const noexcept { return worldHandle; }
     const void* pluginByUri (const std::string& uri) const;
 
+    // Build a PluginDesc from a lilv plugin (walks its ports once). Shared by the
+    // bundle enumeration and the Lv2Scanner so the audio-effect / instrument
+    // classification lives in one place. `world` is a LilvWorld*, `plugin` a
+    // const LilvPlugin*.
+    static PluginDesc describePlugin (void* world, const void* plugin);
+
 private:
     void* worldHandle = nullptr;   // LilvWorld*
     std::vector<PluginDesc> descriptors;

--- a/src/engine/lv2/Lv2Editor.cpp
+++ b/src/engine/lv2/Lv2Editor.cpp
@@ -1,0 +1,296 @@
+#include "Lv2Editor.h"
+#include "Lv2Instance.h"
+
+#include <lilv/lilv.h>
+#include <suil/suil.h>
+#include <lv2/data-access/data-access.h>
+#include <lv2/instance-access/instance-access.h>
+#include <lv2/ui/ui.h>
+#include <lv2/urid/urid.h>
+
+#include <X11/Xlib.h>
+
+#include <algorithm>
+#include <cstring>
+#include <vector>
+
+namespace duskstudio::lv2
+{
+struct Lv2Editor::Impl
+{
+    Lv2Editor*   owner    = nullptr;
+    Lv2Instance* instance = nullptr;
+
+    // Discovered UI (URIs + paths copied out of lilv at open()).
+    std::string uiUri, uiTypeUri, uiBundlePath, uiBinaryPath, pluginUri;
+
+    SuilHost*     suilHost     = nullptr;
+    SuilInstance* suilInstance = nullptr;
+
+    void*         display    = nullptr;   // Display*
+    unsigned long hostWindow = 0;         // our container Window
+    unsigned long uiWindow   = 0;         // suil widget's Window (child of hostWindow)
+
+    // ui:idleInterface, queried from the instantiated UI. Optional.
+    const LV2UI_Idle_Interface* idleIface = nullptr;
+
+    // Feature payloads handed to suil_instance_new — must outlive the instance.
+    LV2UI_Resize               resizeData {};
+    LV2_Extension_Data_Feature extData {};
+    LV2_Feature parentFeature {}, instanceFeature {}, dataFeature {},
+                resizeFeature {}, idleFeature {};
+    std::vector<const LV2_Feature*> features;
+
+    int  prefW = 0, prefH = 0;
+    bool discovered = false, embedded = false, mapped = false, leakOnClose = false;
+
+    // ── suil host callbacks (message thread: the UI runs off our idle pump) ──
+    static void writePort (SuilController c, uint32_t portIndex, uint32_t bufferSize,
+                           uint32_t protocol, const void* buffer)
+    {
+        auto* self = static_cast<Impl*> (c);
+        // ui:floatProtocol only — atom/event writes need a plugin-input atom
+        // routing that isn't wired yet.
+        if (protocol == 0 && bufferSize == sizeof (float) && self->instance != nullptr)
+            self->instance->setControlPortValue (portIndex,
+                                                 *static_cast<const float*> (buffer));
+    }
+
+    static uint32_t portIndex (SuilController c, const char* symbol)
+    {
+        auto* self = static_cast<Impl*> (c);
+        const int idx = self->instance != nullptr
+                          ? self->instance->portIndexForSymbol (symbol) : -1;
+        return idx >= 0 ? (uint32_t) idx : LV2UI_INVALID_PORT_INDEX;
+    }
+
+    static int uiResize (LV2UI_Feature_Handle handle, int w, int h)
+    {
+        auto* self = static_cast<Impl*> (handle);
+        if (w <= 0 || h <= 0) return 1;
+        self->prefW = w; self->prefH = h;
+        if (self->display != nullptr && self->hostWindow != 0)
+        {
+            XResizeWindow ((Display*) self->display, self->hostWindow,
+                           (unsigned) w, (unsigned) h);
+            XFlush ((Display*) self->display);
+        }
+        if (self->owner->onResize) self->owner->onResize (w, h);
+        return 0;
+    }
+};
+
+Lv2Editor::Lv2Editor() : impl (std::make_unique<Impl>()) { impl->owner = this; }
+Lv2Editor::~Lv2Editor() { close(); }
+
+void Lv2Editor::setLeakOnClose (bool b) noexcept { impl->leakOnClose = b; }
+int  Lv2Editor::preferredWidth()  const noexcept { return impl->prefW; }
+int  Lv2Editor::preferredHeight() const noexcept { return impl->prefH; }
+bool Lv2Editor::isOpen()     const noexcept { return impl->discovered; }
+bool Lv2Editor::isEmbedded() const noexcept { return impl->embedded; }
+
+bool Lv2Editor::open (Lv2Instance& inst, std::string& errorOut)
+{
+    const auto* plugin = static_cast<const LilvPlugin*> (inst.lilvPlugin());
+    if (plugin == nullptr) { errorOut = "instance has no plugin"; return false; }
+    impl->instance  = &inst;
+    impl->pluginUri = lilv_node_as_uri (lilv_plugin_get_uri (plugin));
+
+    LilvUIs* uis = lilv_plugin_get_uis (plugin);
+    if (uis == nullptr || lilv_uis_size (uis) == 0)
+    { lilv_uis_free (uis); errorOut = "plugin has no UI"; return false; }
+
+    // Pick the best-supported UI for an X11 container: 1 = native X11UI,
+    // higher = wrappable by a suil module. Lower nonzero quality wins.
+    auto* world = static_cast<LilvWorld*> (inst.lilvWorld());
+    LilvNode* x11Container = lilv_new_uri (world, LV2_UI__X11UI);
+
+    unsigned bestQuality = 0;
+    LILV_FOREACH (uis, it, uis)
+    {
+        const LilvUI* ui = lilv_uis_get (uis, it);
+        const LilvNode* uiType = nullptr;
+        const unsigned q = lilv_ui_is_supported (ui, suil_ui_supported, x11Container, &uiType);
+        if (q == 0) continue;
+        if (bestQuality == 0 || q < bestQuality)
+        {
+            bestQuality = q;
+            impl->uiUri     = lilv_node_as_uri (lilv_ui_get_uri (ui));
+            impl->uiTypeUri = uiType != nullptr ? lilv_node_as_uri (uiType) : LV2_UI__X11UI;
+            char* bundle = lilv_file_uri_parse (lilv_node_as_uri (lilv_ui_get_bundle_uri (ui)), nullptr);
+            char* binary = lilv_file_uri_parse (lilv_node_as_uri (lilv_ui_get_binary_uri (ui)), nullptr);
+            impl->uiBundlePath = bundle != nullptr ? bundle : "";
+            impl->uiBinaryPath = binary != nullptr ? binary : "";
+            lilv_free (bundle);
+            lilv_free (binary);
+        }
+    }
+    lilv_node_free (x11Container);
+    lilv_uis_free (uis);
+
+    if (bestQuality == 0)
+    { errorOut = "plugin has no X11-embeddable UI"; return false; }
+
+    impl->discovered = true;
+    return true;
+}
+
+bool Lv2Editor::embed (unsigned long parentX11, int x, int y, int w, int h, std::string& errorOut)
+{
+    if (! impl->discovered) { errorOut = "no UI discovered"; return false; }
+    if (impl->embedded) return true;
+
+    auto* dpy = XOpenDisplay (nullptr);
+    if (dpy == nullptr) { errorOut = "XOpenDisplay failed"; return false; }
+    impl->display = dpy;
+
+    const int ww = w > 0 ? w : 480;
+    const int hh = h > 0 ? h : 320;
+
+    // Solid background (not None) so the map fills with black instead of stale
+    // framebuffer — same rationale as ClapEditor::embed.
+    XSetWindowAttributes swa {};
+    swa.background_pixel = BlackPixel (dpy, DefaultScreen (dpy));
+    swa.border_pixel     = 0;
+    swa.event_mask       = StructureNotifyMask;
+    impl->hostWindow = XCreateWindow (dpy, (Window) parentX11, x, y,
+                                      (unsigned) ww, (unsigned) hh, 0,
+                                      CopyFromParent, InputOutput, CopyFromParent,
+                                      CWBackPixel | CWBorderPixel | CWEventMask, &swa);
+    // Viewable BEFORE the UI instantiates into it — toolkit wrappers (and JUCE-
+    // wrapped UIs) can abort realising into an unmapped parent.
+    XMapWindow (dpy, impl->hostWindow);
+    XSync (dpy, False);
+
+    if (impl->suilHost == nullptr)
+        impl->suilHost = suil_host_new (&Impl::writePort, &Impl::portIndex, nullptr, nullptr);
+
+    // Features: the instance's URID map/unmap (shared URID space), the parent
+    // window, instance/data access for UIs that reach into their DSP side, and
+    // our ui:resize handler. idleInterface is declared so UIs can rely on it.
+    impl->resizeData = { impl.get(), &Impl::uiResize };
+    auto* lilvInst = static_cast<LilvInstance*> (impl->instance->lilvInstance());
+    impl->extData  = { lilvInst != nullptr ? lilv_instance_get_descriptor (lilvInst)->extension_data
+                                           : nullptr };
+    impl->parentFeature   = { LV2_UI__parent,          (void*) (uintptr_t) impl->hostWindow };
+    impl->instanceFeature = { LV2_INSTANCE_ACCESS_URI, lilvInst != nullptr
+                                                         ? lilv_instance_get_handle (lilvInst) : nullptr };
+    impl->dataFeature     = { LV2_DATA_ACCESS_URI,     &impl->extData };
+    impl->resizeFeature   = { LV2_UI__resize,          &impl->resizeData };
+    impl->idleFeature     = { LV2_UI__idleInterface,   nullptr };
+    impl->features = {
+        static_cast<const LV2_Feature*> (impl->instance->uridMapFeature()),
+        static_cast<const LV2_Feature*> (impl->instance->uridUnmapFeature()),
+        &impl->parentFeature, &impl->instanceFeature, &impl->dataFeature,
+        &impl->resizeFeature, &impl->idleFeature, nullptr };
+
+    impl->suilInstance = suil_instance_new (impl->suilHost, impl.get(), LV2_UI__X11UI,
+                                            impl->pluginUri.c_str(),
+                                            impl->uiUri.c_str(), impl->uiTypeUri.c_str(),
+                                            impl->uiBundlePath.c_str(),
+                                            impl->uiBinaryPath.c_str(),
+                                            impl->features.data());
+    if (impl->suilInstance == nullptr)
+    { errorOut = "suil_instance_new failed"; close(); return false; }
+
+    impl->uiWindow = (unsigned long) (uintptr_t) suil_instance_get_widget (impl->suilInstance);
+    if (impl->uiWindow == 0)
+    { errorOut = "UI produced no widget"; close(); return false; }
+
+    impl->idleIface = static_cast<const LV2UI_Idle_Interface*> (
+        suil_instance_extension_data (impl->suilInstance, LV2_UI__idleInterface));
+
+    // Size: the UI's own window tells us its preferred size unless ui:resize
+    // already did; fit the widget to our host area either way.
+    XWindowAttributes attrs {};
+    if (impl->prefW <= 0 && XGetWindowAttributes (dpy, (Window) impl->uiWindow, &attrs) != 0)
+    { impl->prefW = attrs.width; impl->prefH = attrs.height; }
+
+    XResizeWindow (dpy, (Window) impl->uiWindow, (unsigned) std::max (1, ww),
+                   (unsigned) std::max (1, hh));
+    XMapWindow (dpy, (Window) impl->uiWindow);
+    XSync (dpy, False);
+
+    impl->embedded = true;
+    impl->mapped   = true;
+    return true;
+}
+
+void Lv2Editor::setBounds (int x, int y, int w, int h)
+{
+    if (impl->display == nullptr || impl->hostWindow == 0) return;
+    auto* dpy = (Display*) impl->display;
+    XMoveResizeWindow (dpy, (Window) impl->hostWindow, x, y,
+                       (unsigned) std::max (1, w), (unsigned) std::max (1, h));
+    if (impl->uiWindow != 0)
+        XResizeWindow (dpy, (Window) impl->uiWindow,
+                       (unsigned) std::max (1, w), (unsigned) std::max (1, h));
+    XFlush (dpy);
+}
+
+void Lv2Editor::reveal()
+{
+    if (impl->display == nullptr || impl->hostWindow == 0 || impl->mapped) return;
+    XMapWindow ((Display*) impl->display, (Window) impl->hostWindow);
+    XFlush ((Display*) impl->display);
+    impl->mapped = true;
+}
+
+void Lv2Editor::hide()
+{
+    if (impl->display == nullptr || impl->hostWindow == 0 || ! impl->mapped) return;
+    XUnmapWindow ((Display*) impl->display, (Window) impl->hostWindow);
+    XFlush ((Display*) impl->display);
+    impl->mapped = false;
+}
+
+void Lv2Editor::close()
+{
+    if (! impl->leakOnClose)
+    {
+        if (impl->suilInstance != nullptr) suil_instance_free (impl->suilInstance);
+        if (impl->suilHost != nullptr)     suil_host_free (impl->suilHost);
+    }
+    impl->suilInstance = nullptr;
+    impl->suilHost     = nullptr;
+    impl->idleIface    = nullptr;
+
+    if (impl->display != nullptr)
+    {
+        if (impl->hostWindow != 0)
+            XDestroyWindow ((Display*) impl->display, (Window) impl->hostWindow);
+        // Flush the destroy against a still-valid parent peer before dropping the
+        // connection (see ClapEditor::close).
+        XSync ((Display*) impl->display, False);
+        XCloseDisplay ((Display*) impl->display);
+        impl->display = nullptr;
+    }
+    impl->hostWindow = impl->uiWindow = 0;
+    impl->discovered = impl->embedded = impl->mapped = false;
+}
+
+void Lv2Editor::pump()
+{
+    if (impl->embedded && impl->idleIface != nullptr && impl->suilInstance != nullptr)
+    {
+        // Non-zero: the UI wants to close (spec: "non-zero if the UI has been
+        // closed"). Report once; the owner tears us down.
+        if (impl->idleIface->idle (suil_instance_get_handle (impl->suilInstance)) != 0)
+        {
+            impl->idleIface = nullptr;
+            if (onClosed) onClosed();
+            return;
+        }
+    }
+
+    if (impl->display != nullptr)
+    {
+        auto* dpy = (Display*) impl->display;
+        while (XPending (dpy) > 0)
+        {
+            XEvent e;
+            XNextEvent (dpy, &e);
+        }
+    }
+}
+} // namespace duskstudio::lv2

--- a/src/engine/lv2/Lv2Editor.cpp
+++ b/src/engine/lv2/Lv2Editor.cpp
@@ -210,6 +210,12 @@ bool Lv2Editor::embed (unsigned long parentX11, int x, int y, int w, int h, std:
     // doesn't force it — reparent explicitly (a no-op when already a child).
     XReparentWindow (dpy, (Window) impl->uiWindow, (Window) impl->hostWindow, 0, 0);
 
+    // A UI that reports no size and never fires ui:resize would otherwise keep an
+    // arbitrary widget size forever (the component only adopts prefW when > 0).
+    if (impl->prefW <= 0)
+        XResizeWindow (dpy, (Window) impl->uiWindow,
+                       (unsigned) std::max (1, ww), (unsigned) std::max (1, hh));
+
     XMapWindow (dpy, (Window) impl->uiWindow);
     XSync (dpy, False);
 

--- a/src/engine/lv2/Lv2Editor.cpp
+++ b/src/engine/lv2/Lv2Editor.cpp
@@ -206,8 +206,10 @@ bool Lv2Editor::embed (unsigned long parentX11, int x, int y, int w, int h, std:
     if (impl->prefW <= 0 && XGetWindowAttributes (dpy, (Window) impl->uiWindow, &attrs) != 0)
     { impl->prefW = attrs.width; impl->prefH = attrs.height; }
 
-    XResizeWindow (dpy, (Window) impl->uiWindow, (unsigned) std::max (1, ww),
-                   (unsigned) std::max (1, hh));
+    // Belt-and-braces: most UIs parent themselves under ui:parent, but the spec
+    // doesn't force it — reparent explicitly (a no-op when already a child).
+    XReparentWindow (dpy, (Window) impl->uiWindow, (Window) impl->hostWindow, 0, 0);
+
     XMapWindow (dpy, (Window) impl->uiWindow);
     XSync (dpy, False);
 

--- a/src/engine/lv2/Lv2Editor.h
+++ b/src/engine/lv2/Lv2Editor.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace duskstudio::lv2
+{
+class Lv2Instance;
+
+// Native X11 editor embed for an LV2 plugin UI via suil (Linux). Owns a host X11
+// window created as a child of the app's window; suil instantiates the plugin's
+// UI into it (X11UI natively, foreign toolkits through suil's wrapper modules)
+// and the UI's ui:idleInterface is driven from pump() on the message thread.
+//
+// Lifecycle mirrors ClapEditor with one structural difference: an LV2 UI takes
+// its ui:parent at instantiate time, so open() only discovers the UI and the
+// real instantiation happens in embed() — there is no pre-built unmapped stage.
+//
+// No X11 / lilv / suil types leak here: everything lives behind the pImpl.
+class Lv2Editor
+{
+public:
+    Lv2Editor();
+    ~Lv2Editor();
+    Lv2Editor (const Lv2Editor&)            = delete;
+    Lv2Editor& operator= (const Lv2Editor&) = delete;
+
+    // Discover an embeddable UI for the (created + activated) instance: native
+    // X11UI preferred, else the best UI suil can wrap into X11. False (+errorOut)
+    // when the plugin ships no usable UI. Keeps a reference to `inst` — the slot
+    // owning it must outlive this editor.
+    bool open (Lv2Instance& inst, std::string& errorOut);
+
+    // Create the host X11 window under parentX11 at (x,y,w,h), instantiate the
+    // UI into it via suil, and map it.
+    bool embed (unsigned long parentX11, int x, int y, int w, int h, std::string& errorOut);
+
+    void setBounds (int x, int y, int w, int h);
+    void reveal();   // XMapWindow (idempotent)
+    void hide();     // XUnmapWindow (idempotent)
+    void close();
+
+    // App shutdown: skip suil_instance_free — a foreign-toolkit UI's destructor
+    // can hang on the way out (same rationale as the CLAP editor leak path).
+    void setLeakOnClose (bool b) noexcept;
+
+    // Message thread, ~60 Hz: drive ui:idleInterface + drain our X connection.
+    void pump();
+
+    int  preferredWidth()  const noexcept;
+    int  preferredHeight() const noexcept;
+    bool isOpen()     const noexcept;
+    bool isEmbedded() const noexcept;
+
+    // The UI asked to resize (ui:resize host feature) / reported it closed.
+    std::function<void (int, int)> onResize;
+    std::function<void()>          onClosed;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl;
+};
+} // namespace duskstudio::lv2

--- a/src/engine/lv2/Lv2Instance.cpp
+++ b/src/engine/lv2/Lv2Instance.cpp
@@ -10,6 +10,7 @@
 #include <lv2/urid/urid.h>
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <cmath>
 #include <cstdint>
@@ -107,6 +108,20 @@ struct Lv2Instance::Impl
     // Per-port scratch backing otherPorts: maxFrames floats each, so an audio-rate
     // CV port can safely read silence or sink its output.
     std::vector<std::vector<float>> otherScratch;
+
+    // Baseline audio-port buffers: every audio port is wired to these at activate()
+    // so the LV2 every-port-connected invariant holds even if a caller supplies
+    // fewer channels than the layout advertises; processBlock re-points the main
+    // channels each block. Inputs share the silence, outputs share the sink.
+    std::vector<float> audioSilence, audioSink;
+
+    // UI → audio-thread control-port writes. The UI must not store into portValues
+    // directly (run() reads it concurrently); writes stage here and processBlock
+    // drains them before run(). Same SPSC shape as the CLAP host's param ring.
+    struct PortWrite { uint32_t idx; float value; };
+    static constexpr uint32_t kWriteRingCap = 256;
+    std::array<PortWrite, kWriteRingCap> writeRing {};
+    std::atomic<uint32_t> writeRingW { 0 }, writeRingR { 0 };
 
     // Persistent per-port float storage; control ports are connected to these once
     // and hold their (default) value across blocks. Sized to the port count.
@@ -278,6 +293,15 @@ bool Lv2Instance::activate (double sampleRate, int maxBlockFrames, std::string& 
         lilv_instance_connect_port (impl->instance, idx, impl->otherScratch.back().data());
     }
 
+    // Baseline audio-port wiring (see Impl::audioSilence) — processBlock overrides
+    // the main channels every block.
+    impl->audioSilence.assign ((size_t) impl->maxFrames, 0.0f);
+    impl->audioSink.assign ((size_t) impl->maxFrames, 0.0f);
+    for (uint32_t idx : impl->audioInPorts)
+        lilv_instance_connect_port (impl->instance, idx, impl->audioSilence.data());
+    for (uint32_t idx : impl->audioOutPorts)
+        lilv_instance_connect_port (impl->instance, idx, impl->audioSink.data());
+
     // Seed latency with the port default so getLatencySamples() is sane before the
     // first run() refreshes it.
     impl->latencySamples.store (impl->latencyPortIndex >= 0
@@ -336,6 +360,20 @@ void Lv2Instance::processBlock (const hosting::PortBuffers& io) noexcept
     for (int c = 0; c < nout; ++c)
         lilv_instance_connect_port (impl->instance, impl->audioOutPorts[(size_t) c], io.mainOut[c]);
 
+    // Drain the UI's staged control-port writes (single consumer — this thread).
+    {
+        uint32_t r = impl->writeRingR.load (std::memory_order_relaxed);
+        const uint32_t w = impl->writeRingW.load (std::memory_order_acquire);
+        while (r != w)
+        {
+            const auto& pw = impl->writeRing[(size_t) r];
+            if ((size_t) pw.idx < impl->portValues.size())
+                impl->portValues[(size_t) pw.idx] = pw.value;
+            r = (r + 1u) % Impl::kWriteRingCap;
+        }
+        impl->writeRingR.store (r, std::memory_order_release);
+    }
+
     // Re-advertise output-atom capacity before every run(): the plugin overwrites
     // atom->size with the bytes it wrote last block, so without this the buffer
     // reads as monotonically shrinking (never-recovering) capacity. Output atom
@@ -365,8 +403,14 @@ void*       Lv2Instance::uridUnmapFeature() const noexcept { return &impl->unmap
 
 void Lv2Instance::setControlPortValue (uint32_t portIndex, float value) noexcept
 {
-    if ((size_t) portIndex < impl->portValues.size())
-        impl->portValues[(size_t) portIndex] = value;
+    // Stage into the SPSC ring — the audio thread owns portValues (run() reads
+    // it concurrently) and applies these at the top of its next processBlock.
+    const uint32_t w    = impl->writeRingW.load (std::memory_order_relaxed);
+    const uint32_t next = (w + 1u) % Impl::kWriteRingCap;
+    if (next == impl->writeRingR.load (std::memory_order_acquire))
+        return;   // ring full — drop (only under a pathological flood)
+    impl->writeRing[(size_t) w] = { portIndex, value };
+    impl->writeRingW.store (next, std::memory_order_release);
 }
 
 int Lv2Instance::portIndexForSymbol (const char* symbol) const noexcept

--- a/src/engine/lv2/Lv2Instance.cpp
+++ b/src/engine/lv2/Lv2Instance.cpp
@@ -1,0 +1,314 @@
+#include "Lv2Instance.h"
+#include "Lv2Bundle.h"
+
+#include <lilv/lilv.h>
+#include <lv2/core/lv2.h>
+#include <lv2/atom/atom.h>
+#include <lv2/buf-size/buf-size.h>
+#include <lv2/options/options.h>
+#include <lv2/parameters/parameters.h>
+#include <lv2/urid/urid.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <unordered_map>
+#include <vector>
+
+namespace duskstudio::lv2
+{
+struct Lv2Instance::Impl
+{
+    // ── URID map/unmap host feature (a simple intern table) ──
+    std::unordered_map<std::string, uint32_t> uridForUri;
+    std::vector<std::string> uriForUrid { std::string() };   // index 0 unused (URIDs start at 1)
+    LV2_URID_Map   mapFeature   {};
+    LV2_URID_Unmap unmapFeature {};
+    LV2_Feature    mapFeatureStruct     {};
+    LV2_Feature    unmapFeatureStruct   {};
+    LV2_Feature    optionsFeatureStruct {};
+    LV2_Feature    boundedFeatureStruct {};
+    std::vector<const LV2_Feature*> features;
+
+    // Backing storage for the options feature — must outlive the instance, which
+    // keeps pointers to these. Rebuilt per activate() with the live SR / block size.
+    int32_t optMinBlock = 1, optMaxBlock = 0, optNominalBlock = 0;
+    float   optSampleRate = 0.0f;
+    std::vector<LV2_Options_Option> options;
+
+    static LV2_URID mapUri (LV2_URID_Map_Handle handle, const char* uri)
+    {
+        auto* self = static_cast<Impl*> (handle);
+        const std::string key = uri;
+        if (auto it = self->uridForUri.find (key); it != self->uridForUri.end())
+            return it->second;
+        const auto id = (uint32_t) self->uriForUrid.size();
+        self->uriForUrid.push_back (key);
+        self->uridForUri.emplace (key, id);
+        return id;
+    }
+    static const char* unmapUri (LV2_URID_Unmap_Handle handle, LV2_URID urid)
+    {
+        auto* self = static_cast<Impl*> (handle);
+        return (urid < self->uriForUrid.size()) ? self->uriForUrid[urid].c_str() : nullptr;
+    }
+
+    void buildUridFeatures()
+    {
+        mapFeature.handle   = this;  mapFeature.map     = &Impl::mapUri;
+        unmapFeature.handle = this;  unmapFeature.unmap = &Impl::unmapUri;
+        mapFeatureStruct   = { LV2_URID__map,   &mapFeature };
+        unmapFeatureStruct = { LV2_URID__unmap, &unmapFeature };
+    }
+
+    // Assemble the full feature list for instantiate: urid map/unmap + the block-size
+    // and sample-rate options + boundedBlockLength. JUCE/DPF-wrapped plugins REQUIRE
+    // options + boundedBlockLength and refuse to instantiate without them.
+    void assembleFeatures (double sr, int maxBlock)
+    {
+        optMinBlock = 1;
+        optMaxBlock = maxBlock;
+        optNominalBlock = maxBlock;
+        optSampleRate = (float) sr;
+
+        const LV2_URID kInt   = mapUri (this, LV2_ATOM__Int);
+        const LV2_URID kFloat = mapUri (this, LV2_ATOM__Float);
+        options = {
+            { LV2_OPTIONS_INSTANCE, 0, mapUri (this, LV2_BUF_SIZE__minBlockLength),     sizeof (int32_t), kInt,   &optMinBlock },
+            { LV2_OPTIONS_INSTANCE, 0, mapUri (this, LV2_BUF_SIZE__maxBlockLength),     sizeof (int32_t), kInt,   &optMaxBlock },
+            { LV2_OPTIONS_INSTANCE, 0, mapUri (this, LV2_BUF_SIZE__nominalBlockLength), sizeof (int32_t), kInt,   &optNominalBlock },
+            { LV2_OPTIONS_INSTANCE, 0, mapUri (this, LV2_PARAMETERS__sampleRate),       sizeof (float),   kFloat, &optSampleRate },
+            { LV2_OPTIONS_INSTANCE, 0, 0, 0, 0, nullptr },   // terminator
+        };
+        optionsFeatureStruct = { LV2_OPTIONS__options, options.data() };
+        boundedFeatureStruct = { LV2_BUF_SIZE__boundedBlockLength, nullptr };
+        features = { &mapFeatureStruct, &unmapFeatureStruct,
+                     &optionsFeatureStruct, &boundedFeatureStruct, nullptr };
+    }
+
+    // ── plugin + instance ──
+    const LilvPlugin* plugin = nullptr;   // owned by the bundle's world
+    LilvInstance*     instance = nullptr;
+    bool   active = false;
+    double sampleRate = 0.0;
+    int    maxFrames = 0;
+    std::atomic<int> latencySamples { 0 };
+
+    hosting::PortLayout layout;
+
+    // Port classification (indices into the plugin's port list).
+    std::vector<uint32_t> audioInPorts, audioOutPorts, controlPorts, atomInPorts, atomOutPorts;
+    int latencyPortIndex = -1;
+
+    // Persistent per-port float storage; control ports are connected to these once
+    // and hold their (default) value across blocks. Sized to the port count.
+    std::vector<float> portValues;
+
+    // One atom buffer per atom port (empty input sequence / output chunk capacity).
+    std::vector<std::vector<uint8_t>> atomBuffers;
+
+    void freeInstance()
+    {
+        if (instance != nullptr)
+        {
+            if (active) lilv_instance_deactivate (instance);
+            lilv_instance_free (instance);
+            instance = nullptr;
+        }
+        active = false;
+    }
+};
+
+Lv2Instance::Lv2Instance() : impl (std::make_unique<Impl>()) { impl->buildUridFeatures(); }
+Lv2Instance::~Lv2Instance() { impl->freeInstance(); }
+
+const hosting::PortLayout& Lv2Instance::portLayout() const noexcept { return impl->layout; }
+bool Lv2Instance::isActive() const noexcept { return impl->active; }
+int  Lv2Instance::getLatencySamples() const noexcept { return impl->latencySamples.load (std::memory_order_relaxed); }
+
+bool Lv2Instance::create (const Lv2Bundle& bundle, const std::string& uri, std::string& errorOut)
+{
+    impl->freeInstance();
+    impl->plugin = static_cast<const LilvPlugin*> (bundle.pluginByUri (uri));
+    if (impl->plugin == nullptr) { errorOut = "plugin URI not found in bundle: " + uri; return false; }
+
+    auto* world = static_cast<LilvWorld*> (bundle.world());
+    LilvNode* audioClass   = lilv_new_uri (world, LV2_CORE__AudioPort);
+    LilvNode* controlClass = lilv_new_uri (world, LV2_CORE__ControlPort);
+    LilvNode* inputClass   = lilv_new_uri (world, LV2_CORE__InputPort);
+    LilvNode* atomClass    = lilv_new_uri (world, LV2_ATOM__AtomPort);
+    LilvNode* latencyDesig = lilv_new_uri (world, LV2_CORE__latency);
+
+    impl->audioInPorts.clear();  impl->audioOutPorts.clear();
+    impl->controlPorts.clear();  impl->atomInPorts.clear(); impl->atomOutPorts.clear();
+    impl->latencyPortIndex = -1;
+
+    const uint32_t numPorts = lilv_plugin_get_num_ports (impl->plugin);
+    for (uint32_t i = 0; i < numPorts; ++i)
+    {
+        const LilvPort* port = lilv_plugin_get_port_by_index (impl->plugin, i);
+        const bool isInput = lilv_port_is_a (impl->plugin, port, inputClass);
+
+        if (lilv_port_is_a (impl->plugin, port, audioClass))
+            (isInput ? impl->audioInPorts : impl->audioOutPorts).push_back (i);
+        else if (lilv_port_is_a (impl->plugin, port, controlClass))
+            impl->controlPorts.push_back (i);
+        else if (lilv_port_is_a (impl->plugin, port, atomClass))
+            (isInput ? impl->atomInPorts : impl->atomOutPorts).push_back (i);
+        // CV / other ports fall through; connected to silence scratch in activate().
+    }
+
+    // The port designated lv2:latency (an output control port) reports plugin
+    // latency; read it after run() for PDC.
+    LilvNode* outputClass = lilv_new_uri (world, LV2_CORE__OutputPort);
+    if (const LilvPort* latPort = lilv_plugin_get_port_by_designation (impl->plugin, outputClass, latencyDesig))
+        impl->latencyPortIndex = (int) lilv_port_get_index (impl->plugin, latPort);
+    lilv_node_free (outputClass);
+
+    // Build the host-agnostic layout the InsertAdapter reads.
+    impl->layout = {};
+    if (! impl->audioInPorts.empty())
+    {
+        hosting::BusInfo in;
+        in.kind = hosting::BusInfo::Kind::Audio; in.dir = hosting::BusInfo::Direction::Input;
+        in.role = hosting::BusInfo::Role::Main;  in.channelCount = (int) impl->audioInPorts.size();
+        in.active = true; in.name = "Input";
+        impl->layout.inputs.push_back (in);
+        impl->layout.mainInIndex = 0;
+    }
+    if (! impl->atomInPorts.empty())
+    {
+        hosting::BusInfo ev;
+        ev.kind = hosting::BusInfo::Kind::Event; ev.dir = hosting::BusInfo::Direction::Input;
+        ev.role = hosting::BusInfo::Role::Main;  ev.carriesMidi = true; ev.active = true; ev.name = "Events";
+        impl->layout.eventInIndex = (int) impl->layout.inputs.size();
+        impl->layout.inputs.push_back (ev);
+    }
+    if (! impl->audioOutPorts.empty())
+    {
+        hosting::BusInfo out;
+        out.kind = hosting::BusInfo::Kind::Audio; out.dir = hosting::BusInfo::Direction::Output;
+        out.role = hosting::BusInfo::Role::Main;  out.channelCount = (int) impl->audioOutPorts.size();
+        out.active = true; out.name = "Output";
+        impl->layout.mainOutIndex = 0;
+        impl->layout.outputs.push_back (out);
+    }
+    impl->layout.isInstrument = (impl->audioInPorts.empty()
+                                 && ! impl->atomInPorts.empty()
+                                 && ! impl->audioOutPorts.empty());
+
+    lilv_node_free (audioClass);   lilv_node_free (controlClass);
+    lilv_node_free (inputClass);   lilv_node_free (atomClass);
+    lilv_node_free (latencyDesig);
+    return true;
+}
+
+bool Lv2Instance::activate (double sampleRate, int maxBlockFrames, std::string& errorOut)
+{
+    if (impl->plugin == nullptr) { errorOut = "not created"; return false; }
+    if (impl->active) return true;
+
+    impl->sampleRate = sampleRate;
+    impl->maxFrames  = std::max (1, maxBlockFrames);
+
+    impl->assembleFeatures (sampleRate, impl->maxFrames);   // options need the live SR/block
+    impl->instance = lilv_plugin_instantiate (impl->plugin, sampleRate, impl->features.data());
+    if (impl->instance == nullptr) { errorOut = "lilv_plugin_instantiate failed"; return false; }
+
+    const uint32_t numPorts = lilv_plugin_get_num_ports (impl->plugin);
+
+    // Control ports: connect each to a persistent float initialised to its default.
+    impl->portValues.assign ((size_t) numPorts, 0.0f);
+    lilv_plugin_get_port_ranges_float (impl->plugin, nullptr, nullptr, impl->portValues.data());
+    for (uint32_t idx : impl->controlPorts)
+    {
+        if (std::isnan (impl->portValues[idx])) impl->portValues[idx] = 0.0f;
+        lilv_instance_connect_port (impl->instance, idx, &impl->portValues[(size_t) idx]);
+    }
+
+    // Atom ports: input gets an empty sequence, output a chunk-capacity buffer, so
+    // an effect that declares them doesn't run against unconnected memory.
+    const LV2_URID seqType   = Impl::mapUri (impl.get(), LV2_ATOM__Sequence);
+    const LV2_URID chunkType = Impl::mapUri (impl.get(), LV2_ATOM__Chunk);
+    impl->atomBuffers.clear();
+    auto connectAtom = [&] (uint32_t idx, bool input)
+    {
+        constexpr size_t kCap = 8192;
+        impl->atomBuffers.emplace_back (kCap, (uint8_t) 0);
+        auto* buf = impl->atomBuffers.back().data();
+        auto* atom = reinterpret_cast<LV2_Atom*> (buf);
+        if (input)
+        {
+            auto* seq = reinterpret_cast<LV2_Atom_Sequence*> (buf);
+            seq->atom.type = seqType;
+            seq->atom.size = sizeof (LV2_Atom_Sequence_Body);   // empty: header only
+            seq->body.unit = 0; seq->body.pad = 0;
+        }
+        else
+        {
+            atom->type = chunkType;
+            atom->size = (uint32_t) (kCap - sizeof (LV2_Atom));   // advertise capacity
+        }
+        lilv_instance_connect_port (impl->instance, idx, buf);
+    };
+    for (uint32_t idx : impl->atomInPorts)  connectAtom (idx, true);
+    for (uint32_t idx : impl->atomOutPorts) connectAtom (idx, false);
+
+    lilv_instance_activate (impl->instance);
+    impl->active = true;
+    return true;
+}
+
+void Lv2Instance::deactivate() { impl->freeInstance(); }
+
+bool Lv2Instance::reactivate (double sampleRate, int maxBlockFrames, std::string& errorOut)
+{
+    // LV2 fixes the sample rate at instantiate, so a rate/block change means a fresh
+    // instance. Parameter state is reset to defaults here; preserving it across the
+    // re-instantiate is not yet wired.
+    impl->freeInstance();
+    return activate (sampleRate, maxBlockFrames, errorOut);
+}
+
+void Lv2Instance::processBlock (const hosting::PortBuffers& io) noexcept
+{
+    const int numFrames = io.numFrames;
+
+    auto clearOutputs = [&]
+    {
+        if (io.mainOut == nullptr || numFrames <= 0) return;
+        for (int c = 0; c < io.mainOutChannels; ++c)
+            if (io.mainOut[c] != nullptr)
+                std::memset (io.mainOut[c], 0, sizeof (float) * (size_t) numFrames);
+    };
+
+    if (! impl->active || impl->instance == nullptr
+        || numFrames <= 0 || numFrames > impl->maxFrames
+        || io.mainOut == nullptr || io.mainOutChannels <= 0)
+    {
+        clearOutputs();
+        return;
+    }
+
+    // Connect audio ports to the caller's buffers for this block. Extra plugin
+    // channels beyond what the adapter supplies get silence (mainIn) or a scratch
+    // sink; the adapter already sized to the negotiated counts.
+    const int nin  = std::min (io.mainInChannels,  (int) impl->audioInPorts.size());
+    const int nout = std::min (io.mainOutChannels, (int) impl->audioOutPorts.size());
+    for (int c = 0; c < nin;  ++c)
+        lilv_instance_connect_port (impl->instance, impl->audioInPorts[(size_t) c], io.mainIn[c]);
+    for (int c = 0; c < nout; ++c)
+        lilv_instance_connect_port (impl->instance, impl->audioOutPorts[(size_t) c], io.mainOut[c]);
+
+    lilv_instance_run (impl->instance, (uint32_t) numFrames);
+
+    if (impl->latencyPortIndex >= 0)
+        impl->latencySamples.store ((int) impl->portValues[(size_t) impl->latencyPortIndex],
+                                    std::memory_order_relaxed);
+}
+
+bool Lv2Instance::saveState (std::vector<uint8_t>&) const { return false; }   // state save/load not yet wired
+bool Lv2Instance::loadState (const std::vector<uint8_t>&) { return false; }   // state save/load not yet wired
+} // namespace duskstudio::lv2

--- a/src/engine/lv2/Lv2Instance.cpp
+++ b/src/engine/lv2/Lv2Instance.cpp
@@ -100,7 +100,12 @@ struct Lv2Instance::Impl
 
     // Port classification (indices into the plugin's port list).
     std::vector<uint32_t> audioInPorts, audioOutPorts, controlPorts, atomInPorts, atomOutPorts;
+    std::vector<uint32_t> otherPorts;   // CV / unclassified — LV2 requires every port connected
     int latencyPortIndex = -1;
+
+    // Per-port scratch backing otherPorts: maxFrames floats each, so an audio-rate
+    // CV port can safely read silence or sink its output.
+    std::vector<std::vector<float>> otherScratch;
 
     // Persistent per-port float storage; control ports are connected to these once
     // and hold their (default) value across blocks. Sized to the port count.
@@ -145,6 +150,7 @@ bool Lv2Instance::create (const Lv2Bundle& bundle, const std::string& uri, std::
 
     impl->audioInPorts.clear();  impl->audioOutPorts.clear();
     impl->controlPorts.clear();  impl->atomInPorts.clear(); impl->atomOutPorts.clear();
+    impl->otherPorts.clear();
     impl->latencyPortIndex = -1;
 
     const uint32_t numPorts = lilv_plugin_get_num_ports (impl->plugin);
@@ -159,7 +165,8 @@ bool Lv2Instance::create (const Lv2Bundle& bundle, const std::string& uri, std::
             impl->controlPorts.push_back (i);
         else if (lilv_port_is_a (impl->plugin, port, atomClass))
             (isInput ? impl->atomInPorts : impl->atomOutPorts).push_back (i);
-        // CV / other ports fall through; connected to silence scratch in activate().
+        else
+            impl->otherPorts.push_back (i);   // CV / unknown → scratch in activate()
     }
 
     // The port designated lv2:latency (an output control port) reports plugin
@@ -259,6 +266,22 @@ bool Lv2Instance::activate (double sampleRate, int maxBlockFrames, std::string& 
     for (uint32_t idx : impl->atomInPorts)  connectAtom (idx, true);
     for (uint32_t idx : impl->atomOutPorts) connectAtom (idx, false);
 
+    // CV / unclassified ports: LV2 requires every port connected before run(), so
+    // each gets its own block-sized scratch (silence in, sink out).
+    impl->otherScratch.clear();
+    impl->otherScratch.reserve (impl->otherPorts.size());
+    for (uint32_t idx : impl->otherPorts)
+    {
+        impl->otherScratch.emplace_back ((size_t) impl->maxFrames, 0.0f);
+        lilv_instance_connect_port (impl->instance, idx, impl->otherScratch.back().data());
+    }
+
+    // Seed latency with the port default so getLatencySamples() is sane before the
+    // first run() refreshes it.
+    impl->latencySamples.store (impl->latencyPortIndex >= 0
+                                  ? (int) impl->portValues[(size_t) impl->latencyPortIndex] : 0,
+                                std::memory_order_relaxed);
+
     lilv_instance_activate (impl->instance);
     impl->active = true;
     return true;
@@ -269,10 +292,15 @@ void Lv2Instance::deactivate() { impl->freeInstance(); }
 bool Lv2Instance::reactivate (double sampleRate, int maxBlockFrames, std::string& errorOut)
 {
     // LV2 fixes the sample rate at instantiate, so a rate/block change means a fresh
-    // instance. Parameter state is reset to defaults here; preserving it across the
-    // re-instantiate is not yet wired.
+    // instance. Carry the control-port values across so the user's live settings
+    // survive; full state-extension persistence is a later step.
+    const std::vector<float> saved = impl->portValues;
     impl->freeInstance();
-    return activate (sampleRate, maxBlockFrames, errorOut);
+    if (! activate (sampleRate, maxBlockFrames, errorOut)) return false;
+    if (saved.size() == impl->portValues.size())
+        for (uint32_t idx : impl->controlPorts)
+            impl->portValues[(size_t) idx] = saved[(size_t) idx];
+    return true;
 }
 
 void Lv2Instance::processBlock (const hosting::PortBuffers& io) noexcept
@@ -298,7 +326,8 @@ void Lv2Instance::processBlock (const hosting::PortBuffers& io) noexcept
     // Connect audio ports to the caller's buffers for this block. Extra plugin
     // channels beyond what the adapter supplies get silence (mainIn) or a scratch
     // sink; the adapter already sized to the negotiated counts.
-    const int nin  = std::min (io.mainInChannels,  (int) impl->audioInPorts.size());
+    const int nin  = io.mainIn != nullptr
+                       ? std::min (io.mainInChannels, (int) impl->audioInPorts.size()) : 0;
     const int nout = std::min (io.mainOutChannels, (int) impl->audioOutPorts.size());
     for (int c = 0; c < nin;  ++c)
         lilv_instance_connect_port (impl->instance, impl->audioInPorts[(size_t) c], io.mainIn[c]);

--- a/src/engine/lv2/Lv2Instance.cpp
+++ b/src/engine/lv2/Lv2Instance.cpp
@@ -89,6 +89,7 @@ struct Lv2Instance::Impl
     }
 
     // ── plugin + instance ──
+    LilvWorld*        world  = nullptr;   // owned by the bundle
     const LilvPlugin* plugin = nullptr;   // owned by the bundle's world
     LilvInstance*     instance = nullptr;
     bool   active = false;
@@ -142,6 +143,7 @@ bool Lv2Instance::create (const Lv2Bundle& bundle, const std::string& uri, std::
     if (impl->plugin == nullptr) { errorOut = "plugin URI not found in bundle: " + uri; return false; }
 
     auto* world = static_cast<LilvWorld*> (bundle.world());
+    impl->world = world;
     LilvNode* audioClass   = lilv_new_uri (world, LV2_CORE__AudioPort);
     LilvNode* controlClass = lilv_new_uri (world, LV2_CORE__ControlPort);
     LilvNode* inputClass   = lilv_new_uri (world, LV2_CORE__InputPort);
@@ -354,4 +356,31 @@ void Lv2Instance::processBlock (const hosting::PortBuffers& io) noexcept
 
 bool Lv2Instance::saveState (std::vector<uint8_t>&) const { return false; }   // state save/load not yet wired
 bool Lv2Instance::loadState (const std::vector<uint8_t>&) { return false; }   // state save/load not yet wired
+
+void*       Lv2Instance::lilvWorld()        const noexcept { return impl->world; }
+const void* Lv2Instance::lilvPlugin()       const noexcept { return impl->plugin; }
+void*       Lv2Instance::lilvInstance()     const noexcept { return impl->instance; }
+void*       Lv2Instance::uridMapFeature()   const noexcept { return &impl->mapFeatureStruct; }
+void*       Lv2Instance::uridUnmapFeature() const noexcept { return &impl->unmapFeatureStruct; }
+
+void Lv2Instance::setControlPortValue (uint32_t portIndex, float value) noexcept
+{
+    if ((size_t) portIndex < impl->portValues.size())
+        impl->portValues[(size_t) portIndex] = value;
+}
+
+int Lv2Instance::portIndexForSymbol (const char* symbol) const noexcept
+{
+    if (impl->plugin == nullptr || symbol == nullptr) return -1;
+    // The port symbol is resolvable without the world: walk the ports and compare.
+    const uint32_t numPorts = lilv_plugin_get_num_ports (impl->plugin);
+    for (uint32_t i = 0; i < numPorts; ++i)
+    {
+        const LilvPort* port = lilv_plugin_get_port_by_index (impl->plugin, i);
+        const LilvNode* sym  = lilv_port_get_symbol (impl->plugin, port);
+        if (sym != nullptr && std::strcmp (lilv_node_as_string (sym), symbol) == 0)
+            return (int) i;
+    }
+    return -1;
+}
 } // namespace duskstudio::lv2

--- a/src/engine/lv2/Lv2Instance.cpp
+++ b/src/engine/lv2/Lv2Instance.cpp
@@ -63,7 +63,12 @@ struct Lv2Instance::Impl
         unmapFeature.handle = this;  unmapFeature.unmap = &Impl::unmapUri;
         mapFeatureStruct   = { LV2_URID__map,   &mapFeature };
         unmapFeatureStruct = { LV2_URID__unmap, &unmapFeature };
+        uridFloat  = mapUri (this, LV2_ATOM__Float);
+        uridDouble = mapUri (this, LV2_ATOM__Double);
+        uridInt    = mapUri (this, LV2_ATOM__Int);
+        uridLong   = mapUri (this, LV2_ATOM__Long);
     }
+    LV2_URID uridFloat = 0, uridDouble = 0, uridInt = 0, uridLong = 0;
 
     // Assemble the full feature list for instantiate: urid map/unmap + the block-size
     // and sample-rate options + boundedBlockLength. JUCE/DPF-wrapped plugins REQUIRE
@@ -124,6 +129,13 @@ struct Lv2Instance::Impl
     std::array<PortWrite, kWriteRingCap> writeRing {};
     std::atomic<uint32_t> writeRingW { 0 }, writeRingR { 0 };
 
+    // Message-thread shadow of the UI writes. A bypassed slot never runs
+    // processBlock, so the ring may never drain — state saves and reactivate read
+    // UI-touched ports from here instead of waiting on a drain that may not come.
+    // Audio thread never touches these.
+    std::vector<float>   uiShadow;
+    std::vector<uint8_t> uiDirty;
+
     // Persistent per-port float storage; control ports are connected to these once
     // and hold their (default) value across blocks. Sized to the port count.
     std::vector<float> portValues;
@@ -144,18 +156,15 @@ struct Lv2Instance::Impl
         active = false;
     }
 
+    // Filled at create(); lilv's state save/restore resolves every port by symbol,
+    // so this lookup runs once per port per save — keep it O(1).
+    std::unordered_map<std::string, uint32_t> portIndexBySymbol;
+
     int portIndexForSymbol (const char* symbol) const
     {
-        if (plugin == nullptr || symbol == nullptr) return -1;
-        const uint32_t numPorts = lilv_plugin_get_num_ports (plugin);
-        for (uint32_t i = 0; i < numPorts; ++i)
-        {
-            const LilvPort* port = lilv_plugin_get_port_by_index (plugin, i);
-            const LilvNode* sym  = lilv_port_get_symbol (plugin, port);
-            if (sym != nullptr && std::strcmp (lilv_node_as_string (sym), symbol) == 0)
-                return (int) i;
-        }
-        return -1;
+        if (symbol == nullptr) return -1;
+        const auto it = portIndexBySymbol.find (symbol);
+        return it != portIndexBySymbol.end() ? (int) it->second : -1;
     }
 
     // lilv state callbacks (message thread; save/restore are fenced by the caller
@@ -168,7 +177,11 @@ struct Lv2Instance::Impl
         if (idx < 0 || (size_t) idx >= self->portValues.size())
         { *size = 0; *type = 0; return nullptr; }
         *size = sizeof (float);
-        *type = mapUri (self, LV2_ATOM__Float);
+        *type = self->uridFloat;
+        // UI writes staged while the slot never ran (bypassed) live in the shadow;
+        // portValues would still hold the pre-tweak value.
+        if ((size_t) idx < self->uiDirty.size() && self->uiDirty[(size_t) idx] != 0)
+            return &self->uiShadow[(size_t) idx];
         return &self->portValues[(size_t) idx];
     }
 
@@ -182,17 +195,19 @@ struct Lv2Instance::Impl
 
         // States written by other hosts may carry any numeric atom type.
         float v = 0.0f;
-        const LV2_URID tFloat  = mapUri (self, LV2_ATOM__Float);
-        const LV2_URID tDouble = mapUri (self, LV2_ATOM__Double);
-        const LV2_URID tInt    = mapUri (self, LV2_ATOM__Int);
-        const LV2_URID tLong   = mapUri (self, LV2_ATOM__Long);
-        if      (type == tFloat  && size >= sizeof (float))   v = *static_cast<const float*> (value);
-        else if (type == tDouble && size >= sizeof (double))  v = (float) *static_cast<const double*> (value);
-        else if (type == tInt    && size >= sizeof (int32_t)) v = (float) *static_cast<const int32_t*> (value);
-        else if (type == tLong   && size >= sizeof (int64_t)) v = (float) *static_cast<const int64_t*> (value);
+        if      (type == self->uridFloat  && size >= sizeof (float))   v = *static_cast<const float*> (value);
+        else if (type == self->uridDouble && size >= sizeof (double))  v = (float) *static_cast<const double*> (value);
+        else if (type == self->uridInt    && size >= sizeof (int32_t)) v = (float) *static_cast<const int32_t*> (value);
+        else if (type == self->uridLong   && size >= sizeof (int64_t)) v = (float) *static_cast<const int64_t*> (value);
         else return;
         if (! std::isfinite (v)) return;
         self->portValues[(size_t) idx] = v;
+        // A restore supersedes any staged UI value for this port.
+        if ((size_t) idx < self->uiDirty.size())
+        {
+            self->uiShadow[(size_t) idx] = v;
+            self->uiDirty [(size_t) idx] = 0;
+        }
     }
 };
 
@@ -220,6 +235,9 @@ bool Lv2Instance::create (const Lv2Bundle& bundle, const std::string& uri, std::
     impl->audioInPorts.clear();  impl->audioOutPorts.clear();
     impl->controlPorts.clear();  impl->atomInPorts.clear(); impl->atomOutPorts.clear();
     impl->otherPorts.clear();
+    impl->portIndexBySymbol.clear();
+    impl->uiShadow.clear();
+    impl->uiDirty.clear();
     impl->latencyPortIndex = -1;
 
     const uint32_t numPorts = lilv_plugin_get_num_ports (impl->plugin);
@@ -227,6 +245,8 @@ bool Lv2Instance::create (const Lv2Bundle& bundle, const std::string& uri, std::
     {
         const LilvPort* port = lilv_plugin_get_port_by_index (impl->plugin, i);
         const bool isInput = lilv_port_is_a (impl->plugin, port, inputClass);
+        if (const LilvNode* sym = lilv_port_get_symbol (impl->plugin, port))
+            impl->portIndexBySymbol.emplace (lilv_node_as_string (sym), i);
 
         if (lilv_port_is_a (impl->plugin, port, audioClass))
             (isInput ? impl->audioInPorts : impl->audioOutPorts).push_back (i);
@@ -298,6 +318,13 @@ bool Lv2Instance::activate (double sampleRate, int maxBlockFrames, std::string& 
     const uint32_t numPorts = lilv_plugin_get_num_ports (impl->plugin);
 
     // Control ports: connect each to a persistent float initialised to its default.
+    // The UI shadow survives a reactivate of the same plugin (same port count) so
+    // staged-but-undrained writes aren't lost across a rate change.
+    if (impl->uiShadow.size() != (size_t) numPorts)
+    {
+        impl->uiShadow.assign ((size_t) numPorts, 0.0f);
+        impl->uiDirty .assign ((size_t) numPorts, 0);
+    }
     impl->portValues.assign ((size_t) numPorts, 0.0f);
     lilv_plugin_get_port_ranges_float (impl->plugin, nullptr, nullptr, impl->portValues.data());
     for (uint32_t idx : impl->controlPorts)
@@ -370,19 +397,27 @@ void Lv2Instance::deactivate() { impl->freeInstance(); }
 bool Lv2Instance::reactivate (double sampleRate, int maxBlockFrames, std::string& errorOut)
 {
     // LV2 fixes the sample rate at instantiate, so a rate/block change means a
-    // fresh instance. Carry the full state across (control ports + the plugin's
-    // state:interface blob); the raw port values back it up for plugins whose
-    // state extension is absent or fails.
+    // fresh instance. Carry the state blob across when the plugin can serialize
+    // (control ports + state:interface); fall back to the raw port values when it
+    // can't. The blob already reflects staged UI writes via getPortValue's shadow.
     std::vector<uint8_t> blob;
     saveState (blob);
     const std::vector<float> saved = impl->portValues;
     impl->freeInstance();
     if (! activate (sampleRate, maxBlockFrames, errorOut)) return false;
-    if (saved.size() == impl->portValues.size())
+    if (! blob.empty())
+    {
+        loadState (blob);
+    }
+    else if (saved.size() == impl->portValues.size())
+    {
         for (uint32_t idx : impl->controlPorts)
             impl->portValues[(size_t) idx] = saved[(size_t) idx];
-    if (! blob.empty())
-        loadState (blob);
+        // Staged-but-undrained UI writes supersede the raw carry.
+        for (uint32_t idx : impl->controlPorts)
+            if ((size_t) idx < impl->uiDirty.size() && impl->uiDirty[(size_t) idx] != 0)
+                impl->portValues[(size_t) idx] = impl->uiShadow[(size_t) idx];
+    }
     return true;
 }
 
@@ -502,6 +537,13 @@ void*       Lv2Instance::uridUnmapFeature() const noexcept { return &impl->unmap
 
 void Lv2Instance::setControlPortValue (uint32_t portIndex, float value) noexcept
 {
+    if ((size_t) portIndex >= impl->uiShadow.size()) return;
+    // Shadow first: saves/reactivate read the latest UI value from here even when
+    // the audio thread never drains the ring (bypassed slot), and a ring overflow
+    // can only delay the RT application, never lose the value for persistence.
+    impl->uiShadow[(size_t) portIndex] = value;
+    impl->uiDirty [(size_t) portIndex] = 1;
+
     // Stage into the SPSC ring — the audio thread owns portValues (run() reads
     // it concurrently) and applies these at the top of its next processBlock.
     const uint32_t w    = impl->writeRingW.load (std::memory_order_relaxed);

--- a/src/engine/lv2/Lv2Instance.cpp
+++ b/src/engine/lv2/Lv2Instance.cpp
@@ -106,8 +106,10 @@ struct Lv2Instance::Impl
     // and hold their (default) value across blocks. Sized to the port count.
     std::vector<float> portValues;
 
-    // One atom buffer per atom port (empty input sequence / output chunk capacity).
+    // One atom buffer per atom port: inputs first (empty sequences), then outputs
+    // (chunk-capacity buffers). atomChunkType re-advertises output capacity per block.
     std::vector<std::vector<uint8_t>> atomBuffers;
+    LV2_URID atomChunkType = 0;
 
     void freeInstance()
     {
@@ -232,6 +234,7 @@ bool Lv2Instance::activate (double sampleRate, int maxBlockFrames, std::string& 
     // an effect that declares them doesn't run against unconnected memory.
     const LV2_URID seqType   = Impl::mapUri (impl.get(), LV2_ATOM__Sequence);
     const LV2_URID chunkType = Impl::mapUri (impl.get(), LV2_ATOM__Chunk);
+    impl->atomChunkType = chunkType;
     impl->atomBuffers.clear();
     auto connectAtom = [&] (uint32_t idx, bool input)
     {
@@ -301,6 +304,17 @@ void Lv2Instance::processBlock (const hosting::PortBuffers& io) noexcept
         lilv_instance_connect_port (impl->instance, impl->audioInPorts[(size_t) c], io.mainIn[c]);
     for (int c = 0; c < nout; ++c)
         lilv_instance_connect_port (impl->instance, impl->audioOutPorts[(size_t) c], io.mainOut[c]);
+
+    // Re-advertise output-atom capacity before every run(): the plugin overwrites
+    // atom->size with the bytes it wrote last block, so without this the buffer
+    // reads as monotonically shrinking (never-recovering) capacity. Output atom
+    // buffers follow the input ones in atomBuffers (inputs connected first).
+    for (size_t i = impl->atomInPorts.size(); i < impl->atomBuffers.size(); ++i)
+    {
+        auto* atom = reinterpret_cast<LV2_Atom*> (impl->atomBuffers[i].data());
+        atom->type = impl->atomChunkType;
+        atom->size = (uint32_t) (impl->atomBuffers[i].size() - sizeof (LV2_Atom));
+    }
 
     lilv_instance_run (impl->instance, (uint32_t) numFrames);
 

--- a/src/engine/lv2/Lv2Instance.cpp
+++ b/src/engine/lv2/Lv2Instance.cpp
@@ -7,6 +7,7 @@
 #include <lv2/buf-size/buf-size.h>
 #include <lv2/options/options.h>
 #include <lv2/parameters/parameters.h>
+#include <lv2/state/state.h>
 #include <lv2/urid/urid.h>
 
 #include <algorithm>
@@ -141,6 +142,57 @@ struct Lv2Instance::Impl
             instance = nullptr;
         }
         active = false;
+    }
+
+    int portIndexForSymbol (const char* symbol) const
+    {
+        if (plugin == nullptr || symbol == nullptr) return -1;
+        const uint32_t numPorts = lilv_plugin_get_num_ports (plugin);
+        for (uint32_t i = 0; i < numPorts; ++i)
+        {
+            const LilvPort* port = lilv_plugin_get_port_by_index (plugin, i);
+            const LilvNode* sym  = lilv_port_get_symbol (plugin, port);
+            if (sym != nullptr && std::strcmp (lilv_node_as_string (sym), symbol) == 0)
+                return (int) i;
+        }
+        return -1;
+    }
+
+    // lilv state callbacks (message thread; save/restore are fenced by the caller
+    // when the instance is live, same contract as activate/deactivate).
+    static const void* getPortValue (const char* symbol, void* userData,
+                                     uint32_t* size, uint32_t* type)
+    {
+        auto* self = static_cast<Impl*> (userData);
+        const int idx = self->portIndexForSymbol (symbol);
+        if (idx < 0 || (size_t) idx >= self->portValues.size())
+        { *size = 0; *type = 0; return nullptr; }
+        *size = sizeof (float);
+        *type = mapUri (self, LV2_ATOM__Float);
+        return &self->portValues[(size_t) idx];
+    }
+
+    static void setPortValue (const char* symbol, void* userData,
+                              const void* value, uint32_t size, uint32_t type)
+    {
+        auto* self = static_cast<Impl*> (userData);
+        const int idx = self->portIndexForSymbol (symbol);
+        if (idx < 0 || (size_t) idx >= self->portValues.size() || value == nullptr)
+            return;
+
+        // States written by other hosts may carry any numeric atom type.
+        float v = 0.0f;
+        const LV2_URID tFloat  = mapUri (self, LV2_ATOM__Float);
+        const LV2_URID tDouble = mapUri (self, LV2_ATOM__Double);
+        const LV2_URID tInt    = mapUri (self, LV2_ATOM__Int);
+        const LV2_URID tLong   = mapUri (self, LV2_ATOM__Long);
+        if      (type == tFloat  && size >= sizeof (float))   v = *static_cast<const float*> (value);
+        else if (type == tDouble && size >= sizeof (double))  v = (float) *static_cast<const double*> (value);
+        else if (type == tInt    && size >= sizeof (int32_t)) v = (float) *static_cast<const int32_t*> (value);
+        else if (type == tLong   && size >= sizeof (int64_t)) v = (float) *static_cast<const int64_t*> (value);
+        else return;
+        if (! std::isfinite (v)) return;
+        self->portValues[(size_t) idx] = v;
     }
 };
 
@@ -317,15 +369,20 @@ void Lv2Instance::deactivate() { impl->freeInstance(); }
 
 bool Lv2Instance::reactivate (double sampleRate, int maxBlockFrames, std::string& errorOut)
 {
-    // LV2 fixes the sample rate at instantiate, so a rate/block change means a fresh
-    // instance. Carry the control-port values across so the user's live settings
-    // survive; full state-extension persistence is a later step.
+    // LV2 fixes the sample rate at instantiate, so a rate/block change means a
+    // fresh instance. Carry the full state across (control ports + the plugin's
+    // state:interface blob); the raw port values back it up for plugins whose
+    // state extension is absent or fails.
+    std::vector<uint8_t> blob;
+    saveState (blob);
     const std::vector<float> saved = impl->portValues;
     impl->freeInstance();
     if (! activate (sampleRate, maxBlockFrames, errorOut)) return false;
     if (saved.size() == impl->portValues.size())
         for (uint32_t idx : impl->controlPorts)
             impl->portValues[(size_t) idx] = saved[(size_t) idx];
+    if (! blob.empty())
+        loadState (blob);
     return true;
 }
 
@@ -392,8 +449,50 @@ void Lv2Instance::processBlock (const hosting::PortBuffers& io) noexcept
                                     std::memory_order_relaxed);
 }
 
-bool Lv2Instance::saveState (std::vector<uint8_t>&) const { return false; }   // state save/load not yet wired
-bool Lv2Instance::loadState (const std::vector<uint8_t>&) { return false; }   // state save/load not yet wired
+bool Lv2Instance::saveState (std::vector<uint8_t>& out) const
+{
+    out.clear();
+    if (impl->instance == nullptr || impl->plugin == nullptr || impl->world == nullptr)
+        return false;
+
+    // Snapshot control-port values + the plugin's state:interface blob (JUCE-
+    // wrapped plugins keep everything there) into a lilv state, serialized as
+    // Turtle. No file directories are passed, so file-writing plugins keep
+    // their state abstract/in-memory — fine for effects.
+    LilvState* state = lilv_state_new_from_instance (
+        impl->plugin, impl->instance, &impl->mapFeature,
+        nullptr, nullptr, nullptr, nullptr,
+        &Impl::getPortValue, impl.get(),
+        LV2_STATE_IS_POD | LV2_STATE_IS_PORTABLE, impl->features.data());
+    if (state == nullptr) return false;
+
+    char* ttl = lilv_state_to_string (impl->world, &impl->mapFeature, &impl->unmapFeature,
+                                      state, "urn:duskstudio:lv2state", nullptr);
+    lilv_state_free (state);
+    if (ttl == nullptr) return false;
+
+    out.assign (ttl, ttl + std::strlen (ttl));
+    lilv_free (ttl);
+    return ! out.empty();
+}
+
+bool Lv2Instance::loadState (const std::vector<uint8_t>& in)
+{
+    if (impl->instance == nullptr || impl->world == nullptr || in.empty())
+        return false;
+
+    const std::string ttl (in.begin(), in.end());
+    LilvState* state = lilv_state_new_from_string (impl->world, &impl->mapFeature, ttl.c_str());
+    if (state == nullptr) return false;
+
+    // Restores control ports through setPortValue (the plugin reads portValues on
+    // its next run()) and hands the state:interface blob to the plugin. Callers
+    // fence the audio thread when the instance is live — same as activate().
+    lilv_state_restore (state, impl->instance, &Impl::setPortValue, impl.get(),
+                        0, impl->features.data());
+    lilv_state_free (state);
+    return true;
+}
 
 void*       Lv2Instance::lilvWorld()        const noexcept { return impl->world; }
 const void* Lv2Instance::lilvPlugin()       const noexcept { return impl->plugin; }
@@ -415,16 +514,6 @@ void Lv2Instance::setControlPortValue (uint32_t portIndex, float value) noexcept
 
 int Lv2Instance::portIndexForSymbol (const char* symbol) const noexcept
 {
-    if (impl->plugin == nullptr || symbol == nullptr) return -1;
-    // The port symbol is resolvable without the world: walk the ports and compare.
-    const uint32_t numPorts = lilv_plugin_get_num_ports (impl->plugin);
-    for (uint32_t i = 0; i < numPorts; ++i)
-    {
-        const LilvPort* port = lilv_plugin_get_port_by_index (impl->plugin, i);
-        const LilvNode* sym  = lilv_port_get_symbol (impl->plugin, port);
-        if (sym != nullptr && std::strcmp (lilv_node_as_string (sym), symbol) == 0)
-            return (int) i;
-    }
-    return -1;
+    return impl->portIndexForSymbol (symbol);
 }
 } // namespace duskstudio::lv2

--- a/src/engine/lv2/Lv2Instance.h
+++ b/src/engine/lv2/Lv2Instance.h
@@ -16,9 +16,9 @@ class Lv2Bundle;
 // lilv/lv2 stay behind a pImpl so this header pulls in no LV2 headers.
 //
 // LV2 fixes the sample rate at instantiate (unlike CLAP's activate), so reactivate
-// re-instantiates the plugin, carrying control-port values across; state-extension
-// blobs are not yet wired (saveState/loadState return false). The suil editor
-// attaches through the opaque accessors below (Lv2Editor).
+// re-instantiates the plugin, carrying the full state across (control ports + the
+// plugin's state:interface blob via saveState/loadState — lilv state serialized
+// as Turtle). The suil editor attaches through the opaque accessors below.
 class Lv2Instance : public hosting::INativeInstance
 {
 public:

--- a/src/engine/lv2/Lv2Instance.h
+++ b/src/engine/lv2/Lv2Instance.h
@@ -45,6 +45,23 @@ public:
 
     int getLatencySamples() const noexcept override;
 
+    // ── Editor support (message thread; opaque so this header stays lilv-free) ──
+    // The LilvPlugin*, the live LilvInstance* (null when inactive), and this
+    // instance's URID map/unmap LV2_Features — the UI must share the plugin's
+    // URID space, so the editor forwards these instead of building its own.
+    void*       lilvWorld()        const noexcept;
+    const void* lilvPlugin()       const noexcept;
+    void*       lilvInstance()     const noexcept;
+    void*       uridMapFeature()   const noexcept;
+    void*       uridUnmapFeature() const noexcept;
+
+    // UI → plugin control-port write (ui:floatProtocol). Bounds-checked; the
+    // audio thread reads the same float on its next run() — an aligned 32-bit
+    // store, the standard LV2-host practice for control ports.
+    void setControlPortValue (uint32_t portIndex, float value) noexcept;
+    // Port index for the suil port-index-by-symbol callback; -1 when unknown.
+    int portIndexForSymbol (const char* symbol) const noexcept;
+
 private:
     struct Impl;
     std::unique_ptr<Impl> impl;

--- a/src/engine/lv2/Lv2Instance.h
+++ b/src/engine/lv2/Lv2Instance.h
@@ -16,8 +16,8 @@ class Lv2Bundle;
 // lilv/lv2 stay behind a pImpl so this header pulls in no LV2 headers.
 //
 // LV2 fixes the sample rate at instantiate (unlike CLAP's activate), so reactivate
-// re-instantiates the plugin; preserving parameter state across that re-instantiate
-// is not yet wired. Audio processing only — no state persistence, no editor yet.
+// re-instantiates the plugin, carrying control-port values across; state-extension
+// blobs are not yet wired. Audio processing only — no state persistence, no editor yet.
 class Lv2Instance : public hosting::INativeInstance
 {
 public:

--- a/src/engine/lv2/Lv2Instance.h
+++ b/src/engine/lv2/Lv2Instance.h
@@ -17,7 +17,8 @@ class Lv2Bundle;
 //
 // LV2 fixes the sample rate at instantiate (unlike CLAP's activate), so reactivate
 // re-instantiates the plugin, carrying control-port values across; state-extension
-// blobs are not yet wired. Audio processing only — no state persistence, no editor yet.
+// blobs are not yet wired (saveState/loadState return false). The suil editor
+// attaches through the opaque accessors below (Lv2Editor).
 class Lv2Instance : public hosting::INativeInstance
 {
 public:
@@ -55,9 +56,9 @@ public:
     void*       uridMapFeature()   const noexcept;
     void*       uridUnmapFeature() const noexcept;
 
-    // UI → plugin control-port write (ui:floatProtocol). Bounds-checked; the
-    // audio thread reads the same float on its next run() — an aligned 32-bit
-    // store, the standard LV2-host practice for control ports.
+    // UI → plugin control-port write (ui:floatProtocol). Staged into a lock-free
+    // ring; the audio thread applies it at the top of its next processBlock so
+    // nothing writes portValues while run() reads it.
     void setControlPortValue (uint32_t portIndex, float value) noexcept;
     // Port index for the suil port-index-by-symbol callback; -1 when unknown.
     int portIndexForSymbol (const char* symbol) const noexcept;

--- a/src/engine/lv2/Lv2Instance.h
+++ b/src/engine/lv2/Lv2Instance.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "../hosting/INativeInstance.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace duskstudio::lv2
+{
+class Lv2Bundle;
+
+// One LV2 plugin instance driven through the host-agnostic INativeInstance, so a
+// plugin slot hosts CLAP, VST3 and LV2 alike. Mirrors ClapInstance: create + init
+// from a bundle + URI, activate at a fixed sample rate / block, process audio.
+// lilv/lv2 stay behind a pImpl so this header pulls in no LV2 headers.
+//
+// LV2 fixes the sample rate at instantiate (unlike CLAP's activate), so reactivate
+// re-instantiates the plugin; preserving parameter state across that re-instantiate
+// is not yet wired. Audio processing only — no state persistence, no editor yet.
+class Lv2Instance : public hosting::INativeInstance
+{
+public:
+    Lv2Instance();
+    ~Lv2Instance() override;
+    Lv2Instance (const Lv2Instance&)            = delete;
+    Lv2Instance& operator= (const Lv2Instance&) = delete;
+
+    // Resolve `uri` in `bundle`, classify its ports, and build the PortLayout. The
+    // bundle owns the LilvWorld backing the plugin, so it MUST outlive this instance.
+    // False (+ errorOut) on failure.
+    bool create (const Lv2Bundle& bundle, const std::string& uri, std::string& errorOut);
+
+    const hosting::PortLayout& portLayout() const noexcept override;
+
+    bool activate (double sampleRate, int maxBlockFrames, std::string& errorOut) override;
+    void deactivate() override;
+    bool reactivate (double sampleRate, int maxBlockFrames, std::string& errorOut) override;
+    bool isActive() const noexcept override;
+
+    void processBlock (const hosting::PortBuffers& io) noexcept override;
+
+    bool saveState (std::vector<uint8_t>& out) const override;
+    bool loadState (const std::vector<uint8_t>& in) override;
+
+    int getLatencySamples() const noexcept override;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl;
+};
+} // namespace duskstudio::lv2

--- a/src/engine/lv2/Lv2Scanner.cpp
+++ b/src/engine/lv2/Lv2Scanner.cpp
@@ -16,9 +16,11 @@ std::vector<ScannedLv2> Lv2Scanner::scan()
     {
         const LilvPlugin* p = lilv_plugins_get (all, it);
 
-        // The bundle directory is what NativeLv2Slot::load takes.
-        char* bundleDir = lilv_file_uri_parse (
-            lilv_node_as_uri (lilv_plugin_get_bundle_uri (p)), nullptr);
+        // The bundle directory is what NativeLv2Slot::load takes. A malformed
+        // manifest can yield a plugin with no bundle URI — skip, don't crash.
+        const LilvNode* bundleUri = lilv_plugin_get_bundle_uri (p);
+        if (bundleUri == nullptr) continue;
+        char* bundleDir = lilv_file_uri_parse (lilv_node_as_uri (bundleUri), nullptr);
         if (bundleDir == nullptr) continue;
 
         found.push_back ({ juce::String (juce::CharPointer_UTF8 (bundleDir)),

--- a/src/engine/lv2/Lv2Scanner.cpp
+++ b/src/engine/lv2/Lv2Scanner.cpp
@@ -1,0 +1,32 @@
+#include "Lv2Scanner.h"
+
+#include <lilv/lilv.h>
+
+namespace duskstudio::lv2
+{
+std::vector<ScannedLv2> Lv2Scanner::scan()
+{
+    std::vector<ScannedLv2> found;
+    LilvWorld* world = lilv_world_new();
+    if (world == nullptr) return found;
+    lilv_world_load_all (world);   // $LV2_PATH, else the spec default directories
+
+    const LilvPlugins* all = lilv_world_get_all_plugins (world);
+    LILV_FOREACH (plugins, it, all)
+    {
+        const LilvPlugin* p = lilv_plugins_get (all, it);
+
+        // The bundle directory is what NativeLv2Slot::load takes.
+        char* bundleDir = lilv_file_uri_parse (
+            lilv_node_as_uri (lilv_plugin_get_bundle_uri (p)), nullptr);
+        if (bundleDir == nullptr) continue;
+
+        found.push_back ({ juce::String (juce::CharPointer_UTF8 (bundleDir)),
+                           Lv2Bundle::describePlugin (world, p) });
+        lilv_free (bundleDir);
+    }
+
+    lilv_world_free (world);
+    return found;
+}
+} // namespace duskstudio::lv2

--- a/src/engine/lv2/Lv2Scanner.h
+++ b/src/engine/lv2/Lv2Scanner.h
@@ -17,9 +17,11 @@ struct ScannedLv2
 
 // Discovers installed LV2 plugins via lilv, honouring $LV2_PATH or the spec
 // defaults (~/.lv2, /usr/lib/lv2, /usr/local/lib/lv2, distro multiarch dirs).
-// Message thread only. Discovery is manifest-only: lilv parses the Turtle
-// metadata and never dlopens the plugin binary, so a broken .so cannot crash
-// the scan — no sandbox child needed (unlike binary-loading formats).
+// Runs on whichever thread drives the plugin scan (PluginScanModal's background
+// thread in practice) — it owns a private LilvWorld, so it has no shared state;
+// the CALLER guards whatever it stores the results in. Discovery is
+// manifest-only: lilv parses the Turtle metadata and never dlopens the plugin
+// binary, so a broken .so cannot crash the scan — no sandbox child needed.
 class Lv2Scanner
 {
 public:

--- a/src/engine/lv2/Lv2Scanner.h
+++ b/src/engine/lv2/Lv2Scanner.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "Lv2Bundle.h"
+
+#include <juce_core/juce_core.h>
+
+#include <vector>
+
+namespace duskstudio::lv2
+{
+// One discoverable LV2 plugin: the bundle directory it lives in plus its descriptor.
+struct ScannedLv2
+{
+    juce::String bundlePath;   // absolute path to the .lv2 bundle directory
+    PluginDesc   desc;
+};
+
+// Discovers installed LV2 plugins via lilv, honouring $LV2_PATH or the spec
+// defaults (~/.lv2, /usr/lib/lv2, /usr/local/lib/lv2, distro multiarch dirs).
+// Message thread only. Discovery is manifest-only: lilv parses the Turtle
+// metadata and never dlopens the plugin binary, so a broken .so cannot crash
+// the scan — no sandbox child needed (unlike binary-loading formats).
+class Lv2Scanner
+{
+public:
+    static std::vector<ScannedLv2> scan();
+};
+} // namespace duskstudio::lv2

--- a/src/engine/lv2/NativeLv2Slot.cpp
+++ b/src/engine/lv2/NativeLv2Slot.cpp
@@ -1,0 +1,122 @@
+#include "NativeLv2Slot.h"
+
+#include <cstring>
+
+namespace duskstudio::lv2
+{
+bool NativeLv2Slot::load (const juce::File& path, double sampleRate, int maxBlock,
+                          std::string& errorOut)
+{
+    unload();
+
+    auto b = std::make_unique<Lv2Bundle>();
+    std::string err;
+    if (! b->load (path.getFullPathName().toStdString(), err))
+    { errorOut = "bundle: " + err; return false; }
+    if (b->plugins().empty())
+    { errorOut = "no plugins in bundle"; return false; }
+
+    // First audio effect (audio in + out); fall back to the first advertised plugin.
+    std::string uri = b->plugins().front().uri;
+    for (const auto& d : b->plugins())
+        if (d.audioInputs > 0 && d.audioOutputs > 0) { uri = d.uri; break; }
+
+    auto inst = std::make_unique<Lv2Instance>();
+    if (! inst->create (*b, uri, err))
+    { errorOut = "create: " + err; return false; }
+    if (! inst->activate (sampleRate, maxBlock, err))
+    { errorOut = "activate: " + err; return false; }
+
+    // Publish only after both are fully built; the audio thread's acquire-load of
+    // `ready` pairs with this release so it never sees a half-built instance.
+    bundle     = std::move (b);
+    instance   = std::move (inst);
+    adapter.prepare (instance->portLayout(), maxBlock);   // size the fold scratch
+    loadedPath = path.getFullPathName();
+    ready.store (true, std::memory_order_release);
+    return true;
+}
+
+bool NativeLv2Slot::reactivate (double sampleRate, int maxBlock, std::string& errorOut)
+{
+    if (instance == nullptr) { errorOut = "no instance"; return false; }
+    if (! instance->reactivate (sampleRate, maxBlock, errorOut)) return false;
+    adapter.prepare (instance->portLayout(), maxBlock);
+    return true;
+}
+
+void NativeLv2Slot::unload()
+{
+    ready.store (false, std::memory_order_release);
+    instance.reset();   // free the LilvInstance first
+    bundle.reset();     // then the world backing its plugin
+    loadedPath.clear();
+}
+
+void NativeLv2Slot::leakForShutdown() noexcept
+{
+    ready.store (false, std::memory_order_release);
+    (void) instance.release();
+    (void) bundle.release();
+    loadedPath.clear();
+}
+
+bool NativeLv2Slot::saveState (std::vector<uint8_t>& out) const
+{
+    return instance != nullptr && instance->saveState (out);
+}
+
+bool NativeLv2Slot::loadState (const std::vector<uint8_t>& in)
+{
+    return instance != nullptr && instance->loadState (in);
+}
+
+void NativeLv2Slot::processStereo (const float* inL, const float* inR,
+                                   float* outL, float* outR, int numFrames) noexcept
+{
+    auto clearOutputs = [&]
+    {
+        if (numFrames <= 0) return;
+        const size_t n = sizeof (float) * (size_t) numFrames;
+        if (outL != nullptr) std::memset (outL, 0, n);
+        if (outR != nullptr) std::memset (outR, 0, n);
+    };
+
+    // Clear when empty or momentarily inactive (mid-reactivate, fenced by the
+    // engine gate) — matches the pre-adapter behaviour of a no-op silent pass.
+    if (! ready.load (std::memory_order_acquire) || instance == nullptr
+        || ! instance->isActive() || inL == nullptr)
+    {
+        clearOutputs();
+        return;
+    }
+
+    if (numFrames <= 0) return;
+    const size_t n = sizeof (float) * (size_t) numFrames;
+
+    if (bypassed.load (std::memory_order_relaxed))
+    {
+        // Passthrough — copy in→out (a no-op when called in-place).
+        if (outL != nullptr && outL != inL) std::memcpy (outL, inL, n);
+        const float* r = (inR != nullptr) ? inR : inL;
+        if (outR != nullptr && outR != r)   std::memcpy (outR, r, n);
+        return;
+    }
+
+    // The adapter needs both output buffers to process in place; a missing one is
+    // the same silent no-op the pre-adapter path gave it.
+    if (outL == nullptr || outR == nullptr)
+    {
+        clearOutputs();
+        return;
+    }
+
+    // The InsertAdapter processes in place, so stage the input into the output
+    // buffers first (a no-op for the in-place call sites where out == in).
+    if (outL != inL) std::memcpy (outL, inL, n);
+    const float* r = (inR != nullptr) ? inR : inL;
+    if (outR != r)  std::memcpy (outR, r, n);
+
+    adapter.process (*instance, outL, outR, numFrames);
+}
+} // namespace duskstudio::lv2

--- a/src/engine/lv2/NativeLv2Slot.h
+++ b/src/engine/lv2/NativeLv2Slot.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "Lv2Bundle.h"
+#include "Lv2Instance.h"
+#include "../hosting/InsertAdapter.h"
+
+#include <juce_core/juce_core.h>
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace duskstudio::lv2
+{
+// One insert slot backed by the native LV2 host: owns the bundle + the instance,
+// loads / prepares / processes / unloads an LV2 plugin, and exposes the live
+// instance so the UI can attach an editor. load / unload are message-thread;
+// processStereo is the audio path and reads a lock-free `ready` flag so it no-ops
+// cleanly when empty. Direct mirror of NativeClapSlot — same public contract, so
+// the DSP call sites and session code treat CLAP and LV2 alike.
+//
+// Concurrency: a load / unload while the audio thread might be mid-process must be
+// fenced by the engine's process gate (suspend → silent buffers → swap → resume),
+// per [[project_multicore_dsp]]; the slot itself only guards the steady state via
+// the acquire/release `ready` flag.
+class NativeLv2Slot
+{
+public:
+    NativeLv2Slot() = default;
+
+    // Message thread: load + create + activate the first audio effect in the .lv2
+    // bundle at `path`, replacing any prior load. False (+ errorOut) on failure.
+    bool load (const juce::File& path, double sampleRate, int maxBlock, std::string& errorOut);
+    void unload();
+
+    // Re-activate the already-loaded instance at a new sample-rate / block-size.
+    // LV2 fixes the rate at instantiate, so this re-instantiates the plugin (its
+    // parameter state resets to defaults — state persistence isn't wired yet). No-op
+    // (false) when nothing is loaded. Caller fences the audio thread.
+    bool reactivate (double sampleRate, int maxBlock, std::string& errorOut);
+
+    // App shutdown: release the instance + bundle WITHOUT destroying, matching the
+    // CLAP path — teardown order across lilv + the plugin .so is skipped entirely
+    // on the way out (the OS reclaims the memory as the process exits).
+    void leakForShutdown() noexcept;
+
+    bool isLoaded() const noexcept { return ready.load (std::memory_order_acquire); }
+    const juce::String& getPath() const noexcept { return loadedPath; }
+
+    void setBypassed (bool b) noexcept { bypassed.store (b, std::memory_order_relaxed); }
+    bool isBypassed()   const noexcept { return bypassed.load (std::memory_order_relaxed); }
+
+    bool saveState (std::vector<uint8_t>& out) const;
+    bool loadState (const std::vector<uint8_t>& in);
+
+    // Audio thread: process stereo through the plugin, via the InsertAdapter →
+    // INativeInstance::processBlock. Clears the outputs + returns when no plugin is
+    // loaded; passes audio through when bypassed.
+    void processStereo (const float* inL, const float* inR,
+                        float* outL, float* outR, int numFrames) noexcept;
+
+    // UI: the live instance for editor attach (nullptr when not loaded).
+    Lv2Instance* getInstance() noexcept
+        { return ready.load (std::memory_order_acquire) ? instance.get() : nullptr; }
+
+private:
+    // bundle declared first so it is destroyed LAST — the instance (whose LilvPlugin
+    // points into the bundle's world) must tear down before the world is freed.
+    std::unique_ptr<Lv2Bundle>   bundle;
+    std::unique_ptr<Lv2Instance> instance;
+    hosting::InsertAdapter       adapter;
+    std::atomic<bool> ready    { false };
+    std::atomic<bool> bypassed { false };
+    juce::String      loadedPath;
+};
+} // namespace duskstudio::lv2

--- a/src/engine/lv2/NativeLv2Slot.h
+++ b/src/engine/lv2/NativeLv2Slot.h
@@ -35,7 +35,7 @@ public:
 
     // Re-activate the already-loaded instance at a new sample-rate / block-size.
     // LV2 fixes the rate at instantiate, so this re-instantiates the plugin; its
-    // control-port values carry across (state-extension blobs aren't wired yet).
+    // state (control ports + state:interface blob) carries across.
     // No-op (false) when nothing is loaded. Caller fences the audio thread.
     bool reactivate (double sampleRate, int maxBlock, std::string& errorOut);
 

--- a/src/engine/lv2/NativeLv2Slot.h
+++ b/src/engine/lv2/NativeLv2Slot.h
@@ -21,9 +21,8 @@ namespace duskstudio::lv2
 // the DSP call sites and session code treat CLAP and LV2 alike.
 //
 // Concurrency: a load / unload while the audio thread might be mid-process must be
-// fenced by the engine's process gate (suspend → silent buffers → swap → resume),
-// per [[project_multicore_dsp]]; the slot itself only guards the steady state via
-// the acquire/release `ready` flag.
+// fenced by the engine's process gate (suspend → silent buffers → swap → resume);
+// the slot itself only guards the steady state via the acquire/release `ready` flag.
 class NativeLv2Slot
 {
 public:
@@ -35,9 +34,9 @@ public:
     void unload();
 
     // Re-activate the already-loaded instance at a new sample-rate / block-size.
-    // LV2 fixes the rate at instantiate, so this re-instantiates the plugin (its
-    // parameter state resets to defaults — state persistence isn't wired yet). No-op
-    // (false) when nothing is loaded. Caller fences the audio thread.
+    // LV2 fixes the rate at instantiate, so this re-instantiates the plugin; its
+    // control-port values carry across (state-extension blobs aren't wired yet).
+    // No-op (false) when nothing is loaded. Caller fences the audio thread.
     bool reactivate (double sampleRate, int maxBlock, std::string& errorOut);
 
     // App shutdown: release the instance + bundle WITHOUT destroying, matching the

--- a/src/session/Session.h
+++ b/src/session/Session.h
@@ -802,10 +802,15 @@ struct Track
     juce::String pluginDescriptionXml;
     juce::String pluginStateBase64;
 
-    // Native CLAP insert alternative to the JUCE plugin above (mutually exclusive).
-    // When nativeClapPath is non-empty the insert hosts a .clap via NativeClapSlot.
+    // Native insert alternatives to the JUCE plugin above. An insert hosts at most
+    // ONE of {JUCE plugin, native CLAP, native LV2}: when nativeClapPath is non-empty
+    // the insert is a .clap via NativeClapSlot, when nativeLv2Path is non-empty a
+    // .lv2 via NativeLv2Slot (CLAP wins if both are somehow set). Always present so
+    // non-Linux builds round-trip the fields untouched.
     juce::String nativeClapPath;
     juce::String nativeClapStateBase64;
+    juce::String nativeLv2Path;
+    juce::String nativeLv2StateBase64;
 
     // Track freeze (MIDI tracks): the instrument + pre-fader strip is rendered
     // to a WAV, the plugin is bypassed to free CPU, and playback reads the WAV
@@ -958,12 +963,14 @@ struct AuxLane
     std::array<juce::String, AuxLaneParams::kMaxLanePlugins> pluginDescriptionXml;
     std::array<juce::String, AuxLaneParams::kMaxLanePlugins> pluginStateBase64;
 
-    // Native CLAP host alternative to the JUCE plugin above. When nativeClapPath is
-    // non-empty the slot hosts a .clap via NativeClapSlot instead of a JUCE plugin;
-    // nativeClapStateBase64 is the CLAP state blob. Mutually exclusive with the JUCE
-    // pair (a slot is JUCE / native-CLAP / hardware / empty).
+    // Native host alternatives to the JUCE plugin above. A slot is JUCE /
+    // native-CLAP / native-LV2 / hardware / empty — at most one host per slot
+    // (CLAP wins if both native paths are somehow set). Always present so
+    // non-Linux builds round-trip the fields untouched.
     std::array<juce::String, AuxLaneParams::kMaxLanePlugins> nativeClapPath;
     std::array<juce::String, AuxLaneParams::kMaxLanePlugins> nativeClapStateBase64;
+    std::array<juce::String, AuxLaneParams::kMaxLanePlugins> nativeLv2Path;
+    std::array<juce::String, AuxLaneParams::kMaxLanePlugins> nativeLv2StateBase64;
 
     std::array<HardwareInsertParams, AuxLaneParams::kMaxLanePlugins> hardwareInserts;
 };

--- a/src/session/SessionSerializer.cpp
+++ b/src/session/SessionSerializer.cpp
@@ -337,6 +337,11 @@ juce::DynamicObject::Ptr trackToObject (const Track& t, const juce::File& sessio
         obj->setProperty ("native_clap_path",  t.nativeClapPath);
         obj->setProperty ("native_clap_state", t.nativeClapStateBase64);
     }
+    if (t.nativeLv2Path.isNotEmpty())
+    {
+        obj->setProperty ("native_lv2_path",  t.nativeLv2Path);
+        obj->setProperty ("native_lv2_state", t.nativeLv2StateBase64);
+    }
 
     obj->setProperty ("fader_db",       t.strip.faderDb.load());
     obj->setProperty ("pan",            t.strip.pan.load());
@@ -730,6 +735,8 @@ void restoreTrack (Track& t, const juce::var& v, double defaultRecordBpm,
     t.pluginStateBase64    = v["plugin_state"]   .toString();
     t.nativeClapPath        = v["native_clap_path"] .toString();
     t.nativeClapStateBase64 = v["native_clap_state"].toString();
+    t.nativeLv2Path         = v["native_lv2_path"]  .toString();
+    t.nativeLv2StateBase64  = v["native_lv2_state"] .toString();
 
     auto setFloat = [&v] (std::atomic<float>& a, const char* key)
     {
@@ -1251,6 +1258,11 @@ juce::String SessionSerializer::serialize (const Session& s)
                 slot->setProperty ("native_clap_path",  lane.nativeClapPath[(size_t) p]);
                 slot->setProperty ("native_clap_state", lane.nativeClapStateBase64[(size_t) p]);
             }
+            if (lane.nativeLv2Path[(size_t) p].isNotEmpty())
+            {
+                slot->setProperty ("native_lv2_path",  lane.nativeLv2Path[(size_t) p]);
+                slot->setProperty ("native_lv2_state", lane.nativeLv2StateBase64[(size_t) p]);
+            }
 
             // Hardware-insert side of this slot. Same shape as the
             // Track::hardwareInsert block above.
@@ -1641,6 +1653,8 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
                     lane.pluginStateBase64[(size_t) p]    = sv["plugin_state"]   .toString();
                     lane.nativeClapPath[(size_t) p]        = sv["native_clap_path"] .toString();
                     lane.nativeClapStateBase64[(size_t) p] = sv["native_clap_state"].toString();
+                    lane.nativeLv2Path[(size_t) p]         = sv["native_lv2_path"]  .toString();
+                    lane.nativeLv2StateBase64[(size_t) p]  = sv["native_lv2_state"] .toString();
 
                     // Same default-off rationale as the track hardware_insert.
                     {

--- a/src/ui/AuxLaneComponent.cpp
+++ b/src/ui/AuxLaneComponent.cpp
@@ -320,7 +320,7 @@ AuxLaneComponent::AuxLaneComponent (AuxLane& l, AuxLaneStrip& s, int idx,
         s.openOrAddButton.onClick = [this, i]
         {
             auto& slotRef = strip.getPluginSlot (i);
-            if (slotRef.isLoaded() || strip.isNativeClapLoaded (i))
+            if (slotRef.isLoaded() || strip.isNativeClapLoaded (i) || strip.isNativeLv2Loaded (i))
             {
                 // Native CLAP fills the inline editor area when loaded (same as a JUCE
                 // plugin); clicking the name must not re-open the picker over it.
@@ -345,6 +345,13 @@ AuxLaneComponent::AuxLaneComponent (AuxLane& l, AuxLaneStrip& s, int idx,
             if (strip.isNativeClapLoaded (i))
             {
                 strip.getNativeClapSlot (i).setBypassed (on);
+            }
+            else
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+            if (strip.isNativeLv2Loaded (i))
+            {
+                strip.getNativeLv2Slot (i).setBypassed (on);
             }
             else
 #endif
@@ -669,6 +676,24 @@ void AuxLaneComponent::refreshSlotControls (int i)
         return;
     }
 #endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    if (strip.isNativeLv2Loaded (i))
+    {
+        const auto name = juce::File (strip.getNativeLv2Slot (i).getPath())
+                              .getFileNameWithoutExtension();
+        if (name != ui.displayedName)
+        {
+            ui.displayedName = name;
+            ui.openOrAddButton.setButtonText (name);
+            resized();
+        }
+        ui.bypassButton.setVisible (true);
+        ui.bypassButton.setToggleState (strip.getNativeLv2Slot (i).isBypassed(),
+                                        juce::dontSendNotification);
+        ui.removeButton.setVisible (true);
+        return;
+    }
+#endif
 
     if (slotRef.isLoaded())
     {
@@ -740,6 +765,14 @@ void AuxLaneComponent::openPickerForSlot (int slotIdx)
             self->loadNativeClapForSlot (slotIdx, clapFile);
     };
 #endif
+    std::function<void (const juce::File&)> onLv2;
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    onLv2 = [safe, slotIdx] (const juce::File& bundleDir)
+    {
+        if (auto* self = safe.getComponent())
+            self->loadNativeLv2ForSlot (slotIdx, bundleDir);
+    };
+#endif
     pluginpicker::openPickerMenu (strip.getPluginSlot (slotIdx),
                                     slots[(size_t) slotIdx].openOrAddButton,
                                     activePluginChooser,
@@ -765,6 +798,8 @@ void AuxLaneComponent::openPickerForSlot (int slotIdx)
                                                 self->engine.resumeProcessing();
                                                 self->lane.nativeClapPath[(size_t) slotIdx].clear();
                                                 self->lane.nativeClapStateBase64[(size_t) slotIdx].clear();
+                                                self->lane.nativeLv2Path[(size_t) slotIdx].clear();
+                                                self->lane.nativeLv2StateBase64[(size_t) slotIdx].clear();
                                             }
 
                                             self->refreshSlotControls (slotIdx);
@@ -779,7 +814,8 @@ void AuxLaneComponent::openPickerForSlot (int slotIdx)
                                             self->openHardwareInsertEditor (slotIdx);
                                     },
                                     /*suppressSecondaryButtons*/ false,
-                                    std::move (onClap));
+                                    std::move (onClap),
+                                    std::move (onLv2));
 }
 
 void AuxLaneComponent::openHardwareInsertEditor (int slotIdx)
@@ -831,6 +867,8 @@ void AuxLaneComponent::unloadSlot (int slotIdx)
             self->engine.resumeProcessing();
             self->lane.nativeClapPath[(size_t) slotIdx].clear();
             self->lane.nativeClapStateBase64[(size_t) slotIdx].clear();
+            self->lane.nativeLv2Path[(size_t) slotIdx].clear();
+            self->lane.nativeLv2StateBase64[(size_t) slotIdx].clear();
         }
         // Clear the model's enabled flag so any consumer that polls
         // lane.hardwareInserts[slotIdx].enabled sees a disabled slot
@@ -929,10 +967,53 @@ void AuxLaneComponent::loadNativeClapForSlot (int slotIdx, const juce::File& cla
     // Fresh plugin: don't inherit the previous slot occupant's state blob. The next
     // save re-captures this plugin's real state.
     lane.nativeClapStateBase64[(size_t) slotIdx].clear();
+    // The load evicted any native LV2 in this slot — drop its persisted refs too.
+    lane.nativeLv2Path[(size_t) slotIdx].clear();
+    lane.nativeLv2StateBase64[(size_t) slotIdx].clear();
     refreshSlotControls (slotIdx);
     rebuildSlots();
 }
 #endif // DUSKSTUDIO_HAS_NATIVE_CLAP
+
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+void AuxLaneComponent::loadNativeLv2ForSlot (int slotIdx, const juce::File& bundleDir)
+{
+    if (slotIdx < 0 || slotIdx >= AuxLaneParams::kMaxLanePlugins) return;
+
+    // A slot hosts exactly one thing — drop any editor first (the CLAP editor
+    // references an instance the load below evicts). Mirrors loadNativeClapForSlot.
+    detachEditorForSlot (slotIdx);
+    detachHardwareInsertForSlot (slotIdx);
+    detachClapEditorForSlot (slotIdx);
+
+    // NativeLv2Slot::load is NOT RT-safe; fence the audio thread around the swap.
+    // loadNativeLv2 itself evicts the CLAP + JUCE occupants.
+    std::string err;
+    bool ok = false;
+    engine.suspendProcessing();
+    ok = strip.loadNativeLv2 (slotIdx, bundleDir, err);
+    if (ok)
+        strip.insertMode[(size_t) slotIdx].store (AuxLaneStrip::kInsertPlugin,
+                                                   std::memory_order_release);
+    engine.resumeProcessing();
+
+    if (! ok)
+    {
+        std::fprintf (stderr, "[aux lv2] load failed: %s\n", err.c_str());
+        showDuskAlert (*this, "Couldn't load LV2 plugin",
+                       bundleDir.getFileNameWithoutExtension() + ":\n" + juce::String (err));
+        lane.nativeLv2Path[(size_t) slotIdx].clear();
+        lane.nativeLv2StateBase64[(size_t) slotIdx].clear();
+        return;
+    }
+    lane.nativeLv2Path[(size_t) slotIdx] = bundleDir.getFullPathName();
+    lane.nativeLv2StateBase64[(size_t) slotIdx].clear();
+    lane.nativeClapPath[(size_t) slotIdx].clear();
+    lane.nativeClapStateBase64[(size_t) slotIdx].clear();
+    refreshSlotControls (slotIdx);
+    rebuildSlots();
+}
+#endif // DUSKSTUDIO_HAS_NATIVE_LV2
 
 void AuxLaneComponent::detachClapEditorForSlot (int slotIdx)
 {
@@ -1025,7 +1106,7 @@ void AuxLaneComponent::layoutEditorForSlot (int slotIdx)
     auto& slot = strip.getPluginSlot (slotIdx);
     const int mode = strip.insertMode[(size_t) slotIdx].load (std::memory_order_relaxed);
     if (slot.isLoaded() || slot.isOffline() || mode == AuxLaneStrip::kInsertHardware
-        || strip.isNativeClapLoaded (slotIdx))
+        || strip.isNativeClapLoaded (slotIdx) || strip.isNativeLv2Loaded (slotIdx))
         center.removeFromTop (kSlotHeaderH + 4);
 
     if (center.isEmpty()) return;
@@ -1291,13 +1372,13 @@ void AuxLaneComponent::resized()
     // and removeButton — made visible by refreshSlotControls in HW
     // mode — would never get bounds and the user couldn't dismiss
     // the HW insert.
-    const bool nativeClap = strip.isNativeClapLoaded (0);
-    if (slot0.isLoaded() || slot0.isOffline() || hardware || nativeClap)
+    const bool nativeLoaded = strip.isNativeClapLoaded (0) || strip.isNativeLv2Loaded (0);
+    if (slot0.isLoaded() || slot0.isOffline() || hardware || nativeLoaded)
     {
         auto headerStrip = center.removeFromTop (kSlotHeaderH);
         ui.removeButton.setBounds (headerStrip.removeFromRight (28));
         headerStrip.removeFromRight (4);
-        if (slot0.isLoaded() || nativeClap)
+        if (slot0.isLoaded() || nativeLoaded)
         {
             ui.bypassButton.setBounds (headerStrip.removeFromRight (44));
             headerStrip.removeFromRight (4);

--- a/src/ui/AuxLaneComponent.cpp
+++ b/src/ui/AuxLaneComponent.cpp
@@ -1350,9 +1350,10 @@ void AuxLaneComponent::parentHierarchyChanged()
         for (int i = 0; i < AuxLaneParams::kMaxLanePlugins; ++i)
         {
             detachEditorForSlot (i);
-            // The native CLAP editor's embedded X11 window is also parented to the
-            // destroyed peer; tear it down so rebuildSlots re-embeds it on the new one.
+            // The native editors' embedded X11 windows are also parented to the
+            // destroyed peer; tear them down so rebuildSlots re-embeds on the new one.
             detachClapEditorForSlot (i);
+            detachLv2EditorForSlot (i);
         }
         lastSeenPeer = peer;
     }

--- a/src/ui/AuxLaneComponent.cpp
+++ b/src/ui/AuxLaneComponent.cpp
@@ -2,6 +2,9 @@
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
   #include "ClapPluginEditorComponent.h"   // Linux-only native CLAP editor
 #endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+  #include "Lv2PluginEditorComponent.h"    // Linux-only native LV2 editor (suil)
+#endif
 #include "DuskAlerts.h"
 #include "DuskContextMenu.h"
 #include "HardwareInsertEditor.h"
@@ -792,6 +795,7 @@ void AuxLaneComponent::openPickerForSlot (int slotIdx)
                                                     || self->strip.isNativeLv2Loaded (slotIdx)))
                                             {
                                                 self->detachClapEditorForSlot (slotIdx);
+                                                self->detachLv2EditorForSlot (slotIdx);
                                                 self->engine.suspendProcessing();
                                                 self->strip.unloadNativeClap (slotIdx);
                                                 self->strip.unloadNativeLv2 (slotIdx);
@@ -855,10 +859,10 @@ void AuxLaneComponent::unloadSlot (int slotIdx)
         const bool hadNative = self->strip.isNativeClapLoaded (slotIdx)
                             || self->strip.isNativeLv2Loaded (slotIdx);
         if (hadNative) self->engine.suspendProcessing();
-        // Tear the shared CLAP editor down INSIDE the suspended window: its destructor
-        // runs gui->destroy, and doing that while the audio thread is quiesced keeps it
-        // off the same ClapInstance the audio path is reading.
+        // Tear the shared native editors down INSIDE the suspended window: their
+        // destructors reach into the instance the audio path is reading.
         self->detachClapEditorForSlot (slotIdx);
+        self->detachLv2EditorForSlot (slotIdx);
         self->strip.getPluginSlot (slotIdx).unload();
         if (hadNative)
         {
@@ -939,6 +943,7 @@ void AuxLaneComponent::loadNativeClapForSlot (int slotIdx, const juce::File& cla
     detachEditorForSlot (slotIdx);
     detachHardwareInsertForSlot (slotIdx);
     detachClapEditorForSlot (slotIdx);
+    detachLv2EditorForSlot (slotIdx);
 
     // NativeClapSlot::load is NOT RT-safe (it tears down + rebuilds the instance),
     // so fence the audio thread with the engine process gate around the swap.
@@ -985,6 +990,7 @@ void AuxLaneComponent::loadNativeLv2ForSlot (int slotIdx, const juce::File& bund
     detachEditorForSlot (slotIdx);
     detachHardwareInsertForSlot (slotIdx);
     detachClapEditorForSlot (slotIdx);
+    detachLv2EditorForSlot (slotIdx);
 
     // NativeLv2Slot::load is NOT RT-safe; fence the audio thread around the swap.
     // loadNativeLv2 itself evicts the CLAP + JUCE occupants.
@@ -1027,14 +1033,35 @@ void AuxLaneComponent::detachClapEditorForSlot (int slotIdx)
 #endif
 }
 
+void AuxLaneComponent::detachLv2EditorForSlot (int slotIdx)
+{
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    auto& ui = slots[(size_t) slotIdx];
+    if (ui.lv2Editor == nullptr) return;
+    removeChildComponent (ui.lv2Editor.get());
+    ui.lv2Editor.reset();
+#else
+    juce::ignoreUnused (slotIdx);
+#endif
+}
+
 void AuxLaneComponent::dropAllClapEditors()
 {
+    // Covers both native editor kinds (the LV2 loop rides along; the name predates it).
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
     for (int i = 0; i < AuxLaneParams::kMaxLanePlugins; ++i)
     {
         if (slots[(size_t) i].clapEditor != nullptr)
             slots[(size_t) i].clapEditor->leakForShutdown();   // u-he hangs in gui->destroy
         detachClapEditorForSlot (i);
+    }
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    for (int i = 0; i < AuxLaneParams::kMaxLanePlugins; ++i)
+    {
+        if (slots[(size_t) i].lv2Editor != nullptr)
+            slots[(size_t) i].lv2Editor->leakForShutdown();
+        detachLv2EditorForSlot (i);
     }
 #endif
 }
@@ -1097,6 +1124,10 @@ void AuxLaneComponent::layoutEditorForSlot (int slotIdx)
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
     else if (ui.clapEditor != nullptr && ui.clapEditor->getParentComponent() == this)
         body = ui.clapEditor.get();
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    else if (ui.lv2Editor != nullptr && ui.lv2Editor->getParentComponent() == this)
+        body = ui.lv2Editor.get();
 #endif
     else if (ui.hwInsertEditor != nullptr && ui.hwInsertEditor->getParentComponent() == this)
         body = ui.hwInsertEditor.get();
@@ -1202,6 +1233,32 @@ void AuxLaneComponent::rebuildSlots()
                 continue;
             }
             detachClapEditorForSlot (i);   // native unloaded (no-op stub off Linux)
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+            if (strip.isNativeLv2Loaded (i))
+            {
+                if (ui.editor != nullptr) detachEditorForSlot (i);   // can't coexist
+                auto* lv2Inst = strip.getNativeLv2Slot (i).getInstance();
+                if (ui.lv2Editor == nullptr && lv2Inst != nullptr)
+                {
+                    auto ed = std::make_unique<Lv2PluginEditorComponent>();
+                    juce::String err;
+                    if (ed->attach (*lv2Inst, err))
+                    {
+                        ui.lv2Editor = std::move (ed);
+                        addAndMakeVisible (*ui.lv2Editor);
+                        layoutEditorForSlot (i);
+                    }
+                    else
+                        std::fprintf (stderr, "[aux lv2] editor attach failed: %s\n", err.toRawUTF8());
+                }
+                else if (ui.lv2Editor != nullptr)
+                {
+                    layoutEditorForSlot (i);
+                }
+                continue;
+            }
+            detachLv2EditorForSlot (i);
 #endif
 
             auto* instance = strip.getPluginSlot (i).getInstance();

--- a/src/ui/AuxLaneComponent.cpp
+++ b/src/ui/AuxLaneComponent.cpp
@@ -750,6 +750,23 @@ void AuxLaneComponent::openPickerForSlot (int slotIdx)
                                             self->strip.insertMode[(size_t) slotIdx]
                                                 .store (AuxLaneStrip::kInsertPlugin,
                                                          std::memory_order_release);
+
+                                            // One host per slot: a successful JUCE load evicts any
+                                            // native slot — the audio chain checks natives first, so
+                                            // a lingering native would shadow the picked plugin.
+                                            if (self->strip.getPluginSlot (slotIdx).isLoaded()
+                                                && (self->strip.isNativeClapLoaded (slotIdx)
+                                                    || self->strip.isNativeLv2Loaded (slotIdx)))
+                                            {
+                                                self->detachClapEditorForSlot (slotIdx);
+                                                self->engine.suspendProcessing();
+                                                self->strip.unloadNativeClap (slotIdx);
+                                                self->strip.unloadNativeLv2 (slotIdx);
+                                                self->engine.resumeProcessing();
+                                                self->lane.nativeClapPath[(size_t) slotIdx].clear();
+                                                self->lane.nativeClapStateBase64[(size_t) slotIdx].clear();
+                                            }
+
                                             self->refreshSlotControls (slotIdx);
                                             self->rebuildSlots();
                                         }
@@ -799,7 +816,8 @@ void AuxLaneComponent::unloadSlot (int slotIdx)
         if (self == nullptr) return;
         self->detachEditorForSlot (slotIdx);
         self->detachHardwareInsertForSlot (slotIdx);
-        const bool hadNative = self->strip.isNativeClapLoaded (slotIdx);
+        const bool hadNative = self->strip.isNativeClapLoaded (slotIdx)
+                            || self->strip.isNativeLv2Loaded (slotIdx);
         if (hadNative) self->engine.suspendProcessing();
         // Tear the shared CLAP editor down INSIDE the suspended window: its destructor
         // runs gui->destroy, and doing that while the audio thread is quiesced keeps it
@@ -809,6 +827,7 @@ void AuxLaneComponent::unloadSlot (int slotIdx)
         if (hadNative)
         {
             self->strip.unloadNativeClap (slotIdx);
+            self->strip.unloadNativeLv2 (slotIdx);
             self->engine.resumeProcessing();
             self->lane.nativeClapPath[(size_t) slotIdx].clear();
             self->lane.nativeClapStateBase64[(size_t) slotIdx].clear();

--- a/src/ui/AuxLaneComponent.cpp
+++ b/src/ui/AuxLaneComponent.cpp
@@ -7,6 +7,7 @@
 #endif
 #include "DuskAlerts.h"
 #include "DuskContextMenu.h"
+#include "EmbeddedModal.h"   // kPluginEditorTag
 #include "HardwareInsertEditor.h"
 #include "PlatformWindowing.h"
 #include "PluginPickerHelpers.h"
@@ -907,7 +908,7 @@ void AuxLaneComponent::attachEditorForSlot (int slotIdx)
     // for the lifetime of any modal. Plugin editors (OOP / XEmbed / GL)
     // sometimes render above JUCE's modal layer and steal click input;
     // setVisible(false) for the modal's duration forces them under.
-    ui.editor->getProperties().set ("dusk_pluginEditor", true);
+    ui.editor->getProperties().set (kPluginEditorTag, true);
 
     addAndMakeVisible (*ui.editor);
     layoutEditorForSlot (slotIdx);

--- a/src/ui/AuxLaneComponent.h
+++ b/src/ui/AuxLaneComponent.h
@@ -63,6 +63,9 @@ private:
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
     void loadNativeClapForSlot (int slotIdx, const juce::File& clapFile);   // Linux-only
 #endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    void loadNativeLv2ForSlot (int slotIdx, const juce::File& bundleDir);   // Linux-only, no editor yet
+#endif
     // Stubbed (no-op body) off Linux so the many callers don't each need a guard.
     void detachClapEditorForSlot (int slotIdx);
     void hideEditorsKeepingAlive();

--- a/src/ui/AuxLaneComponent.h
+++ b/src/ui/AuxLaneComponent.h
@@ -68,6 +68,7 @@ private:
 #endif
     // Stubbed (no-op body) off Linux so the many callers don't each need a guard.
     void detachClapEditorForSlot (int slotIdx);
+    void detachLv2EditorForSlot (int slotIdx);
     void hideEditorsKeepingAlive();
     void layoutEditorForSlot (int slotIdx);
     void scheduleEditorRefits (int slotIdx);
@@ -139,6 +140,10 @@ private:
         // NativeClapSlot instance. Mutually exclusive with `editor` above. Linux-only.
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
         std::unique_ptr<ClapPluginEditorComponent>  clapEditor;
+#endif
+        // Native LV2 (suil) editor — same contract as clapEditor.
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+        std::unique_ptr<class Lv2PluginEditorComponent> lv2Editor;
 #endif
         juce::String displayedName;
     };

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -1505,17 +1505,18 @@ ChannelStripComponent::~ChannelStripComponent()
     stopTimer();   // before derived members destruct (base Timer::~Timer is too late)
     engine.removeChangeListener (this);
 
-    // If a popup editor is still on screen when the strip dies (e.g. the
-    // window is closing), force-delete it so its content (which references
-    // `track`) doesn't outlive us. Same SafePointer pattern as the audio
-    // settings dialog in MainComponent.
-    eqEditorModal.close();
-    compEditorModal.close();
-    auxEditorModal.close();
-    // I/O popup re-parents this strip's modeSelector / inputSelector children,
-    // so it must close LAST — before those combo members destruct — so its
-    // deferred body teardown doesn't outlive the controls it borrowed.
-    ioConfigModal.close();
+    // If a popup editor is still open when the strip dies, destroy its body
+    // NOW (synchronously) rather than via close()'s deferred callAsync: on the
+    // app-quit path the message loop has already exited, so a deferred body
+    // teardown never runs (leak) or fires during MessageManager shutdown after
+    // members are gone. The I/O popup additionally re-parents this strip's live
+    // modeSelector / midiActivityLed children, so its body must be gone while
+    // those members are still alive — closeAndDeleteBodyNow() runs here, before
+    // any member destructs. Same variant MainComponent uses for shutdown.
+    eqEditorModal.closeAndDeleteBodyNow();
+    compEditorModal.closeAndDeleteBodyNow();
+    auxEditorModal.closeAndDeleteBodyNow();
+    ioConfigModal.closeAndDeleteBodyNow();
     // Drop the cached editor BEFORE the strip's PluginSlot destructs,
     // since the editor's destructor calls editorBeingDeleted on its
     // owning AudioProcessor. dropPluginEditor() also closes the modal.
@@ -2559,10 +2560,13 @@ void ChannelStripComponent::openIoConfigPopup()
     auto* topLevel = getTopLevelComponent();
     if (topLevel == nullptr) topLevel = this;
 
-    // The panel borrows this strip's live combo children; owning show() adds
-    // them as its children and close() releases them back (re-parented on the
-    // next open). The DuskComboBox dropdowns render as nested in-window modals,
-    // so no CallOutBox-style "sticky while a native popup is up" guard is needed.
+    // The panel borrows this strip's live combo children; owning show() re-parents
+    // them into the panel. On close the panel is destroyed and the combos are left
+    // parentless (still owned as strip members, so they survive) — invisible until
+    // the next open re-parents them, which is what we want: compact mode shows the
+    // ioConfigButton, never the bare combos. The DuskComboBox dropdowns render as
+    // nested in-window modals, so no CallOutBox-style "sticky while a native popup
+    // is up" guard is needed.
     ioConfigModal.show (*topLevel, std::move (panel),
                         /*onDismiss*/ {}, /*dismissOnClickOutside*/ true,
                         /*dismissOnEscape*/ true, kEditorDimAlpha);

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -1430,7 +1430,9 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
         "open the routing editor."));
     pluginSlotButton.onClick = [this]
     {
-        if (pluginSlot.isLoaded() || engine.getChannelStrip (trackIndex).isNativeClapLoaded())
+        if (pluginSlot.isLoaded()
+            || engine.getChannelStrip (trackIndex).isNativeClapLoaded()
+            || engine.getChannelStrip (trackIndex).isNativeLv2Loaded())
         {
             togglePluginEditor();
             return;
@@ -1868,6 +1870,16 @@ void ChannelStripComponent::openPluginPicker (bool useChooser)
                 self->loadNativeClapForChannel (f);
         };
 #endif
+    // Native LV2 route — same shape; LV2-Native rows replace the JUCE LV2 rows.
+    std::function<void (const juce::File&)> onLv2;
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    if (kind == pluginpicker::PluginKind::Effects)
+        onLv2 = [safe] (const juce::File& f)
+        {
+            if (auto* self = safe.getComponent())
+                self->loadNativeLv2ForChannel (f);
+        };
+#endif
 
     if (useChooser)
     {
@@ -1877,7 +1889,8 @@ void ChannelStripComponent::openPluginPicker (bool useChooser)
                                           std::move (onChange),
                                           kind,
                                           std::move (openHwEditor),
-                                          std::move (onClap));
+                                          std::move (onClap),
+                                          std::move (onLv2));
     }
     else
     {
@@ -1892,7 +1905,8 @@ void ChannelStripComponent::openPluginPicker (bool useChooser)
                                        { -1, -1 },
                                        /*onPickHardwareInsert*/ {},
                                        /*suppressSecondaryButtons*/ true,
-                                       std::move (onClap));
+                                       std::move (onClap),
+                                       std::move (onLv2));
     }
 }
 
@@ -1949,6 +1963,22 @@ void ChannelStripComponent::unloadPluginSlot()
         return;
     }
 #endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    {
+        auto& lv2Strip = engine.getChannelStrip (trackIndex);
+        if (lv2Strip.isNativeLv2Loaded())
+        {
+            engine.suspendProcessing();
+            lv2Strip.unloadNativeLv2();
+            lv2Strip.insertMode.store (ChannelStrip::kInsertPlugin, std::memory_order_release);
+            engine.resumeProcessing();
+            track.nativeLv2Path = {};
+            track.nativeLv2StateBase64 = {};
+            refreshPluginSlotButton();
+            return;
+        }
+    }
+#endif
 
     pluginSlot.unload();
     refreshPluginSlotButton();
@@ -1957,7 +1987,8 @@ void ChannelStripComponent::unloadPluginSlot()
 void ChannelStripComponent::showPluginSlotMenu()
 {
     juce::PopupMenu menu;
-    const bool nativeLoaded = engine.getChannelStrip (trackIndex).isNativeClapLoaded();
+    const bool nativeLoaded = engine.getChannelStrip (trackIndex).isNativeClapLoaded()
+                           || engine.getChannelStrip (trackIndex).isNativeLv2Loaded();
     if (pluginSlot.isLoaded() || nativeLoaded)
     {
         // Editor toggle headline so right-click ALSO becomes a way to open
@@ -2037,6 +2068,20 @@ void ChannelStripComponent::refreshPluginSlotButton()
     {
         const auto nm = juce::File (engine.getChannelStrip (trackIndex)
                                       .getNativeClapSlot().getPath())
+                          .getFileNameWithoutExtension();
+        const auto label = juce::String (juce::CharPointer_UTF8 ("\xe2\x96\xbe ")) + nm;
+        if (label == lastSlotName) return;
+        lastSlotName = label;
+        pluginSlotButton.setButtonText (label);
+        return;
+    }
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    if (engine.getChannelStrip (trackIndex).isNativeLv2Loaded())
+    {
+        // Bundle directory name minus the ".lv2" suffix.
+        const auto nm = juce::File (engine.getChannelStrip (trackIndex)
+                                      .getNativeLv2Slot().getPath())
                           .getFileNameWithoutExtension();
         const auto label = juce::String (juce::CharPointer_UTF8 ("\xe2\x96\xbe ")) + nm;
         if (label == lastSlotName) return;
@@ -2479,10 +2524,61 @@ void ChannelStripComponent::loadNativeClapForChannel (const juce::File& clapFile
     // Fresh bundle: don't reuse the previous plugin's state blob. The next save
     // re-captures this plugin's real state.
     track.nativeClapStateBase64 = {};
+    // The load evicted any native LV2 in this insert — drop its persisted refs too.
+    track.nativeLv2Path = {};
+    track.nativeLv2StateBase64 = {};
     refreshPluginSlotButton();
     openPluginEditor();
 }
 #endif // DUSKSTUDIO_HAS_NATIVE_CLAP
+
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+void ChannelStripComponent::loadNativeLv2ForChannel (const juce::File& bundleDir)
+{
+    auto& strip = engine.getChannelStrip (trackIndex);
+
+    // One insert per strip — tear down whatever editor is open first (the CLAP
+    // editor references an instance the load below evicts). Mirrors
+    // loadNativeClapForChannel.
+    closePluginEditor();
+#if DUSKSTUDIO_HAS_NATIVE_CLAP
+    clapEditor.reset();
+#endif
+    pluginEditor.reset();
+    pluginEditorOwner = nullptr;
+   #if JUCE_LINUX && DUSKSTUDIO_HAS_OOP_PLUGINS
+    remoteEditorEmbed.reset();
+   #endif
+   #if DUSKSTUDIO_HAS_OOP_PLUGINS && ! JUCE_LINUX
+    remoteForeignEmbed.reset();
+   #endif
+
+    // NativeLv2Slot::load is NOT RT-safe; fence the audio thread around the swap.
+    // loadNativeLv2 itself evicts the CLAP + JUCE occupants.
+    std::string err;
+    engine.suspendProcessing();
+    const bool ok = strip.loadNativeLv2 (bundleDir, err);
+    if (ok)
+        strip.insertMode.store (ChannelStrip::kInsertPlugin, std::memory_order_release);
+    engine.resumeProcessing();
+
+    if (! ok)
+    {
+        std::fprintf (stderr, "[chan lv2] load failed: %s\n", err.c_str());
+        showDuskAlert (*this, "Couldn't load LV2 plugin",
+                       bundleDir.getFileNameWithoutExtension() + ":\n" + juce::String (err));
+        track.nativeLv2Path = {};
+        track.nativeLv2StateBase64 = {};
+        return;
+    }
+
+    track.nativeLv2Path = bundleDir.getFullPathName();
+    track.nativeLv2StateBase64 = {};
+    track.nativeClapPath = {};
+    track.nativeClapStateBase64 = {};
+    refreshPluginSlotButton();
+}
+#endif // DUSKSTUDIO_HAS_NATIVE_LV2
 
 namespace
 {
@@ -3877,7 +3973,9 @@ void ChannelStripComponent::showColourMenu()
     // Plugin slot menu items, only meaningful when a plugin is loaded.
     // Replace/Remove live here (rather than on the slot button itself) so
     // the slot button's primary click stays as a toggle for the editor.
-    if (pluginSlot.isLoaded() || engine.getChannelStrip (trackIndex).isNativeClapLoaded())
+    if (pluginSlot.isLoaded()
+        || engine.getChannelStrip (trackIndex).isNativeClapLoaded()
+        || engine.getChannelStrip (trackIndex).isNativeLv2Loaded())
     {
         menu.addSeparator();
         menu.addItem (1010, "Replace plugin...");
@@ -4005,10 +4103,11 @@ void ChannelStripComponent::onTrackModeChanged()
         if (willBeMidi != isInstrument)
             unloadPluginSlot();
     }
-    else if (engine.getChannelStrip (trackIndex).isNativeClapLoaded()
+    else if ((engine.getChannelStrip (trackIndex).isNativeClapLoaded()
+              || engine.getChannelStrip (trackIndex).isNativeLv2Loaded())
              && mode == (int) Track::Mode::Midi)
     {
-        // Native CLAP inserts are effects-only; a MIDI strip can't host one.
+        // Native inserts are effects-only; a MIDI strip can't host one.
         unloadPluginSlot();
     }
 

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -1761,9 +1761,26 @@ void ChannelStripComponent::openPluginPicker (bool useChooser)
                                         if (self == nullptr) return;
                                         // Picking a plugin flips the strip back to Plugin mode
                                         // (overriding any prior Hardware selection on this slot).
-                                        self->engine.getChannelStrip (self->trackIndex)
-                                                  .insertMode.store (ChannelStrip::kInsertPlugin,
-                                                                       std::memory_order_release);
+                                        auto& chStrip = self->engine.getChannelStrip (self->trackIndex);
+                                        chStrip.insertMode.store (ChannelStrip::kInsertPlugin,
+                                                                  std::memory_order_release);
+
+                                        // One host per insert: a successful JUCE load evicts any
+                                        // native slot — the audio chain checks natives first, so a
+                                        // lingering native would silently shadow the picked plugin.
+                                        if (self->pluginSlot.isLoaded()
+                                            && (chStrip.isNativeClapLoaded() || chStrip.isNativeLv2Loaded()))
+                                        {
+   #if DUSKSTUDIO_HAS_NATIVE_CLAP
+                                            self->clapEditor.reset();   // references the dying instance
+   #endif
+                                            self->engine.suspendProcessing();
+                                            chStrip.unloadNativeClap();
+                                            chStrip.unloadNativeLv2();
+                                            self->engine.resumeProcessing();
+                                            self->track.nativeClapPath = {};
+                                            self->track.nativeClapStateBase64 = {};
+                                        }
 
                                         // Loading an instrument (soundfont or VST/LV2 synth) on a
                                         // non-MIDI track leaves the strip silent — instrument

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -11,6 +11,9 @@
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
   #include "ClapPluginEditorComponent.h"   // Linux-only native CLAP editor
 #endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+  #include "Lv2PluginEditorComponent.h"    // Linux-only native LV2 editor (suil)
+#endif
 #include "DuskAlerts.h"
 #include "FreezeDialog.h"
 #include "../engine/AudioEngine.h"
@@ -1776,6 +1779,9 @@ void ChannelStripComponent::openPluginPicker (bool useChooser)
    #if DUSKSTUDIO_HAS_NATIVE_CLAP
                                             self->clapEditor.reset();   // references the dying instance
    #endif
+   #if DUSKSTUDIO_HAS_NATIVE_LV2
+                                            self->lv2Editor.reset();
+   #endif
                                             self->engine.suspendProcessing();
                                             chStrip.unloadNativeClap();
                                             chStrip.unloadNativeLv2();
@@ -1968,6 +1974,7 @@ void ChannelStripComponent::unloadPluginSlot()
         auto& lv2Strip = engine.getChannelStrip (trackIndex);
         if (lv2Strip.isNativeLv2Loaded())
         {
+            lv2Editor.reset();   // references the dying instance
             engine.suspendProcessing();
             lv2Strip.unloadNativeLv2();
             lv2Strip.insertMode.store (ChannelStrip::kInsertPlugin, std::memory_order_release);
@@ -2212,6 +2219,26 @@ void ChannelStripComponent::openPluginEditor()
         return;
     }
 #endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    if (engine.getChannelStrip (trackIndex).isNativeLv2Loaded())
+    {
+        auto* inst = engine.getChannelStrip (trackIndex).getNativeLv2Slot().getInstance();
+        if (inst == nullptr) return;
+        if (lv2Editor == nullptr)
+        {
+            lv2Editor = std::make_unique<Lv2PluginEditorComponent>();
+            juce::String err;
+            if (! lv2Editor->attach (*inst, err))
+            {
+                std::fprintf (stderr, "[chan lv2] %s\n", err.toRawUTF8());
+                lv2Editor.reset();
+                return;
+            }
+        }
+        pluginEditorModal.showBorrowed (*parent, *lv2Editor, onClose);
+        return;
+    }
+#endif
 
    #if DUSKSTUDIO_HAS_OOP_PLUGINS
     if (pluginSlot.isRemote())
@@ -2441,6 +2468,13 @@ void ChannelStripComponent::dropPluginEditor()
         clapEditor.reset();
     }
 #endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    if (lv2Editor != nullptr)
+    {
+        lv2Editor->leakForShutdown();
+        lv2Editor.reset();
+    }
+#endif
     // ~AudioProcessorEditor tears down the plugin's internal X11
     // children synchronously (colour pickers, preset browsers,
     // transient popups). On a Wayland session, any of those could
@@ -2486,6 +2520,9 @@ void ChannelStripComponent::loadNativeClapForChannel (const juce::File& clapFile
     // cleanly; only shutdown needs the leak path.
     closePluginEditor();
     clapEditor.reset();
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    lv2Editor.reset();   // an evicted LV2's UI must not outlive its instance
+#endif
     pluginEditor.reset();
     pluginEditorOwner = nullptr;
     // Release any OOP-side embed too — replacing a remote (OOP) plugin with a native
@@ -2544,6 +2581,7 @@ void ChannelStripComponent::loadNativeLv2ForChannel (const juce::File& bundleDir
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
     clapEditor.reset();
 #endif
+    lv2Editor.reset();
     pluginEditor.reset();
     pluginEditorOwner = nullptr;
    #if JUCE_LINUX && DUSKSTUDIO_HAS_OOP_PLUGINS
@@ -2577,6 +2615,7 @@ void ChannelStripComponent::loadNativeLv2ForChannel (const juce::File& bundleDir
     track.nativeClapPath = {};
     track.nativeClapStateBase64 = {};
     refreshPluginSlotButton();
+    openPluginEditor();
 }
 #endif // DUSKSTUDIO_HAS_NATIVE_LV2
 

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -1788,6 +1788,8 @@ void ChannelStripComponent::openPluginPicker (bool useChooser)
                                             self->engine.resumeProcessing();
                                             self->track.nativeClapPath = {};
                                             self->track.nativeClapStateBase64 = {};
+                                            self->track.nativeLv2Path = {};
+                                            self->track.nativeLv2StateBase64 = {};
                                         }
 
                                         // Loading an instrument (soundfont or VST/LV2 synth) on a

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -2271,7 +2271,7 @@ void ChannelStripComponent::openPluginEditor()
             // lifetime of any subsequent settings / quit modal — native
             // X11 z-order otherwise paints the plugin window above the
             // JUCE-rendered modal.
-            remoteEditorEmbed->getProperties().set ("dusk_pluginEditor", true);
+            remoteEditorEmbed->getProperties().set (kPluginEditorTag, true);
         }
         pluginEditorModal.showBorrowed (*parent, *remoteEditorEmbed, onClose);
        #elif JUCE_MAC
@@ -2345,7 +2345,7 @@ void ChannelStripComponent::openPluginEditor()
             // wrapper too (same reason as the Linux XEmbed + in-process
             // paths). Defensive today — createInProcessEditorHost is a Mac
             // stub returning nullptr — but correct once the shell host lands.
-            embed->getProperties().set ("dusk_pluginEditor", true);
+            embed->getProperties().set (kPluginEditorTag, true);
             pluginEditorModal.showBorrowed (*parent, *embed, onClose);
             remoteForeignEmbed = std::move (embed);
         }
@@ -2372,7 +2372,7 @@ void ChannelStripComponent::openPluginEditor()
             // Tag so a later settings / quit modal hides the reparented HWND
             // wrapper too — native window z-order otherwise paints the plugin
             // above the JUCE-rendered modal.
-            embed->getProperties().set ("dusk_pluginEditor", true);
+            embed->getProperties().set (kPluginEditorTag, true);
             pluginEditorModal.showBorrowed (*parent, *embed, onClose);
             remoteForeignEmbed = std::move (embed);
         }
@@ -2422,7 +2422,7 @@ void ChannelStripComponent::openPluginEditor()
     // Tag so EmbeddedModal hides the editor when a settings / quit /
     // alert modal opens. In-process plugin editors with GL contexts or
     // foreign-window embeds can paint above the modal otherwise.
-    pluginEditor->getProperties().set ("dusk_pluginEditor", true);
+    pluginEditor->getProperties().set (kPluginEditorTag, true);
 
     pluginEditorModal.showBorrowed (*parent, *pluginEditor, onClose);
 }

--- a/src/ui/ChannelStripComponent.h
+++ b/src/ui/ChannelStripComponent.h
@@ -334,6 +334,10 @@ private:
     std::unique_ptr<class ClapPluginEditorComponent> clapEditor;
     void loadNativeClapForChannel (const juce::File& clapFile);
 #endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    // Native LV2 insert load (no suil editor yet — the slot hosts audio only).
+    void loadNativeLv2ForChannel (const juce::File& bundleDir);
+#endif
 
    #if JUCE_LINUX && DUSKSTUDIO_HAS_OOP_PLUGINS
     // OOP: child plugin's X11 Window wrapped in XEmbedComponent fed

--- a/src/ui/ChannelStripComponent.h
+++ b/src/ui/ChannelStripComponent.h
@@ -335,7 +335,9 @@ private:
     void loadNativeClapForChannel (const juce::File& clapFile);
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_LV2
-    // Native LV2 insert load (no suil editor yet — the slot hosts audio only).
+    // Native LV2 insert editor (suil) — same kept-alive/showBorrowed lifecycle as
+    // clapEditor above.
+    std::unique_ptr<class Lv2PluginEditorComponent> lv2Editor;
     void loadNativeLv2ForChannel (const juce::File& bundleDir);
 #endif
 

--- a/src/ui/ClapPluginEditorComponent.cpp
+++ b/src/ui/ClapPluginEditorComponent.cpp
@@ -5,6 +5,9 @@ namespace duskstudio
 ClapPluginEditorComponent::ClapPluginEditorComponent()
 {
     setOpaque (false);
+    // EmbeddedModal hides tagged editors while a modal is up — see the same tag
+    // in Lv2PluginEditorComponent.
+    getProperties().set ("dusk_pluginEditor", true);
 }
 
 ClapPluginEditorComponent::~ClapPluginEditorComponent()

--- a/src/ui/ClapPluginEditorComponent.cpp
+++ b/src/ui/ClapPluginEditorComponent.cpp
@@ -1,4 +1,5 @@
 #include "ClapPluginEditorComponent.h"
+#include "EmbeddedModal.h"   // kPluginEditorTag
 
 namespace duskstudio
 {
@@ -7,7 +8,7 @@ ClapPluginEditorComponent::ClapPluginEditorComponent()
     setOpaque (false);
     // EmbeddedModal hides tagged editors while a modal is up — see the same tag
     // in Lv2PluginEditorComponent.
-    getProperties().set ("dusk_pluginEditor", true);
+    getProperties().set (kPluginEditorTag, true);
 }
 
 ClapPluginEditorComponent::~ClapPluginEditorComponent()

--- a/src/ui/EmbeddedModal.h
+++ b/src/ui/EmbeddedModal.h
@@ -40,6 +40,12 @@ inline bool isModalForwardableShortcut (const juce::KeyPress& k) noexcept
         || k == juce::KeyPress::F11Key;
 }
 
+// Component-properties tag marking a plugin-editor component (JUCE editor, OOP
+// embed, native CLAP/LV2 editor). EmbeddedModal hides tagged components while a
+// modal is up — native editor windows otherwise paint above the modal regardless
+// of JUCE z-order, burying dialogs. Every editor wrapper must carry this tag.
+inline constexpr const char* kPluginEditorTag = "dusk_pluginEditor";
+
 // Wraps the "DimOverlay + centred panel" pattern used by piano roll,
 // tuner, audio settings, mixdown, bounce, plugin editor.
 //
@@ -418,7 +424,7 @@ private:
                 continue;
             const bool isPluginEditor =
                 (bool) child->getProperties()
-                            .getWithDefault ("dusk_pluginEditor", false);
+                            .getWithDefault (kPluginEditorTag, false);
             if (isPluginEditor)
             {
                 // Per-editor hide token (dusk_modalHideCount). Each stacked

--- a/src/ui/Lv2PluginEditorComponent.cpp
+++ b/src/ui/Lv2PluginEditorComponent.cpp
@@ -7,6 +7,10 @@ namespace duskstudio
 Lv2PluginEditorComponent::Lv2PluginEditorComponent()
 {
     setOpaque (false);
+    // EmbeddedModal hides tagged editors while a modal is up — the native X11
+    // window otherwise paints ABOVE the modal regardless of JUCE z-order,
+    // burying dialogs under the plugin UI.
+    getProperties().set ("dusk_pluginEditor", true);
 }
 
 Lv2PluginEditorComponent::~Lv2PluginEditorComponent()

--- a/src/ui/Lv2PluginEditorComponent.cpp
+++ b/src/ui/Lv2PluginEditorComponent.cpp
@@ -25,9 +25,17 @@ bool Lv2PluginEditorComponent::attach (lv2::Lv2Instance& shared, juce::String& e
     {
         if (w > 0 && h > 0) setSize (w, h);
     };
-    // The UI reported closed (idle() non-zero): stop treating it as live so the
-    // timer / re-layout can't keep poking a torn-down UI.
-    editor.onClosed = [this] { embedded = false; loaded = false; stopTimer(); };
+    // The UI reported closed (idle() non-zero): stop treating it as live AND tear
+    // the native UI down — leaving it open would keep a dead-by-its-own-request
+    // window mapped. close() is safe from inside pump()'s onClosed dispatch (pump
+    // returns immediately after) and idempotent for the destructor's later call.
+    editor.onClosed = [this]
+    {
+        embedded = false;
+        loaded = false;
+        stopTimer();
+        editor.close();
+    };
 
     // Real size arrives at embed (LV2 UIs size themselves at instantiate); start
     // with a sane placeholder so layout has something to centre.

--- a/src/ui/Lv2PluginEditorComponent.cpp
+++ b/src/ui/Lv2PluginEditorComponent.cpp
@@ -1,5 +1,6 @@
 #include "Lv2PluginEditorComponent.h"
 
+#include "EmbeddedModal.h"   // kPluginEditorTag
 #include "../engine/lv2/Lv2Instance.h"
 
 namespace duskstudio
@@ -10,7 +11,7 @@ Lv2PluginEditorComponent::Lv2PluginEditorComponent()
     // EmbeddedModal hides tagged editors while a modal is up — the native X11
     // window otherwise paints ABOVE the modal regardless of JUCE z-order,
     // burying dialogs under the plugin UI.
-    getProperties().set ("dusk_pluginEditor", true);
+    getProperties().set (kPluginEditorTag, true);
 }
 
 Lv2PluginEditorComponent::~Lv2PluginEditorComponent()

--- a/src/ui/Lv2PluginEditorComponent.cpp
+++ b/src/ui/Lv2PluginEditorComponent.cpp
@@ -1,0 +1,120 @@
+#include "Lv2PluginEditorComponent.h"
+
+#include "../engine/lv2/Lv2Instance.h"
+
+namespace duskstudio
+{
+Lv2PluginEditorComponent::Lv2PluginEditorComponent()
+{
+    setOpaque (false);
+}
+
+Lv2PluginEditorComponent::~Lv2PluginEditorComponent()
+{
+    stopTimer();
+    editor.close();
+}
+
+bool Lv2PluginEditorComponent::attach (lv2::Lv2Instance& shared, juce::String& errorOut)
+{
+    std::string err;
+    if (! editor.open (shared, err))
+    { errorOut = "editor: " + juce::String (err); return false; }
+
+    editor.onResize = [this] (int w, int h)
+    {
+        if (w > 0 && h > 0) setSize (w, h);
+    };
+    // The UI reported closed (idle() non-zero): stop treating it as live so the
+    // timer / re-layout can't keep poking a torn-down UI.
+    editor.onClosed = [this] { embedded = false; loaded = false; stopTimer(); };
+
+    // Real size arrives at embed (LV2 UIs size themselves at instantiate); start
+    // with a sane placeholder so layout has something to centre.
+    setSize (480, 320);
+
+    loaded = true;
+    startTimerHz (60);   // ui:idleInterface + X event drain
+    return true;
+}
+
+unsigned long Lv2PluginEditorComponent::peerX11() const
+{
+    if (auto* peer = getPeer())
+        return (unsigned long) (juce::pointer_sized_uint) peer->getNativeHandle();
+    return 0;
+}
+
+void Lv2PluginEditorComponent::tryEmbed()
+{
+    // Embed ONLY when actually on-screen: the UI instantiates directly into our
+    // host window, and toolkit wrappers can abort realising into a non-viewable
+    // parent (same rule as the CLAP editor).
+    if (! loaded || embedded || ! isShowing()) return;
+    const auto parent = peerX11();
+    if (parent == 0) return;
+
+    const auto area = getTopLevelComponent()->getLocalArea (this, getLocalBounds());
+    std::string err;
+    if (editor.embed (parent, area.getX(), area.getY(),
+                      juce::jmax (1, area.getWidth()), juce::jmax (1, area.getHeight()), err))
+    {
+        embedded = true;
+        // Adopt the UI's own size once known so the modal/lane can fit to it.
+        if (editor.preferredWidth() > 0 && editor.preferredHeight() > 0)
+            setSize (editor.preferredWidth(), editor.preferredHeight());
+        editor.reveal();
+    }
+    else
+    {
+        std::fprintf (stderr, "[lv2 editor] embed failed: %s\n", err.c_str());
+        // A failed embed tears the Lv2Editor down; stop retrying every frame.
+        loaded = false;
+        stopTimer();
+    }
+}
+
+void Lv2PluginEditorComponent::pushBounds()
+{
+    if (! embedded) return;
+    const auto area = getTopLevelComponent()->getLocalArea (this, getLocalBounds());
+    editor.setBounds (area.getX(), area.getY(),
+                      juce::jmax (1, area.getWidth()), juce::jmax (1, area.getHeight()));
+}
+
+void Lv2PluginEditorComponent::resized()                { if (embedded) pushBounds(); else tryEmbed(); }
+void Lv2PluginEditorComponent::moved()                  { pushBounds(); }
+void Lv2PluginEditorComponent::parentHierarchyChanged() { tryEmbed(); }
+
+void Lv2PluginEditorComponent::visibilityChanged()
+{
+    if (! loaded) return;
+    if (isShowing())
+    {
+        if (! embedded) tryEmbed();
+        else            editor.reveal();
+    }
+    else if (embedded)
+    {
+        editor.hide();
+    }
+}
+
+void Lv2PluginEditorComponent::leakForShutdown()
+{
+    stopTimer();
+    editor.setLeakOnClose (true);
+}
+
+void Lv2PluginEditorComponent::timerCallback()
+{
+    // Ancestor visibility changes (tab switches) don't fire visibilityChanged —
+    // poll like the CLAP editor so the native window can't float over another view.
+    if (embedded)
+    {
+        if (isShowing()) editor.reveal();
+        else             editor.hide();
+    }
+    editor.pump();
+}
+} // namespace duskstudio

--- a/src/ui/Lv2PluginEditorComponent.cpp
+++ b/src/ui/Lv2PluginEditorComponent.cpp
@@ -50,14 +50,21 @@ void Lv2PluginEditorComponent::tryEmbed()
     // Embed ONLY when actually on-screen: the UI instantiates directly into our
     // host window, and toolkit wrappers can abort realising into a non-viewable
     // parent (same rule as the CLAP editor).
-    if (! loaded || embedded || ! isShowing()) return;
+    // `embedding` breaks the re-entry cycle: suil instantiation runs the UI's
+    // ui:resize synchronously → onResize → setSize → resized() → tryEmbed again,
+    // which would build a SECOND UI instance and orphan the first (the black-
+    // rectangle bug).
+    if (! loaded || embedded || embedding || ! isShowing()) return;
     const auto parent = peerX11();
     if (parent == 0) return;
 
     const auto area = getTopLevelComponent()->getLocalArea (this, getLocalBounds());
     std::string err;
-    if (editor.embed (parent, area.getX(), area.getY(),
-                      juce::jmax (1, area.getWidth()), juce::jmax (1, area.getHeight()), err))
+    embedding = true;
+    const bool ok = editor.embed (parent, area.getX(), area.getY(),
+                                  juce::jmax (1, area.getWidth()), juce::jmax (1, area.getHeight()), err);
+    embedding = false;
+    if (ok)
     {
         embedded = true;
         // Adopt the UI's own size once known so the modal/lane can fit to it.

--- a/src/ui/Lv2PluginEditorComponent.h
+++ b/src/ui/Lv2PluginEditorComponent.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include "../engine/lv2/Lv2Editor.h"
+
+namespace duskstudio
+{
+namespace lv2 { class Lv2Instance; }
+
+// JUCE bridge for a natively-hosted LV2 plugin UI: attaches to the slot's live
+// Lv2Instance, discovers its UI through suil, and ties the native host window to
+// this Component's peer / bounds / visibility. Mirrors ClapPluginEditorComponent,
+// with one structural difference — an LV2 UI takes its parent at instantiate
+// time, so the embed happens (and the UI first exists) when this component is
+// actually on-screen.
+class Lv2PluginEditorComponent final : public juce::Component,
+                                        private juce::Timer
+{
+public:
+    Lv2PluginEditorComponent();
+    ~Lv2PluginEditorComponent() override;
+
+    // Attach to an ALREADY-loaded instance owned elsewhere (NativeLv2Slot). We do
+    // not own its lifecycle: the slot must outlive this component. False (+errorOut)
+    // when the plugin ships no X11-embeddable UI.
+    bool attach (lv2::Lv2Instance& shared, juce::String& errorOut);
+
+    bool isLoaded() const noexcept { return loaded; }
+
+    // App shutdown: stop pumping + leak the UI (foreign-toolkit destructors hang).
+    void leakForShutdown();
+
+    void resized() override;
+    void parentHierarchyChanged() override;
+    void visibilityChanged() override;
+    void moved() override;
+
+private:
+    void timerCallback() override;
+    void tryEmbed();
+    void pushBounds();
+    unsigned long peerX11() const;
+
+    lv2::Lv2Editor editor;
+    bool loaded   = false;
+    bool embedded = false;
+};
+} // namespace duskstudio

--- a/src/ui/Lv2PluginEditorComponent.h
+++ b/src/ui/Lv2PluginEditorComponent.h
@@ -43,7 +43,8 @@ private:
     unsigned long peerX11() const;
 
     lv2::Lv2Editor editor;
-    bool loaded   = false;
-    bool embedded = false;
+    bool loaded    = false;
+    bool embedded  = false;
+    bool embedding = false;   // guards re-entry: instantiate fires ui:resize → setSize → resized()
 };
 } // namespace duskstudio

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -2700,8 +2700,8 @@ bool MainComponent::finishLoadingSessionFrom (const juce::File& sourceJson,
             for (const auto& f : failures)
                 body += "    " + f.location + "  -  " + f.pluginName + "\n";
             body += "\nCheck that the plugins are still installed for the "
-                    "right format (VST3 / LV2 / AU) and that this binary can "
-                    "find them, then reload the session.";
+                    "right format (VST3 / LV2 / AU / CLAP) and that this binary "
+                    "can find them, then reload the session.";
             juce::Component::SafePointer<MainComponent> safeThis (this);
             juce::MessageManager::callAsync (
                 [body = std::move (body), safeThis]

--- a/src/ui/PluginPickerHelpers.cpp
+++ b/src/ui/PluginPickerHelpers.cpp
@@ -391,7 +391,8 @@ void openPickerMenu (PluginSlot& slot,
                       juce::Point<int> /*screenPosition*/,
                       std::function<void()> onPickHardwareInsert,
                       bool suppressSecondaryButtons,
-                      std::function<void (const juce::File&)> onPickNativeClap)
+                      std::function<void (const juce::File&)> onPickNativeClap,
+                      std::function<void (const juce::File&)> onPickNativeLv2)
 {
     auto& manager = slot.getManagerForUi();
 
@@ -402,6 +403,15 @@ void openPickerMenu (PluginSlot& slot,
     // Merge native-CLAP effects into the unified list when the caller can host them.
     if (onPickNativeClap && kind == PluginKind::Effects)
         descriptions.addArray (manager.getClapEffectDescriptions());
+
+    // Native-LV2 rows replace the JUCE-hosted LV2 effect rows (same plugins, better
+    // host) so each plugin appears once. JUCE LV2 stays the fallback when unset.
+    if (onPickNativeLv2 && kind == PluginKind::Effects)
+    {
+        descriptions.removeIf ([] (const juce::PluginDescription& d)
+                               { return d.pluginFormatName == "LV2"; });
+        descriptions.addArray (manager.getLv2EffectDescriptions());
+    }
 
     auto* parent = target.getTopLevelComponent();
     if (parent == nullptr) parent = &target;
@@ -423,7 +433,7 @@ void openPickerMenu (PluginSlot& slot,
     cb.onCancel = closeModal;
 
     cb.onScan = [closeModal, slotPtr, safeTarget, safeParent, chooserOwnerPtr,
-                  onChange, kind, onPickHardwareInsert, onPickNativeClap]() mutable
+                  onChange, kind, onPickHardwareInsert, onPickNativeClap, onPickNativeLv2]() mutable
     {
         closeModal();
 
@@ -433,13 +443,15 @@ void openPickerMenu (PluginSlot& slot,
         // was added before the picker, so JUCE z-order puts the picker
         // on top), making the result message invisible.
         auto reopenPicker = [slotPtr, safeTarget, chooserOwnerPtr,
-                              onChange, kind, onPickHardwareInsert, onPickNativeClap]() mutable
+                              onChange, kind, onPickHardwareInsert, onPickNativeClap,
+                              onPickNativeLv2]() mutable
         {
             if (auto* t = safeTarget.getComponent())
                 openPickerMenu (*slotPtr, *t, *chooserOwnerPtr,
                                   std::move (onChange), kind, { -1, -1 },
                                   std::move (onPickHardwareInsert), false,
-                                  std::move (onPickNativeClap));
+                                  std::move (onPickNativeClap),
+                                  std::move (onPickNativeLv2));
         };
         runScanModal (slotPtr->getManagerForUi(), safeParent.getComponent(),
                        std::move (reopenPicker));
@@ -482,20 +494,26 @@ void openPickerMenu (PluginSlot& slot,
     }
    #endif
 
-    cb.onPickPlugin = [closeModal, slotPtr, safeTarget, safeParent, onChange, kind, onPickNativeClap]
+    cb.onPickPlugin = [closeModal, slotPtr, safeTarget, safeParent, onChange, kind,
+                       onPickNativeClap, onPickNativeLv2]
                         (const juce::PluginDescription& desc) mutable
     {
         closeModal();
         if (safeTarget.getComponent() == nullptr) return;
 
-        // Native CLAP rows route to the native host, not the JUCE loader. The
-        // onPickNativeClap handler does its own success refresh + failure alert
-        // (loadNativeClapForSlot / loadNativeClapForChannel), so DON'T also fire the
-        // generic onChange here — on a failed load it would refresh state as if the
-        // slot loaded (the JUCE path only refreshes on a successful async load).
+        // Native rows route to the native hosts, not the JUCE loader. The native
+        // handlers do their own success refresh + failure alert (loadNativeXxxFor*),
+        // so DON'T also fire the generic onChange here — on a failed load it would
+        // refresh state as if the slot loaded (the JUCE path only refreshes on a
+        // successful async load).
         if (desc.pluginFormatName == "CLAP")
         {
             if (onPickNativeClap) onPickNativeClap (juce::File (desc.fileOrIdentifier));
+            return;
+        }
+        if (desc.pluginFormatName == "LV2-Native")
+        {
+            if (onPickNativeLv2) onPickNativeLv2 (juce::File (desc.fileOrIdentifier));
             return;
         }
 
@@ -681,7 +699,8 @@ void openInsertChooser (PluginSlot& slot,
                          std::function<void()> onChange,
                          PluginKind kind,
                          std::function<void()> onPickHardwareInsert,
-                         std::function<void (const juce::File&)> onPickNativeClap)
+                         std::function<void (const juce::File&)> onPickNativeClap,
+                         std::function<void (const juce::File&)> onPickNativeLv2)
 {
     auto* parent = target.getTopLevelComponent();
     if (parent == nullptr) parent = &target;
@@ -727,7 +746,7 @@ void openInsertChooser (PluginSlot& slot,
     };
 
     auto onPlugin = [closeChooser, slotPtr, safeTarget, chooserOwnerPtr,
-                       onChange, kind, onPickNativeClap]() mutable
+                       onChange, kind, onPickNativeClap, onPickNativeLv2]() mutable
     {
         closeChooser();
         if (auto* t = safeTarget.getComponent())
@@ -735,7 +754,8 @@ void openInsertChooser (PluginSlot& slot,
                               std::move (onChange), kind, { -1, -1 },
                               /*onPickHardwareInsert*/ {},
                               /*suppressSecondaryButtons*/ true,
-                              std::move (onPickNativeClap));
+                              std::move (onPickNativeClap),
+                              std::move (onPickNativeLv2));
     };
 
     auto onCancel = closeChooser;

--- a/src/ui/PluginPickerHelpers.h
+++ b/src/ui/PluginPickerHelpers.h
@@ -52,6 +52,10 @@ enum class PluginKind { Effects, Instruments };
 // bundle path) instead of the JUCE loader. Used by every surface with a native CLAP
 // host — aux lanes AND channel-strip effect slots — which expose CLAP rows alongside
 // their JUCE-hosted VST3/LV2/AU. Unset → no CLAP rows (surfaces without a native host).
+// `onPickNativeLv2` is the LV2 twin: merges "LV2-Native" rows (bundle-directory
+// paths) and routes their selection here. When set, JUCE-format "LV2" effect rows
+// are hidden so each plugin appears once, hosted natively; unset → JUCE LV2 rows
+// stay as the fallback host.
 void openPickerMenu (PluginSlot& slot,
                       juce::Component& target,
                       std::unique_ptr<juce::FileChooser>& chooserOwner,
@@ -60,7 +64,8 @@ void openPickerMenu (PluginSlot& slot,
                       juce::Point<int> screenPosition = { -1, -1 },
                       std::function<void()> onPickHardwareInsert = {},
                       bool suppressSecondaryButtons = false,
-                      std::function<void (const juce::File&)> onPickNativeClap = {});
+                      std::function<void (const juce::File&)> onPickNativeClap = {},
+                      std::function<void (const juce::File&)> onPickNativeLv2 = {});
 
 // Two-step insert flow. Step 1 shows a small modal with three big
 // buttons — Hardware Insert / Soundfont / Plugin — letting the user
@@ -79,7 +84,8 @@ void openInsertChooser (PluginSlot& slot,
                          std::function<void()> onChange,
                          PluginKind kind,
                          std::function<void()> onPickHardwareInsert = {},
-                         std::function<void (const juce::File&)> onPickNativeClap = {});
+                         std::function<void (const juce::File&)> onPickNativeClap = {},
+                         std::function<void (const juce::File&)> onPickNativeLv2 = {});
 
 // Synchronous scan. Blocks the message thread during scanInstalledPlugins().
 // Shows a Dusk in-window completion alert in `parent` (top-level Component)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,11 @@ FetchContent_MakeAvailable(Catch2)
 
 add_executable(dusk-studio-tests
     smoke_brickwall_limiter.cpp
+    # Shared native-host foundation (PortLayout / PortBuffers / INativeInstance)
+    # is header-only + platform-neutral, so it links in the base target.
+    hosting_port_layout.cpp
+    hosting_insert_adapter.cpp
+    ${CMAKE_SOURCE_DIR}/src/engine/hosting/InsertAdapter.cpp
     # Native CLAP tests + sources are Linux-only (dlopen/poll) — added conditionally below.
     plugin_scan_protocol.cpp
     plugin_backing_check.cpp
@@ -128,6 +133,7 @@ if(DUSKSTUDIO_NATIVE_CLAP)
     target_sources(dusk-studio-tests PRIVATE
         clap_bundle_load.cpp
         clap_instance_process.cpp
+        clap_ab_nulltest.cpp
         clap_native_slot.cpp
         clap_scanner.cpp
         clap_params.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -145,6 +145,16 @@ if(DUSKSTUDIO_NATIVE_CLAP)
     target_compile_definitions(dusk-studio-tests PRIVATE DUSKSTUDIO_HAS_NATIVE_CLAP=1)
 endif()
 
+# Native LV2 host — lilv/suil (ISC), ON when the dev libs are present (detected in
+# the top-level CMakeLists; PkgConfig::LILV etc. are GLOBAL imported targets).
+if(DUSKSTUDIO_NATIVE_LV2)
+    target_sources(dusk-studio-tests PRIVATE
+        lv2_bundle_load.cpp
+        ${CMAKE_SOURCE_DIR}/src/engine/lv2/Lv2Bundle.cpp)
+    target_link_libraries(dusk-studio-tests PRIVATE PkgConfig::LILV PkgConfig::SUIL PkgConfig::LV2)
+    target_compile_definitions(dusk-studio-tests PRIVATE DUSKSTUDIO_HAS_NATIVE_LV2=1)
+endif()
+
 target_link_libraries(dusk-studio-tests PRIVATE
     Catch2::Catch2WithMain
     ${CMAKE_DL_LIBS}   # dl: ClapBundle dlopen

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -150,7 +150,9 @@ endif()
 if(DUSKSTUDIO_NATIVE_LV2)
     target_sources(dusk-studio-tests PRIVATE
         lv2_bundle_load.cpp
-        ${CMAKE_SOURCE_DIR}/src/engine/lv2/Lv2Bundle.cpp)
+        lv2_instance_process.cpp
+        ${CMAKE_SOURCE_DIR}/src/engine/lv2/Lv2Bundle.cpp
+        ${CMAKE_SOURCE_DIR}/src/engine/lv2/Lv2Instance.cpp)
     target_link_libraries(dusk-studio-tests PRIVATE PkgConfig::LILV PkgConfig::SUIL PkgConfig::LV2)
     target_compile_definitions(dusk-studio-tests PRIVATE DUSKSTUDIO_HAS_NATIVE_LV2=1)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -151,8 +151,10 @@ if(DUSKSTUDIO_NATIVE_LV2)
     target_sources(dusk-studio-tests PRIVATE
         lv2_bundle_load.cpp
         lv2_instance_process.cpp
+        lv2_native_slot.cpp
         ${CMAKE_SOURCE_DIR}/src/engine/lv2/Lv2Bundle.cpp
-        ${CMAKE_SOURCE_DIR}/src/engine/lv2/Lv2Instance.cpp)
+        ${CMAKE_SOURCE_DIR}/src/engine/lv2/Lv2Instance.cpp
+        ${CMAKE_SOURCE_DIR}/src/engine/lv2/NativeLv2Slot.cpp)
     target_link_libraries(dusk-studio-tests PRIVATE PkgConfig::LILV PkgConfig::SUIL PkgConfig::LV2)
     target_compile_definitions(dusk-studio-tests PRIVATE DUSKSTUDIO_HAS_NATIVE_LV2=1)
 endif()

--- a/tests/clap_ab_nulltest.cpp
+++ b/tests/clap_ab_nulltest.cpp
@@ -1,9 +1,9 @@
-// F5 A/B null-test: the generalized processBlock (driven through the InsertAdapter,
-// exactly as the DSP call sites will be after F6/F7) must produce the same audio as
-// the legacy processStereo for a stereo plugin. Two fresh instances of the same
-// plugin are fed identical input; their outputs must match sample-for-sample.
-// Gated on DUSKSTUDIO_TEST_CLAP=/path/to.clap so CI without a plugin stays green;
-// assumes a deterministic effect (the test fixture, e.g. DuskVerb).
+// A/B null-test: the generalized processBlock (driven through the InsertAdapter,
+// as the production slot runs it) must produce the same audio as the legacy
+// processStereo for a stereo plugin. Fresh instances of the same plugin are fed
+// identical input; their outputs must match within the plugin's own instance-to-
+// instance variance. Gated on DUSKSTUDIO_TEST_CLAP=/path/to.clap so CI without a
+// plugin stays green.
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>

--- a/tests/clap_ab_nulltest.cpp
+++ b/tests/clap_ab_nulltest.cpp
@@ -1,0 +1,104 @@
+// F5 A/B null-test: the generalized processBlock (driven through the InsertAdapter,
+// exactly as the DSP call sites will be after F6/F7) must produce the same audio as
+// the legacy processStereo for a stereo plugin. Two fresh instances of the same
+// plugin are fed identical input; their outputs must match sample-for-sample.
+// Gated on DUSKSTUDIO_TEST_CLAP=/path/to.clap so CI without a plugin stays green;
+// assumes a deterministic effect (the test fixture, e.g. DuskVerb).
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "engine/clap/ClapBundle.h"
+#include "engine/clap/ClapInstance.h"
+#include "engine/hosting/InsertAdapter.h"
+
+#include <cmath>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+TEST_CASE ("ClapInstance: processBlock nulls against processStereo", "[clap][hosting][ab]")
+{
+    const char* path = std::getenv ("DUSKSTUDIO_TEST_CLAP");
+    if (path == nullptr || *path == '\0')
+    {
+        SUCCEED ("DUSKSTUDIO_TEST_CLAP not set — skipping CLAP A/B null-test");
+        return;
+    }
+
+    using namespace duskstudio;
+    clap::ClapBundle bundle;
+    std::string err;
+    REQUIRE (bundle.load (path, err));
+    REQUIRE_FALSE (bundle.plugins().empty());
+    const auto id = bundle.plugins().front().id;
+
+    constexpr double kSR = 48000.0;
+    constexpr int    kBlock = 256;
+
+    // Three fresh instances of the same plugin: ref1 + ref2 both driven by the
+    // legacy processStereo (their sample-by-sample difference is the plugin's own
+    // instance-to-instance non-determinism floor — tape/analog emulations are not
+    // bit-identical across instances), and gen driven by the generalized
+    // InsertAdapter → processBlock. The generalized path is correct iff gen is no
+    // further from ref1 than ref2 is (plus an FP epsilon). For a deterministic
+    // plugin the floor is 0, so this collapses to an exact null.
+    clap::ClapInstance ref1, ref2, gen;
+    if (! ref1.create (bundle, id, err))
+    {
+        // create() rejects anything but stereo-in/stereo-out (e.g. an instrument
+        // like Diva). Not a valid stereo insert → nothing for this A/B to compare.
+        SUCCEED ("plugin is not a stereo insert (" + err + ") — skipping A/B null-test");
+        return;
+    }
+    REQUIRE (ref2.create (bundle, id, err));
+    REQUIRE (gen .create (bundle, id, err));
+    REQUIRE (ref1.activate (kSR, kBlock, err));
+    REQUIRE (ref2.activate (kSR, kBlock, err));
+    REQUIRE (gen .activate (kSR, kBlock, err));
+
+    hosting::InsertAdapter adapter;
+    adapter.prepare (gen.portLayout(), kBlock);
+
+    std::vector<float> r1L ((size_t) kBlock), r1R ((size_t) kBlock),
+                       r2L ((size_t) kBlock), r2R ((size_t) kBlock),
+                       gL  ((size_t) kBlock), gR  ((size_t) kBlock);
+
+    constexpr double kPi = 3.14159265358979323846;
+    constexpr float  kEps = 1.0e-6f;
+    double phase = 0.0;
+    const double dw = 2.0 * kPi * 440.0 / kSR;
+    float worstFloor = 0.0f;   // ref2-vs-ref1: the plugin's own instance-to-instance variance
+    float worstGen   = 0.0f;   // gen-vs-ref1:  the generalized processBlock path's divergence
+
+    for (int b = 0; b < 32; ++b)   // enough blocks for any internal tail to develop
+    {
+        for (int i = 0; i < kBlock; ++i)
+        {
+            const float s = 0.3f * (float) std::sin (phase);
+            phase += dw;
+            r1L[(size_t) i] = r2L[(size_t) i] = gL[(size_t) i] = s;
+            r1R[(size_t) i] = r2R[(size_t) i] = gR[(size_t) i] = 0.7f * s;   // asymmetric L/R
+        }
+
+        ref1.processStereo (r1L.data(), r1R.data(), r1L.data(), r1R.data(), kBlock);   // in-place, matches the call site
+        ref2.processStereo (r2L.data(), r2R.data(), r2L.data(), r2R.data(), kBlock);
+        adapter.process (gen, gL.data(), gR.data(), kBlock);                           // InsertAdapter → processBlock
+
+        for (int i = 0; i < kBlock; ++i)
+        {
+            const auto n = (size_t) i;
+            worstFloor = std::max ({ worstFloor, std::abs (r2L[n] - r1L[n]), std::abs (r2R[n] - r1R[n]) });
+            worstGen   = std::max ({ worstGen,   std::abs (gL[n]  - r1L[n]), std::abs (gR[n]  - r1R[n]) });
+        }
+    }
+
+    // The generalized path is correct iff it stays within the plugin's own
+    // instance-to-instance non-determinism. For a deterministic plugin the floor
+    // is 0 and this is an exact null; a tape/analog emulation whose two reference
+    // instances already differ gets that same envelope (×4 headroom for a third
+    // instance's independent variance), which still catches a real plumbing bug
+    // (that would push gen orders of magnitude past the floor).
+    WARN ("A/B: worst instance floor = " << worstFloor << ", worst processBlock divergence = " << worstGen);
+    REQUIRE (worstGen <= std::max (kEps, 4.0f * worstFloor));
+}

--- a/tests/hosting_insert_adapter.cpp
+++ b/tests/hosting_insert_adapter.cpp
@@ -6,11 +6,11 @@
 #include <string>
 #include <vector>
 
-// Phase F2: InsertAdapter reconciles a plugin's arbitrary PortLayout to the
-// mixer's fixed stereo-in/stereo-out insert. These tests pin every fold rule
-// (mono sum, mono-out broadcast, multi-out drop, sidechain fill/silence,
-// instrument source) using a stub instance whose processBlock is a known
-// transform, so a fold regression is a hard assertion failure.
+// InsertAdapter reconciles a plugin's arbitrary PortLayout to the mixer's fixed
+// stereo-in/stereo-out insert. These tests pin every fold rule (mono sum, mono-out
+// broadcast, multi-out drop, sidechain fill/silence, instrument source) using a
+// stub instance whose processBlock is a known transform, so a fold regression is a
+// hard assertion failure.
 
 using namespace duskstudio::hosting;
 using Catch::Matchers::WithinAbs;

--- a/tests/hosting_insert_adapter.cpp
+++ b/tests/hosting_insert_adapter.cpp
@@ -81,7 +81,7 @@ constexpr int kN = 8;
 std::vector<float> filled (float v) { return std::vector<float> ((size_t) kN, v); }
 } // namespace
 
-TEST_CASE ("InsertAdapter: stereo→stereo passes L/R straight through", "[hosting][adapter]")
+TEST_CASE ("InsertAdapter: stereo-to-stereo passes L/R straight through", "[hosting][adapter]")
 {
     FoldStub stub (effectLayout (2, 2), /*gain*/ 0.5f);
     std::string e; stub.activate (48000.0, kN, e);

--- a/tests/hosting_insert_adapter.cpp
+++ b/tests/hosting_insert_adapter.cpp
@@ -1,0 +1,186 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "engine/hosting/InsertAdapter.h"
+
+#include <string>
+#include <vector>
+
+// Phase F2: InsertAdapter reconciles a plugin's arbitrary PortLayout to the
+// mixer's fixed stereo-in/stereo-out insert. These tests pin every fold rule
+// (mono sum, mono-out broadcast, multi-out drop, sidechain fill/silence,
+// instrument source) using a stub instance whose processBlock is a known
+// transform, so a fold regression is a hard assertion failure.
+
+using namespace duskstudio::hosting;
+using Catch::Matchers::WithinAbs;
+
+namespace
+{
+BusInfo audioBus (BusInfo::Direction dir, BusInfo::Role role, int chans)
+{
+    BusInfo b;
+    b.kind = BusInfo::Kind::Audio; b.dir = dir; b.role = role;
+    b.channelCount = chans; b.active = true;
+    return b;
+}
+
+PortLayout effectLayout (int inCh, int outCh, int scCh = 0)
+{
+    PortLayout l;
+    l.inputs.push_back (audioBus (BusInfo::Direction::Input, BusInfo::Role::Main, inCh));
+    l.mainInIndex = 0;
+    if (scCh > 0)
+    {
+        l.inputs.push_back (audioBus (BusInfo::Direction::Input, BusInfo::Role::Sidechain, scCh));
+        l.sidechainInIndex = 1;
+    }
+    l.outputs.push_back (audioBus (BusInfo::Direction::Output, BusInfo::Role::Main, outCh));
+    l.mainOutIndex = 0;
+    return l;
+}
+
+// Writes gain*input into each output channel that has a matching input; output
+// channels beyond the input count (and instrument outputs) get `fill`. Records
+// the first sidechain sample it was handed so silence-vs-tap is observable.
+class FoldStub final : public INativeInstance
+{
+public:
+    explicit FoldStub (PortLayout l, float gain = 1.0f, float fill = 0.0f)
+        : layout_ (std::move (l)), gain_ (gain), fill_ (fill) {}
+
+    const PortLayout& portLayout() const noexcept override { return layout_; }
+    bool activate (double, int, std::string&) override { active_ = true; return true; }
+    void deactivate() override { active_ = false; }
+    bool reactivate (double, int, std::string&) override { return true; }
+    bool isActive() const noexcept override { return active_; }
+
+    void processBlock (const PortBuffers& io) noexcept override
+    {
+        sawSidechain = (io.sidechainIn != nullptr && io.sidechainInChannels > 0)
+                         ? io.sidechainIn[0][0] : -999.0f;
+
+        for (int c = 0; c < io.mainOutChannels; ++c)
+            for (int i = 0; i < io.numFrames; ++i)
+                io.mainOut[c][i] = (c < io.mainInChannels) ? io.mainIn[c][i] * gain_ : fill_;
+    }
+
+    bool saveState (std::vector<uint8_t>&) const override { return true; }
+    bool loadState (const std::vector<uint8_t>&) override { return true; }
+    int  getLatencySamples() const noexcept override { return 0; }
+
+    float sawSidechain = -999.0f;
+
+private:
+    PortLayout layout_;
+    float gain_, fill_;
+    bool  active_ = false;
+};
+
+constexpr int kN = 8;
+std::vector<float> filled (float v) { return std::vector<float> ((size_t) kN, v); }
+} // namespace
+
+TEST_CASE ("InsertAdapter: stereo→stereo passes L/R straight through", "[hosting][adapter]")
+{
+    FoldStub stub (effectLayout (2, 2), /*gain*/ 0.5f);
+    std::string e; stub.activate (48000.0, kN, e);
+    InsertAdapter adapter; adapter.prepare (stub.portLayout(), kN);
+
+    auto L = filled (1.0f), R = filled (-1.0f);
+    adapter.process (stub, L.data(), R.data(), kN);
+
+    REQUIRE_THAT (L[0], WithinAbs ( 0.5, 1e-6));
+    REQUIRE_THAT (R[0], WithinAbs (-0.5, 1e-6));
+}
+
+TEST_CASE ("InsertAdapter: mono plugin sums the stereo feed and broadcasts back", "[hosting][adapter]")
+{
+    FoldStub stub (effectLayout (1, 1));   // 1-in / 1-out, unity gain
+    std::string e; stub.activate (48000.0, kN, e);
+    InsertAdapter adapter; adapter.prepare (stub.portLayout(), kN);
+
+    auto L = filled (1.0f), R = filled (3.0f);   // sum/2 = 2.0
+    adapter.process (stub, L.data(), R.data(), kN);
+
+    REQUIRE_THAT (L[0], WithinAbs (2.0, 1e-6));   // broadcast to both sides
+    REQUIRE_THAT (R[0], WithinAbs (2.0, 1e-6));
+}
+
+TEST_CASE ("InsertAdapter: multi-out plugin keeps only channels 0/1", "[hosting][adapter]")
+{
+    // 2-in / 4-out: channels 2,3 are filled with a poison value that must NOT
+    // reach the mixer.
+    FoldStub stub (effectLayout (2, 4), /*gain*/ 1.0f, /*fill*/ 999.0f);
+    std::string e; stub.activate (48000.0, kN, e);
+    InsertAdapter adapter; adapter.prepare (stub.portLayout(), kN);
+
+    auto L = filled (1.0f), R = filled (2.0f);
+    adapter.process (stub, L.data(), R.data(), kN);
+
+    REQUIRE_THAT (L[0], WithinAbs (1.0, 1e-6));
+    REQUIRE_THAT (R[0], WithinAbs (2.0, 1e-6));   // poison ch2/3 dropped
+}
+
+TEST_CASE ("InsertAdapter: sidechain is fed from the tap, or silence when unrouted", "[hosting][adapter]")
+{
+    FoldStub stub (effectLayout (2, 2, /*sidechain*/ 2));
+    std::string e; stub.activate (48000.0, kN, e);
+    InsertAdapter adapter; adapter.prepare (stub.portLayout(), kN);
+    REQUIRE (adapter.sidechainChannels() == 2);
+
+    auto L = filled (0.0f), R = filled (0.0f);
+
+    SECTION ("routed")
+    {
+        auto scL = filled (7.0f), scR = filled (7.0f);
+        adapter.process (stub, L.data(), R.data(), kN, scL.data(), scR.data());
+        REQUIRE_THAT (stub.sawSidechain, WithinAbs (7.0, 1e-6));
+    }
+    SECTION ("unrouted → silence, never a null pointer")
+    {
+        adapter.process (stub, L.data(), R.data(), kN, nullptr, nullptr);
+        REQUIRE_THAT (stub.sawSidechain, WithinAbs (0.0, 1e-6));
+    }
+}
+
+TEST_CASE ("InsertAdapter: instrument output replaces the dry signal", "[hosting][adapter]")
+{
+    PortLayout l;   // no audio input; MIDI in + stereo out
+    l.outputs.push_back (audioBus (BusInfo::Direction::Output, BusInfo::Role::Main, 2));
+    l.mainOutIndex = 0;
+    l.isInstrument = true;
+
+    FoldStub stub (l, /*gain*/ 1.0f, /*fill*/ 0.25f);   // 0 in → every out = fill
+    std::string e; stub.activate (48000.0, kN, e);
+    InsertAdapter adapter; adapter.prepare (stub.portLayout(), kN);
+    REQUIRE (adapter.inputChannels() == 0);
+
+    auto L = filled (9.0f), R = filled (9.0f);   // dry content must be overwritten
+    adapter.process (stub, L.data(), R.data(), kN);
+
+    REQUIRE_THAT (L[0], WithinAbs (0.25, 1e-6));
+    REQUIRE_THAT (R[0], WithinAbs (0.25, 1e-6));
+}
+
+TEST_CASE ("InsertAdapter: oversized block and inactive instance are dry passthrough", "[hosting][adapter]")
+{
+    FoldStub stub (effectLayout (2, 2), 0.5f);
+    InsertAdapter adapter; adapter.prepare (stub.portLayout(), kN);
+
+    SECTION ("inactive → untouched")
+    {
+        auto L = filled (1.0f), R = filled (1.0f);
+        adapter.process (stub, L.data(), R.data(), kN);   // never activated
+        REQUIRE_THAT (L[0], WithinAbs (1.0, 1e-6));
+        REQUIRE_THAT (R[0], WithinAbs (1.0, 1e-6));
+    }
+    SECTION ("numFrames > prepared max → untouched")
+    {
+        std::string e; stub.activate (48000.0, kN, e);
+        auto L = filled (1.0f), R = filled (1.0f);
+        adapter.process (stub, L.data(), R.data(), kN + 1);
+        REQUIRE_THAT (L[0], WithinAbs (1.0, 1e-6));
+        REQUIRE_THAT (R[0], WithinAbs (1.0, 1e-6));
+    }
+}

--- a/tests/hosting_port_layout.cpp
+++ b/tests/hosting_port_layout.cpp
@@ -8,10 +8,9 @@
 #include <string>
 #include <vector>
 
-// Phase F1 of the native VST3/LV2 host: the shared, host-agnostic foundation
-// (PortLayout / PortBuffers / INativeInstance). No format code yet — this test
-// pins the descriptor semantics the InsertAdapter and every host will rely on,
-// and proves INativeInstance is a complete, implementable interface.
+// The shared, host-agnostic native-host foundation (PortLayout / PortBuffers /
+// INativeInstance). This pins the descriptor semantics the InsertAdapter and every
+// host rely on, and proves INativeInstance is a complete, implementable interface.
 
 using namespace duskstudio::hosting;
 

--- a/tests/hosting_port_layout.cpp
+++ b/tests/hosting_port_layout.cpp
@@ -1,0 +1,187 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "engine/hosting/INativeInstance.h"
+#include "engine/hosting/PortBuffers.h"
+#include "engine/hosting/PortLayout.h"
+
+#include <string>
+#include <vector>
+
+// Phase F1 of the native VST3/LV2 host: the shared, host-agnostic foundation
+// (PortLayout / PortBuffers / INativeInstance). No format code yet — this test
+// pins the descriptor semantics the InsertAdapter and every host will rely on,
+// and proves INativeInstance is a complete, implementable interface.
+
+using namespace duskstudio::hosting;
+
+namespace
+{
+BusInfo audioBus (BusInfo::Direction dir, BusInfo::Role role, int chans, const char* name)
+{
+    BusInfo b;
+    b.kind = BusInfo::Kind::Audio;
+    b.dir = dir;
+    b.role = role;
+    b.channelCount = chans;
+    b.active = true;
+    b.name = name;
+    return b;
+}
+
+BusInfo eventBus (BusInfo::Direction dir, const char* name)
+{
+    BusInfo b;
+    b.kind = BusInfo::Kind::Event;
+    b.dir = dir;
+    b.role = BusInfo::Role::Main;
+    b.channelCount = 0;
+    b.active = true;
+    b.carriesMidi = true;
+    b.name = name;
+    return b;
+}
+} // namespace
+
+TEST_CASE ("PortLayout describes a plain stereo insert effect", "[hosting][ports]")
+{
+    PortLayout l;
+    l.inputs.push_back  (audioBus (BusInfo::Direction::Input,  BusInfo::Role::Main, 2, "In"));
+    l.outputs.push_back (audioBus (BusInfo::Direction::Output, BusInfo::Role::Main, 2, "Out"));
+    l.mainInIndex = 0;
+    l.mainOutIndex = 0;
+
+    REQUIRE (l.mainInChannels()  == 2);
+    REQUIRE (l.mainOutChannels() == 2);
+    REQUIRE_FALSE (l.hasSidechain());
+    REQUIRE_FALSE (l.acceptsMidi());
+    REQUIRE_FALSE (l.emitsMidi());
+    REQUIRE_FALSE (l.isInstrument);
+}
+
+TEST_CASE ("PortLayout describes a mono effect", "[hosting][ports]")
+{
+    PortLayout l;
+    l.inputs.push_back  (audioBus (BusInfo::Direction::Input,  BusInfo::Role::Main, 1, "In"));
+    l.outputs.push_back (audioBus (BusInfo::Direction::Output, BusInfo::Role::Main, 1, "Out"));
+    l.mainInIndex = 0;
+    l.mainOutIndex = 0;
+
+    // The InsertAdapter will fold the stereo insert feed to mono and broadcast
+    // the mono result back to L/R; the layout just reports the true shape.
+    REQUIRE (l.mainInChannels()  == 1);
+    REQUIRE (l.mainOutChannels() == 1);
+    REQUIRE_FALSE (l.hasSidechain());
+}
+
+TEST_CASE ("PortLayout describes a sidechain compressor", "[hosting][ports]")
+{
+    PortLayout l;
+    l.inputs.push_back  (audioBus (BusInfo::Direction::Input,  BusInfo::Role::Main,      2, "In"));
+    l.inputs.push_back  (audioBus (BusInfo::Direction::Input,  BusInfo::Role::Sidechain, 2, "Sidechain"));
+    l.outputs.push_back (audioBus (BusInfo::Direction::Output, BusInfo::Role::Main,      2, "Out"));
+    l.mainInIndex = 0;
+    l.sidechainInIndex = 1;
+    l.mainOutIndex = 0;
+
+    REQUIRE (l.hasSidechain());
+    REQUIRE (l.sidechainInIndex == 1);
+    REQUIRE (l.inputs[(size_t) l.sidechainInIndex].role == BusInfo::Role::Sidechain);
+    REQUIRE (l.mainInChannels() == 2);
+}
+
+TEST_CASE ("PortLayout describes a MIDI instrument", "[hosting][ports]")
+{
+    PortLayout l;
+    l.inputs.push_back  (eventBus  (BusInfo::Direction::Input, "MIDI In"));
+    l.outputs.push_back (audioBus  (BusInfo::Direction::Output, BusInfo::Role::Main, 2, "Out"));
+    l.eventInIndex = 0;
+    l.mainOutIndex = 0;
+    l.isInstrument = true;
+
+    REQUIRE (l.acceptsMidi());
+    REQUIRE (l.isInstrument);
+    REQUIRE (l.mainInChannels() == 0);   // no audio input — the plugin is the source
+    REQUIRE (l.mainOutChannels() == 2);
+}
+
+// A minimal INativeInstance to prove the interface is complete + implementable
+// and drives a PortBuffers without a real plugin. Stands in for the concrete
+// Vst3/Lv2/Clap instances that arrive in later phases.
+namespace
+{
+class GainStub final : public INativeInstance
+{
+public:
+    const PortLayout& portLayout() const noexcept override { return layout; }
+
+    bool activate (double, int maxBlockFrames, std::string&) override
+    {
+        maxFrames = maxBlockFrames;
+        active = true;
+        return true;
+    }
+    void deactivate() override { active = false; }
+    bool reactivate (double sr, int mb, std::string& e) override { deactivate(); return activate (sr, mb, e); }
+    bool isActive() const noexcept override { return active; }
+
+    void processBlock (const PortBuffers& io) noexcept override
+    {
+        if (! active || io.numFrames <= 0 || io.numFrames > maxFrames) return;
+        const int ch = juce::jmin (io.mainInChannels, io.mainOutChannels);
+        for (int c = 0; c < ch; ++c)
+            for (int i = 0; i < io.numFrames; ++i)
+                io.mainOut[c][i] = io.mainIn[c][i] * 0.5f;
+    }
+
+    bool saveState (std::vector<uint8_t>& out) const override { out = { 1, 2, 3 }; return true; }
+    bool loadState (const std::vector<uint8_t>& in) override  { return in.size() == 3; }
+    int  getLatencySamples() const noexcept override { return 0; }
+
+    PortLayout layout;
+    bool active = false;
+    int  maxFrames = 0;
+};
+} // namespace
+
+TEST_CASE ("INativeInstance is implementable and processes a PortBuffers", "[hosting][instance]")
+{
+    GainStub stub;
+    stub.layout.inputs.push_back  (audioBus (BusInfo::Direction::Input,  BusInfo::Role::Main, 2, "In"));
+    stub.layout.outputs.push_back (audioBus (BusInfo::Direction::Output, BusInfo::Role::Main, 2, "Out"));
+    stub.layout.mainInIndex = 0;
+    stub.layout.mainOutIndex = 0;
+
+    INativeInstance& inst = stub;   // drive through the base interface
+
+    std::string err;
+    REQUIRE (inst.activate (48000.0, 64, err));
+    REQUIRE (inst.isActive());
+
+    constexpr int n = 16;
+    std::vector<float> inL (n, 1.0f), inR (n, -1.0f), outL (n, 0.0f), outR (n, 0.0f);
+    float* inArr[2]  = { inL.data(), inR.data() };
+    float* outArr[2] = { outL.data(), outR.data() };
+
+    PortBuffers io;
+    io.mainIn = inArr;   io.mainInChannels = 2;
+    io.mainOut = outArr; io.mainOutChannels = 2;
+    io.numFrames = n;
+
+    inst.processBlock (io);
+
+    using Catch::Matchers::WithinAbs;
+    REQUIRE_THAT (outL[0], WithinAbs ( 0.5, 1e-6));
+    REQUIRE_THAT (outR[0], WithinAbs (-0.5, 1e-6));
+
+    std::vector<uint8_t> blob;
+    REQUIRE (inst.saveState (blob));
+    REQUIRE (inst.loadState (blob));
+    REQUIRE (inst.getLatencySamples() == 0);
+
+    // Out-of-range block is a no-op (guards the audio-thread contract).
+    outL[0] = 99.0f;
+    io.numFrames = 999;
+    inst.processBlock (io);
+    REQUIRE_THAT (outL[0], WithinAbs (99.0, 1e-6));
+}

--- a/tests/lv2_bundle_load.cpp
+++ b/tests/lv2_bundle_load.cpp
@@ -1,0 +1,43 @@
+// Loads an LV2 bundle via lilv and enumerates the plugins it advertises. The
+// live case is gated on DUSKSTUDIO_TEST_LV2=/path/to/bundle.lv2 so CI without an
+// LV2 plugin stays green; the failure case always runs and pins lilv linkage.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/lv2/Lv2Bundle.h"
+
+#include <cstdlib>
+#include <string>
+
+TEST_CASE ("Lv2Bundle rejects a non-bundle path cleanly", "[lv2][bundle]")
+{
+    duskstudio::lv2::Lv2Bundle bundle;
+    std::string err;
+    REQUIRE_FALSE (bundle.load ("/nonexistent/path/to/nowhere.lv2", err));
+    REQUIRE_FALSE (bundle.isLoaded());
+    REQUIRE_FALSE (err.empty());
+    REQUIRE (bundle.plugins().empty());
+    REQUIRE (bundle.world() == nullptr);
+}
+
+TEST_CASE ("Lv2Bundle loads + enumerates a real LV2 bundle", "[lv2][bundle]")
+{
+    const char* path = std::getenv ("DUSKSTUDIO_TEST_LV2");
+    if (path == nullptr || *path == '\0')
+    {
+        SUCCEED ("DUSKSTUDIO_TEST_LV2 not set — skipping live LV2-bundle test");
+        return;
+    }
+
+    duskstudio::lv2::Lv2Bundle bundle;
+    std::string err;
+    REQUIRE (bundle.load (path, err));
+    REQUIRE (bundle.isLoaded());
+    REQUIRE_FALSE (bundle.plugins().empty());
+    REQUIRE (bundle.world() != nullptr);
+
+    const auto& first = bundle.plugins().front();
+    REQUIRE_FALSE (first.uri.empty());
+    REQUIRE (bundle.pluginByUri (first.uri) != nullptr);
+    REQUIRE (bundle.pluginByUri ("http://example.org/does-not-exist") == nullptr);
+}

--- a/tests/lv2_instance_process.cpp
+++ b/tests/lv2_instance_process.cpp
@@ -118,9 +118,12 @@ TEST_CASE ("Lv2Instance instantiates + processes an LV2 effect via InsertAdapter
 
     SECTION ("reactivate keeps state (fresh save matches post-reactivate save)")
     {
+        // Same rate, different block size: a rate change may legitimately alter a
+        // plugin's state:interface blob (cached coefficients, sample-domain values),
+        // so byte-equality is only a fair assertion across a block-size change.
         std::vector<uint8_t> before;
         REQUIRE (inst.saveState (before));
-        REQUIRE (inst.reactivate (44100.0, kBlock, err));
+        REQUIRE (inst.reactivate (48000.0, kBlock * 2, err));
         REQUIRE (inst.isActive());
         std::vector<uint8_t> after;
         REQUIRE (inst.saveState (after));

--- a/tests/lv2_instance_process.cpp
+++ b/tests/lv2_instance_process.cpp
@@ -96,4 +96,34 @@ TEST_CASE ("Lv2Instance instantiates + processes an LV2 effect via InsertAdapter
         }
         REQUIRE (peak > 1.0e-4f);   // audio makes it through the plugin
     }
+
+    SECTION ("state round-trips through saveState/loadState")
+    {
+        std::vector<uint8_t> blob;
+        REQUIRE (inst.saveState (blob));
+        REQUIRE_FALSE (blob.empty());
+
+        // A fresh instance fed the saved state must accept it; the blob is
+        // Turtle, so it should at least mention the plugin's state subject.
+        lv2::Lv2Instance other;
+        REQUIRE (other.create (bundle, uri, err));
+        REQUIRE (other.activate (48000.0, kBlock, err));
+        REQUIRE (other.loadState (blob));
+
+        // And the restored instance's own save must be non-empty again.
+        std::vector<uint8_t> blob2;
+        REQUIRE (other.saveState (blob2));
+        REQUIRE_FALSE (blob2.empty());
+    }
+
+    SECTION ("reactivate keeps state (fresh save matches post-reactivate save)")
+    {
+        std::vector<uint8_t> before;
+        REQUIRE (inst.saveState (before));
+        REQUIRE (inst.reactivate (44100.0, kBlock, err));
+        REQUIRE (inst.isActive());
+        std::vector<uint8_t> after;
+        REQUIRE (inst.saveState (after));
+        REQUIRE (before == after);
+    }
 }

--- a/tests/lv2_instance_process.cpp
+++ b/tests/lv2_instance_process.cpp
@@ -1,0 +1,99 @@
+// Instantiate a real LV2 effect and process audio offline THROUGH the InsertAdapter
+// — the same generalized path the DSP call sites use — which is the real test of
+// whether the host-agnostic foundation (INativeInstance / InsertAdapter / PortBuffers)
+// generalizes past CLAP. Gated on DUSKSTUDIO_TEST_LV2=/path/to/bundle.lv2.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/hosting/InsertAdapter.h"
+#include "engine/lv2/Lv2Bundle.h"
+#include "engine/lv2/Lv2Instance.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+TEST_CASE ("Lv2Instance instantiates + processes an LV2 effect via InsertAdapter", "[lv2][instance]")
+{
+    const char* path = std::getenv ("DUSKSTUDIO_TEST_LV2");
+    if (path == nullptr || *path == '\0')
+    {
+        SUCCEED ("DUSKSTUDIO_TEST_LV2 not set — skipping live LV2-process test");
+        return;
+    }
+
+    using namespace duskstudio;
+    lv2::Lv2Bundle bundle;
+    std::string err;
+    REQUIRE (bundle.load (path, err));
+    REQUIRE_FALSE (bundle.plugins().empty());
+
+    // Pick an audio effect (audio in + out); skip instruments / MIDI-only utilities.
+    std::string uri;
+    for (const auto& d : bundle.plugins())
+        if (d.audioInputs > 0 && d.audioOutputs > 0) { uri = d.uri; break; }
+    if (uri.empty())
+    {
+        SUCCEED ("bundle advertises no audio effect — skipping");
+        return;
+    }
+
+    lv2::Lv2Instance inst;
+    REQUIRE (inst.create (bundle, uri, err));
+    REQUIRE (inst.portLayout().mainOutChannels() > 0);
+
+    constexpr int kBlock = 256;
+    REQUIRE (inst.activate (48000.0, kBlock, err));
+    REQUIRE (inst.isActive());
+
+    hosting::InsertAdapter adapter;
+    adapter.prepare (inst.portLayout(), kBlock);
+
+    std::vector<float> L ((size_t) kBlock), R ((size_t) kBlock);
+
+    SECTION ("silence in stays finite and quiet")
+    {
+        std::fill (L.begin(), L.end(), 0.0f);
+        std::fill (R.begin(), R.end(), 0.0f);
+        float peak = 0.0f;
+        for (int b = 0; b < 8; ++b)
+        {
+            adapter.process (inst, L.data(), R.data(), kBlock);
+            for (int i = 0; i < kBlock; ++i)
+            {
+                REQUIRE (std::isfinite (L[(size_t) i]));
+                REQUIRE (std::isfinite (R[(size_t) i]));
+                peak = std::max ({ peak, std::abs (L[(size_t) i]), std::abs (R[(size_t) i]) });
+            }
+        }
+        REQUIRE (peak < 1.0e-2f);   // a default effect doesn't self-oscillate from silence
+    }
+
+    SECTION ("signal passes through the effect")
+    {
+        constexpr double kPi = 3.14159265358979323846;
+        double phase = 0.0;
+        const double dw = 2.0 * kPi * 440.0 / 48000.0;
+        float peak = 0.0f;
+        for (int b = 0; b < 32; ++b)
+        {
+            for (int i = 0; i < kBlock; ++i)
+            {
+                const float s = 0.3f * (float) std::sin (phase);
+                phase += dw;
+                L[(size_t) i] = s;
+                R[(size_t) i] = 0.7f * s;
+            }
+            adapter.process (inst, L.data(), R.data(), kBlock);
+            for (int i = 0; i < kBlock; ++i)
+            {
+                REQUIRE (std::isfinite (L[(size_t) i]));
+                REQUIRE (std::isfinite (R[(size_t) i]));
+                peak = std::max ({ peak, std::abs (L[(size_t) i]), std::abs (R[(size_t) i]) });
+            }
+        }
+        REQUIRE (peak > 1.0e-4f);   // audio makes it through the plugin
+    }
+}

--- a/tests/lv2_native_slot.cpp
+++ b/tests/lv2_native_slot.cpp
@@ -1,0 +1,96 @@
+// NativeLv2Slot lifecycle: load an LV2 effect, process audio through the slot
+// (which routes InsertAdapter → processBlock), unload, reactivate. Gated on
+// DUSKSTUDIO_TEST_LV2=/path/to/bundle.lv2 so CI without an LV2 plugin stays green.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "engine/lv2/NativeLv2Slot.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+namespace
+{
+float driveTone (duskstudio::lv2::NativeLv2Slot& slot, std::vector<float>& L,
+                 std::vector<float>& R, int block, int blocks)
+{
+    constexpr double kPi = 3.14159265358979323846;
+    double phase = 0.0;
+    float peak = 0.0f;
+    for (int b = 0; b < blocks; ++b)
+    {
+        for (int i = 0; i < block; ++i)
+        {
+            const float s = 0.3f * (float) std::sin (phase);
+            phase += 2.0 * kPi * 440.0 / 48000.0;
+            L[(size_t) i] = s;
+            R[(size_t) i] = 0.7f * s;
+        }
+        slot.processStereo (L.data(), R.data(), L.data(), R.data(), block);   // in-place
+        for (int i = 0; i < block; ++i)
+        {
+            REQUIRE (std::isfinite (L[(size_t) i]));
+            REQUIRE (std::isfinite (R[(size_t) i]));
+            peak = std::max ({ peak, std::abs (L[(size_t) i]), std::abs (R[(size_t) i]) });
+        }
+    }
+    return peak;
+}
+} // namespace
+
+TEST_CASE ("NativeLv2Slot loads, processes, and unloads cleanly", "[lv2][slot]")
+{
+    const char* path = std::getenv ("DUSKSTUDIO_TEST_LV2");
+    if (path == nullptr || *path == '\0')
+    {
+        SUCCEED ("DUSKSTUDIO_TEST_LV2 not set — skipping live LV2-slot test");
+        return;
+    }
+
+    using Catch::Matchers::WithinAbs;
+    duskstudio::lv2::NativeLv2Slot slot;
+    std::string err;
+    constexpr int kBlock = 256;
+
+    if (! slot.load (juce::File (juce::String (path)), 48000.0, kBlock, err))
+    {
+        SUCCEED ("bundle has no loadable audio effect (" + err + ") — skipping");
+        return;
+    }
+    REQUIRE (slot.isLoaded());
+    REQUIRE (slot.getInstance() != nullptr);
+
+    std::vector<float> L ((size_t) kBlock), R ((size_t) kBlock);
+
+    SECTION ("signal in produces finite non-silent output")
+    {
+        REQUIRE (driveTone (slot, L, R, kBlock, 32) > 1.0e-4f);
+    }
+
+    SECTION ("unload clears outputs, doesn't leak stale audio")
+    {
+        slot.unload();
+        REQUIRE_FALSE (slot.isLoaded());
+        REQUIRE (slot.getInstance() == nullptr);
+
+        std::fill (L.begin(), L.end(), 9.0f);
+        std::fill (R.begin(), R.end(), 9.0f);
+        slot.processStereo (L.data(), R.data(), L.data(), R.data(), kBlock);
+        for (int i = 0; i < kBlock; ++i)
+        {
+            REQUIRE_THAT (L[(size_t) i], WithinAbs (0.0, 1.0e-9));
+            REQUIRE_THAT (R[(size_t) i], WithinAbs (0.0, 1.0e-9));
+        }
+    }
+
+    SECTION ("reactivate keeps processing")
+    {
+        REQUIRE (slot.reactivate (48000.0, kBlock, err));
+        REQUIRE (slot.isLoaded());
+        REQUIRE (driveTone (slot, L, R, kBlock, 16) > 1.0e-4f);
+    }
+}

--- a/tests/session_round_trip.cpp
+++ b/tests/session_round_trip.cpp
@@ -150,3 +150,34 @@ TEST_CASE ("SessionSerializer round-trips an aux native-CLAP slot", "[session][s
 
     dir.deleteRecursively();
 }
+
+// Same guard for the native-LV2 pair, on both a track and an aux slot.
+TEST_CASE ("SessionSerializer round-trips native-LV2 slots", "[session][serializer][lv2]")
+{
+    using duskstudio::Session;
+    using duskstudio::SessionSerializer;
+
+    const auto dir = makeTempSessionDir();
+    const auto target = dir.getChildFile ("session.json");
+
+    Session a;
+    a.track (2).nativeLv2Path         = "/home/user/.lv2/SilkVerb.lv2";
+    a.track (2).nativeLv2StateBase64  = "TFYyU1RBVEVibG9i";
+    auto& lane = a.auxLane (1);
+    lane.nativeLv2Path[0]        = "/usr/lib64/lv2/a-comp.lv2";
+    lane.nativeLv2StateBase64[0] = "TFYyU1RBVEVibG9i";
+    REQUIRE (SessionSerializer::save (a, target));
+
+    Session b;
+    REQUIRE (SessionSerializer::load (b, target));
+    REQUIRE (b.track (2).nativeLv2Path        == "/home/user/.lv2/SilkVerb.lv2");
+    REQUIRE (b.track (2).nativeLv2StateBase64 == "TFYyU1RBVEVibG9i");
+    REQUIRE (b.auxLane (1).nativeLv2Path[0]        == "/usr/lib64/lv2/a-comp.lv2");
+    REQUIRE (b.auxLane (1).nativeLv2StateBase64[0] == "TFYyU1RBVEVibG9i");
+
+    // Untouched slots stay empty (keys omitted on write).
+    REQUIRE (b.track (0).nativeLv2Path.isEmpty());
+    REQUIRE (b.auxLane (0).nativeLv2Path[0].isEmpty());
+
+    dir.deleteRecursively();
+}


### PR DESCRIPTION
Replaces JUCE LV2 hosting for effects with Dusk Studio's own native host, continuing the JUCE-escape for Wayland UI issues (CLAP shipped earlier; VST3 next).

## What's in
- **Shared native-host foundation** (`src/engine/hosting/`): `INativeInstance` / `PortLayout` / `PortBuffers` / `InsertAdapter` — folds any plugin bus layout onto the mixer's stereo insert. CLAP retrofitted onto it and A/B null-tested bit-identical; production audio now routes through the generalized path.
- **Native LV2 host** (`src/engine/lv2/`): bundle load + enumerate (lilv), `Lv2Instance` (second `INativeInstance`; urid/options/boundedBlockLength features, CV/unknown-port scratch, atom re-advertise), `NativeLv2Slot`, manifest-only scanner (no dlopen — crash-proof discovery), suil X11 editor embed (re-entrancy-guarded, peer-change aware).
- **Mixer integration**: channel + aux insert chains (CLAP → LV2 → JUCE, one-host-per-slot invariant enforced at every load path), session persistence (`nativeLv2Path` + state blob), picker routing ("LV2-Native" rows replace JUCE LV2 effect rows; JUCE LV2 remains the fallback host), PDC now reads native insert latency.
- **State persistence** via the LV2 state extension (control ports + `state:interface` blob as Turtle); survives reactivate and session round-trips.
- **Fixes en route**: buried-modal bug (native editors hid dialogs — now tagged for EmbeddedModal), fullscreen peer-change stale editors, `ui:resize` embed re-entrancy (black-rectangle bug), bypassed-slot UI writes shadowed for saves, UI→RT port writes through an SPSC ring.
- MANUAL.md documents native hosting (CLAP was never documented either — both covered now).

## Verification
- 297/297 Catch2; live-plugin suites green against real bundles (SilkVerb, Universal Compressor, Multi-Q) incl. state round-trip + A/B null tests.
- Xvfb self-test clean; in-app UI flows reproduced + verified via scripted Xvfb/xdotool harness (picker → load → editor embed → tab switches → modal-over-editor).
- Live-Wayland sign-off done (fullscreen toggle, modal over editor, bypassed-slot save).

## Deferred (tracked)
Multi-plugin bundle URI selection (shared with CLAP), LV2 instruments (stay on JUCE host), plugin→UI port_event feedback, `state:makePath` for file-storing effects, cross-format dedup lands with VST3 (third consumer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native LV2 plugin hosting and editor embedding on Linux.
  * Plugin picker and insert flows now recognize native LV2 entries.
  * Session saving/loading now preserves native LV2 plugin state.

* **Bug Fixes**
  * Improved plugin loading and restore behavior to avoid host conflicts and duplicate slots.
  * Updated latency handling and processing so native plugins behave more consistently.

* **Documentation**
  * Expanded setup and user guides for native LV2 and CLAP support.

* **Tests**
  * Added coverage for native hosting, plugin loading, processing, and session round-trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->