### PR TITLE
Native hosts: multi-plugin bundle selection, parameter completeness, scan sandboxing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -727,6 +727,18 @@ if(_duskstudio_oop_enabled)
         target_link_libraries(dusk-studio-plugin-host PRIVATE synchronization)
     endif()
     target_include_directories(dusk-studio-plugin-host PRIVATE src)
+    # Native-format discovery runs sandboxed through this child (--scan-native):
+    # it needs each format's bundle loader, nothing else from the native hosts.
+    if(DUSKSTUDIO_NATIVE_CLAP)
+        target_sources(dusk-studio-plugin-host PRIVATE src/engine/clap/ClapBundle.cpp)
+        target_include_directories(dusk-studio-plugin-host PRIVATE external/clap/include)
+        target_compile_definitions(dusk-studio-plugin-host PRIVATE DUSKSTUDIO_HAS_NATIVE_CLAP=1)
+    endif()
+    if(DUSKSTUDIO_NATIVE_VST3)
+        target_sources(dusk-studio-plugin-host PRIVATE src/engine/vst3/Vst3Bundle.cpp)
+        target_link_libraries(dusk-studio-plugin-host PRIVATE dusk-vst3-hosting)
+        target_compile_definitions(dusk-studio-plugin-host PRIVATE DUSKSTUDIO_HAS_NATIVE_VST3=1)
+    endif()
     set_target_properties(dusk-studio-plugin-host PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY "$<TARGET_FILE_DIR:DuskStudio>")
     add_dependencies(DuskStudio dusk-studio-plugin-host)

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1595,7 +1595,7 @@ In addition to MCU support, any control in Dusk Studio can be bound to a MIDI CC
 
 The binding is captured and immediately active. The next time that CC arrives, the control responds.
 
-**Plugin parameters**: right-click a loaded insert slot and choose **MIDI Learn last-touched parameter**. Move the target knob in the plugin's own editor first, then trigger your controller — the binding targets whichever parameter you touched last. This works for standard-host plugins and for the native hosts on Linux (CLAP, LV2-Native, VST3-Native). One LV2 caveat: plugins whose parameters are atom "patch" properties rather than control ports (JUCE-built LV2s, notably) expose nothing to bind — load the same plugin as VST3-Native or CLAP instead.
+**Plugin parameters**: right-click a loaded insert slot and choose **MIDI Learn last-touched parameter**. Move the target knob in the plugin's own editor first, then trigger your controller — the binding targets whichever parameter you touched last. This works for standard-host plugins and for every native host on Linux (CLAP, LV2-Native, VST3-Native), including LV2 plugins whose parameters are atom "patch" properties (JUCE-built LV2s, notably).
 
 ## Trigger types
 

--- a/src/dsp/AuxLaneStrip.cpp
+++ b/src/dsp/AuxLaneStrip.cpp
@@ -131,7 +131,8 @@ void AuxLaneStrip::bindHardwareInsert (int slotIdx, const HardwareInsertParams& 
 }
 
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
-bool AuxLaneStrip::loadNativeClap (int slotIdx, const juce::File& path, std::string& errorOut)
+bool AuxLaneStrip::loadNativeClap (int slotIdx, const juce::File& path, std::string& errorOut,
+                                   const juce::String& pluginId)
 {
     jassert (slotIdx >= 0 && slotIdx < kMaxPlugins);
     if (preparedSampleRate <= 0.0 || preparedBlockSize <= 0)
@@ -142,7 +143,7 @@ bool AuxLaneStrip::loadNativeClap (int slotIdx, const juce::File& path, std::str
     unloadNativeLv2 (slotIdx);
     unloadNativeVst3 (slotIdx);
     slots[(size_t) slotIdx].unload();
-    const bool ok = nativeClapSlots[(size_t) slotIdx].load (path, preparedSampleRate, preparedBlockSize, errorOut);
+    const bool ok = nativeClapSlots[(size_t) slotIdx].load (path, preparedSampleRate, preparedBlockSize, errorOut, pluginId);
     // User-initiated load always ends any "failed restore" state (see ChannelStrip::
     // loadNativeClap) — clear regardless of outcome so the flag stays caller-independent.
     nativeReloadFailed[(size_t) slotIdx].store (false, std::memory_order_relaxed);
@@ -168,7 +169,8 @@ void AuxLaneStrip::setPendingNativeClap (int slotIdx, const juce::File& path,
 #endif
 
 #if DUSKSTUDIO_HAS_NATIVE_LV2
-bool AuxLaneStrip::loadNativeLv2 (int slotIdx, const juce::File& path, std::string& errorOut)
+bool AuxLaneStrip::loadNativeLv2 (int slotIdx, const juce::File& path, std::string& errorOut,
+                                  const juce::String& pluginId)
 {
     jassert (slotIdx >= 0 && slotIdx < kMaxPlugins);
     if (preparedSampleRate <= 0.0 || preparedBlockSize <= 0)
@@ -177,7 +179,7 @@ bool AuxLaneStrip::loadNativeLv2 (int slotIdx, const juce::File& path, std::stri
     unloadNativeClap (slotIdx);
     unloadNativeVst3 (slotIdx);
     slots[(size_t) slotIdx].unload();
-    const bool ok = nativeLv2Slots[(size_t) slotIdx].load (path, preparedSampleRate, preparedBlockSize, errorOut);
+    const bool ok = nativeLv2Slots[(size_t) slotIdx].load (path, preparedSampleRate, preparedBlockSize, errorOut, pluginId);
     lv2ReloadFailed[(size_t) slotIdx].store (false, std::memory_order_relaxed);
     return ok;
 }
@@ -201,7 +203,8 @@ void AuxLaneStrip::setPendingNativeLv2 (int slotIdx, const juce::File& path,
 #endif
 
 #if DUSKSTUDIO_HAS_NATIVE_VST3
-bool AuxLaneStrip::loadNativeVst3 (int slotIdx, const juce::File& path, std::string& errorOut)
+bool AuxLaneStrip::loadNativeVst3 (int slotIdx, const juce::File& path, std::string& errorOut,
+                                   const juce::String& pluginId)
 {
     jassert (slotIdx >= 0 && slotIdx < kMaxPlugins);
     if (preparedSampleRate <= 0.0 || preparedBlockSize <= 0)
@@ -210,7 +213,7 @@ bool AuxLaneStrip::loadNativeVst3 (int slotIdx, const juce::File& path, std::str
     unloadNativeClap (slotIdx);
     unloadNativeLv2 (slotIdx);
     slots[(size_t) slotIdx].unload();
-    const bool ok = nativeVst3Slots[(size_t) slotIdx].load (path, preparedSampleRate, preparedBlockSize, errorOut);
+    const bool ok = nativeVst3Slots[(size_t) slotIdx].load (path, preparedSampleRate, preparedBlockSize, errorOut, pluginId);
     vst3ReloadFailed[(size_t) slotIdx].store (false, std::memory_order_relaxed);
     return ok;
 }

--- a/src/dsp/AuxLaneStrip.cpp
+++ b/src/dsp/AuxLaneStrip.cpp
@@ -33,11 +33,13 @@ void AuxLaneStrip::prepare (double sampleRate, int blockSize)
             // set to kInsertPlugin by the engine before it stashed this.
             const juce::File p (pendingClapPath[(size_t) s]);
             std::string err;
-            const bool ok = ncs.load (p, preparedSampleRate, preparedBlockSize, err);
+            const bool ok = ncs.load (p, preparedSampleRate, preparedBlockSize, err,
+                                      pendingClapPluginId[(size_t) s]);
             if (ok && ! pendingClapState[(size_t) s].empty())
                 ncs.loadState (pendingClapState[(size_t) s]);
             nativeReloadFailed[(size_t) s].store (! ok, std::memory_order_relaxed);
             pendingClapPath[(size_t) s].clear();
+            pendingClapPluginId[(size_t) s].clear();
             pendingClapState[(size_t) s].clear();
         }
     }
@@ -58,7 +60,8 @@ void AuxLaneStrip::prepare (double sampleRate, int blockSize)
             {
                 const juce::File p (pendingLv2Path[(size_t) s]);
                 std::string err;
-                const bool ok = nls.load (p, preparedSampleRate, preparedBlockSize, err);
+                const bool ok = nls.load (p, preparedSampleRate, preparedBlockSize, err,
+                                          pendingLv2PluginId[(size_t) s]);
                 if (ok && ! pendingLv2State[(size_t) s].empty())
                     nls.loadState (pendingLv2State[(size_t) s]);
                 lv2ReloadFailed[(size_t) s].store (! ok, std::memory_order_relaxed);
@@ -66,6 +69,7 @@ void AuxLaneStrip::prepare (double sampleRate, int blockSize)
             // Consumed either way — a CLAP-suppressed pending must not replay on a
             // later prepare() once the CLAP is unloaded.
             pendingLv2Path[(size_t) s].clear();
+            pendingLv2PluginId[(size_t) s].clear();
             pendingLv2State[(size_t) s].clear();
         }
     }
@@ -86,12 +90,14 @@ void AuxLaneStrip::prepare (double sampleRate, int blockSize)
             {
                 const juce::File p (pendingVst3Path[(size_t) s]);
                 std::string err;
-                const bool ok = nvs.load (p, preparedSampleRate, preparedBlockSize, err);
+                const bool ok = nvs.load (p, preparedSampleRate, preparedBlockSize, err,
+                                          pendingVst3PluginId[(size_t) s]);
                 if (ok && ! pendingVst3State[(size_t) s].empty())
                     nvs.loadState (pendingVst3State[(size_t) s]);
                 vst3ReloadFailed[(size_t) s].store (! ok, std::memory_order_relaxed);
             }
             pendingVst3Path[(size_t) s].clear();
+            pendingVst3PluginId[(size_t) s].clear();
             pendingVst3State[(size_t) s].clear();
         }
     }
@@ -156,15 +162,18 @@ void AuxLaneStrip::unloadNativeClap (int slotIdx) noexcept
     nativeClapSlots[(size_t) slotIdx].unload();
     nativeReloadFailed[(size_t) slotIdx].store (false, std::memory_order_relaxed);   // slot reset — clear stale failure
     pendingClapPath[(size_t) slotIdx].clear();
+    pendingClapPluginId[(size_t) slotIdx].clear();
     pendingClapState[(size_t) slotIdx].clear();
 }
 
 void AuxLaneStrip::setPendingNativeClap (int slotIdx, const juce::File& path,
-                                          std::vector<uint8_t> state) noexcept
+                                          std::vector<uint8_t> state,
+                                          const juce::String& pluginId) noexcept
 {
     jassert (slotIdx >= 0 && slotIdx < kMaxPlugins);
-    pendingClapPath[(size_t) slotIdx]  = path.getFullPathName();
-    pendingClapState[(size_t) slotIdx] = std::move (state);
+    pendingClapPath[(size_t) slotIdx]     = path.getFullPathName();
+    pendingClapPluginId[(size_t) slotIdx] = pluginId;
+    pendingClapState[(size_t) slotIdx]    = std::move (state);
 }
 #endif
 
@@ -190,15 +199,18 @@ void AuxLaneStrip::unloadNativeLv2 (int slotIdx) noexcept
     nativeLv2Slots[(size_t) slotIdx].unload();
     lv2ReloadFailed[(size_t) slotIdx].store (false, std::memory_order_relaxed);
     pendingLv2Path[(size_t) slotIdx].clear();
+    pendingLv2PluginId[(size_t) slotIdx].clear();
     pendingLv2State[(size_t) slotIdx].clear();
 }
 
 void AuxLaneStrip::setPendingNativeLv2 (int slotIdx, const juce::File& path,
-                                         std::vector<uint8_t> state) noexcept
+                                         std::vector<uint8_t> state,
+                                         const juce::String& pluginId) noexcept
 {
     jassert (slotIdx >= 0 && slotIdx < kMaxPlugins);
-    pendingLv2Path[(size_t) slotIdx]  = path.getFullPathName();
-    pendingLv2State[(size_t) slotIdx] = std::move (state);
+    pendingLv2Path[(size_t) slotIdx]     = path.getFullPathName();
+    pendingLv2PluginId[(size_t) slotIdx] = pluginId;
+    pendingLv2State[(size_t) slotIdx]    = std::move (state);
 }
 #endif
 
@@ -224,15 +236,18 @@ void AuxLaneStrip::unloadNativeVst3 (int slotIdx) noexcept
     nativeVst3Slots[(size_t) slotIdx].unload();
     vst3ReloadFailed[(size_t) slotIdx].store (false, std::memory_order_relaxed);
     pendingVst3Path[(size_t) slotIdx].clear();
+    pendingVst3PluginId[(size_t) slotIdx].clear();
     pendingVst3State[(size_t) slotIdx].clear();
 }
 
 void AuxLaneStrip::setPendingNativeVst3 (int slotIdx, const juce::File& path,
-                                          std::vector<uint8_t> state) noexcept
+                                          std::vector<uint8_t> state,
+                                          const juce::String& pluginId) noexcept
 {
     jassert (slotIdx >= 0 && slotIdx < kMaxPlugins);
-    pendingVst3Path[(size_t) slotIdx]  = path.getFullPathName();
-    pendingVst3State[(size_t) slotIdx] = std::move (state);
+    pendingVst3Path[(size_t) slotIdx]     = path.getFullPathName();
+    pendingVst3PluginId[(size_t) slotIdx] = pluginId;
+    pendingVst3State[(size_t) slotIdx]    = std::move (state);
 }
 #endif
 

--- a/src/dsp/AuxLaneStrip.h
+++ b/src/dsp/AuxLaneStrip.h
@@ -128,6 +128,26 @@ public:
     bool nativeVst3ReloadFailed (int) const noexcept { return false; }
 #endif
 
+    // MIDI Learn: last-touched parameter of whichever host owns the slot
+    // (same precedence as the audio chain); -1 when empty or untouched.
+    int insertLastTouchedParamIndex (int slotIdx) const noexcept
+    {
+        jassert (slotIdx >= 0 && slotIdx < kMaxPlugins);
+#if DUSKSTUDIO_HAS_NATIVE_CLAP
+        if (isNativeClapLoaded (slotIdx))
+            return nativeClapSlots[(size_t) slotIdx].lastTouchedParamIndex();
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+        if (isNativeLv2Loaded (slotIdx))
+            return nativeLv2Slots[(size_t) slotIdx].lastTouchedParamIndex();
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_VST3
+        if (isNativeVst3Loaded (slotIdx))
+            return nativeVst3Slots[(size_t) slotIdx].lastTouchedParamIndex();
+#endif
+        return slots[(size_t) slotIdx].getLastTouchedParamIndex();
+    }
+
     enum InsertMode : int { kInsertEmpty = 0, kInsertPlugin = 1, kInsertHardware = 2 };
 
     std::array<std::atomic<int>, kMaxPlugins> insertMode {};

--- a/src/dsp/AuxLaneStrip.h
+++ b/src/dsp/AuxLaneStrip.h
@@ -67,7 +67,8 @@ public:
     // Linux-only native CLAP host (DUSKSTUDIO_HAS_NATIVE_CLAP); stubbed elsewhere so the
     // bool/void API still compiles. getNativeClapSlot returns a clap type → Linux-only.
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
-    bool loadNativeClap   (int slotIdx, const juce::File& path, std::string& errorOut);
+    bool loadNativeClap   (int slotIdx, const juce::File& path, std::string& errorOut,
+                           const juce::String& pluginId = {});
     void unloadNativeClap (int slotIdx) noexcept;
     bool isNativeClapLoaded (int slotIdx) const noexcept { jassert (slotIdx >= 0 && slotIdx < kMaxPlugins); return nativeClapSlots[(size_t) slotIdx].isLoaded(); }
     clap::NativeClapSlot&       getNativeClapSlot (int idx)       noexcept { jassert (idx >= 0 && idx < kMaxPlugins); return nativeClapSlots[(size_t) idx]; }
@@ -92,7 +93,8 @@ public:
 
     // Native LV2 host path — same contract as the CLAP block above.
 #if DUSKSTUDIO_HAS_NATIVE_LV2
-    bool loadNativeLv2   (int slotIdx, const juce::File& path, std::string& errorOut);
+    bool loadNativeLv2   (int slotIdx, const juce::File& path, std::string& errorOut,
+                          const juce::String& pluginId = {});
     void unloadNativeLv2 (int slotIdx) noexcept;
     bool isNativeLv2Loaded (int slotIdx) const noexcept { jassert (slotIdx >= 0 && slotIdx < kMaxPlugins); return nativeLv2Slots[(size_t) slotIdx].isLoaded(); }
     lv2::NativeLv2Slot&       getNativeLv2Slot (int idx)       noexcept { jassert (idx >= 0 && idx < kMaxPlugins); return nativeLv2Slots[(size_t) idx]; }
@@ -108,7 +110,8 @@ public:
 
     // Native VST3 host path — same contract as the CLAP block above.
 #if DUSKSTUDIO_HAS_NATIVE_VST3
-    bool loadNativeVst3   (int slotIdx, const juce::File& path, std::string& errorOut);
+    bool loadNativeVst3   (int slotIdx, const juce::File& path, std::string& errorOut,
+                           const juce::String& pluginId = {});
     void unloadNativeVst3 (int slotIdx) noexcept;
     bool isNativeVst3Loaded (int slotIdx) const noexcept { jassert (slotIdx >= 0 && slotIdx < kMaxPlugins); return nativeVst3Slots[(size_t) slotIdx].isLoaded(); }
     vst3::NativeVst3Slot&       getNativeVst3Slot (int idx)       noexcept { jassert (idx >= 0 && idx < kMaxPlugins); return nativeVst3Slots[(size_t) idx]; }

--- a/src/dsp/AuxLaneStrip.h
+++ b/src/dsp/AuxLaneStrip.h
@@ -78,7 +78,8 @@ public:
     // can run before the engine is prepared. Stash the saved {path, state}; prepare()
     // loads it once the SR is known. (When already prepared, the engine loads directly
     // and never calls this.)
-    void setPendingNativeClap (int slotIdx, const juce::File& path, std::vector<uint8_t> state) noexcept;
+    void setPendingNativeClap (int slotIdx, const juce::File& path, std::vector<uint8_t> state,
+                               const juce::String& pluginId = {}) noexcept;
 
     // True when a sample-rate re-prepare reload of a loaded native CLAP failed (the
     // slot is now empty). The UI reads this to report which lane lost its plugin.
@@ -99,7 +100,8 @@ public:
     bool isNativeLv2Loaded (int slotIdx) const noexcept { jassert (slotIdx >= 0 && slotIdx < kMaxPlugins); return nativeLv2Slots[(size_t) slotIdx].isLoaded(); }
     lv2::NativeLv2Slot&       getNativeLv2Slot (int idx)       noexcept { jassert (idx >= 0 && idx < kMaxPlugins); return nativeLv2Slots[(size_t) idx]; }
     const lv2::NativeLv2Slot& getNativeLv2Slot (int idx) const noexcept { jassert (idx >= 0 && idx < kMaxPlugins); return nativeLv2Slots[(size_t) idx]; }
-    void setPendingNativeLv2 (int slotIdx, const juce::File& path, std::vector<uint8_t> state) noexcept;
+    void setPendingNativeLv2 (int slotIdx, const juce::File& path, std::vector<uint8_t> state,
+                              const juce::String& pluginId = {}) noexcept;
     bool nativeLv2ReloadFailed (int slotIdx) const noexcept { jassert (slotIdx >= 0 && slotIdx < kMaxPlugins); return lv2ReloadFailed[(size_t) slotIdx].load (std::memory_order_relaxed); }
     void markNativeLv2RestoreFailed (int slotIdx) noexcept { jassert (slotIdx >= 0 && slotIdx < kMaxPlugins); lv2ReloadFailed[(size_t) slotIdx].store (true, std::memory_order_relaxed); }
 #else
@@ -116,7 +118,8 @@ public:
     bool isNativeVst3Loaded (int slotIdx) const noexcept { jassert (slotIdx >= 0 && slotIdx < kMaxPlugins); return nativeVst3Slots[(size_t) slotIdx].isLoaded(); }
     vst3::NativeVst3Slot&       getNativeVst3Slot (int idx)       noexcept { jassert (idx >= 0 && idx < kMaxPlugins); return nativeVst3Slots[(size_t) idx]; }
     const vst3::NativeVst3Slot& getNativeVst3Slot (int idx) const noexcept { jassert (idx >= 0 && idx < kMaxPlugins); return nativeVst3Slots[(size_t) idx]; }
-    void setPendingNativeVst3 (int slotIdx, const juce::File& path, std::vector<uint8_t> state) noexcept;
+    void setPendingNativeVst3 (int slotIdx, const juce::File& path, std::vector<uint8_t> state,
+                               const juce::String& pluginId = {}) noexcept;
     bool nativeVst3ReloadFailed (int slotIdx) const noexcept { jassert (slotIdx >= 0 && slotIdx < kMaxPlugins); return vst3ReloadFailed[(size_t) slotIdx].load (std::memory_order_relaxed); }
     void markNativeVst3RestoreFailed (int slotIdx) noexcept { jassert (slotIdx >= 0 && slotIdx < kMaxPlugins); vst3ReloadFailed[(size_t) slotIdx].store (true, std::memory_order_relaxed); }
 #else
@@ -150,18 +153,21 @@ private:
 
     // Pending session-restore load, consummated by prepare() (see setPendingNativeClap).
     std::array<juce::String,           kMaxPlugins> pendingClapPath;
+    std::array<juce::String,           kMaxPlugins> pendingClapPluginId;
     std::array<std::vector<uint8_t>,   kMaxPlugins> pendingClapState;
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_LV2
     std::array<lv2::NativeLv2Slot,   kMaxPlugins> nativeLv2Slots;
     std::array<std::atomic<bool>,    kMaxPlugins> lv2ReloadFailed {};
     std::array<juce::String,         kMaxPlugins> pendingLv2Path;
