### PR TITLE
De-JUCE: File subsystem migration (juce::File → std::filesystem)

### DIFF
--- a/src/dsp/AuxLaneStrip.cpp
+++ b/src/dsp/AuxLaneStrip.cpp
@@ -74,7 +74,7 @@ void AuxLaneStrip::prepare (double sampleRate, int blockSize)
             pendingLv2Path[(size_t) s].clear();
             pendingLv2PluginId[(size_t) s].clear();
             pendingLv2State[(size_t) s].clear();
-            pendingLv2StateDir[(size_t) s] = juce::File();
+            pendingLv2StateDir[(size_t) s].clear();
         }
     }
 #endif
@@ -210,7 +210,7 @@ void AuxLaneStrip::unloadNativeLv2 (int slotIdx) noexcept
 void AuxLaneStrip::setPendingNativeLv2 (int slotIdx, const juce::File& path,
                                          std::vector<uint8_t> state,
                                          const juce::String& pluginId,
-                                         const juce::File& stateDir) noexcept
+                                         const std::filesystem::path& stateDir) noexcept
 {
     jassert (slotIdx >= 0 && slotIdx < kMaxPlugins);
     pendingLv2Path[(size_t) slotIdx]     = path.getFullPathName();

--- a/src/dsp/AuxLaneStrip.h
+++ b/src/dsp/AuxLaneStrip.h
@@ -2,6 +2,7 @@
 
 #include <juce_audio_basics/juce_audio_basics.h>
 #include <array>
+#include <filesystem>
 #include <vector>
 #include "../session/Session.h"
 #include "../engine/PluginSlot.h"
@@ -102,7 +103,7 @@ public:
     const lv2::NativeLv2Slot& getNativeLv2Slot (int idx) const noexcept { jassert (idx >= 0 && idx < kMaxPlugins); return nativeLv2Slots[(size_t) idx]; }
     void setPendingNativeLv2 (int slotIdx, const juce::File& path, std::vector<uint8_t> state,
                               const juce::String& pluginId = {},
-                              const juce::File& stateDir = {}) noexcept;
+                              const std::filesystem::path& stateDir = {}) noexcept;
     bool nativeLv2ReloadFailed (int slotIdx) const noexcept { jassert (slotIdx >= 0 && slotIdx < kMaxPlugins); return lv2ReloadFailed[(size_t) slotIdx].load (std::memory_order_relaxed); }
     void markNativeLv2RestoreFailed (int slotIdx) noexcept { jassert (slotIdx >= 0 && slotIdx < kMaxPlugins); lv2ReloadFailed[(size_t) slotIdx].store (true, std::memory_order_relaxed); }
 #else
@@ -183,7 +184,7 @@ private:
     std::array<juce::String,         kMaxPlugins> pendingLv2Path;
     std::array<juce::String,         kMaxPlugins> pendingLv2PluginId;
     std::array<std::vector<uint8_t>, kMaxPlugins> pendingLv2State;
-    std::array<juce::File, kMaxPlugins>           pendingLv2StateDir;
+    std::array<std::filesystem::path, kMaxPlugins> pendingLv2StateDir;
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_VST3
     std::array<vst3::NativeVst3Slot, kMaxPlugins> nativeVst3Slots;

--- a/src/dsp/ChannelStrip.cpp
+++ b/src/dsp/ChannelStrip.cpp
@@ -140,7 +140,7 @@ void ChannelStrip::prepare (double sampleRate, int blockSize, int oversamplingFa
         pendingLv2Path.clear();
         pendingLv2PluginId.clear();
         pendingLv2State.clear();
-        pendingLv2StateDir = juce::File();
+        pendingLv2StateDir.clear();
     }
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_VST3
@@ -555,7 +555,7 @@ void ChannelStrip::unloadNativeLv2() noexcept
 
 void ChannelStrip::setPendingNativeLv2 (const juce::File& path, std::vector<uint8_t> state,
                                         const juce::String& pluginId,
-                                        const juce::File& stateDir) noexcept
+                                        const std::filesystem::path& stateDir) noexcept
 {
     pendingLv2Path     = path.getFullPathName();
     pendingLv2PluginId = pluginId;

--- a/src/dsp/ChannelStrip.h
+++ b/src/dsp/ChannelStrip.h
@@ -3,6 +3,7 @@
 #include <juce_audio_basics/juce_audio_basics.h>
 #include <juce_dsp/juce_dsp.h>
 #include <array>
+#include <filesystem>
 #include <memory>
 #include <vector>
 #include "../session/Session.h"
@@ -97,7 +98,7 @@ public:
     const lv2::NativeLv2Slot& getNativeLv2Slot() const noexcept { return nativeLv2Slot; }
     void setPendingNativeLv2 (const juce::File& path, std::vector<uint8_t> state,
                               const juce::String& pluginId = {},
-                              const juce::File& stateDir = {}) noexcept;
+                              const std::filesystem::path& stateDir = {}) noexcept;
     bool nativeLv2ReloadFailed() const noexcept { return lv2ReloadFailed.load (std::memory_order_relaxed); }
     void markNativeLv2RestoreFailed() noexcept { lv2ReloadFailed.store (true, std::memory_order_relaxed); }
 #else
@@ -281,7 +282,7 @@ private:
     juce::String         pendingLv2Path;
     juce::String         pendingLv2PluginId;
     std::vector<uint8_t> pendingLv2State;
-    juce::File           pendingLv2StateDir;
+    std::filesystem::path pendingLv2StateDir;
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_VST3
     juce::String         pendingVst3Path;

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -187,11 +187,12 @@ static juce::File audioDeviceStateFile()
 // slots at state/lv2/trackNN, aux slots at state/lv2/auxA_slotS. Empty when
 // the session has no directory yet — saves fall back to blob-only. Save As
 // consolidation copies the whole state/ tree (SessionSerializer).
-static juce::File lv2StateDirFor (Session& session, const juce::String& slotTag)
+static std::filesystem::path lv2StateDirFor (Session& session, const juce::String& slotTag)
 {
     const auto dir = session.getSessionDirectory();
     if (dir == juce::File()) return {};
-    return dir.getChildFile ("state").getChildFile ("lv2").getChildFile (slotTag);
+    return std::filesystem::u8path (dir.getChildFile ("state").getChildFile ("lv2")
+                                        .getChildFile (slotTag).getFullPathName().toStdString());
 }
 #endif
 

--- a/src/engine/PluginManager.cpp
+++ b/src/engine/PluginManager.cpp
@@ -443,9 +443,12 @@ void PluginManager::scanClapPlugins()
     // in under it. The cache write also stays outside so a picker open on the
     // message thread can't stall behind this thread's file I/O.
     juce::Array<juce::PluginDescription> fresh;
