### PR TITLE
Chore/dejuce UI sweep

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -593,6 +593,7 @@ Each channel has one insert slot, which can hold either a plugin or a hardware i
 - Click **+ Plugin** to open the plugin picker.
 - Right-click the slot for **Add / Replace / Remove / Edit / Configure as hardware insert**.
 - When a plugin is loaded, the slot shows its name. Click to open the editor.
+- The LED on the slot's left edge bypasses the insert — green when engaged, dark when bypassed or empty, click to toggle (same grammar as the EQ and COMP LEDs). The insert keeps processing while bypassed, so re-engaging is click-free.
 
 The insert sits **before** the HPF, so any plugin you load drives the rest of the channel's tone shaping.
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1794,6 +1794,12 @@ Shortcuts use **Cmd** on macOS and **Ctrl** on Linux and Windows unless noted.
 | **Shift+[** | Set punch in at playhead      |
 | **Shift+]** | Set punch out at playhead     |
 | **K**       | Toggle virtual MIDI keyboard  |
+| **Shift+←/→** | Previous / next marker (Rewind / Forward tap) |
+| **B**       | Tap tempo                     |
+| **Shift+C** | Toggle count-in               |
+| **F**       | Toggle time / bars display    |
+| **Shift+M** | Time signature menu           |
+| **U**       | Tuner (selected track)        |
 
 ## Tracks
 

--- a/src/dsp/ChannelStrip.cpp
+++ b/src/dsp/ChannelStrip.cpp
@@ -643,6 +643,12 @@ void ChannelStrip::processAndAccumulate (const float* inL,
     //     1.0 when an insert is active (plugin or hardware), 0.0 when
     //     empty (no DSP runs at all).
     const int req = insertMode.load (std::memory_order_acquire);
+    // Bypass rides the same gate as an empty slot: wet ramps out, dry
+    // passes. The insert keeps processing underneath so un-bypass picks
+    // up live tails instead of a cold restart.
+    const bool insertBypassed = paramsRef != nullptr
+        && paramsRef->insertBypassed.load (std::memory_order_relaxed);
+    const float engagedTarget = (insertBypassed ? 0.0f : 1.0f);
     if (req != activeInsertMode)
     {
         if (activeInsertGain.getCurrentValue() > 1.0e-4f)
@@ -655,13 +661,13 @@ void ChannelStrip::processAndAccumulate (const float* inL,
             if (activeInsertMode == kInsertHardware)
                 hardwareSlot.resetTailsAndDelayLine();
             activeInsertGain.setTargetValue (activeInsertMode == kInsertEmpty
-                                              ? 0.0f : 1.0f);
+                                              ? 0.0f : engagedTarget);
         }
     }
     else
     {
         activeInsertGain.setTargetValue (activeInsertMode == kInsertEmpty
-                                          ? 0.0f : 1.0f);
+                                          ? 0.0f : engagedTarget);
     }
 
     lastProcessedPtr = nullptr;

--- a/src/engine/clap/ClapEditor.cpp
+++ b/src/engine/clap/ClapEditor.cpp
@@ -92,6 +92,19 @@ void ClapEditor::setBounds (int x, int y, int w, int h)
     XFlush (dpy);
 }
 
+bool ClapEditor::getActualGeometry (int& x, int& y, int& w, int& h) const
+{
+    if (! embedded || display == nullptr || hostWindow == 0)
+        return false;
+    ::Window root {};
+    unsigned int uw = 0, uh = 0, border = 0, depth = 0;
+    if (XGetGeometry ((Display*) display, (Window) hostWindow,
+                      &root, &x, &y, &uw, &uh, &border, &depth) == 0)
+        return false;
+    w = (int) uw; h = (int) uh;
+    return true;
+}
+
 void ClapEditor::reveal()
 {
     if (display == nullptr || hostWindow == 0 || mapped) return;

--- a/src/engine/clap/ClapEditor.cpp
+++ b/src/engine/clap/ClapEditor.cpp
@@ -55,10 +55,15 @@ bool ClapEditor::embed (unsigned long parentX11, int x, int y, int w, int h, std
     swa.background_pixel = BlackPixel (dpy, DefaultScreen (dpy));
     swa.border_pixel     = 0;
     swa.event_mask       = StructureNotifyMask;
+    // Keep the WM's hands off this window in every transient state (JUCE's
+    // XEmbed host sets the same flag on its host window): under mutter's
+    // x11-frames a managed adoption detaches the compositor-side surface
+    // from the X-space parent-child position.
+    swa.override_redirect = True;
     hostWindow = XCreateWindow (dpy, (Window) parentX11, x, y,
                                 (unsigned) ww, (unsigned) hh, 0,
                                 CopyFromParent, InputOutput, CopyFromParent,
-                                CWBackPixel | CWBorderPixel | CWEventMask, &swa);
+                                CWBackPixel | CWBorderPixel | CWEventMask | CWOverrideRedirect, &swa);
     // Map the host window BEFORE set_parent: some plugins (u-he Satin) abort() when
     // reparented into a non-viewable window. tryEmbed only runs when this component is
     // on-screen, so showing the host now is correct — it sits at the lane's coords with
@@ -90,6 +95,23 @@ void ClapEditor::setBounds (int x, int y, int w, int h)
     if (resizable && gui != nullptr && gui->set_size != nullptr && w > 0 && h > 0)
         gui->set_size (plugin, (uint32_t) w, (uint32_t) h);
     XFlush (dpy);
+}
+
+bool ClapEditor::getRootRelativePosition (unsigned long referenceWindow,
+                                           int& relX, int& relY) const
+{
+    if (! embedded || display == nullptr || hostWindow == 0)
+        return false;
+    auto* dpy = (Display*) display;
+    ::Window dummy {};
+    int hx = 0, hy = 0, rx = 0, ry = 0;
+    if (! XTranslateCoordinates (dpy, (Window) hostWindow,
+                                 DefaultRootWindow (dpy), 0, 0, &hx, &hy, &dummy)
+        || ! XTranslateCoordinates (dpy, (Window) referenceWindow,
+                                    DefaultRootWindow (dpy), 0, 0, &rx, &ry, &dummy))
+        return false;
+    relX = hx - rx; relY = hy - ry;
+    return true;
 }
 
 bool ClapEditor::getActualGeometry (int& x, int& y, int& w, int& h) const

--- a/src/engine/clap/ClapEditor.h
+++ b/src/engine/clap/ClapEditor.h
@@ -40,6 +40,8 @@ public:
     // The host window's REAL geometry (position relative to its X11 parent +
     // size), so the owner can detect and correct drift the message flow
     // missed. False when not embedded or the window is gone.
+    bool getRootRelativePosition (unsigned long referenceWindow,
+                                  int& relX, int& relY) const;
     bool getActualGeometry (int& x, int& y, int& w, int& h) const;
 
     // App shutdown: leak the plugin GUI instead of destroying it. u-he (Satin/Diva)

--- a/src/engine/clap/ClapEditor.h
+++ b/src/engine/clap/ClapEditor.h
@@ -37,6 +37,11 @@ public:
     void hide();     // XUnmapWindow
     void close();
 
+    // The host window's REAL geometry (position relative to its X11 parent +
+    // size), so the owner can detect and correct drift the message flow
+    // missed. False when not embedded or the window is gone.
+    bool getActualGeometry (int& x, int& y, int& w, int& h) const;
+
     // App shutdown: leak the plugin GUI instead of destroying it. u-he (Satin/Diva)
     // hang in gui->destroy on teardown — same reason the JUCE host leaks plugins on
     // quit. close() then skips gui->hide/gui->destroy; the process is exiting anyway.

--- a/src/engine/lv2/Lv2Editor.cpp
+++ b/src/engine/lv2/Lv2Editor.cpp
@@ -157,10 +157,15 @@ bool Lv2Editor::embed (unsigned long parentX11, int x, int y, int w, int h, std:
     swa.background_pixel = BlackPixel (dpy, DefaultScreen (dpy));
     swa.border_pixel     = 0;
     swa.event_mask       = StructureNotifyMask;
+    // Keep the WM's hands off this window in every transient state (JUCE's
+    // XEmbed host sets the same flag on its host window): under mutter's
+    // x11-frames a managed adoption detaches the compositor-side surface
+    // from the X-space parent-child position.
+    swa.override_redirect = True;
     impl->hostWindow = XCreateWindow (dpy, (Window) parentX11, x, y,
                                       (unsigned) ww, (unsigned) hh, 0,
                                       CopyFromParent, InputOutput, CopyFromParent,
-                                      CWBackPixel | CWBorderPixel | CWEventMask, &swa);
+                                      CWBackPixel | CWBorderPixel | CWEventMask | CWOverrideRedirect, &swa);
     // Viewable BEFORE the UI instantiates into it — toolkit wrappers (and JUCE-
     // wrapped UIs) can abort realising into an unmapped parent.
     XMapWindow (dpy, impl->hostWindow);
@@ -238,6 +243,23 @@ void Lv2Editor::setBounds (int x, int y, int w, int h)
         XResizeWindow (dpy, (Window) impl->uiWindow,
                        (unsigned) std::max (1, w), (unsigned) std::max (1, h));
     XFlush (dpy);
+}
+
+bool Lv2Editor::getRootRelativePosition (unsigned long referenceWindow,
+                                          int& relX, int& relY) const
+{
+    if (! impl->embedded || impl->display == nullptr || impl->hostWindow == 0)
+        return false;
+    auto* dpy = (Display*) impl->display;
+    ::Window dummy {};
+    int hx = 0, hy = 0, rx = 0, ry = 0;
+    if (! XTranslateCoordinates (dpy, (Window) impl->hostWindow,
+                                 DefaultRootWindow (dpy), 0, 0, &hx, &hy, &dummy)
+        || ! XTranslateCoordinates (dpy, (Window) referenceWindow,
+                                    DefaultRootWindow (dpy), 0, 0, &rx, &ry, &dummy))
+        return false;
+    relX = hx - rx; relY = hy - ry;
+    return true;
 }
 
 bool Lv2Editor::getActualGeometry (int& x, int& y, int& w, int& h) const

--- a/src/engine/lv2/Lv2Editor.cpp
+++ b/src/engine/lv2/Lv2Editor.cpp
@@ -240,6 +240,19 @@ void Lv2Editor::setBounds (int x, int y, int w, int h)
     XFlush (dpy);
 }
 
+bool Lv2Editor::getActualGeometry (int& x, int& y, int& w, int& h) const
+{
+    if (! impl->embedded || impl->display == nullptr || impl->hostWindow == 0)
+        return false;
+    ::Window root {};
+    unsigned int uw = 0, uh = 0, border = 0, depth = 0;
+    if (XGetGeometry ((Display*) impl->display, (Window) impl->hostWindow,
+                      &root, &x, &y, &uw, &uh, &border, &depth) == 0)
+        return false;
+    w = (int) uw; h = (int) uh;
+    return true;
+}
+
 void Lv2Editor::reveal()
 {
     if (impl->display == nullptr || impl->hostWindow == 0 || impl->mapped) return;

--- a/src/engine/lv2/Lv2Editor.h
+++ b/src/engine/lv2/Lv2Editor.h
@@ -41,6 +41,11 @@ public:
     void hide();     // XUnmapWindow (idempotent)
     void close();
 
+    // The host window's REAL geometry (position relative to its X11 parent +
+    // size), so the owner can detect and correct drift the message flow
+    // missed. False when not embedded or the window is gone.
+    bool getActualGeometry (int& x, int& y, int& w, int& h) const;
+
     // App shutdown: skip suil_instance_free — a foreign-toolkit UI's destructor
     // can hang on the way out (same rationale as the CLAP editor leak path).
     void setLeakOnClose (bool b) noexcept;

--- a/src/engine/lv2/Lv2Editor.h
+++ b/src/engine/lv2/Lv2Editor.h
@@ -44,6 +44,8 @@ public:
     // The host window's REAL geometry (position relative to its X11 parent +
     // size), so the owner can detect and correct drift the message flow
     // missed. False when not embedded or the window is gone.
+    bool getRootRelativePosition (unsigned long referenceWindow,
+                                  int& relX, int& relY) const;
     bool getActualGeometry (int& x, int& y, int& w, int& h) const;
 
     // App shutdown: skip suil_instance_free — a foreign-toolkit UI's destructor

--- a/src/engine/vst3/Vst3Editor.cpp
+++ b/src/engine/vst3/Vst3Editor.cpp
@@ -115,10 +115,15 @@ bool Vst3Editor::embed (unsigned long parentX11, int x, int y, int w, int h, std
     swa.background_pixel = BlackPixel (dpy, DefaultScreen (dpy));
     swa.border_pixel     = 0;
     swa.event_mask       = StructureNotifyMask;
+    // Keep the WM's hands off this window in every transient state (JUCE's
+    // XEmbed host sets the same flag on its host window): under mutter's
+    // x11-frames a managed adoption detaches the compositor-side surface
+    // from the X-space parent-child position.
+    swa.override_redirect = True;
     impl->hostWindow = XCreateWindow (dpy, (Window) parentX11, x, y,
                                       (unsigned) ww, (unsigned) hh, 0,
                                       CopyFromParent, InputOutput, (Visual*) CopyFromParent,
-                                      CWBackPixel | CWBorderPixel | CWEventMask, &swa);
+                                      CWBackPixel | CWBorderPixel | CWEventMask | CWOverrideRedirect, &swa);
     // Viewable BEFORE the view attaches — toolkit-backed editors can abort
     // realising into an unmapped parent.
     XMapWindow (dpy, impl->hostWindow);
@@ -157,6 +162,23 @@ void Vst3Editor::setContentScale (float scale)
 {
     impl->contentScale = scale;
     impl->applyContentScale();
+}
+
+bool Vst3Editor::getRootRelativePosition (unsigned long referenceWindow,
+                                           int& relX, int& relY) const
+{
+    if (! impl->embedded || impl->display == nullptr || impl->hostWindow == 0)
+        return false;
+    auto* dpy = (Display*) impl->display;
+    ::Window dummy {};
+    int hx = 0, hy = 0, rx = 0, ry = 0;
+    if (! XTranslateCoordinates (dpy, (Window) impl->hostWindow,
+                                 DefaultRootWindow (dpy), 0, 0, &hx, &hy, &dummy)
+        || ! XTranslateCoordinates (dpy, (Window) referenceWindow,
+                                    DefaultRootWindow (dpy), 0, 0, &rx, &ry, &dummy))
+        return false;
+    relX = hx - rx; relY = hy - ry;
+    return true;
 }
 
 bool Vst3Editor::getActualGeometry (int& x, int& y, int& w, int& h) const

--- a/src/engine/vst3/Vst3Editor.cpp
+++ b/src/engine/vst3/Vst3Editor.cpp
@@ -159,6 +159,19 @@ void Vst3Editor::setContentScale (float scale)
     impl->applyContentScale();
 }
 
