### PR TITLE
feat(mcu): REW/FFWD marker-jump + hold-to-scrub

### DIFF
--- a/src/engine/McuReceiver.cpp
+++ b/src/engine/McuReceiver.cpp
@@ -347,11 +347,13 @@ void McuReceiver::handleNotePress (int noteNumber, bool pressed) noexcept
     // scrub, mirroring the on-screen Rewind / Forward buttons.
     if (noteNumber == mcu::btn::Rewind)
     {
+        if (pressed) session.mcu.rewPressCount.fetch_add (1, std::memory_order_relaxed);
         session.mcu.rewHeld.store (pressed, std::memory_order_relaxed);
         return;
     }
     if (noteNumber == mcu::btn::FastForward)
     {
+        if (pressed) session.mcu.ffwdPressCount.fetch_add (1, std::memory_order_relaxed);
         session.mcu.ffwdHeld.store (pressed, std::memory_order_relaxed);
         return;
     }

--- a/src/engine/McuReceiver.cpp
+++ b/src/engine/McuReceiver.cpp
@@ -342,6 +342,20 @@ void McuReceiver::handleNotePress (int noteNumber, bool pressed) noexcept
         return;
     }
 
+    // REW / FFWD publish held-state on both edges. TransportBar's timer
+    // turns a short press into a marker jump and a hold into a 10x playhead
+    // scrub, mirroring the on-screen Rewind / Forward buttons.
+    if (noteNumber == mcu::btn::Rewind)
+    {
+        session.mcu.rewHeld.store (pressed, std::memory_order_relaxed);
+        return;
+    }
+    if (noteNumber == mcu::btn::FastForward)
+    {
+        session.mcu.ffwdHeld.store (pressed, std::memory_order_relaxed);
+        return;
+    }
+
     // Transport cluster - dispatch through pendingTransportAction so
     // engine.play() / stop() / record() run on the message thread.
     if (pressed)
@@ -361,16 +375,6 @@ void McuReceiver::handleNotePress (int noteNumber, bool pressed) noexcept
             case mcu::btn::Record:
                 session.pendingTransportAction.store (
                     (int) PendingTransportAction::Record,
-                    std::memory_order_relaxed);
-                return;
-            case mcu::btn::Rewind:
-                session.pendingTransportAction.store (
-                    (int) PendingTransportAction::PrevMarker,
-                    std::memory_order_relaxed);
-                return;
-            case mcu::btn::FastForward:
-                session.pendingTransportAction.store (
-                    (int) PendingTransportAction::NextMarker,
                     std::memory_order_relaxed);
                 return;
             case mcu::btn::Loop:

--- a/src/engine/McuReceiver.cpp
+++ b/src/engine/McuReceiver.cpp
@@ -364,16 +364,13 @@ void McuReceiver::handleNotePress (int noteNumber, bool pressed) noexcept
                     std::memory_order_relaxed);
                 return;
             case mcu::btn::Rewind:
-                session.pendingTransportPlayhead.store (
-                    (juce::int64) 0, std::memory_order_relaxed);
+                session.pendingTransportAction.store (
+                    (int) PendingTransportAction::PrevMarker,
+                    std::memory_order_relaxed);
                 return;
             case mcu::btn::FastForward:
-                // No "end of timeline" concept in Dusk Studio, so FFWD jumps
-                // the playhead to the end of the furthest content. The audio
-                // thread can't walk regions safely / call setPlayhead, so
-                // defer to TransportBar's message-thread drain.
                 session.pendingTransportAction.store (
-                    (int) PendingTransportAction::GoToEnd,
+                    (int) PendingTransportAction::NextMarker,
                     std::memory_order_relaxed);
                 return;
             case mcu::btn::Loop:

--- a/src/session/MidiBindings.h
+++ b/src/session/MidiBindings.h
@@ -300,8 +300,6 @@ enum class PendingTransportAction : int
     Record     = 3,
     Toggle     = 4,
     LoopToggle = 5,   // flip loop on/off (MCU Loop button)
-    PrevMarker = 6,   // MCU REW: mirror the on-screen Rewind tap
-    NextMarker = 7,   // MCU FFWD: mirror the on-screen Forward tap
 };
 
 // Packed into atomic<int>: target enum high bits, track index low 8.

