### PR TITLE
De-JUCE: audio-math primitives (Decibels / SmoothedValue / ScopedNoDenormals)

### DIFF
--- a/src/dsp/MasteringChain.cpp
+++ b/src/dsp/MasteringChain.cpp
@@ -1,4 +1,7 @@
 #include "MasteringChain.h"
+#include "../foundation/Decibels.h"
+#include "../foundation/ScopedNoDenormals.h"
+#include <algorithm>
 #include <cstring>
 
 namespace duskstudio
@@ -10,7 +13,7 @@ void MasteringChain::bind (const MasteringParams& params) noexcept
 
 void MasteringChain::prepare (double sampleRate, int blockSize, int oversamplingFactor)
 {
-    const int bs = juce::jmax (1, blockSize);
+    const int bs = std::max (1, blockSize);
     sampleRateForMeter = sampleRate > 0.0 ? sampleRate : 44100.0;
     vuRmsLinL = vuRmsLinR = 0.0f;
     meterBlockSize = bs;
@@ -67,7 +70,7 @@ int MasteringChain::readScopeLatest (float* dest, int count) const noexcept
 {
     const int ringSize = scopeRing.getNumSamples();
     if (ringSize == 0 || count <= 0 || dest == nullptr) return 0;
-    count = juce::jmin (count, ringSize);
+    count = std::min (count, ringSize);
     const int mask = scopeRingMask.load (std::memory_order_relaxed);
     if (mask == 0) return 0;   // matches pushScope; guards a mask-not-yet-stored race
     const long long wp = scopeWritePos.load (std::memory_order_acquire);
@@ -161,7 +164,7 @@ void MasteringChain::updateLimiterParameters() noexcept
 
 void MasteringChain::processInPlace (float* L, float* R, int numSamples) noexcept
 {
-    juce::ScopedNoDenormals noDenormals;
+    dusk::audio::ScopedNoDenormals noDenormals;
 
     jassert (numSamples <= preparedBlockSize);
     if (numSamples == 0) return;
@@ -181,7 +184,7 @@ void MasteringChain::processInPlace (float* L, float* R, int numSamples) noexcep
         updateCompParameters();
         for (int offset = 0; offset < numSamples; offset += bufSize)
         {
-            const int n = juce::jmin (bufSize, numSamples - offset);
+            const int n = std::min (bufSize, numSamples - offset);
             compStereoBuffer.copyFrom (0, 0, L + offset, n);
             compStereoBuffer.copyFrom (1, 0, R + offset, n);
             compMidi.clear();
@@ -220,11 +223,11 @@ void MasteringChain::processInPlace (float* L, float* R, int numSamples) noexcep
     if (paramsRef != nullptr)
     {
         const auto toDb = [] (float a) { return a > 1.0e-5f
-            ? juce::Decibels::gainToDecibels (a, -100.0f) : -100.0f; };
+            ? dusk::audio::gainToDecibels (a, -100.0f) : -100.0f; };
         paramsRef->meterPostMasterLDb.store (toDb (peakL), std::memory_order_relaxed);
         paramsRef->meterPostMasterRDb.store (toDb (peakR), std::memory_order_relaxed);
 
-        const float invN    = 1.0f / (float) juce::jmax (1, numSamples);
+        const float invN    = 1.0f / (float) std::max (1, numSamples);
         const float rmsBlkL = std::sqrt (sumSqL * invN);
         const float rmsBlkR = std::sqrt (sumSqR * invN);
         const float alpha   = (numSamples == meterBlockSize)

--- a/src/dsp/Metronome.cpp
+++ b/src/dsp/Metronome.cpp
@@ -1,9 +1,12 @@
 #include "Metronome.h"
-#include <juce_audio_basics/juce_audio_basics.h>
+#include "../foundation/Decibels.h"
+#include <algorithm>
 #include <cmath>
 
 namespace duskstudio
 {
+constexpr float kPi = 3.14159265358979323846f;
+
 void Metronome::prepare (double sampleRate)
 {
     sr = sampleRate;
@@ -48,8 +51,8 @@ void Metronome::process (std::int64_t playheadStart, bool transportRolling,
     const double samplesPerBeat = sr * 60.0 / (double) bpm;
     if (samplesPerBeat < 1.0) return;
 
-    const int   bpb  = juce::jmax (1, beatsPerBar.load (std::memory_order_relaxed));
-    const float vol  = juce::Decibels::decibelsToGain (
+    const int   bpb  = std::max (1, beatsPerBar.load (std::memory_order_relaxed));
+    const float vol  = dusk::audio::decibelsToGain (
                          volumeDb.load (std::memory_order_relaxed));
 
     auto triggerClick = [this, poly] (float freq)
@@ -85,7 +88,7 @@ void Metronome::process (std::int64_t playheadStart, bool transportRolling,
     {
         if (pos < 0 || pos >= length) return;
         const float t = (float) pos / (float) sr;
-        const int rampLen = juce::jmax (1, length / 4);
+        const int rampLen = std::max (1, length / 4);
         float env = 1.0f;
         if (pos < rampLen)
             env = (float) pos / (float) rampLen;
@@ -93,9 +96,7 @@ void Metronome::process (std::int64_t playheadStart, bool transportRolling,
             env = (float) (length - pos) / (float) rampLen;
 
         const float accent = (freq > 1000.0f) ? 1.4f : 1.0f;
-        const float s = std::sin (2.0f * juce::MathConstants<float>::pi
-                                   * freq * t)
-                         * env * vol * accent;
+        const float s = std::sin (2.0f * kPi * freq * t) * env * vol * accent;
         L_[i] += s;
         R_[i] += s;
         ++pos;

--- a/src/foundation/Decibels.h
+++ b/src/foundation/Decibels.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+
+// Decibel <-> linear-gain conversions, matching JUCE Decibels exactly
+// (0 dB = gain 1.0; any dB at/below minusInfinityDb maps to gain 0, and a gain
+// of 0 or below maps back to minusInfinityDb). Default floor -100 dB.
+namespace dusk::audio
+{
+template <typename T>
+inline T decibelsToGain (T decibels, T minusInfinityDb = T (-100)) noexcept
+{
+    return decibels > minusInfinityDb ? std::pow (T (10), decibels * T (0.05)) : T();
+}
+
+template <typename T>
+inline T gainToDecibels (T gain, T minusInfinityDb = T (-100)) noexcept
+{
+    return gain > T() ? std::max (minusInfinityDb, static_cast<T> (std::log10 (gain)) * T (20))
+                      : minusInfinityDb;
+}
+} // namespace dusk::audio

--- a/src/foundation/ScopedNoDenormals.h
+++ b/src/foundation/ScopedNoDenormals.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstdint>
+
+// RAII flush-to-zero / denormals-are-zero guard, matching JUCE ScopedNoDenormals:
+// snapshot the FP control register, enable FTZ+DAZ for the scope, restore on exit.
+// Prevents the CPU stalls that subnormal floats cause in audio DSP loops.
+#if defined(__SSE2__) || defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 1)
+ #include <xmmintrin.h>
+ #define DUSK_AUDIO_HAS_FTZ_SSE 1
+#elif defined(__aarch64__) || defined(_M_ARM64)
+ #define DUSK_AUDIO_HAS_FTZ_ARM64 1
+#endif
+
+namespace dusk::audio
+{
+class ScopedNoDenormals
+{
+public:
+    ScopedNoDenormals() noexcept
+    {
+#if defined(DUSK_AUDIO_HAS_FTZ_SSE)
+        saved = _mm_getcsr();
+        _mm_setcsr ((unsigned int) saved | 0x8040u);   // FTZ (0x8000) | DAZ (0x0040)
+#elif defined(DUSK_AUDIO_HAS_FTZ_ARM64)
+        std::uint64_t fpcr;
+        asm volatile ("mrs %0, fpcr" : "=r" (fpcr));
+        saved = fpcr;
+        asm volatile ("msr fpcr, %0" : : "r" (fpcr | (std::uint64_t (1) << 24)));   // FZ
+#endif
+    }
+
+    ~ScopedNoDenormals() noexcept
+    {
+#if defined(DUSK_AUDIO_HAS_FTZ_SSE)
+        _mm_setcsr ((unsigned int) saved);
+#elif defined(DUSK_AUDIO_HAS_FTZ_ARM64)
+        asm volatile ("msr fpcr, %0" : : "r" (saved));
+#endif
+    }
+
+    ScopedNoDenormals (const ScopedNoDenormals&)            = delete;
+    ScopedNoDenormals& operator= (const ScopedNoDenormals&) = delete;
+
+private:
+#if defined(DUSK_AUDIO_HAS_FTZ_SSE) || defined(DUSK_AUDIO_HAS_FTZ_ARM64)
+    std::uint64_t saved = 0;   // MXCSR (x86) / FPCR (arm64) snapshot
+#endif
+};
+} // namespace dusk::audio

--- a/src/foundation/SmoothedValue.h
+++ b/src/foundation/SmoothedValue.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <cmath>
+#include <limits>
+
+// Linear-ramp smoothed value, matching JUCE SmoothedValue<T,
+// ValueSmoothingTypes::Linear> exactly (the only smoothing type Dusk uses):
+// setTargetValue ramps currentValue toward target over the reset() step count,
+// one step per getNextValue(). reset()/setTargetValue()/getNextValue() semantics
+// are bit-for-bit the JUCE ones so the DSP behaviour is unchanged.
+namespace dusk::audio
+{
+namespace detail
+{
+// JUCE approximatelyEqual (finite: absolute floor of the smallest normal, or a
+// relative epsilon; non-finite: exact equality).
+template <typename T>
+inline bool approximatelyEqual (T a, T b) noexcept
+{
+    if (! (std::isfinite (a) && std::isfinite (b)))
+        return a == b;
+    const T diff = std::abs (a - b);
+    return diff <= std::numeric_limits<T>::min()
+        || diff <= std::numeric_limits<T>::epsilon() * std::max (std::abs (a), std::abs (b));
+}
+} // namespace detail
+
+template <typename FloatType>
+class SmoothedValue
+{
+public:
+    SmoothedValue() noexcept = default;
+    explicit SmoothedValue (FloatType initialValue) noexcept
+        : currentValue (initialValue), target (initialValue) {}
+
+    bool      isSmoothing()     const noexcept { return countdown > 0; }
+    FloatType getCurrentValue() const noexcept { return currentValue; }
+    FloatType getTargetValue()  const noexcept { return target; }
+
+    void setCurrentAndTargetValue (FloatType newValue) noexcept
+    {
+        target = currentValue = newValue;
+        countdown = 0;
+    }
+
+    void reset (double sampleRate, double rampLengthInSeconds) noexcept
+    {
+        reset ((int) std::floor (rampLengthInSeconds * sampleRate));
+    }
+
+    void reset (int numSteps) noexcept
+    {
+        stepsToTarget = numSteps;
+        setCurrentAndTargetValue (target);
+    }
+
+    void setTargetValue (FloatType newValue) noexcept
+    {
+        if (detail::approximatelyEqual (newValue, target))
+            return;
+        if (stepsToTarget <= 0)
+        {
+            setCurrentAndTargetValue (newValue);
+            return;
+        }
+        target = newValue;
+        countdown = stepsToTarget;
+        step = (target - currentValue) / (FloatType) countdown;
+    }
+
+    FloatType getNextValue() noexcept
+    {
+        if (! isSmoothing())
+            return target;
+        --countdown;
+        if (isSmoothing()) currentValue += step;
+        else               currentValue = target;
+        return currentValue;
+    }
+
+    FloatType skip (int numSamples) noexcept
+    {
+        if (numSamples >= countdown)
+        {
+            setCurrentAndTargetValue (target);
+            return target;
+        }
+        currentValue += step * (FloatType) numSamples;
+        countdown -= numSamples;
+        return currentValue;
+    }
+
+private:
+    FloatType currentValue = 0, target = 0, step = 0;
+    int countdown = 0, stepsToTarget = 0;
+};
+} // namespace dusk::audio

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -123,6 +123,7 @@ target_sources(dusk-studio-tests PRIVATE
     foundation_fs.cpp
     foundation_special_locations.cpp
     foundation_json.cpp
+    foundation_audio_math.cpp
     lv2_state_paths.cpp)
 
 # Phase 1a de-JUCE: JUCE-free audio file I/O (libsndfile backend), test-only for

--- a/tests/foundation_audio_math.cpp
+++ b/tests/foundation_audio_math.cpp
@@ -1,0 +1,87 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "foundation/Decibels.h"
+#include "foundation/ScopedNoDenormals.h"
+#include "foundation/SmoothedValue.h"
+
+#include <juce_audio_basics/juce_audio_basics.h>
+
+#include <limits>
+
+using Catch::Matchers::WithinAbs;
+using Catch::Matchers::WithinRel;
+
+TEST_CASE ("dusk::audio decibels match juce::Decibels", "[foundation][audio]")
+{
+    for (float db : { -120.f, -100.f, -80.f, -60.f, -12.f, -6.f, 0.f, 6.f, 12.f, 24.f })
+        REQUIRE_THAT (dusk::audio::decibelsToGain (db),
+                      WithinAbs (juce::Decibels::decibelsToGain (db), 0.0f));
+
+    for (float g : { 0.f, 1e-6f, 0.001f, 0.5f, 1.f, 2.f, 4.f })
+        REQUIRE_THAT (dusk::audio::gainToDecibels (g),
+                      WithinAbs (juce::Decibels::gainToDecibels (g), 0.0f));
+
+    // Custom -infinity floor, and the below-floor / zero-gain edges.
+    REQUIRE_THAT (dusk::audio::decibelsToGain (-90.f, -80.f),
+                  WithinAbs (juce::Decibels::decibelsToGain (-90.f, -80.f), 0.0f));
+    REQUIRE_THAT (dusk::audio::gainToDecibels (0.f, -80.f),
+                  WithinAbs (juce::Decibels::gainToDecibels (0.f, -80.f), 0.0f));
+}
+
+TEST_CASE ("dusk::audio::SmoothedValue matches juce (linear)", "[foundation][audio]")
+{
+    dusk::audio::SmoothedValue<float> d;
+    juce::SmoothedValue<float>        j;
+
+    d.reset (48000.0, 0.02);
+    j.reset (48000.0, 0.02);
+    d.setCurrentAndTargetValue (0.f);
+    j.setCurrentAndTargetValue (0.f);
+
+    d.setTargetValue (1.f);
+    j.setTargetValue (1.f);
+    REQUIRE (d.isSmoothing() == j.isSmoothing());
+
+    for (int i = 0; i < 2000; ++i)
+        REQUIRE_THAT (d.getNextValue(), WithinAbs (j.getNextValue(), 0.0f));
+
+    REQUIRE_THAT (d.getCurrentValue(), WithinAbs (j.getCurrentValue(), 0.0f));
+    REQUIRE_THAT (d.getTargetValue(),  WithinAbs (j.getTargetValue(),  0.0f));
+
+    SECTION ("retarget mid-ramp")
+    {
+        d.setTargetValue (1.f);  j.setTargetValue (1.f);
+        for (int i = 0; i < 300; ++i) { d.getNextValue(); j.getNextValue(); }
+        d.setTargetValue (0.3f); j.setTargetValue (0.3f);
+        for (int i = 0; i < 500; ++i)
+            REQUIRE_THAT (d.getNextValue(), WithinAbs (j.getNextValue(), 0.0f));
+    }
+
+    SECTION ("skip matches")
+    {
+        d.setTargetValue (0.9f); j.setTargetValue (0.9f);
+        REQUIRE_THAT (d.skip (100), WithinAbs (j.skip (100), 0.0f));
+    }
+}
+
+TEST_CASE ("dusk::audio::ScopedNoDenormals flushes subnormals", "[foundation][audio]")
+{
+#if defined(DUSK_AUDIO_HAS_FTZ_SSE) || defined(DUSK_AUDIO_HAS_FTZ_ARM64)
+    volatile float subnormal = std::numeric_limits<float>::min() / 4.0f;
+    REQUIRE (subnormal > 0.0f);   // a genuine nonzero subnormal without the guard
+
+    {
+        dusk::audio::ScopedNoDenormals guard;
+        volatile float x = subnormal;
+        volatile float y = x * 0.5f;   // subnormal result is flushed to zero
+        REQUIRE_THAT ((float) y, WithinAbs (0.0f, 0.0f));
+    }
+
+    // Restored on scope exit: subnormal arithmetic is representable again.
+    volatile float z = subnormal * 0.5f;
+    REQUIRE (z > 0.0f);
+#else
+    SUCCEED ("no flush-to-zero support on this platform");
+#endif
+}

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -14,11 +14,9 @@ src/dsp/LoudnessMeter.cpp
 src/dsp/LoudnessMeter.h
 src/dsp/MasterBus.cpp
 src/dsp/MasterBus.h
-src/dsp/MasteringChain.cpp
 src/dsp/MasteringChain.h
 src/dsp/MasteringDigitalEq.cpp
 src/dsp/MasteringDigitalEq.h
-src/dsp/Metronome.cpp
 src/engine/AtomicPark.h
 src/engine/AudioEngine.cpp
 src/engine/AudioEngine.h


### PR DESCRIPTION
## De-JUCE: audio-math primitives

Starts the audio-math tower. Ratchet gate 228 -> 226.

### Additive foundation (`dusk::audio`)
- `Decibels.h` — `decibelsToGain` / `gainToDecibels`, exact JUCE semantics
  (0 dB = gain 1.0, -100 dB floor).
- `SmoothedValue.h` — linear-ramp `SmoothedValue<T>`, bit-for-bit the JUCE
  `ValueSmoothingTypes::Linear` path (including the `approximatelyEqual`
  early-out).
- `ScopedNoDenormals.h` — FTZ|DAZ RAII guard (x86 MXCSR `0x8040`, arm64 FPCR
  FZ), matching `juce::ScopedNoDenormals`.

Each is A/B-tested against its JUCE counterpart (`tests/foundation_audio_math.cpp`).

### Consumers migrated off the ratchet
- `MasteringChain.cpp` and `Metronome.cpp` swap `juce::Decibels` /
  `juce::ScopedNoDenormals` / `jmax` / `jmin` / `MathConstants::pi` for the
  `dusk::audio` + std equivalents, dropping their last JUCE tokens.

The wider swap into still-JUCE-coupled files (String / dsp / AudioProcessor)
is deferred: it moves no ratchet line and adds RT-DSP risk with no metric gain.

### Verification
- App builds clean (zero new warnings)
- 340/340 tests pass (adds the audio-math A/B suite; `metronome_click`
  exercises the migrated path)
- `tools/juce-gate.sh` exit 0 (226)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio utility helpers for decibel/gain conversion, denormal-safe processing, and smooth value ramping.
  * Added automated tests covering audio math, smoothing behavior, and denormal handling.

* **Bug Fixes**
  * Updated mastering and metronome processing to use consistent standard audio/math behavior.
  * Improved numerical handling in level calculations and sample clamping.

* **Tests**
  * Expanded test coverage for audio foundation utilities and DSP edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->