### PR TITLE
De-JUCE: String-leaf batch (Lv2Scanner + MarkerEditActions)

### DIFF
--- a/src/engine/lv2/Lv2Scanner.cpp
+++ b/src/engine/lv2/Lv2Scanner.cpp
@@ -23,7 +23,7 @@ std::vector<ScannedLv2> Lv2Scanner::scan()
         char* bundleDir = lilv_file_uri_parse (lilv_node_as_uri (bundleUri), nullptr);
         if (bundleDir == nullptr) continue;
 
-        found.push_back ({ juce::String (juce::CharPointer_UTF8 (bundleDir)),
+        found.push_back ({ std::string (bundleDir),
                            Lv2Bundle::describePlugin (world, p) });
         lilv_free (bundleDir);
     }

--- a/src/engine/lv2/Lv2Scanner.h
+++ b/src/engine/lv2/Lv2Scanner.h
@@ -2,8 +2,7 @@
 
 #include "Lv2Bundle.h"
 
-#include <juce_core/juce_core.h>
-
+#include <string>
 #include <vector>
 
 namespace duskstudio::lv2
@@ -11,7 +10,7 @@ namespace duskstudio::lv2
 // One discoverable LV2 plugin: the bundle directory it lives in plus its descriptor.
 struct ScannedLv2
 {
-    juce::String bundlePath;   // absolute path to the .lv2 bundle directory
+    std::string  bundlePath;   // absolute path to the .lv2 bundle directory
     PluginDesc   desc;
 };
 

--- a/src/session/MarkerEditActions.cpp
+++ b/src/session/MarkerEditActions.cpp
@@ -13,12 +13,12 @@ void sortMarkers (Session& s)
         { return a.timelineSamples < b.timelineSamples; });
 }
 
-int findMarkerByNameAt (Session& s, const juce::String& name, std::int64_t atSamples)
+int findMarkerByNameAt (Session& s, const std::string& name, std::int64_t atSamples)
 {
     const auto& m = s.getMarkers();
     for (int i = 0; i < (int) m.size(); ++i)
         if (m[(size_t) i].timelineSamples == atSamples
-            && m[(size_t) i].name == name)
+            && m[(size_t) i].name == name.c_str())
             return i;
     return -1;
 }
@@ -26,7 +26,7 @@ int findMarkerByNameAt (Session& s, const juce::String& name, std::int64_t atSam
 
 // ── AddMarkerAction ───────────────────────────────────────────────────────
 
-AddMarkerAction::AddMarkerAction (Session& s, std::int64_t t, juce::String n)
+AddMarkerAction::AddMarkerAction (Session& s, std::int64_t t, std::string n)
     : session (s), timelineSamples (t), name (std::move (n))
 {}
 
@@ -36,9 +36,9 @@ bool AddMarkerAction::perform()
     // Capture the auto-generated name on the FIRST perform so undo knows
     // exactly which marker to remove if the user added more in between.
     if (insertedIdx >= 0 && insertedIdx < (int) session.getMarkers().size()
-        && name.isEmpty())
+        && name.empty())
     {
-        name = session.getMarkers()[(size_t) insertedIdx].name;
+        name = session.getMarkers()[(size_t) insertedIdx].name.toStdString();
     }
     return insertedIdx >= 0;
 }
@@ -81,7 +81,7 @@ bool RemoveMarkerAction::undo()
 
 // ── MoveMarkerAction ──────────────────────────────────────────────────────
 