+bool Vst3Editor::getActualGeometry (int& x, int& y, int& w, int& h) const
+{
+    if (! impl->embedded || impl->display == nullptr || impl->hostWindow == 0)
+        return false;
+    ::Window root {};
+    unsigned int uw = 0, uh = 0, border = 0, depth = 0;
+    if (XGetGeometry ((Display*) impl->display, (Window) impl->hostWindow,
+                      &root, &x, &y, &uw, &uh, &border, &depth) == 0)
+        return false;
+    w = (int) uw; h = (int) uh;
+    return true;
+}
+
 void Vst3Editor::reveal()
 {
     if (impl->display == nullptr || impl->hostWindow == 0 || impl->mapped) return;

--- a/src/engine/vst3/Vst3Editor.h
+++ b/src/engine/vst3/Vst3Editor.h
@@ -41,6 +41,11 @@ public:
     void hide();     // XUnmapWindow (idempotent)
     void close();
 
+    // The host window's REAL geometry (position relative to its X11 parent +
+    // size), so the owner can detect and correct drift the message flow
+    // missed. False when not embedded or the window is gone.
+    bool getActualGeometry (int& x, int& y, int& w, int& h) const;
+
     // Message thread, ~60 Hz: pump the instance's IRunLoop (fds + timers) and
     // drain our X connection.
     void pump (double elapsedMs);

--- a/src/engine/vst3/Vst3Editor.h
+++ b/src/engine/vst3/Vst3Editor.h
@@ -44,6 +44,8 @@ public:
     // The host window's REAL geometry (position relative to its X11 parent +
     // size), so the owner can detect and correct drift the message flow
     // missed. False when not embedded or the window is gone.
+    bool getRootRelativePosition (unsigned long referenceWindow,
+                                  int& relX, int& relY) const;
     bool getActualGeometry (int& x, int& y, int& w, int& h) const;
 
     // Message thread, ~60 Hz: pump the instance's IRunLoop (fds + timers) and

--- a/src/session/Session.h
+++ b/src/session/Session.h
@@ -175,6 +175,10 @@ struct ChannelStripParams
     std::atomic<bool>  mute    { false };
     std::atomic<bool>  solo    { false };
     std::atomic<bool>  phaseInvert { false };
+    // Insert (plugin or hardware) bypass — drives the insert crossfade
+    // gate to dry. The plugin keeps processing so tails stay warm and
+    // un-bypass is click-free.
+    std::atomic<bool>  insertBypassed { false };
 
     // 0 = ungrouped; 1..N = group members. Drag deltas apply across
     // group; anchor values captured at drag-start preserve relative

--- a/src/session/SessionSerializer.cpp
+++ b/src/session/SessionSerializer.cpp
@@ -356,6 +356,8 @@ juce::DynamicObject::Ptr trackToObject (const Track& t, const juce::File& sessio
     obj->setProperty ("mute",           t.strip.mute.load());
     obj->setProperty ("solo",           t.strip.solo.load());
     obj->setProperty ("phase_invert",   t.strip.phaseInvert.load());
+    if (t.strip.insertBypassed.load())
+        obj->setProperty ("insert_bypassed", true);
     obj->setProperty ("fader_group",    t.strip.faderGroupId.load());
     obj->setProperty ("input_monitor",  t.inputMonitor.load());
     obj->setProperty ("print_effects",  t.printEffects.load());
@@ -769,6 +771,8 @@ void restoreTrack (Track& t, const juce::var& v, double defaultRecordBpm,
     setBool  (t.strip.mute,         "mute");
     setBool  (t.strip.solo,         "solo");
     setBool  (t.strip.phaseInvert,  "phase_invert");
+    t.strip.insertBypassed.store (v.hasProperty ("insert_bypassed")
+                                    && (bool) v["insert_bypassed"]);
     setInt   (t.strip.faderGroupId, "fader_group");
     setBool  (t.inputMonitor,       "input_monitor");
     setBool  (t.printEffects,       "print_effects");

--- a/src/ui/AuxLaneComponent.cpp
+++ b/src/ui/AuxLaneComponent.cpp
@@ -817,7 +817,6 @@ void AuxLaneComponent::openPickerForSlot (int slotIdx)
 #endif
     pluginpicker::openPickerMenu (strip.getPluginSlot (slotIdx),
                                     slots[(size_t) slotIdx].openOrAddButton,
-                                    activePluginChooser,
                                     [safe, slotIdx]
                                     {
                                         if (auto* self = safe.getComponent())

--- a/src/ui/AuxLaneComponent.h
+++ b/src/ui/AuxLaneComponent.h
@@ -167,6 +167,5 @@ private:
         juce::String displayedName;
     };
     std::array<SlotUI, AuxLaneParams::kMaxLanePlugins> slots;
-    std::unique_ptr<juce::FileChooser> activePluginChooser;
 };
 } // namespace duskstudio

--- a/src/ui/AuxView.cpp
+++ b/src/ui/AuxView.cpp
@@ -48,6 +48,7 @@ public:
         editor.setText (currentName, juce::dontSendNotification);
         editor.setJustification (juce::Justification::centredLeft);
         editor.setFont (juce::Font (juce::FontOptions (14.0f)));
+        editor.setPopupMenuEnabled (false);   // XWayland popup flash (see DuskComboBox)
         editor.setColour (juce::TextEditor::backgroundColourId, juce::Colour (0xff181820));
         editor.setColour (juce::TextEditor::outlineColourId,    juce::Colour (0xff3a3a42));
         editor.setColour (juce::TextEditor::focusedOutlineColourId, juce::Colour (0xff6a6a78));

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -1430,7 +1430,7 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
     pluginSlotButton.setColour (juce::TextButton::textColourOffId,  juce::Colour (0xff9080c0));
     pluginSlotButton.setColour (juce::TextButton::textColourOnId,   juce::Colour (0xffd0c0e0));
     pluginSlotButton.setTooltip (juce::CharPointer_UTF8 (
-        "Empty: click to pick a plugin (VST3 / LV2) or an External "
+        "Empty: click to pick a plugin (VST3 / CLAP / LV2) or an External "
         "Hardware Insert. Loaded plugin: click to toggle the editor; "
         "right-click for Replace / Remove. Hardware insert: click to "
         "open the routing editor."));

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -1461,6 +1461,21 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
     };
     addAndMakeVisible (pluginSlotButton);
 
+    // Added after the slot button so it z-orders above and gets the click.
+    insertBypassLed = std::make_unique<CompBypassLed> (
+        [this]
+        {
+            return insertSlotOccupied()
+                && ! track.strip.insertBypassed.load (std::memory_order_relaxed);
+        },
+        [this]
+        {
+            const bool now = ! track.strip.insertBypassed.load (std::memory_order_relaxed);
+            track.strip.insertBypassed.store (now, std::memory_order_release);
+        });
+    insertBypassLed->setTooltip ("Insert bypass - green when engaged, click to toggle");
+    addAndMakeVisible (insertBypassLed.get());
+
     // Compact-mode placeholder buttons. Hidden by default; setCompactMode(true)
     // makes them visible and hides the full inline EQ + COMP + AUX controls.
     styleCompactSectionButton (eqCompactButton,   juce::Colour (fourKColors::kLfGreen));
@@ -2090,6 +2105,16 @@ void ChannelStripComponent::refreshInsertButtonForCapture()
 {
     refreshPluginSlotButton();
     repaint();
+}
+
+bool ChannelStripComponent::insertSlotOccupied() const
+{
+    auto& st = engine.getChannelStrip (trackIndex);
+    if (st.isNativeClapLoaded() || st.isNativeLv2Loaded() || st.isNativeVst3Loaded())
+        return true;
+    if (pluginSlot.isLoaded())
+        return true;
+    return st.insertMode.load (std::memory_order_acquire) == ChannelStrip::kInsertHardware;
 }
 
 void ChannelStripComponent::refreshPluginSlotButton()
@@ -3429,6 +3454,8 @@ void ChannelStripComponent::timerCallback()
         // tracks atom changes from external mutation paths.
         eqHeaderBtn->repaint();
     }
+    if (insertBypassLed != nullptr)
+        insertBypassLed->repaint();   // tracks bypass atom + slot load/unload
     // Sync the dedicated E/G chip's label + toggle state from the atom
     // so external writes (popup editor type picker) reflect inline.
     {
@@ -4915,11 +4942,18 @@ void ChannelStripComponent::resized()
 
     // Plugin-slot button right below the IN/ARM/PRINT row. Always visible -
     // available in both compact and full modes since it's independent of the
-    // EQ/COMP collapse.
-    // reduced(4,0) matches the EQ / COMP / AUX compact buttons below so all
-    // four section buttons share one width - otherwise the wider Insert border
-    // sticks out past them and reads as a double / stacked outline.
-    pluginSlotButton.setBounds (area.removeFromTop (18).reduced (4, 0));
+    // EQ/COMP collapse. Full mode matches the EQ/COMP headers' inset (3) so
+    // the insert row reads as the same width as the track; compact keeps the
+    // pills' inset (4) so the stacked section buttons share one width.
+    {
+        const auto insertRow = area.removeFromTop (18);
+        pluginSlotButton.setBounds (insertRow.reduced (compactMode ? 4 : 3, 0));
+        // Hit area = the row's full height x 16 px; the painted dot centres
+        // itself (CompBypassLed caps the visual at 10 px).
+        if (insertBypassLed != nullptr)
+            insertBypassLed->setBounds (pluginSlotButton.getX(), insertRow.getY(),
+                                        16, insertRow.getHeight());
+    }
     area.removeFromTop (2);
 
     // In compact mode the EQ + COMP sections collapse to two narrow buttons

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -1893,7 +1893,6 @@ void ChannelStripComponent::openPluginPicker (bool useChooser)
     {
         pluginpicker::openInsertChooser (pluginSlot,
                                           pluginSlotButton,
-                                          activePluginChooser,
                                           std::move (onChange),
                                           kind,
                                           std::move (openHwEditor),
@@ -1908,7 +1907,6 @@ void ChannelStripComponent::openPluginPicker (bool useChooser)
         // already committed to "this is a plugin".
         pluginpicker::openPickerMenu (pluginSlot,
                                        pluginSlotButton,
-                                       activePluginChooser,
                                        std::move (onChange),
                                        kind,
                                        { -1, -1 },

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -1470,6 +1470,9 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
         },
         [this]
         {
+            // Empty slot: nothing to bypass — don't flip (and persist) state
+            // the user can't see.
+            if (! insertSlotOccupied()) return;
             const bool now = ! track.strip.insertBypassed.load (std::memory_order_relaxed);
             track.strip.insertBypassed.store (now, std::memory_order_release);
         });

--- a/src/ui/ChannelStripComponent.h
+++ b/src/ui/ChannelStripComponent.h
@@ -316,7 +316,6 @@ private:
     void togglePluginEditor();
     void openPluginEditor();
     void closePluginEditor();
-    std::unique_ptr<juce::FileChooser> activePluginChooser;
     // Editor hosted inline as an EmbeddedModal (centred, dim backdrop,
     // click-out / Esc dismiss). showBorrowed doesn't own the body so
     // GL / Cairo / native resources survive close/reopen cycles. Both

--- a/src/ui/ChannelStripComponent.h
+++ b/src/ui/ChannelStripComponent.h
@@ -103,6 +103,10 @@ private:
     };
     PluginSlotButton pluginSlotButton { "+ Plugin" };
     juce::String     lastSlotName;
+    // Bypass LED overlaid on the insert button's left edge — same
+    // grammar as the EQ / COMP header LEDs. Green = insert engaged.
+    std::unique_ptr<class CompBypassLed> insertBypassLed;
+    bool insertSlotOccupied() const;
 
     juce::Rectangle<int> eqArea, compArea;
 

--- a/src/ui/ClapPluginEditorComponent.cpp
+++ b/src/ui/ClapPluginEditorComponent.cpp
@@ -153,6 +153,41 @@ void ClapPluginEditorComponent::leakForShutdown()
     editor.setLeakOnClose (true);
 }
 
