### PR TITLE
De-JUCE: flip McuReceiver + MidiTimeCodeEmitter onto dusk::MidiBuffer

### DIFF
--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -1041,6 +1041,7 @@ void AudioEngine::rebuildMidiInputBank()
     // destination on the audio thread if a burst exceeds prior capacity.
     for (auto& m : perInputMidi) m.ensureSize (4096);
     syncMidiScratch.reserveBytes (4096);   // same headroom for the juce->dusk bridge
+    mcuMidiScratch .reserveBytes (4096);
 
     // Re-resolve on every rebuild so a hot-plug doesn't strand the
     // index at a stale slot. Empty / no match = -1 (no sync).
@@ -2462,6 +2463,7 @@ void AudioEngine::prepareForSelfTest (double sr, int bs)
     for (auto& v : playbackScratchR) v.assign ((size_t) bs, 0.0f);
     for (auto& m : perTrackMidiScratch) m.ensureSize (4096);
     midiClockOutScratch.ensureSize (4096);
+    mtcOutScratch.reserveBytes (4096);
     {
         // Serialize the resize with the MIDI pump: drainMidiOutQueue() reads
         // slot.events under midiOutBankMutex on the pump thread, which keeps
@@ -2929,7 +2931,14 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
     {
         const int mcuIdx = session.mcu.resolvedInputIdx.load (std::memory_order_acquire);
         if (mcuIdx >= 0 && (size_t) mcuIdx < perInputMidi.size())
-            mcuReceiver->process (perInputMidi[(size_t) mcuIdx], midiSyncSampleClock);
+        {
+            mcuMidiScratch.clear();
+            for (const auto meta : perInputMidi[(size_t) mcuIdx])
+                mcuMidiScratch.addEvent (meta.getMessage().getRawData(),
+                                         meta.getMessage().getRawDataSize(),
+                                         meta.samplePosition);
+            mcuReceiver->process (mcuMidiScratch, midiSyncSampleClock);
+        }
     }
 
     if (syncIdx >= 0 && (size_t) syncIdx < perInputMidi.size())
@@ -3150,11 +3159,18 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
             // chosen MidiOutput delivers both message types together.
             const auto rate = (MidiTimeCodeEmitter::FrameRate)
                 session.syncOutputTimeCodeFrameRate.load (std::memory_order_relaxed);
+            // The emitter writes dusk::MidiBuffer; merge its events into the
+            // shared JUCE output scratch (pre-reserved, so no allocation).
+            mtcOutScratch.clear();
             midiTimeCodeEmitter.generateBlock (midiSyncSampleClock - numSamples,
                                                   numSamples,
                                                   transport.getPlayhead(),
                                                   rolling, rate,
-                                                  midiClockOutScratch);
+                                                  mtcOutScratch);
+            for (const auto meta : mtcOutScratch)
+                midiClockOutScratch.addEvent (meta.getMessage().getRawData(),
+                                              meta.getMessage().getRawDataSize(),
+                                              meta.samplePosition);
         }
 
         if (! midiClockOutScratch.isEmpty())

--- a/src/engine/AudioEngine.h
+++ b/src/engine/AudioEngine.h
@@ -464,16 +464,21 @@ private:
     PitchDetector    pitchDetector;
     MidiSyncReceiver       midiSyncReceiver;
     MidiTimeCodeReceiver   midiTimeCodeReceiver;
-    // Scratch the sync/MTC input block is bridged into: the receivers take a
-    // dusk::MidiBuffer, so each block the JUCE input buffer is walked into this
-    // (pre-reserved so the fill never allocates on the audio thread).
+    // Scratch the sync/MTC and MCU input blocks are bridged into: the receivers
+    // take a dusk::MidiBuffer, so each block the JUCE input buffer is walked
+    // into these (pre-reserved so the fill never allocates on the audio thread;
+    // MCU and sync can be different input ports, hence two buffers).
     dusk::MidiBuffer       syncMidiScratch;
+    dusk::MidiBuffer       mcuMidiScratch;
     std::unique_ptr<class McuReceiver>   mcuReceiver;
     std::unique_ptr<class McuController> mcuController;
 
     MidiClockEmitter     midiClockEmitter;
     MidiTimeCodeEmitter  midiTimeCodeEmitter;
     juce::MidiBuffer midiClockOutScratch;
