### PR TITLE
De-JUCE: threading — std::thread for the DSP worker pool

### DIFF
--- a/src/engine/AtomicPark.h
+++ b/src/engine/AtomicPark.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <atomic>
-#include <juce_core/juce_core.h>
+#include <chrono>
+#include <thread>
 
 namespace duskstudio
 {
@@ -40,7 +41,7 @@ T* withParkedAtomicPointer (std::atomic<T*>& slot, Fn&& fn, int sleepMs = 25)
     if (p == nullptr) return nullptr;
     slot.store (nullptr, std::memory_order_release);
     if (sleepMs > 0)
-        juce::Thread::sleep (sleepMs);
+        std::this_thread::sleep_for (std::chrono::milliseconds (sleepMs));
     fn (*p);
     slot.store (p, std::memory_order_release);
     return p;

--- a/src/engine/AudioWorkerPool.cpp
+++ b/src/engine/AudioWorkerPool.cpp
@@ -1,21 +1,44 @@
 #include "AudioWorkerPool.h"
+#include "RtPriority.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <thread>
+
+#if defined(__linux__)
+ #include <pthread.h>
+#endif
 
 namespace duskstudio
 {
-struct AudioWorkerPool::Worker : public juce::Thread
+struct AudioWorkerPool::Worker
 {
-    Worker (AudioWorkerPool& p, int idx)
-        : juce::Thread ("DuskDSP " + juce::String (idx)), pool (p), lane (idx) {}
+    Worker (AudioWorkerPool& p, int idx, int rtPrio)
+        : pool (p), lane (idx), rtJucePriority (rtPrio) {}
 
-    void run() override
+    void start() { th = std::thread ([this] { run(); }); }
+
+    void run()
     {
-        while (! threadShouldExit())
+        // Same realtime priority as the audio I/O thread (RtPriority.h) so RR
+        // round-robins fairly if a worker shares the audio thread's core; on an
+        // RT-denied system the thread simply runs at the default class.
+        rt::applyRealtimeSchedRR (rtJucePriority);
+       #if defined(__linux__)
+        char name[16];
+        std::snprintf (name, sizeof name, "DuskDSP %d", lane);
+        pthread_setname_np (pthread_self(), name);
+       #endif
+
+        while (! shouldExit.load (std::memory_order_acquire))
         {
             // Park until dispatched (or quiesced, or quitting). Auto-reset
             // event: a signal landing between our ack below and this wait() is
             // latched, so a wakeup is never lost.
             wake.wait();
-            if (threadShouldExit() || pool.quit.load (std::memory_order_acquire))
+            if (shouldExit.load (std::memory_order_acquire)
+                || pool.quit.load (std::memory_order_acquire))
                 break;
 
             const auto s = pool.seq.load (std::memory_order_acquire);
@@ -35,10 +58,21 @@ struct AudioWorkerPool::Worker : public juce::Thread
         }
     }
 
+    void requestExitAndWake() noexcept
+    {
+        shouldExit.store (true, std::memory_order_release);
+        wake.signal();   // unpark so run() can observe the exit
+    }
+
+    void join() { if (th.joinable()) th.join(); }
+
     AudioWorkerPool&      pool;
     int                   lane;
-    juce::WaitableEvent   wake;       // auto-reset
+    int                   rtJucePriority;
+    std::thread           th;
+    dusk::AutoResetEvent  wake;             // auto-reset
     std::atomic<uint32_t> acked { 0 };
+    std::atomic<bool>     shouldExit { false };
 };
 
 AudioWorkerPool::AudioWorkerPool() = default;
@@ -53,24 +87,13 @@ void AudioWorkerPool::start (int workers, std::function<void (int)> job, int rtJ
     seq.store (0, std::memory_order_release);
     done.store (0, std::memory_order_release);
 
-    const int want = juce::jmax (0, workers);
+    const int want = std::max (0, workers);
     for (int i = 0; i < want; ++i)
     {
-        auto w = std::make_unique<Worker> (*this, (int) workers_.size());
-        // Same realtime priority as the audio I/O thread (RtPriority.h) so RR
-        // round-robins fairly if a worker shares the audio thread's core; fall
-        // back to the highest normal priority if the OS denies real-time.
-        const bool started = (rtJucePriority >= 0
-                               && w->startRealtimeThread (juce::Thread::RealtimeOptions{}
-                                                              .withPriority (rtJucePriority)))
-                          || w->startThread (juce::Thread::Priority::highest);
-        if (started)
-            workers_.push_back (std::move (w));
-        // A worker that failed to start is dropped: it would never reach its
-        // wake/job loop, so the join would wait forever on its completion.
+        auto w = std::make_unique<Worker> (*this, (int) workers_.size(), rtJucePriority);
+        w->start();
+        workers_.push_back (std::move (w));
     }
-    // numWorkers reflects threads that actually started, so laneCount() and the
-    // join can never expect a completion that won't arrive.
     numWorkers = (int) workers_.size();
 }
 
@@ -78,16 +101,13 @@ void AudioWorkerPool::stop()
 {
     if (workers_.empty()) { numWorkers = 0; return; }
 
-    quiesce();   // joins in-flight lanes so stopThread never kills one mid-job
+    quiesce();   // joins in-flight lanes so no thread is killed mid-job
 
     quit.store (true, std::memory_order_release);
     for (auto& w : workers_)
-    {
-        w->signalThreadShouldExit();
-        w->wake.signal();             // unpark so run() can observe the exit
-    }
+        w->requestExitAndWake();
     for (auto& w : workers_)
-        w->stopThread (1000);
+        w->join();
     workers_.clear();
     numWorkers = 0;
 }
@@ -118,7 +138,7 @@ void AudioWorkerPool::runBlock() noexcept
     {
         if (done.load (std::memory_order_acquire) >= numWorkers)
             return;
-        juce::Thread::yield();
+        std::this_thread::yield();
     }
     int waitedMs = 0;
     while (done.load (std::memory_order_acquire) < numWorkers)
@@ -151,7 +171,7 @@ void AudioWorkerPool::quiesce()
             w->wake.signal();
     for (auto& w : workers_)
         while (w->acked.load (std::memory_order_acquire) != s)
-            juce::Thread::sleep (1);
+            std::this_thread::sleep_for (std::chrono::milliseconds (1));
 
     quiescing.store (false, std::memory_order_release);
 }
@@ -164,7 +184,7 @@ void AudioWorkerPool::dispatchForTest (int signalOnlyFirst)
     done.store (0, std::memory_order_release);
     seq.fetch_add (1, std::memory_order_release);
     const int n = signalOnlyFirst < 0 ? numWorkers
-                                      : juce::jmin (signalOnlyFirst, numWorkers);
+                                      : std::min (signalOnlyFirst, numWorkers);
     for (int i = 0; i < n; ++i)
         workers_[(size_t) i]->wake.signal();
 }