+void ClapPluginEditorComponent::verifyGeometry()
+{
+    // The message flow can miss a move (compositor interference, an event
+    // arriving while unparented) — poll the REAL geometry ~3 Hz, snap back on
+    // drift, and log the numbers so field reports say what actually happened.
+    if (! isShowing() || getParentComponent() == nullptr || getPeer() == nullptr) return;
+    if (++geometryCheckTick < 20) return;
+    geometryCheckTick = 0;
+
+    const auto area = embedscale::toPhysical (
+        *this, getTopLevelComponent()->getLocalArea (this, getLocalBounds()));
+    int ax = 0, ay = 0, aw = 0, ah = 0;
+    if (! editor.getActualGeometry (ax, ay, aw, ah))
+    {
+        if (! geometryLostLogged)
+        {
+            geometryLostLogged = true;
+            std::fprintf (stderr, "[clap editor] host window lost (XGetGeometry failed)\n");
+        }
+        return;
+    }
+    if (ax != area.getX() || ay != area.getY()
+        || aw != juce::jmax (1, area.getWidth()) || ah != juce::jmax (1, area.getHeight()))
+    {
+        if (driftLogsLeft > 0)
+        {
+            --driftLogsLeft;
+            std::fprintf (stderr,
+                "[clap editor] geometry drift: intended (%d,%d %dx%d) actual (%d,%d %dx%d) - re-syncing\n",
+                area.getX(), area.getY(), area.getWidth(), area.getHeight(), ax, ay, aw, ah);
+        }
+        pushBounds();
+    }
+}
+
 void ClapPluginEditorComponent::timerCallback()
 {
     // Keep the native X11 window's mapped state in sync with our real on-screen
@@ -163,6 +198,7 @@ void ClapPluginEditorComponent::timerCallback()
     {
         if (isShowing()) editor.reveal();
         else             editor.hide();
+        verifyGeometry();
     }
 
     const auto now = juce::Time::getMillisecondCounter();

--- a/src/ui/ClapPluginEditorComponent.cpp
+++ b/src/ui/ClapPluginEditorComponent.cpp
@@ -165,6 +165,15 @@ void ClapPluginEditorComponent::verifyGeometry()
     const auto area = embedscale::toPhysical (
         *this, getTopLevelComponent()->getLocalArea (this, getLocalBounds()));
     int ax = 0, ay = 0, aw = 0, ah = 0;
+    if (! embedCheckLogged)
+    {
+        embedCheckLogged = true;
+        int relX = 0, relY = 0;
+        if (editor.getRootRelativePosition (peerX11(), relX, relY))
+            std::fprintf (stderr,
+                "[%s editor] embed check: host rel to peer (%d,%d), intended (%d,%d)\n",
+                "clap", relX, relY, area.getX(), area.getY());
+    }
     if (! editor.getActualGeometry (ax, ay, aw, ah))
     {
         if (! geometryLostLogged)

--- a/src/ui/ClapPluginEditorComponent.cpp
+++ b/src/ui/ClapPluginEditorComponent.cpp
@@ -90,6 +90,11 @@ void ClapPluginEditorComponent::tryEmbed()
                       juce::jmax (1, area.getWidth()), juce::jmax (1, area.getHeight()), err))
     {
         embedded = true;
+        // Re-sync unconditionally: a synchronous gui resize during embed can
+        // move this component (modal recentre) while `embedded` was still
+        // false, so the moved()/resized() pushes were skipped and the native
+        // window would keep the pre-move coords passed to embed().
+        pushBounds();
         editor.reveal();
     }
     else

--- a/src/ui/ClapPluginEditorComponent.cpp
+++ b/src/ui/ClapPluginEditorComponent.cpp
@@ -1,5 +1,6 @@
 #include "ClapPluginEditorComponent.h"
 #include "EmbeddedModal.h"   // kPluginEditorTag
+#include "NativeEditorEmbedScale.h"
 
 namespace duskstudio
 {
@@ -51,14 +52,18 @@ bool ClapPluginEditorComponent::openEditorOn (clap::ClapInstance& inst, juce::St
     // window). The GUI closed → tear the editor down.
     editor.onResize = [this] (int w, int h)
     {
-        if (w > 0 && h > 0) setSize (w, h);
+        if (w > 0 && h > 0)
+            setSize (embedscale::fromPhysical (*this, w),
+                     embedscale::fromPhysical (*this, h));
     };
     // GUI was_destroyed: tear down our state fully. Leaving `loaded` set would let
     // tryEmbed()/the timer keep poking an already-destroyed editor.
     editor.onClosed = [this] { embedded = false; loaded = false; stopTimer(); };
 
-    const int w = editor.preferredWidth()  > 0 ? editor.preferredWidth()  : 480;
-    const int h = editor.preferredHeight() > 0 ? editor.preferredHeight() : 320;
+    const int w = editor.preferredWidth()  > 0
+                    ? embedscale::fromPhysical (*this, editor.preferredWidth())  : 480;
+    const int h = editor.preferredHeight() > 0
+                    ? embedscale::fromPhysical (*this, editor.preferredHeight()) : 320;
     setSize (w, h);
 
     loaded = true;
@@ -84,7 +89,8 @@ void ClapPluginEditorComponent::tryEmbed()
     const auto parent = peerX11();
     if (parent == 0) return;
 
-    const auto area = getTopLevelComponent()->getLocalArea (this, getLocalBounds());
+    const auto area = embedscale::toPhysical (
+        *this, getTopLevelComponent()->getLocalArea (this, getLocalBounds()));
     std::string err;
     if (editor.embed (parent, area.getX(), area.getY(),
                       juce::jmax (1, area.getWidth()), juce::jmax (1, area.getHeight()), err))
@@ -112,7 +118,8 @@ void ClapPluginEditorComponent::tryEmbed()
 void ClapPluginEditorComponent::pushBounds()
 {
     if (! embedded) return;
-    const auto area = getTopLevelComponent()->getLocalArea (this, getLocalBounds());
+    const auto area = embedscale::toPhysical (
+        *this, getTopLevelComponent()->getLocalArea (this, getLocalBounds()));
     editor.setBounds (area.getX(), area.getY(),
                       juce::jmax (1, area.getWidth()), juce::jmax (1, area.getHeight()));
 }

--- a/src/ui/ClapPluginEditorComponent.cpp
+++ b/src/ui/ClapPluginEditorComponent.cpp
@@ -118,6 +118,11 @@ void ClapPluginEditorComponent::tryEmbed()
 void ClapPluginEditorComponent::pushBounds()
 {
     if (! embedded) return;
+    // Borrowed bodies get setBounds'd by EmbeddedModal BEFORE being re-added
+    // to a parent — getTopLevelComponent() is then `this` and the area
+    // degenerates to (0,0), slamming the native window to the origin. Skip
+    // while unparented; parentHierarchyChanged re-syncs once re-added.
+    if (getParentComponent() == nullptr || getPeer() == nullptr) return;
     const auto area = embedscale::toPhysical (
         *this, getTopLevelComponent()->getLocalArea (this, getLocalBounds()));
     editor.setBounds (area.getX(), area.getY(),
@@ -126,7 +131,7 @@ void ClapPluginEditorComponent::pushBounds()
 
 void ClapPluginEditorComponent::resized()              { if (embedded) pushBounds(); else tryEmbed(); }
 void ClapPluginEditorComponent::moved()                { pushBounds(); }
-void ClapPluginEditorComponent::parentHierarchyChanged() { tryEmbed(); }
+void ClapPluginEditorComponent::parentHierarchyChanged() { if (embedded) pushBounds(); else tryEmbed(); }
 
 void ClapPluginEditorComponent::visibilityChanged()
 {

--- a/src/ui/ClapPluginEditorComponent.h
+++ b/src/ui/ClapPluginEditorComponent.h
@@ -63,5 +63,6 @@ private:
     int  geometryCheckTick = 0;
     int  driftLogsLeft     = 10;
     bool geometryLostLogged = false;
+    bool embedCheckLogged   = false;
 };
 } // namespace duskstudio

--- a/src/ui/ClapPluginEditorComponent.h
+++ b/src/ui/ClapPluginEditorComponent.h
@@ -46,6 +46,7 @@ private:
     void timerCallback() override;
     void tryEmbed();
     void pushBounds();
+    void verifyGeometry();
     unsigned long peerX11() const;
 
     bool openEditorOn (clap::ClapInstance& inst, juce::String& errorOut);
@@ -59,5 +60,8 @@ private:
     bool loaded   = false;
     bool embedded = false;
     juce::uint32 lastPumpMs = 0;
+    int  geometryCheckTick = 0;
+    int  driftLogsLeft     = 10;
+    bool geometryLostLogged = false;
 };
 } // namespace duskstudio

--- a/src/ui/CompBypassLed.h
+++ b/src/ui/CompBypassLed.h
@@ -34,7 +34,13 @@ public:
         // (1 px outer + 2 px inner) shrank the visible green to ~50 %
         // of the bounds and made the EQ bypass LED read much smaller
         // than the COMP header button's LED at the same widget size.
-        const auto r = getLocalBounds().toFloat();
+        //
+        // The visual caps at 10 px and centres in the bounds, so callers
+        // can give the widget a larger hit area than the dot — an 8 px
+        // click target is unusable.
+        auto r = getLocalBounds().toFloat();
+        const float d = juce::jmin (r.getWidth(), r.getHeight(), 10.0f);
+        r = r.withSizeKeepingCentre (d, d);
         const bool on = isEnabledFn ? isEnabledFn() : false;
 
         g.setColour (juce::Colour (0xff0a0a0c));

--- a/src/ui/CursorOverlay.cpp
+++ b/src/ui/CursorOverlay.cpp
@@ -57,6 +57,7 @@ void CursorOverlay::setMousePosition (juce::Component& source,
         return;
 
     const bool wasPainting = lastPainting;
+    const auto oldDirty    = glyphDirtyRect (lastLocal, lastCutLineY);
     lastLocal    = myLocal;
     lastMode     = mode;
     lastCutLineY = myCutLine;
@@ -65,13 +66,14 @@ void CursorOverlay::setMousePosition (juce::Component& source,
     if (paints && ! wasPainting)       setNativeCursorVisible (false);
     else if (! paints && wasPainting)  setNativeCursorVisible (true);
 
-    // Full repaint each move so the old glyph position is properly cleared by
-    // JUCE's parent-repaint-under pass — partial-rect repaint was leaving
-    // trails. Skip entirely when neither the old nor the new mode paints a
-    // glyph (Range/Grid moving): paint() is a no-op there, so a repaint would
-    // just invalidate the full surface for nothing.
-    if (paints || wasPainting)
-        repaint();
+    // Invalidate only the glyph-sized rects at the OLD and NEW positions.
+    // The overlay spans the whole window and isn't opaque, so a bare
+    // repaint() forces everything underneath to redraw per mouse pixel —
+    // visibly stuttery on large windows. Repainting the old rect too is
+    // what clears the previous glyph (dirtying only the new one leaves
+    // trails).
+    if (wasPainting) repaint (oldDirty);
+    if (paints)      repaint (glyphDirtyRect (lastLocal, lastCutLineY));
 }
 
 void CursorOverlay::clearMousePosition()
@@ -79,7 +81,20 @@ void CursorOverlay::clearMousePosition()
     if (! lastPainting) return;
     lastPainting = false;
     setNativeCursorVisible (true);
-    repaint();
+    repaint (glyphDirtyRect (lastLocal, lastCutLineY));
+}
+
+juce::Rectangle<int> CursorOverlay::glyphDirtyRect (juce::Point<int> local,
+                                                     juce::Range<int> cutLineY) const
+{
+    // Generous bound around the hotspot: the largest glyph (pencil, 36 px
+    // canvas) plus halo stays within 40 px of the hotspot in every
+    // direction at the 0.85 paint scale.
+    auto r = juce::Rectangle<int> (local.x - 40, local.y - 40, 80, 80);
+    if (! cutLineY.isEmpty())
+        r = r.getUnion ({ local.x - 4, cutLineY.getStart() - 2,
+                          8, cutLineY.getLength() + 4 });
+    return r;
 }
 
 void CursorOverlay::setNativeCursorVisible (bool visible)

--- a/src/ui/CursorOverlay.h
+++ b/src/ui/CursorOverlay.h
@@ -61,6 +61,8 @@ public:
 
 private:
     void setNativeCursorVisible (bool visible);
+    juce::Rectangle<int> glyphDirtyRect (juce::Point<int> local,
+                                          juce::Range<int> cutLineY) const;
 
     juce::Point<int> lastLocal   { -1000, -1000 };
     bool             lastPainting = false;

--- a/src/ui/DpImportDialog.h
+++ b/src/ui/DpImportDialog.h
@@ -48,6 +48,7 @@ public:
         warnings.setReadOnly (true);
         warnings.setCaretVisible (false);
         warnings.setScrollbarsShown (true);
+        warnings.setPopupMenuEnabled (false);   // XWayland popup flash (see DuskComboBox)
         warnings.setColour (juce::TextEditor::backgroundColourId, juce::Colour (0xff14141a));
         warnings.setColour (juce::TextEditor::textColourId, juce::Colour (0xffd0a060));
         warnings.setColour (juce::TextEditor::outlineColourId, juce::Colour (0xff35404a));

--- a/src/ui/DuskAlerts.cpp
+++ b/src/ui/DuskAlerts.cpp
@@ -211,6 +211,7 @@ public:
     {
         setOpaque (true);
         editor.setText (initial, juce::dontSendNotification);
+        editor.setPopupMenuEnabled (false);   // XWayland popup flash (see DuskComboBox)
         editor.setColour (juce::TextEditor::backgroundColourId, juce::Colour (0xff14141a));
         editor.setColour (juce::TextEditor::textColourId,        juce::Colour (0xffe0e0e4));
         editor.setColour (juce::TextEditor::outlineColourId,     juce::Colour (0xff34343c));

--- a/src/ui/EmbeddedModal.h
+++ b/src/ui/EmbeddedModal.h
@@ -56,7 +56,8 @@ inline constexpr const char* kPluginEditorTag = "dusk_pluginEditor";
 //
 // Paints its own opaque rounded backdrop behind the body so panels
 // without solid background don't bleed channel strips through.
-class EmbeddedModal final : private juce::KeyListener
+class EmbeddedModal final : private juce::KeyListener,
+                            private juce::ComponentListener
 {
 public:
     // Singleton focus-restore target. MainComponent registers itself here
@@ -178,6 +179,11 @@ public:
         body.setWantsKeyboardFocus (true);
         body.grabKeyboardFocus();
         body.addKeyListener (this);
+        // Plugin editors announce their real size only once the native
+        // window embeds (after this show) and can rescale live from
+        // their own UI — track it, or the body grows down-right from
+        // the stale centre and the backdrop stays at the old size.
+        body.addComponentListener (this);
 
         hidePluginEditorsUnder (parent);
     }
@@ -211,6 +217,7 @@ public:
         if (borrowedBody_ != nullptr)
         {
             borrowedBody_->removeKeyListener (this);
+            borrowedBody_->removeComponentListener (this);
             host->removeChildComponent (borrowedBody_);
         }
         if (backdrop_ != nullptr) host->removeChildComponent (backdrop_.get());
@@ -289,6 +296,7 @@ public:
             if (borrowedBody_ != nullptr)
             {
                 borrowedBody_->removeKeyListener (this);
+                borrowedBody_->removeComponentListener (this);
                 host->removeChildComponent (borrowedBody_);
             }
             if (backdrop_ != nullptr) host->removeChildComponent (backdrop_.get());
@@ -336,7 +344,12 @@ public:
         const auto bodyBounds = bounds.withSizeKeepingCentre (
             juce::jmin (juce::jmax (1, body->getWidth()),  bounds.getWidth()  - 16),
             juce::jmin (juce::jmax (1, body->getHeight()), bounds.getHeight() - 16));
-        repositionBody (bodyBounds.getTopLeft());
+        body->setTopLeftPosition (bodyBounds.getTopLeft());
+        // Re-fit the backdrop to the body's REAL bounds (not the clamped
+        // rect) — a body that outgrew its open-time size otherwise keeps
+        // the old, smaller frame behind it.
+        if (backdrop_ != nullptr)
+            backdrop_->setBounds (body->getBounds().expanded (kBackdropMargin));
     }
 
 private:
@@ -365,6 +378,16 @@ private:
                 return mc->keyPressed (k);
         }
         return false;