--- a/src/session/MidiBindings.h
+++ b/src/session/MidiBindings.h
@@ -300,7 +300,8 @@ enum class PendingTransportAction : int
     Record     = 3,
     Toggle     = 4,
     LoopToggle = 5,   // flip loop on/off (MCU Loop button)
-    GoToEnd    = 6,   // jump playhead to the end of the last content (MCU FFWD)
+    PrevMarker = 6,   // MCU REW: mirror the on-screen Rewind tap
+    NextMarker = 7,   // MCU FFWD: mirror the on-screen Forward tap
 };
 
 // Packed into atomic<int>: target enum high bits, track index low 8.

--- a/src/session/Session.h
+++ b/src/session/Session.h
@@ -1408,6 +1408,13 @@ public:
         // Rewind / Forward buttons.
         std::atomic<bool> rewHeld  { false };
         std::atomic<bool> ffwdHeld { false };
+
+        // Rising-edge press counter, bumped on every press. A tap whose
+        // press+release both land between two 20 Hz timer polls leaves
+        // rewHeld/ffwdHeld false at both polls, so the timer would miss the
+        // edge; it watches this counter to still fire the tap.
+        std::atomic<juce::uint32> rewPressCount  { 0 };
+        std::atomic<juce::uint32> ffwdPressCount { 0 };
     };
     McuSessionState mcu;
 

--- a/src/session/Session.h
+++ b/src/session/Session.h
@@ -1401,6 +1401,13 @@ public:
 
         // 0..15 — drives EQ/COMP encoder target + plugin-editor focus.
         std::atomic<int> selectedChannel { 0 };
+
+        // REW / FFWD held-state (press = true, release = false). The
+        // TransportBar timer turns a short press into a marker jump and a
+        // hold into a 10x playhead scrub — same gesture as the on-screen
+        // Rewind / Forward buttons.
+        std::atomic<bool> rewHeld  { false };
+        std::atomic<bool> ffwdHeld { false };
     };
     McuSessionState mcu;
 

--- a/src/ui/TransportBar.cpp
+++ b/src/ui/TransportBar.cpp
@@ -336,10 +336,8 @@ TransportBar::TransportBar (AudioEngine& engineRef) : engine (engineRef)
             rewPressedAtMs = 0;
             if (rewIsScrubbing)
                 rewIsScrubbing = false;   // was a hold-scrub, not a tap
-            else if (engine.getTransport().isStopped() && engine.getSession().getMarkers().empty())
-                engine.jumpToZero();
             else
-                engine.jumpToPrevMarker();
+                rewindTap();
         }
     };
 
@@ -355,10 +353,8 @@ TransportBar::TransportBar (AudioEngine& engineRef) : engine (engineRef)
             ffwdPressedAtMs = 0;
             if (ffwdIsScrubbing)
                 ffwdIsScrubbing = false;   // was a hold-scrub, not a tap
-            else if (engine.getTransport().isStopped() && engine.getSession().getMarkers().empty())
-                engine.jumpToLastRecordPoint();
             else
-                engine.jumpToNextMarker();
+                forwardTap();
         }
     };
 
@@ -636,6 +632,22 @@ bool TransportBar::isTapeStripExpanded() const
 
 TransportBar::~TransportBar() { stopTimer(); }   // before derived members destruct
 
+void TransportBar::rewindTap()
+{
+    if (engine.getTransport().isStopped() && engine.getSession().getMarkers().empty())
+        engine.jumpToZero();
+    else
+        engine.jumpToPrevMarker();
+}
+
+void TransportBar::forwardTap()
+{
+    if (engine.getTransport().isStopped() && engine.getSession().getMarkers().empty())
+        engine.jumpToLastRecordPoint();
+    else
+        engine.jumpToNextMarker();
+}
+
 void TransportBar::timerCallback()
 {
     // 10x scrub. Once a REW / FFWD button has been held past
@@ -781,21 +793,8 @@ void TransportBar::timerCallback()
                 s.savedLoopEnabled = tr.isLoopEnabled();
                 break;
             }