--- a/src/engine/AudioWorkerPool.h
+++ b/src/engine/AudioWorkerPool.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <juce_core/juce_core.h>
+#include "../foundation/AutoResetEvent.h"
 
 #include <atomic>
 #include <cstdint>
@@ -15,7 +15,7 @@ namespace duskstudio
 // runs on each of the `workers` worker threads for lane in [0, workers), and on
 // the audio thread itself for lane == workers. So laneCount() == workers + 1.
 //
-// Workers park on an auto-reset juce::WaitableEvent between blocks and are woken
+// Workers park on an auto-reset event between blocks and are woken
 // by the audio thread's signal() — a bounded, uncontended, ns-scale event that
 // is the one deliberate exception to the no-lock-on-the-audio-thread rule, used
 // ONLY in this opt-in parallel mode. The join is a short bounded spin (fast
@@ -42,11 +42,11 @@ public:
     AudioWorkerPool();
     ~AudioWorkerPool();
 
-    // Message thread only. Spawns `workers` real-time threads at the given JUCE
-    // realtime priority (see RtPriority.h; <= 0 or RT-denied falls back to the
-    // highest normal priority); `job` is stored once (never reallocated per
-    // block) and invoked as job(lane). A count <= 0 leaves the pool inactive
-    // (runBlock then runs job(0) inline on the caller).
+    // Message thread only. Spawns `workers` real-time threads at the given
+    // realtime priority on JUCE's 0..10 scale (see RtPriority.h; < 0 or an
+    // RT-denied thread runs at the OS default scheduling class); `job` is stored
+    // once (never reallocated per block) and invoked as job(lane). A count <= 0
+    // leaves the pool inactive (runBlock then runs job(0) inline on the caller).
     void start (int workers, std::function<void (int lane)> job, int rtJucePriority = 5);
     void stop();   // message thread only; quiesces, then joins every worker.
 