+    }
+
+    // Borrowed plugin-editor bodies resize themselves when the native
+    // window embeds or the plugin rescales its UI. Re-centre and re-fit
+    // the backdrop; moves are ignored (recenterBody itself moves the
+    // body, so reacting to them would recurse).
+    void componentMovedOrResized (juce::Component& c, bool, bool wasResized) override
+    {
+        if (wasResized && &c == borrowedBody_)
+            recenterBody();
     }
 
     class Backdrop final : public juce::Component

--- a/src/ui/EmbeddedModal.h
+++ b/src/ui/EmbeddedModal.h
@@ -184,6 +184,11 @@ public:
         // their own UI — track it, or the body grows down-right from
         // the stale centre and the backdrop stays at the old size.
         body.addComponentListener (this);
+        // Track the host too: resizing the main window with an editor
+        // open otherwise leaves the modal at the old centre, clipped at
+        // the new edges. Borrowed-only — owned bodies include anchored
+        // popups (DuskContextMenu / DuskComboBox) that must NOT recentre.
+        parent.addComponentListener (this);
 
         hidePluginEditorsUnder (parent);
     }
@@ -213,6 +218,7 @@ public:
         // doesn't fight with the message-loop teardown path below.
         restoreHiddenPluginEditors();
 
+        host->removeComponentListener (this);
         if (body_         != nullptr) host->removeChildComponent (body_.get());
         if (borrowedBody_ != nullptr)
         {
@@ -292,6 +298,7 @@ public:
 
         if (host != nullptr)
         {
+            host->removeComponentListener (this);
             if (body_         != nullptr) host->removeChildComponent (body_.get());
             if (borrowedBody_ != nullptr)
             {
@@ -381,13 +388,19 @@ private:
     }
 
     // Borrowed plugin-editor bodies resize themselves when the native
-    // window embeds or the plugin rescales its UI. Re-centre and re-fit
-    // the backdrop; moves are ignored (recenterBody itself moves the
-    // body, so reacting to them would recurse).
+    // window embeds or the plugin rescales its UI; the host resizes when
+    // the user resizes the main window with the editor open. Re-centre
+    // and re-fit the backdrop either way; moves are ignored (recenterBody
+    // itself moves the body, so reacting to them would recurse).
     void componentMovedOrResized (juce::Component& c, bool, bool wasResized) override
     {
-        if (wasResized && &c == borrowedBody_)
+        if (! wasResized || borrowedBody_ == nullptr) return;
+        if (&c == borrowedBody_ || &c == host.getComponent())
+        {
             recenterBody();
+            if (dim_ != nullptr && host != nullptr)
+                dim_->setBounds (host->getLocalBounds());
+        }
     }
 
     class Backdrop final : public juce::Component

--- a/src/ui/EmbeddedModal.h
+++ b/src/ui/EmbeddedModal.h
@@ -482,11 +482,10 @@ private:
 // Global KeyListener that forwards transport / navigation hotkeys (Space, R,
 // Home, '.', F11 — see isModalForwardableShortcut) to the registered
 // MainComponent regardless of where focus currently sits.
-// Attach to popup top-levels that bypass EmbeddedModal (juce::CallOutBox,
-// e.g., the COMP / EQ / AUX-send compact-mode editors) so the user can
-// play / stop / record / return-to-zero while those modals are open.
-// EmbeddedModal-based popups already forward in their own keyPressed;
-// CallOutBox doesn't.
+// Attach to modal surfaces that bypass EmbeddedModal (e.g. the TapeMachine
+// gear modal's raw DimOverlay host) so the user can play / stop / record /
+// return-to-zero while those modals are open. EmbeddedModal-based popups
+// already forward in their own keyPressed.
 class TransportKeyForwarder final : public juce::KeyListener
 {
 public:

--- a/src/ui/Lv2PluginEditorComponent.cpp
+++ b/src/ui/Lv2PluginEditorComponent.cpp
@@ -83,6 +83,11 @@ void Lv2PluginEditorComponent::tryEmbed()
         // Adopt the UI's own size once known so the modal/lane can fit to it.
         if (editor.preferredWidth() > 0 && editor.preferredHeight() > 0)
             setSize (editor.preferredWidth(), editor.preferredHeight());
+        // Re-sync unconditionally: a synchronous ui:resize during embed can
+        // move this component (modal recentre) while `embedded` was still
+        // false, so the moved()/resized() pushes were skipped and the native
+        // window would keep the pre-move coords passed to embed().
+        pushBounds();
         editor.reveal();
     }
     else

--- a/src/ui/Lv2PluginEditorComponent.cpp
+++ b/src/ui/Lv2PluginEditorComponent.cpp
@@ -154,6 +154,15 @@ void Lv2PluginEditorComponent::verifyGeometry()
     const auto area = embedscale::toPhysical (
         *this, getTopLevelComponent()->getLocalArea (this, getLocalBounds()));
     int ax = 0, ay = 0, aw = 0, ah = 0;
+    if (! embedCheckLogged)
+    {
+        embedCheckLogged = true;
+        int relX = 0, relY = 0;
+        if (editor.getRootRelativePosition (peerX11(), relX, relY))
+            std::fprintf (stderr,
+                "[%s editor] embed check: host rel to peer (%d,%d), intended (%d,%d)\n",
+                "lv2", relX, relY, area.getX(), area.getY());
+    }
     if (! editor.getActualGeometry (ax, ay, aw, ah))
     {
         if (! geometryLostLogged)

--- a/src/ui/Lv2PluginEditorComponent.cpp
+++ b/src/ui/Lv2PluginEditorComponent.cpp
@@ -107,6 +107,11 @@ void Lv2PluginEditorComponent::tryEmbed()
 void Lv2PluginEditorComponent::pushBounds()
 {
     if (! embedded) return;
+    // Borrowed bodies get setBounds'd by EmbeddedModal BEFORE being re-added
+    // to a parent — getTopLevelComponent() is then `this` and the area
+    // degenerates to (0,0), slamming the native window to the origin. Skip
+    // while unparented; parentHierarchyChanged re-syncs once re-added.
+    if (getParentComponent() == nullptr || getPeer() == nullptr) return;
     const auto area = embedscale::toPhysical (
         *this, getTopLevelComponent()->getLocalArea (this, getLocalBounds()));
     editor.setBounds (area.getX(), area.getY(),
@@ -115,7 +120,7 @@ void Lv2PluginEditorComponent::pushBounds()
 
 void Lv2PluginEditorComponent::resized()                { if (embedded) pushBounds(); else tryEmbed(); }
 void Lv2PluginEditorComponent::moved()                  { pushBounds(); }
-void Lv2PluginEditorComponent::parentHierarchyChanged() { tryEmbed(); }
+void Lv2PluginEditorComponent::parentHierarchyChanged() { if (embedded) pushBounds(); else tryEmbed(); }
 
 void Lv2PluginEditorComponent::visibilityChanged()
 {

--- a/src/ui/Lv2PluginEditorComponent.cpp
+++ b/src/ui/Lv2PluginEditorComponent.cpp
@@ -142,6 +142,41 @@ void Lv2PluginEditorComponent::leakForShutdown()
     editor.setLeakOnClose (true);
 }
 
+void Lv2PluginEditorComponent::verifyGeometry()
+{
+    // The message flow can miss a move (compositor interference, an event
+    // arriving while unparented) — poll the REAL geometry ~3 Hz, snap back on
+    // drift, and log the numbers so field reports say what actually happened.
+    if (! isShowing() || getParentComponent() == nullptr || getPeer() == nullptr) return;
+    if (++geometryCheckTick < 20) return;
+    geometryCheckTick = 0;
+
+    const auto area = embedscale::toPhysical (
+        *this, getTopLevelComponent()->getLocalArea (this, getLocalBounds()));
+    int ax = 0, ay = 0, aw = 0, ah = 0;
+    if (! editor.getActualGeometry (ax, ay, aw, ah))
+    {
+        if (! geometryLostLogged)
+        {
+            geometryLostLogged = true;
+            std::fprintf (stderr, "[lv2 editor] host window lost (XGetGeometry failed)\n");
+        }
+        return;
+    }
+    if (ax != area.getX() || ay != area.getY()
+        || aw != juce::jmax (1, area.getWidth()) || ah != juce::jmax (1, area.getHeight()))
+    {
+        if (driftLogsLeft > 0)
+        {
+            --driftLogsLeft;
+            std::fprintf (stderr,
+                "[lv2 editor] geometry drift: intended (%d,%d %dx%d) actual (%d,%d %dx%d) - re-syncing\n",
+                area.getX(), area.getY(), area.getWidth(), area.getHeight(), ax, ay, aw, ah);
+        }
+        pushBounds();
+    }
+}
+
 void Lv2PluginEditorComponent::timerCallback()
 {
     // Ancestor visibility changes (tab switches) don't fire visibilityChanged —
@@ -154,6 +189,7 @@ void Lv2PluginEditorComponent::timerCallback()
     {
         if (isShowing()) editor.reveal();
         else             editor.hide();
+        verifyGeometry();
     }
     else
     {

--- a/src/ui/Lv2PluginEditorComponent.cpp
+++ b/src/ui/Lv2PluginEditorComponent.cpp
@@ -1,6 +1,7 @@
 #include "Lv2PluginEditorComponent.h"
 
 #include "EmbeddedModal.h"   // kPluginEditorTag
+#include "NativeEditorEmbedScale.h"
 #include "../engine/lv2/Lv2Instance.h"
 
 namespace duskstudio
@@ -28,7 +29,9 @@ bool Lv2PluginEditorComponent::attach (lv2::Lv2Instance& shared, juce::String& e
 
     editor.onResize = [this] (int w, int h)
     {
-        if (w > 0 && h > 0) setSize (w, h);
+        if (w > 0 && h > 0)
+            setSize (embedscale::fromPhysical (*this, w),
+                     embedscale::fromPhysical (*this, h));
     };
     // The UI reported closed (idle() non-zero): stop treating it as live AND tear
     // the native UI down — leaving it open would keep a dead-by-its-own-request
@@ -71,7 +74,8 @@ void Lv2PluginEditorComponent::tryEmbed()
     const auto parent = peerX11();
     if (parent == 0) return;
 
-    const auto area = getTopLevelComponent()->getLocalArea (this, getLocalBounds());
+    const auto area = embedscale::toPhysical (
+        *this, getTopLevelComponent()->getLocalArea (this, getLocalBounds()));
     std::string err;
     embedding = true;
     const bool ok = editor.embed (parent, area.getX(), area.getY(),
@@ -82,7 +86,8 @@ void Lv2PluginEditorComponent::tryEmbed()
         embedded = true;
         // Adopt the UI's own size once known so the modal/lane can fit to it.
         if (editor.preferredWidth() > 0 && editor.preferredHeight() > 0)
-            setSize (editor.preferredWidth(), editor.preferredHeight());
+            setSize (embedscale::fromPhysical (*this, editor.preferredWidth()),
+                     embedscale::fromPhysical (*this, editor.preferredHeight()));
         // Re-sync unconditionally: a synchronous ui:resize during embed can
         // move this component (modal recentre) while `embedded` was still
         // false, so the moved()/resized() pushes were skipped and the native
@@ -102,7 +107,8 @@ void Lv2PluginEditorComponent::tryEmbed()
 void Lv2PluginEditorComponent::pushBounds()
 {
     if (! embedded) return;
-    const auto area = getTopLevelComponent()->getLocalArea (this, getLocalBounds());
+    const auto area = embedscale::toPhysical (
+        *this, getTopLevelComponent()->getLocalArea (this, getLocalBounds()));
     editor.setBounds (area.getX(), area.getY(),
                       juce::jmax (1, area.getWidth()), juce::jmax (1, area.getHeight()));
 }

--- a/src/ui/Lv2PluginEditorComponent.h
+++ b/src/ui/Lv2PluginEditorComponent.h
@@ -40,11 +40,15 @@ private:
     void timerCallback() override;
     void tryEmbed();
     void pushBounds();
+    void verifyGeometry();
     unsigned long peerX11() const;
 
     lv2::Lv2Editor editor;
     bool loaded    = false;
     bool embedded  = false;
     bool embedding = false;   // guards re-entry: instantiate fires ui:resize → setSize → resized()
+    int  geometryCheckTick = 0;
+    int  driftLogsLeft     = 10;
+    bool geometryLostLogged = false;
 };
 } // namespace duskstudio

--- a/src/ui/Lv2PluginEditorComponent.h
+++ b/src/ui/Lv2PluginEditorComponent.h
@@ -50,5 +50,6 @@ private:
     int  geometryCheckTick = 0;
     int  driftLogsLeft     = 10;
     bool geometryLostLogged = false;
+    bool embedCheckLogged   = false;
 };
 } // namespace duskstudio

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -3002,15 +3002,14 @@ void MainComponent::openBounceStemsDialog()
                        + conflicts.joinIntoString ("\n")
                        + "\n\nContinue?";
         juce::Component::SafePointer<MainComponent> safe (this);
-        juce::AlertWindow::showOkCancelBox (
-            juce::MessageBoxIconType::WarningIcon,
-            "Overwrite stems?", msg, "Overwrite", "Cancel", this,
-            juce::ModalCallbackFunction::create (
-                [safe, launch] (int result) mutable
-                {
-                    if (result == 1 && safe.getComponent() != nullptr)
-                        launch();
-                }));
+        showDuskConfirm (*this, "Overwrite stems?", msg,
+                         "Overwrite",
+                         [safe, launch]() mutable
+                         {
+                             if (safe.getComponent() != nullptr)
+                                 launch();
+                         },
+                         "Cancel", {}, /*destructive*/ true);
     });
 }
 

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -270,6 +270,13 @@ MainComponent::MainComponent()
     setTitle ("Dusk Studio mixer");
     setDescription ("16-channel portastudio-style mixer");
 
+    // JUCE's TooltipWindow never disables click interception, and ours is
+    // parented in-window and anchored into the menu row — every visible tip
+    // was an always-on-top click shield over the stage tabs / bank buttons /
+    // transport ("I have to click twice"). Tips are display-only; let every
+    // click pass through to what's underneath.
+    tooltipWindow.setInterceptsMouseClicks (false, false);
+
     juce::LookAndFeel::setDefaultLookAndFeel (&lookAndFeel);
 
    #if DUSKSTUDIO_HAS_OOP_PLUGINS

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -847,6 +847,24 @@ bool MainComponent::keyPressed (const juce::KeyPress& key)
         }
     }
 
