### PR TITLE
De-JUCE: stereo block oversampler + flip BrickwallLimiter

### DIFF
--- a/src/dsp/BrickwallLimiter.cpp
+++ b/src/dsp/BrickwallLimiter.cpp
@@ -1,11 +1,24 @@
 #include "BrickwallLimiter.h"
+#include "../foundation/Decibels.h"
+#include "../foundation/ScopedNoDenormals.h"
+
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 namespace duskstudio
 {
 namespace
 {
+// JUCE approximatelyEqual, finite path (drive / release-ms are always finite):
+// relative epsilon, or an absolute floor at the smallest normal.
+bool approximatelyEqual (float a, float b) noexcept
+{
+    const float diff = std::abs (a - b);
+    return diff <= std::numeric_limits<float>::min()
+        || diff <= std::numeric_limits<float>::epsilon() * std::max (std::abs (a), std::abs (b));
+}
+
 inline float onePoleCoef (float timeMs, double rate) noexcept
 {
     const float t = timeMs * 0.001f * (float) rate;
@@ -30,21 +43,17 @@ void BrickwallLimiter::prepare (double sampleRate, int maxBlockSize, double init
     osFactor = 4;
     osRate   = sr * (double) osFactor;
 
-    const int bs     = juce::jmax (1, maxBlockSize);
-    const int stages = 2;   // two 2x stages = 4x
+    const int bs = std::max (1, maxBlockSize);
 
-    // Linear-phase FIR so the limiter doesn't smear transients with phase
-    // distortion; integer latency keeps delay compensation exact.
-    oversampler = std::make_unique<juce::dsp::Oversampling<float>> (
-        2, (size_t) stages,
-        juce::dsp::Oversampling<float>::filterHalfBandFIREquiripple,
-        true /*max quality*/, true /*integer latency*/);
-    oversampler->initProcessing ((size_t) bs);
-    oversampler->reset();
+    // Linear-phase halfband FIR so the limiter doesn't smear transients with
+    // phase distortion; the group delay is a whole number of base-rate samples
+    // so delay compensation stays exact.
+    oversampler.setFactor (osFactor);
+    oversampler.prepare (bs);
 
     // Size the delay + deque for the MAX lookahead; the active read offset is
     // set below (and re-settable at runtime) within this allocation.
-    maxLookaheadOs = juce::jmax (1, (int) (osRate * kMaxLookaheadMs / 1000.0));
+    maxLookaheadOs = std::max (1, (int) (osRate * kMaxLookaheadMs / 1000.0));
     bufLen         = maxLookaheadOs + 1;
     delayL.assign ((size_t) bufLen, 0.0f);
     delayR.assign ((size_t) bufLen, 0.0f);
@@ -62,7 +71,7 @@ void BrickwallLimiter::prepare (double sampleRate, int maxBlockSize, double init
     }
     sampleCounter = 0;
 
-    holdOs        = juce::jmax (0, (int) (osRate * 5.0 / 1000.0));   // default (Modern)
+    holdOs        = std::max (0, (int) (osRate * 5.0 / 1000.0));   // default (Modern)
     lastReleaseMs = -1.0f;   // force release/hold recompute on first block
     lastMode      = -1;
     {
@@ -72,9 +81,9 @@ void BrickwallLimiter::prepare (double sampleRate, int maxBlockSize, double init
     }
     relDepthCoef  = onePoleCoef (kRelDepthTrackMs, osRate);
 
-    osLatencyBase = (int) std::lround (oversampler->getLatencyInSamples());
+    osLatencyBase = (int) std::lround (oversampler.latency());
     const float la0 = std::isfinite ((float) initialLookaheadMs) ? (float) initialLookaheadMs : 2.0f;
-    lookaheadMs.store (juce::jlimit (kMinLookaheadMs, kMaxLookaheadMs, la0), std::memory_order_relaxed);
+    lookaheadMs.store (std::clamp (la0, kMinLookaheadMs, kMaxLookaheadMs), std::memory_order_relaxed);
     recomputeActiveLookahead();
     lastActiveLaOs = activeLookaheadOs.load (std::memory_order_relaxed);
 
@@ -87,7 +96,7 @@ void BrickwallLimiter::setLookaheadMs (float ms) noexcept
     // compares false against both bounds) and recomputeActiveLookahead would
     // then cast NaN to int — undefined. Ignore garbage, keep the last value.
     if (! std::isfinite (ms)) return;
-    lookaheadMs.store (juce::jlimit (kMinLookaheadMs, kMaxLookaheadMs, ms), std::memory_order_relaxed);
+    lookaheadMs.store (std::clamp (ms, kMinLookaheadMs, kMaxLookaheadMs), std::memory_order_relaxed);
     recomputeActiveLookahead();
 }
 
@@ -99,9 +108,9 @@ void BrickwallLimiter::recomputeActiveLookahead() noexcept
     // oversampled count from it. This keeps laOs an exact multiple of osFactor,
     // so the reported latency (lookaheadBase, base samples) equals the delay
     // actually applied (laOs / osFactor) — no sub-sample drift between them.
-    const int maxLookaheadBase = juce::jmax (1, maxLookaheadOs / osFactor);
-    const int lookaheadBase = juce::jlimit (1, maxLookaheadBase,
-                                            (int) std::lround (sr * (double) ms / 1000.0));
+    const int maxLookaheadBase = std::max (1, maxLookaheadOs / osFactor);
+    const int lookaheadBase = std::clamp ((int) std::lround (sr * (double) ms / 1000.0),
+                                          1, maxLookaheadBase);
     activeLookaheadOs.store (lookaheadBase * osFactor, std::memory_order_relaxed);
     latencySamplesBase.store (osLatencyBase + lookaheadBase, std::memory_order_relaxed);
 }
@@ -120,29 +129,28 @@ void BrickwallLimiter::reset() noexcept
         relDepth[c] = 0.0f;
     }
     lastActiveLaOs = activeLookaheadOs.load (std::memory_order_relaxed);
-    if (oversampler != nullptr)
-        oversampler->reset();
+    oversampler.reset();
     currentGrDb.store (0.0f, std::memory_order_relaxed);
 }
 
 void BrickwallLimiter::processInPlace (float* L, float* R, int numSamples) noexcept
 {
-    if (oversampler == nullptr || bufLen == 0 || numSamples <= 0 || L == nullptr || R == nullptr)
+    if (bufLen == 0 || numSamples <= 0 || L == nullptr || R == nullptr)
         return;
 
-    juce::ScopedNoDenormals noDenormals;
+    dusk::audio::ScopedNoDenormals noDenormals;
 
     const bool  active  = enabled.load (std::memory_order_relaxed);
-    const float drive   = active ? juce::Decibels::decibelsToGain (
+    const float drive   = active ? dusk::audio::decibelsToGain (
                                         inputDrive.load (std::memory_order_relaxed))
                                   : 1.0f;
-    const float ceiling = juce::Decibels::decibelsToGain (
+    const float ceiling = dusk::audio::decibelsToGain (
                             ceilingDb.load (std::memory_order_relaxed));
 
     {
         const int   modeNow = mode.load (std::memory_order_relaxed);
         const float relMs   = releaseMs.load (std::memory_order_relaxed);
-        if (modeNow != lastMode || ! juce::approximatelyEqual (relMs, lastReleaseMs))
+        if (modeNow != lastMode || ! approximatelyEqual (relMs, lastReleaseMs))
         {
             lastMode      = modeNow;
             lastReleaseMs = relMs;
@@ -158,21 +166,19 @@ void BrickwallLimiter::processInPlace (float* L, float* R, int numSamples) noexc
             }
             releaseCoefFast = onePoleCoef (effRelMs * 0.5f, osRate);
             releaseCoefSlow = onePoleCoef (effRelMs * 2.0f, osRate);
-            holdOs      = juce::jmax (0, (int) (osRate * (double) holdMs / 1000.0));
+            holdOs      = std::max (0, (int) (osRate * (double) holdMs / 1000.0));
         }
     }
     const bool linked = stereoLink.load (std::memory_order_relaxed);
 
-    if (! juce::approximatelyEqual (drive, 1.0f))
+    if (! approximatelyEqual (drive, 1.0f))
         for (int i = 0; i < numSamples; ++i) { L[i] *= drive; R[i] *= drive; }
 
-    float* basePtrs[2] = { L, R };
-    juce::dsp::AudioBlock<float> baseBlock (basePtrs, 2, (size_t) numSamples);
-    auto up = oversampler->processSamplesUp (baseBlock);
+    auto up = oversampler.processSamplesUp (L, R, numSamples);
 
-    const int osN = (int) up.getNumSamples();
-    float* uL = up.getChannelPointer (0);
-    float* uR = up.getChannelPointer (1);
+    const int osN = up.numSamples;
+    float* uL = up.L;
+    float* uR = up.R;
 
     const int cap = (int) dqVal[0].size();
     // Active lookahead read once per block — keeps the read offset and the
@@ -206,7 +212,7 @@ void BrickwallLimiter::processInPlace (float* L, float* R, int numSamples) noexc
         float tgt[2];
         if (linked)
         {
-            const float peak = juce::jmax (std::abs (inL), std::abs (inR));
+            const float peak = std::max (std::abs (inL), std::abs (inR));
             tgt[0] = tgt[1] = (peak > ceiling && peak > 1.0e-9f) ? ceiling / peak : 1.0f;
         }
         else
@@ -268,7 +274,7 @@ void BrickwallLimiter::processInPlace (float* L, float* R, int numSamples) noexc
                 // Program-dependent release: blend fast↔slow by the smoothed
                 // reduction depth carried from the (deep, sustained vs brief)
                 // limiting that preceded this recovery.
-                const float blend = juce::jlimit (0.0f, 1.0f, relDepth[c] * kReleaseAdaptGain);
+                const float blend = std::clamp (relDepth[c] * kReleaseAdaptGain, 0.0f, 1.0f);
                 const float coef  = releaseCoefFast + (releaseCoefSlow - releaseCoefFast) * blend;
                 env[c] += (wmin - env[c]) * coef;
             }
@@ -282,33 +288,33 @@ void BrickwallLimiter::processInPlace (float* L, float* R, int numSamples) noexc
         float oR = delayR[(size_t) readPos] * (active ? env[1] : 1.0f);
         if (active)
         {
-            oL = juce::jlimit (-ceiling, ceiling, oL);
-            oR = juce::jlimit (-ceiling, ceiling, oR);
+            oL = std::clamp (oL, -ceiling, ceiling);
+            oR = std::clamp (oR, -ceiling, ceiling);
         }
         uL[i] = oL;
         uR[i] = oR;
 
         if (active)
-            blockMinEnv = juce::jmin (blockMinEnv, juce::jmin (env[0], env[1]));
+            blockMinEnv = std::min (blockMinEnv, std::min (env[0], env[1]));
 
         writePos = (writePos + 1) % bufLen;
         ++sampleCounter;
     }
 
-    oversampler->processSamplesDown (baseBlock);
+    oversampler.processSamplesDown (L, R, numSamples);
 
     // Residual overshoot from the downsampling reconstruction filter - clamp at
     // base rate so the published ceiling is a hard guarantee.
     if (active)
         for (int i = 0; i < numSamples; ++i)
         {
-            L[i] = juce::jlimit (-ceiling, ceiling, L[i]);
-            R[i] = juce::jlimit (-ceiling, ceiling, R[i]);
+            L[i] = std::clamp (L[i], -ceiling, ceiling);
+            R[i] = std::clamp (R[i], -ceiling, ceiling);
         }
 
     const float grDb = (blockMinEnv >= 1.0f)
                         ? 0.0f
-                        : juce::Decibels::gainToDecibels (blockMinEnv, -60.0f);
+                        : dusk::audio::gainToDecibels (blockMinEnv, -60.0f);
     currentGrDb.store (grDb, std::memory_order_relaxed);
 }
 } // namespace duskstudio