-MoveMarkerAction::MoveMarkerAction (Session& s, juce::String n,
+MoveMarkerAction::MoveMarkerAction (Session& s, std::string n,
                                       std::int64_t from, std::int64_t to)
     : session (s), name (std::move (n)), fromSamples (from), toSamples (to)
 {}

--- a/src/session/MarkerEditActions.h
+++ b/src/session/MarkerEditActions.h
@@ -3,6 +3,8 @@
 #include <juce_data_structures/juce_data_structures.h>
 #include "Session.h"
 
+#include <string>
+
 namespace duskstudio
 {
 // UndoableActions for the marker timeline. Mirrors the shape of
@@ -14,7 +16,7 @@ class AddMarkerAction final : public juce::UndoableAction
 {
 public:
     AddMarkerAction (Session& session, std::int64_t timelineSamples,
-                       juce::String name = {});
+                       std::string name = {});
 
     bool perform() override;
     bool undo()    override;
@@ -27,7 +29,7 @@ public:
 private:
     Session&     session;
     std::int64_t  timelineSamples;
-    juce::String name;
+    std::string  name;
     int          insertedIdx = -1;
 };
 
@@ -57,7 +59,7 @@ private:
 class MoveMarkerAction final : public juce::UndoableAction
 {
 public:
-    MoveMarkerAction (Session& session, juce::String markerName,
+    MoveMarkerAction (Session& session, std::string markerName,
                         std::int64_t fromTimelineSamples,
                         std::int64_t toTimelineSamples);
 
@@ -67,7 +69,7 @@ public:
 
 private:
     Session&     session;
-    juce::String name;
+    std::string  name;
     std::int64_t  fromSamples;
     std::int64_t  toSamples;
 };

--- a/src/ui/TapeStrip.cpp
+++ b/src/ui/TapeStrip.cpp
@@ -1946,7 +1946,7 @@ void TapeStrip::mouseUp (const juce::MouseEvent& e)
             auto& mks = session.getMarkers();
             const auto& m = mks[(size_t) markerDrag.index];
             const auto toSamples = m.timelineSamples;
-            const auto name      = m.name;
+            const std::string name = m.name.toStdString();
 
             // Re-sort by timelineSamples so the painter still iterates
             // left-to-right after the drag.

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -79,8 +79,6 @@ src/engine/ipc/PluginIpc.h
 src/engine/ipc/PluginScanProtocol.h
 src/engine/ipc/RemotePluginConnection.cpp
 src/engine/ipc/RemotePluginConnection.h
-src/engine/lv2/Lv2Scanner.cpp
-src/engine/lv2/Lv2Scanner.h
 src/engine/multisample/AriaBank.cpp
 src/engine/multisample/AriaBank.h
 src/engine/multisample/AriaGui.cpp
@@ -93,7 +91,6 @@ src/engine/multisample/Sf2Reader.cpp
 src/engine/multisample/Sf2Reader.h
 src/engine/multisample/Sf2ToSfz.cpp
 src/engine/multisample/Sf2ToSfz.h
-src/session/MarkerEditActions.cpp
 src/session/MarkerEditActions.h
 src/session/MidiBindings.cpp
 src/session/MidiBindings.h


### PR DESCRIPTION
Swaps `juce::String`/`CharPointer_UTF8` to `std::string` in the three units whose only JUCE coupling was the string type, taking the juce-gate ratchet **226 → 223**.

## Files off the ratchet
- `src/engine/lv2/Lv2Scanner.{h,cpp}` — `ScannedLv2::bundlePath` is now `std::string`; the lilv UTF-8 `char*` goes straight into it. Mirrors the already-migrated ClapScanner/Vst3Scanner. `PluginManager` bridges to the `juce::String` `joinNativeIdentifier` param by implicit conversion.
- `src/session/MarkerEditActions.cpp` — marker-name params/members are `std::string`. The `.h` stays coupled (extends `juce::UndoableAction`) and remains on the allowlist. Name comparison against the `juce::String Marker::name` uses the `const char*` `operator==` overload; the auto-name capture bridges via `toStdString()`.
- `src/ui/TapeStrip.cpp` — drag-end name capture bridges with `toStdString()`.

## Verification
- juce-gate: 223, exit 0
- app build: clean
- tests: 340/340 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency when scanning LV2 plugins and handling their bundle paths.
  * Updated marker creation and movement workflows for more reliable name handling.
  * Preserved existing marker drag, undo, sorting, and plugin discovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->