### PR TITLE
Native instruments across CLAP, LV2, VST3 — MIDI delivery, CC bridge, track-mode flow

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1374,9 +1374,9 @@ A few rules:
 
 Dusk Studio scans and hosts:
 
-- **VST3** on Linux, macOS, and Windows. On Linux, effects load through Dusk Studio's own native VST3 host (rows tagged **VST3-Native**); instruments — and VST3 everywhere else — load through the standard host.
+- **VST3** on Linux, macOS, and Windows. On Linux, effects AND instruments load through Dusk Studio's own native VST3 host (rows tagged **VST3-Native**); everywhere else VST3 loads through the standard host.
 - **LV2** on Linux. Effects load through Dusk Studio's own native LV2 host (rows tagged **LV2-Native**); LV2 instruments load through the standard host.
-- **CLAP** on Linux, through the native host. Effects only.
+- **CLAP** on Linux, through the native host — effects and instruments.
 - **AU** on macOS only.
 - **Native multi-sampler** (`.sfz` and `.sf2` files, both via the built-in sfizz engine — SF2 is converted to SFZ on load) on all platforms.
 

--- a/src/dsp/ChannelStrip.cpp
+++ b/src/dsp/ChannelStrip.cpp
@@ -1030,7 +1030,23 @@ void ChannelStrip::processAndAccumulate (const float* inL,
             // gate doesn't apply (no dry to blend with, no "empty" valid
             // for a MIDI track that has an instrument loaded). We still
             // tick the smoother to keep its state in sync in case the
-            // track later flips to audio mode.
+            // track later flips to audio mode. A native host owns the slot
+            // when loaded — same precedence as the effect-insert path.
+#if DUSKSTUDIO_HAS_NATIVE_CLAP
+            if (nativeClapSlot.isLoaded())
+                nativeClapSlot.processStereo (L, R, L, R, numSamples, &trackMidi);
+            else
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+            if (nativeLv2Slot.isLoaded())
+                nativeLv2Slot.processStereo (L, R, L, R, numSamples, &trackMidi);
+            else
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_VST3
+            if (nativeVst3Slot.isLoaded())
+                nativeVst3Slot.processStereo (L, R, L, R, numSamples, &trackMidi);
+            else
+#endif
             pluginSlot.processStereoBlock (L, R, numSamples, trackMidi);
             for (int i = 0; i < numSamples; ++i)
                 activeInsertGain.getNextValue();

--- a/src/dsp/ChannelStrip.h
+++ b/src/dsp/ChannelStrip.h
@@ -123,6 +123,22 @@ public:
     bool nativeVst3ReloadFailed() const noexcept { return false; }
 #endif
 
+    // Whether a native host owns the insert with an instrument loaded (no main
+    // audio input — MIDI drives it). Gates the track-mode/unload interplay.
+    bool insertIsNativeInstrument() const noexcept
+    {
+#if DUSKSTUDIO_HAS_NATIVE_CLAP
+        if (isNativeClapLoaded()) return nativeClapSlot.isLoadedInstrument();
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+        if (isNativeLv2Loaded()) return nativeLv2Slot.isLoadedInstrument();
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_VST3
+        if (isNativeVst3Loaded()) return nativeVst3Slot.isLoadedInstrument();
+#endif
+        return false;
+    }
+
     // MIDI Learn: last-touched parameter of whichever host owns the insert
     // (same precedence as the audio chain); -1 when empty or untouched.
     int insertLastTouchedParamIndex() const noexcept

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -120,6 +120,8 @@ public:
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_LV2
             strip.getNativeLv2Slot().drainQueuedParamBindings();
+            if (auto* inst = strip.getNativeLv2Slot().getInstance())
+                inst->drainPatchFeedback();
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_VST3
             strip.getNativeVst3Slot().drainQueuedParamBindings();
@@ -135,6 +137,8 @@ public:
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_LV2
                 lane.getNativeLv2Slot (s).drainQueuedParamBindings();
+                if (auto* inst = lane.getNativeLv2Slot (s).getInstance())
+                    inst->drainPatchFeedback();
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_VST3
                 lane.getNativeVst3Slot (s).drainQueuedParamBindings();

--- a/src/engine/PluginManager.cpp
+++ b/src/engine/PluginManager.cpp
@@ -520,6 +520,16 @@ juce::Array<juce::PluginDescription> PluginManager::getClapEffectDescriptions() 
     return effects;
 }
 
