### PR TITLE
fix(ui): dismiss the Settings modal on Esc / click-outside

### DIFF
--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -1943,7 +1943,10 @@ void MainComponent::openAudioSettings()
     audioSettingsModal.show (*this, std::move (host), [safeThis]
     {
         if (auto* self = safeThis.getComponent())
+        {
+            self->audioSettingsModal.close();
             self->startTimer (appconfig::getAutosaveIntervalSeconds() * 1000);
+        }
     });
 }
 


### PR DESCRIPTION
openAudioSettings passed an onDismiss that only restarted the autosave timer. EmbeddedModal's Esc/click-outside paths run onDismiss instead of close() when one is supplied, so the Settings panel had no dismiss path — it could only be escaped by quitting. Restart the timer *and* close the modal. Shipped in the v0.12.0 tag; folding in before publish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when closing the audio settings window by ensuring follow-up actions only run if the main UI is still available.
  * Prevents an occasional delayed action from running after the related screen has already been dismissed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->