+    std::array<juce::String,         kMaxPlugins> pendingLv2PluginId;
     std::array<std::vector<uint8_t>, kMaxPlugins> pendingLv2State;
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_VST3
     std::array<vst3::NativeVst3Slot, kMaxPlugins> nativeVst3Slots;
     std::array<std::atomic<bool>,    kMaxPlugins> vst3ReloadFailed {};
     std::array<juce::String,         kMaxPlugins> pendingVst3Path;
+    std::array<juce::String,         kMaxPlugins> pendingVst3PluginId;
     std::array<std::vector<uint8_t>, kMaxPlugins> pendingVst3State;
 #endif
 

--- a/src/dsp/ChannelStrip.cpp
+++ b/src/dsp/ChannelStrip.cpp
@@ -103,11 +103,13 @@ void ChannelStrip::prepare (double sampleRate, int blockSize, int oversamplingFa
     {
         const juce::File p (pendingClapPath);
         std::string err;
-        const bool ok = nativeClapSlot.load (p, preparedSampleRate, preparedBlockSize, err);
+        const bool ok = nativeClapSlot.load (p, preparedSampleRate, preparedBlockSize, err,
+                                             pendingClapPluginId);
         if (ok && ! pendingClapState.empty())
             nativeClapSlot.loadState (pendingClapState);
         nativeReloadFailed.store (! ok, std::memory_order_relaxed);
         pendingClapPath.clear();
+        pendingClapPluginId.clear();
         pendingClapState.clear();
     }
 #endif
@@ -124,7 +126,8 @@ void ChannelStrip::prepare (double sampleRate, int blockSize, int oversamplingFa
         {
             const juce::File p (pendingLv2Path);
             std::string err;
-            const bool ok = nativeLv2Slot.load (p, preparedSampleRate, preparedBlockSize, err);
+            const bool ok = nativeLv2Slot.load (p, preparedSampleRate, preparedBlockSize, err,
+                                                pendingLv2PluginId);
             if (ok && ! pendingLv2State.empty())
                 nativeLv2Slot.loadState (pendingLv2State);
             lv2ReloadFailed.store (! ok, std::memory_order_relaxed);
@@ -132,6 +135,7 @@ void ChannelStrip::prepare (double sampleRate, int blockSize, int oversamplingFa
         // Consumed either way — a CLAP-suppressed pending must not replay on a
         // later prepare() once the CLAP is unloaded.
         pendingLv2Path.clear();
+        pendingLv2PluginId.clear();
         pendingLv2State.clear();
     }
 #endif
@@ -148,12 +152,14 @@ void ChannelStrip::prepare (double sampleRate, int blockSize, int oversamplingFa
         {
             const juce::File p (pendingVst3Path);
             std::string err;
-            const bool ok = nativeVst3Slot.load (p, preparedSampleRate, preparedBlockSize, err);
+            const bool ok = nativeVst3Slot.load (p, preparedSampleRate, preparedBlockSize, err,
+                                                 pendingVst3PluginId);
             if (ok && ! pendingVst3State.empty())
                 nativeVst3Slot.loadState (pendingVst3State);
             vst3ReloadFailed.store (! ok, std::memory_order_relaxed);
         }
         pendingVst3Path.clear();
+        pendingVst3PluginId.clear();
         pendingVst3State.clear();
     }
 #endif
@@ -505,13 +511,16 @@ void ChannelStrip::unloadNativeClap() noexcept
     nativeClapSlot.unload();
     nativeReloadFailed.store (false, std::memory_order_relaxed);   // slot reset — clear stale failure
     pendingClapPath.clear();
+    pendingClapPluginId.clear();
     pendingClapState.clear();
 }
 
-void ChannelStrip::setPendingNativeClap (const juce::File& path, std::vector<uint8_t> state) noexcept
+void ChannelStrip::setPendingNativeClap (const juce::File& path, std::vector<uint8_t> state,
+                                         const juce::String& pluginId) noexcept
 {
-    pendingClapPath  = path.getFullPathName();
-    pendingClapState = std::move (state);
+    pendingClapPath     = path.getFullPathName();
+    pendingClapPluginId = pluginId;
+    pendingClapState    = std::move (state);
 }
 #endif
 
@@ -536,13 +545,16 @@ void ChannelStrip::unloadNativeLv2() noexcept
     nativeLv2Slot.unload();
     lv2ReloadFailed.store (false, std::memory_order_relaxed);
     pendingLv2Path.clear();
+    pendingLv2PluginId.clear();
     pendingLv2State.clear();
 }
 
-void ChannelStrip::setPendingNativeLv2 (const juce::File& path, std::vector<uint8_t> state) noexcept
+void ChannelStrip::setPendingNativeLv2 (const juce::File& path, std::vector<uint8_t> state,
+                                        const juce::String& pluginId) noexcept
 {
-    pendingLv2Path  = path.getFullPathName();
-    pendingLv2State = std::move (state);
+    pendingLv2Path     = path.getFullPathName();
+    pendingLv2PluginId = pluginId;
+    pendingLv2State    = std::move (state);
 }
 #endif
 
@@ -567,13 +579,16 @@ void ChannelStrip::unloadNativeVst3() noexcept
     nativeVst3Slot.unload();
     vst3ReloadFailed.store (false, std::memory_order_relaxed);
     pendingVst3Path.clear();
+    pendingVst3PluginId.clear();
     pendingVst3State.clear();
 }
 
-void ChannelStrip::setPendingNativeVst3 (const juce::File& path, std::vector<uint8_t> state) noexcept
+void ChannelStrip::setPendingNativeVst3 (const juce::File& path, std::vector<uint8_t> state,
+                                         const juce::String& pluginId) noexcept
 {
-    pendingVst3Path  = path.getFullPathName();
-    pendingVst3State = std::move (state);
+    pendingVst3Path     = path.getFullPathName();
+    pendingVst3PluginId = pluginId;
+    pendingVst3State    = std::move (state);
 }
 #endif
 