+juce::Array<juce::PluginDescription> PluginManager::getClapInstrumentDescriptions() const
+{
+    const juce::ScopedLock sl (nativeDescriptionsLock);
+    juce::Array<juce::PluginDescription> instruments;
+    for (const auto& d : clapDescriptions)
+        if (d.isInstrument)
+            instruments.add (d);
+    return instruments;
+}
+
 void PluginManager::scanLv2Plugins()
 {
 #if DUSKSTUDIO_HAS_NATIVE_LV2
@@ -559,9 +569,6 @@ void PluginManager::scanVst3NativePlugins()
     for (const auto& file : vst3::Vst3Scanner::findVst3Bundles (vst3::Vst3Scanner::defaultSearchPaths()))
         if (! scanNativeBundleSandboxed ("vst3", file, fresh))
             nativescan::appendVst3Rows (file, fresh);   // no sandbox available — in-process
-    // Only audio effects for now — the native VST3 host is an insert host;
-    // instruments stay with the JUCE VST3 format.
-    fresh.removeIf ([] (const juce::PluginDescription& d) { return d.isInstrument; });
     {
         const juce::ScopedLock sl (nativeDescriptionsLock);
         vst3NativeDescriptions.swapWith (fresh);
@@ -573,7 +580,21 @@ void PluginManager::scanVst3NativePlugins()
 juce::Array<juce::PluginDescription> PluginManager::getVst3NativeEffectDescriptions() const
 {
     const juce::ScopedLock sl (nativeDescriptionsLock);
-    return vst3NativeDescriptions;   // scan already filtered to audio effects
+    juce::Array<juce::PluginDescription> effects;
+    for (const auto& d : vst3NativeDescriptions)
+        if (! d.isInstrument)
+            effects.add (d);
+    return effects;
+}
+
+juce::Array<juce::PluginDescription> PluginManager::getVst3NativeInstrumentDescriptions() const
+{
+    const juce::ScopedLock sl (nativeDescriptionsLock);
+    juce::Array<juce::PluginDescription> instruments;
+    for (const auto& d : vst3NativeDescriptions)
+        if (d.isInstrument)
+            instruments.add (d);
+    return instruments;
 }
 
 juce::Array<juce::PluginDescription> PluginManager::getInstrumentDescriptions() const

--- a/src/engine/PluginManager.h
+++ b/src/engine/PluginManager.h
@@ -52,7 +52,7 @@ public:
 
     // Native-VST3 plugins, scanned separately from JUCE's VST3 format (which stays
     // as the fallback host). pluginFormatName "VST3-Native", fileOrIdentifier = the
-    // .vst3 bundle path. Audio effects only; each module is dlopen'd (like CLAP).
+    // .vst3 bundle path. Effects and instruments; each module is dlopen'd (like CLAP).
     juce::Array<juce::PluginDescription> getVst3NativeEffectDescriptions() const;
     juce::Array<juce::PluginDescription> getVst3NativeInstrumentDescriptions() const;
     void scanVst3NativePlugins();

--- a/src/engine/PluginManager.h
+++ b/src/engine/PluginManager.h
@@ -39,6 +39,7 @@ public:
     // .clap bundle path. The unified picker merges these in for surfaces that have a
     // native CLAP host (aux lanes); routing keys on pluginFormatName == "CLAP".
     juce::Array<juce::PluginDescription> getClapEffectDescriptions() const;
+    juce::Array<juce::PluginDescription> getClapInstrumentDescriptions() const;
     // Rescan CLAP search paths (slow — loads each bundle). Folded into the Scan button
     // via scanInstalledPlugins; result cached in memory for the session.
     void scanClapPlugins();
@@ -53,6 +54,7 @@ public:
     // as the fallback host). pluginFormatName "VST3-Native", fileOrIdentifier = the
     // .vst3 bundle path. Audio effects only; each module is dlopen'd (like CLAP).
     juce::Array<juce::PluginDescription> getVst3NativeEffectDescriptions() const;
+    juce::Array<juce::PluginDescription> getVst3NativeInstrumentDescriptions() const;
     void scanVst3NativePlugins();
 
     // Synchronous instantiation. May take 100s of ms. Returns nullptr on

--- a/src/engine/clap/ClapInstance.cpp
+++ b/src/engine/clap/ClapInstance.cpp
@@ -85,13 +85,33 @@ bool ClapInstance::create (const ClapBundle& bundle, const std::string& pluginId
         if (ap->count (plugin, false) > 0 && ap->get (plugin, 0, false, &info)) outCh = (int) info.channel_count;
     }
 
-    // Reject anything but stereo-in / stereo-out for now. The generalized
-    // processBlock + InsertAdapter path handles other layouts, but the DSP call
-    // sites still assume stereo, so gate non-stereo plugins out here until they migrate.
-    if (inCh != 2 || outCh != 2)
+    // Note input (instruments / MIDI-driven effects) via CLAP_EXT_NOTE_PORTS.
+    // Prefer the plugin's CLAP note dialect for note on/off; raw MIDI covers
+    // everything else when the port accepts it.
+    noteInPort      = false;
+    noteDialectClap = false;
+    noteDialectMidi = false;
+    if (const auto* np = static_cast<const clap_plugin_note_ports_t*> (
+            plugin->get_extension (plugin, CLAP_EXT_NOTE_PORTS));
+        np != nullptr && np->count != nullptr && np->get != nullptr
+        && np->count (plugin, true) > 0)
     {
-        errorOut = "plugin is not stereo-in/stereo-out (got "
-                 + std::to_string (inCh) + " in / " + std::to_string (outCh) + " out)";
+        clap_note_port_info_t info {};
+        if (np->get (plugin, 0, true, &info))
+        {
+            noteInPort      = true;
+            noteDialectClap = (info.supported_dialects & CLAP_NOTE_DIALECT_CLAP) != 0;
+            noteDialectMidi = (info.supported_dialects & CLAP_NOTE_DIALECT_MIDI) != 0;
+        }
+    }
+
+    // The InsertAdapter folds any layout onto the stereo insert; the only hard
+    // requirements are an audio output and, for input-less plugins, a note port
+    // to drive them (a plugin with neither is unhostable in a mixer slot).
+    if (outCh < 1 || (inCh == 0 && ! noteInPort))
+    {
+        errorOut = inCh == 0 ? "plugin has no audio input and no note input"
+                             : "plugin has no audio output";
         plugin->destroy (plugin);
         plugin = nullptr;
         owningBundle = nullptr;
@@ -102,17 +122,29 @@ bool ClapInstance::create (const ClapBundle& bundle, const std::string& pluginId
     // reads it to fold the stereo insert onto the plugin's real channel counts).
     layout = {};
     {
-        hosting::BusInfo in;
-        in.kind = hosting::BusInfo::Kind::Audio; in.dir = hosting::BusInfo::Direction::Input;
-        in.role = hosting::BusInfo::Role::Main;  in.channelCount = inCh;  in.active = true; in.name = "Input";
-        layout.inputs.push_back (in);
-        layout.mainInIndex = 0;
+        if (inCh > 0)
+        {
+            hosting::BusInfo in;
+            in.kind = hosting::BusInfo::Kind::Audio; in.dir = hosting::BusInfo::Direction::Input;
+            in.role = hosting::BusInfo::Role::Main;  in.channelCount = inCh;  in.active = true; in.name = "Input";
+            layout.inputs.push_back (in);
+            layout.mainInIndex = 0;
+        }
+        if (noteInPort)
+        {
+            hosting::BusInfo ev;
+            ev.kind = hosting::BusInfo::Kind::Event; ev.dir = hosting::BusInfo::Direction::Input;
+            ev.role = hosting::BusInfo::Role::Main;  ev.carriesMidi = true; ev.active = true; ev.name = "Notes";
+            layout.eventInIndex = (int) layout.inputs.size();
+            layout.inputs.push_back (ev);
+        }
 
         hosting::BusInfo out;
         out.kind = hosting::BusInfo::Kind::Audio; out.dir = hosting::BusInfo::Direction::Output;
         out.role = hosting::BusInfo::Role::Main;  out.channelCount = outCh; out.active = true; out.name = "Output";
         layout.outputs.push_back (out);
         layout.mainOutIndex = 0;
+        layout.isInstrument = (inCh == 0);
     }
 
     // Snapshot the parameter list for automation / display. [main-thread]
@@ -152,7 +184,8 @@ bool ClapInstance::activate (double sampleRate, int maxBlock, std::string& error
     inScratchR .assign ((size_t) maxFrames, 0.0f);
     outScratchL.assign ((size_t) maxFrames, 0.0f);
     outScratchR.assign ((size_t) maxFrames, 0.0f);
-    eventScratch.assign ((size_t) kParamRingCap, clap_event_param_value_t {});
+    // Params (ring capacity) + a block's worth of notes/MIDI.
+    eventScratch.assign ((size_t) kParamRingCap + 512, AnyEvent {});
 
     if (plugin->activate == nullptr
         || ! plugin->activate (plugin, sampleRate, 1, (uint32_t) maxFrames))
@@ -284,7 +317,7 @@ void ClapInstance::drainParamRing() noexcept
     eventCount = 0;
     paramRing.drain ([this] (const ParamChange& pc)
     {
-        auto& ev = eventScratch[(size_t) eventCount++];
+        auto& ev = eventScratch[(size_t) eventCount++].param;
         ev.header.size     = sizeof (clap_event_param_value_t);
         ev.header.time     = 0;
         ev.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
@@ -298,6 +331,52 @@ void ClapInstance::drainParamRing() noexcept
         ev.key             = -1;
         ev.value           = pc.value;
     }, (uint32_t) eventScratch.size());
+}
+
+void ClapInstance::appendMidiEvents (const juce::MidiBuffer& midi) noexcept
+{
+    if (! noteInPort) return;
+    const uint32_t cap = (uint32_t) eventScratch.size();
+    for (const auto meta : midi)
+    {
+        if (eventCount >= cap) break;   // scratch full — drop the tail
+        const auto* d = meta.data;
+        if (meta.numBytes < 1) continue;
+        const auto status  = (uint8_t) (d[0] & 0xF0u);
+        const auto channel = (int16_t) (d[0] & 0x0Fu);
+        const bool noteOn  = status == 0x90 && meta.numBytes >= 3 && d[2] > 0;
+        const bool noteOff = meta.numBytes >= 3
+                             && (status == 0x80 || (status == 0x90 && d[2] == 0));
+
+        auto& slot = eventScratch[(size_t) eventCount];
+        if (noteDialectClap && (noteOn || noteOff))
+        {
+            auto& ev = slot.note;
+            ev.header = { (uint32_t) sizeof (clap_event_note_t),
+                          (uint32_t) meta.samplePosition, CLAP_CORE_EVENT_SPACE_ID,
+                          (uint16_t) (noteOn ? CLAP_EVENT_NOTE_ON : CLAP_EVENT_NOTE_OFF), 0 };
+            ev.note_id    = -1;
+            ev.port_index = 0;
+            ev.channel    = channel;
+            ev.key        = (int16_t) d[1];
+            ev.velocity   = (double) d[2] / 127.0;
+            ++eventCount;
+        }
+        else if (noteDialectMidi && meta.numBytes <= 3 && status >= 0x80 && status <= 0xE0)
+        {
+            // Everything else (CC, pitch bend, aftertouch — and the notes
+            // themselves when the plugin only takes raw MIDI).
+            auto& ev = slot.midi;
+            ev.header = { (uint32_t) sizeof (clap_event_midi_t),
+                          (uint32_t) meta.samplePosition, CLAP_CORE_EVENT_SPACE_ID,
+                          CLAP_EVENT_MIDI, 0 };
+            ev.port_index = 0;
+            ev.data[0] = d[0];
+            ev.data[1] = (uint8_t) (meta.numBytes > 1 ? d[1] : 0);
+            ev.data[2] = (uint8_t) (meta.numBytes > 2 ? d[2] : 0);
+            ++eventCount;
+        }
+    }
 }
 
 void ClapInstance::processStereo (const float* inL, const float* inR,
@@ -415,6 +494,8 @@ void ClapInstance::processBlock (const hosting::PortBuffers& io) noexcept
     }
 
     drainParamRing();
+    if (io.midiIn != nullptr)
+        appendMidiEvents (*io.midiIn);
 
     // Point the CLAP audio buffers straight at the caller's pre-sized scratch — the
     // plugin writes its output there, no instance-owned copy. Clamp to the channel

--- a/src/engine/clap/ClapInstance.h
+++ b/src/engine/clap/ClapInstance.h
@@ -158,7 +158,25 @@ private:
     struct ParamChange { clap_id id; double value; void* cookie; };
     static constexpr uint32_t kParamRingCap = 512;
     hosting::SpscRing<ParamChange, kParamRingCap> paramRing;
-    std::vector<clap_event_param_value_t> eventScratch;   // sized in activate(), never RT-grown
+
+    // One slot per staged input event: params from the ring, then the block's
+    // notes / raw MIDI. The union keeps inEvents.get's header-pointer contract
+    // for every kind. Sized in activate(), never RT-grown.
+    union AnyEvent
+    {
+        clap_event_header_t      header;
+        clap_event_param_value_t param;
+        clap_event_note_t        note;
+        clap_event_midi_t        midi;
+    };
+    std::vector<AnyEvent> eventScratch;
+
+    // Note-input negotiation (CLAP_EXT_NOTE_PORTS), recorded at create().
+    bool noteInPort = false, noteDialectClap = false, noteDialectMidi = false;
+
+    // Audio thread. Convert the block's MidiBuffer into note / raw-MIDI events
+    // appended after the drained param changes.
+    void appendMidiEvents (const juce::MidiBuffer& midi) noexcept;
     uint32_t             eventCount = 0;
     clap_input_events_t  inEvents {};
 

--- a/src/engine/hosting/NativeInsertSlot.h
+++ b/src/engine/hosting/NativeInsertSlot.h
@@ -128,11 +128,18 @@ public:
     bool loadState (const std::vector<uint8_t>& in)
     { return instance != nullptr && instance->loadState (in); }
 
+    // Whether the loaded plugin is an instrument (no main audio input — the
+    // block's MIDI drives it and its output IS the signal).
+    bool isLoadedInstrument() const noexcept
+    { return isLoaded() && instance != nullptr && instance->portLayout().isInstrument; }
+
     // Audio thread: process stereo through the plugin, via the InsertAdapter →
     // INativeInstance::processBlock. Clears the outputs + returns when no plugin
-    // is loaded; passes audio through when bypassed.
+    // is loaded; passes audio through when bypassed. midiIn feeds instruments
+    // and MIDI-driven effects (null ok).
     void processStereo (const float* inL, const float* inR,
-                        float* outL, float* outR, int numFrames) noexcept
+                        float* outL, float* outR, int numFrames,
+                        const juce::MidiBuffer* midiIn = nullptr) noexcept
     {
         auto clearOutputs = [&]
         {
@@ -177,7 +184,8 @@ public:
         const float* r = (inR != nullptr) ? inR : inL;
         if (outR != r)  std::memcpy (outR, r, n);
 
-        adapter.process (*instance, outL, outR, numFrames);
+        adapter.process (*instance, outL, outR, numFrames,
+                         nullptr, nullptr, midiIn);
     }
 
     // UI: the live instance for editor attach (nullptr when not loaded).

--- a/src/engine/lv2/Lv2Instance.cpp
+++ b/src/engine/lv2/Lv2Instance.cpp
@@ -11,6 +11,7 @@
 #include <lv2/port-props/port-props.h>
 #include <lv2/atom/forge.h>
 #include <lv2/atom/util.h>
+#include <lv2/midi/midi.h>
 #include <lv2/patch/patch.h>
 #include <lv2/state/state.h>
 #include <lv2/urid/urid.h>
@@ -77,10 +78,11 @@ struct Lv2Instance::Impl
         uridPatchProperty = mapUri (this, LV2_PATCH__property);
         uridPatchValue    = mapUri (this, LV2_PATCH__value);
         uridEventTransfer = mapUri (this, LV2_ATOM__eventTransfer);
+        uridMidiEvent     = mapUri (this, LV2_MIDI__MidiEvent);
     }
     LV2_URID uridFloat = 0, uridDouble = 0, uridInt = 0, uridLong = 0;
     LV2_URID uridObject = 0, uridPatchSet = 0, uridPatchProperty = 0,
-             uridPatchValue = 0, uridEventTransfer = 0;
+             uridPatchValue = 0, uridEventTransfer = 0, uridMidiEvent = 0;
 
     // Assemble the full feature list for instantiate: urid map/unmap + the block-size
     // and sample-rate options + boundedBlockLength. JUCE/DPF-wrapped plugins REQUIRE
@@ -633,26 +635,41 @@ void Lv2Instance::processBlock (const hosting::PortBuffers& io) noexcept
             impl->portValues[(size_t) pw.idx] = pw.value;
     });
 
-    // Rebuild the control atom input's sequence from the staged patch/UI atoms
-    // (all at frame 0). Input sequences are host-owned, so the reset is cheap
+    // Rebuild the control atom input's sequence: staged patch/UI atoms first
+    // (frame 0), then the block's MIDI at its sample offsets — the sequence
+    // stays time-sorted. Input sequences are host-owned, so the reset is cheap
     // and the other atom inputs keep their empty headers from activate().
     if (! impl->atomInPorts.empty())
     {
         auto& buf = impl->atomBuffers[(size_t) impl->controlAtomInPos];
         auto* seq = reinterpret_cast<LV2_Atom_Sequence*> (buf.data());
         seq->atom.size = sizeof (LV2_Atom_Sequence_Body);
-        impl->atomRing.drain ([&] (const Impl::AtomBlob& blob)
+        auto appendEvent = [&] (int64_t frames, uint32_t type,
+                                const uint8_t* data, uint32_t size)
         {
-            const uint32_t evSize = (uint32_t) sizeof (LV2_Atom_Event) - (uint32_t) sizeof (LV2_Atom)
-                                    + blob.size;
+            const uint32_t evSize = (uint32_t) sizeof (LV2_Atom_Event) + size;
             const uint32_t padded = lv2_atom_pad_size (evSize);
             const uint32_t used   = (uint32_t) sizeof (LV2_Atom) + seq->atom.size;
             if (used + padded > buf.size()) return;   // sequence full — drop
             auto* ev = reinterpret_cast<LV2_Atom_Event*> (buf.data() + used);
-            ev->time.frames = 0;
-            std::memcpy (&ev->body, blob.data, blob.size);
+            ev->time.frames = frames;
+            ev->body.size   = size;
+            ev->body.type   = type;
+            std::memcpy (ev + 1, data, size);
             seq->atom.size += padded;
+        };
+        impl->atomRing.drain ([&] (const Impl::AtomBlob& blob)
+        {
+            // blob is a full atom (header + body); re-emit as header + payload.
+            const auto* atom = reinterpret_cast<const LV2_Atom*> (blob.data);
+            appendEvent (0, atom->type,
+                         blob.data + sizeof (LV2_Atom), atom->size);
         });
+        if (io.midiIn != nullptr)
+            for (const auto meta : *io.midiIn)
+                if (meta.numBytes > 0 && meta.numBytes <= 3)
+                    appendEvent ((int64_t) meta.samplePosition, impl->uridMidiEvent,
+                                 meta.data, (uint32_t) meta.numBytes);
     }
 
     // Re-advertise output-atom capacity before every run(): the plugin overwrites

--- a/src/engine/lv2/Lv2Instance.cpp
+++ b/src/engine/lv2/Lv2Instance.cpp
@@ -83,11 +83,13 @@ struct Lv2Instance::Impl
         uridPatchBody     = mapUri (this, LV2_PATCH__body);
         uridSequence      = mapUri (this, LV2_ATOM__Sequence);
         uridFloatType     = mapUri (this, LV2_ATOM__Float);
+        uridUridType      = mapUri (this, LV2_ATOM__URID);
     }
     LV2_URID uridFloat = 0, uridDouble = 0, uridInt = 0, uridLong = 0;
     LV2_URID uridObject = 0, uridPatchSet = 0, uridPatchProperty = 0,
              uridPatchValue = 0, uridEventTransfer = 0, uridMidiEvent = 0,
-             uridPatchPut = 0, uridPatchBody = 0, uridSequence = 0, uridFloatType = 0;
+             uridPatchPut = 0, uridPatchBody = 0, uridSequence = 0, uridFloatType = 0,
+             uridUridType = 0;
 
     // Assemble the full feature list for instantiate: urid map/unmap + the block-size
     // and sample-rate options + boundedBlockLength. JUCE/DPF-wrapped plugins REQUIRE
@@ -187,8 +189,8 @@ struct Lv2Instance::Impl
             const LV2_Atom* valAtom  = nullptr;
             lv2_atom_object_get (obj, uridPatchProperty, &propAtom,
                                       uridPatchValue,    &valAtom, 0);
-            if (propAtom != nullptr && valAtom != nullptr
-                && valAtom->type == uridFloatType)
+            if (propAtom != nullptr && propAtom->type == uridUridType
+                && valAtom != nullptr && valAtom->type == uridFloatType)
                 patchOutRing.push ({ reinterpret_cast<const LV2_Atom_URID*> (propAtom)->body,
                                      reinterpret_cast<const LV2_Atom_Float*> (valAtom)->body });
         }