--- a/src/dsp/BrickwallLimiter.h
+++ b/src/dsp/BrickwallLimiter.h
@@ -1,10 +1,8 @@
 #pragma once
 
-#include <juce_audio_basics/juce_audio_basics.h>
-#include <juce_core/juce_core.h>
-#include <juce_dsp/juce_dsp.h>
+#include "../foundation/StereoOversampler.h"
+
 #include <atomic>
-#include <memory>
 #include <vector>
 
 namespace duskstudio
@@ -103,7 +101,7 @@ private:
     std::atomic<int> latencySamplesBase { 0 };
     int osLatencyBase = 0;   // oversampler FIR latency, base-rate samples
 
-    std::unique_ptr<juce::dsp::Oversampling<float>> oversampler;
+    dusk::audio::StereoOversampler oversampler;
 
     // Stereo delay line at the OVERSAMPLED rate — circular, sized for the max
     // lookahead. The active read offset (activeLookaheadOs) is variable, so the

--- a/src/dsp/LoudnessMeter.cpp
+++ b/src/dsp/LoudnessMeter.cpp
@@ -1,4 +1,7 @@
 #include "LoudnessMeter.h"
+#include "../foundation/Decibels.h"
+
+#include <algorithm>
 #include <cmath>
 
 namespace duskstudio