--- a/src/dsp/ChannelStrip.cpp
+++ b/src/dsp/ChannelStrip.cpp
@@ -481,7 +481,8 @@ void ChannelStrip::bindHardwareInsert (const HardwareInsertParams& params) noexc
 }
 
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
-bool ChannelStrip::loadNativeClap (const juce::File& path, std::string& errorOut)
+bool ChannelStrip::loadNativeClap (const juce::File& path, std::string& errorOut,
+                                   const juce::String& pluginId)
 {
     if (preparedSampleRate <= 0.0 || preparedBlockSize <= 0)
     { errorOut = "channel strip not prepared"; return false; }
@@ -491,7 +492,7 @@ bool ChannelStrip::loadNativeClap (const juce::File& path, std::string& errorOut
     unloadNativeLv2();
     unloadNativeVst3();
     pluginSlot.unload();
-    const bool ok = nativeClapSlot.load (path, preparedSampleRate, preparedBlockSize, errorOut);
+    const bool ok = nativeClapSlot.load (path, preparedSampleRate, preparedBlockSize, errorOut, pluginId);
     // A user-initiated load is not a restore, so it always ends any "failed restore"
     // state — whether it succeeds (recovered) or fails (caller clears the persisted
     // refs). Clearing unconditionally keeps the flag's meaning independent of the caller.
@@ -515,7 +516,8 @@ void ChannelStrip::setPendingNativeClap (const juce::File& path, std::vector<uin
 #endif
 
 #if DUSKSTUDIO_HAS_NATIVE_LV2
-bool ChannelStrip::loadNativeLv2 (const juce::File& path, std::string& errorOut)
+bool ChannelStrip::loadNativeLv2 (const juce::File& path, std::string& errorOut,
+                                  const juce::String& pluginId)
 {
     if (preparedSampleRate <= 0.0 || preparedBlockSize <= 0)
     { errorOut = "channel strip not prepared"; return false; }
@@ -523,7 +525,7 @@ bool ChannelStrip::loadNativeLv2 (const juce::File& path, std::string& errorOut)
     unloadNativeClap();
     unloadNativeVst3();
     pluginSlot.unload();
-    const bool ok = nativeLv2Slot.load (path, preparedSampleRate, preparedBlockSize, errorOut);
+    const bool ok = nativeLv2Slot.load (path, preparedSampleRate, preparedBlockSize, errorOut, pluginId);
     // A user-initiated load always ends any "failed restore" state (see loadNativeClap).
     lv2ReloadFailed.store (false, std::memory_order_relaxed);
     return ok;
@@ -545,7 +547,8 @@ void ChannelStrip::setPendingNativeLv2 (const juce::File& path, std::vector<uint
 #endif
 
 #if DUSKSTUDIO_HAS_NATIVE_VST3
-bool ChannelStrip::loadNativeVst3 (const juce::File& path, std::string& errorOut)
+bool ChannelStrip::loadNativeVst3 (const juce::File& path, std::string& errorOut,
+                                   const juce::String& pluginId)
 {
     if (preparedSampleRate <= 0.0 || preparedBlockSize <= 0)
     { errorOut = "channel strip not prepared"; return false; }
@@ -553,7 +556,7 @@ bool ChannelStrip::loadNativeVst3 (const juce::File& path, std::string& errorOut
     unloadNativeClap();
     unloadNativeLv2();
     pluginSlot.unload();
-    const bool ok = nativeVst3Slot.load (path, preparedSampleRate, preparedBlockSize, errorOut);
+    const bool ok = nativeVst3Slot.load (path, preparedSampleRate, preparedBlockSize, errorOut, pluginId);
     // A user-initiated load always ends any "failed restore" state (see loadNativeClap).
     vst3ReloadFailed.store (false, std::memory_order_relaxed);
     return ok;

--- a/src/dsp/ChannelStrip.h
+++ b/src/dsp/ChannelStrip.h
@@ -123,6 +123,22 @@ public:
     bool nativeVst3ReloadFailed() const noexcept { return false; }
 #endif
 
+    // MIDI Learn: last-touched parameter of whichever host owns the insert
+    // (same precedence as the audio chain); -1 when empty or untouched.
+    int insertLastTouchedParamIndex() const noexcept
+    {
+#if DUSKSTUDIO_HAS_NATIVE_CLAP
+        if (isNativeClapLoaded()) return nativeClapSlot.lastTouchedParamIndex();
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+        if (isNativeLv2Loaded()) return nativeLv2Slot.lastTouchedParamIndex();
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_VST3
+        if (isNativeVst3Loaded()) return nativeVst3Slot.lastTouchedParamIndex();
+#endif
+        return pluginSlot.getLastTouchedParamIndex();
+    }
+
     // Hardware vs plugin insert: one runs per block, chosen by
     // insertMode + 20 ms crossfade gate.
     void bindHardwareInsert (const HardwareInsertParams& params) noexcept;

--- a/src/dsp/ChannelStrip.h
+++ b/src/dsp/ChannelStrip.h
@@ -66,7 +66,8 @@ public:
     // Linux-only (DUSKSTUDIO_HAS_NATIVE_CLAP); stubbed elsewhere so callers compile.
     bool isPrepared() const noexcept { return preparedSampleRate > 0.0 && preparedBlockSize > 0; }
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
-    bool loadNativeClap   (const juce::File& path, std::string& errorOut);
+    bool loadNativeClap   (const juce::File& path, std::string& errorOut,
+                           const juce::String& pluginId = {});
     void unloadNativeClap() noexcept;
     bool isNativeClapLoaded() const noexcept { return nativeClapSlot.isLoaded(); }
     clap::NativeClapSlot&       getNativeClapSlot()       noexcept { return nativeClapSlot; }
@@ -87,7 +88,8 @@ public:
 
     // Native LV2 host path — same contract as the CLAP block above.
 #if DUSKSTUDIO_HAS_NATIVE_LV2
-    bool loadNativeLv2   (const juce::File& path, std::string& errorOut);
+    bool loadNativeLv2   (const juce::File& path, std::string& errorOut,
+                          const juce::String& pluginId = {});
     void unloadNativeLv2() noexcept;
     bool isNativeLv2Loaded() const noexcept { return nativeLv2Slot.isLoaded(); }
     lv2::NativeLv2Slot&       getNativeLv2Slot()       noexcept { return nativeLv2Slot; }
@@ -103,7 +105,8 @@ public:
 
     // Native VST3 host path — same contract as the CLAP block above.
 #if DUSKSTUDIO_HAS_NATIVE_VST3
-    bool loadNativeVst3   (const juce::File& path, std::string& errorOut);
+    bool loadNativeVst3   (const juce::File& path, std::string& errorOut,
+                           const juce::String& pluginId = {});
     void unloadNativeVst3() noexcept;
     bool isNativeVst3Loaded() const noexcept { return nativeVst3Slot.isLoaded(); }
     vst3::NativeVst3Slot&       getNativeVst3Slot()       noexcept { return nativeVst3Slot; }

--- a/src/dsp/ChannelStrip.h
+++ b/src/dsp/ChannelStrip.h
@@ -73,7 +73,8 @@ public:
     clap::NativeClapSlot&       getNativeClapSlot()       noexcept { return nativeClapSlot; }
     const clap::NativeClapSlot& getNativeClapSlot() const noexcept { return nativeClapSlot; }
     // Session restore before the engine is prepared: stash {path,state}; prepare() loads it.
-    void setPendingNativeClap (const juce::File& path, std::vector<uint8_t> state) noexcept;
+    void setPendingNativeClap (const juce::File& path, std::vector<uint8_t> state,
+                               const juce::String& pluginId = {}) noexcept;
     // True when the last prepare()-time reactivate / pending-restore load failed. Lets
     // the save path tell "failed restore" (keep the persisted path) from "user removed".
     bool nativeClapReloadFailed() const noexcept { return nativeReloadFailed.load (std::memory_order_relaxed); }
@@ -94,7 +95,8 @@ public:
     bool isNativeLv2Loaded() const noexcept { return nativeLv2Slot.isLoaded(); }
     lv2::NativeLv2Slot&       getNativeLv2Slot()       noexcept { return nativeLv2Slot; }
     const lv2::NativeLv2Slot& getNativeLv2Slot() const noexcept { return nativeLv2Slot; }
-    void setPendingNativeLv2 (const juce::File& path, std::vector<uint8_t> state) noexcept;
+    void setPendingNativeLv2 (const juce::File& path, std::vector<uint8_t> state,
+                              const juce::String& pluginId = {}) noexcept;
     bool nativeLv2ReloadFailed() const noexcept { return lv2ReloadFailed.load (std::memory_order_relaxed); }
     void markNativeLv2RestoreFailed() noexcept { lv2ReloadFailed.store (true, std::memory_order_relaxed); }
 #else
@@ -111,7 +113,8 @@ public:
     bool isNativeVst3Loaded() const noexcept { return nativeVst3Slot.isLoaded(); }
     vst3::NativeVst3Slot&       getNativeVst3Slot()       noexcept { return nativeVst3Slot; }
     const vst3::NativeVst3Slot& getNativeVst3Slot() const noexcept { return nativeVst3Slot; }
-    void setPendingNativeVst3 (const juce::File& path, std::vector<uint8_t> state) noexcept;
+    void setPendingNativeVst3 (const juce::File& path, std::vector<uint8_t> state,
+                               const juce::String& pluginId = {}) noexcept;
     bool nativeVst3ReloadFailed() const noexcept { return vst3ReloadFailed.load (std::memory_order_relaxed); }
     void markNativeVst3RestoreFailed() noexcept { vst3ReloadFailed.store (true, std::memory_order_relaxed); }
 #else
@@ -238,14 +241,17 @@ private:
     int    preparedBlockSize  = 0;
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
     juce::String         pendingClapPath;    // session-restore load consummated by prepare()
+    juce::String         pendingClapPluginId;
     std::vector<uint8_t> pendingClapState;
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_LV2
     juce::String         pendingLv2Path;
+    juce::String         pendingLv2PluginId;
     std::vector<uint8_t> pendingLv2State;
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_VST3
     juce::String         pendingVst3Path;
+    juce::String         pendingVst3PluginId;
     std::vector<uint8_t> pendingVst3State;
 #endif
 

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -125,6 +125,22 @@ public:
             strip.getNativeVst3Slot().drainQueuedParamBindings();
 #endif
         }
+        for (int a = 0; a < Session::kNumAuxLanes; ++a)
+        {
+            auto& lane = engine.getAuxLaneStrip (a);
+            for (int s = 0; s < AuxLaneParams::kMaxLanePlugins; ++s)
+            {
+#if DUSKSTUDIO_HAS_NATIVE_CLAP
+                lane.getNativeClapSlot (s).drainQueuedParamBindings();
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+                lane.getNativeLv2Slot (s).drainQueuedParamBindings();
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_VST3
+                lane.getNativeVst3Slot (s).drainQueuedParamBindings();
+#endif
+            }
+        }
 
 #if DUSKSTUDIO_HAS_NATIVE_VST3
         // A plugin that signalled kLatencyChanged only reports the new value
@@ -3335,6 +3351,44 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
                                 }
 #endif
                                 strip.getPluginSlot()
+                                    .setParamNormalised (b.paramIndex, frac);
+                            }
+                            break;
+                        }
+                        case MidiBindingTarget::AuxPluginParam:
+                        {
+                            // Same shape as TrackPluginParam: the loaded host
+                            // owns the slot (CLAP → LV2 → VST3 → JUCE).
+                            if (b.targetIndex >= 0
+                                && b.targetIndex < Session::kNumAuxLanes
+                                && b.paramIndex >= 0)
+                            {
+                                auto& lane = auxLaneStrips[(size_t) b.targetIndex];
+#if DUSKSTUDIO_HAS_NATIVE_CLAP
+                                if (lane.isNativeClapLoaded (0))
+                                {
+                                    lane.getNativeClapSlot (0)
+                                        .queueParamBinding ((uint32_t) b.paramIndex, frac);
+                                    break;
+                                }
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+                                if (lane.isNativeLv2Loaded (0))
+                                {
+                                    lane.getNativeLv2Slot (0)
+                                        .queueParamBinding ((uint32_t) b.paramIndex, frac);
+                                    break;
+                                }
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_VST3
+                                if (lane.isNativeVst3Loaded (0))
+                                {
+                                    lane.getNativeVst3Slot (0)
+                                        .queueParamBinding ((uint32_t) b.paramIndex, frac);
+                                    break;
+                                }
+#endif
+                                lane.getPluginSlot (0)
                                     .setParamNormalised (b.paramIndex, frac);
                             }
                             break;

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -155,6 +155,8 @@ public:
         {
             auto cycle = [&] (auto& slot)
             {
+                if (auto* inst = slot.getInstance())
+                    inst->refreshParamInfoIfChanged();
                 if (! slot.consumeLatencyChanged() || ! slot.isLoaded()) return;
                 if (! anyLatencyChanged) engine.suspendProcessing();
                 anyLatencyChanged = true;

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -1356,7 +1356,8 @@ void AudioEngine::publishPluginStateForSave (bool audioCallbackDetached)
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
         if (strip.isNativeClapLoaded())
         {
-            track.nativeClapPath = strip.getNativeClapSlot().getPath();
+            track.nativeClapPath     = strip.getNativeClapSlot().getPath();
+            track.nativeClapPluginId = strip.getNativeClapSlot().getPluginId();
             std::vector<uint8_t> blob;
             if (strip.getNativeClapSlot().saveState (blob) && ! blob.empty())
                 track.nativeClapStateBase64 = juce::Base64::toBase64 (blob.data(), blob.size());
@@ -1371,13 +1372,15 @@ void AudioEngine::publishPluginStateForSave (bool audioCallbackDetached)
             // reference survives to reconnect on a future launch — mirrors how an
             // offline JUCE plugin preserves its descXml.
             track.nativeClapPath.clear();
+            track.nativeClapPluginId.clear();
             track.nativeClapStateBase64.clear();
         }
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_LV2
         if (strip.isNativeLv2Loaded())
         {
-            track.nativeLv2Path = strip.getNativeLv2Slot().getPath();
+            track.nativeLv2Path     = strip.getNativeLv2Slot().getPath();
+            track.nativeLv2PluginId = strip.getNativeLv2Slot().getPluginId();
             std::vector<uint8_t> blob;
             // Preserve the carried blob when a plugin can't serialize (no state
             // extension / save failure) — don't wipe it on a save round-trip.
@@ -1387,13 +1390,15 @@ void AudioEngine::publishPluginStateForSave (bool audioCallbackDetached)
         else if (! strip.nativeLv2ReloadFailed())
         {
             track.nativeLv2Path.clear();
+            track.nativeLv2PluginId.clear();
             track.nativeLv2StateBase64.clear();
         }
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_VST3
         if (strip.isNativeVst3Loaded())
         {
-            track.nativeVst3Path = strip.getNativeVst3Slot().getPath();
+            track.nativeVst3Path     = strip.getNativeVst3Slot().getPath();
+            track.nativeVst3PluginId = strip.getNativeVst3Slot().getPluginId();
             std::vector<uint8_t> blob;
             // See the LV2 block above: preserve the carried blob when the plugin
             // can't serialize.
@@ -1403,6 +1408,7 @@ void AudioEngine::publishPluginStateForSave (bool audioCallbackDetached)
         else if (! strip.nativeVst3ReloadFailed())
         {
             track.nativeVst3Path.clear();
+            track.nativeVst3PluginId.clear();
             track.nativeVst3StateBase64.clear();
         }
 #endif
@@ -1422,7 +1428,8 @@ void AudioEngine::publishPluginStateForSave (bool audioCallbackDetached)
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
             if (strip.isNativeClapLoaded (s))
             {
-                lane.nativeClapPath[(size_t) s] = strip.getNativeClapSlot (s).getPath();
+                lane.nativeClapPath[(size_t) s]     = strip.getNativeClapSlot (s).getPath();
+                lane.nativeClapPluginId[(size_t) s] = strip.getNativeClapSlot (s).getPluginId();
                 std::vector<uint8_t> blob;
                 if (strip.getNativeClapSlot (s).saveState (blob) && ! blob.empty())
                     lane.nativeClapStateBase64[(size_t) s] = juce::Base64::toBase64 (blob.data(), blob.size());
@@ -1435,13 +1442,15 @@ void AudioEngine::publishPluginStateForSave (bool audioCallbackDetached)
                 // failed (path preserved to reconnect later); clear only a genuinely
                 // empty / user-removed slot.
                 lane.nativeClapPath[(size_t) s].clear();
+                lane.nativeClapPluginId[(size_t) s].clear();
                 lane.nativeClapStateBase64[(size_t) s].clear();
             }
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_LV2
             if (strip.isNativeLv2Loaded (s))
             {
-                lane.nativeLv2Path[(size_t) s] = strip.getNativeLv2Slot (s).getPath();
+                lane.nativeLv2Path[(size_t) s]     = strip.getNativeLv2Slot (s).getPath();
+                lane.nativeLv2PluginId[(size_t) s] = strip.getNativeLv2Slot (s).getPluginId();
                 std::vector<uint8_t> blob;
                 // See the track block above: preserve the carried blob when the
                 // plugin can't serialize.
@@ -1451,13 +1460,15 @@ void AudioEngine::publishPluginStateForSave (bool audioCallbackDetached)
             else if (! strip.nativeLv2ReloadFailed (s))
             {
                 lane.nativeLv2Path[(size_t) s].clear();
+                lane.nativeLv2PluginId[(size_t) s].clear();
                 lane.nativeLv2StateBase64[(size_t) s].clear();
             }
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_VST3
             if (strip.isNativeVst3Loaded (s))
             {
-                lane.nativeVst3Path[(size_t) s] = strip.getNativeVst3Slot (s).getPath();
+                lane.nativeVst3Path[(size_t) s]     = strip.getNativeVst3Slot (s).getPath();
+                lane.nativeVst3PluginId[(size_t) s] = strip.getNativeVst3Slot (s).getPluginId();
                 std::vector<uint8_t> blob;
                 if (strip.getNativeVst3Slot (s).saveState (blob) && ! blob.empty())
                     lane.nativeVst3StateBase64[(size_t) s] = juce::Base64::toBase64 (blob.data(), blob.size());
@@ -1465,6 +1476,7 @@ void AudioEngine::publishPluginStateForSave (bool audioCallbackDetached)
             else if (! strip.nativeVst3ReloadFailed (s))
             {
                 lane.nativeVst3Path[(size_t) s].clear();
+                lane.nativeVst3PluginId[(size_t) s].clear();
                 lane.nativeVst3StateBase64[(size_t) s].clear();
             }
 #endif
@@ -1592,7 +1604,7 @@ void AudioEngine::consumePluginStateAfterLoad()
             {
                 suspendProcessing();
                 std::string err;
-                const bool ok = strip.loadNativeClap (clapFile, err);
+                const bool ok = strip.loadNativeClap (clapFile, err, track.nativeClapPluginId);
                 if (ok && ! blob.empty())
                     strip.getNativeClapSlot().loadState (blob);
                 resumeProcessing();
@@ -1612,7 +1624,7 @@ void AudioEngine::consumePluginStateAfterLoad()
                 // hosts unfenced (the prepared path's loadNativeClap evicts them).
                 strip.unloadNativeLv2();
                 strip.unloadNativeVst3();
-                strip.setPendingNativeClap (clapFile, std::move (blob));
+                strip.setPendingNativeClap (clapFile, std::move (blob), track.nativeClapPluginId);
             }
             continue;
         }
@@ -1630,7 +1642,7 @@ void AudioEngine::consumePluginStateAfterLoad()
             {
                 suspendProcessing();
                 std::string err;
-                const bool ok = strip.loadNativeLv2 (lv2File, err);
+                const bool ok = strip.loadNativeLv2 (lv2File, err, track.nativeLv2PluginId);
                 if (ok && ! blob.empty())
                     strip.getNativeLv2Slot().loadState (blob);
                 resumeProcessing();
@@ -1646,7 +1658,7 @@ void AudioEngine::consumePluginStateAfterLoad()
             {
                 strip.unloadNativeClap();   // see the CLAP pending branch above
                 strip.unloadNativeVst3();
-                strip.setPendingNativeLv2 (lv2File, std::move (blob));
+                strip.setPendingNativeLv2 (lv2File, std::move (blob), track.nativeLv2PluginId);
             }
             continue;
         }
@@ -1664,7 +1676,7 @@ void AudioEngine::consumePluginStateAfterLoad()
             {
                 suspendProcessing();
                 std::string err;
-                const bool ok = strip.loadNativeVst3 (vst3File, err);
+                const bool ok = strip.loadNativeVst3 (vst3File, err, track.nativeVst3PluginId);
                 if (ok && ! blob.empty())
                     strip.getNativeVst3Slot().loadState (blob);
                 resumeProcessing();
@@ -1680,7 +1692,7 @@ void AudioEngine::consumePluginStateAfterLoad()
             {
                 strip.unloadNativeClap();   // see the CLAP pending branch above
                 strip.unloadNativeLv2();
-                strip.setPendingNativeVst3 (vst3File, std::move (blob));
+                strip.setPendingNativeVst3 (vst3File, std::move (blob), track.nativeVst3PluginId);
             }
             continue;
         }
@@ -1756,7 +1768,8 @@ void AudioEngine::consumePluginStateAfterLoad()
                 {
                     suspendProcessing();   // load is not RT-safe; fence the audio thread
                     std::string err;
-                    const bool ok = strip.loadNativeClap (s, clapFile, err);
+                    const bool ok = strip.loadNativeClap (s, clapFile, err,
+                                                          lane.nativeClapPluginId[(size_t) s]);
                     if (ok && ! blob.empty())
                         strip.getNativeClapSlot (s).loadState (blob);
                     resumeProcessing();
@@ -1773,7 +1786,8 @@ void AudioEngine::consumePluginStateAfterLoad()
                     // Not prepared → no live audio; clear carried-over native hosts unfenced.
                     strip.unloadNativeLv2 (s);
                     strip.unloadNativeVst3 (s);
-                    strip.setPendingNativeClap (s, clapFile, std::move (blob));
+                    strip.setPendingNativeClap (s, clapFile, std::move (blob),
+                                                lane.nativeClapPluginId[(size_t) s]);
                 }
                 continue;   // native handled — skip the JUCE restore for this slot
             }
@@ -1791,7 +1805,8 @@ void AudioEngine::consumePluginStateAfterLoad()
                 {
                     suspendProcessing();   // load is not RT-safe; fence the audio thread
                     std::string err;
-                    const bool ok = strip.loadNativeLv2 (s, lv2File, err);
+                    const bool ok = strip.loadNativeLv2 (s, lv2File, err,
+                                                         lane.nativeLv2PluginId[(size_t) s]);
                     if (ok && ! blob.empty())
                         strip.getNativeLv2Slot (s).loadState (blob);
                     resumeProcessing();
@@ -1807,7 +1822,8 @@ void AudioEngine::consumePluginStateAfterLoad()
                 {
                     strip.unloadNativeClap (s);   // see the CLAP pending branch above
                     strip.unloadNativeVst3 (s);
-                    strip.setPendingNativeLv2 (s, lv2File, std::move (blob));
+                    strip.setPendingNativeLv2 (s, lv2File, std::move (blob),
+                                               lane.nativeLv2PluginId[(size_t) s]);
                 }
                 continue;   // native handled — skip the JUCE restore for this slot
             }
@@ -1825,7 +1841,8 @@ void AudioEngine::consumePluginStateAfterLoad()
                 {
                     suspendProcessing();   // load is not RT-safe; fence the audio thread
                     std::string err;
-                    const bool ok = strip.loadNativeVst3 (s, vst3File, err);
+                    const bool ok = strip.loadNativeVst3 (s, vst3File, err,
+                                                          lane.nativeVst3PluginId[(size_t) s]);
                     if (ok && ! blob.empty())
                         strip.getNativeVst3Slot (s).loadState (blob);
                     resumeProcessing();
@@ -1841,7 +1858,8 @@ void AudioEngine::consumePluginStateAfterLoad()
                 {
                     strip.unloadNativeClap (s);   // see the CLAP pending branch above
                     strip.unloadNativeLv2 (s);
-                    strip.setPendingNativeVst3 (s, vst3File, std::move (blob));
+                    strip.setPendingNativeVst3 (s, vst3File, std::move (blob),
+                                                lane.nativeVst3PluginId[(size_t) s]);
                 }
                 continue;   // native handled — skip the JUCE restore for this slot
             }

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -125,6 +125,38 @@ public:
             strip.getNativeVst3Slot().drainQueuedParamBindings();
 #endif
         }
+
+#if DUSKSTUDIO_HAS_NATIVE_VST3
+        // A plugin that signalled kLatencyChanged only reports the new value
+        // across a setActive cycle: reactivate the flagged slots under one
+        // engine fence, then let PDC re-align the mixer. Aux slots join the
+        // sweep for their instances' sake even though aux latency doesn't
+        // feed PDC.
+        bool anyLatencyChanged = false;
+        const double sr    = engine.getCurrentSampleRate();
+        const int    block = engine.getCurrentBlockSize();
+        if (sr > 0.0 && block > 0)
+        {
+            auto cycle = [&] (auto& slot)
+            {
+                if (! slot.consumeLatencyChanged() || ! slot.isLoaded()) return;
+                if (! anyLatencyChanged) engine.suspendProcessing();
+                anyLatencyChanged = true;
+                std::string err;
+                slot.reactivate (sr, block, err);
+            };
+            for (int t = 0; t < Session::kNumTracks; ++t)
+                cycle (engine.getChannelStrip (t).getNativeVst3Slot());
+            for (int a = 0; a < Session::kNumAuxLanes; ++a)
+                for (int s = 0; s < AuxLaneParams::kMaxLanePlugins; ++s)
+                    cycle (engine.getAuxLaneStrip (a).getNativeVst3Slot (s));
+            if (anyLatencyChanged)
+            {
+                engine.resumeProcessing();
+                engine.recomputePdc();
+            }
+        }
+#endif
     }
 private:
     AudioEngine& engine;

--- a/src/engine/NativeScanRows.h
+++ b/src/engine/NativeScanRows.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <juce_audio_processors/juce_audio_processors.h>
+
+#if DUSKSTUDIO_HAS_NATIVE_CLAP
+ #include "clap/ClapBundle.h"
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_VST3
+ #include "vst3/Vst3Bundle.h"
+#endif
+#include "hosting/NativePluginId.h"
+
+namespace duskstudio::nativescan
+{
+// One bundle → picker rows, shared verbatim by the sandboxed scan child
+// (dusk-studio-plugin-host --scan-native) and the parent's in-process fallback,
+// so both sides emit identical descriptions. Loading a bundle executes its code
+// (dlopen + factory read) — that is exactly what the sandbox exists for; call
+// these in-process only as the fallback when the child can't spawn.
+
+#if DUSKSTUDIO_HAS_NATIVE_CLAP
+inline void appendClapRows (const juce::File& bundle,
+                            juce::Array<juce::PluginDescription>& into)
+{
+    clap::ClapBundle b;
+    std::string err;
+    if (! b.load (bundle.getFullPathName().toStdString(), err))
+        return;
+    for (const auto& d : b.plugins())
+    {
+        juce::PluginDescription desc;
+        desc.name             = juce::String (juce::CharPointer_UTF8 (d.name.c_str()));
+        desc.manufacturerName = juce::String (juce::CharPointer_UTF8 (d.vendor.c_str()));
+        desc.version          = juce::String (juce::CharPointer_UTF8 (d.version.c_str()));
+        desc.pluginFormatName = "CLAP";
+        desc.fileOrIdentifier = hosting::joinNativeIdentifier (
+            bundle.getFullPathName(), juce::String (juce::CharPointer_UTF8 (d.id.c_str())));
+        desc.isInstrument     = d.isInstrument();
+        into.add (desc);
+    }
+}
+#endif
+
+#if DUSKSTUDIO_HAS_NATIVE_VST3
+inline void appendVst3Rows (const juce::File& bundle,
+                            juce::Array<juce::PluginDescription>& into)
+{
+    vst3::Vst3Bundle b;
+    std::string err;
+    if (! b.load (bundle.getFullPathName().toStdString(), err))
+        return;
+    for (const auto& d : b.plugins())
+    {
+        juce::PluginDescription desc;
+        desc.name             = juce::String (juce::CharPointer_UTF8 (d.name.c_str()));
+        desc.manufacturerName = juce::String (juce::CharPointer_UTF8 (d.vendor.c_str()));
+        desc.version          = juce::String (juce::CharPointer_UTF8 (d.version.c_str()));
+        desc.pluginFormatName = "VST3-Native";
+        desc.fileOrIdentifier = hosting::joinNativeIdentifier (
+            bundle.getFullPathName(), juce::String (juce::CharPointer_UTF8 (d.id.c_str())));
+        desc.isInstrument     = d.isInstrument;
+        into.add (desc);
+    }
+}
+#endif
+} // namespace duskstudio::nativescan

--- a/src/engine/PluginManager.cpp
+++ b/src/engine/PluginManager.cpp
@@ -8,6 +8,9 @@
 #include "ipc/PluginScanProtocol.h"
 #include "PluginBackingCheck.h"
 #include "hosting/NativePluginId.h"
+#if DUSKSTUDIO_HAS_NATIVE_CLAP || DUSKSTUDIO_HAS_NATIVE_VST3
+ #include "NativeScanRows.h"
+#endif
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
   #include "clap/ClapScanner.h"   // Linux-only native CLAP discovery
 #endif
@@ -374,28 +377,78 @@ int PluginManager::scanInstalledPlugins (
     return added;
 }
 
+#if DUSKSTUDIO_HAS_NATIVE_CLAP || DUSKSTUDIO_HAS_NATIVE_VST3
+// One native bundle → picker rows through the sandbox child (loading a bundle
+// executes its code; a broken .so must kill the child, not the app). False =
+// couldn't spawn (caller falls back in-process); a spawned child that crashes
+// or times out yields no payload and the bundle is skipped — re-probed next
+// scan, but never fatal.
+bool PluginManager::scanNativeBundleSandboxed (const char* format, const juce::File& bundle,
+                                               juce::Array<juce::PluginDescription>& into) const
+{
+    const juce::File hostExe (getHostExecutablePath());
+    if (hostExe == juce::File() || ! hostExe.existsAsFile())
+        return false;
+
+    juce::ChildProcess proc;
+    const juce::StringArray args { hostExe.getFullPathName(), "--scan-native",
+                                   format, bundle.getFullPathName() };
+    if (! proc.start (args, juce::ChildProcess::wantStdOut))
+        return false;
+
+    juce::MemoryOutputStream captured;
+    char buf[8192];
+    const juce::uint32 startMs = juce::Time::getMillisecondCounter();
+    for (;;)
+    {
+        const int n = proc.readProcessOutput (buf, (int) sizeof buf);
+        if (n > 0) { captured.write (buf, (size_t) n); continue; }
+        if (! proc.isRunning())
+        {
+            int extra;
+            while ((extra = proc.readProcessOutput (buf, (int) sizeof buf)) > 0)
+                captured.write (buf, (size_t) extra);
+            break;
+        }
+        if (juce::Time::getMillisecondCounter() - startMs >= (juce::uint32) kScanTimeoutMs)
+        {
+            proc.kill();
+            proc.waitForProcessToFinish (200);   // reap the SIGKILLed child, no zombie
+            break;
+        }
+        juce::Thread::sleep (5);
+    }
+
+    const juce::String payload = scanproto::extractPayload (captured.toString());
+    if (payload.isEmpty())
+    {
+        // Crash / hang / no sentinels — treat as handled (skip the bundle) so the
+        // caller doesn't re-execute the crashing code in-process.
+        std::fprintf (stderr, "[Dusk Studio/scan] native %s bundle skipped (child failed): %s\n",
+                      format, bundle.getFullPathName().toRawUTF8());
+        return true;
+    }
+    juce::OwnedArray<juce::PluginDescription> found;
+    scanproto::parsePayload (payload, found);
+    for (const auto* d : found)
+        into.add (*d);
+    return true;
+}
+#endif
+
 void PluginManager::scanClapPlugins()
 {
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
-    // Discover OUTSIDE the lock (dlopens every bundle — slow), swap in under it.
-    // The cache write also stays outside so a picker open on the message thread
-    // can't stall behind this thread's file I/O.
-    const auto scanned = clap::ClapScanner::scan();
+    // Discover OUTSIDE the lock (executes every bundle's factory — slow), swap
+    // in under it. The cache write also stays outside so a picker open on the
+    // message thread can't stall behind this thread's file I/O.
+    juce::Array<juce::PluginDescription> fresh;
+    for (const auto& file : clap::ClapScanner::findClapFiles (clap::ClapScanner::defaultSearchPaths()))
+        if (! scanNativeBundleSandboxed ("clap", file, fresh))
+            nativescan::appendClapRows (file, fresh);   // no sandbox available — in-process
     {
         const juce::ScopedLock sl (nativeDescriptionsLock);
-        clapDescriptions.clearQuick();
-        for (const auto& s : scanned)
-        {
-            juce::PluginDescription d;
-            d.name             = juce::String (juce::CharPointer_UTF8 (s.desc.name.c_str()));
-            d.manufacturerName = juce::String (juce::CharPointer_UTF8 (s.desc.vendor.c_str()));
-            d.version          = juce::String (juce::CharPointer_UTF8 (s.desc.version.c_str()));
-            d.pluginFormatName = "CLAP";
-            d.fileOrIdentifier = hosting::joinNativeIdentifier (
-                s.bundlePath, juce::String (juce::CharPointer_UTF8 (s.desc.id.c_str())));
-            d.isInstrument     = s.desc.isInstrument();
-            clapDescriptions.add (d);
-        }
+        clapDescriptions.swapWith (fresh);
     }
     saveNativeCache (clapDescriptions, "clap-cache.xml", "CLAP_PLUGINS");
 #endif
@@ -502,26 +555,16 @@ juce::Array<juce::PluginDescription> PluginManager::getLv2EffectDescriptions() c
 void PluginManager::scanVst3NativePlugins()
 {
 #if DUSKSTUDIO_HAS_NATIVE_VST3
-    const auto scanned = vst3::Vst3Scanner::scan();   // dlopens every module — outside the lock
+    juce::Array<juce::PluginDescription> fresh;
+    for (const auto& file : vst3::Vst3Scanner::findVst3Bundles (vst3::Vst3Scanner::defaultSearchPaths()))
+        if (! scanNativeBundleSandboxed ("vst3", file, fresh))
+            nativescan::appendVst3Rows (file, fresh);   // no sandbox available — in-process
+    // Only audio effects for now — the native VST3 host is an insert host;
+    // instruments stay with the JUCE VST3 format.
+    fresh.removeIf ([] (const juce::PluginDescription& d) { return d.isInstrument; });
     {
         const juce::ScopedLock sl (nativeDescriptionsLock);
-        vst3NativeDescriptions.clearQuick();
-        for (const auto& s : scanned)
-        {
-            // Only audio effects for now — the native VST3 host is an insert host;
-            // instruments stay with the JUCE VST3 format.
-            if (s.desc.isInstrument)
-                continue;
-            juce::PluginDescription d;
-            d.name             = juce::String (juce::CharPointer_UTF8 (s.desc.name.c_str()));
-            d.manufacturerName = juce::String (juce::CharPointer_UTF8 (s.desc.vendor.c_str()));
-            d.version          = juce::String (juce::CharPointer_UTF8 (s.desc.version.c_str()));
-            d.pluginFormatName = "VST3-Native";
-            d.fileOrIdentifier = hosting::joinNativeIdentifier (
-                s.bundlePath, juce::String (juce::CharPointer_UTF8 (s.desc.id.c_str())));
-            d.isInstrument     = false;
-            vst3NativeDescriptions.add (d);
-        }
+        vst3NativeDescriptions.swapWith (fresh);
     }
     saveNativeCache (vst3NativeDescriptions, "vst3-native-cache.xml", "VST3_NATIVE_PLUGINS");
 #endif

--- a/src/engine/PluginManager.cpp
+++ b/src/engine/PluginManager.cpp
@@ -7,6 +7,7 @@
 
 #include "ipc/PluginScanProtocol.h"
 #include "PluginBackingCheck.h"
+#include "hosting/NativePluginId.h"
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
   #include "clap/ClapScanner.h"   // Linux-only native CLAP discovery
 #endif
@@ -390,7 +391,8 @@ void PluginManager::scanClapPlugins()
             d.manufacturerName = juce::String (juce::CharPointer_UTF8 (s.desc.vendor.c_str()));
             d.version          = juce::String (juce::CharPointer_UTF8 (s.desc.version.c_str()));
             d.pluginFormatName = "CLAP";
-            d.fileOrIdentifier = s.bundlePath;
+            d.fileOrIdentifier = hosting::joinNativeIdentifier (
+                s.bundlePath, juce::String (juce::CharPointer_UTF8 (s.desc.id.c_str())));
             d.isInstrument     = s.desc.isInstrument();
             clapDescriptions.add (d);
         }
@@ -424,7 +426,9 @@ void PluginManager::loadNativeCache (juce::Array<juce::PluginDescription>& into,
                 continue;
             // Drop entries whose bundle is gone since the cache was written, so
             // the picker never offers a removed plugin until a rescan rebuilds it.
-            const juce::File bundle (d.fileOrIdentifier);
+            // fileOrIdentifier carries "bundle\npluginId" — check the bundle half.
+            const juce::File bundle (
+                hosting::splitNativeIdentifier (d.fileOrIdentifier).bundlePath);
             if (bundleIsDirectory ? bundle.isDirectory() : bundle.exists())
                 fresh.add (d);
         }
@@ -479,7 +483,8 @@ void PluginManager::scanLv2Plugins()
             juce::PluginDescription d;
             d.name             = juce::String (juce::CharPointer_UTF8 (s.desc.name.c_str()));
             d.pluginFormatName = "LV2-Native";
-            d.fileOrIdentifier = s.bundlePath;
+            d.fileOrIdentifier = hosting::joinNativeIdentifier (
+                s.bundlePath, juce::String (juce::CharPointer_UTF8 (s.desc.uri.c_str())));
             d.isInstrument     = false;
             lv2Descriptions.add (d);
         }
@@ -512,7 +517,8 @@ void PluginManager::scanVst3NativePlugins()
             d.manufacturerName = juce::String (juce::CharPointer_UTF8 (s.desc.vendor.c_str()));
             d.version          = juce::String (juce::CharPointer_UTF8 (s.desc.version.c_str()));
             d.pluginFormatName = "VST3-Native";
-            d.fileOrIdentifier = s.bundlePath;
+            d.fileOrIdentifier = hosting::joinNativeIdentifier (
+                s.bundlePath, juce::String (juce::CharPointer_UTF8 (s.desc.id.c_str())));
             d.isInstrument     = false;
             vst3NativeDescriptions.add (d);
         }

--- a/src/engine/PluginManager.h
+++ b/src/engine/PluginManager.h
@@ -122,6 +122,13 @@ private:
     // rewritten after each scan. `bundleIsDirectory` selects the staleness check
     // (LV2 bundles are directories; CLAP/VST3 accept files or bundle dirs).
     juce::File nativeCacheFile (const char* fileName) const;
+#if DUSKSTUDIO_HAS_NATIVE_CLAP || DUSKSTUDIO_HAS_NATIVE_VST3
+    // Enumerate one native bundle via the sandbox child (--scan-native). False =
+    // child couldn't spawn (caller falls back in-process); crash/timeout inside
+    // the child skips the bundle and still returns true.
+    bool scanNativeBundleSandboxed (const char* format, const juce::File& bundle,
+                                    juce::Array<juce::PluginDescription>& into) const;
+#endif
     void loadNativeCache (juce::Array<juce::PluginDescription>& into,
                           const char* fileName, bool bundleIsDirectory);
     void saveNativeCache (const juce::Array<juce::PluginDescription>& from,

--- a/src/engine/clap/NativeClapSlot.h
+++ b/src/engine/clap/NativeClapSlot.h
@@ -12,12 +12,17 @@ struct ClapSlotTraits
     using Instance = ClapInstance;
     static constexpr const char* bundleNoun = "bundle";
 
-    static bool pickPlugin (const ClapBundle& b, std::string& idOut, std::string& errorOut)
+    static bool pickPlugin (const ClapBundle& b, const std::string& requestedId,
+                            std::string& idOut, std::string& errorOut)
     {
         if (b.plugins().empty())
         { errorOut = "no plugins in bundle"; return false; }
-        idOut = b.plugins().front().id;
-        return true;
+        if (requestedId.empty())
+        { idOut = b.plugins().front().id; return true; }
+        for (const auto& d : b.plugins())
+            if (d.id == requestedId) { idOut = requestedId; return true; }
+        errorOut = "bundle no longer advertises plugin '" + requestedId + "'";
+        return false;
     }
 };
 

--- a/src/engine/hosting/NativeInsertSlot.h
+++ b/src/engine/hosting/NativeInsertSlot.h
@@ -20,7 +20,11 @@ namespace duskstudio::hosting
 //
 //   using Bundle / Instance;                  // Instance implements INativeInstance
 //   static constexpr const char* bundleNoun;  // load-error prefix ("bundle"/"module")
-//   static bool pickPlugin (const Bundle&, std::string& idOut, std::string& errorOut);
+//   static bool pickPlugin (const Bundle&, const std::string& requestedId,
+//                           std::string& idOut, std::string& errorOut);
+//     — empty requestedId: the format's default (first effect); non-empty: honour
+//       it when the bundle advertises it, else fail (a renamed/removed class must
+//       not silently load a different plugin).
 //
 // load / unload / state are message-thread; processStereo is the audio path and
 // reads a lock-free `ready` flag so it no-ops cleanly when empty.
@@ -37,9 +41,11 @@ public:
 
     NativeInsertSlot() = default;
 
-    // Message thread: load the bundle at `path` and instantiate the plugin the
-    // Traits pick, replacing any prior load. False (+ errorOut) on failure.
-    bool load (const juce::File& path, double sampleRate, int maxBlock, std::string& errorOut)
+    // Message thread: load the bundle at `path` and instantiate `pluginId` (empty =
+    // the format's default pick — the first effect), replacing any prior load.
+    // False (+ errorOut) on failure.
+    bool load (const juce::File& path, double sampleRate, int maxBlock, std::string& errorOut,
+               const juce::String& pluginId = {})
     {
         unload();
         bindingRing.clear();   // writes queued against the previous occupant
@@ -49,12 +55,12 @@ public:
         if (! b->load (path.getFullPathName().toStdString(), err))
         { errorOut = std::string (Traits::bundleNoun) + ": " + err; return false; }
 
-        std::string pluginId;
-        if (! Traits::pickPlugin (*b, pluginId, errorOut))
+        std::string pickedId;
+        if (! Traits::pickPlugin (*b, pluginId.toStdString(), pickedId, errorOut))
             return false;
 
         auto inst = std::make_unique<Instance>();
-        if (! inst->create (*b, pluginId, err))
+        if (! inst->create (*b, pickedId, err))
         { errorOut = "create: " + err; return false; }
         if (! inst->activate (sampleRate, maxBlock, err))
         { errorOut = "activate: " + err; return false; }
@@ -64,7 +70,8 @@ public:
         bundle     = std::move (b);
         instance   = std::move (inst);
         adapter.prepare (instance->portLayout(), maxBlock);   // size the fold scratch
-        loadedPath = path.getFullPathName();
+        loadedPath     = path.getFullPathName();
+        loadedPluginId = juce::String (pickedId);
         ready.store (true, std::memory_order_release);
         return true;
     }
@@ -75,6 +82,7 @@ public:
         instance.reset();   // destroy the plugin first — its vtables live in the bundle
         bundle.reset();     // then unload the .so / world backing them
         loadedPath.clear();
+        loadedPluginId.clear();
     }
 
     // Re-activate the loaded instance at a new sample-rate / block-size WITHOUT a
@@ -100,10 +108,14 @@ public:
         (void) instance.release();
         (void) bundle.release();
         loadedPath.clear();
+        loadedPluginId.clear();
     }
 
     bool isLoaded() const noexcept { return ready.load (std::memory_order_acquire); }
     const juce::String& getPath() const noexcept { return loadedPath; }
+    // The instantiated plugin's id within its bundle (class UID / URI / CLAP id) —
+    // resolved even when load() defaulted, so sessions persist the actual pick.
+    const juce::String& getPluginId() const noexcept { return loadedPluginId; }
 
     // Bypass: processStereo passes audio through untouched (the plugin stays loaded).
     void setBypassed (bool b) noexcept { bypassed.store (b, std::memory_order_relaxed); }
@@ -210,6 +222,7 @@ protected:
     std::atomic<bool> ready    { false };
     std::atomic<bool> bypassed { false };
     juce::String      loadedPath;
+    juce::String      loadedPluginId;
 
 private:
     struct ParamBinding { uint32_t paramIndex; float frac; };

--- a/src/engine/hosting/NativePluginId.h
+++ b/src/engine/hosting/NativePluginId.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+namespace duskstudio::hosting
+{
+// Native picker rows carry "which plugin inside the bundle" alongside the bundle
+// path in juce::PluginDescription::fileOrIdentifier, newline-separated (a newline
+// can't appear in a path or a class id). A bundle with one plugin still encodes
+// its id so the decode is uniform; JUCE-format rows never pass through these.
+
+inline juce::String joinNativeIdentifier (const juce::String& bundlePath,
+                                          const juce::String& pluginId)
+{
+    return pluginId.isEmpty() ? bundlePath : bundlePath + "\n" + pluginId;
+}
+
+struct NativeIdentifier
+{
+    juce::String bundlePath;
+    juce::String pluginId;   // empty = the format's default pick
+};
+
+inline NativeIdentifier splitNativeIdentifier (const juce::String& fileOrIdentifier)
+{
+    const int nl = fileOrIdentifier.indexOfChar ('\n');
+    if (nl < 0) return { fileOrIdentifier, {} };
+    return { fileOrIdentifier.substring (0, nl), fileOrIdentifier.substring (nl + 1) };
+}
+} // namespace duskstudio::hosting

--- a/src/engine/ipc/PluginHostMain.cpp
+++ b/src/engine/ipc/PluginHostMain.cpp
@@ -33,6 +33,9 @@
 
 #include "PluginIpc.h"
 #include "PluginScanProtocol.h"
+#if DUSKSTUDIO_HAS_NATIVE_CLAP || DUSKSTUDIO_HAS_NATIVE_VST3
+ #include "../NativeScanRows.h"
+#endif
 #include "../JuceCompat.h"
 #include "platform/IpcChannel.h"
 #include "platform/IpcShm.h"
@@ -898,6 +901,43 @@ int runIpcHost (int argc, const char* const* argv) noexcept
 // code, which runs BEFORE we print kScanPayloadBegin, so the parent's
 // extract-between-sentinels parse skips it.
 //
+#if DUSKSTUDIO_HAS_NATIVE_CLAP || DUSKSTUDIO_HAS_NATIVE_VST3
+// Sandboxed native-format discovery: load ONE bundle through the native host's
+// own loader and print the resulting picker rows between the scan sentinels.
+// Same crash-isolation contract as --scan: a broken .so kills this process,
+// the parent times out / sees no payload and skips the bundle.
+int runScanNative (int argc, const char* const* argv) noexcept
+{
+    int idx = -1;
+    for (int i = 1; i < argc; ++i)
+        if (std::strcmp (argv[i], "--scan-native") == 0) { idx = i; break; }
+    if (idx < 0 || idx + 2 >= argc)
+    {
+        std::fprintf (stderr, "[dusk-studio-plugin-host] --scan-native needs <clap|vst3> <bundle>\n");
+        return 64;
+    }
+    const juce::String format { juce::CharPointer_UTF8 (argv[idx + 1]) };
+    const juce::File   bundle { juce::String (juce::CharPointer_UTF8 (argv[idx + 2])) };
+
+    juce::ScopedJuceInitialiser_GUI juceInit;
+
+    juce::Array<juce::PluginDescription> rows;
+#if DUSKSTUDIO_HAS_NATIVE_CLAP
+    if (format == "clap") duskstudio::nativescan::appendClapRows (bundle, rows);
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_VST3
+    if (format == "vst3") duskstudio::nativescan::appendVst3Rows (bundle, rows);
+#endif
+
+    juce::OwnedArray<juce::PluginDescription> found;
+    for (const auto& r : rows)
+        found.add (new juce::PluginDescription (r));
+    std::fputs (duskstudio::scanproto::makePayload (found).toRawUTF8(), stdout);
+    std::fflush (stdout);
+    return 0;
+}
+#endif // native formats
+
 int runScan (int argc, const char* const* argv) noexcept
 {
     int scanIdx = -1;
@@ -961,6 +1001,9 @@ int main (int argc, char** argv)
         if (std::strcmp (argv[i], "--ipc-stub") == 0) ipcStub = true;
         if (std::strcmp (argv[i], "--ipc-host") == 0) ipcHost = true;
         if (std::strcmp (argv[i], "--scan")     == 0) scan    = true;
+#if DUSKSTUDIO_HAS_NATIVE_CLAP || DUSKSTUDIO_HAS_NATIVE_VST3
+        if (std::strcmp (argv[i], "--scan-native") == 0) return runScanNative (argc, argv);
+#endif
     }
 
     if (scan)    return runScan (argc, argv);

--- a/src/engine/lv2/Lv2Editor.cpp
+++ b/src/engine/lv2/Lv2Editor.cpp
@@ -49,11 +49,15 @@ struct Lv2Editor::Impl
                            uint32_t protocol, const void* buffer)
     {
         auto* self = static_cast<Impl*> (c);
-        // ui:floatProtocol only — atom/event writes need a plugin-input atom
-        // routing that isn't wired yet. FromUi stamps MIDI Learn's last-touched.
-        if (protocol == 0 && bufferSize == sizeof (float) && self->instance != nullptr)
+        if (self->instance == nullptr) return;
+        // ui:floatProtocol writes a control port; ui:eventTransfer carries an
+        // atom (JUCE-built UIs send ALL their parameters as patch:Set events).
+        // FromUi/forward both stamp MIDI Learn's last-touched.
+        if (protocol == 0 && bufferSize == sizeof (float))
             self->instance->setControlPortValueFromUi (portIndex,
                                                        *static_cast<const float*> (buffer));
+        else if (protocol == self->instance->uiEventTransferUrid())
+            self->instance->forwardUiAtomEvent (buffer, bufferSize);
     }
 
     static uint32_t portIndex (SuilController c, const char* symbol)

--- a/src/engine/lv2/Lv2Instance.cpp
+++ b/src/engine/lv2/Lv2Instance.cpp
@@ -9,6 +9,9 @@
 #include <lv2/options/options.h>
 #include <lv2/parameters/parameters.h>
 #include <lv2/port-props/port-props.h>
+#include <lv2/atom/forge.h>
+#include <lv2/atom/util.h>
+#include <lv2/patch/patch.h>
 #include <lv2/state/state.h>
 #include <lv2/urid/urid.h>
 
@@ -69,8 +72,15 @@ struct Lv2Instance::Impl
         uridDouble = mapUri (this, LV2_ATOM__Double);
         uridInt    = mapUri (this, LV2_ATOM__Int);
         uridLong   = mapUri (this, LV2_ATOM__Long);
+        uridObject        = mapUri (this, LV2_ATOM__Object);
+        uridPatchSet      = mapUri (this, LV2_PATCH__Set);
+        uridPatchProperty = mapUri (this, LV2_PATCH__property);
+        uridPatchValue    = mapUri (this, LV2_PATCH__value);
+        uridEventTransfer = mapUri (this, LV2_ATOM__eventTransfer);
     }
     LV2_URID uridFloat = 0, uridDouble = 0, uridInt = 0, uridLong = 0;
+    LV2_URID uridObject = 0, uridPatchSet = 0, uridPatchProperty = 0,
+             uridPatchValue = 0, uridEventTransfer = 0;
 
     // Assemble the full feature list for instantiate: urid map/unmap + the block-size
     // and sample-rate options + boundedBlockLength. JUCE/DPF-wrapped plugins REQUIRE
@@ -129,9 +139,34 @@ struct Lv2Instance::Impl
     struct PortWrite { uint32_t idx; float value; };
     hosting::SpscRing<PortWrite, 256> writeRing;
 
-    // Input control ports as a parameter surface (MIDI bindings / MIDI Learn).
+    // Input control ports + patch:writable float properties as a parameter
+    // surface (MIDI bindings / MIDI Learn). Patch-property ids carry the high
+    // bit so they can't collide with port indices.
+    static constexpr uint32_t kPatchIdFlag = 0x80000000u;
     std::vector<ParamInfo> params;
-    std::atomic<int64_t>   lastTouchedPort { -1 };
+    std::atomic<int64_t>   lastTouchedParam { -1 };   // index into params
+
+    int paramIndexForId (uint32_t id) const noexcept
+    {
+        for (size_t i = 0; i < params.size(); ++i)
+            if (params[i].id == id) return (int) i;
+        return -1;
+    }
+
+    // patch:Set atoms staged UI/host-side, injected into the control atom input
+    // at the top of the next process block. 128 bytes covers a patch:Set with a
+    // float payload several times over; larger UI atoms are dropped (only the
+    // instance-access shortcut loses nothing — see forwardUiAtomEvent).
+    struct AtomBlob { uint32_t size = 0; uint8_t data[128]; };
+    hosting::SpscRing<AtomBlob, 64> atomRing;
+
+    // Which atomInPorts entry takes injected events: the lv2:control-designated
+    // port, else the first atom input.
+    int controlAtomInPos = 0;
+
+    // Last host/UI-written value per patch property (message thread) — the
+    // read-back source until patch:Put parsing exists.
+    std::unordered_map<LV2_URID, float> patchShadow;
 
     // Message-thread shadow of the UI writes. A bypassed slot never runs
     // processBlock, so the ring may never drain — state saves and reactivate read
@@ -266,7 +301,7 @@ bool Lv2Instance::create (const Lv2Bundle& bundle, const std::string& uri, std::
     // MIDI Learn). Snapshot name + range + steppedness now so later reads
     // never touch lilv.
     impl->params.clear();
-    impl->lastTouchedPort.store (-1, std::memory_order_relaxed);
+    impl->lastTouchedParam.store (-1, std::memory_order_relaxed);
     {
         LilvNode* toggledProp  = lilv_new_uri (world, LV2_CORE__toggled);
         LilvNode* integerProp  = lilv_new_uri (world, LV2_CORE__integer);
@@ -309,11 +344,92 @@ bool Lv2Instance::create (const Lv2Bundle& bundle, const std::string& uri, std::
                      || lilv_port_has_property (impl->plugin, port, enumProp);
             impl->params.push_back (std::move (p));
         }
+        lilv_node_free (notOnGuiProp);
+
+        // patch:writable float properties join the surface — JUCE-built LV2s
+        // expose ALL their parameters this way (their control ports are only
+        // the designated host-managed ones). Non-float ranges (paths, strings)
+        // aren't parameters and are skipped.
+        LilvNode* patchWritable = lilv_new_uri (world, LV2_PATCH__writable);
+        LilvNode* rdfsLabel     = lilv_new_uri (world, "http://www.w3.org/2000/01/rdf-schema#label");
+        LilvNode* rdfsRange     = lilv_new_uri (world, "http://www.w3.org/2000/01/rdf-schema#range");
+        LilvNode* atomFloat     = lilv_new_uri (world, LV2_ATOM__Float);
+        LilvNode* lv2Min        = lilv_new_uri (world, LV2_CORE__minimum);
+        LilvNode* lv2Max        = lilv_new_uri (world, LV2_CORE__maximum);
+        LilvNode* lv2Default    = lilv_new_uri (world, LV2_CORE__default);
+        LilvNode* portPropPred  = lilv_new_uri (world, LV2_CORE_PREFIX "portProperty");
+        if (LilvNodes* props = lilv_world_find_nodes (world,
+                                   lilv_plugin_get_uri (impl->plugin), patchWritable, nullptr))
+        {
+            LILV_FOREACH (nodes, it, props)
+            {
+                const LilvNode* prop = lilv_nodes_get (props, it);
+                if (! lilv_node_is_uri (prop)) continue;
+                LilvNode* range = lilv_world_get (world, prop, rdfsRange, nullptr);
+                const bool isFloat = range != nullptr && lilv_node_equals (range, atomFloat);
+                lilv_node_free (range);
+                if (! isFloat) continue;
+
+                ParamInfo p;
+                p.id = Impl::kPatchIdFlag
+                     | Impl::mapUri (impl.get(), lilv_node_as_uri (prop));
+                p.isPatchProperty = true;
+                if (LilvNode* nm = lilv_world_get (world, prop, rdfsLabel, nullptr))
+                { p.name = lilv_node_as_string (nm); lilv_node_free (nm); }
+                if (p.name.empty())
+                    p.name = lilv_node_as_uri (prop);
+                auto numberOf = [&] (const LilvNode* pred, float fallback)
+                {
+                    float v = fallback;
+                    if (LilvNode* n = lilv_world_get (world, prop, pred, nullptr))
+                    { v = lilv_node_as_float (n); lilv_node_free (n); }
+                    return v;
+                };
+                p.minValue     = numberOf (lv2Min, 0.0f);
+                p.maxValue     = numberOf (lv2Max, 1.0f);
+                p.defaultValue = numberOf (lv2Default, p.minValue);
+                if (! (p.minValue < p.maxValue)) { p.minValue = 0.0f; p.maxValue = 1.0f; }
+                if (LilvNodes* pps = lilv_world_find_nodes (world, prop, portPropPred, nullptr))
+                {
+                    LILV_FOREACH (nodes, pit, pps)
+                    {
+                        const LilvNode* pp = lilv_nodes_get (pps, pit);
+                        if (lilv_node_equals (pp, toggledProp)
+                            || lilv_node_equals (pp, integerProp)
+                            || lilv_node_equals (pp, enumProp))
+                            p.stepped = true;
+                    }
+                    lilv_nodes_free (pps);
+                }
+                impl->patchShadow[p.id & ~Impl::kPatchIdFlag] = p.defaultValue;
+                impl->params.push_back (std::move (p));
+            }
+            lilv_nodes_free (props);
+        }
+        lilv_node_free (patchWritable); lilv_node_free (rdfsLabel);
+        lilv_node_free (rdfsRange);     lilv_node_free (atomFloat);
+        lilv_node_free (lv2Min);        lilv_node_free (lv2Max);
+        lilv_node_free (lv2Default);    lilv_node_free (portPropPred);
         lilv_node_free (toggledProp);
         lilv_node_free (integerProp);
         lilv_node_free (enumProp);
         lilv_node_free (designation);
-        lilv_node_free (notOnGuiProp);
+    }
+
+    // Which atom input takes injected patch events: the lv2:control-designated
+    // one, else the first.
+    impl->controlAtomInPos = 0;
+    {
+        LilvNode* ctrlDesig  = lilv_new_uri (world, LV2_CORE_PREFIX "control");
+        LilvNode* inputClass2 = lilv_new_uri (world, LV2_CORE__InputPort);
+        if (const LilvPort* cp = lilv_plugin_get_port_by_designation (impl->plugin, inputClass2, ctrlDesig))
+        {
+            const uint32_t idx = lilv_port_get_index (impl->plugin, cp);
+            for (size_t i = 0; i < impl->atomInPorts.size(); ++i)
+                if (impl->atomInPorts[i] == idx) { impl->controlAtomInPos = (int) i; break; }
+        }
+        lilv_node_free (ctrlDesig);
+        lilv_node_free (inputClass2);
     }
 
     // The port designated lv2:latency (an output control port) reports plugin
@@ -517,6 +633,28 @@ void Lv2Instance::processBlock (const hosting::PortBuffers& io) noexcept
             impl->portValues[(size_t) pw.idx] = pw.value;
     });
 