-            case PendingTransportAction::GoToEnd:
-            {
-                // No fixed timeline end — jump to the end of the furthest
-                // content across all tracks (audio + MIDI regions).
-                juce::int64 end = 0;
-                for (int t = 0; t < Session::kNumTracks; ++t)
-                {
-                    for (const auto& r : s.track (t).regions)
-                        end = juce::jmax (end, r.timelineStart + r.lengthInSamples);
-                    for (const auto& r : s.track (t).midiRegions.current())
-                        end = juce::jmax (end, r.timelineStart + r.lengthInSamples);
-                }
-                engine.getTransport().setPlayhead (end);
-                break;
-            }
+            case PendingTransportAction::PrevMarker: rewindTap();  break;
+            case PendingTransportAction::NextMarker: forwardTap(); break;
             case PendingTransportAction::None:   break;
         }
 

--- a/src/ui/TransportBar.cpp
+++ b/src/ui/TransportBar.cpp
@@ -660,12 +660,12 @@ void TransportBar::timerCallback()
     const double sr  = engine.getCurrentSampleRate();
     if (sr > 0.0)
     {
-        const auto handleScrub = [&] (TransportIconButton& btn,
+        const auto handleScrub = [&] (bool isHeld,
                                         juce::int64& pressedAt,
                                         bool& scrubbing,
                                         int direction)
         {
-            if (! btn.isHeldDown() || pressedAt == 0) return;
+            if (! isHeld || pressedAt == 0) return;
             const auto held = nowMs - pressedAt;
             if (held < kHoldThresholdMs) return;
             scrubbing = true;
@@ -681,9 +681,34 @@ void TransportBar::timerCallback()
             engine.getTransport().setPlayhead (juce::jmax ((juce::int64) 0,
                 cur + (juce::int64) direction * delta));
         };
-        handleScrub (rewButton,  rewPressedAtMs,  rewIsScrubbing,  -1);
-        handleScrub (ffwdButton, ffwdPressedAtMs, ffwdIsScrubbing, +1);
-        if (! rewIsScrubbing && ! ffwdIsScrubbing) lastScrubTickMs = 0;
+
+        // MCU REW/FFWD have no Component events; synthesise press/release
+        // edges from the receiver's held-flags so they share the buttons'
+        // tap-on-release + hold-scrub gesture.
+        auto& sess = engine.getSession();
+        const bool mcuRew  = sess.mcu.rewHeld.load  (std::memory_order_relaxed);
+        const bool mcuFfwd = sess.mcu.ffwdHeld.load (std::memory_order_relaxed);
+        const auto mcuEdge = [&] (bool isHeld, juce::int64& pressedAt, bool& scrubbing, auto tap)
+        {
+            if (isHeld && pressedAt == 0)
+                pressedAt = nowMs;
+            else if (! isHeld && pressedAt != 0)
+            {
+                const bool wasScrub = scrubbing;
+                pressedAt = 0;
+                scrubbing = false;
+                if (! wasScrub) tap();   // short press → marker jump
+            }
+        };
+        mcuEdge (mcuRew,  mcuRewPressedAtMs,  mcuRewIsScrubbing,  [this] { rewindTap();  });
+        mcuEdge (mcuFfwd, mcuFfwdPressedAtMs, mcuFfwdIsScrubbing, [this] { forwardTap(); });
+
+        handleScrub (rewButton.isHeldDown(),  rewPressedAtMs,  rewIsScrubbing,  -1);
+        handleScrub (ffwdButton.isHeldDown(), ffwdPressedAtMs, ffwdIsScrubbing, +1);
+        handleScrub (mcuRew,  mcuRewPressedAtMs,  mcuRewIsScrubbing,  -1);
+        handleScrub (mcuFfwd, mcuFfwdPressedAtMs, mcuFfwdIsScrubbing, +1);
+        if (! rewIsScrubbing && ! ffwdIsScrubbing
+            && ! mcuRewIsScrubbing && ! mcuFfwdIsScrubbing) lastScrubTickMs = 0;
     }
 
     const auto playhead = engine.getTransport().getPlayhead();
@@ -793,8 +818,6 @@ void TransportBar::timerCallback()
                 s.savedLoopEnabled = tr.isLoopEnabled();
                 break;
             }
-            case PendingTransportAction::PrevMarker: rewindTap();  break;
-            case PendingTransportAction::NextMarker: forwardTap(); break;
             case PendingTransportAction::None:   break;
         }
 

