### PR TITLE
Fix/wayland label editor popups

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -33,3 +33,13 @@ tries to switch the device). The complete fix is an offline batch
 resample: rewrite every region/take/freeze WAV at the new rate and
 rescale every sample-domain position (regions, automation points,
 markers, loop/punch, tempo-map anchors) in one undoable pass.
+
+## Native LV2 instruments
+
+The picker's native-LV2 rows replace JUCE-hosted LV2 EFFECTS only
+(PluginPickerHelpers.cpp gates the swap on kind == Effects; PluginManager
+has no getLv2InstrumentDescriptions). LV2 instruments therefore still load
+through the standard JUCE host — the last reachable standard-host editor
+window on Linux, i.e. the last Wayland-fragile plugin-UI path. Extending
+the native LV2 host to instruments (MIDI delivery + CC bridge parity with
+the CLAP/VST3 native instrument work in #25) removes it.

--- a/TODO.md
+++ b/TODO.md
@@ -33,13 +33,3 @@ tries to switch the device). The complete fix is an offline batch
 resample: rewrite every region/take/freeze WAV at the new rate and
 rescale every sample-domain position (regions, automation points,
 markers, loop/punch, tempo-map anchors) in one undoable pass.
-
-## Native LV2 instruments
-
-The picker's native-LV2 rows replace JUCE-hosted LV2 EFFECTS only
-(PluginPickerHelpers.cpp gates the swap on kind == Effects; PluginManager
-has no getLv2InstrumentDescriptions). LV2 instruments therefore still load
-through the standard JUCE host — the last reachable standard-host editor
-window on Linux, i.e. the last Wayland-fragile plugin-UI path. Extending
-the native LV2 host to instruments (MIDI delivery + CC bridge parity with
-the CLAP/VST3 native instrument work in #25) removes it.

--- a/src/session/MidiBindings.h
+++ b/src/session/MidiBindings.h
@@ -387,8 +387,9 @@ void showLearnMenu (juce::Component& target,
 // The learn menu is built as a juce::PopupMenu but SHOWN through this hook,
 // so the UI layer can render it in-window (DuskContextMenu) rather than a
 // native popup — native popups flash / mis-dismiss / mis-stack on X11 and
-// Wayland. The UI sets this once at startup; if it's left unset, showLearnMenu
-// falls back to juce::PopupMenu::showMenuAsync.
+// Wayland. The UI sets this once at startup; if it's left unset,
+// showLearnMenu logs, asserts and drops the menu (a native popup must
+// never ship).
 using LearnMenuShowFn = std::function<void (const juce::PopupMenu&, juce::Component&)>;
 void setLearnMenuShowHook (LearnMenuShowFn fn);
 } // namespace midilearn

--- a/src/ui/AudioRegionEditor.cpp
+++ b/src/ui/AudioRegionEditor.cpp
@@ -1,6 +1,7 @@
 #include "AudioRegionEditor.h"
 #include "AppConfig.h"
 #include "DuskAlerts.h"
+#include "DuskLabelEditor.h"
 #include "DuskContextMenu.h"
 #include "EditCursors.h"
 #include "EditModeToolbar.h"
@@ -117,6 +118,7 @@ AudioRegionEditor::AudioRegionEditor (Session& s, AudioEngine& e, int t, int r)
     // " dB" / " ms" / " / N ms" so the user can retype the displayed
     // string verbatim. Bad input reverts on the next status refresh.
     gainLabel.setEditable (false, true, false);
+    disableLabelEditorPopup (gainLabel);
     gainLabel.setColour (juce::Label::backgroundWhenEditingColourId, juce::Colour (0xff202028));
     gainLabel.setColour (juce::Label::textWhenEditingColourId,        juce::Colours::white);
     gainLabel.setTooltip ("Double-click to type a dB value (range -24 to +12).");
@@ -139,6 +141,7 @@ AudioRegionEditor::AudioRegionEditor (Session& s, AudioEngine& e, int t, int r)
     };
 
     fadeLabel.setEditable (false, true, false);