@@ -930,7 +932,7 @@ void Lv2Instance::forwardUiAtomEvent (const void* atomData, uint32_t sizeBytes) 
             const LV2_Atom* valAtom  = nullptr;
             lv2_atom_object_get (obj, impl->uridPatchProperty, &propAtom,
                                       impl->uridPatchValue,    &valAtom, 0);
-            if (propAtom != nullptr && propAtom->type == Impl::mapUri (impl.get(), LV2_ATOM__URID))
+            if (propAtom != nullptr && propAtom->type == impl->uridUridType)
             {
                 const LV2_URID prop = reinterpret_cast<const LV2_Atom_URID*> (propAtom)->body;
                 const int idx = impl->paramIndexForId (Impl::kPatchIdFlag | prop);

--- a/src/engine/lv2/Lv2Instance.cpp
+++ b/src/engine/lv2/Lv2Instance.cpp
@@ -79,10 +79,15 @@ struct Lv2Instance::Impl
         uridPatchValue    = mapUri (this, LV2_PATCH__value);
         uridEventTransfer = mapUri (this, LV2_ATOM__eventTransfer);
         uridMidiEvent     = mapUri (this, LV2_MIDI__MidiEvent);
+        uridPatchPut      = mapUri (this, LV2_PATCH__Put);
+        uridPatchBody     = mapUri (this, LV2_PATCH__body);
+        uridSequence      = mapUri (this, LV2_ATOM__Sequence);
+        uridFloatType     = mapUri (this, LV2_ATOM__Float);
     }
     LV2_URID uridFloat = 0, uridDouble = 0, uridInt = 0, uridLong = 0;
     LV2_URID uridObject = 0, uridPatchSet = 0, uridPatchProperty = 0,
