### PR TITLE
Fix Mojibake and UTF8 issues on import window

### DIFF
--- a/src/ui/DpImportDialog.h
+++ b/src/ui/DpImportDialog.h
@@ -29,16 +29,21 @@ public:
         title.setColour (juce::Label::textColourId, juce::Colours::white);
         addAndMakeVisible (title);
 
+        // Em-dash and middle dots are UTF-8 multibyte — route through
+        // CharPointer_UTF8 (operator<< on a char* reads bytes as single
+        // characters and renders mojibake, GH issue #27).
+        const juce::String dot (juce::CharPointer_UTF8 ("  \xc2\xb7  "));
         juce::String s;
         s << shown << (shown == 1 ? " track" : " tracks");
         if ((int) scan.tracks.size() > maxTracks)
-            s << " (of " << (int) scan.tracks.size() << " found \xe2\x80\x94 "
+            s << " (of " << (int) scan.tracks.size()
+              << juce::String (juce::CharPointer_UTF8 (" found \xe2\x80\x94 "))
               << maxTracks << "-track limit)";
         if (scan.stereoPairs > 0)
-            s << "  \xc2\xb7  " << scan.stereoPairs
+            s << dot << scan.stereoPairs
               << (scan.stereoPairs == 1 ? " stereo pair" : " stereo pairs");
         if (scan.sampleRate > 0.0)
-            s << "  \xc2\xb7  " << juce::String (scan.sampleRate / 1000.0, 1)
+            s << dot << juce::String (scan.sampleRate / 1000.0, 1)
               << " kHz / " << scan.bitDepth << "-bit";
         summary.setText (s, juce::dontSendNotification);
         summary.setColour (juce::Label::textColourId, juce::Colour (0xffb0b0b8));

--- a/src/ui/ImportTargetPicker.cpp
+++ b/src/ui/ImportTargetPicker.cpp
@@ -62,10 +62,14 @@ juce::String modeBadgeText (Track::Mode m)
 
 juce::String summaryLine (const ImportTargetPicker::FileSummary& s)
 {
+    // Middle dots are UTF-8 multibyte — they must go through CharPointer_UTF8.
+    // juce::String (const char*) reads bytes as single characters, so a plain
+    // literal renders the classic mojibake ("Â·", GH issue #27).
     if (s.isMidi)
     {
-        return juce::String ("MIDI \xc2\xb7 ") + juce::String (s.numMidiNotes)
-             + juce::String (" notes \xc2\xb7 ")
+        return juce::String (juce::CharPointer_UTF8 ("MIDI \xc2\xb7 "))
+             + juce::String (s.numMidiNotes)
+             + juce::String (juce::CharPointer_UTF8 (" notes \xc2\xb7 "))
              + juce::String ((int) std::llround ((double) s.lengthTicks
                                                   / (double) kMidiTicksPerQuarter))
              + juce::String (" beats");
@@ -75,8 +79,9 @@ juce::String summaryLine (const ImportTargetPicker::FileSummary& s)
                               : 0.0;
     const auto khz = juce::String ((int) std::llround (s.sampleRate / 1000.0));
     const auto chs = s.numChannels == 2 ? juce::String ("stereo") : juce::String ("mono");
-    return khz + juce::String (" k\xc2\xb7") + chs
-         + juce::String (" \xc2\xb7 ") + juce::String (seconds, 1) + juce::String (" s");
+    return khz + juce::String (juce::CharPointer_UTF8 (" kHz \xc2\xb7 ")) + chs
+         + juce::String (juce::CharPointer_UTF8 (" \xc2\xb7 "))
+         + juce::String (seconds, 1) + juce::String (" s");
 }
 } // namespace
 

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -3975,7 +3975,9 @@ juce::PopupMenu MainComponent::getMenuForIndex (int topLevelMenuIndex,
                 // looks broken without explanation. The click handler
                 // shows the alert if loadSessionFromJson fails.
                 recents.addItem (kMenuFileRecentBase + i,
-                                  dir.getFileName() + "  \xe2\x80\x94  " + parent);
+                                  dir.getFileName()
+                                    + juce::String (juce::CharPointer_UTF8 ("  \xe2\x80\x94  "))
+                                    + parent);
                 juce::ignoreUnused (json);
             }
             recents.addSeparator();


### PR DESCRIPTION
Fixes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text rendering issues in several UI labels so special punctuation now displays correctly.
  * Improved formatting in import and session summary text, including separators and symbols, to avoid garbled characters on some systems.
  * Updated recent-session menu text to show the separator consistently with the rest of the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->