+    disableLabelEditorPopup (fadeLabel);
     fadeLabel.setColour (juce::Label::backgroundWhenEditingColourId, juce::Colour (0xff202028));
     fadeLabel.setColour (juce::Label::textWhenEditingColourId,        juce::Colours::white);
     fadeLabel.setTooltip ("Double-click to type \"IN / OUT\" fade lengths in ms "
@@ -180,6 +183,7 @@ AudioRegionEditor::AudioRegionEditor (Session& s, AudioEngine& e, int t, int r)
     titleLabel.setColour (juce::Label::backgroundColourId, juce::Colour (0xff181820));
     titleLabel.setFont (juce::Font (juce::FontOptions (12.5f, juce::Font::bold)));
     titleLabel.setEditable (false, true, false);
+    disableLabelEditorPopup (titleLabel);
     titleLabel.setColour (juce::Label::backgroundWhenEditingColourId, juce::Colour (0xff202028));
     titleLabel.setColour (juce::Label::textWhenEditingColourId,        juce::Colours::white);
     titleLabel.setTooltip ("Double-click to rename the region. Empty = use filename.");

--- a/src/ui/AuxLaneComponent.cpp
+++ b/src/ui/AuxLaneComponent.cpp
@@ -1,4 +1,5 @@
 #include "AuxLaneComponent.h"
+#include "DuskLabelEditor.h"
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
   #include "ClapPluginEditorComponent.h"   // Linux-only native CLAP editor
 #endif
@@ -202,6 +203,7 @@ AuxLaneComponent::AuxLaneComponent (AuxLane& l, AuxLaneStrip& s, int idx,
     nameLabel.setColour (juce::Label::textColourId, juce::Colours::white);
     nameLabel.setFont (juce::Font (juce::FontOptions (14.0f, juce::Font::bold)));
     nameLabel.setEditable (false, true, false);
+    disableLabelEditorPopup (nameLabel);
     nameLabel.setColour (juce::Label::backgroundWhenEditingColourId, juce::Colour (0xff202024));
     nameLabel.setColour (juce::Label::textWhenEditingColourId,       juce::Colours::white);
     nameLabel.onTextChange = [this]

--- a/src/ui/BusComponent.cpp
+++ b/src/ui/BusComponent.cpp
@@ -1,6 +1,7 @@
 #include "BusComponent.h"
 #include "../engine/AudioEngine.h"
 #include "DuskContextMenu.h"
+#include "DuskLabelEditor.h"
 #include "SteppedKnob.h"
 #include "CompBypassLed.h"
 #include "DuskStudioLookAndFeel.h"  // fourKColors palette
@@ -489,6 +490,7 @@ BusComponent::BusComponent (Bus& b, Session& s, AudioEngine& e, int idx)
     nameLabel.setColour (juce::Label::textColourId, juce::Colours::white);
     nameLabel.setFont (juce::Font (juce::FontOptions (12.0f, juce::Font::bold)));
     nameLabel.setEditable (false, true, false);
+    disableLabelEditorPopup (nameLabel);
     nameLabel.setColour (juce::Label::backgroundWhenEditingColourId, juce::Colour (0xff202024));
     nameLabel.setColour (juce::Label::textWhenEditingColourId,       juce::Colours::white);
     nameLabel.setTooltip ("Double-click to rename this bus.");

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -1,6 +1,7 @@
 #include "ChannelStripComponent.h"
 #include "CompBypassLed.h"
 #include "DuskContextMenu.h"
+#include "DuskLabelEditor.h"
 #include "DuskStudioLookAndFeel.h"
 #include "ChannelEqEditor.h"
 #include "ChannelCompEditor.h"
@@ -268,6 +269,7 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
     nameLabel.setColour (juce::Label::textColourId, juce::Colours::white);
     nameLabel.setFont (juce::Font (juce::FontOptions (13.0f, juce::Font::bold)));
     nameLabel.setEditable (false, true, false);  // single-click no, double-click YES, no submit-on-empty
+    disableLabelEditorPopup (nameLabel);
     nameLabel.setTooltip ("Double-click to rename, right-click for colour");
     nameLabel.onTextChange = [this]
     {
@@ -1304,6 +1306,7 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
         lbl.setTooltip ("Double-click to rename this AUX send (e.g. \"Reverb\", \"Delay\"). "
                           "Renames the aux lane globally so all channel strips show the same name.");
         lbl.setEditable (false, true, false);
+        disableLabelEditorPopup (lbl);
         lbl.setColour (juce::Label::backgroundWhenEditingColourId, juce::Colour (0xff202024));
         lbl.setColour (juce::Label::textWhenEditingColourId,       juce::Colours::white);
         lbl.onTextChange = [this, i]
@@ -3219,6 +3222,7 @@ public:
             il.setMinimumHorizontalScale (0.5f);
             il.setTooltip ("Double-click to rename this AUX send.");
             il.setEditable (false, true, false);
+            disableLabelEditorPopup (il);
             il.setColour (juce::Label::backgroundWhenEditingColourId, juce::Colour (0xff202024));
             il.setColour (juce::Label::textWhenEditingColourId,       juce::Colours::white);
             il.onTextChange = [this, i]

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -3516,14 +3516,13 @@ void ChannelStripComponent::timerCallback()
     // popup. Bullet character + brighter background when on.
     if (compactMode)
     {
-        // Channel-strip EQ illuminates when the user has explicitly
-        // enabled the 4-band EQ (auto-armed on first knob touch, also
-        // user-toggleable via the LED in the EQ header) OR when HPF is
-        // engaged (HPF has its own atomic gate independent of eqEnabled).
-        // Comp has a real on/off atom.
+        // Channel-strip EQ illuminates on eqEnabled alone — the same state the
+        // pill's left-click toggles and the expanded EQ header reflects. HPF is
+        // deliberately excluded: it has its own independent gate, and folding it
+        // in here left the pill stuck lit while HPF was engaged, so a click
+        // toggled eqEnabled with no visible change. Comp has a real on/off atom.
         const auto& sp = track.strip;
-        const bool eqOn   = sp.eqEnabled.load (std::memory_order_relaxed)
-                          || sp.hpfEnabled.load (std::memory_order_relaxed);
+        const bool eqOn   = sp.eqEnabled.load (std::memory_order_relaxed);
         const bool compOn = sp.compEnabled.load (std::memory_order_relaxed);
 
         const auto eqAccent   = juce::Colour (fourKColors::kLfGreen);

--- a/src/ui/DuskLabelEditor.h
+++ b/src/ui/DuskLabelEditor.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+namespace duskstudio
+{
+// A double-click-editable juce::Label spawns an internal TextEditor when the
+// edit begins, and that editor keeps the default built-in right-click menu —
+// a native PopupMenu window, i.e. the XWayland popup flash every explicit
+// TextEditor in the app already disables (see DuskComboBox). Call once after
+// setEditable so the spawned editor gets the same treatment.
+inline void disableLabelEditorPopup (juce::Label& label)
+{
+    label.onEditorShow = [&label]
+    {
+        if (auto* ed = label.getCurrentTextEditor())
+            ed->setPopupMenuEnabled (false);
+    };
+}
+} // namespace duskstudio

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -287,15 +287,14 @@ void showImportError (const juce::String& title, const juce::String& message)
                 return;
             }
     }
-    // Fallback only when no top-level exists (shouldn't happen in
-    // normal use; safety net for headless / shutdown paths).
-    juce::AlertWindow::showAsync (
-        juce::MessageBoxOptions()
-            .withIconType (juce::MessageBoxIconType::WarningIcon)
-            .withTitle (title)
-            .withMessage (message)
-            .withButton ("OK"),
-        nullptr);
+    // No top-level to host the in-window alert (headless / shutdown paths
+    // only). A native AlertWindow here would be the one separate-window
+    // dialog left in the app — and on a headless path it can't be seen
+    // anyway. Log instead; the assert makes a reachable-in-normal-use
+    // regression loud in debug builds.
+    std::fprintf (stderr, "[Dusk Studio] %s: %s\n",
+                  title.toRawUTF8(), message.toRawUTF8());
+    jassertfalse;
 }
 } // namespace
 