--- a/src/ui/TransportBar.cpp
+++ b/src/ui/TransportBar.cpp
@@ -688,8 +688,11 @@ void TransportBar::timerCallback()
         auto& sess = engine.getSession();
         const bool mcuRew  = sess.mcu.rewHeld.load  (std::memory_order_relaxed);
         const bool mcuFfwd = sess.mcu.ffwdHeld.load (std::memory_order_relaxed);
-        const auto mcuEdge = [&] (bool isHeld, juce::int64& pressedAt, bool& scrubbing, auto tap)
+        const auto mcuEdge = [&] (bool isHeld, juce::uint32 pressCount, juce::uint32& lastCount,
+                                  juce::int64& pressedAt, bool& scrubbing, auto tap)
         {
+            const bool newPress = pressCount != lastCount;
+            lastCount = pressCount;
             if (isHeld && pressedAt == 0)
                 pressedAt = nowMs;
             else if (! isHeld && pressedAt != 0)
@@ -699,9 +702,13 @@ void TransportBar::timerCallback()
                 scrubbing = false;
                 if (! wasScrub) tap();   // short press → marker jump
             }
+            else if (! isHeld && pressedAt == 0 && newPress)
+                tap();   // press+release fell entirely between two polls → fast tap
         };
-        mcuEdge (mcuRew,  mcuRewPressedAtMs,  mcuRewIsScrubbing,  [this] { rewindTap();  });
-        mcuEdge (mcuFfwd, mcuFfwdPressedAtMs, mcuFfwdIsScrubbing, [this] { forwardTap(); });
+        mcuEdge (mcuRew,  sess.mcu.rewPressCount.load  (std::memory_order_relaxed),
+                 mcuRewLastPressCount,  mcuRewPressedAtMs,  mcuRewIsScrubbing,  [this] { rewindTap();  });
+        mcuEdge (mcuFfwd, sess.mcu.ffwdPressCount.load (std::memory_order_relaxed),
+                 mcuFfwdLastPressCount, mcuFfwdPressedAtMs, mcuFfwdIsScrubbing, [this] { forwardTap(); });
 
         handleScrub (rewButton.isHeldDown(),  rewPressedAtMs,  rewIsScrubbing,  -1);
         handleScrub (ffwdButton.isHeldDown(), ffwdPressedAtMs, ffwdIsScrubbing, +1);

--- a/src/ui/TransportBar.h
+++ b/src/ui/TransportBar.h
@@ -95,6 +95,11 @@ private:
     // the user doesn't think a silently-dropped take was captured.
     void surfaceRecordSetupFailures();
 
+    // MCU REW/FFWD reuse the on-screen Rewind/Forward tap behaviour so the
+    // control surface and the on-screen buttons never diverge.
+    void rewindTap();
+    void forwardTap();
+
     AudioEngine& engine;
     TransportIconButton stopButton   { "Stop",     TransportIconButton::Icon::Stop,
                                         juce::Colour (0xffd0d0d0) };

--- a/src/ui/TransportBar.h
+++ b/src/ui/TransportBar.h
@@ -133,6 +133,10 @@ private:
     juce::int64 mcuFfwdPressedAtMs = 0;
     bool        mcuRewIsScrubbing  = false;
     bool        mcuFfwdIsScrubbing = false;