-    for (const auto& file : clap::ClapScanner::findClapFiles (clap::ClapScanner::defaultSearchPaths()))
+    for (const auto& path : clap::ClapScanner::findClapFiles (clap::ClapScanner::defaultSearchPaths()))
+    {
+        const juce::File file (juce::String::fromUTF8 (path.u8string().c_str()));
         if (! scanNativeBundleSandboxed ("clap", file, fresh))
             nativescan::appendClapRows (file, fresh);   // no sandbox available — in-process
+    }
     {
         const juce::ScopedLock sl (nativeDescriptionsLock);
         clapDescriptions.swapWith (fresh);
@@ -573,9 +576,12 @@ void PluginManager::scanVst3NativePlugins()
 {
 #if DUSKSTUDIO_HAS_NATIVE_VST3
     juce::Array<juce::PluginDescription> fresh;
-    for (const auto& file : vst3::Vst3Scanner::findVst3Bundles (vst3::Vst3Scanner::defaultSearchPaths()))
+    for (const auto& path : vst3::Vst3Scanner::findVst3Bundles (vst3::Vst3Scanner::defaultSearchPaths()))
+    {
+        const juce::File file (juce::String::fromUTF8 (path.u8string().c_str()));
         if (! scanNativeBundleSandboxed ("vst3", file, fresh))
             nativescan::appendVst3Rows (file, fresh);   // no sandbox available — in-process
+    }
     {
         const juce::ScopedLock sl (nativeDescriptionsLock);
         vst3NativeDescriptions.swapWith (fresh);

--- a/src/engine/clap/ClapScanner.cpp
+++ b/src/engine/clap/ClapScanner.cpp
@@ -1,37 +1,48 @@
 #include "ClapScanner.h"
 
+#include "../../foundation/Fs.h"
+#include "../../foundation/Text.h"
+
 #include <cstdlib>
+#include <system_error>
 
 namespace duskstudio::clap
 {
-std::vector<juce::File> ClapScanner::defaultSearchPaths()
+namespace stdfs = std::filesystem;
+
+std::vector<stdfs::path> ClapScanner::defaultSearchPaths()
 {
-    std::vector<juce::File> dirs;
-    auto add = [&dirs] (const juce::File& d)
+    std::vector<stdfs::path> dirs;
+    std::error_code ec;
+    auto add = [&] (const stdfs::path& d)
     {
-        if (! d.isDirectory()) return;
+        if (! stdfs::is_directory (d, ec)) return;
         for (const auto& existing : dirs) if (existing == d) return;
         dirs.push_back (d);
     };
 
     // $CLAP_PATH overrides / extends the defaults (':'-separated, like $PATH).
     if (const char* env = std::getenv ("CLAP_PATH"))
-        for (const auto& tok : juce::StringArray::fromTokens (juce::String (env), ":", ""))
-            if (tok.isNotEmpty()) add (juce::File (tok.trim()));
+        for (const auto& tok : dusk::text::split (env, ':'))
+        {
+            const auto trimmed = dusk::text::trim (tok);
+            if (! trimmed.empty()) add (stdfs::u8path (trimmed));
+        }
 
-    add (juce::File::getSpecialLocation (juce::File::userHomeDirectory).getChildFile (".clap"));
-    add (juce::File ("/usr/lib/clap"));
-    add (juce::File ("/usr/local/lib/clap"));
+    add (dusk::fs::userHomeDir() / ".clap");
+    add ("/usr/lib/clap");
+    add ("/usr/local/lib/clap");
     return dirs;
 }
 
-std::vector<juce::File> ClapScanner::findClapFiles (const std::vector<juce::File>& dirs)
+std::vector<stdfs::path> ClapScanner::findClapFiles (const std::vector<stdfs::path>& dirs)
 {
-    std::vector<juce::File> files;
+    std::vector<stdfs::path> files;
+    std::error_code ec;
     for (const auto& dir : dirs)
     {
-        if (! dir.isDirectory()) continue;
-        for (const auto& f : dir.findChildFiles (juce::File::findFiles, true, "*.clap"))
+        if (! stdfs::is_directory (dir, ec)) continue;
+        for (const auto& f : dusk::fs::findChildFiles (dir, "*.clap", true))
         {
             bool seen = false;
             for (const auto& g : files) if (g == f) { seen = true; break; }
@@ -41,17 +52,17 @@ std::vector<juce::File> ClapScanner::findClapFiles (const std::vector<juce::File
     return files;
 }
 
-std::vector<ScannedClap> ClapScanner::scan (const std::vector<juce::File>& dirs)
+std::vector<ScannedClap> ClapScanner::scan (const std::vector<stdfs::path>& dirs)
 {
     std::vector<ScannedClap> found;
     for (const auto& file : findClapFiles (dirs))
     {
         ClapBundle bundle;
         std::string err;
-        if (! bundle.load (file.getFullPathName().toStdString(), err))
+        if (! bundle.load (file.u8string(), err))
             continue;
         for (const auto& d : bundle.plugins())
-            found.push_back ({ file.getFullPathName(), d });
+            found.push_back ({ file.u8string(), d });
     }
     return found;
 }

--- a/src/engine/clap/ClapScanner.cpp
+++ b/src/engine/clap/ClapScanner.cpp
@@ -39,9 +39,12 @@ std::vector<stdfs::path> ClapScanner::findClapFiles (const std::vector<stdfs::pa
 {
     std::vector<stdfs::path> files;
     std::error_code ec;
-    for (const auto& dir : dirs)
+    for (const auto& dirIn : dirs)
     {
-        if (! stdfs::is_directory (dir, ec)) continue;
+        // Absolute so a cached bundle path (and its native identifier) stays
+        // stable regardless of cwd, even for a relative $CLAP_PATH entry.
+        const auto dir = stdfs::absolute (dirIn, ec);
+        if (ec || ! stdfs::is_directory (dir, ec)) continue;
         for (const auto& f : dusk::fs::findChildFiles (dir, "*.clap", true))
         {
             bool seen = false;

--- a/src/engine/clap/ClapScanner.h
+++ b/src/engine/clap/ClapScanner.h
@@ -2,8 +2,8 @@
 
 #include "ClapBundle.h"
 
-#include <juce_core/juce_core.h>
-
+#include <filesystem>
+#include <string>
 #include <vector>
 
 namespace duskstudio::clap
@@ -11,8 +11,8 @@ namespace duskstudio::clap
 // One discoverable CLAP plugin: the bundle file it lives in plus its descriptor.
 struct ScannedClap
 {
-    juce::String bundlePath;   // absolute path to the .clap file
-    PluginDesc   desc;         // id / name / vendor / version / description
+    std::string bundlePath;   // absolute path to the .clap file
+    PluginDesc  desc;         // id / name / vendor / version / description
 };
 
 // Discovers installed CLAP plugins. Message thread only (each bundle is dlopen'd
@@ -24,14 +24,14 @@ class ClapScanner
 {
 public:
     // Existing default search directories for this platform (skips missing ones).
-    static std::vector<juce::File> defaultSearchPaths();
+    static std::vector<std::filesystem::path> defaultSearchPaths();
 
     // Recursively collect *.clap files under each directory.
-    static std::vector<juce::File> findClapFiles (const std::vector<juce::File>& dirs);
+    static std::vector<std::filesystem::path> findClapFiles (const std::vector<std::filesystem::path>& dirs);
 
     // Load every discovered bundle and gather its advertised plugins. Bundles that
     // fail to load are skipped silently — a broken .clap must not abort the scan.
-    static std::vector<ScannedClap> scan (const std::vector<juce::File>& dirs);
+    static std::vector<ScannedClap> scan (const std::vector<std::filesystem::path>& dirs);
     static std::vector<ScannedClap> scan() { return scan (defaultSearchPaths()); }
 };
 } // namespace duskstudio::clap

--- a/src/engine/lv2/Lv2Instance.cpp
+++ b/src/engine/lv2/Lv2Instance.cpp
@@ -1,5 +1,6 @@
 #include "Lv2Instance.h"
 #include "Lv2Bundle.h"
+#include "Lv2StatePaths.h"
 #include "../hosting/SpscRing.h"
 
 #include <lilv/lilv.h>
@@ -98,28 +99,19 @@ struct Lv2Instance::Impl
     // ABSTRACT (cur/-relative) paths, so we supply the mapping back to
     // absolute ourselves. Returned strings are malloc'd — the plugin frees
     // them through freePathCb (or plain free()), per the state spec.
-    juce::File stateDir;
+    std::filesystem::path stateDir;
 
     static char* absolutePathCb (LV2_State_Map_Path_Handle handle, const char* abstractPath)
     {
         if (abstractPath == nullptr) return nullptr;
         auto* self = static_cast<Impl*> (handle);
-        const auto abs = juce::String::fromUTF8 (abstractPath);
-        if (self->stateDir == juce::File() || juce::File::isAbsolutePath (abs))
-            return ::strdup (abstractPath);
-        return ::strdup (self->stateDir.getChildFile ("cur").getChildFile (abs)
-                             .getFullPathName().toRawUTF8());
+        return ::strdup (statepaths::toAbsolute (self->stateDir, abstractPath).c_str());
     }
     static char* abstractPathCb (LV2_State_Map_Path_Handle handle, const char* absolutePath)
     {
         if (absolutePath == nullptr) return nullptr;
         auto* self = static_cast<Impl*> (handle);
-        const juce::File f { juce::String::fromUTF8 (absolutePath) };
-        const auto cur = self->stateDir.getChildFile ("cur");
-        if (self->stateDir != juce::File() && f.isAChildOf (cur))
-            return ::strdup (f.getRelativePathFrom (cur)
-                                 .replaceCharacter ('\\', '/').toRawUTF8());
-        return ::strdup (absolutePath);
+        return ::strdup (statepaths::toAbstract (self->stateDir, absolutePath).c_str());
     }
     static void freePathCb (LV2_State_Free_Path_Handle, char* path) { ::free (path); }
 
@@ -791,7 +783,7 @@ void Lv2Instance::processBlock (const hosting::PortBuffers& io) noexcept
                                     std::memory_order_relaxed);
 }
 
-void Lv2Instance::setStateDirectory (const juce::File& dir)
+void Lv2Instance::setStateDirectory (const std::filesystem::path& dir)
 {
     impl->stateDir = dir;
 }
@@ -808,28 +800,32 @@ bool Lv2Instance::saveState (std::vector<uint8_t>& out) const
     // state (sample banks, IRs) into <dir>/cur/ and emits abstract paths in
     // the Turtle; without one, file-writing plugins keep only their in-memory
     // state (the pre-file-state behaviour, fine for effects).
-    juce::String curPath;
-    if (impl->stateDir != juce::File())
+    std::string curPath;
+    if (! impl->stateDir.empty())
     {
         // Rotate generations instead of wiping: a disk-streaming sampler may
         // still be reading the files the PREVIOUS save snapshotted — those
         // survive one more save cycle in prev/.
-        const auto cur  = impl->stateDir.getChildFile ("cur");
-        const auto prev = impl->stateDir.getChildFile ("prev");
-        bool rotated = prev.deleteRecursively();
-        if (rotated && cur.isDirectory())
-            rotated = cur.moveFileTo (prev);
+        std::error_code ec;
+        const auto cur  = impl->stateDir / "cur";
+        const auto prev = impl->stateDir / "prev";
+        std::filesystem::remove_all (prev, ec);
+        bool rotated = ! ec;
+        if (rotated && std::filesystem::is_directory (cur, ec))
+        {
+            std::filesystem::rename (cur, prev, ec);
+            rotated = ! ec;
+        }
         if (rotated)
         {
-            cur.createDirectory();
-            curPath = cur.getFullPathName();
+            std::filesystem::create_directories (cur, ec);
+            curPath = cur.u8string();
         }
         // Rotation failed: leave curPath empty so lilv gets no directory and
         // falls back to a blob-only (in-memory) save rather than writing a new
         // generation on top of the stale cur/ files.
     }
-    const auto curUtf8 = curPath.toStdString();
-    const char* dirC   = curUtf8.empty() ? nullptr : curUtf8.c_str();
+    const char* dirC = curPath.empty() ? nullptr : curPath.c_str();
 
     LilvState* state = lilv_state_new_from_instance (
         impl->plugin, impl->instance, &impl->mapFeature,

--- a/src/engine/lv2/Lv2Instance.h
+++ b/src/engine/lv2/Lv2Instance.h
@@ -2,7 +2,7 @@
 
 #include "../hosting/INativeInstance.h"
 
-#include <juce_core/juce_core.h>
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <vector>
@@ -65,7 +65,7 @@ public:
     // the engine before saveState/loadState. saveState rotates
     // <dir>/prev <- <dir>/cur and snapshots referenced files into cur/;
     // loadState resolves the blob's abstract paths against cur/.
-    void setStateDirectory (const juce::File& dir);
+    void setStateDirectory (const std::filesystem::path& dir);
 
     int getLatencySamples() const noexcept override;
 

--- a/src/engine/lv2/Lv2StatePaths.h
+++ b/src/engine/lv2/Lv2StatePaths.h
@@ -11,13 +11,20 @@
 namespace duskstudio::lv2::statepaths
 {
 // Restore side: an abstract path from a state blob resolves against <dir>/cur.
-// Already-absolute abstract paths (and an empty stateDir) pass through.
+// Already-absolute abstract paths (and an empty stateDir) pass through. A blob
+// with "../" segments that would escape cur/ is refused (passed through
+// unresolved) rather than mapped to a file outside the state directory.
 inline std::string toAbsolute (const std::filesystem::path& stateDir,
                                const std::string& abstractPath)
 {
     if (stateDir.empty() || std::filesystem::path (abstractPath).is_absolute())
         return abstractPath;
-    return (stateDir / "cur" / std::filesystem::u8path (abstractPath)).u8string();
+    const auto cur      = stateDir / "cur";
+    const auto resolved = (cur / std::filesystem::u8path (abstractPath)).lexically_normal();
+    const auto rel      = resolved.lexically_relative (cur);
+    if (rel.empty() || *rel.begin() == std::filesystem::path (".."))
+        return abstractPath;
+    return resolved.u8string();
 }
 
 // Save side: an absolute path lilv hands us becomes a cur/-relative abstract

--- a/src/engine/lv2/Lv2StatePaths.h
+++ b/src/engine/lv2/Lv2StatePaths.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+// LV2 state:mapPath path translation for file-backed plugin state. Pure path
+// logic, split out so it can be unit-tested without a lilv world or a real
+// file-writing plugin (the live path is otherwise only exercised by a gated
+// integration test). stateDir empty => paths pass through unchanged, matching
+// the blob-only (in-memory) save behaviour.
+namespace duskstudio::lv2::statepaths
+{
+// Restore side: an abstract path from a state blob resolves against <dir>/cur.
+// Already-absolute abstract paths (and an empty stateDir) pass through.
+inline std::string toAbsolute (const std::filesystem::path& stateDir,
+                               const std::string& abstractPath)
+{
+    if (stateDir.empty() || std::filesystem::path (abstractPath).is_absolute())
+        return abstractPath;
+    return (stateDir / "cur" / std::filesystem::u8path (abstractPath)).u8string();
+}
+
+// Save side: an absolute path lilv hands us becomes a cur/-relative abstract
+// path when the file lives under <dir>/cur; otherwise it passes through.
+inline std::string toAbstract (const std::filesystem::path& stateDir,
+                               const std::string& absolutePath)
+{
+    if (stateDir.empty()) return absolutePath;
+    const auto cur = stateDir / "cur";
+    const auto rel = std::filesystem::u8path (absolutePath).lexically_relative (cur);
+    // lexically_relative yields "" for unrelated roots, "." for the dir itself,
+    // and a "../"-leading path for siblings — none of which are children.
+    if (! rel.empty() && rel != std::filesystem::path (".")
+        && *rel.begin() != std::filesystem::path (".."))
+        return rel.generic_string();
+    return absolutePath;
+}
+} // namespace duskstudio::lv2::statepaths

--- a/src/engine/lv2/NativeLv2Slot.h
+++ b/src/engine/lv2/NativeLv2Slot.h
@@ -39,7 +39,7 @@ class NativeLv2Slot final : public hosting::NativeInsertSlot<Lv2SlotTraits>
 public:
     // Session-scoped file-state directory — set by the engine ahead of
     // saveState/loadState (see Lv2Instance::setStateDirectory).
-    void setStateDirectory (const juce::File& dir)
+    void setStateDirectory (const std::filesystem::path& dir)
         { if (instance != nullptr) instance->setStateDirectory (dir); }
 
     // Parameters (message thread for read/enumerate; setParamValue is the control

--- a/src/engine/vst3/Vst3Scanner.cpp
+++ b/src/engine/vst3/Vst3Scanner.cpp
@@ -45,20 +45,31 @@ std::vector<stdfs::path> Vst3Scanner::findVst3Bundles (const std::vector<stdfs::
         files.push_back (f);
     };
 
+    // ec-aware increment (like dusk::fs::findChildFiles): a directory mutated
+    // mid-scan stops the walk cleanly instead of throwing from operator++.
     for (const auto& dir : dirs)
     {
+        std::error_code walkEc, entryEc;
         if (! stdfs::is_directory (dir, ec)) continue;
         // Bundle entries (file or directory) with a .vst3 extension, not descending
         // into them (their inner .so is not a module path the SDK loader takes).
-        for (const auto& e : stdfs::directory_iterator (dir, ec))
-            if (dusk::fs::hasExtension (e.path(), "vst3"))
-                add (e.path());
+        for (auto it = stdfs::directory_iterator (dir, walkEc);
+             ! walkEc && it != stdfs::directory_iterator(); it.increment (walkEc))
+            if (dusk::fs::hasExtension (it->path(), "vst3"))
+                add (it->path());
         // Plain subdirectories (vendor folders) one level down.
-        for (const auto& e : stdfs::directory_iterator (dir, ec))
-            if (e.is_directory (ec) && ! dusk::fs::hasExtension (e.path(), "vst3"))
-                for (const auto& f : stdfs::directory_iterator (e.path(), ec))
-                    if (dusk::fs::hasExtension (f.path(), "vst3"))
-                        add (f.path());
+        walkEc.clear();
+        for (auto it = stdfs::directory_iterator (dir, walkEc);
+             ! walkEc && it != stdfs::directory_iterator(); it.increment (walkEc))
+        {
+            if (! it->is_directory (entryEc) || dusk::fs::hasExtension (it->path(), "vst3"))
+                continue;
+            std::error_code subEc;
+            for (auto sub = stdfs::directory_iterator (it->path(), subEc);
+                 ! subEc && sub != stdfs::directory_iterator(); sub.increment (subEc))
+                if (dusk::fs::hasExtension (sub->path(), "vst3"))
+                    add (sub->path());
+        }
     }
     return files;
 }

--- a/src/engine/vst3/Vst3Scanner.cpp
+++ b/src/engine/vst3/Vst3Scanner.cpp
@@ -1,34 +1,45 @@
 #include "Vst3Scanner.h"
 
+#include "../../foundation/Fs.h"
+#include "../../foundation/Text.h"
+
 #include <cstdlib>
+#include <system_error>
 
 namespace duskstudio::vst3
 {
-std::vector<juce::File> Vst3Scanner::defaultSearchPaths()
+namespace stdfs = std::filesystem;
+
+std::vector<stdfs::path> Vst3Scanner::defaultSearchPaths()
 {
-    std::vector<juce::File> dirs;
-    auto add = [&dirs] (const juce::File& d)
+    std::vector<stdfs::path> dirs;
+    std::error_code ec;
+    auto add = [&] (const stdfs::path& d)
     {
-        if (! d.isDirectory()) return;
+        if (! stdfs::is_directory (d, ec)) return;
         for (const auto& existing : dirs) if (existing == d) return;
         dirs.push_back (d);
     };
 
     // $VST3_PATH overrides / extends the defaults (':'-separated, like $PATH).
     if (const char* env = std::getenv ("VST3_PATH"))
-        for (const auto& tok : juce::StringArray::fromTokens (juce::String (env), ":", ""))
-            if (tok.isNotEmpty()) add (juce::File (tok.trim()));
+        for (const auto& tok : dusk::text::split (env, ':'))
+        {
+            const auto trimmed = dusk::text::trim (tok);
+            if (! trimmed.empty()) add (stdfs::u8path (trimmed));
+        }
 
-    add (juce::File::getSpecialLocation (juce::File::userHomeDirectory).getChildFile (".vst3"));
-    add (juce::File ("/usr/lib/vst3"));
-    add (juce::File ("/usr/local/lib/vst3"));
+    add (dusk::fs::userHomeDir() / ".vst3");
+    add ("/usr/lib/vst3");
+    add ("/usr/local/lib/vst3");
     return dirs;
 }
 
-std::vector<juce::File> Vst3Scanner::findVst3Bundles (const std::vector<juce::File>& dirs)
+std::vector<stdfs::path> Vst3Scanner::findVst3Bundles (const std::vector<stdfs::path>& dirs)
 {
-    std::vector<juce::File> files;
-    auto add = [&files] (const juce::File& f)
+    std::vector<stdfs::path> files;
+    std::error_code ec;
+    auto add = [&] (const stdfs::path& f)
     {
         for (const auto& g : files) if (g == f) return;
         files.push_back (f);
@@ -36,35 +47,33 @@ std::vector<juce::File> Vst3Scanner::findVst3Bundles (const std::vector<juce::Fi
 
     for (const auto& dir : dirs)
     {
-        if (! dir.isDirectory()) continue;
-        // Bundle directories first — don't descend into them (their inner .so is
-        // not a module path the SDK loader takes).
-        for (const auto& f : dir.findChildFiles (juce::File::findFilesAndDirectories, false))
-        {
-            if (! f.hasFileExtension ("vst3")) continue;
-            add (f);
-        }
+        if (! stdfs::is_directory (dir, ec)) continue;
+        // Bundle entries (file or directory) with a .vst3 extension, not descending
+        // into them (their inner .so is not a module path the SDK loader takes).
+        for (const auto& e : stdfs::directory_iterator (dir, ec))
+            if (dusk::fs::hasExtension (e.path(), "vst3"))
+                add (e.path());
         // Plain subdirectories (vendor folders) one level down.
-        for (const auto& sub : dir.findChildFiles (juce::File::findDirectories, false))
-            if (! sub.hasFileExtension ("vst3"))
-                for (const auto& f : sub.findChildFiles (juce::File::findFilesAndDirectories, false))
-                    if (f.hasFileExtension ("vst3"))
-                        add (f);
+        for (const auto& e : stdfs::directory_iterator (dir, ec))
+            if (e.is_directory (ec) && ! dusk::fs::hasExtension (e.path(), "vst3"))
+                for (const auto& f : stdfs::directory_iterator (e.path(), ec))
+                    if (dusk::fs::hasExtension (f.path(), "vst3"))
+                        add (f.path());
     }
     return files;
 }
 
-std::vector<ScannedVst3> Vst3Scanner::scan (const std::vector<juce::File>& dirs)
+std::vector<ScannedVst3> Vst3Scanner::scan (const std::vector<stdfs::path>& dirs)
 {
     std::vector<ScannedVst3> found;
     for (const auto& file : findVst3Bundles (dirs))
     {
         Vst3Bundle bundle;
         std::string err;
-        if (! bundle.load (file.getFullPathName().toStdString(), err))
+        if (! bundle.load (file.u8string(), err))
             continue;
         for (const auto& d : bundle.plugins())
-            found.push_back ({ file.getFullPathName(), d });
+            found.push_back ({ file.u8string(), d });
     }
     return found;
 }

--- a/src/engine/vst3/Vst3Scanner.cpp
+++ b/src/engine/vst3/Vst3Scanner.cpp
@@ -47,10 +47,13 @@ std::vector<stdfs::path> Vst3Scanner::findVst3Bundles (const std::vector<stdfs::
 
     // ec-aware increment (like dusk::fs::findChildFiles): a directory mutated
     // mid-scan stops the walk cleanly instead of throwing from operator++.
-    for (const auto& dir : dirs)
+    for (const auto& dirIn : dirs)
     {
         std::error_code walkEc, entryEc;
-        if (! stdfs::is_directory (dir, ec)) continue;
+        // Absolute so a cached bundle path stays stable regardless of cwd, even
+        // for a relative $VST3_PATH entry.
+        const auto dir = stdfs::absolute (dirIn, ec);
+        if (ec || ! stdfs::is_directory (dir, ec)) continue;
         // Bundle entries (file or directory) with a .vst3 extension, not descending
         // into them (their inner .so is not a module path the SDK loader takes).
         for (auto it = stdfs::directory_iterator (dir, walkEc);

--- a/src/engine/vst3/Vst3Scanner.h
+++ b/src/engine/vst3/Vst3Scanner.h
@@ -2,8 +2,8 @@
 
 #include "Vst3Bundle.h"
 
-#include <juce_core/juce_core.h>
-
+#include <filesystem>
+#include <string>
 #include <vector>
 
 namespace duskstudio::vst3
@@ -11,8 +11,8 @@ namespace duskstudio::vst3
 // One discoverable VST3 plugin: the module it lives in plus its descriptor.
 struct ScannedVst3
 {
-    juce::String bundlePath;   // absolute path to the .vst3 bundle
-    PluginDesc   desc;
+    std::string bundlePath;   // absolute path to the .vst3 bundle
+    PluginDesc  desc;
 };
 
 // Discovers installed VST3 plugins. Message thread only (each module is dlopen'd
@@ -23,16 +23,16 @@ class Vst3Scanner
 {
 public:
     // Existing default search directories for this platform (skips missing ones).
-    static std::vector<juce::File> defaultSearchPaths();
+    static std::vector<std::filesystem::path> defaultSearchPaths();
 
     // Collect *.vst3 bundles under each directory. On Linux a .vst3 is a bundle
     // DIRECTORY (Contents/<arch>-linux/*.so) or, for old builds, a bare .so.
-    static std::vector<juce::File> findVst3Bundles (const std::vector<juce::File>& dirs);
+    static std::vector<std::filesystem::path> findVst3Bundles (const std::vector<std::filesystem::path>& dirs);
 
     // Load every discovered module and gather its advertised effect classes.
     // Modules that fail to load are skipped silently — a broken .vst3 must not
     // abort the scan.
-    static std::vector<ScannedVst3> scan (const std::vector<juce::File>& dirs);
+    static std::vector<ScannedVst3> scan (const std::vector<std::filesystem::path>& dirs);
     static std::vector<ScannedVst3> scan() { return scan (defaultSearchPaths()); }
 };
 } // namespace duskstudio::vst3

--- a/src/foundation/Fs.h
+++ b/src/foundation/Fs.h
@@ -260,21 +260,30 @@ inline std::filesystem::path tempDir()
 inline std::filesystem::path currentExecutablePath()
 {
 #if defined(_WIN32)
-    wchar_t buf[MAX_PATH + 256];
-    buf[0] = 0;
-    GetModuleFileNameW (nullptr, buf, (DWORD) (sizeof (buf) / sizeof (buf[0])));
-    return std::filesystem::path (buf);
+    std::vector<wchar_t> buf (MAX_PATH);
+    for (;;)
+    {
+        const DWORD n = GetModuleFileNameW (nullptr, buf.data(), (DWORD) buf.size());
+        if (n == 0) return {};
+        if (n < buf.size()) return std::filesystem::path (std::wstring (buf.data(), n));
+        buf.resize (buf.size() * 2);   // truncated (n == size) — grow and retry
+    }
 #elif defined(__APPLE__)
-    char buf[4096];
-    std::uint32_t size = sizeof (buf);
-    if (_NSGetExecutablePath (buf, &size) != 0) return {};
-    return std::filesystem::path (buf);
+    std::uint32_t size = 0;
+    _NSGetExecutablePath (nullptr, &size);   // sets size to the required length
+    std::vector<char> buf (size + 1, '\0');
+    if (_NSGetExecutablePath (buf.data(), &size) != 0) return {};
+    return std::filesystem::u8path (std::string (buf.data()));
 #else
-    char buf[4096];
-    const auto n = ::readlink ("/proc/self/exe", buf, sizeof (buf) - 1);
-    if (n <= 0) return {};
-    buf[n] = 0;
-    return std::filesystem::path (buf);
+    std::vector<char> buf (4096);
+    for (;;)
+    {
+        const auto n = ::readlink ("/proc/self/exe", buf.data(), buf.size());
+        if (n < 0) return {};
+        if ((std::size_t) n < buf.size())
+            return std::filesystem::u8path (std::string (buf.data(), (std::size_t) n));
+        buf.resize (buf.size() * 2);   // possibly truncated — grow and retry
+    }
 #endif
 }
 } // namespace dusk::fs

--- a/src/foundation/Fs.h
+++ b/src/foundation/Fs.h
@@ -212,10 +212,14 @@ inline std::filesystem::path userConfigDir()
     if (const char* appdata = std::getenv ("APPDATA"))
         return std::filesystem::path (appdata);   // %APPDATA%, matches CSIDL_APPDATA
     return {};
-#elif defined(__APPLE__)
-    return userHomeDir() / "Library";
 #else
-    return resolveXdgFolder ("XDG_CONFIG_HOME", userHomeDir() / ".config");
+    const auto home = userHomeDir();
+    if (home.empty()) return {};   // never build a CWD-relative config path
+ #if defined(__APPLE__)
+    return home / "Library";
+ #else
+    return resolveXdgFolder ("XDG_CONFIG_HOME", home / ".config");
+ #endif
 #endif
 }
 
@@ -226,10 +230,14 @@ inline std::filesystem::path userMusicDir()
     if (const char* profile = std::getenv ("USERPROFILE"))
         return std::filesystem::path (profile) / "Music";
     return {};
-#elif defined(__APPLE__)
-    return userHomeDir() / "Music";
 #else
-    return resolveXdgFolder ("XDG_MUSIC_DIR", userHomeDir() / "Music");
+    const auto home = userHomeDir();
+    if (home.empty()) return {};   // never build a CWD-relative music path
+ #if defined(__APPLE__)
+    return home / "Music";
+ #else
+    return resolveXdgFolder ("XDG_MUSIC_DIR", home / "Music");
+ #endif
 #endif
 }
 

--- a/src/foundation/Fs.h
+++ b/src/foundation/Fs.h
@@ -9,6 +9,19 @@
 
 #include "Text.h"
 
+#if defined(_WIN32)
+ #ifndef NOMINMAX
+  #define NOMINMAX
+ #endif
+ #include <windows.h>
+#else
+ #include <pwd.h>
+ #include <unistd.h>
+#endif
+#if defined(__APPLE__)
+ #include <mach-o/dyld.h>
+#endif
+
 // Filesystem helpers over std::filesystem for the JUCE File operations that
 // don't map 1:1 (whole-file read/write, wildcard child search, size, mtime).
 // The 1:1 operations (getChildFile, exists, getFileName, extension, ...) are
@@ -101,5 +114,157 @@ inline bool hasExtension (const std::filesystem::path& path, std::string_view ex
     if (! a.empty() && a[0] == '.') a.erase (0, 1);
     if (! b.empty() && b[0] == '.') b.erase (0, 1);
     return a == b;
+}
+
+// ---- Special-location helpers (JUCE File::getSpecialLocation equivalents) ----
+// These map to no std::filesystem primitive. Paths mirror JUCE exactly so a
+// migrated build still finds the same config/recent/session files JUCE wrote.
+// Verified against juce_core/native/juce_Files_{linux,mac,windows}.
+namespace detail
+{
+inline bool isXdgWhitespace (char c) noexcept
+{
+    return c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '\f' || c == '\v';
+}
+
+inline std::string trimBoth (std::string s)
+{
+    size_t b = 0, e = s.size();
+    while (b < e && isXdgWhitespace (s[b])) ++b;
+    while (e > b && isXdgWhitespace (s[e - 1])) --e;
+    return s.substr (b, e - b);
+}
+
+inline std::string trimStart (std::string s)
+{
+    size_t b = 0;
+    while (b < s.size() && isXdgWhitespace (s[b])) ++b;
+    return s.substr (b);
+}
+
+// JUCE String::unquoted: drops one leading and one trailing quote independently.
+inline std::string unquote (std::string s)
+{
+    if (s.empty()) return s;
+    const size_t dropStart = (s.front() == '"' || s.front() == '\'') ? 1 : 0;
+    const size_t dropEnd   = (s.back()  == '"' || s.back()  == '\'') ? 1 : 0;
+    if (dropStart + dropEnd > s.size()) return {};
+    return s.substr (dropStart, s.size() - dropStart - dropEnd);
+}
+
+inline std::string replaceAll (std::string s, const std::string& from, const std::string& to)
+{
+    if (from.empty()) return s;
+    for (size_t pos = 0; (pos = s.find (from, pos)) != std::string::npos; pos += to.size())
+        s.replace (pos, from.size(), to);
+    return s;
+}
+} // namespace detail
+
+inline std::filesystem::path userHomeDir()
+{
+#if defined(_WIN32)
+    if (const char* profile = std::getenv ("USERPROFILE"))
+        return std::filesystem::path (profile);
+    return {};
+#else
+    if (const char* home = std::getenv ("HOME"))
+        return std::filesystem::path (home);
+    if (auto* pw = ::getpwuid (::getuid()))
+        return std::filesystem::path (pw->pw_dir);
+    return {};
+#endif
+}
+
+#if ! defined(_WIN32) && ! defined(__APPLE__)
+// Replicates juce_core's resolveXDGFolder: parses ~/.config/user-dirs.dirs for a
+// KEY=... line (KEY is the freedesktop name, NOT an env var), returns its dir if
+// it exists, else the tilde-expanded fallback.
+inline std::filesystem::path resolveXdgFolder (const std::string& key,
+                                               const std::filesystem::path& fallback)
+{
+    std::ifstream in (userHomeDir() / ".config" / "user-dirs.dirs");
+    std::string line;
+    while (std::getline (in, line))
+    {
+        const std::string trimmed = detail::trimStart (line);
+        if (trimmed.rfind (key, 0) != 0) continue;
+
+        const auto eq = trimmed.find ('=');
+        if (eq == std::string::npos) continue;
+
+        std::string value = detail::replaceAll (trimmed.substr (eq + 1), "$HOME",
+                                                userHomeDir().string());
+        value = detail::unquote (detail::trimBoth (value));
+
+        std::error_code ec;
+        if (std::filesystem::is_directory (value, ec))
+            return std::filesystem::path (value);
+    }
+    return fallback;
+}
+#endif
+
+// JUCE File::userApplicationDataDirectory.
+inline std::filesystem::path userConfigDir()
+{
+#if defined(_WIN32)
+    if (const char* appdata = std::getenv ("APPDATA"))
+        return std::filesystem::path (appdata);   // %APPDATA%, matches CSIDL_APPDATA
+    return {};
+#elif defined(__APPLE__)
+    return userHomeDir() / "Library";
+#else
+    return resolveXdgFolder ("XDG_CONFIG_HOME", userHomeDir() / ".config");
+#endif
+}
+
+// JUCE File::userMusicDirectory.
+inline std::filesystem::path userMusicDir()
+{
+#if defined(_WIN32)
+    if (const char* profile = std::getenv ("USERPROFILE"))
+        return std::filesystem::path (profile) / "Music";
+    return {};
+#elif defined(__APPLE__)
+    return userHomeDir() / "Music";
+#else
+    return resolveXdgFolder ("XDG_MUSIC_DIR", userHomeDir() / "Music");
+#endif
+}
+
+// JUCE File::tempDirectory.
+inline std::filesystem::path tempDir()
+{
+#if defined(_WIN32)
+    if (const char* t = std::getenv ("TEMP")) return std::filesystem::path (t);
+    if (const char* t = std::getenv ("TMP"))  return std::filesystem::path (t);
+    return std::filesystem::path ("C:\\Windows\\Temp");
+#else
+    if (const char* t = std::getenv ("TMPDIR")) return std::filesystem::path (t);
+    return std::filesystem::path ("/tmp");
+#endif
+}
+
+// JUCE File::currentExecutableFile.
+inline std::filesystem::path currentExecutablePath()
+{
+#if defined(_WIN32)
+    wchar_t buf[MAX_PATH + 256];
+    buf[0] = 0;
+    GetModuleFileNameW (nullptr, buf, (DWORD) (sizeof (buf) / sizeof (buf[0])));
+    return std::filesystem::path (buf);
+#elif defined(__APPLE__)
+    char buf[4096];
+    std::uint32_t size = sizeof (buf);
+    if (_NSGetExecutablePath (buf, &size) != 0) return {};
+    return std::filesystem::path (buf);
+#else
+    char buf[4096];
+    const auto n = ::readlink ("/proc/self/exe", buf, sizeof (buf) - 1);
+    if (n <= 0) return {};
+    buf[n] = 0;
+    return std::filesystem::path (buf);
+#endif
 }
 } // namespace dusk::fs

--- a/src/foundation/Fs.h
+++ b/src/foundation/Fs.h
@@ -183,7 +183,10 @@ inline std::filesystem::path userHomeDir()
 inline std::filesystem::path resolveXdgFolder (const std::string& key,
                                                const std::filesystem::path& fallback)
 {
-    std::ifstream in (userHomeDir() / ".config" / "user-dirs.dirs");
+    const auto home = userHomeDir();
+    if (home.empty()) return fallback;   // never open/build a CWD-relative path
+
+    std::ifstream in (home / ".config" / "user-dirs.dirs");
     std::string line;
     while (std::getline (in, line))
     {
@@ -193,8 +196,7 @@ inline std::filesystem::path resolveXdgFolder (const std::string& key,
         const auto eq = trimmed.find ('=');
         if (eq == std::string::npos) continue;
 
-        std::string value = detail::replaceAll (trimmed.substr (eq + 1), "$HOME",
-                                                userHomeDir().string());
+        std::string value = detail::replaceAll (trimmed.substr (eq + 1), "$HOME", home.string());
         value = detail::unquote (detail::trimBoth (value));
 
         std::error_code ec;

--- a/src/session/RecentSessions.cpp
+++ b/src/session/RecentSessions.cpp
@@ -39,16 +39,21 @@ std::vector<stdfs::path> RecentSessions::load()
     std::string line;
     while (std::getline (in, line))
     {
-        const auto trimmed = dusk::text::trim (line);
-        if (trimmed.empty()) continue;
+        if (! line.empty() && line.back() == '\r') line.pop_back();   // tolerate CRLF
+        if (line.empty()) continue;
 
-        const stdfs::path f (trimmed);
+        // Paths are stored as UTF-8; u8path round-trips them exactly (including
+        // non-ASCII and whitespace-bearing directory names) on every platform.
+        const stdfs::path f = stdfs::u8path (line);
         // Prune stale entries - a removed session directory is worse than
         // useless in the picker UI. Also dedupe (load can be called after a
         // partial write).
         if (stdfs::is_directory (f, ec)
             && std::find (result.begin(), result.end(), f) == result.end())
+        {
             result.push_back (f);
+            if ((int) result.size() >= kMaxEntries) break;   // documented cap
+        }
     }
     return result;
 }
@@ -72,7 +77,7 @@ void RecentSessions::add (const stdfs::path& sessionDirectory)
 
     std::vector<std::string> lines;
     lines.reserve (entries.size());
-    for (auto& f : entries) lines.push_back (f.string());
+    for (auto& f : entries) lines.push_back (f.u8string());
     dusk::fs::writeStringToFile (store, dusk::text::joinIntoString (lines, "\n"));
 }
 

--- a/src/session/RecentSessions.cpp
+++ b/src/session/RecentSessions.cpp
@@ -1,56 +1,79 @@
 #include "RecentSessions.h"
 
+#include "../foundation/Fs.h"
+#include "../foundation/Text.h"
+
+#include <algorithm>
+#include <fstream>
+#include <string>
+
 namespace duskstudio
 {
-juce::File RecentSessions::getStoreFile()
+namespace stdfs = std::filesystem;
+
+static stdfs::path configRoot()
 {
-    auto cfgDir = juce::File::getSpecialLocation (juce::File::userApplicationDataDirectory)
-                      .getChildFile ("Dusk Studio");
-    if (! cfgDir.isDirectory() && cfgDir.createDirectory().failed())
-        return {};   // empty File - load() returns empty, add() drops the write
-    return cfgDir.getChildFile ("recent.txt");
+    const auto cfg = dusk::fs::userConfigDir();
+    return cfg.empty() ? stdfs::path {} : cfg / "Dusk Studio";
 }
 
-juce::Array<juce::File> RecentSessions::load()
+stdfs::path RecentSessions::getStoreFile()
 {
-    juce::Array<juce::File> result;
+    const auto cfgDir = configRoot();
+    if (cfgDir.empty()) return {};
+
+    std::error_code ec;
+    if (! stdfs::is_directory (cfgDir, ec) && ! stdfs::create_directories (cfgDir, ec))
+        return {};   // empty path - load() returns empty, add() drops the write
+    return cfgDir / "recent.txt";
+}
+
+std::vector<stdfs::path> RecentSessions::load()
+{
+    std::vector<stdfs::path> result;
     const auto store = getStoreFile();
-    if (! store.existsAsFile()) return result;
+    std::error_code ec;
+    if (store.empty() || ! stdfs::is_regular_file (store, ec)) return result;
 
-    juce::StringArray lines;
-    store.readLines (lines);
-    for (auto& line : lines)
+    std::ifstream in (store);
+    std::string line;
+    while (std::getline (in, line))
     {
-        const auto trimmed = line.trim();
-        if (trimmed.isEmpty()) continue;
+        const auto trimmed = dusk::text::trim (line);
+        if (trimmed.empty()) continue;
 
-        const juce::File f (trimmed);
+        const stdfs::path f (trimmed);
         // Prune stale entries - a removed session directory is worse than
         // useless in the picker UI. Also dedupe (load can be called after a
         // partial write).
-        if (f.isDirectory() && ! result.contains (f))
-            result.add (f);
+        if (stdfs::is_directory (f, ec)
+            && std::find (result.begin(), result.end(), f) == result.end())
+            result.push_back (f);
     }
     return result;
 }
 
-void RecentSessions::add (const juce::File& sessionDirectory)
+void RecentSessions::add (const stdfs::path& sessionDirectory)
 {
-    if (sessionDirectory == juce::File()) return;
+    if (sessionDirectory.empty()) return;
 
     auto entries = load();
 
     // Newest goes to the front; remove any existing copy first so we don't
     // promote a duplicate.
-    entries.removeAllInstancesOf (sessionDirectory);
-    entries.insert (0, sessionDirectory);
+    entries.erase (std::remove (entries.begin(), entries.end(), sessionDirectory), entries.end());
+    entries.insert (entries.begin(), sessionDirectory);
 
-    while (entries.size() > kMaxEntries)
-        entries.remove (entries.size() - 1);
+    if ((int) entries.size() > kMaxEntries)
+        entries.resize (kMaxEntries);
 
-    juce::StringArray lines;
-    for (auto& f : entries) lines.add (f.getFullPathName());
-    getStoreFile().replaceWithText (lines.joinIntoString ("\n"));
+    const auto store = getStoreFile();
+    if (store.empty()) return;
+
+    std::vector<std::string> lines;
+    lines.reserve (entries.size());
+    for (auto& f : entries) lines.push_back (f.string());
+    dusk::fs::writeStringToFile (store, dusk::text::joinIntoString (lines, "\n"));
 }
 
 void RecentSessions::clear()
@@ -58,10 +81,11 @@ void RecentSessions::clear()
     // Compute the path WITHOUT getStoreFile() - that creates the config dir as
     // a side effect, so clearing a never-used recents list would spawn an empty
     // "Dusk Studio" config dir. If the dir isn't there, there's nothing to clear.
-    auto cfgDir = juce::File::getSpecialLocation (juce::File::userApplicationDataDirectory)
-                      .getChildFile ("Dusk Studio");
-    if (! cfgDir.isDirectory()) return;
-    const auto store = cfgDir.getChildFile ("recent.txt");
-    if (store.existsAsFile()) store.deleteFile();
+    const auto cfgDir = configRoot();
+    std::error_code ec;
+    if (cfgDir.empty() || ! stdfs::is_directory (cfgDir, ec)) return;
+    const auto store = cfgDir / "recent.txt";
+    if (stdfs::is_regular_file (store, ec))
+        stdfs::remove (store, ec);
 }
 } // namespace duskstudio

--- a/src/session/RecentSessions.h
+++ b/src/session/RecentSessions.h
@@ -1,11 +1,12 @@
 #pragma once
 
-#include <juce_core/juce_core.h>
+#include <filesystem>
+#include <vector>
 
 namespace duskstudio
 {
 // Persistent list of session directories the user has recently saved/loaded.
-// Stored as a newline-delimited file at <userApplicationDataDirectory>/Dusk Studio/recent.txt
+// Stored as a newline-delimited file at <userConfigDir>/Dusk Studio/recent.txt
 // (one absolute path per line, most recent first). Cap at kMaxEntries - older
 // entries are evicted on overflow. Stale paths (directory removed) are pruned
 // on read so the startup dialog never shows broken entries.
@@ -18,11 +19,11 @@ class RecentSessions
 public:
     static constexpr int kMaxEntries = 10;
 
-    static juce::Array<juce::File> load();
-    static void                    add (const juce::File& sessionDirectory);
-    static void                    clear();
+    static std::vector<std::filesystem::path> load();
+    static void                               add (const std::filesystem::path& sessionDirectory);
+    static void                               clear();
 
 private:
-    static juce::File getStoreFile();
+    static std::filesystem::path getStoreFile();
 };
 } // namespace duskstudio

--- a/src/ui/AppConfig.cpp
+++ b/src/ui/AppConfig.cpp
@@ -1,8 +1,20 @@
 #include "AppConfig.h"
 #include "../engine/AudioEngine.h"   // AudioEngine::getMaxWorkerCount()
 
+#include "../foundation/Fs.h"
+#include "../foundation/Text.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
 namespace duskstudio::appconfig
 {
+namespace stdfs = std::filesystem;
+
 namespace
 {
 constexpr const char* kKeyUiScale            = "ui_scale";
@@ -16,85 +28,126 @@ constexpr const char* kKeyMulticoreManual    = "multicore_dsp_workers";
 constexpr const char* kKeyMidiSoftTakeover   = "midi_soft_takeover";
 constexpr const char* kKeyAutosaveInterval   = "autosave_interval_sec";
 
-juce::File getStorePath()
+int numCpus()
 {
-    auto cfgDir = juce::File::getSpecialLocation (juce::File::userApplicationDataDirectory)
-                      .getChildFile ("Dusk Studio");
-    if (! cfgDir.exists()) cfgDir.createDirectory();
-    return cfgDir.getChildFile ("app-config.properties");
+    const unsigned n = std::thread::hardware_concurrency();
+    return n == 0 ? 1 : (int) n;   // hardware_concurrency may report 0 (unknowable)
 }
 
-// Tiny key=value parser. The data is one or two scalar entries - a real
-// PropertiesFile is overkill, and JUCE's PropertiesFile doesn't honour
-// XDG paths on Linux (it stores under ~/<folderName>/, not ~/.config/),
-// which makes it the wrong tool for a per-machine config we want
-// alongside window-state.txt and recent.txt.
-juce::String readKey (const juce::String& key)
+// Trailing-zero-trimmed decimal, matching JUCE String(float)'s readable form
+// (1.5, not 1.500000) so the config file stays hand-editable.
+std::string floatToString (float v)
+{
+    std::string s = std::to_string (v);
+    if (s.find ('.') != std::string::npos)
+    {
+        size_t last = s.find_last_not_of ('0');
+        if (s[last] == '.') --last;
+        s.erase (last + 1);
+    }
+    return s;
+}
+
+bool isTruthy (const std::string& s)
+{
+    const auto low = dusk::text::toLowerCase (s);
+    return s == "1" || low == "true" || low == "yes";
+}
+
+stdfs::path getStorePath()
+{
+    const auto cfg = dusk::fs::userConfigDir();
+    if (cfg.empty()) return {};
+    const auto cfgDir = cfg / "Dusk Studio";
+    std::error_code ec;
+    if (! stdfs::exists (cfgDir, ec)) stdfs::create_directories (cfgDir, ec);
+    return cfgDir / "app-config.properties";
+}
+
+std::vector<std::string> readLines (const stdfs::path& file)
+{
+    std::vector<std::string> out;
+    std::ifstream in (file);
+    std::string line;
+    while (std::getline (in, line))
+    {
+        if (! line.empty() && line.back() == '\r') line.pop_back();
+        out.push_back (line);
+    }
+    return out;
+}
+
+// Tiny key=value parser. The data is a handful of scalar entries - a real
+// PropertiesFile is overkill, and JUCE's PropertiesFile doesn't honour XDG
+// paths on Linux (it stores under ~/<folderName>/, not ~/.config/), which
+// makes it the wrong tool for a per-machine config we want alongside
+// window-state.txt and recent.txt.
+std::string readKey (const std::string& key)
 {
     const auto file = getStorePath();
-    if (! file.existsAsFile()) return {};
+    std::error_code ec;
+    if (file.empty() || ! stdfs::is_regular_file (file, ec)) return {};
 
-    juce::StringArray lines;
-    file.readLines (lines);
-    for (auto& raw : lines)
+    for (const auto& raw : readLines (file))
     {
-        const auto line = raw.trim();
-        if (line.isEmpty() || line.startsWithChar ('#')) continue;
-        const auto eq = line.indexOfChar ('=');
-        if (eq <= 0) continue;
-        if (line.substring (0, eq).trim() == key)
-            return line.substring (eq + 1).trim();
+        const auto line = dusk::text::trim (raw);
+        if (line.empty() || line[0] == '#') continue;
+        const auto eq = line.find ('=');
+        if (eq == std::string::npos || eq == 0) continue;
+        if (dusk::text::trim (line.substr (0, eq)) == key)
+            return dusk::text::trim (line.substr (eq + 1));
     }
     return {};
 }
 
-void writeKey (const juce::String& key, const juce::String& value)
+void writeKey (const std::string& key, const std::string& value)
 {
     const auto file = getStorePath();
-    juce::StringArray lines;
-    if (file.existsAsFile()) file.readLines (lines);
+    if (file.empty()) return;
+
+    std::error_code ec;
+    auto lines = stdfs::is_regular_file (file, ec) ? readLines (file)
+                                                   : std::vector<std::string> {};
 
     bool replaced = false;
     for (auto& raw : lines)
     {
-        const auto trimmed = raw.trim();
-        if (trimmed.isEmpty() || trimmed.startsWithChar ('#')) continue;
-        const auto eq = trimmed.indexOfChar ('=');
-        if (eq <= 0) continue;
-        if (trimmed.substring (0, eq).trim() == key)
+        const auto trimmed = dusk::text::trim (raw);
+        if (trimmed.empty() || trimmed[0] == '#') continue;
+        const auto eq = trimmed.find ('=');
+        if (eq == std::string::npos || eq == 0) continue;
+        if (dusk::text::trim (trimmed.substr (0, eq)) == key)
         {
             raw = key + "=" + value;
             replaced = true;
             break;
         }
     }
-    if (! replaced) lines.add (key + "=" + value);
+    if (! replaced) lines.push_back (key + "=" + value);
 
-    file.replaceWithText (lines.joinIntoString ("\n"));
+    dusk::fs::writeStringToFile (file, dusk::text::joinIntoString (lines, "\n"));
 }
 } // namespace
 
 float getUiScaleOverride()
 {
     const auto raw = readKey (kKeyUiScale);
-    if (raw.isEmpty()) return kUiScaleDefault;
-    const float value = raw.getFloatValue();
-    return juce::jlimit (kUiScaleMin, kUiScaleMax,
-                          value > 0.0f ? value : kUiScaleDefault);
+    if (raw.empty()) return kUiScaleDefault;
+    const float value = dusk::text::getFloatValue (raw);
+    return std::clamp (value > 0.0f ? value : kUiScaleDefault, kUiScaleMin, kUiScaleMax);
 }
 
 void setUiScaleOverride (float scale)
 {
-    const float clamped = juce::jlimit (kUiScaleMin, kUiScaleMax, scale);
-    writeKey (kKeyUiScale, juce::String (clamped));
+    const float clamped = std::clamp (scale, kUiScaleMin, kUiScaleMax);
+    writeKey (kKeyUiScale, floatToString (clamped));
 }
 
 bool getScanPluginsOnStartup()
 {
     const auto raw = readKey (kKeyScanOnStartup);
-    if (raw.isEmpty()) return false;   // default off — caches are cheap, scans aren't
-    return raw == "1" || raw.equalsIgnoreCase ("true")
-        || raw.equalsIgnoreCase ("yes");
+    if (raw.empty()) return false;   // default off — caches are cheap, scans aren't
+    return isTruthy (raw);
 }
 
 void setScanPluginsOnStartup (bool scan)
@@ -105,9 +158,8 @@ void setScanPluginsOnStartup (bool scan)
 bool getTapeStripExpandedDefault()
 {
     const auto raw = readKey (kKeyTapeStripExpanded);
-    if (raw.isEmpty()) return false;   // default collapsed — strips get full body
-    return raw == "1" || raw.equalsIgnoreCase ("true")
-        || raw.equalsIgnoreCase ("yes");
+    if (raw.empty()) return false;   // default collapsed — strips get full body
+    return isTruthy (raw);
 }
 
 void setTapeStripExpandedDefault (bool expanded)
@@ -118,9 +170,8 @@ void setTapeStripExpandedDefault (bool expanded)
 bool getFollowPlayheadDefault()
 {
     const auto raw = readKey (kKeyFollowPlayhead);
-    if (raw.isEmpty()) return false;   // default off — view stays put unless asked
-    return raw == "1" || raw.equalsIgnoreCase ("true")
-        || raw.equalsIgnoreCase ("yes");
+    if (raw.empty()) return false;   // default off — view stays put unless asked
+    return isTruthy (raw);
 }
 
 void setFollowPlayheadDefault (bool follow)
@@ -131,22 +182,21 @@ void setFollowPlayheadDefault (bool follow)
 int getAutosaveIntervalSeconds()
 {
     const auto raw = readKey (kKeyAutosaveInterval);
-    if (raw.isEmpty()) return kAutosaveIntervalDefaultSec;
-    const int v = raw.getIntValue();
+    if (raw.empty()) return kAutosaveIntervalDefaultSec;
+    const int v = dusk::text::getIntValue (raw);
     return (v >= 10 && v <= 600) ? v : kAutosaveIntervalDefaultSec;
 }
 
 void setAutosaveIntervalSeconds (int seconds)
 {
-    writeKey (kKeyAutosaveInterval, juce::String (juce::jlimit (10, 600, seconds)));
+    writeKey (kKeyAutosaveInterval, std::to_string (std::clamp (seconds, 10, 600)));
 }
 
 bool getMidiSoftTakeover()
 {
     const auto raw = readKey (kKeyMidiSoftTakeover);
-    if (raw.isEmpty()) return false;   // default off — controllers track 1:1
-    return raw == "1" || raw.equalsIgnoreCase ("true")
-        || raw.equalsIgnoreCase ("yes");
+    if (raw.empty()) return false;   // default off — controllers track 1:1
+    return isTruthy (raw);
 }
 
 void setMidiSoftTakeover (bool on)
@@ -157,15 +207,15 @@ void setMidiSoftTakeover (bool on)
 StopBehavior getStopBehavior()
 {
     const auto raw = readKey (kKeyStopBehavior);
-    if (raw.isEmpty()) return StopBehavior::PauseInPlace;
-    const int v = raw.getIntValue();
+    if (raw.empty()) return StopBehavior::PauseInPlace;
+    const int v = dusk::text::getIntValue (raw);
     if (v >= 0 && v <= 2) return (StopBehavior) v;
     return StopBehavior::PauseInPlace;
 }
 
 void setStopBehavior (StopBehavior b)
 {
-    writeKey (kKeyStopBehavior, juce::String ((int) b));
+    writeKey (kKeyStopBehavior, std::to_string ((int) b));
 }
 
 MulticoreDspMode getMulticoreDspMode()
@@ -173,16 +223,16 @@ MulticoreDspMode getMulticoreDspMode()
     const auto raw = readKey (kKeyMulticoreMode);
     // Reject empty or non-numeric: getIntValue() coerces "abc" to 0, which would
     // silently pass the range check and flip behaviour instead of defaulting.
-    if (raw.isEmpty() || ! raw.containsOnly ("0123456789"))
+    if (raw.empty() || raw.find_first_not_of ("0123456789") != std::string::npos)
         return MulticoreDspMode::Auto;   // default: use spare cores
-    const int v = raw.getIntValue();
+    const int v = dusk::text::getIntValue (raw);
     if (v >= 0 && v <= 2) return (MulticoreDspMode) v;
     return MulticoreDspMode::Auto;
 }
 
 void setMulticoreDspMode (MulticoreDspMode m)
 {
-    writeKey (kKeyMulticoreMode, juce::String ((int) m));
+    writeKey (kKeyMulticoreMode, std::to_string ((int) m));
 }
 
 int maxMulticoreWorkers()
@@ -190,8 +240,7 @@ int maxMulticoreWorkers()
     // Never advertise more than the engine will actually use, regardless of CPU
     // count — otherwise the settings UI / manual-worker cap drift above what
     // resolveWorkerCount can request. AudioEngine is the single source of truth.
-    return juce::jlimit (0, AudioEngine::getMaxWorkerCount(),
-                          juce::SystemStats::getNumCpus() - 2);
+    return std::clamp (numCpus() - 2, 0, AudioEngine::getMaxWorkerCount());
 }
 
 int getMulticoreManualWorkers()
@@ -200,17 +249,17 @@ int getMulticoreManualWorkers()
     // clamps Manual to 0 too — so allow 0 here instead of forcing 1, otherwise
     // the stored/displayed count (1) disagrees with what actually runs (0).
     const int mx = maxMulticoreWorkers();
-    const int lo = juce::jmin (1, mx);   // 1 when workers are possible, else 0
+    const int lo = std::min (1, mx);   // 1 when workers are possible, else 0
     const auto raw = readKey (kKeyMulticoreManual);
-    if (raw.isEmpty()) return mx;        // default to the full available count
-    return juce::jlimit (lo, mx, raw.getIntValue());
+    if (raw.empty()) return mx;        // default to the full available count
+    return std::clamp (dusk::text::getIntValue (raw), lo, mx);
 }
 
 void setMulticoreManualWorkers (int n)
 {
     const int mx = maxMulticoreWorkers();
-    const int lo = juce::jmin (1, mx);
-    writeKey (kKeyMulticoreManual, juce::String (juce::jlimit (lo, mx, n)));
+    const int lo = std::min (1, mx);
+    writeKey (kKeyMulticoreManual, std::to_string (std::clamp (n, lo, mx)));
 }
 
 int resolveWorkerCount()
@@ -220,10 +269,9 @@ int resolveWorkerCount()
         case MulticoreDspMode::Off:    return 0;
         // Auto fans out only on >= 4-core hosts (cores - 2 workers); smaller
         // machines stay single-core, matching the manual's documented behaviour.
-        case MulticoreDspMode::Auto:   return juce::SystemStats::getNumCpus() >= 4
-                                                  ? maxMulticoreWorkers() : 0;
-        case MulticoreDspMode::Manual: return juce::jmin (getMulticoreManualWorkers(),
-                                                          maxMulticoreWorkers());
+        case MulticoreDspMode::Auto:   return numCpus() >= 4 ? maxMulticoreWorkers() : 0;
+        case MulticoreDspMode::Manual: return std::min (getMulticoreManualWorkers(),
+                                                        maxMulticoreWorkers());
     }
     return 0;
 }
@@ -231,12 +279,12 @@ int resolveWorkerCount()
 int getVkbCentreNote()
 {
     const auto raw = readKey (kKeyVkbCentreNote);
-    if (raw.isEmpty()) return kVkbCentreDefault;
-    return juce::jlimit (0, 120, raw.getIntValue());
+    if (raw.empty()) return kVkbCentreDefault;
+    return std::clamp (dusk::text::getIntValue (raw), 0, 120);
 }
 
 void setVkbCentreNote (int midiNote)
 {
-    writeKey (kKeyVkbCentreNote, juce::String (juce::jlimit (0, 120, midiNote)));
+    writeKey (kKeyVkbCentreNote, std::to_string (std::clamp (midiNote, 0, 120)));
 }
 } // namespace duskstudio::appconfig

--- a/src/ui/AppConfig.cpp
+++ b/src/ui/AppConfig.cpp
@@ -54,13 +54,22 @@ bool isTruthy (const std::string& s)
     return s == "1" || low == "true" || low == "yes";
 }
 
+// getIntValue() coerces non-numeric strings to 0; require a well-formed
+// non-negative integer so a garbage value falls back to the default instead
+// of reading as a valid 0.
+bool looksNumeric (const std::string& s)
+{
+    return ! s.empty() && s.find_first_not_of ("0123456789") == std::string::npos;
+}
+
 stdfs::path getStorePath()
 {
     const auto cfg = dusk::fs::userConfigDir();
     if (cfg.empty()) return {};
     const auto cfgDir = cfg / "Dusk Studio";
     std::error_code ec;
-    if (! stdfs::exists (cfgDir, ec)) stdfs::create_directories (cfgDir, ec);
+    if (! stdfs::is_directory (cfgDir, ec) && ! stdfs::create_directories (cfgDir, ec))
+        return {};   // config dir unusable (missing + uncreatable, or a non-dir file)
     return cfgDir / "app-config.properties";
 }
 
@@ -182,7 +191,7 @@ void setFollowPlayheadDefault (bool follow)
 int getAutosaveIntervalSeconds()
 {
     const auto raw = readKey (kKeyAutosaveInterval);
-    if (raw.empty()) return kAutosaveIntervalDefaultSec;
+    if (! looksNumeric (raw)) return kAutosaveIntervalDefaultSec;
     const int v = dusk::text::getIntValue (raw);
     return (v >= 10 && v <= 600) ? v : kAutosaveIntervalDefaultSec;
 }
@@ -207,7 +216,7 @@ void setMidiSoftTakeover (bool on)
 StopBehavior getStopBehavior()
 {
     const auto raw = readKey (kKeyStopBehavior);
-    if (raw.empty()) return StopBehavior::PauseInPlace;
+    if (! looksNumeric (raw)) return StopBehavior::PauseInPlace;
     const int v = dusk::text::getIntValue (raw);
     if (v >= 0 && v <= 2) return (StopBehavior) v;
     return StopBehavior::PauseInPlace;
@@ -221,10 +230,7 @@ void setStopBehavior (StopBehavior b)
 MulticoreDspMode getMulticoreDspMode()
 {
     const auto raw = readKey (kKeyMulticoreMode);
-    // Reject empty or non-numeric: getIntValue() coerces "abc" to 0, which would
-    // silently pass the range check and flip behaviour instead of defaulting.
-    if (raw.empty() || raw.find_first_not_of ("0123456789") != std::string::npos)
-        return MulticoreDspMode::Auto;   // default: use spare cores
+    if (! looksNumeric (raw)) return MulticoreDspMode::Auto;   // default: use spare cores
     const int v = dusk::text::getIntValue (raw);
     if (v >= 0 && v <= 2) return (MulticoreDspMode) v;
     return MulticoreDspMode::Auto;
@@ -251,7 +257,7 @@ int getMulticoreManualWorkers()
     const int mx = maxMulticoreWorkers();
     const int lo = std::min (1, mx);   // 1 when workers are possible, else 0
     const auto raw = readKey (kKeyMulticoreManual);
-    if (raw.empty()) return mx;        // default to the full available count
+    if (! looksNumeric (raw)) return mx;   // default to the full available count
     return std::clamp (dusk::text::getIntValue (raw), lo, mx);
 }
 
@@ -279,7 +285,7 @@ int resolveWorkerCount()
 int getVkbCentreNote()
 {
     const auto raw = readKey (kKeyVkbCentreNote);
-    if (raw.empty()) return kVkbCentreDefault;
+    if (! looksNumeric (raw)) return kVkbCentreDefault;
     return std::clamp (dusk::text::getIntValue (raw), 0, 120);
 }
 

--- a/src/ui/AppConfig.h
+++ b/src/ui/AppConfig.h
@@ -1,17 +1,14 @@
 #pragma once
 
-#include <juce_data_structures/juce_data_structures.h>
-
 namespace duskstudio::appconfig
 {
-// Per-machine preferences. Backed by a juce::PropertiesFile at
-//   <userApplicationDataDirectory>/Dusk Studio/app-config.properties
+// Per-machine preferences. Stored as a key=value text file at
+//   <userConfigDir>/Dusk Studio/app-config.properties
 // - separate store from window-state.txt (geometry) and recent.txt
 // (recent sessions list) so each file has a single concern.
 //
-// All accessors are message-thread only. The PropertiesFile has its own
-// internal locking, but values returned here aren't atomic on their own,
-// so don't poll from the audio thread.
+// All accessors are message-thread only; values aren't atomic, so don't
+// poll from the audio thread.
 
 // User-controlled UI scale multiplier on top of JUCE's per-display DPI.
 // Default 1.0 (no extra zoom). Clamped to [0.5, 2.0] on write - the

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -46,6 +46,13 @@ namespace duskstudio
 {
 namespace
 {
+juce::Array<juce::File> toFileArray (const std::vector<std::filesystem::path>& paths)
+{
+    juce::Array<juce::File> out;
+    for (auto& p : paths) out.add (juce::File (p.string()));
+    return out;
+}
+
 // Shared helpers for the file-import flow (both menu-driven and
 // drag-and-drop). Lives at file scope so the TapeStrip drop callback
 // wired up in the MainComponent ctor can reference them.
@@ -2072,7 +2079,7 @@ void MainComponent::doMixdown()
 
 void MainComponent::launchStartupDialog()
 {
-    auto recents = RecentSessions::load();
+    auto recents = toFileArray (RecentSessions::load());
 
     startupDialog = std::make_unique<StartupDialog> (recents);
     // Fixed size — the table scrolls internally when the list grows past
@@ -2381,7 +2388,7 @@ bool MainComponent::saveSessionTo (const juce::File& dir)
             // prompt.
             deleteAutosaveFor (oldDir);
         }
-        RecentSessions::add (dir);
+        RecentSessions::add (dir.getFullPathName().toStdString());
         // A successful manual save makes the autosave stale - drop it so the
         // recovery prompt doesn't fire on the next clean load.
         deleteAutosaveFor (dir);
@@ -3196,7 +3203,7 @@ bool MainComponent::finishLoadingSessionFrom (const juce::File& sourceJson,
         tapeStrip->refreshAfterSessionLoad();
     const auto tAfterConsole = juce::Time::getMillisecondCounterHiRes();
 
-    RecentSessions::add (dir);
+    RecentSessions::add (dir.getFullPathName().toStdString());
     setStatusForPath ("Loaded", sourceJson, /*isAutosave*/ loadedFromAutosave);
 
     // Seed the saved-state snapshot from the live in-memory session now
@@ -4270,7 +4277,7 @@ juce::PopupMenu MainComponent::getMenuForIndex (int topLevelMenuIndex,
         // "Recent Sessions" submenu: cached on the way out so the click
         // handler can resolve by index. Capped at RecentSessions::kMaxEntries
         // (the on-disk file is also capped, so this match isn't load-bearing).
-        menuRecentSessions = RecentSessions::load();
+        menuRecentSessions = toFileArray (RecentSessions::load());
         juce::Logger::writeToLog ("[Dusk Studio/MainComponent] Recent Sessions submenu: "
                                      + juce::String (menuRecentSessions.size())
                                      + " entries from RecentSessions::load()");

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -46,10 +46,22 @@ namespace duskstudio
 {
 namespace
 {
+// UTF-8-safe bridges across the RecentSessions (std::filesystem) boundary -
+// native narrow conversions lose non-ASCII paths on Windows.
+juce::File toFile (const std::filesystem::path& p)
+{
+    return juce::File (juce::String::fromUTF8 (p.u8string().c_str()));
+}
+
+std::filesystem::path toPath (const juce::File& f)
+{
+    return std::filesystem::u8path (f.getFullPathName().toStdString());
+}
+
 juce::Array<juce::File> toFileArray (const std::vector<std::filesystem::path>& paths)
 {
     juce::Array<juce::File> out;
-    for (auto& p : paths) out.add (juce::File (p.string()));
+    for (auto& p : paths) out.add (toFile (p));
     return out;
 }
 
@@ -2388,7 +2400,7 @@ bool MainComponent::saveSessionTo (const juce::File& dir)
             // prompt.
             deleteAutosaveFor (oldDir);
         }
-        RecentSessions::add (dir.getFullPathName().toStdString());
+        RecentSessions::add (toPath (dir));
         // A successful manual save makes the autosave stale - drop it so the
         // recovery prompt doesn't fire on the next clean load.
         deleteAutosaveFor (dir);
@@ -3203,7 +3215,7 @@ bool MainComponent::finishLoadingSessionFrom (const juce::File& sourceJson,
         tapeStrip->refreshAfterSessionLoad();
     const auto tAfterConsole = juce::Time::getMillisecondCounterHiRes();
 
-    RecentSessions::add (dir.getFullPathName().toStdString());
+    RecentSessions::add (toPath (dir));
     setStatusForPath ("Loaded", sourceJson, /*isAutosave*/ loadedFromAutosave);
 
     // Seed the saved-state snapshot from the live in-memory session now

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -122,7 +122,8 @@ target_sources(dusk-studio-tests PRIVATE
     foundation_text.cpp
     foundation_fs.cpp
     foundation_special_locations.cpp
-    foundation_json.cpp)
+    foundation_json.cpp
+    lv2_state_paths.cpp)
 
 # Phase 1a de-JUCE: JUCE-free audio file I/O (libsndfile backend), test-only for
 # now. Optional — where libsndfile isn't installed (some CI platforms) the unit

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -121,6 +121,7 @@ target_include_directories(dusk-studio-tests SYSTEM PRIVATE ${CMAKE_SOURCE_DIR}/
 target_sources(dusk-studio-tests PRIVATE
     foundation_text.cpp
     foundation_fs.cpp
+    foundation_special_locations.cpp
     foundation_json.cpp)
 
 # Phase 1a de-JUCE: JUCE-free audio file I/O (libsndfile backend), test-only for

--- a/tests/clap_scanner.cpp
+++ b/tests/clap_scanner.cpp
@@ -7,14 +7,25 @@
 
 #include "engine/clap/ClapScanner.h"
 
+#include <juce_core/juce_core.h>
+
 #include <cstdlib>
+#include <filesystem>
 
 using duskstudio::clap::ClapScanner;
+
+namespace
+{
+std::filesystem::path toPath (const juce::File& f)
+{
+    return std::filesystem::u8path (f.getFullPathName().toStdString());
+}
+} // namespace
 
 TEST_CASE ("ClapScanner default search paths are existing directories", "[clap][scan]")
 {
     for (const auto& d : ClapScanner::defaultSearchPaths())
-        REQUIRE (d.isDirectory());
+        REQUIRE (std::filesystem::is_directory (d));
 }
 
 TEST_CASE ("ClapScanner finds nothing in an empty directory", "[clap][scan]")
@@ -25,8 +36,8 @@ TEST_CASE ("ClapScanner finds nothing in an empty directory", "[clap][scan]")
     tmp.deleteRecursively();
     REQUIRE (tmp.createDirectory());
 
-    REQUIRE (ClapScanner::findClapFiles ({ tmp }).empty());
-    REQUIRE (ClapScanner::scan ({ tmp }).empty());
+    REQUIRE (ClapScanner::findClapFiles ({ toPath (tmp) }).empty());
+    REQUIRE (ClapScanner::scan ({ toPath (tmp) }).empty());
 
     tmp.deleteRecursively();
 }
@@ -43,13 +54,13 @@ TEST_CASE ("ClapScanner discovers and describes a real CLAP bundle", "[clap][sca
     const juce::File bundle (juce::String (path).trim());
     REQUIRE (bundle.existsAsFile());
 
-    const auto found = ClapScanner::scan ({ bundle.getParentDirectory() });
+    const auto found = ClapScanner::scan ({ toPath (bundle.getParentDirectory()) });
     REQUIRE_FALSE (found.empty());
 
     bool sawBundle = false;
     for (const auto& s : found)
     {
-        if (s.bundlePath == bundle.getFullPathName())
+        if (s.bundlePath == bundle.getFullPathName().toStdString())
         {
             sawBundle = true;
             REQUIRE_FALSE (s.desc.id.empty());     // a usable plugin id to instantiate

--- a/tests/foundation_special_locations.cpp
+++ b/tests/foundation_special_locations.cpp
@@ -36,7 +36,15 @@ TEST_CASE ("dusk::fs special locations match juce::File", "[foundation][fs]")
 
     SECTION ("tempDir")
     {
+#if defined(__linux__)
         REQUIRE (fs::tempDir() == jucePath (juce::File::tempDirectory));
+#else
+        // JUCE's macOS/Windows tempDirectory has bespoke semantics
+        // (~/Library/Caches/<exe>, GetTempPath); dusk::fs::tempDir deliberately
+        // follows the POSIX $TMPDIR/TMP convention. Temp files are ephemeral, so
+        // this divergence is intentional — assert only that it is usable.
+        REQUIRE (std::filesystem::is_directory (fs::tempDir()));
+#endif
     }
 
     SECTION ("currentExecutablePath points at the same file as juce")

--- a/tests/foundation_special_locations.cpp
+++ b/tests/foundation_special_locations.cpp
@@ -1,0 +1,53 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "foundation/Fs.h"
+
+#include <juce_core/juce_core.h>
+
+#include <filesystem>
+
+using namespace dusk;
+namespace stdfs = std::filesystem;
+
+namespace
+{
+stdfs::path jucePath (juce::File::SpecialLocationType type)
+{
+    return stdfs::path (juce::File::getSpecialLocation (type).getFullPathName().toStdString());
+}
+} // namespace
+
+TEST_CASE ("dusk::fs special locations match juce::File", "[foundation][fs]")
+{
+    SECTION ("userHomeDir")
+    {
+        REQUIRE (fs::userHomeDir() == jucePath (juce::File::userHomeDirectory));
+    }
+
+    SECTION ("userConfigDir == userApplicationDataDirectory")
+    {
+        REQUIRE (fs::userConfigDir() == jucePath (juce::File::userApplicationDataDirectory));
+    }
+
+    SECTION ("userMusicDir")
+    {
+        REQUIRE (fs::userMusicDir() == jucePath (juce::File::userMusicDirectory));
+    }
+
+    SECTION ("tempDir")
+    {
+        REQUIRE (fs::tempDir() == jucePath (juce::File::tempDirectory));
+    }
+
+    SECTION ("currentExecutablePath points at the same file as juce")
+    {
+        // JUCE resolves via dladdr (path relative to CWD); dusk reads /proc/self/exe.
+        // Both name the running binary — compare canonical form.
+        std::error_code ec1, ec2;
+        const auto dusk = stdfs::canonical (fs::currentExecutablePath(), ec1);
+        const auto juce = stdfs::canonical (jucePath (juce::File::currentExecutableFile), ec2);
+        REQUIRE_FALSE (ec1);
+        REQUIRE_FALSE (ec2);
+        REQUIRE (dusk == juce);
+    }
+}

--- a/tests/foundation_special_locations.cpp
+++ b/tests/foundation_special_locations.cpp
@@ -13,7 +13,9 @@ namespace
 {
 stdfs::path jucePath (juce::File::SpecialLocationType type)
 {
-    return stdfs::path (juce::File::getSpecialLocation (type).getFullPathName().toStdString());
+    // toStdString() is UTF-8; u8path interprets it as such (path(std::string)
+    // would use the active code page on Windows).
+    return stdfs::u8path (juce::File::getSpecialLocation (type).getFullPathName().toStdString());
 }
 } // namespace
 

--- a/tests/lv2_state_paths.cpp
+++ b/tests/lv2_state_paths.cpp
@@ -1,0 +1,51 @@
+// LV2 state:mapPath abstract<->absolute translation. The live file-backed path
+// is only exercised by a gated integration test needing a file-writing plugin,
+// so the pure path logic is unit-tested here directly.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/lv2/Lv2StatePaths.h"
+
+#include <filesystem>
+
+using namespace duskstudio::lv2::statepaths;
+namespace stdfs = std::filesystem;
+
+TEST_CASE ("LV2 state paths: empty stateDir passes through", "[lv2][state]")
+{
+    REQUIRE (toAbsolute ({}, "samples/kick.wav") == "samples/kick.wav");
+    REQUIRE (toAbstract ({}, "/anywhere/kick.wav") == "/anywhere/kick.wav");
+}
+
+TEST_CASE ("LV2 state paths: abstract resolves under cur/", "[lv2][state]")
+{
+    const stdfs::path dir = "/session/state/lv2/track01";
+
+    REQUIRE (toAbsolute (dir, "samples/kick.wav")
+             == "/session/state/lv2/track01/cur/samples/kick.wav");
+
+    // An already-absolute abstract path is left untouched.
+    REQUIRE (toAbsolute (dir, "/opt/shared/ir.wav") == "/opt/shared/ir.wav");
+}
+
+TEST_CASE ("LV2 state paths: absolute under cur/ becomes relative", "[lv2][state]")
+{
+    const stdfs::path dir = "/session/state/lv2/track01";
+
+    REQUIRE (toAbstract (dir, "/session/state/lv2/track01/cur/samples/kick.wav")
+             == "samples/kick.wav");
+
+    // Files outside cur/ (and cur/ itself) pass through as absolute.
+    REQUIRE (toAbstract (dir, "/etc/passwd") == "/etc/passwd");
+    REQUIRE (toAbstract (dir, "/session/state/lv2/track01/cur")
+             == "/session/state/lv2/track01/cur");
+}
+
+TEST_CASE ("LV2 state paths: abstract<->absolute round-trips under cur/", "[lv2][state]")
+{
+    const stdfs::path dir = "/session/state/lv2/track01";
+    const std::string abstractPath = "banks/piano/A0.flac";
+
+    const auto absolute = toAbsolute (dir, abstractPath);
+    REQUIRE (toAbstract (dir, absolute) == abstractPath);
+}

--- a/tests/lv2_state_paths.cpp
+++ b/tests/lv2_state_paths.cpp
@@ -21,24 +21,34 @@ TEST_CASE ("LV2 state paths: abstract resolves under cur/", "[lv2][state]")
 {
     const stdfs::path dir = "/session/state/lv2/track01";
 
-    REQUIRE (toAbsolute (dir, "samples/kick.wav")
-             == "/session/state/lv2/track01/cur/samples/kick.wav");
+    // Compare as paths so the separator is platform-agnostic (toAbsolute
+    // returns a native-separator string).
+    REQUIRE (stdfs::path (toAbsolute (dir, "samples/kick.wav"))
+             == (dir / "cur" / "samples" / "kick.wav").lexically_normal());
 
     // An already-absolute abstract path is left untouched.
-    REQUIRE (toAbsolute (dir, "/opt/shared/ir.wav") == "/opt/shared/ir.wav");
+    const auto abs = (stdfs::current_path() / "shared" / "ir.wav").u8string();
+    REQUIRE (toAbsolute (dir, abs) == abs);
 }
 
 TEST_CASE ("LV2 state paths: absolute under cur/ becomes relative", "[lv2][state]")
 {
     const stdfs::path dir = "/session/state/lv2/track01";
 
-    REQUIRE (toAbstract (dir, "/session/state/lv2/track01/cur/samples/kick.wav")
-             == "samples/kick.wav");
+    const auto under = (dir / "cur" / "samples" / "kick.wav").u8string();
+    REQUIRE (toAbstract (dir, under) == "samples/kick.wav");
 
-    // Files outside cur/ (and cur/ itself) pass through as absolute.
+    // Files outside cur/ (and cur/ itself) pass through unchanged.
     REQUIRE (toAbstract (dir, "/etc/passwd") == "/etc/passwd");
-    REQUIRE (toAbstract (dir, "/session/state/lv2/track01/cur")
-             == "/session/state/lv2/track01/cur");
+    const auto curStr = (dir / "cur").u8string();
+    REQUIRE (toAbstract (dir, curStr) == curStr);
+}
+
+TEST_CASE ("LV2 state paths: refuse escaping abstract paths", "[lv2][state]")
+{
+    const stdfs::path dir = "/session/state/lv2/track01";
+    // A blob that tries to climb out of cur/ is handed back unresolved.
+    REQUIRE (toAbsolute (dir, "../../secret.wav") == "../../secret.wav");
 }
 
 TEST_CASE ("LV2 state paths: abstract<->absolute round-trips under cur/", "[lv2][state]")

--- a/tests/vst3_scanner.cpp
+++ b/tests/vst3_scanner.cpp
@@ -7,14 +7,25 @@
 
 #include "engine/vst3/Vst3Scanner.h"
 
+#include <juce_core/juce_core.h>
+
 #include <cstdlib>
+#include <filesystem>
 
 using duskstudio::vst3::Vst3Scanner;
+
+namespace
+{
+std::filesystem::path toPath (const juce::File& f)
+{
+    return std::filesystem::u8path (f.getFullPathName().toStdString());
+}
+} // namespace
 
 TEST_CASE ("Vst3Scanner default search paths are existing directories", "[vst3][scan]")
 {
     for (const auto& d : Vst3Scanner::defaultSearchPaths())
-        REQUIRE (d.isDirectory());
+        REQUIRE (std::filesystem::is_directory (d));
 }
 
 TEST_CASE ("Vst3Scanner finds nothing in an empty directory", "[vst3][scan]")
@@ -25,8 +36,8 @@ TEST_CASE ("Vst3Scanner finds nothing in an empty directory", "[vst3][scan]")
     tmp.deleteRecursively();
     REQUIRE (tmp.createDirectory());
 
-    REQUIRE (Vst3Scanner::findVst3Bundles ({ tmp }).empty());
-    REQUIRE (Vst3Scanner::scan ({ tmp }).empty());
+    REQUIRE (Vst3Scanner::findVst3Bundles ({ toPath (tmp) }).empty());
+    REQUIRE (Vst3Scanner::scan ({ toPath (tmp) }).empty());
 
     tmp.deleteRecursively();
 }
@@ -48,13 +59,13 @@ TEST_CASE ("Vst3Scanner matches bundles without descending into them", "[vst3][s
     REQUIRE (nested.getParentDirectory().createDirectory());
     REQUIRE (nested.create());
 
-    const auto found = Vst3Scanner::findVst3Bundles ({ tmp });
+    const auto found = Vst3Scanner::findVst3Bundles ({ toPath (tmp) });
     REQUIRE (found.size() == 2);
     bool sawBundle = false, sawNested = false;
     for (const auto& f : found)
     {
-        if (f == bundle) sawBundle = true;
-        if (f == nested) sawNested = true;
+        if (f == toPath (bundle)) sawBundle = true;
+        if (f == toPath (nested)) sawNested = true;
     }
     REQUIRE (sawBundle);
     REQUIRE (sawNested);
@@ -74,13 +85,13 @@ TEST_CASE ("Vst3Scanner discovers and describes a real VST3 module", "[vst3][sca
     const juce::File bundle (juce::String (path).trim());
     REQUIRE (bundle.exists());
 
-    const auto found = Vst3Scanner::scan ({ bundle.getParentDirectory() });
+    const auto found = Vst3Scanner::scan ({ toPath (bundle.getParentDirectory()) });
     REQUIRE_FALSE (found.empty());
 
     bool sawBundle = false;
     for (const auto& s : found)
     {
-        if (s.bundlePath == bundle.getFullPathName())
+        if (s.bundlePath == bundle.getFullPathName().toStdString())
         {
             sawBundle = true;
             REQUIRE_FALSE (s.desc.id.empty());     // a usable class id to instantiate

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -81,11 +81,8 @@ src/engine/ipc/PluginIpc.h
 src/engine/ipc/PluginScanProtocol.h
 src/engine/ipc/RemotePluginConnection.cpp
 src/engine/ipc/RemotePluginConnection.h
-src/engine/lv2/Lv2Instance.cpp
-src/engine/lv2/Lv2Instance.h
 src/engine/lv2/Lv2Scanner.cpp
 src/engine/lv2/Lv2Scanner.h
-src/engine/lv2/NativeLv2Slot.h
 src/engine/multisample/AriaBank.cpp
 src/engine/multisample/AriaBank.h
 src/engine/multisample/AriaGui.cpp

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -107,8 +107,6 @@ src/session/MarkerEditActions.h
 src/session/MidiBindings.cpp
 src/session/MidiBindings.h
 src/session/ParamEditAction.h
-src/session/RecentSessions.cpp
-src/session/RecentSessions.h
 src/session/RegionEditActions.cpp
 src/session/RegionEditActions.h
 src/session/Session.cpp

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -70,8 +70,6 @@ src/engine/alsa/AlsaPerformanceTest.cpp
 src/engine/alsa/AlsaPerformanceTest.h
 src/engine/clap/ClapInstance.cpp
 src/engine/clap/ClapInstance.h
-src/engine/clap/ClapScanner.cpp
-src/engine/clap/ClapScanner.h
 src/engine/hosting/InsertAdapter.cpp
 src/engine/hosting/InsertAdapter.h
 src/engine/hosting/NativeInsertSlot.h
@@ -100,8 +98,6 @@ src/engine/multisample/Sf2Reader.cpp
 src/engine/multisample/Sf2Reader.h
 src/engine/multisample/Sf2ToSfz.cpp
 src/engine/multisample/Sf2ToSfz.h
-src/engine/vst3/Vst3Scanner.cpp
-src/engine/vst3/Vst3Scanner.h
 src/session/MarkerEditActions.cpp
 src/session/MarkerEditActions.h
 src/session/MidiBindings.cpp

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -116,8 +116,6 @@ src/session/SessionSerializer.h
 src/session/SessionTemplates.cpp
 src/ui/AnalogVuMeter.cpp
 src/ui/AnalogVuMeter.h
-src/ui/AppConfig.cpp
-src/ui/AppConfig.h
 src/ui/AudioRegionEditor.cpp
 src/ui/AudioRegionEditor.h
 src/ui/AudioSettingsPanel.cpp


### PR DESCRIPTION
## De-JUCE: File subsystem migration

Migrates the cleanly-separable `juce::File` surface to `std::filesystem` +
`dusk::fs` / `dusk::text`. Ratchet gate 239 → 228 (11 files off JUCE).

### Additive foundation
- `dusk::fs` special-location helpers (`userHomeDir`, `userConfigDir`,
  `userMusicDir`, `tempDir`, `currentExecutablePath`) — the
  `getSpecialLocation` cases `std::filesystem` has no equivalent for. Paths
  mirror JUCE exactly (Linux replicates `resolveXDGFolder`'s
  `~/.config/user-dirs.dirs` parse; macOS `~/Library`; Windows `%APPDATA%`),
  A/B-tested against `juce::File::getSpecialLocation`.

### Units migrated off the ratchet
- **RecentSessions** — `std::vector<std::filesystem::path>`; MainComponent
  bridges at its `juce::Array<juce::File>` menu boundary.
- **AppConfig** — key=value store on `std::filesystem` + `std::clamp` /
  `std::thread::hardware_concurrency`; on-disk format and accessors unchanged.
- **CLAP/VST3 scanners** — search-path enumeration and bundle discovery on
  `std::filesystem`; `bundlePath` is a UTF-8 `std::string`. PluginManager
  bridges `path → juce::File` at the two native-scan loops.
- **Lv2Instance + NativeLv2Slot** — file-backed state directory on
  `std::filesystem`; the `state:mapPath` abstract↔absolute translation moves
  into a pure, unit-tested `Lv2StatePaths` header. The state-dir chain carries
  a `path` end to end, bridging from `juce::File` once at the session source.

### Notes
- UTF-8 path round-trip via `u8path` / `u8string` at every juce↔std boundary,
  so non-ASCII session directories survive a Windows restart.
- Empty-home and unusable-config-dir guards avoid ever building a CWD-relative
  config path.
- Two-reviewer pass; findings fixed (empty-home self-guard, `error_code`-aware
  VST3 directory walk).

Blocked (tower-entangled, deferred): WindowState (`juce::Desktop`),
CrashHandler (`FileLogger` / `getStackBacktrace`), DpAligner
(`AudioFormatReader` + `juce::dsp`).

### Verification
- App builds clean (zero new warnings)
- 336/336 tests pass (adds special-location A/B, LV2 path-mapping, scanner tests)
- `tools/juce-gate.sh` exit 0 (228)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced plugin discovery for CLAP and VST3 using standard filesystem paths.
  * More robust saving/restoring of LV2 plugin state directories across prepares and sessions.

* **Bug Fixes**
  * Improved recent sessions persistence, cleanup of stale entries, and duplicate handling.
  * Safer, stricter app config parsing with sensible defaults and clamped numeric/boolean values.
  * More reliable LV2 state path mapping under the configured `cur/` directory (prevents incorrect path translation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->