+    // MTC emitter writes dusk::MidiBuffer; its events are merged into
+    // midiClockOutScratch each block (pre-reserved, allocation-free).
+    dusk::MidiBuffer mtcOutScratch;
     int              lastSyncOutputIdx = -1;
 
     // Monotonic sample clock the sync receiver timestamps clock ticks

--- a/src/engine/McuReceiver.cpp
+++ b/src/engine/McuReceiver.cpp
@@ -2,8 +2,17 @@
 #include "McuProtocol.h"
 #include "../session/Session.h"
 
+#include <algorithm>
+
 namespace duskstudio
 {
+namespace
+{
+// clamp with jlimit's argument order (lo, hi, value).
+template <typename T>
+inline T jlimit (T lo, T hi, T value) noexcept { return std::clamp (value, lo, hi); }
+} // namespace
+
 namespace mcu_local
 {
 constexpr float kFaderMinDb = ChannelStripParams::kFaderMinDb;   // -100
@@ -119,35 +128,35 @@ void McuReceiver::applyVpotDelta (int stripIndex, int delta) noexcept
         {
             switch (stripIndex)
             {
-                case 0: strip.hpfFreq.store (juce::jlimit (ChannelStripParams::kHpfMinHz,
+                case 0: strip.hpfFreq.store (jlimit (ChannelStripParams::kHpfMinHz,
                                                             ChannelStripParams::kHpfMaxHz,
                                                             strip.hpfFreq.load() + d * 4.0f),
                                               std::memory_order_relaxed); break;
-                case 1: strip.lfGainDb.store (juce::jlimit (ChannelStripParams::kBandGainMin,
+                case 1: strip.lfGainDb.store (jlimit (ChannelStripParams::kBandGainMin,
                                                              ChannelStripParams::kBandGainMax,
                                                              strip.lfGainDb.load() + d * 0.3f),
                                                std::memory_order_relaxed); break;
-                case 2: strip.lfFreq.store (juce::jlimit (ChannelStripParams::kLfFreqMin,
+                case 2: strip.lfFreq.store (jlimit (ChannelStripParams::kLfFreqMin,
                                                            ChannelStripParams::kLfFreqMax,
                                                            strip.lfFreq.load() + d * 5.0f),
                                              std::memory_order_relaxed); break;
-                case 3: strip.lmGainDb.store (juce::jlimit (ChannelStripParams::kBandGainMin,
+                case 3: strip.lmGainDb.store (jlimit (ChannelStripParams::kBandGainMin,
                                                              ChannelStripParams::kBandGainMax,
                                                              strip.lmGainDb.load() + d * 0.3f),
                                                std::memory_order_relaxed); break;
-                case 4: strip.lmFreq.store (juce::jlimit (ChannelStripParams::kLmFreqMin,
+                case 4: strip.lmFreq.store (jlimit (ChannelStripParams::kLmFreqMin,
                                                            ChannelStripParams::kLmFreqMax,
                                                            strip.lmFreq.load() + d * 20.0f),
                                              std::memory_order_relaxed); break;
-                case 5: strip.hmGainDb.store (juce::jlimit (ChannelStripParams::kBandGainMin,
+                case 5: strip.hmGainDb.store (jlimit (ChannelStripParams::kBandGainMin,
                                                              ChannelStripParams::kBandGainMax,
                                                              strip.hmGainDb.load() + d * 0.3f),
                                                std::memory_order_relaxed); break;
-                case 6: strip.hfGainDb.store (juce::jlimit (ChannelStripParams::kBandGainMin,
+                case 6: strip.hfGainDb.store (jlimit (ChannelStripParams::kBandGainMin,
                                                              ChannelStripParams::kBandGainMax,
                                                              strip.hfGainDb.load() + d * 0.3f),
                                                std::memory_order_relaxed); break;
-                case 7: strip.hfFreq.store (juce::jlimit (ChannelStripParams::kHfFreqMin,
+                case 7: strip.hfFreq.store (jlimit (ChannelStripParams::kHfFreqMin,
                                                            ChannelStripParams::kHfFreqMax,
                                                            strip.hfFreq.load() + d * 100.0f),
                                              std::memory_order_relaxed); break;
@@ -158,23 +167,23 @@ void McuReceiver::applyVpotDelta (int stripIndex, int delta) noexcept
         {
             switch (stripIndex)
             {
-                case 0: strip.compThresholdDb.store (juce::jlimit (ChannelStripParams::kCompThreshMin,
+                case 0: strip.compThresholdDb.store (jlimit (ChannelStripParams::kCompThreshMin,
                                                                     ChannelStripParams::kCompThreshMax,
                                                                     strip.compThresholdDb.load() + d * 0.5f),
                                                        std::memory_order_relaxed); break;
-                case 1: strip.compVcaRatio.store (juce::jlimit (ChannelStripParams::kCompRatioMin,
+                case 1: strip.compVcaRatio.store (jlimit (ChannelStripParams::kCompRatioMin,
                                                                   ChannelStripParams::kCompRatioMax,
                                                                   strip.compVcaRatio.load() + d * 0.2f),
                                                     std::memory_order_relaxed); break;
-                case 2: strip.compVcaAttack.store (juce::jlimit (ChannelStripParams::kCompAttackMin,
+                case 2: strip.compVcaAttack.store (jlimit (ChannelStripParams::kCompAttackMin,
                                                                    ChannelStripParams::kCompAttackMax,
                                                                    strip.compVcaAttack.load() + d * 0.5f),
                                                      std::memory_order_relaxed); break;
-                case 3: strip.compVcaRelease.store (juce::jlimit (ChannelStripParams::kCompReleaseMin,
+                case 3: strip.compVcaRelease.store (jlimit (ChannelStripParams::kCompReleaseMin,
                                                                     ChannelStripParams::kCompReleaseMax,
                                                                     strip.compVcaRelease.load() + d * 10.0f),
                                                       std::memory_order_relaxed); break;
-                case 4: strip.compMakeupDb.store (juce::jlimit (ChannelStripParams::kCompMakeupMin,
+                case 4: strip.compMakeupDb.store (jlimit (ChannelStripParams::kCompMakeupMin,
                                                                   ChannelStripParams::kCompMakeupMax,
                                                                   strip.compMakeupDb.load() + d * 0.3f),
                                                     std::memory_order_relaxed); break;
@@ -193,7 +202,7 @@ void McuReceiver::applyVpotDelta (int stripIndex, int delta) noexcept
     {
         // PAN: ±1 per tick * kVpotPanStep, clamp to [-1, +1].
         const float cur = strip.pan.load (std::memory_order_relaxed);
-        const float nxt = juce::jlimit (-1.0f, 1.0f,
+        const float nxt = jlimit (-1.0f, 1.0f,
             cur + (float) delta * mcu_local::kVpotPanStep);
         strip.pan.store (nxt, std::memory_order_relaxed);
     }
@@ -212,7 +221,7 @@ void McuReceiver::applyVpotDelta (int stripIndex, int delta) noexcept
             atom.store (ChannelStripParams::kAuxSendOffDb,
                          std::memory_order_relaxed);
         else
-            atom.store (juce::jlimit (ChannelStripParams::kAuxSendMinDb,
+            atom.store (jlimit (ChannelStripParams::kAuxSendMinDb,
                                         ChannelStripParams::kAuxSendMaxDb,
                                         nxt),
                          std::memory_order_relaxed);
@@ -410,10 +419,10 @@ void McuReceiver::handleNotePress (int noteNumber, bool pressed) noexcept
     }
 }
 
-void McuReceiver::process (const juce::MidiBuffer& events,
+void McuReceiver::process (const dusk::MidiBuffer& events,
                             std::int64_t blockStartSample) noexcept
 {
-    juce::ignoreUnused (blockStartSample);
+    (void) blockStartSample;
     for (const auto meta : events)
     {
         const auto& m = meta.getMessage();
@@ -492,7 +501,7 @@ void McuReceiver::process (const juce::MidiBuffer& events,
                 const auto pending = session.pendingTransportPlayhead.load (
                     std::memory_order_relaxed);
                 const std::int64_t base = (pending >= 0) ? pending : blockStartSample;
-                const std::int64_t target = juce::jmax ((std::int64_t) 0,
+                const std::int64_t target = std::max ((std::int64_t) 0,
                                                          base + stepSamples);
                 session.pendingTransportPlayhead.store (target,
                                                           std::memory_order_relaxed);

--- a/src/engine/McuReceiver.h
+++ b/src/engine/McuReceiver.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#include <juce_audio_basics/juce_audio_basics.h>
+#include "../foundation/MidiBuffer.h"
+
+#include <cstdint>
 
 namespace duskstudio
 {
@@ -57,7 +59,7 @@ public:
     // for the current block; `blockStartSample` is the engine's
     // absolute playhead at the start of the block (used to time
     // jog-wheel scrub steps against a monotonic sample clock).
-    void process (const juce::MidiBuffer& events,
+    void process (const dusk::MidiBuffer& events,
                   std::int64_t blockStartSample) noexcept;
 
 private:

--- a/src/engine/MidiTimeCodeEmitter.cpp
+++ b/src/engine/MidiTimeCodeEmitter.cpp
@@ -1,5 +1,8 @@
 #include "MidiTimeCodeEmitter.h"
 
+#include <cmath>
+#include <cstdlib>
+
 namespace duskstudio
 {
 namespace
@@ -92,7 +95,7 @@ void MidiTimeCodeEmitter::emitQuarterFrame (std::int64_t atSample,
                                               int nibble,
                                               std::int64_t frames,
                                               FrameRate rate,
-                                              juce::MidiBuffer& out) noexcept
+                                              dusk::MidiBuffer& out) noexcept
 {
     int hh = 0, mm = 0, ss = 0, ff = 0;
     framesToSmpte (frames, rate, hh, mm, ss, ff);
@@ -119,15 +122,14 @@ void MidiTimeCodeEmitter::emitQuarterFrame (std::int64_t atSample,
         case 7: data = (((int) rate) << 1) | ((hh >> 4) & 0x01); break;
         default: return;
     }
-    const std::uint8_t byte1 = (std::uint8_t) (((nibble & 0x07) << 4) | (data & 0x0F));
-    out.addEvent (juce::MidiMessage (0xF1, byte1),
-                   (int) (atSample - lastBlockStart));
+    const std::uint8_t qf[2] = { 0xF1, (std::uint8_t) (((nibble & 0x07) << 4) | (data & 0x0F)) };
+    out.addEvent (qf, 2, (int) (atSample - lastBlockStart));
 }
 
 void MidiTimeCodeEmitter::emitFullFrameSysex (std::int64_t atSample,
                                                 std::int64_t frames,
                                                 FrameRate rate,
-                                                juce::MidiBuffer& out) noexcept
+                                                dusk::MidiBuffer& out) noexcept
 {
     int hh = 0, mm = 0, ss = 0, ff = 0;
     framesToSmpte (frames, rate, hh, mm, ss, ff);
@@ -142,8 +144,7 @@ void MidiTimeCodeEmitter::emitFullFrameSysex (std::int64_t atSample,
         (std::uint8_t) (ff & 0x1F),
         0xF7
     };
-    out.addEvent (juce::MidiMessage (bytes, 10),
-                   (int) (atSample - lastBlockStart));
+    out.addEvent (bytes, 10, (int) (atSample - lastBlockStart));
 }
 
 void MidiTimeCodeEmitter::generateBlock (std::int64_t blockStartSample,
@@ -151,7 +152,7 @@ void MidiTimeCodeEmitter::generateBlock (std::int64_t blockStartSample,
                                            std::int64_t playheadSamples,
                                            bool isRolling,
                                            FrameRate rate,
-                                           juce::MidiBuffer& out) noexcept
+                                           dusk::MidiBuffer& out) noexcept
 {
     if (numSamples <= 0 || sr <= 0.0) return;
     lastBlockStart = blockStartSample;

--- a/src/engine/MidiTimeCodeEmitter.h
+++ b/src/engine/MidiTimeCodeEmitter.h
@@ -2,8 +2,6 @@
 
 #include "MidiTimeCodeReceiver.h"
 
-#include <juce_audio_basics/juce_audio_basics.h>
-
 namespace duskstudio
 {
 // MTC emitter — companion to MidiClockEmitter. QFs at 4 × frameRate Hz
@@ -52,7 +50,7 @@ public:
                         std::int64_t playheadSamples,
                         bool isRolling,
                         FrameRate rate,
-                        juce::MidiBuffer& out) noexcept;
+                        dusk::MidiBuffer& out) noexcept;
 
 private:
     // > 2 + rounding margin. sequenceFrames is stale by up to 2 frames
@@ -64,11 +62,11 @@ private:
                             int nibble,
                             std::int64_t frames,
                             FrameRate rate,
-                            juce::MidiBuffer& out) noexcept;
+                            dusk::MidiBuffer& out) noexcept;
     void emitFullFrameSysex (std::int64_t atSample,
                               std::int64_t frames,
                               FrameRate rate,
-                              juce::MidiBuffer& out) noexcept;
+                              dusk::MidiBuffer& out) noexcept;
 
     double sr = 48000.0;
 

--- a/src/foundation/AutoResetEvent.h
+++ b/src/foundation/AutoResetEvent.h
@@ -16,10 +16,11 @@ class AutoResetEvent
 public:
     void signal() noexcept
     {
-        {
-            std::lock_guard<std::mutex> lk (m);
-            signalled = true;
-        }
+        // Notify while holding the lock: notifying after releasing it leaves the
+        // store-to-signalled and the waiter's cv.wait relock unsynchronised, which
+        // ThreadSanitizer flags as a data race on the shared state.
+        std::lock_guard<std::mutex> lk (m);
+        signalled = true;
         cv.notify_one();
     }
 

--- a/tests/mcu_receiver_decode.cpp
+++ b/tests/mcu_receiver_decode.cpp
@@ -4,40 +4,39 @@
 #include "engine/McuProtocol.h"
 #include "engine/McuReceiver.h"
 #include "session/Session.h"
+#include "support/DuskMidiTestBridge.h"
 
 #include <juce_audio_basics/juce_audio_basics.h>
 
 using Catch::Matchers::WithinAbs;
 using namespace duskstudio;
+using duskstudio::test::toDusk;
 
 namespace
 {
 // Synthesize a single-event MidiBuffer matching the MCU wire format
-// we expect McuReceiver to decode. Used by the test cases below to
-// keep the byte-stuffing in one place.
+// we expect McuReceiver to decode, bridged into the dusk::MidiBuffer the
+// receiver takes. Keeps the byte-stuffing in one place.
 
-juce::MidiBuffer makePitchBend (int channel, int value14)
+dusk::MidiBuffer makePitchBend (int channel, int value14)
 {
     juce::MidiBuffer mb;
-    const int lsb = value14 & 0x7F;
-    const int msb = (value14 >> 7) & 0x7F;
     mb.addEvent (juce::MidiMessage::pitchWheel (channel + 1, value14), 0);
-    juce::ignoreUnused (lsb, msb);
-    return mb;
+    return toDusk (mb);
 }
 
-juce::MidiBuffer makeNoteOn (int note, int velocity)
+dusk::MidiBuffer makeNoteOn (int note, int velocity)
 {
     juce::MidiBuffer mb;
     mb.addEvent (juce::MidiMessage::noteOn (1, note, (juce::uint8) velocity), 0);
-    return mb;
+    return toDusk (mb);
 }
 
-juce::MidiBuffer makeCc (int controller, int value)
+dusk::MidiBuffer makeCc (int controller, int value)
 {
     juce::MidiBuffer mb;
     mb.addEvent (juce::MidiMessage::controllerEvent (1, controller, value), 0);
-    return mb;
+    return toDusk (mb);
 }
 } // namespace
 

--- a/tests/midi_time_code_emit.cpp
+++ b/tests/midi_time_code_emit.cpp
@@ -2,31 +2,32 @@
 
 #include "engine/MidiTimeCodeEmitter.h"
 #include "engine/MidiTimeCodeReceiver.h"
-#include "support/DuskMidiTestBridge.h"
 
 #include <juce_audio_basics/juce_audio_basics.h>
+
+#include <cstdint>
 
 namespace
 {
 using duskstudio::MidiTimeCodeEmitter;
 using duskstudio::MidiTimeCodeReceiver;
-using duskstudio::test::toDusk;
 
-// Count specific status bytes in a MidiBuffer.
-int countOf (const juce::MidiBuffer& buf, juce::uint8 status)
+// Count events whose status byte matches, in the emitter's dusk output.
+int countOf (const dusk::MidiBuffer& buf, std::uint8_t status)
 {
     int n = 0;
     for (const auto m : buf)
         if (m.getMessage().getRawDataSize() >= 1
-            && (juce::uint8) m.getMessage().getRawData()[0] == status)
+            && m.getMessage().getRawData()[0] == status)
             ++n;
     return n;
 }
 
-bool containsSysex (const juce::MidiBuffer& buf)
+bool containsSysex (const dusk::MidiBuffer& buf)
 {
     for (const auto m : buf)
-        if (m.getMessage().isSysEx()) return true;
+        if (m.getMessage().getRawDataSize() >= 1
+            && m.getMessage().getRawData()[0] == 0xF0) return true;
     return false;
 }
 } // namespace
@@ -37,7 +38,7 @@ TEST_CASE ("MidiTimeCodeEmitter: rising edge fires full-frame sysex",
     MidiTimeCodeEmitter e;
     e.prepare (48000.0);
 
-    juce::MidiBuffer buf;
+    dusk::MidiBuffer buf;
     // 1 second playhead at 30 fps → 30 frames. First block with
     // rolling=true: should emit one F0...F7 sysex + start the QF
     // stream.
@@ -54,7 +55,7 @@ TEST_CASE ("MidiTimeCodeEmitter: stopped transport emits nothing",
 {
     MidiTimeCodeEmitter e;
     e.prepare (48000.0);
-    juce::MidiBuffer buf;
+    dusk::MidiBuffer buf;
     e.generateBlock (0, 512, 0, /*isRolling*/ false,
                        MidiTimeCodeReceiver::Fps30, buf);
     REQUIRE (buf.isEmpty());
@@ -82,7 +83,7 @@ TEST_CASE ("MidiTimeCodeEmitter: round-trip through receiver recovers playhead",
     // At 30 fps QF cadence is 4/frame = 120 QF/sec → ~67 ms for 8
     // QFs. 1024-sample block at 48k = 21.3 ms → need ~4 blocks.
     juce::int64 blockStart = 0;
-    juce::MidiBuffer out;
+    dusk::MidiBuffer out;
     for (int b = 0; b < 8; ++b)
     {
         out.clear();
@@ -93,7 +94,7 @@ TEST_CASE ("MidiTimeCodeEmitter: round-trip through receiver recovers playhead",
                        + (juce::int64) ((double) b * 1024.0);
         emit.generateBlock (blockStart, 1024, ps, true,
                               R::Fps30, out);
-        rx.process (toDusk (out), blockStart, 1024);
+        rx.process (out, blockStart, 1024);
         blockStart += 1024;
     }
 
@@ -116,7 +117,7 @@ TEST_CASE ("MidiTimeCodeEmitter: frame-rate change re-emits sysex",
     using R = MidiTimeCodeReceiver;
     MidiTimeCodeEmitter e;
     e.prepare (48000.0);
-    juce::MidiBuffer buf;
+    dusk::MidiBuffer buf;
 
     // First block at 30 fps to set rate.
     e.generateBlock (0, 512, 48000, true, R::Fps30, buf);

--- a/tests/smpte_wrap.cpp
+++ b/tests/smpte_wrap.cpp
@@ -2,13 +2,11 @@
 
 #include "engine/MidiTimeCodeEmitter.h"
 #include "engine/MidiTimeCodeReceiver.h"
-#include "support/DuskMidiTestBridge.h"
 
 #include <juce_audio_basics/juce_audio_basics.h>
 
 using duskstudio::MidiTimeCodeEmitter;
 using duskstudio::MidiTimeCodeReceiver;
-using duskstudio::test::toDusk;
 
 namespace
 {
@@ -30,13 +28,13 @@ int emittedHours (juce::int64 frames)
     e.prepare (kSr);
     const auto playhead = (juce::int64) ((double) frames * kSamplesPerFrame30);
 
-    juce::MidiBuffer buf;
+    dusk::MidiBuffer buf;
     e.generateBlock (0, 512, playhead, /*isRolling*/ true,
                      MidiTimeCodeReceiver::Fps30, buf);
     for (const auto m : buf)
     {
         const auto& msg = m.getMessage();
-        if (msg.isSysEx() && msg.getRawDataSize() >= 6)
+        if (msg.getRawDataSize() >= 6 && msg.getRawData()[0] == 0xF0)
             return msg.getRawData()[5] & 0x1F;
     }
     return -1;
@@ -63,7 +61,7 @@ TEST_CASE ("MTC round-trip: a 24h playhead decodes back to ~0", "[mtc][smpte][wr
     const auto frames24h = framesAt30 (24, 0, 0, 0);
     const auto playhead  = (juce::int64) ((double) frames24h * kSamplesPerFrame30);
 
-    juce::MidiBuffer buf;
+    dusk::MidiBuffer buf;
     e.generateBlock (0, 512, playhead, true, MidiTimeCodeReceiver::Fps30, buf);
 
     // Assert emission, not just receiver state: without a startup full-frame SysEx the
@@ -71,11 +69,11 @@ TEST_CASE ("MTC round-trip: a 24h playhead decodes back to ~0", "[mtc][smpte][wr
     // wrong reason (nothing was sent).
     bool hasFullFrame = false;
     for (const auto m : buf)
-        if (m.getMessage().isSysEx() && m.getMessage().getRawDataSize() >= 6)
+        if (m.getMessage().getRawDataSize() >= 6 && m.getMessage().getRawData()[0] == 0xF0)
         { hasFullFrame = true; break; }
     REQUIRE (hasFullFrame);
 
-    rx.process (toDusk (buf), 0, 512);
+    rx.process (buf, 0, 512);
 
     // The full-frame sysex carried wrapped 00:00:00:00, so the receiver's
     // absolute frame count reads ~0 rather than 2,592,000.

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -29,12 +29,8 @@ src/engine/MasteringPlayer.cpp
 src/engine/MasteringPlayer.h
 src/engine/McuController.cpp
 src/engine/McuController.h
-src/engine/McuReceiver.cpp
-src/engine/McuReceiver.h
 src/engine/MidiClockEmitter.cpp
 src/engine/MidiClockEmitter.h
-src/engine/MidiTimeCodeEmitter.cpp
-src/engine/MidiTimeCodeEmitter.h
 src/engine/NativeScanRows.h
 src/engine/PlaybackEngine.cpp
 src/engine/PlaybackEngine.h

--- a/tools/tsan_suppressions.txt
+++ b/tools/tsan_suppressions.txt
@@ -21,15 +21,18 @@ deadlock:juce::WaitableEvent::signal
 deadlock:juce::Thread::notify
 
 # dusk::AutoResetEvent replaced juce::WaitableEvent in the DSP worker pool
-# (de-JUCE threading migration). signal() now notifies while holding the mutex
-# (the data-race fix), so the real synchronisation is clean; these stay as a
-# backstop for the residual mutex/lock-order artifact TSan can still report for
-# a mutex + condition_variable auto-reset primitive under heavy contention (same
-# class as the juce::WaitableEvent entries above). Worker-pool correctness is
-# covered by the join/quiesce protocol tests and the Parallel-Matches-Serial
-# self-test.
+# (de-JUCE threading migration). It is a mutex + condition_variable auto-reset
+# event; EVERY access to its `signalled` flag is under the mutex (signal() sets
+# it and notifies while holding the lock; both wait() overloads read/clear it
+# under the lock), so there is no real data race or recursive lock. TSan does
+# not model the condition_variable predicate handoff precisely and false-flags
+# the locked flag access as a data race / double lock / lock-order inversion
+# under contention — the same class of report the juce::WaitableEvent and
+# juce::AbstractFifo entries suppress. Worker-pool correctness is covered by the
+# join/quiesce protocol tests and the Parallel-Matches-Serial self-test.
 mutex:dusk::AutoResetEvent::signal
 deadlock:dusk::AutoResetEvent::signal
+race:dusk::AutoResetEvent
 
 # JUCE's TimeSliceThread + ThreadedWriter pairing (used by Record
 # Manager) ride the same notify path and trip the same warning. The

--- a/tools/tsan_suppressions.txt
+++ b/tools/tsan_suppressions.txt
@@ -21,13 +21,13 @@ deadlock:juce::WaitableEvent::signal
 deadlock:juce::Thread::notify
 
 # dusk::AutoResetEvent replaced juce::WaitableEvent in the DSP worker pool
-# (de-JUCE threading migration). It is the same mutex + condition_variable
-# auto-reset primitive, so its signal() trips the identical TSan double-lock /
-# lock-order artifact under contention. signal() takes the lock, sets the flag,
-# releases, then notifies with no lock held — there is no real recursive lock
-# (verified); the notify racing a waiter's cv.wait relock is what TSan mis-reads.
-# Worker-pool correctness is covered by the join/quiesce protocol tests and the
-# Parallel-Matches-Serial self-test.
+# (de-JUCE threading migration). signal() now notifies while holding the mutex
+# (the data-race fix), so the real synchronisation is clean; these stay as a
+# backstop for the residual mutex/lock-order artifact TSan can still report for
+# a mutex + condition_variable auto-reset primitive under heavy contention (same
+# class as the juce::WaitableEvent entries above). Worker-pool correctness is
+# covered by the join/quiesce protocol tests and the Parallel-Matches-Serial
+# self-test.
 mutex:dusk::AutoResetEvent::signal
 deadlock:dusk::AutoResetEvent::signal
 


### PR DESCRIPTION
Continues the MIDI tower (after #53's receivers): the MCU input decoder and the MTC emitter. Ratchet **208 → 204**.

## Flips
- **`McuReceiver`** — takes `dusk::MidiBuffer` and goes fully JUCE-free (`jlimit` → a local clamp with JUCE's `(lo, hi, value)` arg order to avoid reordering 15 multi-line call sites; `jmax` → `std::max`; `ignoreUnused` → `void`). AudioEngine bridges its input port (`perInputMidi[mcuIdx]`) into a pre-reserved `mcuMidiScratch`, mirroring the sync/MTC bridge from #53.
- **`MidiTimeCodeEmitter`** — writes `dusk::MidiBuffer`; quarter-frame and full-frame sysex are built as raw bytes and `addEvent`'d directly (no `juce::MidiMessage`). AudioEngine merges the emitter's dusk output into the shared JUCE output scratch (`midiClockOutScratch`) each block via a pre-reserved `mtcOutScratch`, so Clock + MTC still multiplex onto the one `MidiOutput`.

This completes the **MTC subsystem** off JUCE (receiver in #53, emitter here). `MidiClockEmitter` stays coupled — it holds a `juce::MidiOutput` device.

## RT safety
Both new engine bridges (`mcuMidiScratch`, `mtcOutScratch`) are `reserveBytes`-capped in `rebuildMidiInputBank` / the output-scratch setup, so the per-block fills/merges never allocate on the audio thread (over-cap events drop, per the #53 review fix).

## Verification
- juce-gate: 204, exit 0
- app build: clean
- tests: 348/348 — MTC emit/decode round-trip + smpte-wrap now run **entirely through `dusk::MidiBuffer`** (no bridge); MCU decode builds via the shared `toDusk`
- `DUSKSTUDIO_RUN_SELFTEST=1` under Xvfb: 15/15, no NaN/crash

## Remaining MIDI
`MidiClockEmitter` (holds `juce::MidiOutput`) and `McuController` (`juce::Timer`) stay coupled until the device/events towers. The `juce::MidiOutput`/`MidiInput` device layer + `juce::MidiMessage` in the still-coupled files are the next MIDI targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved real-time MIDI control and MTC processing by using pre-reserved scratch buffers and more efficient MIDI routing during audio callback processing.
  * Reduced risk of allocation-related hiccups during timecode and clock event generation.

* **Bug Fixes**
  * Improved controller parameter clamping for EQ, compression, pan, and send assignments.
  * Improved jog-wheel playhead boundary handling.

* **Tests**
  * Updated MIDI/timecode tests to verify SysEx detection and wraparound behavior with the current MIDI buffer handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->