@@ -13,18 +16,17 @@ namespace
 //
 // Reference Q values come from the spec (Stage 1: 1/sqrt(2) = 0.707;
 // Stage 2: ~0.5).
-juce::dsp::IIR::Coefficients<float>::Ptr makeKStage1 (double sampleRate)
+duskaudio::BiquadCoeffs makeKStage1 (double sampleRate)
 {
     // High-shelf, +4 dB at 1681 Hz, Q ≈ 0.707.
-    return juce::dsp::IIR::Coefficients<float>::makeHighShelf (
-        sampleRate, 1681.0, 1.0 / std::sqrt (2.0), juce::Decibels::decibelsToGain (4.0f));
+    return duskaudio::Biquad::shelf (sampleRate, 1681.0f, 4.0f,
+                                     (float) (1.0 / std::sqrt (2.0)), /*high*/ true);
 }
 
-juce::dsp::IIR::Coefficients<float>::Ptr makeKStage2 (double sampleRate)
+duskaudio::BiquadCoeffs makeKStage2 (double sampleRate)
 {
     // 2nd-order high-pass, ~38 Hz, Q ≈ 0.5.
-    return juce::dsp::IIR::Coefficients<float>::makeHighPass (
-        sampleRate, 38.0, 0.5);
+    return duskaudio::Biquad::highPass (sampleRate, 38.0f, 0.5f);
 }
 
 // Convert mean-square energy to LUFS. BS.1770: L = -0.691 + 10·log10(MS),
@@ -37,12 +39,7 @@ inline float msToLUFS (double meanSquared)
 }
 } // namespace
 