--- a/src/ui/TransportBar.cpp
+++ b/src/ui/TransportBar.cpp
@@ -1,6 +1,7 @@
 #include "TransportBar.h"
 #include "DuskAlerts.h"
 #include "DuskContextMenu.h"
+#include "DuskLabelEditor.h"
 #include "../session/RegionEditActions.h"
 #include "../util/StringParsing.h"
 #include <algorithm>
@@ -382,6 +383,7 @@ TransportBar::TransportBar (AudioEngine& engineRef) : engine (engineRef)
     // Bad input reverts the label to the running-time format on the next
     // timer tick, no error dialog (cheap + stays out of the way).
     clockLabel.setEditable (false, true, false);
+    disableLabelEditorPopup (clockLabel);
     clockLabel.setColour (juce::Label::backgroundWhenEditingColourId, juce::Colour (0xff202028));
     clockLabel.setColour (juce::Label::textWhenEditingColourId,        juce::Colours::white);
     clockLabel.setTooltip ("Playhead position. Double-click to type a time "


### PR DESCRIPTION
more JUCE removal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Simplified in-place label editing across the app by removing the extra popup menu during text edits.
  - The compact EQ indicator now reflects EQ status only, so HPF no longer makes it appear active.
  - Import errors now appear in the console when a dialog can’t be shown, instead of opening a separate warning window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->