+    // Rebuild the control atom input's sequence from the staged patch/UI atoms
+    // (all at frame 0). Input sequences are host-owned, so the reset is cheap
+    // and the other atom inputs keep their empty headers from activate().
+    if (! impl->atomInPorts.empty())
+    {
+        auto& buf = impl->atomBuffers[(size_t) impl->controlAtomInPos];
+        auto* seq = reinterpret_cast<LV2_Atom_Sequence*> (buf.data());
+        seq->atom.size = sizeof (LV2_Atom_Sequence_Body);
+        impl->atomRing.drain ([&] (const Impl::AtomBlob& blob)
+        {
+            const uint32_t evSize = (uint32_t) sizeof (LV2_Atom_Event) - (uint32_t) sizeof (LV2_Atom)
+                                    + blob.size;
+            const uint32_t padded = lv2_atom_pad_size (evSize);
+            const uint32_t used   = (uint32_t) sizeof (LV2_Atom) + seq->atom.size;
+            if (used + padded > buf.size()) return;   // sequence full — drop
+            auto* ev = reinterpret_cast<LV2_Atom_Event*> (buf.data() + used);
+            ev->time.frames = 0;
+            std::memcpy (&ev->body, blob.data, blob.size);
+            seq->atom.size += padded;
+        });
+    }
+
     // Re-advertise output-atom capacity before every run(): the plugin overwrites
     // atom->size with the bytes it wrote last block, so without this the buffer
     // reads as monotonically shrinking (never-recovering) capacity. Output atom