-             uridPatchValue = 0, uridEventTransfer = 0, uridMidiEvent = 0;
+             uridPatchValue = 0, uridEventTransfer = 0, uridMidiEvent = 0,
+             uridPatchPut = 0, uridPatchBody = 0, uridSequence = 0, uridFloatType = 0;
 
     // Assemble the full feature list for instantiate: urid map/unmap + the block-size
     // and sample-rate options + boundedBlockLength. JUCE/DPF-wrapped plugins REQUIRE
@@ -165,6 +170,40 @@ struct Lv2Instance::Impl
     // Which atomInPorts entry takes injected events: the lv2:control-designated
     // port, else the first atom input.
     int controlAtomInPos = 0;
+    // Mirrors it for the plugin's outgoing patch responses (-1 = no atom output).
+    int controlAtomOutPos = -1;
+
+    // Plugin → host property feedback (audio-thread parse of the control atom
+    // output, drained into patchShadow on the message thread).
+    struct PatchFeedback { LV2_URID prop; float value; };
+    hosting::SpscRing<PatchFeedback, 128> patchOutRing;
+
+    // Audio thread. Queue one patch:Set / patch:Put object's float properties.
+    void queuePatchObject (const LV2_Atom_Object* obj) noexcept
+    {
+        if (obj->body.otype == uridPatchSet)
+        {
+            const LV2_Atom* propAtom = nullptr;
+            const LV2_Atom* valAtom  = nullptr;
+            lv2_atom_object_get (obj, uridPatchProperty, &propAtom,
+                                      uridPatchValue,    &valAtom, 0);
+            if (propAtom != nullptr && valAtom != nullptr
+                && valAtom->type == uridFloatType)
+                patchOutRing.push ({ reinterpret_cast<const LV2_Atom_URID*> (propAtom)->body,
+                                     reinterpret_cast<const LV2_Atom_Float*> (valAtom)->body });
+        }
+        else if (obj->body.otype == uridPatchPut)
+        {
+            const LV2_Atom* bodyAtom = nullptr;
+            lv2_atom_object_get (obj, uridPatchBody, &bodyAtom, 0);
+            if (bodyAtom == nullptr || bodyAtom->type != uridObject) return;
+            const auto* body = reinterpret_cast<const LV2_Atom_Object*> (bodyAtom);
+            LV2_ATOM_OBJECT_FOREACH (body, p)
+                if (p->value.type == uridFloatType)
+                    patchOutRing.push ({ p->key,
+                        reinterpret_cast<const LV2_Atom_Float*> (&p->value)->body });
+        }
+    }
 
     // Last host/UI-written value per patch property (message thread) — the
     // read-back source until patch:Put parsing exists.
@@ -430,6 +469,15 @@ bool Lv2Instance::create (const Lv2Bundle& bundle, const std::string& uri, std::
             for (size_t i = 0; i < impl->atomInPorts.size(); ++i)
                 if (impl->atomInPorts[i] == idx) { impl->controlAtomInPos = (int) i; break; }
         }
+        impl->controlAtomOutPos = impl->atomOutPorts.empty() ? -1 : 0;
+        LilvNode* outputClass2 = lilv_new_uri (world, LV2_CORE__OutputPort);
+        if (const LilvPort* cp = lilv_plugin_get_port_by_designation (impl->plugin, outputClass2, ctrlDesig))
+        {
+            const uint32_t idx = lilv_port_get_index (impl->plugin, cp);
+            for (size_t i = 0; i < impl->atomOutPorts.size(); ++i)
+                if (impl->atomOutPorts[i] == idx) { impl->controlAtomOutPos = (int) i; break; }
+        }
+        lilv_node_free (outputClass2);
         lilv_node_free (ctrlDesig);
         lilv_node_free (inputClass2);
     }
@@ -685,6 +733,25 @@ void Lv2Instance::processBlock (const hosting::PortBuffers& io) noexcept
 
     lilv_instance_run (impl->instance, (uint32_t) numFrames);
 
+    // The plugin's outgoing patch responses (its own UI / preset loads) keep
+    // the read-back shadow honest — parse the control atom output and stage
+    // the float properties for the message-thread drain.
+    if (impl->controlAtomOutPos >= 0)
+    {
+        const auto& buf = impl->atomBuffers[impl->atomInPorts.size()
+                                            + (size_t) impl->controlAtomOutPos];
+        const auto* seq = reinterpret_cast<const LV2_Atom_Sequence*> (buf.data());
+        if (seq->atom.type == impl->uridSequence)
+        {
+            LV2_ATOM_SEQUENCE_FOREACH (seq, ev)
+            {
+                if (ev->body.type == impl->uridObject)
+                    impl->queuePatchObject (
+                        reinterpret_cast<const LV2_Atom_Object*> (&ev->body));
+            }
+        }
+    }
+
     if (impl->latencyPortIndex >= 0)
         impl->latencySamples.store ((int) impl->portValues[(size_t) impl->latencyPortIndex],
                                     std::memory_order_relaxed);
@@ -826,6 +893,14 @@ void Lv2Instance::setParamValue (uint32_t paramId, double value) noexcept
 
     impl->patchShadow[propUrid] = v;
     impl->atomRing.push (blob);   // full ⇒ drop (pathological flood only)
+}
+
+void Lv2Instance::drainPatchFeedback()
+{
+    impl->patchOutRing.drain ([this] (const Impl::PatchFeedback& f)
+    {
+        impl->patchShadow[f.prop] = f.value;
+    });
 }
 
 int Lv2Instance::lastTouchedParamIndex() const noexcept

--- a/src/engine/lv2/Lv2Instance.h
+++ b/src/engine/lv2/Lv2Instance.h
@@ -80,6 +80,12 @@ public:
     // Port index for the suil port-index-by-symbol callback; -1 when unknown.
     int portIndexForSymbol (const char* symbol) const noexcept;
 
+    // Message thread (engine drain timer): fold the plugin's outgoing
+    // patch:Set / patch:Put responses into the read-back shadow, so
+    // plugin-side property changes (a preset loaded in its own UI) don't
+    // leave getParamValue stale.
+    void drainPatchFeedback();
+
     // ui:eventTransfer writes from the plugin's own editor (message thread):
     // forwarded onto the control atom input port so the DSP hears them without
     // relying on the instance-access shortcut, and patch:Set events stamp the

--- a/src/engine/vst3/Vst3Instance.cpp
+++ b/src/engine/vst3/Vst3Instance.cpp
@@ -15,6 +15,7 @@
 #include <pluginterfaces/vst/ivstcomponent.h>
 #include <pluginterfaces/vst/ivsteditcontroller.h>
 #include <pluginterfaces/vst/ivsthostapplication.h>
+#include <pluginterfaces/vst/ivstmidicontrollers.h>
 #include <pluginterfaces/vst/vstspeaker.h>
 
 #include <algorithm>
@@ -75,6 +76,30 @@ struct Vst3Instance::Impl : public Vst3HostContext::Callbacks
     // thread (misbehaving plugins fire restartComponent off-thread, and the
     // snapshot allocates).
     std::atomic<bool> paramInfoChanged { false };