-LoudnessMeter::LoudnessMeter()
-    : oversampler (2 /*channels*/,
-                    2 /*stages - 2^2 = 4× oversampling, ITU BS.1770 Annex 2*/,
-                    juce::dsp::Oversampling<float>::filterHalfBandPolyphaseIIR,
-                    /*isMaximumQuality*/ true)
-{}
+LoudnessMeter::LoudnessMeter() = default;
 
 void LoudnessMeter::prepare (double sampleRate, int maxBlockSize)
 {
@@ -50,20 +47,14 @@ void LoudnessMeter::prepare (double sampleRate, int maxBlockSize)
     blockSize = (int) (sampleRate * 0.1);  // 100 ms
     if (blockSize <= 0) blockSize = 1;
 
-    preparedMaxBlockSize = juce::jmax (1, maxBlockSize);
-    oversampleInput.setSize (2, preparedMaxBlockSize, false, false, true);
-    oversampler.initProcessing ((size_t) preparedMaxBlockSize);
-    oversampler.reset();
+    preparedMaxBlockSize = std::max (1, maxBlockSize);
+    oversampler.setFactor (4);   // ITU BS.1770 Annex 2 true-peak
+    oversampler.prepare (preparedMaxBlockSize);
 
-    auto s1 = makeKStage1 (sampleRate);
-    auto s2 = makeKStage2 (sampleRate);
-    kStage1L.coefficients = s1;
-    kStage1R.coefficients = s1;
-    kStage2L.coefficients = s2;
-    kStage2R.coefficients = s2;
-    juce::dsp::ProcessSpec spec { sampleRate, 1, 1 };
-    kStage1L.prepare (spec); kStage1R.prepare (spec);
-    kStage2L.prepare (spec); kStage2R.prepare (spec);
+    const auto s1 = makeKStage1 (sampleRate);
+    const auto s2 = makeKStage2 (sampleRate);
+    kStage1L.setCoeffs (s1); kStage1R.setCoeffs (s1);
+    kStage2L.setCoeffs (s2); kStage2R.setCoeffs (s2);
 
     reset();
 }
@@ -95,7 +86,7 @@ void LoudnessMeter::finishBlock()
 {
     // Mean squared over this 100 ms block (sum of L^2 + R^2 across both
     // channels, normalized by samples × 2 channels of weight 1.0).
-    const double ms = blockSumSquared / juce::jmax (1, blockSize);
+    const double ms = blockSumSquared / std::max (1, blockSize);
     if (blockHistory.size() < (size_t) kMaxHistoryBlocks)
     {
         blockHistory.push_back (ms);
@@ -139,7 +130,7 @@ void LoudnessMeter::finishBlock()
         const double relativeGateLUFS = msToLUFS (meanPass1) - 10.0;
         const double relativeMS = std::pow (10.0,
                                               (relativeGateLUFS + 0.691) / 10.0);
-        const double gateMS = juce::jmax (absoluteMS, relativeMS);
+        const double gateMS = std::max (absoluteMS, relativeMS);
 
         double sumPass2 = 0.0;
         int    countPass2 = 0;
@@ -164,8 +155,8 @@ void LoudnessMeter::process (const float* L, const float* R, int numSamples) noe
     // ── K-weighted block accumulation (LUFS) ──
     for (int i = 0; i < numSamples; ++i)
     {
-        const float kL = kStage2L.processSample (kStage1L.processSample (L[i]));
-        const float kR = kStage2R.processSample (kStage1R.processSample (R[i]));
+        const float kL = kStage2L.process (kStage1L.process (L[i]));
+        const float kR = kStage2R.process (kStage1R.process (R[i]));
 
         blockSumSquared += (double) kL * kL + (double) kR * kR;
         if (--blockSamplesRemaining == 0) finishBlock();
@@ -175,33 +166,25 @@ void LoudnessMeter::process (const float* L, const float* R, int numSamples) noe
     // Per ITU BS.1770 Annex 2, true-peak is measured on the 4×-upsampled
     // signal. The downsampled output is discarded - we only need the
     // upsampled samples for the peak scan.
-    const int n = juce::jmin (numSamples, preparedMaxBlockSize);
+    const int n = std::min (numSamples, preparedMaxBlockSize);
     if (n > 0)
     {
-        oversampleInput.copyFrom (0, 0, L, n);
-        oversampleInput.copyFrom (1, 0, R, n);
-
-        float* channels[2] = { oversampleInput.getWritePointer (0),
-                                oversampleInput.getWritePointer (1) };
-        juce::dsp::AudioBlock<float> inBlock (channels, 2, (size_t) n);
-        auto upBlock = oversampler.processSamplesUp (inBlock);
-
-        const int upN = (int) upBlock.getNumSamples();
+        // Upsample straight from L/R into the oversampler's own scratch; we
+        // never downsample, so the FIR state advances but the samples are read
+        // once for the peak scan and discarded.
+        const auto up = oversampler.processSamplesUp (L, R, n);
         float peak = currentTruePeak;
-        for (int ch = 0; ch < 2; ++ch)
-        {
-            const float* p = upBlock.getChannelPointer ((size_t) ch);
-            for (int i = 0; i < upN; ++i)
+        for (const float* p : { up.L, up.R })
+            for (int i = 0; i < up.numSamples; ++i)
             {
                 const float a = std::fabs (p[i]);
                 if (a > peak) peak = a;
             }
-        }
         currentTruePeak = peak;
     }
 
     truePeakDb.store (currentTruePeak > 1.0e-5f
-                        ? juce::Decibels::gainToDecibels (currentTruePeak, -100.0f)
+                        ? dusk::audio::gainToDecibels (currentTruePeak, -100.0f)
                         : -100.0f,
                        std::memory_order_relaxed);
 }

--- a/src/dsp/LoudnessMeter.h
+++ b/src/dsp/LoudnessMeter.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include <juce_audio_basics/juce_audio_basics.h>
-#include <juce_dsp/juce_dsp.h>
+#include "../foundation/StereoOversampler.h"
+
+#include <dsp/DuskFilters.hpp>
+
 #include <atomic>
 #include <vector>
 
@@ -66,8 +68,8 @@ private:
     double sr = 0.0;
 
     // K-weighting - two cascaded biquads per channel (one per stage).
-    juce::dsp::IIR::Filter<float> kStage1L, kStage1R;
-    juce::dsp::IIR::Filter<float> kStage2L, kStage2R;
+    duskaudio::Biquad kStage1L, kStage1R;
+    duskaudio::Biquad kStage2L, kStage2R;
 
     // Per-block accumulators.
     int    blockSamplesRemaining = 0;
@@ -90,10 +92,9 @@ private:
     float currentTruePeak = 0.0f;
 
     // 4× oversampler for true-peak detection. Used purely for measurement
-    // - we don't keep the upsampled audio. Sized at prepare(); thread
-    // confined to the audio thread for processing.
-    juce::dsp::Oversampling<float> oversampler;
-    juce::AudioBuffer<float>       oversampleInput;  // 2 ch × maxBlockSize, pre-allocated
+    // - we scan the upsampled samples for the peak and discard them (never
+    // downsample). Sized at prepare(); audio-thread confined.
+    dusk::audio::StereoOversampler oversampler;
     int preparedMaxBlockSize = 0;
 
     std::atomic<float> momentaryLufs   { -100.0f };

--- a/src/dsp/MasteringDigitalEq.cpp
+++ b/src/dsp/MasteringDigitalEq.cpp
@@ -21,7 +21,7 @@ bool approximatelyEqual (float a, float b) noexcept
 }
 } // namespace
 
