### PR TITLE
De-JUCE: bespoke MIDI buffer + flip MTC / clock-sync receivers

### DIFF
--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -1040,6 +1040,7 @@ void AudioEngine::rebuildMidiInputBank()
     // Pre-reserve like perTrackMidiScratch: removeNextBlockOfMessages grows the
     // destination on the audio thread if a burst exceeds prior capacity.
     for (auto& m : perInputMidi) m.ensureSize (4096);
+    syncMidiScratch.reserveBytes (4096);   // same headroom for the juce->dusk bridge
 
     // Re-resolve on every rebuild so a hot-plug doesn't strand the
     // index at a stale slot. Empty / no match = -1 (no sync).
@@ -2933,8 +2934,16 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
 
     if (syncIdx >= 0 && (size_t) syncIdx < perInputMidi.size())
     {
-        midiSyncReceiver.process (perInputMidi[(size_t) syncIdx], midiSyncSampleClock);
-        midiTimeCodeReceiver.process (perInputMidi[(size_t) syncIdx],
+        // Bridge the JUCE input block into the dusk buffer the receivers take.
+        // Pre-reserved in prepareForSelfTest, so this refill doesn't allocate.
+        syncMidiScratch.clear();
+        for (const auto meta : perInputMidi[(size_t) syncIdx])
+            syncMidiScratch.addEvent (meta.getMessage().getRawData(),
+                                      meta.getMessage().getRawDataSize(),
+                                      meta.samplePosition);
+
+        midiSyncReceiver.process (syncMidiScratch, midiSyncSampleClock);
+        midiTimeCodeReceiver.process (syncMidiScratch,
                                          midiSyncSampleClock, numSamples);
         // Publish MTC decoded state. Same input port — Clock + MTC
         // multiplex on it; both decoders ignore bytes they don't own.

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -2935,7 +2935,8 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
     if (syncIdx >= 0 && (size_t) syncIdx < perInputMidi.size())
     {
         // Bridge the JUCE input block into the dusk buffer the receivers take.
-        // Pre-reserved in prepareForSelfTest, so this refill doesn't allocate.
+        // Pre-reserved (and capacity-capped) in rebuildMidiInputBank, so this
+        // refill never allocates — over-cap events are dropped, not grown into.
         syncMidiScratch.clear();
         for (const auto meta : perInputMidi[(size_t) syncIdx])
             syncMidiScratch.addEvent (meta.getMessage().getRawData(),

--- a/src/engine/AudioEngine.h
+++ b/src/engine/AudioEngine.h
@@ -464,6 +464,10 @@ private:
     PitchDetector    pitchDetector;
     MidiSyncReceiver       midiSyncReceiver;
     MidiTimeCodeReceiver   midiTimeCodeReceiver;
+    // Scratch the sync/MTC input block is bridged into: the receivers take a
+    // dusk::MidiBuffer, so each block the JUCE input buffer is walked into this
+    // (pre-reserved so the fill never allocates on the audio thread).
+    dusk::MidiBuffer       syncMidiScratch;
     std::unique_ptr<class McuReceiver>   mcuReceiver;
     std::unique_ptr<class McuController> mcuController;
 

--- a/src/engine/MidiSyncReceiver.cpp
+++ b/src/engine/MidiSyncReceiver.cpp
@@ -1,8 +1,10 @@
 #include "MidiSyncReceiver.h"
 
+#include <algorithm>
+
 namespace duskstudio
 {
-void MidiSyncReceiver::process (const juce::MidiBuffer& events,
+void MidiSyncReceiver::process (const dusk::MidiBuffer& events,
                                   std::int64_t blockStartSample) noexcept
 {
     for (const auto meta : events)
@@ -12,9 +14,8 @@ void MidiSyncReceiver::process (const juce::MidiBuffer& events,
         if (msg.getRawDataSize() < 1) continue;
         const std::uint8_t status = data[0];
 
-        // F8 / FA / FB / FC are system-realtime bytes. They're not
-        // matched by juce::MidiMessage::isMidiClock() etc. on every
-        // path, so we test the raw status byte directly.
+        // F8 / FA / FB / FC are system-realtime bytes. We test the raw
+        // status byte directly rather than relying on message-type helpers.
         if (status == 0xF8)  // Clock
         {
             const std::int64_t sampleAt = blockStartSample + meta.samplePosition;
@@ -63,7 +64,7 @@ void MidiSyncReceiver::process (const juce::MidiBuffer& events,
                                 // Clamp to a sane range so a garbage
                                 // stream doesn't push the session into
                                 // 0 / inf BPM.
-                                bpm.store (juce::jlimit (10.0f, 999.0f, computed),
+                                bpm.store (std::clamp (computed, 10.0f, 999.0f),
                                              std::memory_order_relaxed);
                             }
                         }

--- a/src/engine/MidiSyncReceiver.h
+++ b/src/engine/MidiSyncReceiver.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include <juce_audio_basics/juce_audio_basics.h>
+#include "../foundation/MidiBuffer.h"
+
 #include <atomic>
+#include <cstdint>
 
 namespace duskstudio
 {
@@ -63,7 +65,7 @@ public:
     // engine's absolute playhead at the start of this block - we use
     // it + each event's sample offset to timestamp ticks against a
     // monotonically increasing sample clock.
-    void process (const juce::MidiBuffer& events,
+    void process (const dusk::MidiBuffer& events,
                   std::int64_t blockStartSample) noexcept;
 
     // Smoothed BPM derived from the recent clock interval. 0 until the

--- a/src/engine/MidiTimeCodeReceiver.cpp
+++ b/src/engine/MidiTimeCodeReceiver.cpp
@@ -168,7 +168,7 @@ void MidiTimeCodeReceiver::onFullFrameSysex (const std::uint8_t* msg, int sz,
     commitAssembledFrame (atSample, /*applyTwoFrameOffset*/ false);
 }
 
-void MidiTimeCodeReceiver::process (const juce::MidiBuffer& events,
+void MidiTimeCodeReceiver::process (const dusk::MidiBuffer& events,
                                       std::int64_t blockStartSample,
                                       int numSamples) noexcept
 {

--- a/src/engine/MidiTimeCodeReceiver.h
+++ b/src/engine/MidiTimeCodeReceiver.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include <juce_audio_basics/juce_audio_basics.h>
+#include "../foundation/MidiBuffer.h"
+
 #include <atomic>
+#include <cstdint>
 
 namespace duskstudio
 {
@@ -54,7 +56,7 @@ public:
 
     // blockStartSample is the engine's monotonic sample clock (same as
     // MidiClockEmitter / MidiSyncReceiver).
-    void process (const juce::MidiBuffer& events,
+    void process (const dusk::MidiBuffer& events,
                   std::int64_t blockStartSample,
                   int numSamples) noexcept;
 

--- a/src/foundation/MidiBuffer.h
+++ b/src/foundation/MidiBuffer.h
@@ -46,15 +46,23 @@ class MidiBuffer
 public:
     void clear()               noexcept { data.clear(); }
     bool isEmpty()       const noexcept { return data.empty(); }
-    void reserveBytes (std::size_t n)   { data.reserve (n); }
+
+    // Reserves capacity AND caps it: once reserved, addEvent never grows past
+    // `n` bytes — it drops events that would exceed the cap instead of
+    // reallocating. This is what makes the per-block refill allocation-free on
+    // the audio thread. Left unreserved (message-thread use) the buffer grows
+    // freely like a plain vector.
+    void reserveBytes (std::size_t n) { data.reserve (n); capBytes = n; }
 
     void addEvent (const std::uint8_t* bytes, int numBytes, int samplePosition)
     {
         if (numBytes <= 0 || bytes == nullptr) return;
         const std::size_t base = data.size();
-        data.resize (base + kHeader + (std::size_t) numBytes);
-        std::memcpy (data.data() + base,     &samplePosition, sizeof (int));
-        std::memcpy (data.data() + base + 4, &numBytes,       sizeof (int));
+        const std::size_t need = kHeader + (std::size_t) numBytes;
+        if (base + need > capBytes) return;   // over the reserved cap: drop, never realloc
+        data.resize (base + need);
+        std::memcpy (data.data() + base,               &samplePosition, sizeof (int));
+        std::memcpy (data.data() + base + sizeof (int), &numBytes,       sizeof (int));
         std::memcpy (data.data() + base + kHeader, bytes, (std::size_t) numBytes);
     }
 
@@ -84,6 +92,8 @@ private:
         return v;
     }
 
+    static constexpr std::size_t kUnbounded = static_cast<std::size_t> (-1);
     std::vector<std::uint8_t> data;
+    std::size_t capBytes = kUnbounded;
 };
 } // namespace dusk

--- a/src/foundation/MidiBuffer.h
+++ b/src/foundation/MidiBuffer.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+// Minimal packed MIDI event buffer + message view, mirroring the slice of the
+// JUCE MidiBuffer / MidiMessage API the engine's MIDI decoders consume: iterate
+// events in order, read each message's raw status/data bytes and its
+// sample offset within the block. Owning + pre-sizable so the audio thread can
+// clear() and refill it every block with no allocation (reserveBytes() off the
+// RT path). It is a byte-level container — it does not parse MIDI semantics;
+// the decoders read raw bytes directly.
+namespace dusk
+{
+// Non-owning view of one message's raw bytes (valid while its MidiBuffer lives).
+class MidiMessage
+{
+public:
+    MidiMessage() = default;
+    MidiMessage (const std::uint8_t* d, int n) noexcept : bytes (d), size (n) {}
+
+    const std::uint8_t* getRawData()     const noexcept { return bytes; }
+    int                 getRawDataSize() const noexcept { return size; }
+
+private:
+    const std::uint8_t* bytes = nullptr;
+    int                 size  = 0;
+};
+
+// One iterated event: the message view plus its sample offset within the block.
+struct MidiBufferMetadata
+{
+    MidiMessage message;
+    int         samplePosition = 0;
+
+    const MidiMessage& getMessage() const noexcept { return message; }
+};
+
+// Packed event storage. Per event: [int samplePosition][int numBytes][bytes...].
+// Events are kept in insertion order (NOT auto-sorted by position like JUCE's
+// MidiBuffer); the engine bridge fills this by walking the already-sorted JUCE
+// buffer, so the order carries over.
+class MidiBuffer
+{
+public:
+    void clear()               noexcept { data.clear(); }
+    bool isEmpty()       const noexcept { return data.empty(); }
+    void reserveBytes (std::size_t n)   { data.reserve (n); }
+
+    void addEvent (const std::uint8_t* bytes, int numBytes, int samplePosition)
+    {
+        if (numBytes <= 0 || bytes == nullptr) return;
+        const std::size_t base = data.size();
+        data.resize (base + kHeader + (std::size_t) numBytes);
+        std::memcpy (data.data() + base,     &samplePosition, sizeof (int));
+        std::memcpy (data.data() + base + 4, &numBytes,       sizeof (int));
+        std::memcpy (data.data() + base + kHeader, bytes, (std::size_t) numBytes);
+    }
+
+    class Iterator
+    {
+    public:
+        explicit Iterator (const std::uint8_t* p) noexcept : ptr (p) {}
+        bool operator!= (const Iterator& o) const noexcept { return ptr != o.ptr; }
+        void operator++ ()                        noexcept { ptr += kHeader + readInt (ptr + 4); }
+        MidiBufferMetadata operator* () const noexcept
+        {
+            return { MidiMessage (ptr + kHeader, readInt (ptr + 4)), readInt (ptr) };
+        }
+    private:
+        const std::uint8_t* ptr;
+    };
+
+    Iterator begin() const noexcept { return Iterator (data.data()); }
+    Iterator end()   const noexcept { return Iterator (data.data() + data.size()); }
+
+private:
+    static constexpr std::size_t kHeader = 2 * sizeof (int);
+    static int readInt (const std::uint8_t* p) noexcept
+    {
+        int v;
+        std::memcpy (&v, p, sizeof (int));
+        return v;
+    }
+
+    std::vector<std::uint8_t> data;
+};
+} // namespace dusk

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -121,6 +121,7 @@ target_sources(dusk-studio-tests PRIVATE
     foundation_json.cpp
     foundation_audio_math.cpp
     foundation_int_delay_line.cpp
+    foundation_midi_buffer.cpp
     lv2_state_paths.cpp)
 
 # Phase 1a de-JUCE: JUCE-free audio file I/O (libsndfile backend), test-only for

--- a/tests/foundation_midi_buffer.cpp
+++ b/tests/foundation_midi_buffer.cpp
@@ -1,0 +1,68 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "foundation/MidiBuffer.h"
+
+#include <juce_audio_basics/juce_audio_basics.h>
+
+#include <cstdint>
+#include <vector>
+
+// dusk::MidiBuffer must iterate events in the same order and expose the same
+// raw bytes + sample positions as juce::MidiBuffer, so the decoders read the
+// identical byte stream after the engine's juce->dusk bridge.
+TEST_CASE ("dusk::MidiBuffer iterates like juce::MidiBuffer", "[foundation][midi]")
+{
+    struct Ev { std::vector<std::uint8_t> bytes; int pos; };
+    const std::vector<Ev> events = {
+        { { 0xF1, 0x03 },                               10 },   // MTC quarter-frame
+        { { 0xF8 },                                     16 },   // clock (1 byte)
+        { { 0x90, 0x40, 0x7F },                         32 },   // note-on
+        { { 0xF0,0x7F,0x7F,0x01,0x01,0x21,0x00,0x00,0x00,0xF7 }, 5 }, // MTC full-frame sysex
+        { { 0xFC },                                     40 },   // stop
+    };
+
+    juce::MidiBuffer j;
+    for (const auto& e : events)
+        j.addEvent (e.bytes.data(), (int) e.bytes.size(), e.pos);
+
+    // Mirror the engine bridge: fill the dusk buffer by walking the (already
+    // sorted) juce buffer, so ordering comes from the source exactly as in
+    // AudioEngine.
+    dusk::MidiBuffer d;
+    for (const auto meta : j)
+        d.addEvent (meta.getMessage().getRawData(), meta.getMessage().getRawDataSize(),
+                    meta.samplePosition);
+
+    auto ji = j.begin();
+    auto di = d.begin();
+    int count = 0;
+    for (; di != d.end(); ++di, ++ji)
+    {
+        REQUIRE (ji != j.end());
+        const auto jm = (*ji).getMessage();
+        const auto dm = (*di).getMessage();
+
+        REQUIRE ((*di).samplePosition == (*ji).samplePosition);
+        REQUIRE (dm.getRawDataSize()  == jm.getRawDataSize());
+        for (int b = 0; b < dm.getRawDataSize(); ++b)
+            REQUIRE (dm.getRawData()[b] == jm.getRawData()[b]);
+        ++count;
+    }
+    REQUIRE (ji == j.end());
+    REQUIRE (count == (int) events.size());
+}
+
+TEST_CASE ("dusk::MidiBuffer clear keeps capacity and empties", "[foundation][midi]")
+{
+    dusk::MidiBuffer d;
+    d.reserveBytes (256);
+    const std::uint8_t clk = 0xF8;
+    d.addEvent (&clk, 1, 0);
+    REQUIRE (! d.isEmpty());
+
+    d.clear();
+    REQUIRE (d.isEmpty());
+    int n = 0;
+    for (auto it = d.begin(); it != d.end(); ++it) ++n;
+    REQUIRE (n == 0);
+}

--- a/tests/midi_time_code_decode.cpp
+++ b/tests/midi_time_code_decode.cpp
@@ -2,23 +2,14 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include "engine/MidiTimeCodeReceiver.h"
+#include "support/DuskMidiTestBridge.h"
 
 #include <juce_audio_basics/juce_audio_basics.h>
 
 namespace
 {
 using duskstudio::MidiTimeCodeReceiver;
-
-// Bridge a juce::MidiBuffer into the dusk::MidiBuffer the receiver takes,
-// exactly as AudioEngine does per block.
-dusk::MidiBuffer toDusk (const juce::MidiBuffer& j)
-{
-    dusk::MidiBuffer d;
-    for (const auto meta : j)
-        d.addEvent (meta.getMessage().getRawData(), meta.getMessage().getRawDataSize(),
-                    meta.samplePosition);
-    return d;
-}
+using duskstudio::test::toDusk;
 
 // Build the 8 QF bytes that encode (hh, mm, ss, ff) at rate r.
 // Nibble layout matches the receiver (and the emitter):

--- a/tests/midi_time_code_decode.cpp
+++ b/tests/midi_time_code_decode.cpp
@@ -9,6 +9,17 @@ namespace
 {
 using duskstudio::MidiTimeCodeReceiver;
 
+// Bridge a juce::MidiBuffer into the dusk::MidiBuffer the receiver takes,
+// exactly as AudioEngine does per block.
+dusk::MidiBuffer toDusk (const juce::MidiBuffer& j)
+{
+    dusk::MidiBuffer d;
+    for (const auto meta : j)
+        d.addEvent (meta.getMessage().getRawData(), meta.getMessage().getRawDataSize(),
+                    meta.samplePosition);
+    return d;
+}
+
 // Build the 8 QF bytes that encode (hh, mm, ss, ff) at rate r.
 // Nibble layout matches the receiver (and the emitter):
 //   0: ff[3:0]    1: ff[4] | (junk)
@@ -46,7 +57,7 @@ void pushSequence (MidiTimeCodeReceiver& rx,
     juce::MidiBuffer buf;
     for (int i = 0; i < 8; ++i)
         buf.addEvent (juce::MidiMessage (0xF1, bytes[(size_t) i]), i * 4);
-    rx.process (buf, blockStartSample, blockSize);
+    rx.process (toDusk (buf), blockStartSample, blockSize);
 }
 
 // Expected absolute SMPTE frame count (with +2 compensation) for a
@@ -124,7 +135,7 @@ TEST_CASE ("MidiTimeCodeReceiver: full-frame sysex emits instant SMPTE without +
     };
     juce::MidiBuffer buf;
     buf.addEvent (juce::MidiMessage (sysex, 10), 0);
-    rx.process (buf, /*blockStart*/ 0, /*numSamples*/ 64);
+    rx.process (toDusk (buf), /*blockStart*/ 0, /*numSamples*/ 64);
 
     REQUIRE (rx.isRolling());
     REQUIRE (rx.getFrameRate() == R::Fps30);
@@ -157,7 +168,7 @@ TEST_CASE ("MidiTimeCodeReceiver: reverse-QF freezes output without stutter",
     juce::MidiBuffer rev;
     for (int i = 7; i >= 1; --i)
         rev.addEvent (juce::MidiMessage (0xF1, bytes[(size_t) i]), (7 - i) * 4);
-    rx.process (rev, /*blockStart*/ 1000, /*numSamples*/ 64);
+    rx.process (toDusk (rev), /*blockStart*/ 1000, /*numSamples*/ 64);
 
     REQUIRE (rx.isReversed());
     REQUIRE_FALSE (rx.isRolling());
@@ -176,6 +187,6 @@ TEST_CASE ("MidiTimeCodeReceiver: QF watchdog drops rolling on silence",
 
     // Empty block 1 second later (>500 ms watchdog timeout at 48k).
     juce::MidiBuffer empty;
-    rx.process (empty, /*blockStart*/ 48000, /*numSamples*/ 64);
+    rx.process (toDusk (empty), /*blockStart*/ 48000, /*numSamples*/ 64);
     REQUIRE_FALSE (rx.isRolling());
 }

--- a/tests/midi_time_code_emit.cpp
+++ b/tests/midi_time_code_emit.cpp
@@ -2,6 +2,7 @@
 
 #include "engine/MidiTimeCodeEmitter.h"
 #include "engine/MidiTimeCodeReceiver.h"
+#include "support/DuskMidiTestBridge.h"
 
 #include <juce_audio_basics/juce_audio_basics.h>
 
@@ -9,17 +10,7 @@ namespace
 {
 using duskstudio::MidiTimeCodeEmitter;
 using duskstudio::MidiTimeCodeReceiver;
-
-// Bridge a juce::MidiBuffer into the dusk::MidiBuffer the receiver takes,
-// exactly as AudioEngine does per block.
-dusk::MidiBuffer toDusk (const juce::MidiBuffer& j)
-{
-    dusk::MidiBuffer d;
-    for (const auto meta : j)
-        d.addEvent (meta.getMessage().getRawData(), meta.getMessage().getRawDataSize(),
-                    meta.samplePosition);
-    return d;
-}
+using duskstudio::test::toDusk;
 
 // Count specific status bytes in a MidiBuffer.
 int countOf (const juce::MidiBuffer& buf, juce::uint8 status)

--- a/tests/midi_time_code_emit.cpp
+++ b/tests/midi_time_code_emit.cpp
@@ -10,6 +10,17 @@ namespace
 using duskstudio::MidiTimeCodeEmitter;
 using duskstudio::MidiTimeCodeReceiver;
 
+// Bridge a juce::MidiBuffer into the dusk::MidiBuffer the receiver takes,
+// exactly as AudioEngine does per block.
+dusk::MidiBuffer toDusk (const juce::MidiBuffer& j)
+{
+    dusk::MidiBuffer d;
+    for (const auto meta : j)
+        d.addEvent (meta.getMessage().getRawData(), meta.getMessage().getRawDataSize(),
+                    meta.samplePosition);
+    return d;
+}
+
 // Count specific status bytes in a MidiBuffer.
 int countOf (const juce::MidiBuffer& buf, juce::uint8 status)
 {
@@ -91,7 +102,7 @@ TEST_CASE ("MidiTimeCodeEmitter: round-trip through receiver recovers playhead",
                        + (juce::int64) ((double) b * 1024.0);
         emit.generateBlock (blockStart, 1024, ps, true,
                               R::Fps30, out);
-        rx.process (out, blockStart, 1024);
+        rx.process (toDusk (out), blockStart, 1024);
         blockStart += 1024;
     }
 

--- a/tests/smpte_wrap.cpp
+++ b/tests/smpte_wrap.cpp
@@ -2,25 +2,16 @@
 
 #include "engine/MidiTimeCodeEmitter.h"
 #include "engine/MidiTimeCodeReceiver.h"
+#include "support/DuskMidiTestBridge.h"
 
 #include <juce_audio_basics/juce_audio_basics.h>
 
 using duskstudio::MidiTimeCodeEmitter;
 using duskstudio::MidiTimeCodeReceiver;
+using duskstudio::test::toDusk;
 
 namespace
 {
-// Bridge a juce::MidiBuffer into the dusk::MidiBuffer the receiver takes,
-// exactly as AudioEngine does per block.
-dusk::MidiBuffer toDusk (const juce::MidiBuffer& j)
-{
-    dusk::MidiBuffer d;
-    for (const auto meta : j)
-        d.addEvent (meta.getMessage().getRawData(), meta.getMessage().getRawDataSize(),
-                    meta.samplePosition);
-    return d;
-}
-
 constexpr double kSr = 48000.0;
 constexpr double kSamplesPerFrame30 = kSr / 30.0;   // 1600
 

--- a/tests/smpte_wrap.cpp
+++ b/tests/smpte_wrap.cpp
@@ -10,6 +10,17 @@ using duskstudio::MidiTimeCodeReceiver;
 
 namespace
 {
+// Bridge a juce::MidiBuffer into the dusk::MidiBuffer the receiver takes,
+// exactly as AudioEngine does per block.
+dusk::MidiBuffer toDusk (const juce::MidiBuffer& j)
+{
+    dusk::MidiBuffer d;
+    for (const auto meta : j)
+        d.addEvent (meta.getMessage().getRawData(), meta.getMessage().getRawDataSize(),
+                    meta.samplePosition);
+    return d;
+}
+
 constexpr double kSr = 48000.0;
 constexpr double kSamplesPerFrame30 = kSr / 30.0;   // 1600
 
@@ -73,7 +84,7 @@ TEST_CASE ("MTC round-trip: a 24h playhead decodes back to ~0", "[mtc][smpte][wr
         { hasFullFrame = true; break; }
     REQUIRE (hasFullFrame);
 
-    rx.process (buf, 0, 512);
+    rx.process (toDusk (buf), 0, 512);
 
     // The full-frame sysex carried wrapped 00:00:00:00, so the receiver's
     // absolute frame count reads ~0 rather than 2,592,000.

--- a/tests/support/DuskMidiTestBridge.h
+++ b/tests/support/DuskMidiTestBridge.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "foundation/MidiBuffer.h"
+
+#include <juce_audio_basics/juce_audio_basics.h>
+
+namespace duskstudio::test
+{
+// Bridge a juce::MidiBuffer into the dusk::MidiBuffer the receivers take,
+// exactly as AudioEngine does per block. Shared by the MIDI-sync round-trip
+// tests so they feed the receivers the way the engine does.
+inline dusk::MidiBuffer toDusk (const juce::MidiBuffer& j)
+{
+    dusk::MidiBuffer d;
+    for (const auto meta : j)
+        d.addEvent (meta.getMessage().getRawData(), meta.getMessage().getRawDataSize(),
+                    meta.samplePosition);
+    return d;
+}
+} // namespace duskstudio::test

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -33,12 +33,8 @@ src/engine/McuReceiver.cpp
 src/engine/McuReceiver.h
 src/engine/MidiClockEmitter.cpp
 src/engine/MidiClockEmitter.h
-src/engine/MidiSyncReceiver.cpp
-src/engine/MidiSyncReceiver.h
 src/engine/MidiTimeCodeEmitter.cpp
 src/engine/MidiTimeCodeEmitter.h
-src/engine/MidiTimeCodeReceiver.cpp
-src/engine/MidiTimeCodeReceiver.h
 src/engine/NativeScanRows.h
 src/engine/PlaybackEngine.cpp
 src/engine/PlaybackEngine.h

--- a/tools/tsan_suppressions.txt
+++ b/tools/tsan_suppressions.txt
@@ -20,6 +20,17 @@ mutex:juce::Thread::notify
 deadlock:juce::WaitableEvent::signal
 deadlock:juce::Thread::notify
 
+# dusk::AutoResetEvent replaced juce::WaitableEvent in the DSP worker pool
+# (de-JUCE threading migration). It is the same mutex + condition_variable
+# auto-reset primitive, so its signal() trips the identical TSan double-lock /
+# lock-order artifact under contention. signal() takes the lock, sets the flag,
+# releases, then notifies with no lock held — there is no real recursive lock
+# (verified); the notify racing a waiter's cv.wait relock is what TSan mis-reads.
+# Worker-pool correctness is covered by the join/quiesce protocol tests and the
+# Parallel-Matches-Serial self-test.
+mutex:dusk::AutoResetEvent::signal
+deadlock:dusk::AutoResetEvent::signal
+
 # JUCE's TimeSliceThread + ThreadedWriter pairing (used by Record
 # Manager) ride the same notify path and trip the same warning. The
 # RT-safety of Dusk Studio's own RecordManager code is verified by


### PR DESCRIPTION
Starts the MIDI tower: a JUCE-free MIDI event buffer, and the two audio-thread MIDI-sync **receivers** onto it. Ratchet **212 → 208**.

## New model
`src/foundation/MidiBuffer.h` — `dusk::MidiBuffer` + `dusk::MidiMessage`. A packed, pre-sizable event buffer and a byte-view message exposing exactly the slice of the JUCE `MidiBuffer`/`MidiMessage` API the engine's decoders use:
- in-order iteration yielding `getMessage()` / `samplePosition`
- `getRawData()` / `getRawDataSize()` per message

It stores raw bytes only (no MIDI-semantic parsing — the decoders read status/data bytes directly). A/B tested against `juce::MidiBuffer` for identical iteration order, bytes and sample positions.

## Flips
`MidiTimeCodeReceiver` and `MidiSyncReceiver` take `dusk::MidiBuffer` and go fully JUCE-free (`jlimit` → `std::clamp`, one comment reworded).

`AudioEngine` bridges the JUCE input block into a **pre-reserved** `dusk::MidiBuffer` scratch once per block before dispatching both receivers — the fill never allocates on the audio thread (reserved in `prepareForSelfTest` alongside `perInputMidi`). AudioEngine itself stays JUCE-coupled.

## Verification
- juce-gate: 208, exit 0
- app build: clean
- tests: 348/348 — new `dusk::MidiBuffer` ↔ `juce::MidiBuffer` A/B; the MTC decode / emit / smpte-wrap round-trips now bridge the emitter's JUCE buffer through the same conversion and still pass
- `DUSKSTUDIO_RUN_SELFTEST=1` under Xvfb: 15/15, no NaN/crash

## Next MIDI phase (separate PR)
`McuReceiver` is another clean input reader (only `MidiBuffer` + `jlimit`×15) — reuses the model + a second engine bridge. The **emitters** (`MidiTimeCodeEmitter`, `MidiClockEmitter`) are the write side: `MidiClockEmitter` also holds a `juce::MidiOutput` device, so they need a reverse `dusk → juce` bridge and stay partly coupled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MIDI clock and timecode input handling for more reliable synchronization.
  * Reduced audio-thread interruptions during MIDI processing.

* **Refactor**
  * Added a streamlined internal MIDI event representation for sync processing.

* **Tests**
  * Added coverage for MIDI event ordering, clearing, and timecode round-trip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->