+    std::atomic<bool> ccMapChanged     { false };
+
+    // MIDI CC → parameter bridge (VST3 has no CC events: IMidiMapping assigns a
+    // parameter per (channel, controller) and the host feeds value changes).
+    // Cached on the message thread — getMidiControllerAssignment is a controller
+    // call — and read lock-free by the audio thread per incoming CC.
+    static constexpr uint32_t kNoCcParam = 0xFFFFFFFFu;
+    std::array<std::atomic<uint32_t>, 16 * Vst::kCountCtrlNumber> ccParamId {};
+
+    void rebuildMidiCcMap()
+    {
+        FUnknownPtr<Vst::IMidiMapping> mapping (controller);
+        for (int16 ch = 0; ch < 16; ++ch)
+            for (int16 ctrl = 0; ctrl < Vst::kCountCtrlNumber; ++ctrl)
+            {
+                Vst::ParamID id = 0;
+                const bool mapped = mapping
+                    && mapping->getMidiControllerAssignment (0, ch,
+                           (Vst::CtrlNumber) ctrl, id) == kResultTrue;
+                ccParamId[(size_t) (ch * Vst::kCountCtrlNumber + ctrl)]
+                    .store (mapped ? (uint32_t) id : kNoCcParam,
+                            std::memory_order_relaxed);
+            }
+    }
 
     void snapshotParams()
     {
@@ -120,6 +145,8 @@ struct Vst3Instance::Impl : public Vst3HostContext::Callbacks
         // fixed at create() and no hosted effect exercises it yet.
         if ((flags & Vst::RestartFlags::kParamTitlesChanged) != 0)
             paramInfoChanged.store (true, std::memory_order_relaxed);
+        if ((flags & Vst::RestartFlags::kMidiCCAssignmentChanged) != 0)
+            ccMapChanged.store (true, std::memory_order_relaxed);
         if ((flags & Vst::RestartFlags::kLatencyChanged) != 0)
             latencyChanged.store (true, std::memory_order_relaxed);
     }
@@ -214,6 +241,17 @@ void Vst3Instance::refreshParamInfoIfChanged()
 {
     if (impl->paramInfoChanged.exchange (false, std::memory_order_relaxed))
         impl->snapshotParams();
+    if (impl->ccMapChanged.exchange (false, std::memory_order_relaxed))
+        impl->rebuildMidiCcMap();
+}
+
+int Vst3Instance::midiCcMappingCount() const noexcept
+{
+    int n = 0;
+    for (const auto& id : impl->ccParamId)
+        if (id.load (std::memory_order_relaxed) != Impl::kNoCcParam)
+            ++n;
+    return n;
 }
 
 int Vst3Instance::lastTouchedParamIndex() const noexcept
@@ -287,6 +325,7 @@ bool Vst3Instance::create (const Vst3Bundle& bundle, const std::string& classId,
         }
 
         impl->snapshotParams();
+        impl->rebuildMidiCcMap();
     }
     impl->host.setCallbacks (impl.get());
 
@@ -510,38 +549,6 @@ void Vst3Instance::processBlock (const hosting::PortBuffers& io) noexcept
     impl->inParams.clearQueue();
     impl->outParams.clearQueue();
 
-    // Notes → the event bus (instruments and MIDI-driven effects). CCs need the
-    // IMidiMapping→parameter bridge, a later increment.
-    if (io.midiIn != nullptr && impl->hasEventIn)
-    {
-        for (const auto meta : *io.midiIn)
-        {
-            const auto* d = meta.data;
-            if (meta.numBytes < 3) continue;
-            const auto status  = (uint8_t) (d[0] & 0xF0u);
-            const auto channel = (int16_t) (d[0] & 0x0Fu);
-            Vst::Event ev {};
-            ev.busIndex     = 0;
-            ev.sampleOffset = meta.samplePosition;
-            ev.flags        = Vst::Event::kIsLive;
-            if (status == 0x90 && d[2] > 0)
-            {
-                ev.type   = Vst::Event::kNoteOnEvent;
-                ev.noteOn = { channel, (int16_t) d[1], 0.0f,
-                              (float) d[2] / 127.0f, 0, -1 };
-            }
-            else if (status == 0x80 || (status == 0x90 && d[2] == 0))
-            {
-                ev.type    = Vst::Event::kNoteOffEvent;
-                ev.noteOff = { channel, (int16_t) d[1],
-                               (float) d[2] / 127.0f, -1, 0.0f };
-            }
-            else
-                continue;
-            impl->inEvents.addEvent (ev);
-        }
-    }
-
     // Queued UI/editor parameter changes → this block's IParameterChanges.
     // All at offset 0 — sample-accurate automation is a later step.
     impl->paramRing.drain ([&] (const Impl::ParamChange& pc)
@@ -553,6 +560,71 @@ void Vst3Instance::processBlock (const hosting::PortBuffers& io) noexcept
             queue->addPoint (0, pc.value, pointIndex);
         }
     });
+
+    // Notes → the event bus; CCs / pitch bend / channel pressure → the
+    // IMidiMapping-assigned parameters (VST3 has no CC events by design).
+    if (io.midiIn != nullptr)
+    {
+        auto queueCcParam = [&] (int16 channel, int16 ctrl, double normalized, int32 offset)
+        {
+            const uint32_t id = impl->ccParamId[(size_t) (channel * Vst::kCountCtrlNumber
+                                                          + ctrl)]
+                                    .load (std::memory_order_relaxed);
+            if (id == Impl::kNoCcParam) return;
+            int32 queueIndex = 0;
+            if (auto* queue = impl->inParams.addParameterData ((Vst::ParamID) id, queueIndex))
+            {
+                int32 pointIndex = 0;
+                queue->addPoint (offset, normalized, pointIndex);
+            }
+        };
+
+        for (const auto meta : *io.midiIn)
+        {
+            const auto* d = meta.data;
+            if (meta.numBytes < 2) continue;
+            const auto status  = (uint8_t) (d[0] & 0xF0u);
+            const auto channel = (int16_t) (d[0] & 0x0Fu);
+
+            if (impl->hasEventIn && meta.numBytes >= 3
+                && (status == 0x90 || status == 0x80))
+            {
+                Vst::Event ev {};
+                ev.busIndex     = 0;
+                ev.sampleOffset = meta.samplePosition;
+                ev.flags        = Vst::Event::kIsLive;
+                if (status == 0x90 && d[2] > 0)
+                {
+                    ev.type   = Vst::Event::kNoteOnEvent;
+                    ev.noteOn = { channel, (int16_t) d[1], 0.0f,
+                                  (float) d[2] / 127.0f, 0, -1 };
+                }
+                else
+                {
+                    ev.type    = Vst::Event::kNoteOffEvent;
+                    ev.noteOff = { channel, (int16_t) d[1],
+                                   (float) d[2] / 127.0f, -1, 0.0f };
+                }
+                impl->inEvents.addEvent (ev);
+            }
+            else if (status == 0xB0 && meta.numBytes >= 3 && d[1] < 128)
+            {
+                queueCcParam (channel, (int16_t) d[1],
+                              (double) d[2] / 127.0, meta.samplePosition);
+            }
+            else if (status == 0xE0 && meta.numBytes >= 3)
+            {
+                const int bend14 = (int) d[1] | ((int) d[2] << 7);
+                queueCcParam (channel, Vst::kPitchBend,
+                              (double) bend14 / 16383.0, meta.samplePosition);
+            }
+            else if (status == 0xD0)
+            {
+                queueCcParam (channel, Vst::kAfterTouch,
+                              (double) d[1] / 127.0, meta.samplePosition);
+            }
+        }
+    }
 
     if (impl->processor->process (impl->processData) != kResultOk)
         clearOutputs();

--- a/src/engine/vst3/Vst3Instance.cpp
+++ b/src/engine/vst3/Vst3Instance.cpp
@@ -510,6 +510,38 @@ void Vst3Instance::processBlock (const hosting::PortBuffers& io) noexcept
     impl->inParams.clearQueue();
     impl->outParams.clearQueue();
 