@@ -82,8 +82,9 @@ private:
     std::atomic<bool>     quiescing { false };
     std::atomic<bool>     quit { false };
     std::atomic<int>      joinStalls { 0 };    // count of >2 s join stalls (diagnostic)
-    juce::WaitableEvent   completion;          // auto-reset; signalled by the last worker
+    dusk::AutoResetEvent  completion;          // auto-reset; signalled by the last worker
 
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (AudioWorkerPool)
+    AudioWorkerPool (const AudioWorkerPool&) = delete;
+    AudioWorkerPool& operator= (const AudioWorkerPool&) = delete;
 };
 } // namespace duskstudio

--- a/src/engine/RtPriority.h
+++ b/src/engine/RtPriority.h
@@ -2,7 +2,8 @@
 
 #include <algorithm>
 
-#if JUCE_LINUX
+#if defined(__linux__)
+ #include <pthread.h>
  #include <sched.h>
  #include <sys/resource.h>
 #endif
@@ -43,9 +44,30 @@ inline int jucePriorityForSchedCeiling (int ceilingSched, int rrMin, int rrMax) 
     return std::max (-1, p);
 }
 
+// Puts the CALLING thread on SCHED_RR at the sched_priority that a JUCE
+// realtime priority p in [0, 10] maps to (rrMin + p·span/10, the same forward
+// map queryRealtimePriority walks) — the native equivalent of JUCE's
+// startRealtimeThread(RealtimeOptions().withPriority(p)). Returns false if the
+// kernel refuses (EPERM over RLIMIT_RTPRIO, non-Linux), leaving the thread at
+// its default scheduling class.
+inline bool applyRealtimeSchedRR (int jucePriority) noexcept
+{
+   #if defined(__linux__)
+    const int rrMin = std::max (0, sched_get_priority_min (SCHED_RR));
+    const int rrMax = std::max (1, sched_get_priority_max (SCHED_RR));
+    const int p     = std::clamp (jucePriority, 0, 10);
+    sched_param sp {};
+    sp.sched_priority = rrMin + (p * (rrMax - rrMin)) / 10;
+    return pthread_setschedparam (pthread_self(), SCHED_RR, &sp) == 0;
+   #else
+    (void) jucePriority;
+    return false;
+   #endif
+}
+
 inline RtPriorityInfo queryRealtimePriority() noexcept
 {
-   #if JUCE_LINUX
+   #if defined(__linux__)
     struct rlimit rl {};
     if (getrlimit (RLIMIT_RTPRIO, &rl) != 0)
         return { -1, false, -1 };

--- a/src/foundation/AutoResetEvent.h
+++ b/src/foundation/AutoResetEvent.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <condition_variable>
+#include <chrono>
+#include <mutex>
+
+// Auto-reset event, matching JUCE's WaitableEvent default (auto-reset)
+// semantics: signal() latches; the next wait() consumes the latch and clears it
+// so exactly one waiter is released per signal. A signal delivered while no one
+// is waiting is remembered, so a wakeup is never lost between a worker's ack and
+// its next wait (the invariant AudioWorkerPool relies on).
+namespace dusk
+{
+class AutoResetEvent
+{
+public:
+    void signal() noexcept
+    {
+        {
+            std::lock_guard<std::mutex> lk (m);
+            signalled = true;
+        }
+        cv.notify_one();
+    }
+
+    void wait() noexcept
+    {
+        std::unique_lock<std::mutex> lk (m);
+        cv.wait (lk, [this] { return signalled; });
+        signalled = false;
+    }
+
+    // Returns true if the event was signalled within the timeout (and consumes
+    // it), false on timeout.
+    bool wait (int timeoutMs) noexcept
+    {
+        std::unique_lock<std::mutex> lk (m);
+        if (! cv.wait_for (lk, std::chrono::milliseconds (timeoutMs),
+                           [this] { return signalled; }))
+            return false;
+        signalled = false;
+        return true;
+    }
+
+private:
+    std::mutex              m;
+    std::condition_variable cv;
+    bool                    signalled = false;
+};
+} // namespace dusk

--- a/tests/audio_worker_pool.cpp
+++ b/tests/audio_worker_pool.cpp
@@ -2,6 +2,8 @@
 
 #include "engine/AudioWorkerPool.h"
 
+#include <juce_core/juce_core.h>   // test-side timing / manual-reset gate only
+
 #include <array>
 #include <atomic>
 #include <cstdio>

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -9,13 +9,10 @@ src/dsp/ChannelStrip.h
 src/dsp/MasterBus.cpp
 src/dsp/MasterBus.h
 src/dsp/MasteringChain.h
-src/engine/AtomicPark.h
 src/engine/AudioEngine.cpp
 src/engine/AudioEngine.h
 src/engine/AudioPipelineSelfTest.cpp
 src/engine/AudioPipelineSelfTest.h
-src/engine/AudioWorkerPool.cpp
-src/engine/AudioWorkerPool.h
 src/engine/BounceEngine.cpp
 src/engine/BounceEngine.h
 src/engine/DpAligner.cpp


### PR DESCRIPTION
Removes the JUCE threading primitives from the multicore DSP path. Ratchet **215 → 212**.

## What
- **`dusk::AutoResetEvent`** (`src/foundation/AutoResetEvent.h`) — a `mutex` + `condition_variable` auto-reset event with JUCE `WaitableEvent`'s latching, single-consumer semantics: a `signal()` landing between a worker's ack and its next `wait()` is remembered, so a wakeup is never lost (the invariant the join/quiesce protocol depends on).
- **`AudioWorkerPool`** — workers move from `juce::Thread` to `std::thread`, parking on `AutoResetEvent` instead of `juce::WaitableEvent`. The epoch/ack quiesce, bounded-spin + blocking-completion join, and RT-safe stall diagnostic are unchanged.
- **`RtPriority.h`** gains `applyRealtimeSchedRR()` — the native `SCHED_RR` setup JUCE did inside `startRealtimeThread`, using the same forward map (`rrMin + p·span/10`) so workers land at the audio thread's priority. Switches `JUCE_LINUX` → `__linux__` so the header no longer needs a JUCE include.
- **`AtomicPark`** — the message-thread park-sleep moves to `std::this_thread::sleep_for`.

## Notes
- These two files were the only threading-primitive users that go **fully** JUCE-clean; every other `juce::Thread`/`WaitableEvent` user is also `AudioProcessor`/`Component`/`File`-coupled, so swapping the thread primitive there moves no ratchet line.
- RT-denied fallback: where the kernel refuses `SCHED_RR` (no `RLIMIT_RTPRIO`, e.g. CI), workers run at the default scheduling class — correctness is priority-independent, verified below.

## Verification
- juce-gate: 212, exit 0
- app build: clean
- tests: 346/346 — incl. the worker-pool soak / quiesce / orphan-drain / partial-orphan protocol tests (real threads) and the `RtPriority` mapping tests
- `DUSKSTUDIO_RUN_SELFTEST=1` under Xvfb: 15/15, including **Parallel Matches Serial** (6 workers bit-identical to serial)

Live-hardware RT-priority sign-off still owed (CI has no rtprio limit, so it exercises the fallback path).