### PR TITLE
De-JUCE: own integer delay line, flip HardwareInsertSlot clean

### DIFF
--- a/src/dsp/HardwareInsertSlot.cpp
+++ b/src/dsp/HardwareInsertSlot.cpp
@@ -1,10 +1,15 @@
 #include "HardwareInsertSlot.h"
 #include "../session/Session.h"
+#include "../foundation/Decibels.h"
+#include "../foundation/ScopedNoDenormals.h"
 
+#include <algorithm>
 #include <cmath>
 
 namespace duskstudio
 {
+namespace { constexpr double kPi = 3.141592653589793238; }
+
 HardwareInsertSlot::HardwareInsertSlot() = default;
 HardwareInsertSlot::~HardwareInsertSlot() = default;
 
@@ -13,19 +18,10 @@ void HardwareInsertSlot::prepare (double sampleRate, int blockSize)
     prepSampleRate = sampleRate;
     prepBlockSize  = blockSize;
 
-    juce::dsp::ProcessSpec spec;
-    spec.sampleRate       = sampleRate;
-    spec.maximumBlockSize = (std::uint32_t) blockSize;
-    spec.numChannels      = 1;
-
-    dryDelayL.prepare (spec);
-    dryDelayR.prepare (spec);
     dryDelayL.setMaximumDelayInSamples (kMaxDelaySamples);
     dryDelayR.setMaximumDelayInSamples (kMaxDelaySamples);
-    dryDelayL.reset();
-    dryDelayR.reset();
-    dryDelayL.setDelay (0.0f);
-    dryDelayR.setDelay (0.0f);
+    dryDelayL.setDelay (0);
+    dryDelayR.setDelay (0);
 
     // Ping calibration buffers. Chirp is pre-rendered at session SR so
     // the audio thread never builds a sine table in-callback. Capture
@@ -74,29 +70,29 @@ void HardwareInsertSlot::renderChirp (double sampleRate)
     // don't read as Diracs to the hardware's input stage. Pre-computed
     // sum of the squared samples seeds the auto-correlation peak used
     // by the result-threshold check.
-    const int targetLen = juce::jmin (kChirpMaxSamples,
-                                        (int) std::lround (0.100 * sampleRate));
-    chirpLength = juce::jmax (64, targetLen);
+    const int targetLen = std::min (kChirpMaxSamples,
+                                      (int) std::lround (0.100 * sampleRate));
+    chirpLength = std::max (64, targetLen);
 
     const double f0 = 20.0;
     const double f1 = 20000.0;
     const double duration = (double) chirpLength / sampleRate;
     const double sweepRate = (f1 - f0) / duration;
     constexpr float peak = 0.2512f;   // -12 dBFS
-    const int fadeSamples = juce::jmin (chirpLength / 4,
-                                          (int) std::lround (0.005 * sampleRate));
+    const int fadeSamples = std::min (chirpLength / 4,
+                                        (int) std::lround (0.005 * sampleRate));
 
     pingAutoPeak = 0.0f;
     for (int i = 0; i < chirpLength; ++i)
     {
         const double t = (double) i / sampleRate;
-        const double phase = 2.0 * juce::MathConstants<double>::pi
+        const double phase = 2.0 * kPi
                                 * (f0 * t + 0.5 * sweepRate * t * t);
         float s = peak * (float) std::sin (phase);
 
         if (i < fadeSamples)
         {
-            const float w = 0.5f * (1.0f - std::cos (juce::MathConstants<float>::pi
+            const float w = 0.5f * (1.0f - std::cos ((float) kPi
                                                        * (float) i / (float) fadeSamples));
             s *= w;
         }
@@ -107,7 +103,7 @@ void HardwareInsertSlot::renderChirp (double sampleRate)
             // the last sample of the tail (at i = chirpLength - 1) was
             // outside both branches and stayed at full amplitude.
             const int j = chirpLength - i;
-            const float w = 0.5f * (1.0f - std::cos (juce::MathConstants<float>::pi
+            const float w = 0.5f * (1.0f - std::cos ((float) kPi
                                                        * (float) j / (float) fadeSamples));
             s *= w;
         }
@@ -155,7 +151,7 @@ void HardwareInsertSlot::processStereoBlock (float* L, float* R, int numSamples,
                                                 float* const*       deviceOutputs,
                                                 int numDeviceOutputs) noexcept
 {
-    juce::ScopedNoDenormals nd;
+    dusk::audio::ScopedNoDenormals nd;
     if (paramsRef == nullptr || L == nullptr || R == nullptr || numSamples <= 0)
         return;
 
@@ -169,23 +165,23 @@ void HardwareInsertSlot::processStereoBlock (float* L, float* R, int numSamples,
     // Update the dry-path delay length when the user changes the latency
     // setpoint. The delay line was pre-sized to kMaxDelaySamples in
     // prepare(), so setDelay() is a parameter update only - no realloc.
-    const int requestedLatency = juce::jlimit (0, kMaxDelaySamples,
-                                                  routing.latencySamples);
+    const int requestedLatency = std::clamp (routing.latencySamples,
+                                                0, kMaxDelaySamples);
     const int previousLatency = cachedLatencySamples.load (std::memory_order_relaxed);
     if (requestedLatency != previousLatency)
     {
         cachedLatencySamples.store (requestedLatency, std::memory_order_relaxed);
-        dryDelayL.setDelay ((float) requestedLatency);
-        dryDelayR.setDelay ((float) requestedLatency);
+        dryDelayL.setDelay (requestedLatency);
+        dryDelayR.setDelay (requestedLatency);
     }
 
     // Pull the latest knob values onto the smoother targets.
     const float outDb = paramsRef->outputGainDb.load (std::memory_order_relaxed);
     const float inDb  = paramsRef->inputGainDb .load (std::memory_order_relaxed);
     const float dw    = paramsRef->dryWet      .load (std::memory_order_relaxed);
-    outGainLin  .setTargetValue (juce::Decibels::decibelsToGain (outDb));
-    inGainLin   .setTargetValue (juce::Decibels::decibelsToGain (inDb));
-    dryWetSmooth.setTargetValue (juce::jlimit (0.0f, 1.0f, dw));
+    outGainLin  .setTargetValue (dusk::audio::decibelsToGain (outDb));
+    inGainLin   .setTargetValue (dusk::audio::decibelsToGain (inDb));
+    dryWetSmooth.setTargetValue (std::clamp (dw, 0.0f, 1.0f));
 
     const bool midSide = (routing.format == 1);
 
@@ -207,8 +203,8 @@ void HardwareInsertSlot::processStereoBlock (float* L, float* R, int numSamples,
     // capture finishes.
     if (pingState == PingState::Correlating)
     {
-        const int chirpLen = juce::jmin (chirpLength, (int) chirpBuffer.size());
-        const int maxK = juce::jmax (0, (int) captureBuffer.size() - chirpLen);
+        const int chirpLen = std::min (chirpLength, (int) chirpBuffer.size());
+        const int maxK = std::max (0, (int) captureBuffer.size() - chirpLen);
         int kCount = 0;
         while (pingCorrelateK < maxK && kCount < kCorrelationsPerBlock)
         {
@@ -265,10 +261,10 @@ void HardwareInsertSlot::processStereoBlock (float* L, float* R, int numSamples,
         // Phase-align the dry copy with the wet return. The hardware
         // takes `latency` samples to round-trip the audio; we delay
         // the dry by the same amount so the dry/wet mix is coherent.
-        dryDelayL.pushSample (0, drySrcL);
-        dryDelayR.pushSample (0, drySrcR);
-        const float dryL = dryDelayL.popSample (0);
-        const float dryR = dryDelayR.popSample (0);
+        dryDelayL.pushSample (drySrcL);
+        dryDelayR.pushSample (drySrcR);
+        const float dryL = dryDelayL.popSample();
+        const float dryR = dryDelayR.popSample();
 
         // Encode the SEND. Mid/Side uses 0.5 scaling on encode so the
         // matching decode below (which sums M+S and M-S unscaled)

--- a/src/dsp/HardwareInsertSlot.h
+++ b/src/dsp/HardwareInsertSlot.h
@@ -1,14 +1,15 @@
 #pragma once
 
-#include <juce_audio_basics/juce_audio_basics.h>
-#include <juce_dsp/juce_dsp.h>
+#include "../foundation/IntDelayLine.h"
+#include "../foundation/SmoothedValue.h"
+
 #include <atomic>
 #include <vector>
 
 namespace duskstudio
 {
 // HardwareInsertParams / Routing live in Session.h. Forward declared
-// here so juce_dsp doesn't leak into Session.h.
+// here so the header doesn't pull in Session.h.
 struct HardwareInsertParams;
 struct HardwareInsertRouting;
 
@@ -77,14 +78,12 @@ private:
     double prepSampleRate = 0.0;
     int    prepBlockSize  = 0;
 
-    juce::dsp::DelayLine<float, juce::dsp::DelayLineInterpolationTypes::None>
-        dryDelayL { kMaxDelaySamples };
-    juce::dsp::DelayLine<float, juce::dsp::DelayLineInterpolationTypes::None>
-        dryDelayR { kMaxDelaySamples };
+    dusk::audio::IntDelayLine dryDelayL;
+    dusk::audio::IntDelayLine dryDelayR;
 
-    juce::SmoothedValue<float> outGainLin;
-    juce::SmoothedValue<float> inGainLin;
-    juce::SmoothedValue<float> dryWetSmooth;
+    dusk::audio::SmoothedValue<float> outGainLin;
+    dusk::audio::SmoothedValue<float> inGainLin;
+    dusk::audio::SmoothedValue<float> dryWetSmooth;
 
     std::atomic<int> cachedLatencySamples { 0 };
 

--- a/src/foundation/IntDelayLine.h
+++ b/src/foundation/IntDelayLine.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <algorithm>
+#include <vector>
+
+// Single-channel integer delay line, bit-for-bit equivalent to JUCE
+// dsp::DelayLine<float, DelayLineInterpolationTypes::None>: setDelay truncates
+// to whole samples (floor), push writes at the write head and decrements it
+// mod totalSize, pop reads at (readPos + delayInt) mod totalSize and decrements
+// readPos the same way. totalSize = max(4, maxDelay + 2) matches JUCE so the
+// index arithmetic — and therefore the delayed output — is identical. JUCE's
+// DelayLine is per-instance-multichannel; Dusk only ever uses one channel per
+// instance, so this drops the channel argument.
+namespace dusk::audio
+{
+class IntDelayLine
+{
+public:
+    void setMaximumDelayInSamples (int maxDelay) noexcept
+    {
+        totalSize = std::max (4, maxDelay + 2);
+        buffer.assign ((size_t) totalSize, 0.0f);
+        reset();
+    }
+
+    void setDelay (int newDelayInSamples) noexcept
+    {
+        delayInt = std::clamp (newDelayInSamples, 0, totalSize - 2);
+    }
+
+    void reset() noexcept
+    {
+        std::fill (buffer.begin(), buffer.end(), 0.0f);
+        writePos = 0;
+        readPos  = 0;
+    }
+
+    void pushSample (float sample) noexcept
+    {
+        buffer[(size_t) writePos] = sample;
+        writePos = (writePos + totalSize - 1) % totalSize;
+    }
+
+    float popSample() noexcept
+    {
+        const float result = buffer[(size_t) ((readPos + delayInt) % totalSize)];
+        readPos = (readPos + totalSize - 1) % totalSize;
+        return result;
+    }
+
+private:
+    std::vector<float> buffer;
+    int totalSize = 4;
+    int writePos  = 0;
+    int readPos   = 0;
+    int delayInt  = 0;
+};
+} // namespace dusk::audio

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -124,6 +124,7 @@ target_sources(dusk-studio-tests PRIVATE
     foundation_special_locations.cpp
     foundation_json.cpp
     foundation_audio_math.cpp
+    foundation_int_delay_line.cpp
     lv2_state_paths.cpp)
 
 # Phase 1a de-JUCE: JUCE-free audio file I/O (libsndfile backend), test-only for

--- a/tests/foundation_int_delay_line.cpp
+++ b/tests/foundation_int_delay_line.cpp
@@ -1,0 +1,76 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "foundation/IntDelayLine.h"
+
+#include <juce_dsp/juce_dsp.h>
+
+#include <random>
+#include <vector>
+
+// Ground-truth A/B: dusk::audio::IntDelayLine must produce bit-identical output
+// to juce::dsp::DelayLine<float, None> for every delay in the used range.
+namespace
+{
+using JuceDelay = juce::dsp::DelayLine<float, juce::dsp::DelayLineInterpolationTypes::None>;
+
+void primeJuce (JuceDelay& j, int maxDelay, int blockSize)
+{
+    juce::dsp::ProcessSpec spec;
+    spec.sampleRate       = 48000.0;
+    spec.maximumBlockSize = (std::uint32_t) blockSize;
+    spec.numChannels      = 1;
+    j.prepare (spec);
+    j.setMaximumDelayInSamples (maxDelay);
+    j.reset();
+}
+} // namespace
+
+TEST_CASE ("IntDelayLine matches juce::dsp::DelayLine<None>", "[foundation][dsp]")
+{
+    constexpr int maxDelay = 16384;
+
+    std::mt19937 rng (0xD05C);
+    std::uniform_real_distribution<float> dist (-1.0f, 1.0f);
+    std::vector<float> input (4096);
+    for (auto& s : input) s = dist (rng);
+
+    for (int delay : { 0, 1, 2, 3, 100, 4095, 4096, 16384 })
+    {
+        dusk::audio::IntDelayLine d;
+        d.setMaximumDelayInSamples (maxDelay);
+        d.setDelay (delay);
+
+        JuceDelay j;
+        primeJuce (j, maxDelay, (int) input.size());
+        j.setDelay ((float) delay);
+
+        for (float x : input)
+        {
+            d.pushSample (x);
+            j.pushSample (0, x);
+            REQUIRE (d.popSample() == j.popSample (0));
+        }
+    }
+}
+
+TEST_CASE ("IntDelayLine reset clears history like juce", "[foundation][dsp]")
+{
+    constexpr int maxDelay = 256;
+    dusk::audio::IntDelayLine d;
+    JuceDelay j;
+    d.setMaximumDelayInSamples (maxDelay);
+    primeJuce (j, maxDelay, 64);
+    d.setDelay (100);
+    j.setDelay (100.0f);
+
+    for (int i = 0; i < 50; ++i) { d.pushSample (1.0f); j.pushSample (0, 1.0f); d.popSample(); j.popSample (0); }
+    d.reset();
+    j.reset();
+
+    for (int i = 0; i < maxDelay; ++i)
+    {
+        d.pushSample (0.0f);
+        j.pushSample (0, 0.0f);
+        REQUIRE (d.popSample() == j.popSample (0));
+    }
+}

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -8,8 +8,6 @@ src/dsp/BusStrip.cpp
 src/dsp/BusStrip.h
 src/dsp/ChannelStrip.cpp
 src/dsp/ChannelStrip.h
-src/dsp/HardwareInsertSlot.cpp
-src/dsp/HardwareInsertSlot.h
 src/dsp/LoudnessMeter.cpp
 src/dsp/LoudnessMeter.h
 src/dsp/MasterBus.cpp


### PR DESCRIPTION
First `src/dsp` file off the juce-gate. Starts the `juce::dsp` tower.

## What
- **`src/foundation/IntDelayLine.h`** — new `dusk::audio::IntDelayLine`, a single-channel integer delay line **bit-for-bit equivalent** to `juce::dsp::DelayLine<float, None>`: same `totalSize = max(4, maxDelay+2)`, same write/read pointer decrement-mod arithmetic, floor-truncated delay. Header-only.
- **`tests/foundation_int_delay_line.cpp`** — A/B vs the JUCE type over the used delay range (0…16384) + across `reset()`. Bit-exact (`==`, not tolerance).
- **`HardwareInsertSlot.{h,cpp}`** — swaps both dry-path delay lines onto `IntDelayLine`, and its smoothers / decibel / denormal / min-max helpers onto the existing `dusk::audio` primitives + `std`. Drops `juce_dsp` + `juce_audio_basics`.

## Why this file first
Of every `juce::dsp` user, `HardwareInsertSlot` is the only one whose ratchet win needs **no oversampler swap** — it uses only an integer `DelayLine`, which is null-exact. The remaining `src/dsp` files all gate on the oversampler (a genuine sound/latency change), handled in later phases.

## Verification
- juce-gate: 226 → **224**, exit 0
- app build: clean
- tests: **342/342** (+2 new)
- Output unchanged: integer delay is null-exact; the other primitives were already A/B-proven.

Branched off `main` (pre-#48); files are disjoint from #48, rebases cleanly after it merges.