### PR TITLE
fix(bounce): engage master-stage aux PDC in offline renders

### DIFF
--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -778,6 +778,26 @@ void AudioEngine::recomputePdc() noexcept
                                                std::memory_order_relaxed);
 }
 
+void AudioEngine::applyMasterPdcTargetsNow() noexcept
+{
+    recomputePdc();
+
+    masterDryPdcApplied = masterDryPdcTarget.load (std::memory_order_relaxed);
+    masterDryPdcL.reset();
+    masterDryPdcR.reset();
+    masterDryPdcL.setDelay ((float) masterDryPdcApplied);
+    masterDryPdcR.setDelay ((float) masterDryPdcApplied);
+    for (int a = 0; a < Session::kNumAuxLanes; ++a)
+    {
+        const int t = auxReturnPdcTarget[(size_t) a].load (std::memory_order_relaxed);
+        auxReturnPdcApplied[(size_t) a] = t;
+        auxReturnPdcL[(size_t) a].reset();
+        auxReturnPdcR[(size_t) a].reset();
+        auxReturnPdcL[(size_t) a].setDelay ((float) t);
+        auxReturnPdcR[(size_t) a].setDelay ((float) t);
+    }
+}
+
 bool AudioEngine::freezePrepare (int trackIndex, juce::File& outFile, juce::int64& lenSamples)
 {
     lastFreezeError.clear();

--- a/src/engine/AudioEngine.h
+++ b/src/engine/AudioEngine.h
@@ -295,6 +295,22 @@ public:
         return aggregatePdcLatencySamples.load (std::memory_order_relaxed);
     }
 
+    // Deepest aux-lane latency the master-stage PDC delays the mix by. Bounce
+    // adds it to the lead-in trim: the rendered mix starts this many samples
+    // late once the master-stage delays are engaged.
+    int getMasterDryPdcTargetSamples() const noexcept
+    {
+        return masterDryPdcTarget.load (std::memory_order_relaxed);
+    }
+
+    // Offline-render only — call with the audio callback DETACHED. The
+    // in-callback relatch of the master-stage PDC is gated on a stopped
+    // transport, which an offline drive never satisfies (it forces Playing
+    // before the first driven block), so without this a bounce rendered with
+    // wet returns misaligned against the dry mix whenever an aux lane
+    // reported latency. Recomputes targets, then latches them directly.
+    void applyMasterPdcTargetsNow() noexcept;
+
     // Test-only. Next callback merges `events` into perInputMidi[inputIdx]
     // AFTER collector drain. Cleared after one block.
     void stageTestMidiInjection (int inputIdx, juce::MidiBuffer events);

--- a/src/engine/BounceEngine.cpp
+++ b/src/engine/BounceEngine.cpp
@@ -283,6 +283,11 @@ void BounceEngine::run()
         transport.setPlayhead (0);
         transport.setState (Transport::State::Playing);
         engine.getPlaybackEngine().preparePlayback();
+        // The in-callback relatch of the master-stage aux PDC only runs while
+        // stopped — and this offline drive is Playing from the first block.
+        // Latch the targets here (callback is detached) or the render plays
+        // wet returns misaligned against the dry mix.
+        engine.applyMasterPdcTargetsNow();
     }
     else
     {
@@ -293,13 +298,15 @@ void BounceEngine::run()
         engine.getMasteringPlayer().play();
     }
 
-    // PDC lead-in: with cross-track compensation the master mix is delayed by
-    // the deepest track latency. Render that many extra samples and discard
+    // PDC lead-in: cross-track compensation delays the master mix by the
+    // deepest track latency, and the master-stage aux PDC delays it again by
+    // the deepest aux-lane latency. Render that many extra samples and discard
     // them up front so the file isn't shifted. The MasteringChain path bypasses
-    // the channel strips, so it carries no per-track PDC lead-in.
+    // the channel strips and aux lanes, so it carries no lead-in.
     const juce::int64 leadIn = (renderMode == Mode::MasteringChain)
                                  ? 0
-                                 : (juce::int64) engine.getAggregatePdcLatencySamples();
+                                 : (juce::int64) engine.getAggregatePdcLatencySamples()
+                                     + (juce::int64) engine.getMasterDryPdcTargetSamples();
     const juce::int64 toRender = totalSamples + leadIn;
 
     juce::int64 done    = 0;   // samples processed through the engine
@@ -460,9 +467,11 @@ bool BounceEngine::renderOneStem (const juce::File& outFile,
     engine.getPlaybackEngine().preparePlayback();
 
     // Same PDC lead-in trim as the master render: each stem runs the full strip
-    // path, so it's delayed by the deepest track latency. Drop those leading
-    // samples so all stems stay mutually aligned and start at sample 0.
-    const juce::int64 leadIn  = (juce::int64) engine.getAggregatePdcLatencySamples();
+    // path, so it's delayed by the deepest track latency plus the
+    // master-stage aux PDC. Drop those leading samples so all stems stay
+    // mutually aligned and start at sample 0.
+    const juce::int64 leadIn  = (juce::int64) engine.getAggregatePdcLatencySamples()
+                                  + (juce::int64) engine.getMasterDryPdcTargetSamples();
     const juce::int64 toRender = lenSamples + leadIn;
 
     juce::int64 done    = 0;
@@ -564,6 +573,10 @@ bool BounceEngine::runStemsMode()
     const auto savedPlayhead       = transport.getPlayhead();
     const auto savedStage          = engine.getStage();
     engine.setStage (AudioEngine::Stage::Mixing);
+    // Same reason as the master-mix path: the stem drive runs Playing from
+    // block 0, so the in-callback (stopped-only) relatch never engages the
+    // master-stage aux PDC — latch it while the callback is detached.
+    engine.applyMasterPdcTargetsNow();
 
     bool succeeded = true;
     const int  numStems = (int) tracksToRender.size();


### PR DESCRIPTION
Offline renders were not applying the master-stage aux-return plugin delay compensation, so aux returns landed early relative to the real-time mix. Engage the master-stage aux PDC and trim the lead-in accordingly during bounce.

Builds clean, full suite green.