### PR TITLE
fix(lv2): review follow-ups — dedup native getters, clarify manual

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1379,7 +1379,7 @@ A few rules:
 Dusk Studio scans and hosts:
 
 - **VST3** on Linux, macOS, and Windows. On Linux, effects AND instruments load through Dusk Studio's own native VST3 host (rows tagged **VST3-Native**); everywhere else VST3 loads through the standard host.
-- **LV2** on Linux. Effects and instruments load through Dusk Studio's own native LV2 host (rows tagged **LV2-Native**). Instruments added by a plugin re-scan if they don't appear after updating.
+- **LV2** on Linux. Effects and instruments load through Dusk Studio's own native LV2 host (rows tagged **LV2-Native**). If a plugin update adds new instruments, run **Scan plugins** for them to appear.
 - **CLAP** on Linux, through the native host — effects and instruments.
 - **AU** on macOS only.
 - **Native multi-sampler** (`.sfz` and `.sf2` files, both via the built-in sfizz engine — SF2 is converted to SFZ on load) on all platforms.
@@ -1428,7 +1428,7 @@ This holds on all platforms, including the macOS out-of-process sandbox. Rather 
 
 ## Native plugin hosting (Linux)
 
-On Linux, CLAP plugins and LV2/VST3 effects are hosted by Dusk Studio's own plugin hosts rather than the standard hosting layer. This exists for one reason: plugin editor windows embedded through the standard layer are the biggest source of UI breakage on Wayland desktops. The native hosts own the editor embedding directly and sidestep that class of problem.
+On Linux, CLAP, LV2, and VST3 plugins — effects and instruments — are hosted by Dusk Studio's own plugin hosts rather than the standard hosting layer. This exists for one reason: plugin editor windows embedded through the standard layer are the biggest source of UI breakage on Wayland desktops. The native hosts own the editor embedding directly and sidestep that class of problem.
 
 In practice the differences are small:
 

--- a/src/engine/PluginManager.cpp
+++ b/src/engine/PluginManager.cpp
@@ -510,24 +510,25 @@ void PluginManager::saveNativeCache (const juce::Array<juce::PluginDescription>&
     root.writeTo (file);
 }
 
-juce::Array<juce::PluginDescription> PluginManager::getClapEffectDescriptions() const
+juce::Array<juce::PluginDescription> PluginManager::filterByInstrumentFlag (
+    const juce::Array<juce::PluginDescription>& source, bool wantInstrument) const
 {
     const juce::ScopedLock sl (nativeDescriptionsLock);
-    juce::Array<juce::PluginDescription> effects;
-    for (const auto& d : clapDescriptions)
-        if (! d.isInstrument)
-            effects.add (d);
-    return effects;
+    juce::Array<juce::PluginDescription> out;
+    for (const auto& d : source)
+        if (d.isInstrument == wantInstrument)
+            out.add (d);
+    return out;
+}
+
+juce::Array<juce::PluginDescription> PluginManager::getClapEffectDescriptions() const
+{
+    return filterByInstrumentFlag (clapDescriptions, false);
 }
 
 juce::Array<juce::PluginDescription> PluginManager::getClapInstrumentDescriptions() const
 {
-    const juce::ScopedLock sl (nativeDescriptionsLock);
-    juce::Array<juce::PluginDescription> instruments;
-    for (const auto& d : clapDescriptions)
-        if (d.isInstrument)
-            instruments.add (d);
-    return instruments;
+    return filterByInstrumentFlag (clapDescriptions, true);
 }
 
 void PluginManager::scanLv2Plugins()
@@ -560,22 +561,12 @@ void PluginManager::scanLv2Plugins()
 
 juce::Array<juce::PluginDescription> PluginManager::getLv2EffectDescriptions() const
 {
-    const juce::ScopedLock sl (nativeDescriptionsLock);
-    juce::Array<juce::PluginDescription> effects;
-    for (const auto& d : lv2Descriptions)
-        if (! d.isInstrument)
-            effects.add (d);
-    return effects;
+    return filterByInstrumentFlag (lv2Descriptions, false);
 }
 
 juce::Array<juce::PluginDescription> PluginManager::getLv2InstrumentDescriptions() const
 {
-    const juce::ScopedLock sl (nativeDescriptionsLock);
-    juce::Array<juce::PluginDescription> instruments;
-    for (const auto& d : lv2Descriptions)
-        if (d.isInstrument)
-            instruments.add (d);
-    return instruments;
+    return filterByInstrumentFlag (lv2Descriptions, true);
 }
 
 void PluginManager::scanVst3NativePlugins()
@@ -595,22 +586,12 @@ void PluginManager::scanVst3NativePlugins()
 
 juce::Array<juce::PluginDescription> PluginManager::getVst3NativeEffectDescriptions() const
 {
-    const juce::ScopedLock sl (nativeDescriptionsLock);
-    juce::Array<juce::PluginDescription> effects;
-    for (const auto& d : vst3NativeDescriptions)
-        if (! d.isInstrument)
-            effects.add (d);
-    return effects;
+    return filterByInstrumentFlag (vst3NativeDescriptions, false);
 }
 
 juce::Array<juce::PluginDescription> PluginManager::getVst3NativeInstrumentDescriptions() const
 {
-    const juce::ScopedLock sl (nativeDescriptionsLock);
-    juce::Array<juce::PluginDescription> instruments;
-    for (const auto& d : vst3NativeDescriptions)
-        if (d.isInstrument)
-            instruments.add (d);
-    return instruments;
+    return filterByInstrumentFlag (vst3NativeDescriptions, true);
 }
 
 juce::Array<juce::PluginDescription> PluginManager::getInstrumentDescriptions() const

--- a/src/engine/PluginManager.h
+++ b/src/engine/PluginManager.h
@@ -117,6 +117,9 @@ private:
     juce::Array<juce::PluginDescription> vst3NativeDescriptions; // native VST3 (scanned separately)
     bool                           oopEnabled { false };
 
+    juce::Array<juce::PluginDescription> filterByInstrumentFlag (
+        const juce::Array<juce::PluginDescription>& source, bool wantInstrument) const;
+
     void loadCache();
     void saveCache() const;
 

--- a/tests/lv2_bundle_load.cpp
+++ b/tests/lv2_bundle_load.cpp
@@ -6,6 +6,7 @@
 
 #include "engine/lv2/Lv2Bundle.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <string>
 
@@ -60,8 +61,7 @@ TEST_CASE ("Lv2Bundle classifies an instrument bundle", "[lv2][bundle]")
     REQUIRE (bundle.load (path, err));
     REQUIRE_FALSE (bundle.plugins().empty());
 
-    bool anyInstrument = false;
-    for (const auto& p : bundle.plugins())
-        anyInstrument = anyInstrument || p.isInstrument;
-    REQUIRE (anyInstrument);
+    const auto& plugins = bundle.plugins();
+    REQUIRE (std::any_of (plugins.begin(), plugins.end(),
+                          [] (const auto& p) { return p.isInstrument; }));
 }


### PR DESCRIPTION
Follow-ups to #34:
- PluginManager: fold the six native effect/instrument description getters onto a shared `filterByInstrumentFlag` helper (one lock + filter path).
- MANUAL: native hosting covers LV2/VST3 instruments, not just effects; reword the LV2 re-scan sentence.
- test: `std::any_of` for the instrument-present check.

Builds clean, 319/319 tests green.