### PR TITLE
Feat/native lv2 instruments

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -30,7 +30,7 @@ Dusk Studio includes:
 - Four mix buses, each with a 3-band EQ and console-style bus compressor.
 - A master bus with tape saturation, a tube program EQ, bus compressor, and mono-sum check.
 - A dedicated mastering stage with 5-band digital EQ, multiband compressor, brick-wall limiter, and BS.1770 loudness metering.
-- VST3, LV2, AU, and CLAP plugin hosting, with optional out-of-process sandboxing for crash isolation. On Linux, CLAP and LV2 effects run through Dusk Studio's own native hosts.
+- VST3, LV2, AU, and CLAP plugin hosting, with optional out-of-process sandboxing for crash isolation. On Linux, CLAP, LV2 and VST3 — effects and instruments — run through Dusk Studio's own native hosts.
 - External hardware insert per channel and per aux, with automatic latency measurement.
 - A multi-sampler that plays `.sfz` files and `.sf2` SoundFonts on MIDI tracks, both through the built-in sfizz engine (SF2 files are converted to SFZ on load — no external synth required).
 - MIDI Clock and MIDI Time Code chase and emit.
@@ -1379,7 +1379,7 @@ A few rules:
 Dusk Studio scans and hosts:
 
 - **VST3** on Linux, macOS, and Windows. On Linux, effects AND instruments load through Dusk Studio's own native VST3 host (rows tagged **VST3-Native**); everywhere else VST3 loads through the standard host.
-- **LV2** on Linux. Effects load through Dusk Studio's own native LV2 host (rows tagged **LV2-Native**); LV2 instruments load through the standard host.
+- **LV2** on Linux. Effects and instruments load through Dusk Studio's own native LV2 host (rows tagged **LV2-Native**). Instruments added by a plugin re-scan if they don't appear after updating.
 - **CLAP** on Linux, through the native host — effects and instruments.
 - **AU** on macOS only.
 - **Native multi-sampler** (`.sfz` and `.sf2` files, both via the built-in sfizz engine — SF2 is converted to SFZ on load) on all platforms.
@@ -1409,7 +1409,7 @@ In the **plugin picker** modal:
 - Each row shows the plugin name and its format (VST3 / LV2 / AU / CLAP / LV2-Native / VST3-Native).
 - Click a row to load and dismiss.
 
-On Linux, effect slots list LV2 and VST3 plugins as **LV2-Native** / **VST3-Native** rows — the same plugins, hosted by Dusk Studio's native hosts instead of the standard one. Each plugin appears once; there is no duplicate plain-LV2 or plain-VST3 row.
+On Linux, both the effect and instrument pickers list LV2 and VST3 plugins as **LV2-Native** / **VST3-Native** rows — the same plugins, hosted by Dusk Studio's native hosts instead of the standard one. Each plugin appears once; there is no duplicate plain-LV2 or plain-VST3 row.
 
 The picker filters by intent: only effect plugins appear when you're loading onto a channel insert or aux lane; only instruments appear when you're loading onto a MIDI track.
 

--- a/src/engine/PluginManager.cpp
+++ b/src/engine/PluginManager.cpp
@@ -539,16 +539,18 @@ void PluginManager::scanLv2Plugins()
         lv2Descriptions.clearQuick();
         for (const auto& s : scanned)
         {
-            // Only audio effects for now — the native LV2 host is an insert host;
-            // instruments and MIDI utilities stay with the JUCE LV2 format.
-            if (s.desc.audioInputs <= 0 || s.desc.audioOutputs <= 0)
+            // Audio effects (audio in + out) and instruments (atom/MIDI in,
+            // audio out, no audio in — classified by Lv2Bundle::describePlugin).
+            // MIDI-only utilities stay with the JUCE LV2 format.
+            const bool effect = s.desc.audioInputs > 0 && s.desc.audioOutputs > 0;
+            if (! effect && ! s.desc.isInstrument)
                 continue;
             juce::PluginDescription d;
             d.name             = juce::String (juce::CharPointer_UTF8 (s.desc.name.c_str()));
             d.pluginFormatName = "LV2-Native";
             d.fileOrIdentifier = hosting::joinNativeIdentifier (
                 s.bundlePath, juce::String (juce::CharPointer_UTF8 (s.desc.uri.c_str())));
-            d.isInstrument     = false;
+            d.isInstrument     = s.desc.isInstrument;
             lv2Descriptions.add (d);
         }
     }
@@ -559,7 +561,21 @@ void PluginManager::scanLv2Plugins()
 juce::Array<juce::PluginDescription> PluginManager::getLv2EffectDescriptions() const
 {
     const juce::ScopedLock sl (nativeDescriptionsLock);
-    return lv2Descriptions;   // scan already filtered to audio effects
+    juce::Array<juce::PluginDescription> effects;
+    for (const auto& d : lv2Descriptions)
+        if (! d.isInstrument)
+            effects.add (d);
+    return effects;
+}
+
+juce::Array<juce::PluginDescription> PluginManager::getLv2InstrumentDescriptions() const
+{
+    const juce::ScopedLock sl (nativeDescriptionsLock);
+    juce::Array<juce::PluginDescription> instruments;
+    for (const auto& d : lv2Descriptions)
+        if (d.isInstrument)
+            instruments.add (d);
+    return instruments;
 }
 
 void PluginManager::scanVst3NativePlugins()