@@ -602,7 +740,9 @@ void Lv2Instance::setControlPortValue (uint32_t portIndex, float value) noexcept
 
 void Lv2Instance::setControlPortValueFromUi (uint32_t portIndex, float value) noexcept
 {
-    impl->lastTouchedPort.store ((int64_t) portIndex, std::memory_order_relaxed);
+    const int idx = impl->paramIndexForId (portIndex);
+    if (idx >= 0)
+        impl->lastTouchedParam.store ((int64_t) idx, std::memory_order_relaxed);
     setControlPortValue (portIndex, value);
 }
 
@@ -614,43 +754,113 @@ const Lv2Instance::ParamInfo* Lv2Instance::paramInfo (int index) const noexcept
              ? &impl->params[(size_t) index] : nullptr;
 }
 
-bool Lv2Instance::getParamValue (uint32_t portIndex, double& out) const
+bool Lv2Instance::getParamValue (uint32_t paramId, double& out) const
 {
-    for (const auto& p : impl->params)
-        if (p.id == portIndex)
-        {
-            // A staged UI/host write the audio thread hasn't drained yet (bypassed
-            // slot) lives in the shadow; portValues still holds the older value.
-            if ((size_t) portIndex < impl->uiDirty.size()
-                && impl->uiDirty[(size_t) portIndex] != 0)
-                out = (double) impl->uiShadow[(size_t) portIndex];
-            else if ((size_t) portIndex < impl->portValues.size())
-                out = (double) impl->portValues[(size_t) portIndex];
-            else
-                return false;
-            return true;
-        }
-    return false;
+    const int idx = impl->paramIndexForId (paramId);
+    if (idx < 0) return false;
+    if (impl->params[(size_t) idx].isPatchProperty)
+    {
+        const auto it = impl->patchShadow.find (paramId & ~Impl::kPatchIdFlag);
+        if (it == impl->patchShadow.end()) return false;
+        out = (double) it->second;
+        return true;
+    }
+    const uint32_t portIndex = paramId;
+    // A staged UI/host write the audio thread hasn't drained yet (bypassed
+    // slot) lives in the shadow; portValues still holds the older value.
+    if ((size_t) portIndex < impl->uiDirty.size()
+        && impl->uiDirty[(size_t) portIndex] != 0)
+        out = (double) impl->uiShadow[(size_t) portIndex];
+    else if ((size_t) portIndex < impl->portValues.size())
+        out = (double) impl->portValues[(size_t) portIndex];
+    else
+        return false;
+    return true;
 }
 
-void Lv2Instance::setParamValue (uint32_t portIndex, double value) noexcept
+void Lv2Instance::setParamValue (uint32_t paramId, double value) noexcept
 {
-    for (const auto& p : impl->params)
-        if (p.id == portIndex)
-        {
-            const float v = (float) std::clamp (value, (double) p.minValue, (double) p.maxValue);
-            setControlPortValue (portIndex, v);
-            return;
-        }
+    const int idx = impl->paramIndexForId (paramId);
+    if (idx < 0) return;
+    const auto& p = impl->params[(size_t) idx];
+    const float v = (float) std::clamp (value, (double) p.minValue, (double) p.maxValue);
+    if (! p.isPatchProperty)
+    {
+        setControlPortValue (paramId, v);
+        return;
+    }
+
+    // patch:Set { property = <prop>, value = Float } forged into a blob the
+    // audio thread injects into the control atom port next block.
+    const LV2_URID propUrid = paramId & ~Impl::kPatchIdFlag;
+    Impl::AtomBlob blob;
+    LV2_Atom_Forge forge;
+    lv2_atom_forge_init (&forge, &impl->mapFeature);
+    lv2_atom_forge_set_buffer (&forge, blob.data, sizeof (blob.data));
+    LV2_Atom_Forge_Frame frame;
+    lv2_atom_forge_object (&forge, &frame, 0, impl->uridPatchSet);
+    lv2_atom_forge_key (&forge, impl->uridPatchProperty);
+    lv2_atom_forge_urid (&forge, propUrid);
+    lv2_atom_forge_key (&forge, impl->uridPatchValue);
+    lv2_atom_forge_float (&forge, v);
+    lv2_atom_forge_pop (&forge, &frame);
+    const auto* atom = reinterpret_cast<const LV2_Atom*> (blob.data);
+    blob.size = (uint32_t) sizeof (LV2_Atom) + atom->size;
+
+    impl->patchShadow[propUrid] = v;
+    impl->atomRing.push (blob);   // full ⇒ drop (pathological flood only)
 }
 
 int Lv2Instance::lastTouchedParamIndex() const noexcept
 {
-    const auto port = impl->lastTouchedPort.load (std::memory_order_relaxed);
-    if (port < 0) return -1;
-    for (size_t i = 0; i < impl->params.size(); ++i)
-        if ((int64_t) impl->params[i].id == port) return (int) i;
-    return -1;
+    const auto idx = impl->lastTouchedParam.load (std::memory_order_relaxed);
+    return (idx >= 0 && idx < (int64_t) impl->params.size()) ? (int) idx : -1;
+}
+
+uint32_t Lv2Instance::uiEventTransferUrid() const noexcept
+{
+    return impl->uridEventTransfer;
+}
+
+void Lv2Instance::forwardUiAtomEvent (const void* atomData, uint32_t sizeBytes) noexcept
+{
+    if (atomData == nullptr || sizeBytes < sizeof (LV2_Atom)) return;
+    const auto* atom = static_cast<const LV2_Atom*> (atomData);
+    if (sizeof (LV2_Atom) + atom->size != sizeBytes) return;
+
+    // patch:Set → stamp MIDI Learn's last-touched + the read-back shadow.
+    if (atom->type == impl->uridObject)
+    {
+        const auto* obj = reinterpret_cast<const LV2_Atom_Object*> (atom);
+        if (obj->body.otype == impl->uridPatchSet)
+        {
+            const LV2_Atom* propAtom = nullptr;
+            const LV2_Atom* valAtom  = nullptr;
+            lv2_atom_object_get (obj, impl->uridPatchProperty, &propAtom,
+                                      impl->uridPatchValue,    &valAtom, 0);
+            if (propAtom != nullptr && propAtom->type == Impl::mapUri (impl.get(), LV2_ATOM__URID))
+            {
+                const LV2_URID prop = reinterpret_cast<const LV2_Atom_URID*> (propAtom)->body;
+                const int idx = impl->paramIndexForId (Impl::kPatchIdFlag | prop);
+                if (idx >= 0)
+                    impl->lastTouchedParam.store ((int64_t) idx, std::memory_order_relaxed);
+                if (valAtom != nullptr && valAtom->type == impl->uridFloat)
+                    impl->patchShadow[prop] =
+                        reinterpret_cast<const LV2_Atom_Float*> (valAtom)->body;
+            }
+        }
+    }
+
+    // Forward onto the control atom port so the DSP hears the event without
+    // relying on the instance-access shortcut. Oversized atoms are dropped —
+    // for JUCE-built UIs instance access already carried the change.
+    if (sizeBytes <= sizeof (Impl::AtomBlob::data))
+    {
+        Impl::AtomBlob blob;
+        std::memcpy (blob.data, atomData, sizeBytes);
+        blob.size = sizeBytes;
+        impl->atomRing.push (blob);
+    }
 }
 
 int Lv2Instance::portIndexForSymbol (const char* symbol) const noexcept