+    // ── Shift+Left / Shift+Right mirror the transport Rewind / Forward taps:
+    // previous / next marker, with the buttons' stopped-and-empty fallbacks
+    // (start of session / last record point). Cmd+arrows are region nudge,
+    // plain arrows are strip focus — this claims the remaining pair.
+    if (shift && ! cmd && ! mods.isAltDown()
+        && (key == juce::KeyPress::leftKey || key == juce::KeyPress::rightKey))
+    {
+        const bool back = key == juce::KeyPress::leftKey;
+        if (engine.getTransport().isStopped() && session.getMarkers().empty())
+        {
+            if (back) engine.jumpToZero();
+            else      engine.jumpToLastRecordPoint();
+        }
+        else if (back) engine.jumpToPrevMarker();
+        else           engine.jumpToNextMarker();
+        return true;
+    }
+
     // ── Plain Left/Right move the channel-strip focus ring across the 24
     // strips (Recording / Mixing stages), auto-flipping the visible bank at a
     // boundary. The focused strip becomes the A / S / X target. Cmd+arrows are
@@ -1153,6 +1171,31 @@ bool MainComponent::keyPressed (const juce::KeyPress& key)
         auto& enabled = session.metronomeEnabled;
         enabled.store (! enabled.load (std::memory_order_relaxed),
                         std::memory_order_relaxed);