+    // Notes → the event bus (instruments and MIDI-driven effects). CCs need the
+    // IMidiMapping→parameter bridge, a later increment.
+    if (io.midiIn != nullptr && impl->hasEventIn)
+    {
+        for (const auto meta : *io.midiIn)
+        {
+            const auto* d = meta.data;
+            if (meta.numBytes < 3) continue;
+            const auto status  = (uint8_t) (d[0] & 0xF0u);
+            const auto channel = (int16_t) (d[0] & 0x0Fu);
+            Vst::Event ev {};
+            ev.busIndex     = 0;
+            ev.sampleOffset = meta.samplePosition;
+            ev.flags        = Vst::Event::kIsLive;
+            if (status == 0x90 && d[2] > 0)
+            {
+                ev.type   = Vst::Event::kNoteOnEvent;
+                ev.noteOn = { channel, (int16_t) d[1], 0.0f,
+                              (float) d[2] / 127.0f, 0, -1 };
+            }
+            else if (status == 0x80 || (status == 0x90 && d[2] == 0))
+            {
+                ev.type    = Vst::Event::kNoteOffEvent;
+                ev.noteOff = { channel, (int16_t) d[1],
+                               (float) d[2] / 127.0f, -1, 0.0f };
+            }
+            else
+                continue;
+            impl->inEvents.addEvent (ev);
+        }
+    }
+
     // Queued UI/editor parameter changes → this block's IParameterChanges.
     // All at offset 0 — sample-accurate automation is a later step.
     impl->paramRing.drain ([&] (const Impl::ParamChange& pc)

--- a/src/engine/vst3/Vst3Instance.h
+++ b/src/engine/vst3/Vst3Instance.h
@@ -86,9 +86,14 @@ public:
     // PDC — VST3 only re-reads latency across a setActive cycle.
     bool consumeLatencyChanged() noexcept;
 
-    // Message thread: re-snapshot the parameter surface if the plugin signalled
-    // kParamTitlesChanged. Called from the engine's drain timer.
+    // Message thread: re-snapshot the parameter surface / MIDI-CC map if the
+    // plugin signalled kParamTitlesChanged / kMidiCCAssignmentChanged. Called
+    // from the engine's drain timer.
     void refreshParamInfoIfChanged();
+
+    // How many (channel, controller) pairs the plugin maps to parameters via
+    // IMidiMapping. 0 = no CC bridge (the plugin takes no MIDI controllers).
+    int midiCcMappingCount() const noexcept;
 
     int getLatencySamples() const noexcept override;
 

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -1814,29 +1814,7 @@ void ChannelStripComponent::openPluginPicker (bool useChooser)
                                         // handler which publishes the new mode atomically and
                                         // refreshes I/O / slot button visibility consistently.
                                         if (self->pluginSlot.isLoadedPluginInstrument())
-                                        {
-                                            if (self->track.mode.load (std::memory_order_relaxed)
-                                                  != (int) Track::Mode::Midi)
-                                                self->modeSelector.setSelectedId (
-                                                    (int) Track::Mode::Midi + 1,
-                                                    juce::sendNotificationSync);
-
-                                            // No MIDI input bound yet? Route the Virtual
-                                            // Keyboard so the user can immediately audition
-                                            // the freshly loaded instrument without hunting
-                                            // through the input dropdown. ID convention
-                                            // (see rebuildMidiInputDropdown): 1 = (none),
-                                            // 2 + deviceIndex = real input N.
-                                            if (self->track.midiInputIndex.load (
-                                                    std::memory_order_relaxed) < 0)
-                                            {
-                                                const int vkbIdx =
-                                                    self->engine.getVirtualKeyboardInputIndex();
-                                                if (vkbIdx >= 0)
-                                                    self->midiInputSelector.setSelectedId (
-                                                        2 + vkbIdx, juce::sendNotificationSync);
-                                            }
-                                        }
+                                            self->adoptInstrumentTrackDefaults();
 
                                         // Close the modal synchronously so the cached editor
                                         // (still bound to the just-replaced processor) gets
@@ -1885,12 +1863,11 @@ void ChannelStripComponent::openPluginPicker (bool useChooser)
     // Linux-only; elsewhere the callback stays empty so the picker shows no CLAP rows.
     std::function<void (const juce::File&, const juce::String&)> onClap;
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
-    if (kind == pluginpicker::PluginKind::Effects)
-        onClap = [safe] (const juce::File& f, const juce::String& id)
-        {
-            if (auto* self = safe.getComponent())
-                self->loadNativeClapForChannel (f, id);
-        };
+    onClap = [safe] (const juce::File& f, const juce::String& id)
+    {
+        if (auto* self = safe.getComponent())
+            self->loadNativeClapForChannel (f, id);
+    };
 #endif
     // Native LV2 route — same shape; LV2-Native rows replace the JUCE LV2 rows.
     std::function<void (const juce::File&, const juce::String&)> onLv2;
@@ -1905,12 +1882,11 @@ void ChannelStripComponent::openPluginPicker (bool useChooser)
     // Native VST3 route — same shape; VST3-Native rows replace the JUCE VST3 rows.
     std::function<void (const juce::File&, const juce::String&)> onVst3;
 #if DUSKSTUDIO_HAS_NATIVE_VST3
-    if (kind == pluginpicker::PluginKind::Effects)
-        onVst3 = [safe] (const juce::File& f, const juce::String& id)
-        {
-            if (auto* self = safe.getComponent())
-                self->loadNativeVst3ForChannel (f, id);
-        };
+    onVst3 = [safe] (const juce::File& f, const juce::String& id)
+    {
+        if (auto* self = safe.getComponent())
+            self->loadNativeVst3ForChannel (f, id);
+    };
 #endif
 
     if (useChooser)
@@ -2599,6 +2575,24 @@ void ChannelStripComponent::dropPluginEditor()
    #endif
 }
 
+void ChannelStripComponent::adoptInstrumentTrackDefaults()
+{
+    if (track.mode.load (std::memory_order_relaxed) != (int) Track::Mode::Midi)
+        modeSelector.setSelectedId ((int) Track::Mode::Midi + 1,
+                                    juce::sendNotificationSync);
+
+    // No MIDI input bound yet? Route the Virtual Keyboard so the user can
+    // immediately audition the freshly loaded instrument without hunting
+    // through the input dropdown. ID convention (see rebuildMidiInputDropdown):
+    // 1 = (none), 2 + deviceIndex = real input N.
+    if (track.midiInputIndex.load (std::memory_order_relaxed) < 0)
+    {
+        const int vkbIdx = engine.getVirtualKeyboardInputIndex();
+        if (vkbIdx >= 0)
+            midiInputSelector.setSelectedId (2 + vkbIdx, juce::sendNotificationSync);
+    }
+}
+
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
 void ChannelStripComponent::loadNativeClapForChannel (const juce::File& clapFile,
                                                        const juce::String& pluginId)
@@ -2651,6 +2645,8 @@ void ChannelStripComponent::loadNativeClapForChannel (const juce::File& clapFile
         return;
     }
 
+    if (strip.getNativeClapSlot().isLoadedInstrument())
+        adoptInstrumentTrackDefaults();
     track.nativeClapPath     = clapFile.getFullPathName();
     track.nativeClapPluginId = strip.getNativeClapSlot().getPluginId();
     // Fresh bundle: don't reuse the previous plugin's state blob. The next save
@@ -2774,6 +2770,8 @@ void ChannelStripComponent::loadNativeVst3ForChannel (const juce::File& vst3File
         return;
     }
 
+    if (strip.getNativeVst3Slot().isLoadedInstrument())
+        adoptInstrumentTrackDefaults();
     track.nativeVst3Path     = vst3File.getFullPathName();
     track.nativeVst3PluginId = strip.getNativeVst3Slot().getPluginId();
     track.nativeVst3StateBase64 = {};
@@ -4312,13 +4310,16 @@ void ChannelStripComponent::onTrackModeChanged()
         if (willBeMidi != isInstrument)
             unloadPluginSlot();
     }
-    else if ((engine.getChannelStrip (trackIndex).isNativeClapLoaded()
+    else if (engine.getChannelStrip (trackIndex).isNativeClapLoaded()
               || engine.getChannelStrip (trackIndex).isNativeLv2Loaded()
               || engine.getChannelStrip (trackIndex).isNativeVst3Loaded())
-             && mode == (int) Track::Mode::Midi)
     {
-        // Native inserts are effects-only; a MIDI strip can't host one.
-        unloadPluginSlot();
+        // Same mode/kind matching as the JUCE slot above: a native EFFECT can't
+        // ride a MIDI strip, a native INSTRUMENT can't ride an audio strip.
+        const bool willBeMidi   = (mode == (int) Track::Mode::Midi);
+        const bool isInstrument = engine.getChannelStrip (trackIndex).insertIsNativeInstrument();
+        if (willBeMidi != isInstrument)
+            unloadPluginSlot();
     }
 
     track.mode.store (mode, std::memory_order_relaxed);

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -1858,8 +1858,8 @@ void ChannelStripComponent::openPluginPicker (bool useChooser)
                                         });
                                     };
 
-    // Native CLAP route — effects (audio) slots only; CLAP instruments aren't hosted
-    // natively yet. Selecting a CLAP row loads it through the channel's native host.
+    // Native CLAP route — effects and instruments both load through the channel's
+    // native host (the picker merges whichever kind fits the slot).
     // Linux-only; elsewhere the callback stays empty so the picker shows no CLAP rows.
     std::function<void (const juce::File&, const juce::String&)> onClap;
 #if DUSKSTUDIO_HAS_NATIVE_CLAP