+    // Last press-counter value seen by the timer, to catch taps that fall
+    // entirely between two polls (see Session::McuSessionState).
+    juce::uint32 mcuRewLastPressCount  = 0;
+    juce::uint32 mcuFfwdLastPressCount = 0;
     juce::int64 lastScrubTickMs = 0;
     TransportIconButton clickToggle { "Metronome",
                                           TransportIconButton::Icon::Metronome,

--- a/src/ui/TransportBar.h
+++ b/src/ui/TransportBar.h
@@ -128,6 +128,11 @@ private:
     juce::int64 ffwdPressedAtMs = 0;
     bool        rewIsScrubbing  = false;
     bool        ffwdIsScrubbing = false;
+    // MCU REW/FFWD mirror the above, edge-detected from session.mcu held-flags.
+    juce::int64 mcuRewPressedAtMs  = 0;
+    juce::int64 mcuFfwdPressedAtMs = 0;
+    bool        mcuRewIsScrubbing  = false;
+    bool        mcuFfwdIsScrubbing = false;
     juce::int64 lastScrubTickMs = 0;
     TransportIconButton clickToggle { "Metronome",
                                           TransportIconButton::Icon::Metronome,

--- a/tests/mcu_receiver_decode.cpp
+++ b/tests/mcu_receiver_decode.cpp
@@ -215,13 +215,21 @@ TEST_CASE ("McuReceiver: PLAY / STOP / RECORD buttons enqueue pendingTransportAc
              == (int) PendingTransportAction::Record);
 }
 
-TEST_CASE ("McuReceiver: REWIND button locates playhead to 0 via pendingTransportPlayhead",
+TEST_CASE ("McuReceiver: REWIND / FAST-FORWARD enqueue prev/next-marker actions",
            "[mcu][receiver]")
 {
     Session s;
     McuReceiver r (s);
+
     r.process (makeNoteOn (mcu::btn::Rewind, 0x7F), 0);
-    REQUIRE (s.pendingTransportPlayhead.load (std::memory_order_relaxed) == 0);
+    REQUIRE (s.pendingTransportAction.load (std::memory_order_relaxed)
+             == (int) PendingTransportAction::PrevMarker);
+
+    s.pendingTransportAction.store ((int) PendingTransportAction::None,
+                                      std::memory_order_relaxed);
+    r.process (makeNoteOn (mcu::btn::FastForward, 0x7F), 0);
+    REQUIRE (s.pendingTransportAction.load (std::memory_order_relaxed)
+             == (int) PendingTransportAction::NextMarker);
 }
 
 TEST_CASE ("McuReceiver: fader touch sense flips faderTouched latch", "[mcu][receiver]")

--- a/tests/mcu_receiver_decode.cpp
+++ b/tests/mcu_receiver_decode.cpp
@@ -215,21 +215,21 @@ TEST_CASE ("McuReceiver: PLAY / STOP / RECORD buttons enqueue pendingTransportAc
              == (int) PendingTransportAction::Record);
 }
 
-TEST_CASE ("McuReceiver: REWIND / FAST-FORWARD enqueue prev/next-marker actions",
+TEST_CASE ("McuReceiver: REWIND / FAST-FORWARD publish held-state on press and release",
            "[mcu][receiver]")
 {
     Session s;
     McuReceiver r (s);
 
-    r.process (makeNoteOn (mcu::btn::Rewind, 0x7F), 0);
-    REQUIRE (s.pendingTransportAction.load (std::memory_order_relaxed)
-             == (int) PendingTransportAction::PrevMarker);
+    r.process (makeNoteOn (mcu::btn::Rewind, 0x7F), 0);   // press
+    REQUIRE (s.mcu.rewHeld.load (std::memory_order_relaxed));
+    r.process (makeNoteOn (mcu::btn::Rewind, 0x00), 0);   // release
+    REQUIRE (! s.mcu.rewHeld.load (std::memory_order_relaxed));
 
-    s.pendingTransportAction.store ((int) PendingTransportAction::None,
-                                      std::memory_order_relaxed);
     r.process (makeNoteOn (mcu::btn::FastForward, 0x7F), 0);
-    REQUIRE (s.pendingTransportAction.load (std::memory_order_relaxed)
-             == (int) PendingTransportAction::NextMarker);
+    REQUIRE (s.mcu.ffwdHeld.load (std::memory_order_relaxed));
+    r.process (makeNoteOn (mcu::btn::FastForward, 0x00), 0);
+    REQUIRE (! s.mcu.ffwdHeld.load (std::memory_order_relaxed));
 }
 
 TEST_CASE ("McuReceiver: fader touch sense flips faderTouched latch", "[mcu][receiver]")


### PR DESCRIPTION
...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Rewind and Fast-Forward controls now respond more smoothly on both hardware controllers and on-screen transport controls.
  - Quick taps jump to the previous/next marker, while holding them scrubs through the timeline faster.

- **Bug Fixes**
  - Improved detection of short transport button presses so tap actions are more reliable.
  - Removed an older end-of-timeline jump behavior from the transport flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->