+        return true;
+    }
+
+    // ── Count-in toggle: Shift+C (pairs with plain C's metronome). The
+    // transport bar's C/I button re-syncs from the atom on its timer.
+    if (code == 'C' && shift && ! cmd && ! mods.isAltDown())
+    {
+        auto& ci = session.countInEnabled;
+        ci.store (! ci.load (std::memory_order_relaxed), std::memory_order_relaxed);
+        return true;
+    }
+
+    // ── Remaining transport-bar controls, one key each so every transport
+    // control is reachable without the mouse: B = tap tempo ("BPM"),
+    // Shift+M = time-signature menu (plain M drops a marker), U = tuner,
+    // F = time/bars display format.
+    if (transportBar != nullptr)
+    {
+        if (code == 'B' && noMods)                            { transportBar->tapTempo();         return true; }
+        if (code == 'M' && shift && ! cmd && ! mods.isAltDown()) { transportBar->openTimeSigMenu();  return true; }
+        if (code == 'F' && noMods)                            { transportBar->toggleTimeFormat(); return true; }
+    }
+    if (code == 'U' && noMods)
+    {
+        toggleTuner();
         return true;
     }
 

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -2685,6 +2685,17 @@ bool MainComponent::finishLoadingSessionFrom (const juce::File& sourceJson,
     // referenced AudioRegion. Belt-and-suspenders: also resets redo.
     engine.getUndoManager().clearUndoHistory();
 
+    // Native plugin editors (CLAP/LV2/VST3) reference the instances the
+    // reload below evicts — a suil/plugin UI whose pump timer ticks after
+    // the instance is gone crashes inside the plugin's own event loop.
+    // Tear every editor down NOW, while the instances are still alive
+    // (same order the strip loaders use). The console is rebuilt after
+    // the load anyway; aux lanes lazily re-embed on next show.
+    if (consoleView != nullptr)
+        consoleView->dropAllPluginEditors();
+    if (auxView != nullptr)
+        auxView->dropAllNativeEditors();
+
     engine.consumePluginStateAfterLoad();
     // Surface any plugin restore failures as a single summary dialog so
     // the user doesn't think a saved-with-Diva mix is intact when Diva

--- a/src/ui/MasteringView.h
+++ b/src/ui/MasteringView.h
@@ -88,7 +88,6 @@ private:
 
     juce::TextButton exportButton { "Export master..." };
 
-    std::unique_ptr<juce::FileChooser> fileChooser;
     std::unique_ptr<WaveformDisplay>   waveform;
 
     // EQ = custom curve + band controls. Comp embeds ONLY the donor's

--- a/src/ui/MidiBindingsPanel.h
+++ b/src/ui/MidiBindingsPanel.h
@@ -64,13 +64,6 @@ private:
     juce::TextButton importButton   { "Import..." };
     juce::TextButton clearAllButton { "Clear all" };
     juce::TextButton doneButton     { "Done" };
-    // Async file choosers kept alive across the OS dialog's lifetime.
-    // Two slots because the user CAN trigger both flows back-to-back
-    // (open Export, then click Import before the Export dialog closes);
-    // a single slot would let the second click reassign the unique_ptr
-    // and destroy the first FileChooser mid-callback, which JUCE forbids.
-    std::unique_ptr<juce::FileChooser> exportChooser;
-    std::unique_ptr<juce::FileChooser> importChooser;
 
     void exportPreset();
     void importPreset();

--- a/src/ui/NativeEditorEmbedScale.h
+++ b/src/ui/NativeEditorEmbedScale.h
@@ -5,16 +5,19 @@
 namespace duskstudio::embedscale
 {
 // JUCE component coordinates are logical; raw X11 windows live in physical
-// pixels (physical = logical × peer scale, see LinuxComponentPeer::setBounds).
-// The native editor components must convert on both sides of the boundary or
-// the embedded plugin window drifts from its JUCE body by the scale factor.
-// Plugin-reported sizes (resizeView / ui:resize / clap gui) are physical.
+// pixels. The full logical→physical factor is the peer's platform scale TIMES
+// the Desktop global scale — the app-set UI zoom (appconfig ui_scale →
+// Desktop::setGlobalScaleFactor) is NOT part of getPlatformScaleFactor(), and
+// missing it drifts every native editor window down-right by zoom% of its
+// position. Plugin-reported sizes (resizeView / ui:resize / clap gui) are
+// physical.
 
 inline double factor (const juce::Component& c)
 {
+    const double global = juce::Desktop::getInstance().getGlobalScaleFactor();
     if (auto* peer = c.getPeer())
-        return peer->getPlatformScaleFactor();
-    return 1.0;
+        return global * peer->getPlatformScaleFactor();
+    return global;
 }
 
 inline juce::Rectangle<int> toPhysical (const juce::Component& c,

--- a/src/ui/NativeEditorEmbedScale.h
+++ b/src/ui/NativeEditorEmbedScale.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+namespace duskstudio::embedscale
+{
+// JUCE component coordinates are logical; raw X11 windows live in physical
+// pixels (physical = logical × peer scale, see LinuxComponentPeer::setBounds).
+// The native editor components must convert on both sides of the boundary or
+// the embedded plugin window drifts from its JUCE body by the scale factor.
+// Plugin-reported sizes (resizeView / ui:resize / clap gui) are physical.
+
+inline double factor (const juce::Component& c)
+{
+    if (auto* peer = c.getPeer())
+        return peer->getPlatformScaleFactor();
+    return 1.0;
+}
+
+inline juce::Rectangle<int> toPhysical (const juce::Component& c,
+                                        juce::Rectangle<int> logical)
+{
+    const double s = factor (c);
+    return { juce::roundToInt (logical.getX()      * s),
+             juce::roundToInt (logical.getY()      * s),
+             juce::roundToInt (logical.getWidth()  * s),
+             juce::roundToInt (logical.getHeight() * s) };
+}
+
+inline int fromPhysical (const juce::Component& c, int physical)
+{
+    return juce::jmax (1, juce::roundToInt (physical / factor (c)));
+}
+} // namespace duskstudio::embedscale

--- a/src/ui/NativeEditorEmbedScale.h
+++ b/src/ui/NativeEditorEmbedScale.h
@@ -23,11 +23,14 @@ inline double factor (const juce::Component& c)
 inline juce::Rectangle<int> toPhysical (const juce::Component& c,
                                         juce::Rectangle<int> logical)
 {
+    // Round the corners, not the dimensions — independently rounded x and
+    // width can land the right/bottom edge 1px off the painted edge.
     const double s = factor (c);
-    return { juce::roundToInt (logical.getX()      * s),
-             juce::roundToInt (logical.getY()      * s),
-             juce::roundToInt (logical.getWidth()  * s),
-             juce::roundToInt (logical.getHeight() * s) };
+    const int x0 = juce::roundToInt (logical.getX()      * s);
+    const int y0 = juce::roundToInt (logical.getY()      * s);
+    const int x1 = juce::roundToInt (logical.getRight()  * s);
+    const int y1 = juce::roundToInt (logical.getBottom() * s);
+    return { x0, y0, x1 - x0, y1 - y0 };
 }
 
 inline int fromPhysical (const juce::Component& c, int physical)

--- a/src/ui/PianoRollComponent.cpp
+++ b/src/ui/PianoRollComponent.cpp
@@ -43,6 +43,7 @@ public:
         setOpaque (true);
         editor.setText (initial, false);
         editor.setSelectAllWhenFocused (true);
+        editor.setPopupMenuEnabled (false);   // XWayland popup flash (see DuskComboBox)
         editor.setColour (juce::TextEditor::backgroundColourId, juce::Colour (0xff15151c));
         editor.setColour (juce::TextEditor::outlineColourId,    juce::Colour (0xff3a3a42));
         editor.setColour (juce::TextEditor::textColourId,       juce::Colours::white);

--- a/src/ui/PluginPickerHelpers.cpp
+++ b/src/ui/PluginPickerHelpers.cpp
@@ -629,7 +629,7 @@ public:
             sfBtn.onClick = [this] { if (onSfFn) onSfFn(); };
             addAndMakeVisible (sfBtn);
         }
-        pluginBtn.setButtonText ("Plugin (VST3 / LV2)");
+        pluginBtn.setButtonText ("Plugin (VST3 / CLAP / LV2)");
         style (pluginBtn, juce::Colour (0xff385a38));
         pluginBtn.onClick = [this] { if (onPluginFn) onPluginFn(); };
         addAndMakeVisible (pluginBtn);

--- a/src/ui/PluginPickerHelpers.cpp
+++ b/src/ui/PluginPickerHelpers.cpp
@@ -255,8 +255,7 @@ void rejectMismatchedKind (PluginSlot& slot, PluginKind kind)
 } // namespace
 
 void openFileChooser (PluginSlot& slot,
-                       std::unique_ptr<juce::FileChooser>& chooserOwner,
-                       std::function<void()> onChange,
+                        std::function<void()> onChange,
                        juce::Component::SafePointer<juce::Component> parentForLifetime,
                        PluginKind expectedKind)
 {
@@ -273,12 +272,6 @@ void openFileChooser (PluginSlot& slot,
 #endif
     auto* host = parentForLifetime.getComponent();
     if (host == nullptr) return;
-
-    // DuskFileBrowser owns its own lifetime (in-window EmbeddedModal).
-    // The legacy chooserOwner unique_ptr is unused on this path; left
-    // in the signature for source-compat with callers that still hold
-    // it (removed in a follow-up pass).
-    juce::ignoreUnused (chooserOwner);
 
     filebrowser::open (*host, {
         /*title*/                  "Select a plugin",
@@ -322,12 +315,10 @@ void openFileChooser (PluginSlot& slot,
 // browse / session save / bounce dialogs. No standalone window, no
 // XWayland / Mutter positioning workarounds.
 static void openSoundfontFileChooser (PluginSlot& slot,
-                                       std::unique_ptr<juce::FileChooser>& chooserOwner,
-                                       std::function<void()> onChange,
+                                                        std::function<void()> onChange,
                                        juce::Component::SafePointer<juce::Component> parentForLifetime)
 {
-    juce::ignoreUnused (chooserOwner);
-    auto* host = parentForLifetime.getComponent();
+        auto* host = parentForLifetime.getComponent();
     if (host == nullptr) return;
     const auto defaultDir = juce::File::getSpecialLocation (juce::File::userHomeDirectory);
     filebrowser::open (*host, {
@@ -386,7 +377,6 @@ static void openSoundfontFileChooser (PluginSlot& slot,
 
 void openPickerMenu (PluginSlot& slot,
                       juce::Component& target,
-                      std::unique_ptr<juce::FileChooser>& chooserOwner,
                       std::function<void()> onChange,
                       PluginKind kind,
                       juce::Point<int> /*screenPosition*/,
@@ -433,7 +423,6 @@ void openPickerMenu (PluginSlot& slot,
     juce::Component::SafePointer<juce::Component> safeTarget (&target);
     juce::Component::SafePointer<juce::Component> safeParent  (parent);
     auto* slotPtr = &slot;
-    auto* chooserOwnerPtr = &chooserOwner;
 
     // Shared closure helpers - all callbacks close the modal first so
     // the picker disappears immediately, then run the action.
@@ -446,8 +435,7 @@ void openPickerMenu (PluginSlot& slot,
 
     cb.onCancel = closeModal;
 
-    cb.onScan = [closeModal, slotPtr, safeTarget, safeParent, chooserOwnerPtr,
-                  onChange, kind, onPickHardwareInsert, onPickNativeClap, onPickNativeLv2,
+    cb.onScan = [closeModal, slotPtr, safeTarget, safeParent,                   onChange, kind, onPickHardwareInsert, onPickNativeClap, onPickNativeLv2,
                   onPickNativeVst3]() mutable
     {
         closeModal();
@@ -457,13 +445,11 @@ void openPickerMenu (PluginSlot& slot,
         // alert — otherwise the picker stacks back over the alert (alert
         // was added before the picker, so JUCE z-order puts the picker
         // on top), making the result message invisible.
-        auto reopenPicker = [slotPtr, safeTarget, chooserOwnerPtr,
-                              onChange, kind, onPickHardwareInsert, onPickNativeClap,
+        auto reopenPicker = [slotPtr, safeTarget,                               onChange, kind, onPickHardwareInsert, onPickNativeClap,
                               onPickNativeLv2, onPickNativeVst3]() mutable
         {
             if (auto* t = safeTarget.getComponent())
-                openPickerMenu (*slotPtr, *t, *chooserOwnerPtr,
-                                  std::move (onChange), kind, { -1, -1 },
+                openPickerMenu (*slotPtr, *t, std::move (onChange), kind, { -1, -1 },
                                   std::move (onPickHardwareInsert), false,
                                   std::move (onPickNativeClap),
                                   std::move (onPickNativeLv2),
@@ -473,13 +459,11 @@ void openPickerMenu (PluginSlot& slot,
                        std::move (reopenPicker));
     };
 
-    cb.onBrowseFile = [closeModal, slotPtr, safeTarget, chooserOwnerPtr,
-                        onChange, kind]() mutable
+    cb.onBrowseFile = [closeModal, slotPtr, safeTarget,                         onChange, kind]() mutable
     {
         closeModal();
         if (safeTarget.getComponent() == nullptr) return;
-        openFileChooser (*slotPtr, *chooserOwnerPtr,
-                           std::move (onChange), safeTarget, kind);
+        openFileChooser (*slotPtr, std::move (onChange), safeTarget, kind);
     };
 
     // Hardware-insert + soundfont bottom-row buttons are SUPPRESSED when
@@ -499,13 +483,11 @@ void openPickerMenu (PluginSlot& slot,
    #if DUSKSTUDIO_HAS_MULTISAMPLE
     if (kind == PluginKind::Instruments && ! suppressSecondaryButtons)
     {
-        cb.onLoadSoundfont = [closeModal, slotPtr, safeTarget, chooserOwnerPtr,
-                                onChange]() mutable
+        cb.onLoadSoundfont = [closeModal, slotPtr, safeTarget,                                 onChange]() mutable
         {
             closeModal();
             if (safeTarget.getComponent() == nullptr) return;
-            openSoundfontFileChooser (*slotPtr, *chooserOwnerPtr,
-                                         std::move (onChange), safeTarget);
+            openSoundfontFileChooser (*slotPtr, std::move (onChange), safeTarget);
         };
     }
    #endif
@@ -716,8 +698,7 @@ private:
 
 void openInsertChooser (PluginSlot& slot,
                          juce::Component& target,
-                         std::unique_ptr<juce::FileChooser>& chooserOwner,
-                         std::function<void()> onChange,
+                            std::function<void()> onChange,
                          PluginKind kind,
                          std::function<void()> onPickHardwareInsert,
                          std::function<void (const juce::File&, const juce::String&)> onPickNativeClap,
@@ -729,7 +710,6 @@ void openInsertChooser (PluginSlot& slot,
 
     juce::Component::SafePointer<juce::Component> safeTarget (&target);
     auto* slotPtr = &slot;
-    auto* chooserOwnerPtr = &chooserOwner;
 
     auto closeChooser = [] { sharedChooserModal().close(); };
 
@@ -754,27 +734,23 @@ void openInsertChooser (PluginSlot& slot,
         if (hw) hw();
     };
 
-    auto onSf = [closeChooser, slotPtr, safeTarget, chooserOwnerPtr,
-                  onChange]() mutable
+    auto onSf = [closeChooser, slotPtr, safeTarget,                   onChange]() mutable
     {
         closeChooser();
         if (safeTarget.getComponent() == nullptr) return;
        #if DUSKSTUDIO_HAS_MULTISAMPLE
-        openSoundfontFileChooser (*slotPtr, *chooserOwnerPtr,
-                                     std::move (onChange), safeTarget);
+        openSoundfontFileChooser (*slotPtr, std::move (onChange), safeTarget);
        #else
-        juce::ignoreUnused (slotPtr, chooserOwnerPtr, onChange);
+        juce::ignoreUnused (slotPtr, onChange);
        #endif
     };
 
-    auto onPlugin = [closeChooser, slotPtr, safeTarget, chooserOwnerPtr,
-                       onChange, kind, onPickNativeClap, onPickNativeLv2,
+    auto onPlugin = [closeChooser, slotPtr, safeTarget,                        onChange, kind, onPickNativeClap, onPickNativeLv2,
                        onPickNativeVst3]() mutable
     {
         closeChooser();
         if (auto* t = safeTarget.getComponent())
-            openPickerMenu (*slotPtr, *t, *chooserOwnerPtr,
-                              std::move (onChange), kind, { -1, -1 },
+            openPickerMenu (*slotPtr, *t, std::move (onChange), kind, { -1, -1 },
                               /*onPickHardwareInsert*/ {},
                               /*suppressSecondaryButtons*/ true,
                               std::move (onPickNativeClap),

--- a/src/ui/PluginPickerHelpers.h
+++ b/src/ui/PluginPickerHelpers.h
@@ -29,8 +29,7 @@ enum class PluginKind { Effects, Instruments };
 // Open a popup menu of installed plugins anchored on `target`. On selection:
 //   • 1..N → resolves to KnownPluginList types and loadFromDescription.
 //   • "Scan plugins" → runs the synchronous scan + reopens the picker.
-//   • "Browse for file..." → launches a juce::FileChooser owned by
-//     `chooserOwner` (kept alive across the async callback).
+//   • "Browse for file..." → opens the in-window DuskFileBrowser.
 // `onChange` runs on every successful change to the slot.
 //
 // `kind` filters the visible list: Effects hides instruments,
@@ -60,7 +59,6 @@ enum class PluginKind { Effects, Instruments };
 // paths), hides the JUCE-format "VST3" effect rows, and routes selection here.
 void openPickerMenu (PluginSlot& slot,
                       juce::Component& target,
-                      std::unique_ptr<juce::FileChooser>& chooserOwner,
                       std::function<void()> onChange,
                       PluginKind kind,
                       juce::Point<int> screenPosition = { -1, -1 },
@@ -83,7 +81,6 @@ void openPickerMenu (PluginSlot& slot,
 // an audio/effect slot) are hidden.
 void openInsertChooser (PluginSlot& slot,
                          juce::Component& target,
-                         std::unique_ptr<juce::FileChooser>& chooserOwner,
                          std::function<void()> onChange,
                          PluginKind kind,
                          std::function<void()> onPickHardwareInsert = {},
@@ -101,19 +98,16 @@ void openInsertChooser (PluginSlot& slot,
 void runScanModal (PluginManager& manager, juce::Component* parent = nullptr,
                     std::function<void()> onAlertDismiss = {});
 
-// Run a juce::FileChooser to pick a plugin file (.vst3 / .so / .lv2),
-// loading on selection. `chooserOwner` keeps the chooser alive across the
-// async callback. `onChange` runs on successful load. `expectedKind`
+// Open the in-window DuskFileBrowser to pick a plugin file (.vst3 / .so /
+// .lv2), loading on selection. `onChange` runs on successful load. `expectedKind`
 // gates the load: if the picked plugin's effect/instrument flag doesn't
 // match (e.g. user browses to a synth on an audio track expecting an
 // effect), the slot is unloaded and an alert is shown.
 //
-// `parentForLifetime` is a SafePointer to the UI component that owns
-// `chooserOwner`. The async callback captures it and bails if the
-// parent is destroyed while the dialog is still open (user switches
-// stages, quits, etc.) - prevents a UAF deref on the now-dead unique_ptr.
+// `parentForLifetime` is a SafePointer to the UI component hosting the
+// browser. The async callback captures it and bails if the parent is
+// destroyed while the dialog is still open (user switches stages, quits).
 void openFileChooser (PluginSlot& slot,
-                       std::unique_ptr<juce::FileChooser>& chooserOwner,
                        std::function<void()> onChange,
                        juce::Component::SafePointer<juce::Component> parentForLifetime,
                        PluginKind expectedKind = PluginKind::Effects);

--- a/src/ui/PluginPickerPanel.cpp
+++ b/src/ui/PluginPickerPanel.cpp
@@ -275,6 +275,7 @@ PluginPickerPanel::PluginPickerPanel (juce::Array<juce::PluginDescription> descr
     titleLabel.setFont (juce::Font (juce::FontOptions (15.0f, juce::Font::bold)));
     addAndMakeVisible (titleLabel);
 
+    filterEditor.setPopupMenuEnabled (false);   // XWayland popup flash (see DuskComboBox)
     filterEditor.setTextToShowWhenEmpty ("Filter...", juce::Colour (0xff707078));
     filterEditor.setColour (juce::TextEditor::backgroundColourId, juce::Colour (0xff14141a));
     filterEditor.setColour (juce::TextEditor::textColourId,        juce::Colour (0xffe0e0e4));

--- a/src/ui/SelfTestPanel.cpp
+++ b/src/ui/SelfTestPanel.cpp
@@ -16,6 +16,7 @@ SelfTestPanel::SelfTestPanel (AudioEngine& e,
     logView.setCaretVisible (false);
     logView.setReturnKeyStartsNewLine (false);
     logView.setFont (juce::Font (juce::Font::getDefaultMonospacedFontName(), 12.0f, 0));
+    logView.setPopupMenuEnabled (false);   // XWayland popup flash (see DuskComboBox)
     logView.setColour (juce::TextEditor::backgroundColourId, juce::Colour (0xff101012));
     logView.setColour (juce::TextEditor::textColourId, juce::Colour (0xffd0d0d0));
     logView.setText ("Press [Run] to execute the audio pipeline self-test. "

--- a/src/ui/ShortcutsPanel.h
+++ b/src/ui/ShortcutsPanel.h
@@ -35,7 +35,10 @@ public:
                 { "1", "Bank 1" }, { "2", "Bank 2" }, { "3", "Bank 3" }, { "4", "Bank 4" } } },
             { "Transport", {
                 { "Space", "Play / Stop" }, { "R", "Record" },
-                { "Home", "Playhead to start" }, { ".", "Stop + rewind to start" } } },
+                { "Home", "Playhead to start" }, { ".", "Stop + rewind to start" },
+                { juce::CharPointer_UTF8 ("Shift+\xe2\x86\x90/\xe2\x86\x92"), "Prev / next marker" },
+                { "B", "Tap tempo" }, { "Shift+C", "Count-in on / off" },
+                { "F", "Time / bars display" } } },
             { "Markers & loop", {
                 { "M", "Drop marker" }, { "[", "Set loop / punch in" },
                 { "]", "Set loop / punch out" }, { "L", "Toggle loop" },
@@ -46,6 +49,7 @@ public:
             { "Tools & view", {
                 { "G", "Grab / move edit mode" }, { "C", "Metronome on / off" },
                 { "K", "Virtual MIDI keyboard" }, { "T", "Show / hide timeline" },
+                { "U", "Tuner" }, { "Shift+M", "Time signature" },
                 { mod ('E'), "Split region at playhead / cursor" },
                 { "F11", "Fullscreen" }, { alt + "T", "Cycle take (Shift = back)" },
                 { "?", "This shortcut list" } } },
@@ -56,7 +60,7 @@ public:
                 { mod ('S', juce::ModifierKeys::shiftModifier), "Save as" },
                 { mod ('I'), "Import Audio or MIDI" }, { mod ('B'), "Bounce" }, { mod ('Q'), "Quit" } } },
         };
-        setSize (560, 660);
+        setSize (560, 720);
     }
 
     void paint (juce::Graphics& g) override

--- a/src/ui/TapeStrip.cpp
+++ b/src/ui/TapeStrip.cpp
@@ -47,6 +47,7 @@ public:
         setOpaque (true);
         editor.setText (initial, false);
         editor.setSelectAllWhenFocused (true);
+        editor.setPopupMenuEnabled (false);   // XWayland popup flash (see DuskComboBox)
         editor.setColour (juce::TextEditor::backgroundColourId, juce::Colour (0xff15151c));
         editor.setColour (juce::TextEditor::outlineColourId,    juce::Colour (0xff3a3a42));
         editor.setColour (juce::TextEditor::textColourId,       juce::Colours::white);

--- a/src/ui/TransportBar.cpp
+++ b/src/ui/TransportBar.cpp
@@ -318,9 +318,9 @@ TransportBar::TransportBar (AudioEngine& engineRef) : engine (engineRef)
     //     REW = jump to prev marker, FFWD = jump to next marker.
     //     Stopped with no markers falls back to goto zero / goto last record point.
     //   Held: 10x scrub via the timer (drives the playhead while button down).
-    rewButton.setTooltip  ("Rewind. Hold to scrub back at 10x. Tap for previous marker "
+    rewButton.setTooltip  ("Rewind (Shift+Left). Hold to scrub back at 10x. Tap for previous marker "
                             "(jumps to zero when stopped with no markers).");
-    ffwdButton.setTooltip ("Forward. Hold to scrub forward at 10x. Tap for next marker "
+    ffwdButton.setTooltip ("Forward (Shift+Right). Hold to scrub forward at 10x. Tap for next marker "
                             "(jumps to last record point when stopped with no markers).");
 
     rewButton.onStateChange = [this]
@@ -442,7 +442,7 @@ TransportBar::TransportBar (AudioEngine& engineRef) : engine (engineRef)
     };
     addAndMakeVisible (clockLabel);
 
-    timeFormatToggle.setTooltip ("Flip display between Bars/Beats and mm:ss.ms. "
+    timeFormatToggle.setTooltip ("Flip display between Bars/Beats and mm:ss.ms (F). "
                                    "Affects the clock, tape ruler, and editor rulers. "
                                    "Right-click the clock to flip when this button is hidden.");
     auto flipTimeMode = [this]
@@ -518,7 +518,7 @@ TransportBar::TransportBar (AudioEngine& engineRef) : engine (engineRef)
 
     // Metronome toggle + BPM editable display.
     clickToggle.setClickingTogglesState (true);
-    clickToggle.setTooltip ("Left-click: toggle metronome on/off. Right-click: choose when the click fires (recording / count-in / playing / polyphonic).");
+    clickToggle.setTooltip ("Left-click: toggle metronome on/off (C). Right-click: choose when the click fires (recording / count-in / playing / polyphonic).");
     clickToggle.setToggleState (engine.getSession().metronomeEnabled.load(),
                                   juce::dontSendNotification);
     clickToggle.onClick = [this]
@@ -532,7 +532,7 @@ TransportBar::TransportBar (AudioEngine& engineRef) : engine (engineRef)
     clickToggle.addMouseListener (this, false);
     addAndMakeVisible (clickToggle);
 
-    countInToggle.setTooltip ("Count-in: when on, hitting Record rolls the playhead "
+    countInToggle.setTooltip ("Count-in (Shift+C): when on, hitting Record rolls the playhead "
                                "back one bar so the metronome ticks a full bar before "
                                "the take begins. The pre-roll audio is NOT recorded.");
     countInToggle.setToggleState (engine.getSession().countInEnabled.load(),
@@ -570,7 +570,7 @@ TransportBar::TransportBar (AudioEngine& engineRef) : engine (engineRef)
 
     tapButton.setColour (juce::TextButton::buttonColourId,   juce::Colour (0xff202024));
     tapButton.setColour (juce::TextButton::textColourOffId,  juce::Colour (0xffe0c050));
-    tapButton.setTooltip ("Tap to set tempo. Click in time with the music; "
+    tapButton.setTooltip ("Tap to set tempo (B). Click in time with the music; "
                           "BPM updates after the second tap and averages "
                           "across the most recent few. Two-second silence "
                           "resets the pulse.");
@@ -579,7 +579,7 @@ TransportBar::TransportBar (AudioEngine& engineRef) : engine (engineRef)
 
     timeSigButton.setColour (juce::TextButton::buttonColourId,  juce::Colour (0xff202024));
     timeSigButton.setColour (juce::TextButton::textColourOffId, juce::Colour (0xffd0d0d0));
-    timeSigButton.setTooltip ("Time signature. Click to pick a common time "
+    timeSigButton.setTooltip ("Time signature (Shift+M). Click to pick a common time "
                               "(3/4, 4/4, 5/4, 6/8, 7/8, 12/8) or open Custom...");
     timeSigButton.onClick = [this] { showTimeSigMenu(); };
     addAndMakeVisible (timeSigButton);
@@ -589,7 +589,7 @@ TransportBar::TransportBar (AudioEngine& engineRef) : engine (engineRef)
     // Selection of which track to tune lives on MainComponent (it knows
     // the focused track from the TapeStrip selection); this button just
     // toggles the overlay.
-    tuneButton.setTooltip ("Tuner - shows the pitch of the selected track's input. "
+    tuneButton.setTooltip ("Tuner (U) - shows the pitch of the selected track's input. "
                             "Click a track first, then press TUNE.");
     tuneButton.onClick = [this] { if (onTunerToggle) onTunerToggle(); };
     addAndMakeVisible (tuneButton);
@@ -1270,6 +1270,10 @@ void TransportBar::promptEditTempoAtPlayhead()
                                       juce::dontSendNotification);
         });
 }
+
+void TransportBar::tapTempo()         { onTap(); }
+void TransportBar::openTimeSigMenu()  { showTimeSigMenu(); }
+void TransportBar::toggleTimeFormat() { if (flipTimeModeOnClock) flipTimeModeOnClock(); }
 
 void TransportBar::onTap()
 {

--- a/src/ui/TransportBar.h
+++ b/src/ui/TransportBar.h
@@ -52,6 +52,12 @@ public:
     // Hidden when MainComponent overlays stage + bank buttons on top.
     void setHintVisible (bool visible);
 
+    // Keyboard-shortcut entry points (MainComponent::keyPressed) — same
+    // code paths as the corresponding buttons.
+    void tapTempo();
+    void openTimeSigMenu();
+    void toggleTimeFormat();
+
     // Hard-coding tuner X from outside is fragile — the right-anchored
     // cluster (BPM / tap / time-sig / mode toggles) shifts the tuner
     // left by ~376 px in expanded mode and ~280 px in compact mode.

--- a/src/ui/Vst3PluginEditorComponent.cpp
+++ b/src/ui/Vst3PluginEditorComponent.cpp
@@ -140,6 +140,15 @@ void Vst3PluginEditorComponent::verifyGeometry()
     const auto area = embedscale::toPhysical (
         *this, getTopLevelComponent()->getLocalArea (this, getLocalBounds()));
     int ax = 0, ay = 0, aw = 0, ah = 0;
+    if (! embedCheckLogged)
+    {
+        embedCheckLogged = true;
+        int relX = 0, relY = 0;
+        if (editor.getRootRelativePosition (peerX11(), relX, relY))
+            std::fprintf (stderr,
+                "[%s editor] embed check: host rel to peer (%d,%d), intended (%d,%d)\n",
+                "vst3", relX, relY, area.getX(), area.getY());
+    }
     if (! editor.getActualGeometry (ax, ay, aw, ah))
     {
         if (! geometryLostLogged)

--- a/src/ui/Vst3PluginEditorComponent.cpp
+++ b/src/ui/Vst3PluginEditorComponent.cpp
@@ -74,6 +74,11 @@ void Vst3PluginEditorComponent::tryEmbed()
         // Adopt the view's own size once known so the modal/lane can fit to it.
         if (editor.preferredWidth() > 0 && editor.preferredHeight() > 0)
             setSize (editor.preferredWidth(), editor.preferredHeight());
+        // Re-sync unconditionally: a synchronous resizeView during embed can
+        // move this component (modal recentre) while `embedded` was still
+        // false, so the moved()/resized() pushes were skipped and the native
+        // window would keep the pre-move coords passed to embed().
+        pushBounds();
         editor.reveal();
     }
     else

--- a/src/ui/Vst3PluginEditorComponent.cpp
+++ b/src/ui/Vst3PluginEditorComponent.cpp
@@ -99,6 +99,11 @@ void Vst3PluginEditorComponent::tryEmbed()
 void Vst3PluginEditorComponent::pushBounds()
 {
     if (! embedded) return;
+    // Borrowed bodies get setBounds'd by EmbeddedModal BEFORE being re-added
+    // to a parent — getTopLevelComponent() is then `this` and the area
+    // degenerates to (0,0), slamming the native window to the origin. Skip
+    // while unparented; parentHierarchyChanged re-syncs once re-added.
+    if (getParentComponent() == nullptr || getPeer() == nullptr) return;
     const auto area = embedscale::toPhysical (
         *this, getTopLevelComponent()->getLocalArea (this, getLocalBounds()));
     editor.setBounds (area.getX(), area.getY(),
@@ -107,7 +112,7 @@ void Vst3PluginEditorComponent::pushBounds()
 
 void Vst3PluginEditorComponent::resized()                { if (embedded) pushBounds(); else tryEmbed(); }
 void Vst3PluginEditorComponent::moved()                  { pushBounds(); }
-void Vst3PluginEditorComponent::parentHierarchyChanged() { tryEmbed(); }
+void Vst3PluginEditorComponent::parentHierarchyChanged() { if (embedded) pushBounds(); else tryEmbed(); }
 
 void Vst3PluginEditorComponent::visibilityChanged()
 {

--- a/src/ui/Vst3PluginEditorComponent.cpp
+++ b/src/ui/Vst3PluginEditorComponent.cpp
@@ -1,6 +1,7 @@
 #include "Vst3PluginEditorComponent.h"
 
 #include "EmbeddedModal.h"   // kPluginEditorTag
+#include "NativeEditorEmbedScale.h"
 #include "../engine/vst3/Vst3Instance.h"
 
 namespace duskstudio
@@ -28,11 +29,14 @@ bool Vst3PluginEditorComponent::attach (vst3::Vst3Instance& shared, juce::String
 
     editor.onResize = [this] (int w, int h)
     {
-        if (w > 0 && h > 0) setSize (w, h);
+        if (w > 0 && h > 0)
+            setSize (embedscale::fromPhysical (*this, w),
+                     embedscale::fromPhysical (*this, h));
     };
 
     if (editor.preferredWidth() > 0 && editor.preferredHeight() > 0)
-        setSize (editor.preferredWidth(), editor.preferredHeight());
+        setSize (embedscale::fromPhysical (*this, editor.preferredWidth()),
+                 embedscale::fromPhysical (*this, editor.preferredHeight()));
     else
         setSize (480, 320);
 
@@ -62,7 +66,8 @@ void Vst3PluginEditorComponent::tryEmbed()
     if (auto* peer = getPeer())
         editor.setContentScale ((float) peer->getPlatformScaleFactor());
 
-    const auto area = getTopLevelComponent()->getLocalArea (this, getLocalBounds());
+    const auto area = embedscale::toPhysical (
+        *this, getTopLevelComponent()->getLocalArea (this, getLocalBounds()));
     std::string err;
     embedding = true;
     const bool ok = editor.embed (parent, area.getX(), area.getY(),
@@ -73,7 +78,8 @@ void Vst3PluginEditorComponent::tryEmbed()
         embedded = true;
         // Adopt the view's own size once known so the modal/lane can fit to it.
         if (editor.preferredWidth() > 0 && editor.preferredHeight() > 0)
-            setSize (editor.preferredWidth(), editor.preferredHeight());
+            setSize (embedscale::fromPhysical (*this, editor.preferredWidth()),
+                     embedscale::fromPhysical (*this, editor.preferredHeight()));
         // Re-sync unconditionally: a synchronous resizeView during embed can
         // move this component (modal recentre) while `embedded` was still
         // false, so the moved()/resized() pushes were skipped and the native
@@ -93,7 +99,8 @@ void Vst3PluginEditorComponent::tryEmbed()
 void Vst3PluginEditorComponent::pushBounds()
 {
     if (! embedded) return;
-    const auto area = getTopLevelComponent()->getLocalArea (this, getLocalBounds());
+    const auto area = embedscale::toPhysical (
+        *this, getTopLevelComponent()->getLocalArea (this, getLocalBounds()));
     editor.setBounds (area.getX(), area.getY(),
                       juce::jmax (1, area.getWidth()), juce::jmax (1, area.getHeight()));
 }

--- a/src/ui/Vst3PluginEditorComponent.cpp
+++ b/src/ui/Vst3PluginEditorComponent.cpp
@@ -128,6 +128,41 @@ void Vst3PluginEditorComponent::visibilityChanged()
     }
 }
 
+void Vst3PluginEditorComponent::verifyGeometry()
+{
+    // The message flow can miss a move (compositor interference, an event
+    // arriving while unparented) — poll the REAL geometry ~3 Hz, snap back on
+    // drift, and log the numbers so field reports say what actually happened.
+    if (! isShowing() || getParentComponent() == nullptr || getPeer() == nullptr) return;
+    if (++geometryCheckTick < 20) return;
+    geometryCheckTick = 0;
+
+    const auto area = embedscale::toPhysical (
+        *this, getTopLevelComponent()->getLocalArea (this, getLocalBounds()));
+    int ax = 0, ay = 0, aw = 0, ah = 0;
+    if (! editor.getActualGeometry (ax, ay, aw, ah))
+    {
+        if (! geometryLostLogged)
+        {
+            geometryLostLogged = true;
+            std::fprintf (stderr, "[vst3 editor] host window lost (XGetGeometry failed)\n");
+        }
+        return;
+    }
+    if (ax != area.getX() || ay != area.getY()
+        || aw != juce::jmax (1, area.getWidth()) || ah != juce::jmax (1, area.getHeight()))
+    {
+        if (driftLogsLeft > 0)
+        {
+            --driftLogsLeft;
+            std::fprintf (stderr,
+                "[vst3 editor] geometry drift: intended (%d,%d %dx%d) actual (%d,%d %dx%d) - re-syncing\n",
+                area.getX(), area.getY(), area.getWidth(), area.getHeight(), ax, ay, aw, ah);
+        }
+        pushBounds();
+    }
+}
+
 void Vst3PluginEditorComponent::timerCallback()
 {
     // Ancestor visibility changes (tab switches) don't fire visibilityChanged —
@@ -140,6 +175,7 @@ void Vst3PluginEditorComponent::timerCallback()
     {
         if (isShowing()) editor.reveal();
         else             editor.hide();
+        verifyGeometry();
     }
     else
     {

--- a/src/ui/Vst3PluginEditorComponent.h
+++ b/src/ui/Vst3PluginEditorComponent.h
@@ -36,6 +36,7 @@ private:
     void timerCallback() override;
     void tryEmbed();
     void pushBounds();
+    void verifyGeometry();
     unsigned long peerX11() const;
 
     vst3::Vst3Editor editor;
@@ -43,5 +44,8 @@ private:
     bool loaded    = false;
     bool embedded  = false;
     bool embedding = false;   // guards re-entry: attached() can fire resizeView → setSize → resized()
+    int  geometryCheckTick = 0;
+    int  driftLogsLeft     = 10;
+    bool geometryLostLogged = false;
 };
 } // namespace duskstudio

--- a/src/ui/Vst3PluginEditorComponent.h
+++ b/src/ui/Vst3PluginEditorComponent.h
@@ -47,5 +47,6 @@ private:
     int  geometryCheckTick = 0;
     int  driftLogsLeft     = 10;
     bool geometryLostLogged = false;
+    bool embedCheckLogged   = false;
 };
 } // namespace duskstudio

--- a/src/ui/multisample/DuskMultisampleEditor.h
+++ b/src/ui/multisample/DuskMultisampleEditor.h
@@ -63,7 +63,6 @@ private:
     DuskComboBox             ariaProgramSelector;
     std::vector<juce::File>  ariaProgramFiles;   // parallel to selector items
 
-    std::unique_ptr<juce::FileChooser> fileChooser;
 
     // Skin = the per-soundfont custom UI (when the loaded .sfz ships
     // an ARIA bank.xml + GUI XML). nullptr = fall back to the

--- a/tests/session_round_trip.cpp
+++ b/tests/session_round_trip.cpp
@@ -51,6 +51,7 @@ TEST_CASE ("SessionSerializer round-trip preserves transport + per-track state",
     t1.strip.faderDb.store (1.5f, std::memory_order_relaxed);
     t1.strip.hpfFreq.store (80.0f, std::memory_order_relaxed);
     t1.strip.lfGainDb.store (2.0f, std::memory_order_relaxed);
+    t1.strip.insertBypassed.store (true, std::memory_order_relaxed);
 
     auto& t2 = a.track (2);
     t2.name = "Vocal";
@@ -92,6 +93,8 @@ TEST_CASE ("SessionSerializer round-trip preserves transport + per-track state",
                   WithinAbs (80.0f, 1e-3f));
     REQUIRE_THAT (b.track (1).strip.lfGainDb.load (std::memory_order_relaxed),
                   WithinAbs (2.0f, 1e-4f));
+    REQUIRE (b.track (1).strip.insertBypassed.load (std::memory_order_relaxed));
+    REQUIRE_FALSE (b.track (0).strip.insertBypassed.load (std::memory_order_relaxed));
 
     REQUIRE (b.track (2).name == "Vocal");
     REQUIRE (b.track (2).mode.load (std::memory_order_relaxed) == (int) Track::Mode::Midi);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an insert bypass control with indicator for occupied insert slots, plus support for saving and restoring bypass state in sessions.
  * Improved embedded plugin window handling for more reliable positioning and resizing.
  * Expanded transport shortcuts and on-screen labels for marker navigation, tap tempo, count-in, time display, time signature, and tuner.

* **Bug Fixes**
  * Reduced popup/menu flashing in several text-entry and picker dialogs.
  * Improved native editor behavior to prevent window-management glitches and keep embedded UIs in sync.
  * Fixed click-through behavior on tooltip windows and tightened session loading stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->