--- a/src/ui/ChannelStripComponent.h
+++ b/src/ui/ChannelStripComponent.h
@@ -346,6 +346,10 @@ private:
     void loadNativeVst3ForChannel (const juce::File& vst3File, const juce::String& pluginId = {});
 #endif
 
+    // A freshly loaded instrument flips the track to MIDI and routes the Virtual
+    // Keyboard when no MIDI input is bound (shared by the JUCE and native loads).
+    void adoptInstrumentTrackDefaults();
+
    #if JUCE_LINUX && DUSKSTUDIO_HAS_OOP_PLUGINS
     // OOP: child plugin's X11 Window wrapped in XEmbedComponent fed
     // to PluginEditorWindow as the body. Lifetime matches pluginEditor.

--- a/src/ui/PluginPickerHelpers.cpp
+++ b/src/ui/PluginPickerHelpers.cpp
@@ -402,9 +402,11 @@ void openPickerMenu (PluginSlot& slot,
                           ? manager.getInstrumentDescriptions()
                           : manager.getEffectDescriptions();
 
-    // Merge native-CLAP effects into the unified list when the caller can host them.
-    if (onPickNativeClap && kind == PluginKind::Effects)
-        descriptions.addArray (manager.getClapEffectDescriptions());
+    // Merge native-CLAP plugins into the unified list when the caller can host them.
+    if (onPickNativeClap)
+        descriptions.addArray (kind == PluginKind::Effects
+                                 ? manager.getClapEffectDescriptions()
+                                 : manager.getClapInstrumentDescriptions());
 
     // Native-LV2 rows replace the JUCE-hosted LV2 effect rows (same plugins, better
     // host) so each plugin appears once. JUCE LV2 stays the fallback when unset.
@@ -415,12 +417,14 @@ void openPickerMenu (PluginSlot& slot,
         descriptions.addArray (manager.getLv2EffectDescriptions());
     }
 
-    // Native-VST3 rows replace the JUCE-hosted VST3 effect rows, same as LV2.
-    if (onPickNativeVst3 && kind == PluginKind::Effects)
+    // Native-VST3 rows replace the JUCE-hosted VST3 rows for both kinds.
+    if (onPickNativeVst3)
     {
         descriptions.removeIf ([] (const juce::PluginDescription& d)
                                { return d.pluginFormatName == "VST3"; });
-        descriptions.addArray (manager.getVst3NativeEffectDescriptions());
+        descriptions.addArray (kind == PluginKind::Effects
+                                 ? manager.getVst3NativeEffectDescriptions()
+                                 : manager.getVst3NativeInstrumentDescriptions());
     }
 
     auto* parent = target.getTopLevelComponent();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -157,6 +157,10 @@ if(DUSKSTUDIO_NATIVE_LV2)
     target_compile_definitions(dusk-studio-tests PRIVATE DUSKSTUDIO_HAS_NATIVE_LV2=1)
 endif()
 
+if(DUSKSTUDIO_NATIVE_CLAP OR DUSKSTUDIO_NATIVE_LV2 OR DUSKSTUDIO_NATIVE_VST3)
+    target_sources(dusk-studio-tests PRIVATE native_instrument_process.cpp)
+endif()
+
 # Native VST3 host — SDK hosting subset (see the dusk-vst3-hosting target in the
 # top-level CMakeLists), ON when the external/vst3sdk submodule is initialized.
 if(DUSKSTUDIO_NATIVE_VST3)

--- a/tests/native_instrument_process.cpp
+++ b/tests/native_instrument_process.cpp
@@ -1,0 +1,136 @@
+// Natively-hosted instruments: load a real synth through each format's slot,
+// feed it a note, and require audible output (and silence without notes).
+// Gated on DUSKSTUDIO_TEST_INSTRUMENT_{CLAP,VST3,LV2}=/path/to/bundle so CI
+// without synths stays green.
+
+#include <catch2/catch_test_macros.hpp>
+
+#if DUSKSTUDIO_HAS_NATIVE_CLAP
+ #include "engine/clap/NativeClapSlot.h"
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+ #include "engine/lv2/NativeLv2Slot.h"
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_VST3
+ #include "engine/vst3/NativeVst3Slot.h"
+#endif
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <vector>
+
+namespace
+{
+constexpr int kBlock = 512;
+
+// Drive `blocks` blocks; a note-on lands in the first block, a note-off midway.
+// Returns the output peak across the run.
+template <typename Slot>
+float driveNote (Slot& slot, int blocks)
+{
+    std::vector<float> L ((size_t) kBlock), R ((size_t) kBlock);
+    float peak = 0.0f;
+    for (int b = 0; b < blocks; ++b)
+    {
+        juce::MidiBuffer midi;
+        // Several keys so drum-mapped instruments (kick/snare/hat) trigger too.
+        const int keys[] = { 36, 38, 42, 60 };
+        if (b == 0)
+            for (const int k : keys)
+                midi.addEvent (juce::MidiMessage::noteOn (1, k, (juce::uint8) 100), 0);
+        if (b == blocks / 2)
+            for (const int k : keys)
+                midi.addEvent (juce::MidiMessage::noteOff (1, k), 0);
+        std::fill (L.begin(), L.end(), 0.0f);
+        std::fill (R.begin(), R.end(), 0.0f);
+        slot.processStereo (L.data(), R.data(), L.data(), R.data(), kBlock, &midi);
+        for (int i = 0; i < kBlock; ++i)
+        {
+            REQUIRE (std::isfinite (L[(size_t) i]));
+            REQUIRE (std::isfinite (R[(size_t) i]));
+            peak = std::max ({ peak, std::abs (L[(size_t) i]), std::abs (R[(size_t) i]) });
+        }
+    }
+    return peak;
+}
+
+template <typename Slot>
+float driveSilence (Slot& slot, int blocks)
+{
+    std::vector<float> L ((size_t) kBlock), R ((size_t) kBlock);
+    float peak = 0.0f;
+    for (int b = 0; b < blocks; ++b)
+    {
+        std::fill (L.begin(), L.end(), 0.0f);
+        std::fill (R.begin(), R.end(), 0.0f);
+        slot.processStereo (L.data(), R.data(), L.data(), R.data(), kBlock, nullptr);
+        for (int i = 0; i < kBlock; ++i)
+            peak = std::max ({ peak, std::abs (L[(size_t) i]), std::abs (R[(size_t) i]) });
+    }
+    return peak;
+}
+} // namespace
+
+#if DUSKSTUDIO_HAS_NATIVE_CLAP
+TEST_CASE ("Native CLAP instrument produces audio from notes", "[clap][instrument]")
+{
+    const char* path = std::getenv ("DUSKSTUDIO_TEST_INSTRUMENT_CLAP");
+    if (path == nullptr || *path == '\0')
+    { SUCCEED ("DUSKSTUDIO_TEST_INSTRUMENT_CLAP not set — skipping"); return; }
+
+    duskstudio::clap::NativeClapSlot slot;
+    std::string err;
+    REQUIRE (slot.load (juce::File (juce::String (path)), 48000.0, kBlock, err));
+    REQUIRE (slot.isLoadedInstrument());
+
+    REQUIRE (driveSilence (slot, 8) < 1.0e-2f);
+    REQUIRE (driveNote (slot, 32) > 1.0e-3f);
+}
+#endif
+
+#if DUSKSTUDIO_HAS_NATIVE_VST3
+TEST_CASE ("Native VST3 instrument produces audio from notes", "[vst3][instrument]")
+{
+    const char* path = std::getenv ("DUSKSTUDIO_TEST_INSTRUMENT_VST3");
+    if (path == nullptr || *path == '\0')
+    { SUCCEED ("DUSKSTUDIO_TEST_INSTRUMENT_VST3 not set — skipping"); return; }
+
+    // The default pick is effects-only; instruments load by explicit class id.
+    duskstudio::vst3::Vst3Bundle bundle;
+    std::string err;
+    REQUIRE (bundle.load (path, err));
+    juce::String classId;
+    for (const auto& d : bundle.plugins())
+        if (d.isInstrument) { classId = juce::String (juce::CharPointer_UTF8 (d.id.c_str())); break; }
+    if (classId.isEmpty())
+    { SUCCEED ("module advertises no instrument class — skipping"); return; }
+
+    duskstudio::vst3::NativeVst3Slot slot;
+    REQUIRE (slot.load (juce::File (juce::String (path)), 48000.0, kBlock, err, classId));
+    // No isLoadedInstrument assert: instrument-flagged hybrids with an audio
+    // input bus exist (drum-replacement tools). Notes making sound is the test.
+
+    REQUIRE (driveSilence (slot, 8) < 1.0e-2f);
+    REQUIRE (driveNote (slot, 32) > 1.0e-3f);
+}
+#endif
+
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+TEST_CASE ("Native LV2 instrument produces audio from notes", "[lv2][instrument]")
+{
+    const char* path = std::getenv ("DUSKSTUDIO_TEST_INSTRUMENT_LV2");
+    if (path == nullptr || *path == '\0')
+    { SUCCEED ("DUSKSTUDIO_TEST_INSTRUMENT_LV2 not set — skipping"); return; }
+
+    duskstudio::lv2::NativeLv2Slot slot;
+    std::string err;
+    REQUIRE (slot.load (juce::File (juce::String (path)), 48000.0, kBlock, err));
+    // No isLoadedInstrument assert: JUCE-built LV2 instruments expose an audio
+    // input bus, so the layout legitimately isn't input-less. The strip's MIDI
+    // branch only needs isLoaded — what matters is that notes make sound.
+
+    REQUIRE (driveSilence (slot, 8) < 1.0e-2f);
+    REQUIRE (driveNote (slot, 32) > 1.0e-3f);
+}
+#endif

--- a/tests/native_instrument_process.cpp
+++ b/tests/native_instrument_process.cpp
@@ -34,14 +34,18 @@ float driveNote (Slot& slot, int blocks)
     for (int b = 0; b < blocks; ++b)
     {
         juce::MidiBuffer midi;
-        // Several keys so drum-mapped instruments (kick/snare/hat) trigger too.
+        // Several keys so drum-mapped instruments (kick/snare/hat) trigger too,
+        // re-struck periodically — sample-library instruments can still be
+        // streaming their kit when the first note lands.
         const int keys[] = { 36, 38, 42, 60 };
-        if (b == 0)
+        if (b % 16 == 0)
             for (const int k : keys)
-                midi.addEvent (juce::MidiMessage::noteOn (1, k, (juce::uint8) 100), 0);
-        if (b == blocks / 2)
+                for (const int ch : { 1, 10 })   // 10: GM drum-channel convention
+                    midi.addEvent (juce::MidiMessage::noteOn (ch, k, (juce::uint8) 100), 0);
+        if (b % 16 == 12)
             for (const int k : keys)
-                midi.addEvent (juce::MidiMessage::noteOff (1, k), 0);
+                for (const int ch : { 1, 10 })
+                    midi.addEvent (juce::MidiMessage::noteOff (ch, k), 0);
         std::fill (L.begin(), L.end(), 0.0f);
         std::fill (R.begin(), R.end(), 0.0f);
         slot.processStereo (L.data(), R.data(), L.data(), R.data(), kBlock, &midi);
@@ -84,8 +88,9 @@ TEST_CASE ("Native CLAP instrument produces audio from notes", "[clap][instrumen
     REQUIRE (slot.load (juce::File (juce::String (path)), 48000.0, kBlock, err));
     REQUIRE (slot.isLoadedInstrument());
 
+    driveSilence (slot, 188);   // ~2 s warmup: sample libraries stream their kits
     REQUIRE (driveSilence (slot, 8) < 1.0e-2f);
-    REQUIRE (driveNote (slot, 32) > 1.0e-3f);
+    REQUIRE (driveNote (slot, 64) > 1.0e-3f);
 }
 #endif
 
@@ -111,8 +116,9 @@ TEST_CASE ("Native VST3 instrument produces audio from notes", "[vst3][instrumen
     // No isLoadedInstrument assert: instrument-flagged hybrids with an audio
     // input bus exist (drum-replacement tools). Notes making sound is the test.
 
+    driveSilence (slot, 188);   // ~2 s warmup: sample libraries stream their kits
     REQUIRE (driveSilence (slot, 8) < 1.0e-2f);
-    REQUIRE (driveNote (slot, 32) > 1.0e-3f);
+    REQUIRE (driveNote (slot, 64) > 1.0e-3f);
 }
 #endif
 
@@ -130,7 +136,8 @@ TEST_CASE ("Native LV2 instrument produces audio from notes", "[lv2][instrument]
     // input bus, so the layout legitimately isn't input-less. The strip's MIDI
     // branch only needs isLoaded — what matters is that notes make sound.
 
+    driveSilence (slot, 188);   // ~2 s warmup: sample libraries stream their kits
     REQUIRE (driveSilence (slot, 8) < 1.0e-2f);
-    REQUIRE (driveNote (slot, 32) > 1.0e-3f);
+    REQUIRE (driveNote (slot, 64) > 1.0e-3f);
 }
 #endif

--- a/tests/native_instrument_process.cpp
+++ b/tests/native_instrument_process.cpp
@@ -119,6 +119,11 @@ TEST_CASE ("Native VST3 instrument produces audio from notes", "[vst3][instrumen
     driveSilence (slot, 188);   // ~2 s warmup: sample libraries stream their kits
     REQUIRE (driveSilence (slot, 8) < 1.0e-2f);
     REQUIRE (driveNote (slot, 64) > 1.0e-3f);
+
+    // The CC bridge cached the plugin's IMidiMapping. Zero is legitimate (drum
+    // instruments map no controllers), so only synth-style plugins that map
+    // anything prove the bridge — Diva maps the usual suspects.
+    INFO ("IMidiMapping assignments: " << slot.getInstance()->midiCcMappingCount());
 }
 #endif
 


### PR DESCRIPTION
## Summary

Follow-up to #24 and the last big feature in the de-JUCE plugin-hosting mission: natively-hosted **instruments**. `PortBuffers` carried MIDI since the foundation and the `InsertAdapter` forwarded it — the instances just never read it.

### MIDI delivery (per format)

- **CLAP**: `CLAP_EXT_NOTE_PORTS` negotiated at create, and the legacy stereo-only gate is gone — an audio output plus either an audio input or a note port is enough (this also unblocks mono CLAP effects). The per-block event list becomes a union of param changes and converted notes / raw MIDI, delivered in the plugin's preferred dialect.
- **VST3**: notes convert onto the event bus. CCs get the real thing: the `IMidiMapping` assignment table (all channels × controllers, pitch bend and channel pressure included) is cached on the message thread and rebuilt on `kMidiCCAssignmentChanged`; the audio thread resolves CCs lock-free into sample-offset `IParameterChanges` points, ordered after the UI ring's offset-0 points. Mod wheel, sustain, and pitch bend work on a native VST3 synth.
- **LV2**: `midi:MidiEvent` atoms append to the control sequence at their sample offsets, after the frame-0 patch atoms so it stays time-sorted. Bonus: the control atom *output* is now parsed post-run, folding the plugin's `patch:Set`/`patch:Put` responses into the read-back shadow — a preset loaded in the plugin's own UI no longer leaves `getParamValue` stale.

### App integration

Instrument rows join the native picker merges (native VST3 rows replace the JUCE ones, same as effects; LV2 instruments stay with the standard host — JUCE-built LV2 instruments are audio-input hybrids). Loading a native instrument flips the track to MIDI and routes the Virtual Keyboard when nothing is bound, via the same defaults the JUCE path used (now shared). The track-mode gate matches *kind* for native slots exactly like JUCE ones — instruments survive the switch to MIDI, effects don't ride MIDI strips — instead of unloading every native plugin on a mode flip.

## Testing

- 310/310 unit suite; new gated per-format instrument tests: a note chord must produce audible output, silence must stay silent, with a 2 s warmup for sample-streaming instruments and GM channel-10 notes
- Live: **Diva through both CLAP and VST3** (u-he — the strict-host case), MininnDrum (VST3), Ardour's reasonablesynth (LV2, pure atom MIDI, no JUCE-wrapper shortcut); effects regressions clean across all three formats
- In-app under Xvfb: a session carrying Diva as a native VST3 instrument restores onto a MIDI strip and opens the full Diva editor through the native embed
- Ugritone Drums stays silent on a fresh instance — through the JUCE host as well (headless harness verdict: SILENCE), i.e. the plugin waits for kit content; not a hosting gap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native instrument plugins now load and appear in the plugin picker on Linux for CLAP and VST3, alongside effects.
  * MIDI input is now passed through more consistently to supported native instruments and MIDI-driven effects.
  * VST3 plugins can now respond to MIDI CC mappings, pitch bend, and aftertouch.
* **Bug Fixes**
  * Improved handling for instrument plugins with nonstandard I/O setups.
  * Fixed patch/value feedback so plugin-side changes stay in sync (including LV2 patch feedback).
* **Documentation**
  * Updated Linux plugin hosting guidance for VST3 and CLAP.
* **Tests**
  * Added native instrument processing coverage for CLAP, VST3, and LV2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->