--- a/src/engine/lv2/Lv2Instance.h
+++ b/src/engine/lv2/Lv2Instance.h
@@ -22,14 +22,18 @@ class Lv2Bundle;
 class Lv2Instance : public hosting::INativeInstance
 {
 public:
-    // One plugin parameter = one input control port (snapshot at create()).
-    // Values are in the port's own units (min..max), like CLAP.
+    // One plugin parameter: an input control port, or a patch:writable float
+    // property (JUCE-built LV2s expose ONLY the latter). Values are in the
+    // parameter's own units (min..max), like CLAP. `id` is opaque — port index
+    // for control ports, a marked property token for patch properties; round-trip
+    // it through get/setParamValue, don't interpret it.
     struct ParamInfo
     {
-        uint32_t    id = 0;   // port index
+        uint32_t    id = 0;
         std::string name;
         float       minValue = 0.0f, maxValue = 1.0f, defaultValue = 0.0f;
-        bool        stepped = false;   // lv2:toggled / lv2:integer / lv2:enumeration
+        bool        stepped = false;           // toggled / integer / enumeration
+        bool        isPatchProperty = false;   // written as a patch:Set atom, not a port
     };
 
     Lv2Instance();
@@ -76,12 +80,23 @@ public:
     // Port index for the suil port-index-by-symbol callback; -1 when unknown.
     int portIndexForSymbol (const char* symbol) const noexcept;
 
-    // Parameters (message thread). Enumerated once at create(); id = port index.
+    // ui:eventTransfer writes from the plugin's own editor (message thread):
+    // forwarded onto the control atom input port so the DSP hears them without
+    // relying on the instance-access shortcut, and patch:Set events stamp the
+    // MIDI Learn last-touched tracker + the patch read-back shadow.
+    uint32_t uiEventTransferUrid() const noexcept;
+    void forwardUiAtomEvent (const void* atomData, uint32_t sizeBytes) noexcept;
+
+    // Parameters (message thread). Enumerated once at create().
     int              paramCount() const noexcept;
     const ParamInfo* paramInfo (int index) const noexcept;
-    bool getParamValue (uint32_t portIndex, double& out) const;
-    // Clamps to the port's range and stages through setControlPortValue.
-    void setParamValue (uint32_t portIndex, double value) noexcept;
+    // Patch properties read back the last host/UI-written value (the plugin's
+    // own patch:Put responses aren't parsed yet).
+    bool getParamValue (uint32_t paramId, double& out) const;
+    // Clamps to the parameter's range; control ports stage through
+    // setControlPortValue, patch properties as a patch:Set atom on the control
+    // atom port (applied at the top of the next process block).
+    void setParamValue (uint32_t paramId, double value) noexcept;
     // Index (into paramInfo order) of the port the user last moved in the
     // plugin's own UI; -1 when nothing has been touched.
     int lastTouchedParamIndex() const noexcept;

--- a/src/engine/lv2/NativeLv2Slot.h
+++ b/src/engine/lv2/NativeLv2Slot.h
@@ -12,10 +12,18 @@ struct Lv2SlotTraits
     using Instance = Lv2Instance;
     static constexpr const char* bundleNoun = "bundle";
 
-    static bool pickPlugin (const Lv2Bundle& b, std::string& idOut, std::string& errorOut)
+    static bool pickPlugin (const Lv2Bundle& b, const std::string& requestedId,
+                            std::string& idOut, std::string& errorOut)
     {
         if (b.plugins().empty())
         { errorOut = "no plugins in bundle"; return false; }
+        if (! requestedId.empty())
+        {
+            for (const auto& d : b.plugins())
+                if (d.uri == requestedId) { idOut = requestedId; return true; }
+            errorOut = "bundle no longer advertises plugin '" + requestedId + "'";
+            return false;
+        }
         // First audio effect (audio in + out); fall back to the first advertised plugin.
         idOut = b.plugins().front().uri;
         for (const auto& d : b.plugins())

--- a/src/engine/vst3/NativeVst3Slot.h
+++ b/src/engine/vst3/NativeVst3Slot.h
@@ -12,8 +12,16 @@ struct Vst3SlotTraits
     using Instance = Vst3Instance;
     static constexpr const char* bundleNoun = "module";
 
-    static bool pickPlugin (const Vst3Bundle& b, std::string& idOut, std::string& errorOut)
+    static bool pickPlugin (const Vst3Bundle& b, const std::string& requestedId,
+                            std::string& idOut, std::string& errorOut)
     {
+        if (! requestedId.empty())
+        {
+            for (const auto& d : b.plugins())
+                if (d.id == requestedId) { idOut = requestedId; return true; }
+            errorOut = "module no longer advertises class '" + requestedId + "'";
+            return false;
+        }
         // First audio effect class; instruments need a source, not an insert.
         for (const auto& d : b.plugins())
             if (! d.isInstrument) { idOut = d.id; return true; }

--- a/src/engine/vst3/NativeVst3Slot.h
+++ b/src/engine/vst3/NativeVst3Slot.h
@@ -49,6 +49,10 @@ public:
     int lastTouchedParamIndex() const noexcept
         { return instance != nullptr ? instance->lastTouchedParamIndex() : -1; }
 
+    // True once after the plugin signalled a latency change (see Vst3Instance).
+    bool consumeLatencyChanged() noexcept
+        { return instance != nullptr && instance->consumeLatencyChanged(); }
+
 protected:
     // MIDI binding: VST3 parameters are normalized — the fraction maps directly.
     void applyParamBinding (uint32_t paramIndex, float frac) override

--- a/src/engine/vst3/Vst3Instance.cpp
+++ b/src/engine/vst3/Vst3Instance.cpp
@@ -68,6 +68,32 @@ struct Vst3Instance::Impl : public Vst3HostContext::Callbacks
     // Last param id the plugin's editor touched (performEdit), for MIDI Learn.
     std::atomic<int64_t> lastTouchedParamId { -1 };
 
+    // kLatencyChanged arrived; the engine's drain timer consumes it and cycles
+    // the instance (VST3 latency only re-reads across a setActive cycle).
+    std::atomic<bool> latencyChanged { false };
+
+    void snapshotParams()
+    {
+        params.clear();
+        if (! controller) return;
+        const int32 numParams = controller->getParameterCount();
+        params.reserve ((size_t) std::max<int32> (0, numParams));
+        for (int32 i = 0; i < numParams; ++i)
+        {
+            Vst::ParameterInfo pi {};
+            if (controller->getParameterInfo (i, pi) != kResultOk)
+                continue;
+            ParamInfo p;
+            p.id           = (uint32_t) pi.id;
+            p.name         = VST3::StringConvert::convert (pi.title);
+            p.defaultValue = pi.defaultNormalizedValue;
+            p.stepCount    = (int) pi.stepCount;
+            p.canAutomate  = (pi.flags & Vst::ParameterInfo::kCanAutomate) != 0;
+            p.isReadOnly   = (pi.flags & Vst::ParameterInfo::kIsReadOnly)  != 0;
+            params.push_back (std::move (p));
+        }
+    }
+
     // ── Vst3HostContext::Callbacks (message thread) ──
     void onPerformEdit (uint32_t paramId, double normalised) override
     {
@@ -79,6 +105,19 @@ struct Vst3Instance::Impl : public Vst3HostContext::Callbacks
     bool onResizeView (int w, int h) override
     {
         return resizeViewFn != nullptr && resizeViewFn (w, h);
+    }
+    void onRestartComponent (int32_t flags) override
+    {
+        // Message thread. Values need no action (nothing caches them); a
+        // param-info change re-snapshots the surface in place (read from the
+        // message thread only). Latency defers to the engine's drain timer —
+        // picking it up needs a fenced setActive cycle this callback can't do.
+        // kIoChanged (a live bus re-layout) stays unhandled: the PortLayout is
+        // fixed at create() and no hosted effect exercises it yet.
+        if ((flags & Vst::RestartFlags::kParamTitlesChanged) != 0)
+            snapshotParams();
+        if ((flags & Vst::RestartFlags::kLatencyChanged) != 0)
+            latencyChanged.store (true, std::memory_order_relaxed);
     }
 
     void destroy()
@@ -162,6 +201,11 @@ void Vst3Instance::setResizeViewHandler (std::function<bool (int, int)> fn)
     impl->resizeViewFn = std::move (fn);
 }
 
+bool Vst3Instance::consumeLatencyChanged() noexcept
+{
+    return impl->latencyChanged.exchange (false, std::memory_order_relaxed);
+}
+
 int Vst3Instance::lastTouchedParamIndex() const noexcept
 {
     const auto id = impl->lastTouchedParamId.load (std::memory_order_relaxed);
@@ -232,22 +276,7 @@ bool Vst3Instance::create (const Vst3Bundle& bundle, const std::string& classId,
             impl->controller->setComponentState (&stream);
         }
 
-        const int32 numParams = impl->controller->getParameterCount();
-        impl->params.reserve ((size_t) std::max<int32> (0, numParams));
-        for (int32 i = 0; i < numParams; ++i)
-        {
-            Vst::ParameterInfo pi {};
-            if (impl->controller->getParameterInfo (i, pi) != kResultOk)
-                continue;
-            ParamInfo p;
-            p.id           = (uint32_t) pi.id;
-            p.name         = VST3::StringConvert::convert (pi.title);
-            p.defaultValue = pi.defaultNormalizedValue;
-            p.stepCount    = (int) pi.stepCount;
-            p.canAutomate  = (pi.flags & Vst::ParameterInfo::kCanAutomate) != 0;
-            p.isReadOnly   = (pi.flags & Vst::ParameterInfo::kIsReadOnly)  != 0;
-            impl->params.push_back (std::move (p));
-        }
+        impl->snapshotParams();
     }
     impl->host.setCallbacks (impl.get());
 

--- a/src/engine/vst3/Vst3Instance.cpp
+++ b/src/engine/vst3/Vst3Instance.cpp
@@ -71,6 +71,10 @@ struct Vst3Instance::Impl : public Vst3HostContext::Callbacks
     // kLatencyChanged arrived; the engine's drain timer consumes it and cycles
     // the instance (VST3 latency only re-reads across a setActive cycle).
     std::atomic<bool> latencyChanged { false };
+    // kParamTitlesChanged arrived; the drain timer re-snapshots on the message
+    // thread (misbehaving plugins fire restartComponent off-thread, and the
+    // snapshot allocates).
+    std::atomic<bool> paramInfoChanged { false };
 
     void snapshotParams()
     {
@@ -108,14 +112,14 @@ struct Vst3Instance::Impl : public Vst3HostContext::Callbacks
     }
     void onRestartComponent (int32_t flags) override
     {
-        // Message thread. Values need no action (nothing caches them); a
-        // param-info change re-snapshots the surface in place (read from the
-        // message thread only). Latency defers to the engine's drain timer —
-        // picking it up needs a fenced setActive cycle this callback can't do.
+        // Flag-only: values need no action (nothing caches them), param-info and
+        // latency changes are consumed by the engine's message-thread drain
+        // timer (the snapshot allocates and the latency pickup needs a fenced
+        // setActive cycle — and misbehaving plugins call this off-thread).
         // kIoChanged (a live bus re-layout) stays unhandled: the PortLayout is
         // fixed at create() and no hosted effect exercises it yet.
         if ((flags & Vst::RestartFlags::kParamTitlesChanged) != 0)
-            snapshotParams();
+            paramInfoChanged.store (true, std::memory_order_relaxed);
         if ((flags & Vst::RestartFlags::kLatencyChanged) != 0)
             latencyChanged.store (true, std::memory_order_relaxed);
     }
@@ -204,6 +208,12 @@ void Vst3Instance::setResizeViewHandler (std::function<bool (int, int)> fn)
 bool Vst3Instance::consumeLatencyChanged() noexcept
 {
     return impl->latencyChanged.exchange (false, std::memory_order_relaxed);
+}
+
+void Vst3Instance::refreshParamInfoIfChanged()
+{
+    if (impl->paramInfoChanged.exchange (false, std::memory_order_relaxed))
+        impl->snapshotParams();
 }
 
 int Vst3Instance::lastTouchedParamIndex() const noexcept

--- a/src/engine/vst3/Vst3Instance.h
+++ b/src/engine/vst3/Vst3Instance.h
@@ -86,6 +86,10 @@ public:
     // PDC — VST3 only re-reads latency across a setActive cycle.
     bool consumeLatencyChanged() noexcept;
 
+    // Message thread: re-snapshot the parameter surface if the plugin signalled
+    // kParamTitlesChanged. Called from the engine's drain timer.
+    void refreshParamInfoIfChanged();
+
     int getLatencySamples() const noexcept override;
 
     // The host context this instance hands to the plugin (component handler,

--- a/src/engine/vst3/Vst3Instance.h
+++ b/src/engine/vst3/Vst3Instance.h
@@ -81,6 +81,11 @@ public:
     // touched. Message thread.
     int lastTouchedParamIndex() const noexcept;
 
+    // True once after the plugin signalled kLatencyChanged (restartComponent).
+    // The caller reactivates the instance under the engine gate and recomputes
+    // PDC — VST3 only re-reads latency across a setActive cycle.
+    bool consumeLatencyChanged() noexcept;
+
     int getLatencySamples() const noexcept override;
 
     // The host context this instance hands to the plugin (component handler,

--- a/src/session/MidiBindings.cpp
+++ b/src/session/MidiBindings.cpp
@@ -156,6 +156,8 @@ juce::String describeBindingTarget (const MidiBinding& b,
         case MidiBindingTarget::BusSolo:         return "Bus " + trk() + " solo";
         case MidiBindingTarget::AuxLaneFader:    return "AUX " + trk() + " return";
         case MidiBindingTarget::AuxLaneMute:     return "AUX " + trk() + " mute";
+        case MidiBindingTarget::AuxPluginParam:  return "AUX " + trk() + " plugin param "
+                                                        + juce::String (b.paramIndex + 1);
         case MidiBindingTarget::MasterFader:     return "Master fader";
 
         // Mirror the grammar of the track / bus / master labels so the
@@ -233,6 +235,7 @@ const char* nameForTarget (MidiBindingTarget t) noexcept
         case MidiBindingTarget::BusSolo:         return "Bus solo";
         case MidiBindingTarget::AuxLaneFader:    return "AUX return";
         case MidiBindingTarget::AuxLaneMute:     return "AUX mute";
+        case MidiBindingTarget::AuxPluginParam:  return "AUX plugin parameter";
         case MidiBindingTarget::MasterFader:     return "Master fader";
 
         // Short category names for the bindings-panel section headers
@@ -589,6 +592,7 @@ std::optional<std::vector<MidiBinding>> deserializeBindingsPreset (const juce::S
             case MidiBindingTarget::BusSolo:
             case MidiBindingTarget::AuxLaneFader:
             case MidiBindingTarget::AuxLaneMute:
+            case MidiBindingTarget::AuxPluginParam:
             case MidiBindingTarget::MasterFader:
             // Bank-relative variants — were silently dropped, breaking preset
             // round-trip for any banked binding.

--- a/src/session/MidiBindings.h
+++ b/src/session/MidiBindings.h
@@ -90,6 +90,9 @@ enum class MidiBindingTarget : int
 
     AuxLaneFader      = 160,
     AuxLaneMute       = 161,
+    AuxPluginParam    = 162, // targetIndex = lane; paramIndex = plugin parameter.
+                              // Single insert slot per lane today — the layout
+                              // block that grows kMaxLanePlugins revisits this.
 
     MasterFader       = 200,
 
@@ -155,6 +158,7 @@ constexpr bool isContinuousTarget (MidiBindingTarget t) noexcept
         || t == MidiBindingTarget::BusFader
         || t == MidiBindingTarget::BusPan
         || t == MidiBindingTarget::AuxLaneFader
+        || t == MidiBindingTarget::AuxPluginParam
         || t == MidiBindingTarget::MasterFader
         // Continuous bus + master targets.
         || t == MidiBindingTarget::BusEqGain
@@ -206,7 +210,8 @@ constexpr bool needsBusIndex (MidiBindingTarget t) noexcept
 constexpr bool needsAuxLaneIndex (MidiBindingTarget t) noexcept
 {
     return t == MidiBindingTarget::AuxLaneFader
-        || t == MidiBindingTarget::AuxLaneMute;
+        || t == MidiBindingTarget::AuxLaneMute
+        || t == MidiBindingTarget::AuxPluginParam;
 }
 
 // Only the absolute-track variant. TrackAuxSendBank uses a smaller

--- a/src/session/Session.h
+++ b/src/session/Session.h
@@ -808,10 +808,13 @@ struct Track
     // several are somehow set). Always present so non-Linux builds round-trip
     // the fields untouched.
     juce::String nativeClapPath;
+    juce::String nativeClapPluginId;   // which plugin inside the bundle; empty = first effect
     juce::String nativeClapStateBase64;
     juce::String nativeLv2Path;
+    juce::String nativeLv2PluginId;
     juce::String nativeLv2StateBase64;
     juce::String nativeVst3Path;
+    juce::String nativeVst3PluginId;
     juce::String nativeVst3StateBase64;
 
     // Track freeze (MIDI tracks): the instrument + pre-fader strip is rendered
@@ -971,10 +974,13 @@ struct AuxLane
     // somehow set). Always present so non-Linux builds round-trip the fields
     // untouched.
     std::array<juce::String, AuxLaneParams::kMaxLanePlugins> nativeClapPath;
+    std::array<juce::String, AuxLaneParams::kMaxLanePlugins> nativeClapPluginId;
     std::array<juce::String, AuxLaneParams::kMaxLanePlugins> nativeClapStateBase64;
     std::array<juce::String, AuxLaneParams::kMaxLanePlugins> nativeLv2Path;
+    std::array<juce::String, AuxLaneParams::kMaxLanePlugins> nativeLv2PluginId;
     std::array<juce::String, AuxLaneParams::kMaxLanePlugins> nativeLv2StateBase64;
     std::array<juce::String, AuxLaneParams::kMaxLanePlugins> nativeVst3Path;
+    std::array<juce::String, AuxLaneParams::kMaxLanePlugins> nativeVst3PluginId;
     std::array<juce::String, AuxLaneParams::kMaxLanePlugins> nativeVst3StateBase64;
 
     std::array<HardwareInsertParams, AuxLaneParams::kMaxLanePlugins> hardwareInserts;

--- a/src/session/SessionSerializer.cpp
+++ b/src/session/SessionSerializer.cpp
@@ -334,18 +334,21 @@ juce::DynamicObject::Ptr trackToObject (const Track& t, const juce::File& sessio
         obj->setProperty ("plugin_state",    t.pluginStateBase64);
     if (t.nativeClapPath.isNotEmpty())
     {
-        obj->setProperty ("native_clap_path",  t.nativeClapPath);
-        obj->setProperty ("native_clap_state", t.nativeClapStateBase64);
+        obj->setProperty ("native_clap_path",   t.nativeClapPath);
+        obj->setProperty ("native_clap_plugin", t.nativeClapPluginId);
+        obj->setProperty ("native_clap_state",  t.nativeClapStateBase64);
     }
     if (t.nativeLv2Path.isNotEmpty())
     {
-        obj->setProperty ("native_lv2_path",  t.nativeLv2Path);
-        obj->setProperty ("native_lv2_state", t.nativeLv2StateBase64);
+        obj->setProperty ("native_lv2_path",   t.nativeLv2Path);
+        obj->setProperty ("native_lv2_plugin", t.nativeLv2PluginId);
+        obj->setProperty ("native_lv2_state",  t.nativeLv2StateBase64);
     }
     if (t.nativeVst3Path.isNotEmpty())
     {
-        obj->setProperty ("native_vst3_path",  t.nativeVst3Path);
-        obj->setProperty ("native_vst3_state", t.nativeVst3StateBase64);
+        obj->setProperty ("native_vst3_path",   t.nativeVst3Path);
+        obj->setProperty ("native_vst3_plugin", t.nativeVst3PluginId);
+        obj->setProperty ("native_vst3_state",  t.nativeVst3StateBase64);
     }
 
     obj->setProperty ("fader_db",       t.strip.faderDb.load());
@@ -738,12 +741,15 @@ void restoreTrack (Track& t, const juce::var& v, double defaultRecordBpm,
     // reads these back and asks each PluginSlot to reinstantiate.
     t.pluginDescriptionXml = v["plugin_desc_xml"].toString();
     t.pluginStateBase64    = v["plugin_state"]   .toString();
-    t.nativeClapPath        = v["native_clap_path"] .toString();
-    t.nativeClapStateBase64 = v["native_clap_state"].toString();
-    t.nativeLv2Path         = v["native_lv2_path"]  .toString();
-    t.nativeLv2StateBase64  = v["native_lv2_state"] .toString();
-    t.nativeVst3Path        = v["native_vst3_path"] .toString();
-    t.nativeVst3StateBase64 = v["native_vst3_state"].toString();
+    t.nativeClapPath        = v["native_clap_path"]  .toString();
+    t.nativeClapPluginId    = v["native_clap_plugin"].toString();
+    t.nativeClapStateBase64 = v["native_clap_state"] .toString();
+    t.nativeLv2Path         = v["native_lv2_path"]   .toString();
+    t.nativeLv2PluginId     = v["native_lv2_plugin"] .toString();
+    t.nativeLv2StateBase64  = v["native_lv2_state"]  .toString();
+    t.nativeVst3Path        = v["native_vst3_path"]  .toString();
+    t.nativeVst3PluginId    = v["native_vst3_plugin"].toString();
+    t.nativeVst3StateBase64 = v["native_vst3_state"] .toString();
 
     auto setFloat = [&v] (std::atomic<float>& a, const char* key)
     {
@@ -1262,18 +1268,21 @@ juce::String SessionSerializer::serialize (const Session& s)
             // when set, so JUCE-only sessions are unchanged.
             if (lane.nativeClapPath[(size_t) p].isNotEmpty())
             {
-                slot->setProperty ("native_clap_path",  lane.nativeClapPath[(size_t) p]);
-                slot->setProperty ("native_clap_state", lane.nativeClapStateBase64[(size_t) p]);
+                slot->setProperty ("native_clap_path",   lane.nativeClapPath[(size_t) p]);
+                slot->setProperty ("native_clap_plugin", lane.nativeClapPluginId[(size_t) p]);
+                slot->setProperty ("native_clap_state",  lane.nativeClapStateBase64[(size_t) p]);
             }
             if (lane.nativeLv2Path[(size_t) p].isNotEmpty())
             {
-                slot->setProperty ("native_lv2_path",  lane.nativeLv2Path[(size_t) p]);
-                slot->setProperty ("native_lv2_state", lane.nativeLv2StateBase64[(size_t) p]);
+                slot->setProperty ("native_lv2_path",   lane.nativeLv2Path[(size_t) p]);
+                slot->setProperty ("native_lv2_plugin", lane.nativeLv2PluginId[(size_t) p]);
+                slot->setProperty ("native_lv2_state",  lane.nativeLv2StateBase64[(size_t) p]);
             }
             if (lane.nativeVst3Path[(size_t) p].isNotEmpty())
             {
-                slot->setProperty ("native_vst3_path",  lane.nativeVst3Path[(size_t) p]);
-                slot->setProperty ("native_vst3_state", lane.nativeVst3StateBase64[(size_t) p]);
+                slot->setProperty ("native_vst3_path",   lane.nativeVst3Path[(size_t) p]);
+                slot->setProperty ("native_vst3_plugin", lane.nativeVst3PluginId[(size_t) p]);
+                slot->setProperty ("native_vst3_state",  lane.nativeVst3StateBase64[(size_t) p]);
             }
 
             // Hardware-insert side of this slot. Same shape as the
@@ -1663,12 +1672,15 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
                     if (! sv.isObject()) continue;
                     lane.pluginDescriptionXml[(size_t) p] = sv["plugin_desc_xml"].toString();
                     lane.pluginStateBase64[(size_t) p]    = sv["plugin_state"]   .toString();
-                    lane.nativeClapPath[(size_t) p]        = sv["native_clap_path"] .toString();
-                    lane.nativeClapStateBase64[(size_t) p] = sv["native_clap_state"].toString();
-                    lane.nativeLv2Path[(size_t) p]         = sv["native_lv2_path"]  .toString();
-                    lane.nativeLv2StateBase64[(size_t) p]  = sv["native_lv2_state"] .toString();
-                    lane.nativeVst3Path[(size_t) p]        = sv["native_vst3_path"] .toString();
-                    lane.nativeVst3StateBase64[(size_t) p] = sv["native_vst3_state"].toString();
+                    lane.nativeClapPath[(size_t) p]        = sv["native_clap_path"]  .toString();
+                    lane.nativeClapPluginId[(size_t) p]    = sv["native_clap_plugin"].toString();
+                    lane.nativeClapStateBase64[(size_t) p] = sv["native_clap_state"] .toString();
+                    lane.nativeLv2Path[(size_t) p]         = sv["native_lv2_path"]   .toString();
+                    lane.nativeLv2PluginId[(size_t) p]     = sv["native_lv2_plugin"] .toString();
+                    lane.nativeLv2StateBase64[(size_t) p]  = sv["native_lv2_state"]  .toString();
+                    lane.nativeVst3Path[(size_t) p]        = sv["native_vst3_path"]  .toString();
+                    lane.nativeVst3PluginId[(size_t) p]    = sv["native_vst3_plugin"].toString();
+                    lane.nativeVst3StateBase64[(size_t) p] = sv["native_vst3_state"] .toString();
 
                     // Same default-off rationale as the track hardware_insert.
                     {

--- a/src/session/SessionSerializer.cpp
+++ b/src/session/SessionSerializer.cpp
@@ -2075,6 +2075,7 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
                     case (int) MidiBindingTarget::BusSolo:
                     case (int) MidiBindingTarget::AuxLaneFader:
                     case (int) MidiBindingTarget::AuxLaneMute:
+                    case (int) MidiBindingTarget::AuxPluginParam:
                     case (int) MidiBindingTarget::MasterFader:
                     // Were silently coerced to None on load, dropping the
                     // binding from a saved session.

--- a/src/ui/AuxLaneComponent.cpp
+++ b/src/ui/AuxLaneComponent.cpp
@@ -790,28 +790,28 @@ void AuxLaneComponent::openPickerForSlot (int slotIdx)
     const auto cursor = juce::Desktop::getMousePosition();
     juce::Component::SafePointer<AuxLaneComponent> safe (this);
     // Native CLAP route — Linux-only; empty elsewhere so the picker shows no CLAP rows.
-    std::function<void (const juce::File&)> onClap;
+    std::function<void (const juce::File&, const juce::String&)> onClap;
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
-    onClap = [safe, slotIdx] (const juce::File& clapFile)
+    onClap = [safe, slotIdx] (const juce::File& clapFile, const juce::String& id)
     {
         if (auto* self = safe.getComponent())
-            self->loadNativeClapForSlot (slotIdx, clapFile);
+            self->loadNativeClapForSlot (slotIdx, clapFile, id);
     };
 #endif
-    std::function<void (const juce::File&)> onLv2;
+    std::function<void (const juce::File&, const juce::String&)> onLv2;
 #if DUSKSTUDIO_HAS_NATIVE_LV2
-    onLv2 = [safe, slotIdx] (const juce::File& bundleDir)
+    onLv2 = [safe, slotIdx] (const juce::File& bundleDir, const juce::String& id)
     {
         if (auto* self = safe.getComponent())
-            self->loadNativeLv2ForSlot (slotIdx, bundleDir);
+            self->loadNativeLv2ForSlot (slotIdx, bundleDir, id);
     };
 #endif
-    std::function<void (const juce::File&)> onVst3;
+    std::function<void (const juce::File&, const juce::String&)> onVst3;
 #if DUSKSTUDIO_HAS_NATIVE_VST3
-    onVst3 = [safe, slotIdx] (const juce::File& vst3File)
+    onVst3 = [safe, slotIdx] (const juce::File& vst3File, const juce::String& id)
     {
         if (auto* self = safe.getComponent())
-            self->loadNativeVst3ForSlot (slotIdx, vst3File);
+            self->loadNativeVst3ForSlot (slotIdx, vst3File, id);
     };
 #endif
     pluginpicker::openPickerMenu (strip.getPluginSlot (slotIdx),
@@ -980,7 +980,8 @@ void AuxLaneComponent::detachEditorForSlot (int slotIdx)
 }
 
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
-void AuxLaneComponent::loadNativeClapForSlot (int slotIdx, const juce::File& clapFile)
+void AuxLaneComponent::loadNativeClapForSlot (int slotIdx, const juce::File& clapFile,
+                                              const juce::String& pluginId)
 {
     if (slotIdx < 0 || slotIdx >= AuxLaneParams::kMaxLanePlugins) return;
 
@@ -1001,7 +1002,7 @@ void AuxLaneComponent::loadNativeClapForSlot (int slotIdx, const juce::File& cla
     bool ok = false;
     engine.suspendProcessing();
     strip.getPluginSlot (slotIdx).unload();   // ensure no JUCE plugin lingers
-    ok = strip.loadNativeClap (slotIdx, clapFile, err);
+    ok = strip.loadNativeClap (slotIdx, clapFile, err, pluginId);
     if (ok)
         strip.insertMode[(size_t) slotIdx].store (AuxLaneStrip::kInsertPlugin,
                                                    std::memory_order_release);
@@ -1033,7 +1034,8 @@ void AuxLaneComponent::loadNativeClapForSlot (int slotIdx, const juce::File& cla
 #endif // DUSKSTUDIO_HAS_NATIVE_CLAP
 
 #if DUSKSTUDIO_HAS_NATIVE_LV2
-void AuxLaneComponent::loadNativeLv2ForSlot (int slotIdx, const juce::File& bundleDir)
+void AuxLaneComponent::loadNativeLv2ForSlot (int slotIdx, const juce::File& bundleDir,
+                                             const juce::String& pluginId)
 {
     if (slotIdx < 0 || slotIdx >= AuxLaneParams::kMaxLanePlugins) return;
 
@@ -1050,7 +1052,7 @@ void AuxLaneComponent::loadNativeLv2ForSlot (int slotIdx, const juce::File& bund
     std::string err;
     bool ok = false;
     engine.suspendProcessing();
-    ok = strip.loadNativeLv2 (slotIdx, bundleDir, err);
+    ok = strip.loadNativeLv2 (slotIdx, bundleDir, err, pluginId);
     if (ok)
         strip.insertMode[(size_t) slotIdx].store (AuxLaneStrip::kInsertPlugin,
                                                    std::memory_order_release);
@@ -1077,7 +1079,8 @@ void AuxLaneComponent::loadNativeLv2ForSlot (int slotIdx, const juce::File& bund
 #endif // DUSKSTUDIO_HAS_NATIVE_LV2
 
 #if DUSKSTUDIO_HAS_NATIVE_VST3
-void AuxLaneComponent::loadNativeVst3ForSlot (int slotIdx, const juce::File& vst3File)
+void AuxLaneComponent::loadNativeVst3ForSlot (int slotIdx, const juce::File& vst3File,
+                                              const juce::String& pluginId)
 {
     if (slotIdx < 0 || slotIdx >= AuxLaneParams::kMaxLanePlugins) return;
 
@@ -1094,7 +1097,7 @@ void AuxLaneComponent::loadNativeVst3ForSlot (int slotIdx, const juce::File& vst
     std::string err;
     bool ok = false;
     engine.suspendProcessing();
-    ok = strip.loadNativeVst3 (slotIdx, vst3File, err);
+    ok = strip.loadNativeVst3 (slotIdx, vst3File, err, pluginId);
     if (ok)
         strip.insertMode[(size_t) slotIdx].store (AuxLaneStrip::kInsertPlugin,
                                                    std::memory_order_release);

--- a/src/ui/AuxLaneComponent.cpp
+++ b/src/ui/AuxLaneComponent.cpp
@@ -324,6 +324,7 @@ AuxLaneComponent::AuxLaneComponent (AuxLane& l, AuxLaneStrip& s, int idx,
         s.openOrAddButton.setColour (juce::TextButton::buttonOnColourId, juce::Colour (0xff5a4880));
         s.openOrAddButton.setColour (juce::TextButton::textColourOffId, juce::Colour (0xff9080c0));
         s.openOrAddButton.setColour (juce::TextButton::textColourOnId,  juce::Colours::white);
+        s.openOrAddButton.addMouseListener (this, false);   // right-click → MIDI Learn
         s.openOrAddButton.onClick = [this, i]
         {
             auto& slotRef = strip.getPluginSlot (i);
@@ -1691,6 +1692,23 @@ void AuxLaneComponent::mouseDown (const juce::MouseEvent& e)
     {
         midilearn::showLearnMenu (muteButton, session,
                                     MidiBindingTarget::AuxLaneMute, laneIndex);
+        return;
+    }
+    // Slot name button → learn the plugin parameter the user last moved in the
+    // slot's editor. Only offered while some host has a plugin loaded (the
+    // resolve site reads that host's last-touched tracker when the MIDI source
+    // arrives, so an untouched plugin just cancels the learn).
+    for (int i = 0; i < AuxLaneParams::kMaxLanePlugins; ++i)
+    {
+        auto& ui = slots[(size_t) i];
+        if (e.eventComponent != &ui.openOrAddButton) continue;
+        const bool loaded = strip.getPluginSlot (i).isLoaded()
+                         || strip.isNativeClapLoaded (i)
+                         || strip.isNativeLv2Loaded (i)
+                         || strip.isNativeVst3Loaded (i);
+        if (loaded)
+            midilearn::showLearnMenu (ui.openOrAddButton, session,
+                                        MidiBindingTarget::AuxPluginParam, laneIndex);
         return;
     }
 }

--- a/src/ui/AuxLaneComponent.cpp
+++ b/src/ui/AuxLaneComponent.cpp
@@ -842,10 +842,13 @@ void AuxLaneComponent::openPickerForSlot (int slotIdx)
                                                 self->strip.unloadNativeVst3 (slotIdx);
                                                 self->engine.resumeProcessing();
                                                 self->lane.nativeClapPath[(size_t) slotIdx].clear();
+                                                self->lane.nativeClapPluginId[(size_t) slotIdx].clear();
                                                 self->lane.nativeClapStateBase64[(size_t) slotIdx].clear();
                                                 self->lane.nativeLv2Path[(size_t) slotIdx].clear();
+                                                self->lane.nativeLv2PluginId[(size_t) slotIdx].clear();
                                                 self->lane.nativeLv2StateBase64[(size_t) slotIdx].clear();
                                                 self->lane.nativeVst3Path[(size_t) slotIdx].clear();
+                                                self->lane.nativeVst3PluginId[(size_t) slotIdx].clear();
                                                 self->lane.nativeVst3StateBase64[(size_t) slotIdx].clear();
                                             }
 
@@ -917,10 +920,13 @@ void AuxLaneComponent::unloadSlot (int slotIdx)
             self->strip.unloadNativeVst3 (slotIdx);
             self->engine.resumeProcessing();
             self->lane.nativeClapPath[(size_t) slotIdx].clear();
+            self->lane.nativeClapPluginId[(size_t) slotIdx].clear();
             self->lane.nativeClapStateBase64[(size_t) slotIdx].clear();
             self->lane.nativeLv2Path[(size_t) slotIdx].clear();
+            self->lane.nativeLv2PluginId[(size_t) slotIdx].clear();
             self->lane.nativeLv2StateBase64[(size_t) slotIdx].clear();
             self->lane.nativeVst3Path[(size_t) slotIdx].clear();
+            self->lane.nativeVst3PluginId[(size_t) slotIdx].clear();
             self->lane.nativeVst3StateBase64[(size_t) slotIdx].clear();
         }
         // Clear the model's enabled flag so any consumer that polls
@@ -1016,17 +1022,21 @@ void AuxLaneComponent::loadNativeClapForSlot (int slotIdx, const juce::File& cla
         // Slot is empty now — drop any persisted refs (incl. a previous plugin's state
         // blob) so a save doesn't carry a stale path/state for a slot the user sees empty.
         lane.nativeClapPath[(size_t) slotIdx].clear();
+        lane.nativeClapPluginId[(size_t) slotIdx].clear();
         lane.nativeClapStateBase64[(size_t) slotIdx].clear();
         return;
     }
-    lane.nativeClapPath[(size_t) slotIdx] = clapFile.getFullPathName();
+    lane.nativeClapPath[(size_t) slotIdx]     = clapFile.getFullPathName();
+    lane.nativeClapPluginId[(size_t) slotIdx] = strip.getNativeClapSlot (slotIdx).getPluginId();
     // Fresh plugin: don't inherit the previous slot occupant's state blob. The next
     // save re-captures this plugin's real state.
     lane.nativeClapStateBase64[(size_t) slotIdx].clear();
     // The load evicted the other native hosts in this slot — drop their refs too.
     lane.nativeLv2Path[(size_t) slotIdx].clear();
+    lane.nativeLv2PluginId[(size_t) slotIdx].clear();
     lane.nativeLv2StateBase64[(size_t) slotIdx].clear();
     lane.nativeVst3Path[(size_t) slotIdx].clear();
+    lane.nativeVst3PluginId[(size_t) slotIdx].clear();
     lane.nativeVst3StateBase64[(size_t) slotIdx].clear();
     refreshSlotControls (slotIdx);
     rebuildSlots();
@@ -1064,14 +1074,18 @@ void AuxLaneComponent::loadNativeLv2ForSlot (int slotIdx, const juce::File& bund
         showDuskAlert (*this, "Couldn't load LV2 plugin",
                        bundleDir.getFileNameWithoutExtension() + ":\n" + juce::String (err));
         lane.nativeLv2Path[(size_t) slotIdx].clear();
+        lane.nativeLv2PluginId[(size_t) slotIdx].clear();
         lane.nativeLv2StateBase64[(size_t) slotIdx].clear();
         return;
     }
-    lane.nativeLv2Path[(size_t) slotIdx] = bundleDir.getFullPathName();
+    lane.nativeLv2Path[(size_t) slotIdx]     = bundleDir.getFullPathName();
+    lane.nativeLv2PluginId[(size_t) slotIdx] = strip.getNativeLv2Slot (slotIdx).getPluginId();
     lane.nativeLv2StateBase64[(size_t) slotIdx].clear();
     lane.nativeClapPath[(size_t) slotIdx].clear();
+    lane.nativeClapPluginId[(size_t) slotIdx].clear();
     lane.nativeClapStateBase64[(size_t) slotIdx].clear();
     lane.nativeVst3Path[(size_t) slotIdx].clear();
+    lane.nativeVst3PluginId[(size_t) slotIdx].clear();
     lane.nativeVst3StateBase64[(size_t) slotIdx].clear();
     refreshSlotControls (slotIdx);
     rebuildSlots();
@@ -1109,14 +1123,18 @@ void AuxLaneComponent::loadNativeVst3ForSlot (int slotIdx, const juce::File& vst
         showDuskAlert (*this, "Couldn't load VST3 plugin",
                        vst3File.getFileNameWithoutExtension() + ":\n" + juce::String (err));
         lane.nativeVst3Path[(size_t) slotIdx].clear();
+        lane.nativeVst3PluginId[(size_t) slotIdx].clear();
         lane.nativeVst3StateBase64[(size_t) slotIdx].clear();
         return;
     }
-    lane.nativeVst3Path[(size_t) slotIdx] = vst3File.getFullPathName();
+    lane.nativeVst3Path[(size_t) slotIdx]     = vst3File.getFullPathName();
+    lane.nativeVst3PluginId[(size_t) slotIdx] = strip.getNativeVst3Slot (slotIdx).getPluginId();
     lane.nativeVst3StateBase64[(size_t) slotIdx].clear();
     lane.nativeClapPath[(size_t) slotIdx].clear();
+    lane.nativeClapPluginId[(size_t) slotIdx].clear();
     lane.nativeClapStateBase64[(size_t) slotIdx].clear();
     lane.nativeLv2Path[(size_t) slotIdx].clear();
+    lane.nativeLv2PluginId[(size_t) slotIdx].clear();
     lane.nativeLv2StateBase64[(size_t) slotIdx].clear();
     refreshSlotControls (slotIdx);
     rebuildSlots();

--- a/src/ui/AuxLaneComponent.h
+++ b/src/ui/AuxLaneComponent.h
@@ -69,13 +69,16 @@ private:
     void attachHardwareInsertForSlot (int slotIdx);
     void detachHardwareInsertForSlot (int slotIdx);
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
-    void loadNativeClapForSlot (int slotIdx, const juce::File& clapFile);   // Linux-only
+    void loadNativeClapForSlot (int slotIdx, const juce::File& clapFile,
+                                const juce::String& pluginId = {});   // Linux-only
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_LV2
-    void loadNativeLv2ForSlot (int slotIdx, const juce::File& bundleDir);   // Linux-only, no editor yet
+    void loadNativeLv2ForSlot (int slotIdx, const juce::File& bundleDir,
+                               const juce::String& pluginId = {});   // Linux-only
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_VST3
-    void loadNativeVst3ForSlot (int slotIdx, const juce::File& vst3File);   // Linux-only
+    void loadNativeVst3ForSlot (int slotIdx, const juce::File& vst3File,
+                                const juce::String& pluginId = {});   // Linux-only
 #endif
     // Stubbed (no-op body) off Linux so the many callers don't each need a guard.
     void detachClapEditorForSlot (int slotIdx);

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -2068,25 +2068,8 @@ void ChannelStripComponent::showPluginSlotMenu()
         // loaded (no last-touched stamp to bind to). Native slots track
         // touches from their editors.
         {
-            auto& chStrip = engine.getChannelStrip (trackIndex);
-            int lastParam = -1;
-#if DUSKSTUDIO_HAS_NATIVE_CLAP
-            if (chStrip.isNativeClapLoaded())
-                lastParam = chStrip.getNativeClapSlot().lastTouchedParamIndex();
-            else
-#endif
-#if DUSKSTUDIO_HAS_NATIVE_LV2
-            if (chStrip.isNativeLv2Loaded())
-                lastParam = chStrip.getNativeLv2Slot().lastTouchedParamIndex();
-            else
-#endif
-#if DUSKSTUDIO_HAS_NATIVE_VST3
-            if (chStrip.isNativeVst3Loaded())
-                lastParam = chStrip.getNativeVst3Slot().lastTouchedParamIndex();
-            else
-#endif
-            if (! nativeLoaded)
-                lastParam = pluginSlot.getLastTouchedParamIndex();
+            const int lastParam = engine.getChannelStrip (trackIndex)
+                                        .insertLastTouchedParamIndex();
             menu.addSeparator();
             menu.addItem (2005,
                            "MIDI Learn last-touched parameter",

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -1880,33 +1880,33 @@ void ChannelStripComponent::openPluginPicker (bool useChooser)
     // Native CLAP route — effects (audio) slots only; CLAP instruments aren't hosted
     // natively yet. Selecting a CLAP row loads it through the channel's native host.
     // Linux-only; elsewhere the callback stays empty so the picker shows no CLAP rows.
-    std::function<void (const juce::File&)> onClap;
+    std::function<void (const juce::File&, const juce::String&)> onClap;
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
     if (kind == pluginpicker::PluginKind::Effects)
-        onClap = [safe] (const juce::File& f)
+        onClap = [safe] (const juce::File& f, const juce::String& id)
         {
             if (auto* self = safe.getComponent())
-                self->loadNativeClapForChannel (f);
+                self->loadNativeClapForChannel (f, id);
         };
 #endif
     // Native LV2 route — same shape; LV2-Native rows replace the JUCE LV2 rows.
-    std::function<void (const juce::File&)> onLv2;
+    std::function<void (const juce::File&, const juce::String&)> onLv2;
 #if DUSKSTUDIO_HAS_NATIVE_LV2
     if (kind == pluginpicker::PluginKind::Effects)
-        onLv2 = [safe] (const juce::File& f)
+        onLv2 = [safe] (const juce::File& f, const juce::String& id)
         {
             if (auto* self = safe.getComponent())
-                self->loadNativeLv2ForChannel (f);
+                self->loadNativeLv2ForChannel (f, id);
         };
 #endif
     // Native VST3 route — same shape; VST3-Native rows replace the JUCE VST3 rows.
-    std::function<void (const juce::File&)> onVst3;
+    std::function<void (const juce::File&, const juce::String&)> onVst3;
 #if DUSKSTUDIO_HAS_NATIVE_VST3
     if (kind == pluginpicker::PluginKind::Effects)
-        onVst3 = [safe] (const juce::File& f)
+        onVst3 = [safe] (const juce::File& f, const juce::String& id)
         {
             if (auto* self = safe.getComponent())
-                self->loadNativeVst3ForChannel (f);
+                self->loadNativeVst3ForChannel (f, id);
         };
 #endif
 
@@ -2611,7 +2611,8 @@ void ChannelStripComponent::dropPluginEditor()
 }
 
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
-void ChannelStripComponent::loadNativeClapForChannel (const juce::File& clapFile)
+void ChannelStripComponent::loadNativeClapForChannel (const juce::File& clapFile,
+                                                       const juce::String& pluginId)
 {
     auto& strip = engine.getChannelStrip (trackIndex);
 
@@ -2643,7 +2644,7 @@ void ChannelStripComponent::loadNativeClapForChannel (const juce::File& clapFile
     std::string err;
     engine.suspendProcessing();
     pluginSlot.unload();                       // ensure no JUCE plugin lingers
-    const bool ok = strip.loadNativeClap (clapFile, err);
+    const bool ok = strip.loadNativeClap (clapFile, err, pluginId);
     if (ok)
         strip.insertMode.store (ChannelStrip::kInsertPlugin, std::memory_order_release);
     engine.resumeProcessing();
@@ -2675,7 +2676,8 @@ void ChannelStripComponent::loadNativeClapForChannel (const juce::File& clapFile
 #endif // DUSKSTUDIO_HAS_NATIVE_CLAP
 
 #if DUSKSTUDIO_HAS_NATIVE_LV2
-void ChannelStripComponent::loadNativeLv2ForChannel (const juce::File& bundleDir)
+void ChannelStripComponent::loadNativeLv2ForChannel (const juce::File& bundleDir,
+                                                      const juce::String& pluginId)
 {
     auto& strip = engine.getChannelStrip (trackIndex);
 
@@ -2703,7 +2705,7 @@ void ChannelStripComponent::loadNativeLv2ForChannel (const juce::File& bundleDir
     // loadNativeLv2 itself evicts the CLAP + JUCE occupants.
     std::string err;
     engine.suspendProcessing();
-    const bool ok = strip.loadNativeLv2 (bundleDir, err);
+    const bool ok = strip.loadNativeLv2 (bundleDir, err, pluginId);
     if (ok)
         strip.insertMode.store (ChannelStrip::kInsertPlugin, std::memory_order_release);
     engine.resumeProcessing();
@@ -2730,7 +2732,8 @@ void ChannelStripComponent::loadNativeLv2ForChannel (const juce::File& bundleDir
 #endif // DUSKSTUDIO_HAS_NATIVE_LV2
 
 #if DUSKSTUDIO_HAS_NATIVE_VST3
-void ChannelStripComponent::loadNativeVst3ForChannel (const juce::File& vst3File)
+void ChannelStripComponent::loadNativeVst3ForChannel (const juce::File& vst3File,
+                                                       const juce::String& pluginId)
 {
     auto& strip = engine.getChannelStrip (trackIndex);
 
@@ -2758,7 +2761,7 @@ void ChannelStripComponent::loadNativeVst3ForChannel (const juce::File& vst3File
     // loadNativeVst3 itself evicts the CLAP + LV2 + JUCE occupants.
     std::string err;
     engine.suspendProcessing();
-    const bool ok = strip.loadNativeVst3 (vst3File, err);
+    const bool ok = strip.loadNativeVst3 (vst3File, err, pluginId);
     if (ok)
         strip.insertMode.store (ChannelStrip::kInsertPlugin, std::memory_order_release);
     engine.resumeProcessing();

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -1796,10 +1796,13 @@ void ChannelStripComponent::openPluginPicker (bool useChooser)
                                             chStrip.unloadNativeVst3();
                                             self->engine.resumeProcessing();
                                             self->track.nativeClapPath = {};
+                                            self->track.nativeClapPluginId = {};
                                             self->track.nativeClapStateBase64 = {};
                                             self->track.nativeLv2Path = {};
+                                            self->track.nativeLv2PluginId = {};
                                             self->track.nativeLv2StateBase64 = {};
                                             self->track.nativeVst3Path = {};
+                                            self->track.nativeVst3PluginId = {};
                                             self->track.nativeVst3StateBase64 = {};
                                         }
 
@@ -1989,6 +1992,7 @@ void ChannelStripComponent::unloadPluginSlot()
         strip.insertMode.store (ChannelStrip::kInsertPlugin, std::memory_order_release);
         engine.resumeProcessing();
         track.nativeClapPath = {};
+        track.nativeClapPluginId = {};
         track.nativeClapStateBase64 = {};
         refreshPluginSlotButton();
         return;
@@ -2005,6 +2009,7 @@ void ChannelStripComponent::unloadPluginSlot()
             lv2Strip.insertMode.store (ChannelStrip::kInsertPlugin, std::memory_order_release);
             engine.resumeProcessing();
             track.nativeLv2Path = {};
+            track.nativeLv2PluginId = {};
             track.nativeLv2StateBase64 = {};
             refreshPluginSlotButton();
             return;
@@ -2022,6 +2027,7 @@ void ChannelStripComponent::unloadPluginSlot()
             vst3Strip.insertMode.store (ChannelStrip::kInsertPlugin, std::memory_order_release);
             engine.resumeProcessing();
             track.nativeVst3Path = {};
+            track.nativeVst3PluginId = {};
             track.nativeVst3StateBase64 = {};
             refreshPluginSlotButton();
             return;
@@ -2657,18 +2663,22 @@ void ChannelStripComponent::loadNativeClapForChannel (const juce::File& clapFile
         // The runtime slot is now empty — clear the persisted native-CLAP refs so a
         // save doesn't carry a stale path/state for a slot the user sees as empty.
         track.nativeClapPath = {};
+        track.nativeClapPluginId = {};
         track.nativeClapStateBase64 = {};
         return;
     }
 
-    track.nativeClapPath = clapFile.getFullPathName();
+    track.nativeClapPath     = clapFile.getFullPathName();
+    track.nativeClapPluginId = strip.getNativeClapSlot().getPluginId();
     // Fresh bundle: don't reuse the previous plugin's state blob. The next save
     // re-captures this plugin's real state.
     track.nativeClapStateBase64 = {};
     // The load evicted the other native hosts in this insert — drop their refs too.
     track.nativeLv2Path = {};
+    track.nativeLv2PluginId = {};
     track.nativeLv2StateBase64 = {};
     track.nativeVst3Path = {};
+    track.nativeVst3PluginId = {};
     track.nativeVst3StateBase64 = {};
     refreshPluginSlotButton();
     openPluginEditor();
@@ -2716,15 +2726,19 @@ void ChannelStripComponent::loadNativeLv2ForChannel (const juce::File& bundleDir
         showDuskAlert (*this, "Couldn't load LV2 plugin",
                        bundleDir.getFileNameWithoutExtension() + ":\n" + juce::String (err));
         track.nativeLv2Path = {};
+        track.nativeLv2PluginId = {};
         track.nativeLv2StateBase64 = {};
         return;
     }
 
-    track.nativeLv2Path = bundleDir.getFullPathName();
+    track.nativeLv2Path     = bundleDir.getFullPathName();
+    track.nativeLv2PluginId = strip.getNativeLv2Slot().getPluginId();
     track.nativeLv2StateBase64 = {};
     track.nativeClapPath = {};
+    track.nativeClapPluginId = {};
     track.nativeClapStateBase64 = {};
     track.nativeVst3Path = {};
+    track.nativeVst3PluginId = {};
     track.nativeVst3StateBase64 = {};
     refreshPluginSlotButton();
     openPluginEditor();
@@ -2772,15 +2786,19 @@ void ChannelStripComponent::loadNativeVst3ForChannel (const juce::File& vst3File
         showDuskAlert (*this, "Couldn't load VST3 plugin",
                        vst3File.getFileNameWithoutExtension() + ":\n" + juce::String (err));
         track.nativeVst3Path = {};
+        track.nativeVst3PluginId = {};
         track.nativeVst3StateBase64 = {};
         return;
     }
 
-    track.nativeVst3Path = vst3File.getFullPathName();
+    track.nativeVst3Path     = vst3File.getFullPathName();
+    track.nativeVst3PluginId = strip.getNativeVst3Slot().getPluginId();
     track.nativeVst3StateBase64 = {};
     track.nativeClapPath = {};
+    track.nativeClapPluginId = {};
     track.nativeClapStateBase64 = {};
     track.nativeLv2Path = {};
+    track.nativeLv2PluginId = {};
     track.nativeLv2StateBase64 = {};
     refreshPluginSlotButton();
     openPluginEditor();

--- a/src/ui/ChannelStripComponent.h
+++ b/src/ui/ChannelStripComponent.h
@@ -332,18 +332,18 @@ private:
     // (u-he hangs in gui->destroy); leaked on shutdown via dropPluginEditor. Linux-only.
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
     std::unique_ptr<class ClapPluginEditorComponent> clapEditor;
-    void loadNativeClapForChannel (const juce::File& clapFile);
+    void loadNativeClapForChannel (const juce::File& clapFile, const juce::String& pluginId = {});
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_LV2
     // Native LV2 insert editor (suil) — same kept-alive/showBorrowed lifecycle as
     // clapEditor above.
     std::unique_ptr<class Lv2PluginEditorComponent> lv2Editor;
-    void loadNativeLv2ForChannel (const juce::File& bundleDir);
+    void loadNativeLv2ForChannel (const juce::File& bundleDir, const juce::String& pluginId = {});
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_VST3
     // Native VST3 insert editor (IPlugView) — same lifecycle as clapEditor above.
     std::unique_ptr<class Vst3PluginEditorComponent> vst3Editor;
-    void loadNativeVst3ForChannel (const juce::File& vst3File);
+    void loadNativeVst3ForChannel (const juce::File& vst3File, const juce::String& pluginId = {});
 #endif
 
    #if JUCE_LINUX && DUSKSTUDIO_HAS_OOP_PLUGINS

--- a/src/ui/PluginPickerHelpers.cpp
+++ b/src/ui/PluginPickerHelpers.cpp
@@ -5,6 +5,7 @@
 #include "PluginPickerPanel.h"
 #include "../engine/PluginManager.h"
 #include "../engine/PluginSlot.h"
+#include "../engine/hosting/NativePluginId.h"
 #if DUSKSTUDIO_HAS_MULTISAMPLE
  #include "../engine/multisample/AriaBank.h"
 #endif
@@ -391,9 +392,9 @@ void openPickerMenu (PluginSlot& slot,
                       juce::Point<int> /*screenPosition*/,
                       std::function<void()> onPickHardwareInsert,
                       bool suppressSecondaryButtons,
-                      std::function<void (const juce::File&)> onPickNativeClap,
-                      std::function<void (const juce::File&)> onPickNativeLv2,
-                      std::function<void (const juce::File&)> onPickNativeVst3)
+                      std::function<void (const juce::File&, const juce::String&)> onPickNativeClap,
+                      std::function<void (const juce::File&, const juce::String&)> onPickNativeLv2,
+                      std::function<void (const juce::File&, const juce::String&)> onPickNativeVst3)
 {
     auto& manager = slot.getManagerForUi();
 
@@ -517,19 +518,19 @@ void openPickerMenu (PluginSlot& slot,
         // so DON'T also fire the generic onChange here — on a failed load it would
         // refresh state as if the slot loaded (the JUCE path only refreshes on a
         // successful async load).
-        if (desc.pluginFormatName == "CLAP")
+        if (desc.pluginFormatName == "CLAP"
+            || desc.pluginFormatName == "LV2-Native"
+            || desc.pluginFormatName == "VST3-Native")
         {
-            if (onPickNativeClap) onPickNativeClap (juce::File (desc.fileOrIdentifier));
-            return;
-        }
-        if (desc.pluginFormatName == "LV2-Native")
-        {
-            if (onPickNativeLv2) onPickNativeLv2 (juce::File (desc.fileOrIdentifier));
-            return;
-        }
-        if (desc.pluginFormatName == "VST3-Native")
-        {
-            if (onPickNativeVst3) onPickNativeVst3 (juce::File (desc.fileOrIdentifier));
+            // fileOrIdentifier carries "bundle\npluginId" so a row picks ITS
+            // plugin out of a multi-plugin bundle, not the bundle's first.
+            const auto ident = hosting::splitNativeIdentifier (desc.fileOrIdentifier);
+            if (desc.pluginFormatName == "CLAP")
+            { if (onPickNativeClap) onPickNativeClap (juce::File (ident.bundlePath), ident.pluginId); }
+            else if (desc.pluginFormatName == "LV2-Native")
+            { if (onPickNativeLv2)  onPickNativeLv2  (juce::File (ident.bundlePath), ident.pluginId); }
+            else
+            { if (onPickNativeVst3) onPickNativeVst3 (juce::File (ident.bundlePath), ident.pluginId); }
             return;
         }
 
@@ -715,9 +716,9 @@ void openInsertChooser (PluginSlot& slot,
                          std::function<void()> onChange,
                          PluginKind kind,
                          std::function<void()> onPickHardwareInsert,
-                         std::function<void (const juce::File&)> onPickNativeClap,
-                         std::function<void (const juce::File&)> onPickNativeLv2,
-                         std::function<void (const juce::File&)> onPickNativeVst3)
+                         std::function<void (const juce::File&, const juce::String&)> onPickNativeClap,
+                         std::function<void (const juce::File&, const juce::String&)> onPickNativeLv2,
+                         std::function<void (const juce::File&, const juce::String&)> onPickNativeVst3)
 {
     auto* parent = target.getTopLevelComponent();
     if (parent == nullptr) parent = &target;

--- a/src/ui/PluginPickerHelpers.h
+++ b/src/ui/PluginPickerHelpers.h
@@ -66,9 +66,9 @@ void openPickerMenu (PluginSlot& slot,
                       juce::Point<int> screenPosition = { -1, -1 },
                       std::function<void()> onPickHardwareInsert = {},
                       bool suppressSecondaryButtons = false,
-                      std::function<void (const juce::File&)> onPickNativeClap = {},
-                      std::function<void (const juce::File&)> onPickNativeLv2 = {},
-                      std::function<void (const juce::File&)> onPickNativeVst3 = {});
+                      std::function<void (const juce::File&, const juce::String&)> onPickNativeClap = {},
+                      std::function<void (const juce::File&, const juce::String&)> onPickNativeLv2 = {},
+                      std::function<void (const juce::File&, const juce::String&)> onPickNativeVst3 = {});
 
 // Two-step insert flow. Step 1 shows a small modal with three big
 // buttons — Hardware Insert / Soundfont / Plugin — letting the user
@@ -87,9 +87,9 @@ void openInsertChooser (PluginSlot& slot,
                          std::function<void()> onChange,
                          PluginKind kind,
                          std::function<void()> onPickHardwareInsert = {},
-                         std::function<void (const juce::File&)> onPickNativeClap = {},
-                         std::function<void (const juce::File&)> onPickNativeLv2 = {},
-                         std::function<void (const juce::File&)> onPickNativeVst3 = {});
+                         std::function<void (const juce::File&, const juce::String&)> onPickNativeClap = {},
+                         std::function<void (const juce::File&, const juce::String&)> onPickNativeLv2 = {},
+                         std::function<void (const juce::File&, const juce::String&)> onPickNativeVst3 = {});
 
 // Synchronous scan. Blocks the message thread during scanInstalledPlugins().
 // Shows a Dusk in-window completion alert in `parent` (top-level Component)

--- a/src/ui/TransportBar.cpp
+++ b/src/ui/TransportBar.cpp
@@ -830,25 +830,10 @@ void TransportBar::timerCallback()
                 && b.targetIndex >= 0
                 && b.targetIndex < Session::kNumTracks)
             {
-                // A native host owns the insert when loaded — read ITS
-                // last-touched tracker (same precedence as the audio chain).
-                auto& strip = engine.getChannelStrip (b.targetIndex);
-#if DUSKSTUDIO_HAS_NATIVE_CLAP
-                if (strip.isNativeClapLoaded())
-                    b.paramIndex = strip.getNativeClapSlot().lastTouchedParamIndex();
-                else
-#endif
-#if DUSKSTUDIO_HAS_NATIVE_LV2
-                if (strip.isNativeLv2Loaded())
-                    b.paramIndex = strip.getNativeLv2Slot().lastTouchedParamIndex();
-                else
-#endif
-#if DUSKSTUDIO_HAS_NATIVE_VST3
-                if (strip.isNativeVst3Loaded())
-                    b.paramIndex = strip.getNativeVst3Slot().lastTouchedParamIndex();
-                else
-#endif
-                    b.paramIndex = strip.getPluginSlot().getLastTouchedParamIndex();
+                // Whichever host owns the insert resolves the last touch
+                // (precedence lives on the strip, next to the audio chain's).
+                b.paramIndex = engine.getChannelStrip (b.targetIndex)
+                                     .insertLastTouchedParamIndex();
                 if (b.paramIndex < 0)
                 {
                     // No parameter touched since the slot loaded -
@@ -864,24 +849,8 @@ void TransportBar::timerCallback()
                 && b.targetIndex >= 0
                 && b.targetIndex < Session::kNumAuxLanes)
             {
-                // Same shape as the track resolve above, against the lane's slot.
-                auto& lane = engine.getAuxLaneStrip (b.targetIndex);
-#if DUSKSTUDIO_HAS_NATIVE_CLAP
-                if (lane.isNativeClapLoaded (0))
-                    b.paramIndex = lane.getNativeClapSlot (0).lastTouchedParamIndex();
-                else
-#endif
-#if DUSKSTUDIO_HAS_NATIVE_LV2
-                if (lane.isNativeLv2Loaded (0))
-                    b.paramIndex = lane.getNativeLv2Slot (0).lastTouchedParamIndex();
-                else
-#endif
-#if DUSKSTUDIO_HAS_NATIVE_VST3
-                if (lane.isNativeVst3Loaded (0))
-                    b.paramIndex = lane.getNativeVst3Slot (0).lastTouchedParamIndex();
-                else
-#endif
-                    b.paramIndex = lane.getPluginSlot (0).getLastTouchedParamIndex();
+                b.paramIndex = engine.getAuxLaneStrip (b.targetIndex)
+                                     .insertLastTouchedParamIndex (0);
                 if (b.paramIndex < 0)
                 {
                     s.midiLearnCapture.store (0, std::memory_order_relaxed);

--- a/src/ui/TransportBar.cpp
+++ b/src/ui/TransportBar.cpp
@@ -860,6 +860,35 @@ void TransportBar::timerCallback()
                     return;
                 }
             }
+            if (b.target == MidiBindingTarget::AuxPluginParam
+                && b.targetIndex >= 0
+                && b.targetIndex < Session::kNumAuxLanes)
+            {
+                // Same shape as the track resolve above, against the lane's slot.
+                auto& lane = engine.getAuxLaneStrip (b.targetIndex);
+#if DUSKSTUDIO_HAS_NATIVE_CLAP
+                if (lane.isNativeClapLoaded (0))
+                    b.paramIndex = lane.getNativeClapSlot (0).lastTouchedParamIndex();
+                else
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+                if (lane.isNativeLv2Loaded (0))
+                    b.paramIndex = lane.getNativeLv2Slot (0).lastTouchedParamIndex();
+                else
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_VST3
+                if (lane.isNativeVst3Loaded (0))
+                    b.paramIndex = lane.getNativeVst3Slot (0).lastTouchedParamIndex();
+                else
+#endif
+                    b.paramIndex = lane.getPluginSlot (0).getLastTouchedParamIndex();
+                if (b.paramIndex < 0)
+                {
+                    s.midiLearnCapture.store (0, std::memory_order_relaxed);
+                    s.midiLearnPending.store (-1, std::memory_order_relaxed);
+                    return;
+                }
+            }
             // Drop any existing binding from the same source before
             // appending the new one - prevents stacking duplicate
             // mappings if a user re-learns the same fader.

--- a/tests/clap_native_slot.cpp
+++ b/tests/clap_native_slot.cpp
@@ -32,6 +32,22 @@ TEST_CASE ("NativeClapSlot loads, processes, and unloads cleanly", "[clap][slot]
     std::vector<float> inL ((size_t) kBlock), inR ((size_t) kBlock),
                        outL ((size_t) kBlock), outR ((size_t) kBlock);
 
+
+    SECTION ("explicit plugin id: round-trips, bogus id refuses to load")
+    {
+        const juce::String pickedId = slot.getPluginId();
+        REQUIRE (pickedId.isNotEmpty());
+
+        slot.unload();
+        REQUIRE (slot.load (juce::File (juce::String (path)), 48000.0, kBlock, err, pickedId));
+        REQUIRE (slot.getPluginId() == pickedId);
+
+        slot.unload();
+        REQUIRE_FALSE (slot.load (juce::File (juce::String (path)), 48000.0, kBlock, err,
+                                  "urn:duskstudio:no-such-plugin"));
+        REQUIRE_FALSE (slot.isLoaded());
+    }
+
     SECTION ("MIDI-binding writes reach the parameter surface")
     {
         // queueParamBinding is the audio-thread half of a binding apply;

--- a/tests/lv2_native_slot.cpp
+++ b/tests/lv2_native_slot.cpp
@@ -110,6 +110,39 @@ TEST_CASE ("NativeLv2Slot loads, processes, and unloads cleanly", "[lv2][slot]")
         REQUIRE_FALSE (slot.isLoaded());
     }
 
+    SECTION ("patch-property writes reach the plugin, not just the shadow")
+    {
+        // The shadow read-back in getParamValue can't prove the patch:Set atom
+        // was injected into the control atom port — the plugin's own saved
+        // state can: it changes only if the DSP side heard the event.
+        auto* inst = slot.getInstance();
+        int patchIdx = -1;
+        for (int i = 0; i < inst->paramCount(); ++i)
+        {
+            const auto* p = inst->paramInfo (i);
+            if (p->isPatchProperty && ! p->stepped && p->maxValue > p->minValue)
+            { patchIdx = i; break; }
+        }
+        if (patchIdx < 0)
+        {
+            SUCCEED ("plugin exposes no continuous patch properties — skipping");
+            return;
+        }
+        const auto* target = inst->paramInfo (patchIdx);
+
+        std::vector<uint8_t> before, after;
+        REQUIRE (slot.saveState (before));
+
+        inst->setParamValue (target->id, (double) target->maxValue);
+        std::fill (L.begin(), L.end(), 0.0f);
+        std::fill (R.begin(), R.end(), 0.0f);
+        for (int b = 0; b < 4; ++b)
+            slot.processStereo (L.data(), R.data(), L.data(), R.data(), kBlock);
+
+        REQUIRE (slot.saveState (after));
+        REQUIRE (before != after);
+    }
+
     SECTION ("MIDI-binding writes reach the parameter surface")
     {
         // queueParamBinding is the audio-thread half of a binding apply;
@@ -126,9 +159,7 @@ TEST_CASE ("NativeLv2Slot loads, processes, and unloads cleanly", "[lv2][slot]")
         }
         if (targetIdx < 0)
         {
-            // JUCE-wrapped LV2s carry their real parameters as atom patch
-            // messages, not control ports — nothing to bind through this surface.
-            SUCCEED ("plugin exposes no continuous control-port parameters — skipping");
+            SUCCEED ("plugin exposes no continuous parameters — skipping");
             return;
         }
         const auto* target = slot.paramInfo (targetIdx);

--- a/tests/lv2_native_slot.cpp
+++ b/tests/lv2_native_slot.cpp
@@ -94,6 +94,22 @@ TEST_CASE ("NativeLv2Slot loads, processes, and unloads cleanly", "[lv2][slot]")
         REQUIRE (driveTone (slot, L, R, kBlock, 16) > 1.0e-4f);
     }
 
+
+    SECTION ("explicit plugin id: round-trips, bogus id refuses to load")
+    {
+        const juce::String pickedId = slot.getPluginId();
+        REQUIRE (pickedId.isNotEmpty());
+
+        slot.unload();
+        REQUIRE (slot.load (juce::File (juce::String (path)), 48000.0, kBlock, err, pickedId));
+        REQUIRE (slot.getPluginId() == pickedId);
+
+        slot.unload();
+        REQUIRE_FALSE (slot.load (juce::File (juce::String (path)), 48000.0, kBlock, err,
+                                  "urn:duskstudio:no-such-plugin"));
+        REQUIRE_FALSE (slot.isLoaded());
+    }
+
     SECTION ("MIDI-binding writes reach the parameter surface")
     {
         // queueParamBinding is the audio-thread half of a binding apply;

--- a/tests/session_round_trip.cpp
+++ b/tests/session_round_trip.cpp
@@ -136,12 +136,14 @@ TEST_CASE ("SessionSerializer round-trips an aux native-CLAP slot", "[session][s
     Session a;
     auto& lane = a.auxLane (1);
     lane.nativeClapPath[0]        = "/home/user/.clap/DuskVerb.clap";
+    lane.nativeClapPluginId[0]    = "com.dusk.duskverb";
     lane.nativeClapStateBase64[0] = "Q0xBUFNUQVRFYmxvYg==";
     REQUIRE (SessionSerializer::save (a, target));
 
     Session b;
     REQUIRE (SessionSerializer::load (b, target));
     REQUIRE (b.auxLane (1).nativeClapPath[0]        == "/home/user/.clap/DuskVerb.clap");
+    REQUIRE (b.auxLane (1).nativeClapPluginId[0]    == "com.dusk.duskverb");
     REQUIRE (b.auxLane (1).nativeClapStateBase64[0] == "Q0xBUFNUQVRFYmxvYg==");
 
     // A lane with no native CLAP stays empty (keys omitted on write).
@@ -162,6 +164,7 @@ TEST_CASE ("SessionSerializer round-trips native-LV2 slots", "[session][serializ
 
     Session a;
     a.track (2).nativeLv2Path         = "/home/user/.lv2/SilkVerb.lv2";
+    a.track (2).nativeLv2PluginId     = "https://dusk.audio/silkverb";
     a.track (2).nativeLv2StateBase64  = "TFYyU1RBVEVibG9i";
     auto& lane = a.auxLane (1);
     lane.nativeLv2Path[0]        = "/usr/lib64/lv2/a-comp.lv2";
@@ -171,6 +174,7 @@ TEST_CASE ("SessionSerializer round-trips native-LV2 slots", "[session][serializ
     Session b;
     REQUIRE (SessionSerializer::load (b, target));
     REQUIRE (b.track (2).nativeLv2Path        == "/home/user/.lv2/SilkVerb.lv2");
+    REQUIRE (b.track (2).nativeLv2PluginId    == "https://dusk.audio/silkverb");
     REQUIRE (b.track (2).nativeLv2StateBase64 == "TFYyU1RBVEVibG9i");
     REQUIRE (b.auxLane (1).nativeLv2Path[0]        == "/usr/lib64/lv2/a-comp.lv2");
     REQUIRE (b.auxLane (1).nativeLv2StateBase64[0] == "TFYyU1RBVEVibG9i");
@@ -193,6 +197,7 @@ TEST_CASE ("SessionSerializer round-trips native-VST3 slots", "[session][seriali
 
     Session a;
     a.track (2).nativeVst3Path        = "/home/user/.vst3/SilkVerb.vst3";
+    a.track (2).nativeVst3PluginId    = "ABCDEF0123456789ABCDEF0123456789";
     a.track (2).nativeVst3StateBase64 = "VlNUM1NUQVRFYmxvYg==";
     auto& lane = a.auxLane (1);
     lane.nativeVst3Path[0]        = "/usr/lib/vst3/DuskVerb.vst3";
@@ -202,6 +207,7 @@ TEST_CASE ("SessionSerializer round-trips native-VST3 slots", "[session][seriali
     Session b;
     REQUIRE (SessionSerializer::load (b, target));
     REQUIRE (b.track (2).nativeVst3Path        == "/home/user/.vst3/SilkVerb.vst3");
+    REQUIRE (b.track (2).nativeVst3PluginId    == "ABCDEF0123456789ABCDEF0123456789");
     REQUIRE (b.track (2).nativeVst3StateBase64 == "VlNUM1NUQVRFYmxvYg==");
     REQUIRE (b.auxLane (1).nativeVst3Path[0]        == "/usr/lib/vst3/DuskVerb.vst3");
     REQUIRE (b.auxLane (1).nativeVst3StateBase64[0] == "VlNUM1NUQVRFYmxvYg==");

--- a/tests/vst3_instance_process.cpp
+++ b/tests/vst3_instance_process.cpp
@@ -8,7 +8,10 @@
 
 #include "engine/hosting/InsertAdapter.h"
 #include "engine/vst3/Vst3Bundle.h"
+#include "engine/vst3/Vst3HostContext.h"
 #include "engine/vst3/Vst3Instance.h"
+
+#include <pluginterfaces/vst/ivsteditcontroller.h>
 
 #include <algorithm>
 #include <cmath>
@@ -158,6 +161,27 @@ TEST_CASE ("Vst3Instance instantiates + processes a VST3 effect via InsertAdapte
         std::string text;
         if (inst.paramValueToText (target->id, 0.25, text))
             REQUIRE_FALSE (text.empty());
+    }
+
+    SECTION ("restartComponent: latency flag consumes once, param-info refreshes")
+    {
+        // Drive the handler exactly as a plugin would.
+        auto* handler = static_cast<Steinberg::Vst::IComponentHandler*> (
+            inst.getHost().componentHandler());
+        REQUIRE (handler != nullptr);
+
+        REQUIRE_FALSE (inst.consumeLatencyChanged());
+        handler->restartComponent (Steinberg::Vst::RestartFlags::kLatencyChanged);
+        REQUIRE (inst.consumeLatencyChanged());
+        REQUIRE_FALSE (inst.consumeLatencyChanged());
+
+        const int before = inst.paramCount();
+        REQUIRE (before > 0);
+        handler->restartComponent (Steinberg::Vst::RestartFlags::kParamTitlesChanged);
+        inst.refreshParamInfoIfChanged();
+        REQUIRE (inst.paramCount() == before);   // rebuilt from the same controller
+        REQUIRE (inst.paramInfo (0) != nullptr);
+        REQUIRE_FALSE (inst.paramInfo (0)->name.empty());
     }
 
     SECTION ("reactivate at a new rate keeps processing")

--- a/tests/vst3_native_slot.cpp
+++ b/tests/vst3_native_slot.cpp
@@ -116,6 +116,22 @@ TEST_CASE ("NativeVst3Slot loads, processes, and unloads cleanly", "[vst3][slot]
         REQUIRE (driveTone (slot, L, R, kBlock, 16) > 1.0e-4f);
     }
 
+
+    SECTION ("explicit plugin id: round-trips, bogus id refuses to load")
+    {
+        const juce::String pickedId = slot.getPluginId();
+        REQUIRE (pickedId.isNotEmpty());
+
+        slot.unload();
+        REQUIRE (slot.load (juce::File (juce::String (path)), 48000.0, kBlock, err, pickedId));
+        REQUIRE (slot.getPluginId() == pickedId);
+
+        slot.unload();
+        REQUIRE_FALSE (slot.load (juce::File (juce::String (path)), 48000.0, kBlock, err,
+                                  "urn:duskstudio:no-such-plugin"));
+        REQUIRE_FALSE (slot.isLoaded());
+    }
+
     SECTION ("MIDI-binding writes reach the parameter surface")
     {
         // queueParamBinding is the audio-thread half of a binding apply;


### PR DESCRIPTION
## Summary

Follow-up to #23. Three themes:

### Multi-plugin bundle selection (correctness)

The picker listed one row per plugin class, but native rows routed only the bundle path — clicking any row loaded the bundle's **first** effect, and sessions restored the same. Now:

- `NativeInsertSlot::load` takes a plugin id; Traits validate it against what the bundle advertises — a renamed/removed class **fails the load** instead of silently instantiating a different plugin. The slot records the resolved id even when it defaulted.
- Picker rows carry `bundle\npluginId` in `fileOrIdentifier` (a newline can't appear in either half); routing, the channel/aux loaders, and the strip API pass it down.
- `native_*_plugin` persists next to path/state on tracks and aux slots. Emitted only alongside a path, so existing sessions are byte-compatible; a missing key restores the default pick — exactly what those sessions loaded. Verified end-to-end under Xvfb (real class UIDs in session.json, relaunch restores by id).

### Parameter completeness

- **VST3 `restartComponent`**: `kLatencyChanged` flags the instance and the engine's drain timer cycles flagged slots under one process-gate fence, then recomputes PDC (VST3 re-reads latency only across a setActive cycle). `kParamTitlesChanged` re-snapshots the parameter surface in place.
- **LV2 patch-property parameters**: `patch:writable` float properties join the binding surface (marker-bit ids, manifest name/range/steppedness). Writes forge a `patch:Set` atom into a ring the audio thread injects into the `lv2:control`-designated atom input. The suil editor's `ui:eventTransfer` writes — previously dropped, reaching the DSP only through the JUCE wrapper's instance-access shortcut — now forward onto the same port and stamp MIDI Learn's last-touched. Proven by a state-diff live test: a patch write changes the plugin's own saved state, which only happens if the DSP heard the atom. This makes JUCE-built LV2s fully bindable; the manual caveat is gone.
- **Aux-slot plugin-param bindings**: new `AuxPluginParam` target with learn on the slot's name button; resolve/apply mirror track inserts. Also fixes the engine drain timer never draining aux slots' binding rings.

### Scan sandboxing (robustness)

Native CLAP/VST3 discovery dlopen'd every module in-process — one broken .so crashed the app mid-scan, while JUCE-format scanning has been crash-isolated for ages. The scan child grows `--scan-native <clap|vst3> <bundle>`: one bundle per child, rows printed between the existing scan sentinels, parent reuses the proven spawn/timeout/payload machinery. Crash/hang skips just that bundle; an unspawnable child falls back to in-process enumeration; row building is shared so both sides emit identical descriptions. LV2 stays in-process by design (manifest-only discovery never executes plugin code).

## Testing

- 307/307 unit suite; new coverage: explicit-id load round-trip + bogus-id refusal (all three formats, live), session plugin-id round-trip, LV2 patch-write state-diff proof
- Live: 5 LV2 bundles (JUCE-built now bind through patch properties; Ardour a-* through control ports), CLAP + VST3 suites green
- Sandbox child verified against real bundles (encoded rows intact through the XML payload) and a garbage bundle (clean empty payload, no crash)
- Xvfb: headless selftest green; SilkVerb editor embed after the writePort rewire; in-app save/reload with explicit plugin ids

Caught during validation: a lilv node use-after-free in the patch-property enumeration (heap corruption in the SilkVerb test) — fixed before it left the branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Native plugin pickers now preserve and reopen the same plugin inside a bundle.
  * MIDI Learn now supports aux lane plugin parameters.
  * LV2 patch-property parameters are now exposed and writable like standard parameters.

* **Bug Fixes**
  * Session restore now keeps native plugin identity for CLAP, LV2, and VST3 slots.
  * Native plugin loading is more reliable when a specific plugin can’t be found.
  * VST3 latency changes are now handled more smoothly during playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->