-void MasteringDigitalEq::prepare (double sampleRate, int blockSize)
+void MasteringDigitalEq::prepare (double sampleRate, int /*blockSize*/)
 {
     // The biquads run oversampled, so their coefficients are computed at the
     // oversampled rate. Clamp the base rate first: a 0 or non-finite sampleRate

--- a/src/foundation/StereoOversampler.h
+++ b/src/foundation/StereoOversampler.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <dsp/DuskOversampler.hpp>   // duskaudio::HalfbandFIR + hbtaps (donor)
+
+#include <cstddef>
+#include <vector>
+
+// Stereo block oversampler built from the donor's halfband-FIR kernels. Where
+// duskaudio::Oversampler fuses up + process + down behind a single-channel
+// per-sample functor, this splits the round trip into a block UP phase and a
+// block DOWN phase so a stereo, look-ahead, sample-buffered algorithm (the
+// brickwall limiter, true-peak metering) can run its own pass over BOTH
+// channels' oversampled samples in between — the functor form can't, because it
+// hands back each processed sample before the next channel is seen.
+//
+// The FIR operations, tap sets and per-stage ordering are exactly the donor's
+// (2x = stage A 47-tap, 4x = stage A then stage B 15-tap), so up→down with no
+// intervening processing is the same linear-phase round trip the donor performs
+// — verified sample-for-sample against duskaudio::Oversampler in the tests.
+namespace dusk::audio
+{
+class StereoOversampler
+{
+public:
+    // factor must be 1, 2, or 4 (1 = passthrough). Set before prepare().
+    void setFactor (int f) noexcept { factor = (f == 4) ? 4 : (f == 2 ? 2 : 1); }
+    int  getFactor() const noexcept { return factor; }
+
+    // Sizes the oversampled scratch for the largest block/factor. Idempotent.
+    void prepare (int maxBlockSize) noexcept
+    {
+        const std::size_t n = (std::size_t) (maxBlockSize > 0 ? maxBlockSize : 0) * 4;
+        scratchL.assign (n, 0.0f);
+        scratchR.assign (n, 0.0f);
+        reset();
+    }
+
+    void reset() noexcept
+    {
+        for (int c = 0; c < 2; ++c)
+        {
+            upA[c].reset();  downA[c].reset();
+            upB[c].reset();  downB[c].reset();
+        }
+    }
+
+    // Fixed group delay of the up+down FIR round trip, in base-rate samples
+    // (mirrors duskaudio::Oversampler::latency): 2x stage 23, 4x adds 3.5.
+    float latency() const noexcept
+    {
+        if (factor == 4) return 23.0f + 3.5f;
+        if (factor == 2) return 23.0f;
+        return 0.0f;
+    }
+
+    // Writable view of one channel's oversampled samples, returned by up().
+    struct Block { float* L; float* R; int numSamples; };
+
+    // Upsamples L/R (numSamples each) into the internal scratch and returns
+    // pointers to it. The caller processes the samples in place, then calls
+    // processSamplesDown to fold them back. Pointers stay valid until the next
+    // up/down call.
+    Block processSamplesUp (const float* L, const float* R, int numSamples) noexcept
+    {
+        upChannel (0, L, scratchL.data(), numSamples);
+        upChannel (1, R, scratchR.data(), numSamples);
+        return { scratchL.data(), scratchR.data(), numSamples * factor };
+    }
+
+    // Downsamples the (caller-modified) scratch back into L/R.
+    void processSamplesDown (float* L, float* R, int numSamples) noexcept
+    {
+        downChannel (0, scratchL.data(), L, numSamples);
+        downChannel (1, scratchR.data(), R, numSamples);
+    }
+
+private:
+    void upChannel (int c, const float* in, float* out, int numSamples) noexcept
+    {
+        int oi = 0;
+        for (int n = 0; n < numSamples; ++n)
+        {
+            const float x = in[n];
+            if (factor == 1) { out[oi++] = x; continue; }
+
+            upA[c].push (x);    const float a0 = 2.0f * upA[c].out (duskaudio::hbtaps::kA);
+            upA[c].push (0.0f); const float a1 = 2.0f * upA[c].out (duskaudio::hbtaps::kA);
+            if (factor == 2) { out[oi++] = a0; out[oi++] = a1; continue; }
+
+            for (float a : { a0, a1 })
+            {
+                upB[c].push (a);    out[oi++] = 2.0f * upB[c].out (duskaudio::hbtaps::kB);
+                upB[c].push (0.0f); out[oi++] = 2.0f * upB[c].out (duskaudio::hbtaps::kB);
+            }
+        }
+    }
+
+    void downChannel (int c, const float* os, float* out, int numSamples) noexcept
+    {
+        int oi = 0;
+        for (int n = 0; n < numSamples; ++n)
+        {
+            if (factor == 1) { out[n] = os[oi++]; continue; }
+
+            if (factor == 2)
+            {
+                downA[c].push (os[oi++]); downA[c].push (os[oi++]);
+                out[n] = downA[c].out (duskaudio::hbtaps::kA);
+                continue;
+            }
+
+            downB[c].push (os[oi++]); downB[c].push (os[oi++]);
+            const float d0 = downB[c].out (duskaudio::hbtaps::kB);
+            downB[c].push (os[oi++]); downB[c].push (os[oi++]);
+            const float d1 = downB[c].out (duskaudio::hbtaps::kB);
+            downA[c].push (d0); downA[c].push (d1);
+            out[n] = downA[c].out (duskaudio::hbtaps::kA);
+        }
+    }
+
+    int factor = 4;
+    duskaudio::HalfbandFIR<47, 12> upA[2], downA[2];   // base <-> 2x
+    duskaudio::HalfbandFIR<15, 4>  upB[2], downB[2];   // 2x  <-> 4x
+    std::vector<float> scratchL, scratchR;
+};
+} // namespace dusk::audio

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,6 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(Catch2)
 
 add_executable(dusk-studio-tests
-    smoke_brickwall_limiter.cpp
     # Shared native-host foundation (PortLayout / PortBuffers / INativeInstance)
     # is header-only + platform-neutral, so it links in the base target.
     hosting_port_layout.cpp
@@ -91,7 +90,6 @@ add_executable(dusk-studio-tests
     # multisample editor now uses (its showPopup override) — link it so the
     # editor TU resolves.
     ${CMAKE_SOURCE_DIR}/src/ui/DuskComboBox.cpp
-    ${CMAKE_SOURCE_DIR}/src/dsp/BrickwallLimiter.cpp
     ${CMAKE_SOURCE_DIR}/src/dsp/HardwareInsertSlot.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/FileImporter.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/DpImporter.cpp
@@ -299,6 +297,9 @@ if(DUSK_PLUGINS_PATH)
         bus_strip.cpp
         mastering_chain.cpp
         mastering_digital_eq.cpp
+        dsp_stereo_oversampler.cpp
+        smoke_brickwall_limiter.cpp
+        ${CMAKE_SOURCE_DIR}/src/dsp/BrickwallLimiter.cpp
         ${CMAKE_SOURCE_DIR}/src/dsp/BusStrip.cpp
         ${CMAKE_SOURCE_DIR}/src/dsp/MasteringChain.cpp
         ${CMAKE_SOURCE_DIR}/src/dsp/MasteringDigitalEq.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -299,6 +299,7 @@ if(DUSK_PLUGINS_PATH)
         mastering_digital_eq.cpp
         dsp_stereo_oversampler.cpp
         smoke_brickwall_limiter.cpp
+        dsp_loudness_meter.cpp
         ${CMAKE_SOURCE_DIR}/src/dsp/BrickwallLimiter.cpp
         ${CMAKE_SOURCE_DIR}/src/dsp/BusStrip.cpp
         ${CMAKE_SOURCE_DIR}/src/dsp/MasteringChain.cpp

--- a/tests/dsp_loudness_meter.cpp
+++ b/tests/dsp_loudness_meter.cpp
@@ -1,0 +1,79 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "dsp/LoudnessMeter.h"
+
+#include <dsp/DuskFilters.hpp>
+#include <juce_dsp/juce_dsp.h>
+
+#include <cmath>
+#include <random>
+#include <vector>
+
+using Catch::Matchers::WithinAbs;
+
+namespace
+{
+// Feeds `n` samples through a juce IIR filter and a donor Biquad carrying the
+// same coefficients, and asserts they agree sample-for-sample.
+void requireFilterParity (juce::dsp::IIR::Coefficients<float>::Ptr jc,
+                          const duskaudio::BiquadCoeffs& dc, unsigned seed)
+{
+    juce::dsp::IIR::Filter<float> j;
+    j.coefficients = jc;
+    j.reset();
+
+    duskaudio::Biquad d;
+    d.setCoeffs (dc);
+
+    std::mt19937 rng (seed);
+    std::uniform_real_distribution<float> dist (-1.0f, 1.0f);
+    for (int i = 0; i < 4096; ++i)
+    {
+        const float x = dist (rng);
+        REQUIRE_THAT (d.process (x), WithinAbs (j.processSample (x), 1.0e-6f));
+    }
+}
+} // namespace
+
+// K-weighting is the measurement front end — it must match the JUCE-designed
+// BS.1770 filters it replaces, or every LUFS reading drifts. The donor shelf /
+// highPass designers claim juce::dsp::IIR parity; verify it at the exact
+// K-weight coefficients across sample rates.
+TEST_CASE ("LoudnessMeter K-weighting matches the JUCE-designed filters", "[dsp][loudness]")
+{
+    for (double sr : { 44100.0, 48000.0, 96000.0 })
+    {
+        // Stage 1: high-shelf +4 dB @ 1681 Hz, Q = 1/sqrt2.
+        const auto js1 = juce::dsp::IIR::Coefficients<float>::makeHighShelf (
+            sr, 1681.0, 1.0 / std::sqrt (2.0), juce::Decibels::decibelsToGain (4.0f));
+        const auto ds1 = duskaudio::Biquad::shelf (sr, 1681.0f, 4.0f,
+                                                   (float) (1.0 / std::sqrt (2.0)), true);
+        requireFilterParity (js1, ds1, 0xA1);
+
+        // Stage 2: high-pass @ 38 Hz, Q = 0.5.
+        const auto js2 = juce::dsp::IIR::Coefficients<float>::makeHighPass (sr, 38.0, 0.5);
+        const auto ds2 = duskaudio::Biquad::highPass (sr, 38.0f, 0.5f);
+        requireFilterParity (js2, ds2, 0xB2);
+    }
+}
+
+TEST_CASE ("LoudnessMeter true peak tracks a hot signal", "[dsp][loudness]")
+{
+    constexpr double sr = 48000.0;
+    constexpr int    N  = 4096;
+    duskstudio::LoudnessMeter m;
+    m.prepare (sr, N);
+
+    // Full-scale 1 kHz sine: true peak sits at/above 0 dBFS (inter-sample peaks
+    // of a near-Nyquist-safe tone are ~0 dB); silence reads the -100 floor.
+    std::vector<float> L (N), R (N);
+    for (int i = 0; i < N; ++i)
+        L[(size_t) i] = R[(size_t) i] = std::sin (2.0 * M_PI * 1000.0 * i / sr);
+    for (int blk = 0; blk < 4; ++blk)
+        m.process (L.data(), R.data(), N);
+
+    REQUIRE (m.getTruePeakDb() > -1.0f);
+    REQUIRE (m.getTruePeakDb() < 1.5f);
+    REQUIRE (m.getMomentaryLufs() > -30.0f);   // a hot tone is loud
+}

--- a/tests/dsp_loudness_meter.cpp
+++ b/tests/dsp_loudness_meter.cpp
@@ -60,8 +60,9 @@ TEST_CASE ("LoudnessMeter K-weighting matches the JUCE-designed filters", "[dsp]
 
 TEST_CASE ("LoudnessMeter true peak tracks a hot signal", "[dsp][loudness]")
 {
-    constexpr double sr = 48000.0;
-    constexpr int    N  = 4096;
+    constexpr double sr    = 48000.0;
+    constexpr double kTwoPi = 6.283185307179586476925286766559;
+    constexpr int    N     = 4096;
     duskstudio::LoudnessMeter m;
     m.prepare (sr, N);
 
@@ -69,7 +70,7 @@ TEST_CASE ("LoudnessMeter true peak tracks a hot signal", "[dsp][loudness]")
     // of a near-Nyquist-safe tone are ~0 dB); silence reads the -100 floor.
     std::vector<float> L (N), R (N);
     for (int i = 0; i < N; ++i)
-        L[(size_t) i] = R[(size_t) i] = std::sin (2.0 * M_PI * 1000.0 * i / sr);
+        L[(size_t) i] = R[(size_t) i] = std::sin (kTwoPi * 1000.0 * i / sr);
     for (int blk = 0; blk < 4; ++blk)
         m.process (L.data(), R.data(), N);
 

--- a/tests/dsp_stereo_oversampler.cpp
+++ b/tests/dsp_stereo_oversampler.cpp
@@ -1,0 +1,53 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "foundation/StereoOversampler.h"
+
+#include <dsp/DuskOversampler.hpp>
+
+#include <random>
+#include <vector>
+
+// The split block up/down must reproduce the donor's fused per-sample round
+// trip exactly: with no processing in between, StereoOversampler up→down on a
+// channel is bit-identical to duskaudio::Oversampler::processSample(x, identity)
+// fed the same samples. Same FIR kernels, same stage order, so the only thing
+// this proves is that splitting up from down (and running both channels through
+// independent FIR state) didn't perturb the arithmetic.
+TEST_CASE ("StereoOversampler up/down matches the donor round trip", "[dsp][oversampler]")
+{
+    constexpr int N = 2048;
+
+    std::mt19937 rng (0x0537u);
+    std::uniform_real_distribution<float> dist (-1.0f, 1.0f);
+    std::vector<float> in (N);
+    for (auto& s : in) s = dist (rng);
+
+    for (int factor : { 1, 2, 4 })
+    {
+        // Donor reference: fused, single channel, identity functor.
+        duskaudio::Oversampler ref;
+        ref.setFactor (factor);
+        ref.reset();
+        std::vector<float> refOut (N);
+        for (int n = 0; n < N; ++n)
+            refOut[(size_t) n] = ref.processSample (in[(size_t) n], [] (float s) noexcept { return s; });
+
+        // Split, stereo: feed the same signal to L; feed a scaled copy to R to
+        // confirm the channels are independent (no cross-talk).
+        dusk::audio::StereoOversampler os;
+        os.setFactor (factor);
+        os.prepare (N);
+
+        std::vector<float> L (in), R (N);
+        for (int n = 0; n < N; ++n) R[(size_t) n] = -0.5f * in[(size_t) n];
+
+        os.processSamplesUp (L.data(), R.data(), N);      // fills internal scratch
+        os.processSamplesDown (L.data(), R.data(), N);    // no processing between
+
+        for (int n = 0; n < N; ++n)
+        {
+            REQUIRE (L[(size_t) n] == refOut[(size_t) n]);
+            REQUIRE (R[(size_t) n] == -0.5f * refOut[(size_t) n]);   // linear ⇒ scales exactly
+        }
+    }
+}

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -2,8 +2,6 @@ src/DuskStudioApp.cpp
 src/DuskStudioApp.h
 src/dsp/AuxLaneStrip.cpp
 src/dsp/AuxLaneStrip.h
-src/dsp/BrickwallLimiter.cpp
-src/dsp/BrickwallLimiter.h
 src/dsp/BusStrip.cpp
 src/dsp/BusStrip.h
 src/dsp/ChannelStrip.cpp

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -6,8 +6,6 @@ src/dsp/BusStrip.cpp
 src/dsp/BusStrip.h
 src/dsp/ChannelStrip.cpp
 src/dsp/ChannelStrip.h
-src/dsp/LoudnessMeter.cpp
-src/dsp/LoudnessMeter.h
 src/dsp/MasterBus.cpp
 src/dsp/MasterBus.h
 src/dsp/MasteringChain.h


### PR DESCRIPTION
Adds the reusable stereo block oversampler the `juce::dsp` tower needs, and flips the true-peak limiter onto it. Ratchet **219 → 217**.

## New primitive
`src/foundation/StereoOversampler.h` (`dusk::audio::StereoOversampler`) — built from the donor's halfband-FIR kernels (`duskaudio::HalfbandFIR` + tap sets). The donor `Oversampler` fuses up + process + down behind a *single-channel per-sample functor*; that can't express a **stereo, look-ahead, sample-buffered** algorithm, because it hands each processed sample back before the other channel is seen. This splits the round trip into a block **UP** and block **DOWN** phase so the caller runs its own pass over both channels' oversampled samples in between.

Same FIR kernels + stage order as the donor, so `up → down` with nothing in between is **bit-identical** to `duskaudio::Oversampler::processSample(x, identity)` — proved for factors 1/2/4 on both channels (`tests/dsp_stereo_oversampler.cpp`).

## Limiter flip
`BrickwallLimiter` moves onto it, dropping `juce_dsp` / `juce_core` / `juce_audio_basics` (oversampler + `AudioBlock` + `Decibels` + `ScopedNoDenormals` + `jmax/jmin/jlimit` → `StereoOversampler` + `dusk::audio` + `std`). The stereo-linked true-peak lookahead/deque/gain logic is untouched.

The oversampler is a deliberate re-baseline (donor halfband FIR vs JUCE's FIR equiripple) — but the **hard-ceiling guarantee is verified**: the smoke test measures the limiter's output inter-sample peaks with an *independent* JUCE oversampler and confirms they stay at/below the ceiling.

## Build
`BrickwallLimiter` now depends on the donor headers, so it + its smoke test move to the `DUSK_PLUGINS_PATH`-gated test block.

## Verification
- juce-gate: 217, exit 0
- app build: clean
- tests: 344/344 (incl. new StereoOversampler↔donor A/B; ceiling smoke test still green)
- `DUSKSTUDIO_RUN_SELFTEST=1` under Xvfb: 15/15, no NaN/crash

## Next
`LoudnessMeter` reuses this primitive for its 4× true-peak path; its K-weighting IIR → `duskaudio::Biquad`. Carries an `AudioBuffer`→AudioEngine signature ripple, so it's a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stereo oversampling support for audio processing with 1x, 2x, and 4x modes.
  - Improved limiter and loudness-meter processing through updated oversampling and filtering behavior.

- **Bug Fixes**
  - Improved limiter lookahead, latency handling, gain conversion, and output clamping.
  - Enhanced loudness and true-peak measurement consistency across sample rates.

- **Tests**
  - Added coverage for stereo oversampling, loudness filtering, true-peak detection, and momentary loudness behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->