--- a/src/engine/PluginManager.h
+++ b/src/engine/PluginManager.h
@@ -46,8 +46,9 @@ public:
 
     // Native-LV2 plugins, scanned separately from JUCE's LV2 format (which stays as
     // the fallback host). pluginFormatName "LV2-Native", fileOrIdentifier = the .lv2
-    // bundle directory. Audio effects only; discovery is manifest-only via lilv.
+    // bundle directory. Effects and instruments; discovery is manifest-only via lilv.
     juce::Array<juce::PluginDescription> getLv2EffectDescriptions() const;
+    juce::Array<juce::PluginDescription> getLv2InstrumentDescriptions() const;
     void scanLv2Plugins();
 
     // Native-VST3 plugins, scanned separately from JUCE's VST3 format (which stays

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -1890,12 +1890,11 @@ void ChannelStripComponent::openPluginPicker (bool useChooser)
     // Native LV2 route — same shape; LV2-Native rows replace the JUCE LV2 rows.
     std::function<void (const juce::File&, const juce::String&)> onLv2;
 #if DUSKSTUDIO_HAS_NATIVE_LV2
-    if (kind == pluginpicker::PluginKind::Effects)
-        onLv2 = [safe] (const juce::File& f, const juce::String& id)
-        {
-            if (auto* self = safe.getComponent())
-                self->loadNativeLv2ForChannel (f, id);
-        };
+    onLv2 = [safe] (const juce::File& f, const juce::String& id)
+    {
+        if (auto* self = safe.getComponent())
+            self->loadNativeLv2ForChannel (f, id);
+    };
 #endif
     // Native VST3 route — same shape; VST3-Native rows replace the JUCE VST3 rows.
     std::function<void (const juce::File&, const juce::String&)> onVst3;
@@ -2736,6 +2735,8 @@ void ChannelStripComponent::loadNativeLv2ForChannel (const juce::File& bundleDir
         return;
     }
 
+    if (strip.getNativeLv2Slot().isLoadedInstrument())
+        adoptInstrumentTrackDefaults();
     track.nativeLv2Path     = bundleDir.getFullPathName();
     track.nativeLv2PluginId = strip.getNativeLv2Slot().getPluginId();
     track.nativeLv2StateBase64 = {};

--- a/src/ui/PluginPickerHelpers.cpp
+++ b/src/ui/PluginPickerHelpers.cpp
@@ -398,13 +398,16 @@ void openPickerMenu (PluginSlot& slot,
                                  ? manager.getClapEffectDescriptions()
                                  : manager.getClapInstrumentDescriptions());
 
-    // Native-LV2 rows replace the JUCE-hosted LV2 effect rows (same plugins, better
-    // host) so each plugin appears once. JUCE LV2 stays the fallback when unset.
-    if (onPickNativeLv2 && kind == PluginKind::Effects)
+    // Native-LV2 rows replace the JUCE-hosted LV2 rows for both kinds (same
+    // plugins, better host) so each plugin appears once. JUCE LV2 stays the
+    // fallback when unset.
+    if (onPickNativeLv2)
     {
         descriptions.removeIf ([] (const juce::PluginDescription& d)
                                { return d.pluginFormatName == "LV2"; });
-        descriptions.addArray (manager.getLv2EffectDescriptions());
+        descriptions.addArray (kind == PluginKind::Effects
+                                 ? manager.getLv2EffectDescriptions()
+                                 : manager.getLv2InstrumentDescriptions());
     }
 
     // Native-VST3 rows replace the JUCE-hosted VST3 rows for both kinds.

--- a/tests/lv2_bundle_load.cpp
+++ b/tests/lv2_bundle_load.cpp
@@ -41,3 +41,27 @@ TEST_CASE ("Lv2Bundle loads + enumerates a real LV2 bundle", "[lv2][bundle]")
     REQUIRE (bundle.pluginByUri (first.uri) != nullptr);
     REQUIRE (bundle.pluginByUri ("http://example.org/does-not-exist") == nullptr);
 }
+
+// Instrument classification drives the native-instrument picker rows: an
+// atom/MIDI-in + audio-out + no-audio-in plugin must describe as an
+// instrument. Gated like the live bundle test so CI without a synth stays
+// green (point it at e.g. /usr/lib64/lv2/sfizz.lv2 locally).
+TEST_CASE ("Lv2Bundle classifies an instrument bundle", "[lv2][bundle]")
+{
+    const char* path = std::getenv ("DUSKSTUDIO_TEST_LV2_INSTRUMENT");
+    if (path == nullptr || *path == '\0')
+    {
+        SUCCEED ("DUSKSTUDIO_TEST_LV2_INSTRUMENT not set — skipping");
+        return;
+    }
+
+    duskstudio::lv2::Lv2Bundle bundle;
+    std::string err;
+    REQUIRE (bundle.load (path, err));
+    REQUIRE_FALSE (bundle.plugins().empty());
+
+    bool anyInstrument = false;
+    for (const auto& p : bundle.plugins())
+        anyInstrument = anyInstrument || p.isInstrument;
+    REQUIRE (anyInstrument);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Linux plugin pickers now show native LV2 and VST3 entries for both effects and instruments.
  * Added support for loading LV2 instruments alongside LV2 effects.
* **Bug Fixes**
  * Fixed plugin lists so LV2/VST3 entries no longer appear as duplicate plain rows on Linux.
  * Improved instrument detection so loaded LV2 instruments use the correct track defaults.
* **Documentation**
  * Clarified plugin-hosting documentation for Linux behavior and picker labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->