### PR TITLE
De-JUCE: strip donor cores — comp/EQ/tube onto framework-free duskaudio DSP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -785,8 +785,10 @@ if(DEFINED DUSK_PLUGINS_PATH)
         "${DUSK_PLUGINS_PATH}/plugins/shared-dpf"
         "${DUSK_PLUGINS_PATH}/plugins/shared/AnalogEmulation"
         "${DUSK_PLUGINS_PATH}/plugins/shared/channel-comp"
+        "${DUSK_PLUGINS_PATH}/plugins/shared-dpf/dsp"
         "${DUSK_PLUGINS_PATH}/plugins/multi-q"
         "${DUSK_PLUGINS_PATH}/plugins/multi-comp"
+        "${DUSK_PLUGINS_PATH}/plugins/multi-comp/core"
         "${DUSK_PLUGINS_PATH}/plugins/multi-comp/HardwareEmulation"
         "${DUSK_PLUGINS_PATH}/plugins/tape-echo/Source/DSP"
         "${DUSK_PLUGINS_PATH}/plugins/TapeMachine/Source"
@@ -795,8 +797,12 @@ if(DEFINED DUSK_PLUGINS_PATH)
     # Compile multi-comp's processor + editor + shared LEDMeter so
     # UniversalCompressor links cleanly. Editor sources are linked but not
     # invoked from Dusk Studio's UI — they exist only because UniversalCompressor's
-    # createEditor() references them.
+    # createEditor() references them. The framework-free cores
+    # (UniversalCompressorDSP / FourKEQDSP) are the de-JUCE'd donors BusStrip
+    # uses directly.
     target_sources(DuskStudio PRIVATE
+        "${DUSK_PLUGINS_PATH}/plugins/multi-comp/core/UniversalCompressorDSP.cpp"
+        "${DUSK_PLUGINS_PATH}/plugins/shared-dpf/dsp/FourKEQDSP.cpp"
         "${DUSK_PLUGINS_PATH}/plugins/multi-comp/multicomp.cpp"
         "${DUSK_PLUGINS_PATH}/plugins/multi-comp/AnalogLookAndFeel.cpp"
         "${DUSK_PLUGINS_PATH}/plugins/multi-comp/EnhancedCompressorEditor.cpp"

--- a/src/dsp/BusStrip.cpp
+++ b/src/dsp/BusStrip.cpp
@@ -1,9 +1,18 @@
 #include "BusStrip.h"
+#include "../foundation/Decibels.h"
+#include "../foundation/ScopedNoDenormals.h"
+#include <algorithm>
 #include <cmath>
 #include <cstring>
 
 namespace duskstudio
 {
+namespace
+{
+constexpr float kHalfPi = 1.57079632679489661923f;
+constexpr float kSqrt2  = 1.41421356237309504880f;
+} // namespace
+
 void BusStrip::bind (const BusParams& params) noexcept
 {
     paramsRef = &params;
@@ -13,7 +22,7 @@ void BusStrip::prepare (double sampleRate, int blockSize, int oversamplingFactor
 {
     sampleRateForMeter = sampleRate > 0.0 ? sampleRate : 44100.0;
     vuRmsLinL = vuRmsLinR = 0.0f;
-    meterBlockSize = juce::jmax (1, blockSize);
+    meterBlockSize = std::max (1, blockSize);
     meterRmsAlpha  = std::exp (-((float) meterBlockSize / (float) sampleRateForMeter) / 0.3f);
     faderGain.reset (sampleRate, 0.020);
     faderGain.setCurrentAndTargetValue (1.0f);
@@ -22,39 +31,25 @@ void BusStrip::prepare (double sampleRate, int blockSize, int oversamplingFactor
     panGainL .setCurrentAndTargetValue (1.0f);
     panGainR .setCurrentAndTargetValue (1.0f);
 
-    // Bus oversampling: wrap (EQ + UC) externally. UC's internal toggle is
-    // disabled because Dusk Studio does the up/downsample around the chain — having
-    // UC oversample on top would compound. EQ has no internal toggle, so the
-    // external wrap is the only way to suppress its console-saturation
-    // aliasing. Two stages = 4×, one stage = 2×, none = 1× (no oversampling).
+    // Bus oversampling: wrap the comp externally. The core's own oversampling
+    // path is never engaged because Dusk Studio does the up/downsample around
+    // it — having the core oversample on top would compound. The EQ runs
+    // linear (saturation zero), so it stays outside the wrap entirely.
+    // 4x, 2x, or 1x (no oversampling).
     const int factor = (oversamplingFactor == 2 || oversamplingFactor == 4)
                             ? oversamplingFactor : 1;
-    oversamplerStages = (factor == 4) ? 2 : (factor == 2) ? 1 : 0;
-    const int bsClamped = juce::jmax (1, blockSize);
-    if (oversamplerStages > 0)
-    {
-        oversampler = std::make_unique<juce::dsp::Oversampling<float>> (
-            2, (size_t) oversamplerStages,
-            juce::dsp::Oversampling<float>::filterHalfBandPolyphaseIIR,
-            /*isMaximumQuality*/ true);
-        oversampler->initProcessing ((size_t) bsClamped);
-        oversampler->reset();
-        osLatencySamples = juce::jmin (kMaxOsLatency,
-            (int) std::lround (oversampler->getLatencyInSamples()));
-    }
-    else
-    {
-        oversampler.reset();
-        osLatencySamples = 0;
-    }
+    osFactor = factor;
+    const int bsClamped = std::max (1, blockSize);
+    oversampler.setFactor (factor);
+    oversampler.prepare (bsClamped);
+    osLatencySamples = (factor > 1)
+        ? std::min (kMaxOsLatency, (int) std::lround (oversampler.latency()))
+        : 0;
 
-    const juce::dsp::ProcessSpec osSpec { sampleRate, (std::uint32_t) bsClamped, 1 };
-    osSkipDelayL.prepare (osSpec);
-    osSkipDelayR.prepare (osSpec);
     osSkipDelayL.setMaximumDelayInSamples (kMaxOsLatency);
     osSkipDelayR.setMaximumDelayInSamples (kMaxOsLatency);
-    osSkipDelayL.setDelay ((float) osLatencySamples);
-    osSkipDelayR.setDelay ((float) osLatencySamples);
+    osSkipDelayL.setDelay (osLatencySamples);
+    osSkipDelayR.setDelay (osLatencySamples);
     osSkipDelayL.reset();
     osSkipDelayR.reset();
 
@@ -65,113 +60,91 @@ void BusStrip::prepare (double sampleRate, int blockSize, int oversamplingFactor
     // The bus EQ is linear tone-shaping (no saturation), so it never aliases
     // and is prepared at NATIVE rate — it always runs outside the oversampler.
     // Only the comp (below) is wrapped, and only when engaged.
-    eq.prepare (sampleRate, bsClamped, 2);
+    //
+    // Bus EQ frequencies + gain range mirror Harrison Mixbus's mix-bus Tone EQ
+    // exactly: LO 300 Hz shelf / MID 800 Hz Q0.7 bell / HI 2 kHz shelf,
+    // +/-9 dB — wide, musical tone-shaping for subgroups. (NOT the narrower
+    // Mixbus master-bus EQ, which is 90/300/4000 Hz +/-6 dB.) Everything but
+    // the three band gains (updateEqParameters) is fixed here.
+    eq.setHpfEnabled (false); eq.setHpfFreq (80.0f);
+    eq.setLpfEnabled (false); eq.setLpfFreq (20000.0f);
+    eq.setLfFreq (300.0f);    eq.setLfBell (false);   // shelf
+    eq.setLmFreq (800.0f);    eq.setLmQ (0.7f);
+    // HM unused; Bus EQ exposes only LF / MID / HF.
+    eq.setHmGain (0.0f);      eq.setHmFreq (4000.0f); eq.setHmQ (0.7f);
+    eq.setHfFreq (2000.0f);   eq.setHfBell (false);
+    eq.setEqType (0);         // Brown (E-series voicing)
+    eq.setSaturation (0.0f);
+    eq.setInputGainDb (0.0f);
+    eq.setOutputGainDb (0.0f);
+    eq.setOversampling (0);   // 1x — linear chain, and the strip owns any OS
+    eq.setMsMode (false);
+    eq.setAutoGain (false);
+    eq.setBypass (false);
+    eq.setLfGain (lastEqGains.lf);
+    eq.setLmGain (lastEqGains.mid);
+    eq.setHfGain (lastEqGains.hf);
+    eq.prepare (sampleRate, bsClamped);
     eq.reset();
 
-    busComp.setPlayConfigDetails (2, 2, prepSr, prepBs);
-    busComp.prepareToPlay (prepSr, prepBs);
-    // External wrap handles oversampling; UC's internal toggle is OFF.
-    busComp.setInternalOversamplingEnabled (false);
-    compStereoBuffer.setSize (2, prepBs, false, false, true);
-    compMidi.clear();
-    bindCompParams();
+    busComp.setMode (3);            // Bus mode
+    busComp.setMix (100.0f);
+    busComp.setBusMix (100.0f);
+    busComp.setAutoMakeup (false);
+    // No injected analog hiss under signal: the core does not port the donor's
+    // noise stage, so no explicit force-off is needed here (the JUCE donors in
+    // MasterBus::bindCompParams still store noise_enable = 0).
+    busComp.prepare (prepSr, prepBs);
+    busComp.reset();
+    compMaxBlock = prepBs;
 #endif
 }
 
 #if DUSKSTUDIO_HAS_DUSK_DSP
-void BusStrip::bindCompParams() noexcept
-{
-    auto& apvts = busComp.getParameters();
-    compModeAtom       = apvts.getRawParameterValue ("mode");
-    compBypassAtom     = apvts.getRawParameterValue ("bypass");
-    compMixAtom        = apvts.getRawParameterValue ("mix");
-    compAutoMakeupAtom = apvts.getRawParameterValue ("auto_makeup");
-    compBusThreshAtom  = apvts.getRawParameterValue ("bus_threshold");
-    compBusRatioAtom   = apvts.getRawParameterValue ("bus_ratio");
-    compBusAttackAtom  = apvts.getRawParameterValue ("bus_attack");
-    compBusReleaseAtom = apvts.getRawParameterValue ("bus_release");
-    compBusMakeupAtom  = apvts.getRawParameterValue ("bus_makeup");
-    compBusMixAtom     = apvts.getRawParameterValue ("bus_mix");
-
-    storeAtom (compModeAtom, 3.0f);            // Bus mode
-    storeAtom (compMixAtom,         100.0f);
-    storeAtom (compBusMixAtom,      100.0f);
-    storeAtom (compAutoMakeupAtom,    0.0f);
-    // No injected analog hiss under signal — see MasterBus::bindCompParams.
-    storeAtom (apvts.getRawParameterValue ("noise_enable"), 0.0f);
-}
-
 void BusStrip::updateEqParameters() noexcept
 {
     if (paramsRef == nullptr) return;
-    // Value-init padding to zero so the memcmp cache against lastEqParams
-    // is reliable - see ChannelStrip equivalent for full reasoning.
-    BritishEQProcessor::Parameters p {};
-    p.hpfEnabled = false; p.hpfFreq = 80.0f;
-    p.lpfEnabled = false; p.lpfFreq = 20000.0f;
-
-    // Bus EQ frequencies + gain range mirror Harrison Mixbus's mix-bus Tone EQ
-    // exactly: LO 300 Hz Q1.0 shelf / MID 800 Hz Q0.7 bell / HI 2 kHz Q1.0
-    // shelf, +/-9 dB — wide, musical tone-shaping for subgroups. (NOT the
-    // narrower Mixbus master-bus EQ, which is 90/300/4000 Hz +/-6 dB.)
-    p.lfGain  = paramsRef->eqLfGainDb.load  (std::memory_order_relaxed);
-    p.lfFreq  = 300.0f;
-    p.lfBell  = false;  // shelf
-
-    p.lmGain  = paramsRef->eqMidGainDb.load (std::memory_order_relaxed);
-    p.lmFreq  = 800.0f;
-    p.lmQ     = 0.7f;
-
-    p.hmGain  = 0.0f;  // HM unused; Bus EQ exposes only LF / MID / HF.
-    p.hmFreq  = 4000.0f;
-    p.hmQ     = 0.7f;
-
-    p.hfGain  = paramsRef->eqHfGainDb.load  (std::memory_order_relaxed);
-    p.hfFreq  = 2000.0f;
-    p.hfBell  = false;
-
-    p.isBlackMode = false;
-    p.saturation  = 0.0f;
-    p.inputGain   = 0.0f;
-    p.outputGain  = 0.0f;
-    if (std::memcmp (&p, &lastEqParams, sizeof (p)) != 0)
+    EqGains g;
+    g.lf  = paramsRef->eqLfGainDb.load  (std::memory_order_relaxed);
+    g.mid = paramsRef->eqMidGainDb.load (std::memory_order_relaxed);
+    g.hf  = paramsRef->eqHfGainDb.load  (std::memory_order_relaxed);
+    if (std::memcmp (&g, &lastEqGains, sizeof (g)) != 0)
     {
-        eq.setParameters (p);
-        lastEqParams = p;
+        eq.setLfGain (g.lf);
+        eq.setLmGain (g.mid);
+        eq.setHfGain (g.hf);
+        lastEqGains = g;
     }
 }
 
 void BusStrip::updateCompParameters() noexcept
 {
     if (paramsRef == nullptr) return;
-    storeAtom (compBypassAtom,
-               paramsRef->compEnabled.load (std::memory_order_relaxed) ? 0.0f : 1.0f);
-    storeAtom (compBusThreshAtom,  paramsRef->compThreshDb.load   (std::memory_order_relaxed));
+    busComp.setBypass (! paramsRef->compEnabled.load (std::memory_order_relaxed));
+    busComp.setBusThreshold (paramsRef->compThreshDb.load (std::memory_order_relaxed));
     // The donor's bus_ratio / bus_attack / bus_release are SSL-style stepped
     // Choice params, NOT continuous. Storing the raw knob value treated it as
     // an out-of-range index (ratio 4.0 -> 2:1, attack 10 ms -> 30 ms). Map to
     // the nearest discrete index — same as a real SSL bus comp's stepped knobs.
     //   bus_ratio:  0=2:1, 1=4:1, 2=10:1
     //   bus_attack: 0=0.1  1=0.3  2=1  3=3  4=10  5=30  (ms)
-    const float ratio  = paramsRef->compRatio.load (std::memory_order_relaxed);
-    storeAtom (compBusRatioAtom, ratio < 3.0f ? 0.0f : (ratio < 7.0f ? 1.0f : 2.0f));
-    const float atkMs  = paramsRef->compAttackMs.load (std::memory_order_relaxed);
-    storeAtom (compBusAttackAtom,
-               atkMs < 0.2f ? 0.0f
-             : (atkMs < 0.65f ? 1.0f
-             : (atkMs < 2.0f ? 2.0f
-             : (atkMs < 6.5f ? 3.0f
-             : (atkMs < 20.0f ? 4.0f : 5.0f)))));
+    const float ratio = paramsRef->compRatio.load (std::memory_order_relaxed);
+    busComp.setBusRatio (ratio < 3.0f ? 0 : (ratio < 7.0f ? 1 : 2));
+    const float atkMs = paramsRef->compAttackMs.load (std::memory_order_relaxed);
+    busComp.setBusAttack (atkMs < 0.2f ? 0
+                        : (atkMs < 0.65f ? 1
+                        : (atkMs < 2.0f ? 2
+                        : (atkMs < 6.5f ? 3
+                        : (atkMs < 20.0f ? 4 : 5)))));
     // bus_release is a Choice {0.1s, 0.3s, 0.6s, 1.2s, Auto}; see
     // MasterBus::updateCompParameters for the mapping rationale.
     const bool autoRel = paramsRef->compReleaseAuto.load (std::memory_order_relaxed);
     const float relMs  = paramsRef->compReleaseMs.load   (std::memory_order_relaxed);
-    const float relIdx = autoRel ? 4.0f
-                       : (relMs < 200.0f ? 0.0f
-                       : (relMs < 450.0f ? 1.0f
-                       : (relMs < 900.0f ? 2.0f : 3.0f)));
-    storeAtom (compBusReleaseAtom, relIdx);
-    storeAtom (compBusMakeupAtom,  paramsRef->compMakeupDb.load   (std::memory_order_relaxed));
+    busComp.setBusRelease (autoRel ? 4
+                         : (relMs < 200.0f ? 0
+                         : (relMs < 450.0f ? 1
+                         : (relMs < 900.0f ? 2 : 3))));
+    busComp.setBusMakeup (paramsRef->compMakeupDb.load (std::memory_order_relaxed));
 }
 #endif
 
@@ -187,26 +160,21 @@ void BusStrip::updateGainTargets() noexcept
     const float faderDb = paramsRef->liveFaderDb.load (std::memory_order_relaxed);
     const float gain = (faderDb <= ChannelStripParams::kFaderInfThreshDb)
                        ? 0.0f
-                       : juce::Decibels::decibelsToGain (faderDb);
+                       : dusk::audio::decibelsToGain (faderDb);
     faderGain.setTargetValue (gain);
 
     // Equal-power L/R balance - pan -1..1 → angle 0..pi/2.
-    const float p     = juce::jlimit (-1.0f, 1.0f, paramsRef->livePan.load (std::memory_order_relaxed));
-    const float angle = (p + 1.0f) * (juce::MathConstants<float>::halfPi * 0.5f);
-    panGainL.setTargetValue (std::cos (angle) * juce::MathConstants<float>::sqrt2);
-    panGainR.setTargetValue (std::sin (angle) * juce::MathConstants<float>::sqrt2);
+    const float p     = std::clamp (paramsRef->livePan.load (std::memory_order_relaxed),
+                                    -1.0f, 1.0f);
+    const float angle = (p + 1.0f) * (kHalfPi * 0.5f);
+    panGainL.setTargetValue (std::cos (angle) * kSqrt2);
+    panGainR.setTargetValue (std::sin (angle) * kSqrt2);
 }
 
 void BusStrip::processInPlace (float* L, float* R, int numSamples) noexcept
 {
-    juce::ScopedNoDenormals noDenormals;
+    dusk::audio::ScopedNoDenormals noDenormals;
     if (numSamples == 0) return;
-
-   #if DUSKSTUDIO_HAS_DUSK_DSP
-    // Contract: numSamples must fit the buffer prepare() sized for the comp.
-    // The chunk loop below is the production safety net.
-    jassert (numSamples <= compStereoBuffer.getNumSamples());
-   #endif
 
     updateGainTargets();
 
@@ -231,58 +199,46 @@ void BusStrip::processInPlace (float* L, float* R, int numSamples) noexcept
 
     if (eqEnabled)
     {
-        float* channels[2] = { L, R };
-        juce::AudioBuffer<float> buf (channels, 2, numSamples);
-        eq.process (buf);
+        const float* eqIn[2]  = { L, R };
+        float*       eqOut[2] = { L, R };
+        eq.processBlock (eqIn, eqOut, 2, numSamples);
     }
 
-    if (compEnabled && oversamplerStages > 0 && oversampler != nullptr)
+    if (compEnabled && osFactor > 1)
     {
         // Oversample around the comp only — band-limits its saturation. The
-        // comp was prepared at sampleRate × factor in prepare().
-        const float* readPtrs[2]  = { L, R };
-        float*       writePtrs[2] = { L, R };
-        juce::dsp::AudioBlock<const float> nativeIn  (readPtrs,  2, (size_t) numSamples);
-        juce::dsp::AudioBlock<float>       nativeOut (writePtrs, 2, (size_t) numSamples);
-
-        auto upBlock = oversampler->processSamplesUp (nativeIn);
-        const int upN = (int) upBlock.getNumSamples();
-        float* upPtrs[2] = { upBlock.getChannelPointer (0),
-                              upBlock.getChannelPointer (1) };
-
-        const int compBufSize = compStereoBuffer.getNumSamples();
-        for (int offset = 0; offset < upN; offset += compBufSize)
+        // comp was prepared at sampleRate × factor in prepare(). Contract:
+        // numSamples must not exceed the blockSize passed to prepare — the
+        // engine bails on host-oversized blocks before the strips run.
+        auto up = oversampler.processSamplesUp (L, R, numSamples);
+        for (int offset = 0; offset < up.numSamples; offset += compMaxBlock)
         {
-            const int n = juce::jmin (compBufSize, upN - offset);
-            float* compView[2] = { upPtrs[0] + offset, upPtrs[1] + offset };
-            juce::AudioBuffer<float> compBuf (compView, 2, n);
-            compMidi.clear();
-            busComp.processBlock (compBuf, compMidi);
+            const int n = std::min (compMaxBlock, up.numSamples - offset);
+            const float* compIn[2]  = { up.L + offset, up.R + offset };
+            float*       compOut[2] = { up.L + offset, up.R + offset };
+            busComp.processBlock (compIn, compOut, 2, n);
         }
-
-        oversampler->processSamplesDown (nativeOut);
+        oversampler.processSamplesDown (L, R, numSamples);
     }
     else if (compEnabled)
     {
         // Native comp (factor == 1).
-        const int bufSize = compStereoBuffer.getNumSamples();
-        for (int offset = 0; offset < numSamples; offset += bufSize)
+        for (int offset = 0; offset < numSamples; offset += compMaxBlock)
         {
-            const int n = juce::jmin (bufSize, numSamples - offset);
-            float* lrView[2] = { L + offset, R + offset };
-            juce::AudioBuffer<float> compBuf (lrView, 2, n);
-            compMidi.clear();
-            busComp.processBlock (compBuf, compMidi);
+            const int n = std::min (compMaxBlock, numSamples - offset);
+            const float* compIn[2]  = { L + offset, R + offset };
+            float*       compOut[2] = { L + offset, R + offset };
+            busComp.processBlock (compIn, compOut, 2, n);
         }
     }
-    else if (oversamplerStages > 0 && osLatencySamples > 0)
+    else if (osFactor > 1 && osLatencySamples > 0)
     {
         // Comp off but an OS factor is active → the comp's oversampler was
         // skipped. Delay the EQ-only signal by its latency to hold alignment.
         for (int i = 0; i < numSamples; ++i)
         {
-            osSkipDelayL.pushSample (0, L[i]);  L[i] = osSkipDelayL.popSample (0);
-            osSkipDelayR.pushSample (0, R[i]);  R[i] = osSkipDelayR.popSample (0);
+            osSkipDelayL.pushSample (L[i]);  L[i] = osSkipDelayL.popSample();
+            osSkipDelayR.pushSample (R[i]);  R[i] = osSkipDelayR.popSample();
         }
     }
 
@@ -311,11 +267,11 @@ void BusStrip::processInPlace (float* L, float* R, int numSamples) noexcept
     if (paramsRef != nullptr)
     {
         const auto toDb = [] (float a) { return a > 1.0e-5f
-            ? juce::Decibels::gainToDecibels (a, -100.0f) : -100.0f; };
+            ? dusk::audio::gainToDecibels (a, -100.0f) : -100.0f; };
         paramsRef->meterPostBusLDb.store (toDb (postPeakL), std::memory_order_relaxed);
         paramsRef->meterPostBusRDb.store (toDb (postPeakR), std::memory_order_relaxed);
 
-        const float invN     = 1.0f / (float) juce::jmax (1, numSamples);
+        const float invN     = 1.0f / (float) std::max (1, numSamples);
         const float rmsBlkL  = std::sqrt (sumSqL * invN);
         const float rmsBlkR  = std::sqrt (sumSqR * invN);
         const float alpha    = (numSamples == meterBlockSize)

--- a/src/dsp/BusStrip.cpp
+++ b/src/dsp/BusStrip.cpp
@@ -204,8 +204,24 @@ void BusStrip::processInPlace (float* L, float* R, int numSamples) noexcept
         eq.processBlock (eqIn, eqOut, 2, numSamples);
     }
 
-    if (compEnabled && osFactor > 1)
+    const bool compOsActive = compEnabled && osFactor > 1;
+    if (compOsActive && ! prevCompOsActive)
+        oversampler.reset();
+    prevCompOsActive = compOsActive;
+
+    if (compOsActive)
     {
+        // Keep the skip ring warm (see header) — push the pre-comp signal,
+        // discard the pops.
+        if (osLatencySamples > 0)
+        {
+            for (int i = 0; i < numSamples; ++i)
+            {
+                osSkipDelayL.pushSample (L[i]);  osSkipDelayL.popSample();
+                osSkipDelayR.pushSample (R[i]);  osSkipDelayR.popSample();
+            }
+        }
+
         // Oversample around the comp only — band-limits its saturation. The
         // comp was prepared at sampleRate × factor in prepare(). Contract:
         // numSamples must not exceed the blockSize passed to prepare — the

--- a/src/dsp/BusStrip.h
+++ b/src/dsp/BusStrip.h
@@ -76,6 +76,13 @@ private:
     dusk::audio::IntDelayLine osSkipDelayR;
     int osLatencySamples = 0;
 
+    // The skip ring is fed on EVERY block at OS factors > 1 (comp-on blocks
+    // push and discard) so a comp-off toggle emits continuous delayed dry
+    // instead of a zero-filled gap while the ring refills. The oversampler is
+    // reset on the comp-on edge so its FIR ramps in from silence, not a stale
+    // tail from the last time the comp ran.
+    bool prevCompOsActive { false };
+
     // Skip the EQ filter entirely when the bus EQ is disengaged (it would
     // otherwise run at unity, burning cycles for nothing). Init true so the
     // first block with EQ off doesn't fire a spurious reset; reset on the

--- a/src/dsp/BusStrip.h
+++ b/src/dsp/BusStrip.h
@@ -1,23 +1,24 @@
 #pragma once
 
-#include <juce_audio_basics/juce_audio_basics.h>
-#include <juce_dsp/juce_dsp.h>
+#include "../foundation/IntDelayLine.h"
+#include "../foundation/SmoothedValue.h"
+#include "../foundation/StereoOversampler.h"
 #include "../session/Session.h"
 #include <atomic>
-#include <memory>
 
 #if DUSKSTUDIO_HAS_DUSK_DSP
-  #include "BritishEQProcessor.h"
-  #include "UniversalCompressor.h"
+  #include <dsp/FourKEQDSP.hpp>
+  #include <core/UniversalCompressorDSP.hpp>
 #endif
 
 namespace duskstudio
 {
 // Phase 1a aux bus: 3-band EQ → bus compressor → pan → fader → meter.
-// EQ uses BritishEQProcessor's LF / LM / HF bands (with the LM band exposed
-// as MID and the HM band fixed-zero). Comp uses UniversalCompressor's Bus
-// mode. Both DSP instances are owned by the strip; APVTS atoms for the comp
-// are cached in bind so updateCompParameters can write lock-free.
+// EQ uses FourKEQDSP's LF / LM / HF bands (with the LM band exposed as MID and
+// the HM band fixed-zero). Comp uses UniversalCompressorDSP's Bus mode. Both
+// cores are framework-free donor DSP; their parameter setters are atomic, so
+// updateEqParameters / updateCompParameters write lock-free from the audio
+// thread.
 //
 // Buses are subgroups (16 channels → 4 buses → master). They do NOT host
 // plugins - that responsibility lives on the AUX return lanes accessed via
@@ -28,11 +29,10 @@ public:
     BusStrip() = default;
 
     // oversamplingFactor: 1 (native, default), 2 or 4. Drives the per-bus
-    // Dusk Studio-side juce::dsp::Oversampling wrapper that this strip applies
-    // around BOTH the BritishEQ and the UniversalCompressor (UC). UC's own
-    // internal-oversampling toggle is intentionally left OFF here — the
-    // external wrapper covers both stages, and engaging UC's internal OS
-    // would compound and double-oversample the comp path.
+    // Dusk Studio-side oversampler that this strip applies around the
+    // compressor. The comp core's internal-oversampling path is intentionally
+    // never engaged — the external wrapper covers the only saturating stage,
+    // and doubling oversampling would compound.
     void prepare (double sampleRate, int blockSize, int oversamplingFactor = 1);
     void bind (const BusParams& params) noexcept;
 
@@ -42,33 +42,38 @@ public:
 
 private:
     const BusParams* paramsRef = nullptr;
-    juce::SmoothedValue<float> faderGain { 1.0f };
-    juce::SmoothedValue<float> panGainL  { 1.0f };
-    juce::SmoothedValue<float> panGainR  { 1.0f };
+    dusk::audio::SmoothedValue<float> faderGain { 1.0f };
+    dusk::audio::SmoothedValue<float> panGainL  { 1.0f };
+    dusk::audio::SmoothedValue<float> panGainR  { 1.0f };
 
 #if DUSKSTUDIO_HAS_DUSK_DSP
-    BritishEQProcessor       eq;
-    BritishEQProcessor::Parameters lastEqParams {};   // see ChannelStrip equivalent
-    UniversalCompressor      busComp;
-    juce::MidiBuffer         compMidi;
-    juce::AudioBuffer<float> compStereoBuffer;
+    duskaudio::FourKEQDSP eq;
+    // Only the three band gains vary at runtime (every other EQ param is fixed
+    // in prepare); cache them so the per-block update pushes setters only on
+    // change — see the ChannelStrip equivalent.
+    struct EqGains { float lf = 0.0f, mid = 0.0f, hf = 0.0f; };
+    EqGains lastEqGains {};
+    duskaudio::UniversalCompressorDSP busComp;
+    // Max samples per busComp.processBlock call (the oversampled prepare block
+    // size — the core degrades to dry passthrough beyond it); the process
+    // chunk loops split anything larger.
+    int compMaxBlock = 0;
 
-    // Per-bus Dusk Studio-side oversampler wrapping (EQ + UC). The donor's
-    // BritishEQ has console saturation and UC has saturation - both alias
-    // hard at native rate. UC's internal-oversampling toggle is left OFF
-    // here because we wrap externally; doubling oversampling would compound.
-    std::unique_ptr<juce::dsp::Oversampling<float>> oversampler;
-    int oversamplerStages = 0;
+    // Per-bus Dusk Studio-side oversampler wrapping the comp. Its saturation
+    // aliases hard at native rate; the bus EQ runs with saturation at zero
+    // (linear), so only the comp needs the wrap.
+    dusk::audio::StereoOversampler oversampler;
+    int osFactor = 1;
 
     // When the comp is bypassed we skip the oversampler (the bus EQ is linear
-    // and never aliases). The oversampler imposes ~3-4.4 native samples of
-    // latency though, so delay the skip path by that amount to keep this bus
-    // time-aligned with the rest of the mix regardless of comp on/off. Integer
-    // (None) delay — sub-sample rounding residual is inaudible.
-    static constexpr int kMaxOsLatency = 16;
-    using OsDelayLine = juce::dsp::DelayLine<float, juce::dsp::DelayLineInterpolationTypes::None>;
-    OsDelayLine osSkipDelayL { kMaxOsLatency };
-    OsDelayLine osSkipDelayR { kMaxOsLatency };
+    // and never aliases). The oversampler's FIR round trip imposes 23 (2x) /
+    // 26.5 (4x) native samples of latency though, so delay the skip path by
+    // that amount to keep this bus time-aligned with the rest of the mix
+    // regardless of comp on/off. Integer delay — the 0.5-sample rounding
+    // residual at 4x is inaudible.
+    static constexpr int kMaxOsLatency = 32;
+    dusk::audio::IntDelayLine osSkipDelayL;
+    dusk::audio::IntDelayLine osSkipDelayR;
     int osLatencySamples = 0;
 
     // Skip the EQ filter entirely when the bus EQ is disengaged (it would
@@ -77,24 +82,8 @@ private:
     // off→on edge clears stale filter state so re-enabling doesn't click.
     bool prevEqEnabled { true };
 
-    std::atomic<float>* compModeAtom        = nullptr;
-    std::atomic<float>* compBypassAtom      = nullptr;
-    std::atomic<float>* compMixAtom         = nullptr;
-    std::atomic<float>* compAutoMakeupAtom  = nullptr;
-    std::atomic<float>* compBusThreshAtom   = nullptr;
-    std::atomic<float>* compBusRatioAtom    = nullptr;
-    std::atomic<float>* compBusAttackAtom   = nullptr;
-    std::atomic<float>* compBusReleaseAtom  = nullptr;
-    std::atomic<float>* compBusMakeupAtom   = nullptr;
-    std::atomic<float>* compBusMixAtom      = nullptr;
-
-    void bindCompParams() noexcept;
     void updateEqParameters() noexcept;
     void updateCompParameters() noexcept;
-    static inline void storeAtom (std::atomic<float>* a, float v) noexcept
-    {
-        if (a != nullptr) a->store (v, std::memory_order_relaxed);
-    }
 #endif
 
     void updateGainTargets() noexcept;

--- a/src/dsp/ChannelStrip.cpp
+++ b/src/dsp/ChannelStrip.cpp
@@ -1,10 +1,18 @@
 #include "ChannelStrip.h"
+#include "../foundation/Decibels.h"
+#include "../foundation/ScopedNoDenormals.h"
+#include <algorithm>
 #include <cmath>
 #include <cstring>
 
 namespace duskstudio
 {
-// Always-on console drive for the channel EQ. The BritishEQProcessor's
+namespace
+{
+constexpr float kHalfPi = 1.57079632679489661923f;
+} // namespace
+
+// Always-on console drive for the channel EQ. The FourKEQDSP's
 // ConsoleSaturation is an ADAA polynomial waveshaper; this fixed amount sets
 // the large-format-console harmonic signature to the real hardware's bench
 // THD: E-series (Brown) ≈ 0.02 % THD (H2 ≈ -74 dB) at 0 VU (-18 dBFS), the
@@ -58,14 +66,10 @@ void ChannelStrip::prepare (double sampleRate, int blockSize, int oversamplingFa
     // by the engine's PDC aggregator; here we just (re)latch the applied length
     // and clear history. pdcSilentRun starts maxed so a pending change can apply
     // on the very first block.
-    const juce::dsp::ProcessSpec pdcSpec
-        { sampleRate, (std::uint32_t) juce::jmax (1, blockSize), 1 };
-    pdcDelayL.prepare (pdcSpec);
-    pdcDelayR.prepare (pdcSpec);
     pdcDelayL.setMaximumDelayInSamples (kMaxPdcSamples);
     pdcDelayR.setMaximumDelayInSamples (kMaxPdcSamples);
-    pdcDelayL.setDelay ((float) pdcAppliedSamples);
-    pdcDelayR.setDelay ((float) pdcAppliedSamples);
+    pdcDelayL.setDelay (pdcAppliedSamples);
+    pdcDelayR.setDelay (pdcAppliedSamples);
     pdcDelayL.reset();
     pdcDelayR.reset();
     pdcSilentRun = (std::int64_t) kMaxPdcSamples;
@@ -75,7 +79,6 @@ void ChannelStrip::prepare (double sampleRate, int blockSize, int oversamplingFa
     // channel-voice messages per block; far above any sane density even
     // for instrument plugins generating dense controller streams.
     pluginMidiScratch.ensureSize (4096);
-    compMidiScratch  .ensureSize (4096);
 
     // Plugin slot - prepared at the same SR/BS so the audio thread never
     // sees an unprepared instance. If the slot has no plugin loaded, this
@@ -168,44 +171,24 @@ void ChannelStrip::prepare (double sampleRate, int blockSize, int oversamplingFa
     }
 #endif
 
-    // Oversampling: build a Dusk Studio-side wrapper around (EQ + Comp) when the
-    // user picks 2× / 4× in Audio Settings. The donor's BritishEQ console
-    // saturation and ChannelComp/UC saturation alias hard at native rate;
-    // wrapping the chain with juce::dsp::Oversampling moves the entire
-    // per-channel DSP to oversampled rate so the saturation is band-limited
-    // before downsampling. EQ + Comp are then prepared at the OVERSAMPLED
-    // sample rate / block size so their coefficients and scratch are sized
-    // correctly. Two oversampler instances (1ch + 2ch) so mono / stereo
-    // tracks each get the right channel count without wasted DSP.
+    // Oversampling: wrap (EQ + Comp) in a Dusk Studio-side oversampler when the
+    // user picks 2× / 4× in Audio Settings. The EQ's always-on console
+    // saturation and the comp's saturation alias hard at native rate; the wrap
+    // moves the entire per-channel DSP to the oversampled rate so the half-band
+    // FIRs band-limit it before downsampling. EQ + Comp are then prepared at the
+    // OVERSAMPLED sample rate / block size so their coefficients and scratch are
+    // sized correctly. One StereoOversampler serves both widths (mono uses
+    // channel 0 with a silent channel 1 — see osMonoScratchR).
     const int factor = (oversamplingFactor == 2 || oversamplingFactor == 4)
                             ? oversamplingFactor : 1;
-    oversamplerStages = (factor == 4) ? 2 : (factor == 2) ? 1 : 0;
-    oversampleFactor  = factor;
+    oversampleFactor = factor;
     const int bsClamped = juce::jmax (1, blockSize);
-    if (oversamplerStages > 0)
-    {
-        const auto stages = (size_t) oversamplerStages;
-        oversamplerMono = std::make_unique<juce::dsp::Oversampling<float>> (
-            1, stages,
-            juce::dsp::Oversampling<float>::filterHalfBandPolyphaseIIR,
-            /*isMaximumQuality*/ true);
-        oversamplerStereo = std::make_unique<juce::dsp::Oversampling<float>> (
-            2, stages,
-            juce::dsp::Oversampling<float>::filterHalfBandPolyphaseIIR,
-            /*isMaximumQuality*/ true);
-        oversamplerMono  ->initProcessing ((size_t) bsClamped);
-        oversamplerStereo->initProcessing ((size_t) bsClamped);
-        oversamplerMono  ->reset();
-        oversamplerStereo->reset();
-        osLatencySamples = juce::jmin (kMaxOsLatency,
-            (int) std::lround (oversamplerMono->getLatencyInSamples()));
-    }
-    else
-    {
-        oversamplerMono.reset();
-        oversamplerStereo.reset();
-        osLatencySamples = 0;
-    }
+    oversampler.setFactor (factor);
+    oversampler.prepare (bsClamped);
+    osMonoScratchR.assign ((size_t) bsClamped, 0.0f);
+    osLatencySamples = (factor > 1)
+        ? std::min (kMaxOsLatency, (int) std::lround (oversampler.latency()))
+        : 0;
 
     const double prepSr = sampleRate * (double) factor;
     const int    prepBs = bsClamped * factor;
@@ -215,40 +198,45 @@ void ChannelStrip::prepare (double sampleRate, int blockSize, int oversamplingFa
     // filter coefficients + scratch sizes track the upsampled buffer the
     // chain processes when factor > 1. At factor == 1 this collapses to
     // (sampleRate, blockSize), preserving the legacy path.
-    eq.prepare (prepSr, prepBs, 2);
+    //
+    // The EQ core runs 1x internally (setOversampling(0)) — the strip's wrap is
+    // the only oversampling, so its console saturation is band-limited there,
+    // not doubled. M/S, auto-gain and bypass are neutralised once; the variable
+    // band / HPF / type / saturation params are pushed per block by
+    // updateEqParameters through the memcmp gate. setOversampling must precede
+    // prepare (prepare reads it to choose the internal factor).
+    eq.setOversampling (0);
+    eq.setMsMode (false);
+    eq.setAutoGain (false);
+    eq.setBypass (false);
+    eq.prepare (prepSr, prepBs);
     eq.reset();
     // H8 idempotence: re-clear the memcmp cache + the false→true edge
     // detector so a re-prepare (sample-rate change, oversampling toggle,
-    // mid-session blockSize bump) forces a fresh setParameters call
-    // against the now-reset filter state. Without this, lastEqParams
-    // could hold the SAME params as the live paramsRef → memcmp returns
-    // 0 → setParameters skipped → filters keep their zero coefficients
-    // post-reset → silent EQ.
+    // mid-session blockSize bump) forces a fresh setter push against the
+    // now-reset filter state. Without this, lastEqParams could hold the SAME
+    // params as the live paramsRef → memcmp returns 0 → setters skipped →
+    // filters keep their reset (silent-EQ) state.
     lastEqParams  = {};
     prevEqEnabled = true;
 
-    // Force the full multi-comp processing path (sidechain HP, true-peak,
-    // transient shaper, stereo linking, auto-makeup, bypass-fade, lookahead)
-    // and disable the donor's internal oversampling since Dusk Studio already
-    // wraps the strip in its own oversampler.
-    compressor.setMinimalProcessing (false);
-    compressor.setInternalOversamplingEnabled (false);
-    compressor.setPlayConfigDetails (2, 2, prepSr, juce::jmax (1, prepBs));
-    compressor.prepareToPlay (prepSr, juce::jmax (1, prepBs));
-    // H8 belt-and-braces: explicit reset() after prepareToPlay so any
-    // detector / envelope state cached across the prior session
-    // (different sample rate, different block size) is wiped to
-    // initial conditions. Some donor builds reset internal state
-    // inside prepareToPlay, some do not — calling reset() makes the
-    // behaviour deterministic across donor revisions and rules out
-    // NaN-prone detectors firing on the first post-prepare block.
+    // Full comp path at the OVERSAMPLED rate; the core's internal oversampling
+    // is never engaged since the strip already wraps the chain. Mix fully wet,
+    // auto-makeup off (makeup is via the per-mode output param). No analog-hiss
+    // force-off — the core carries no noise stage (see BusStrip). Mode + the
+    // continuous params are pushed per block by updateCompParameters.
+    compressor.setMix (100.0f);
+    compressor.setAutoMakeup (false);
+    compressor.prepare (prepSr, std::max (1, prepBs));
+    // Explicit reset() after prepare so any detector / envelope state cached
+    // across a prior session (different rate / block size) is wiped to initial
+    // conditions before the first post-prepare block.
     compressor.reset();
-    bindCompParams();
 
-    // SmoothedValue ramp at the OVERSAMPLED sample rate (the rate the
-    // donor sees inside processBlock). 20 ms is the same constant the
-    // fader / pan / bus gains use.
-    auto seedComp = [prepSr] (juce::SmoothedValue<float>& sv, float v)
+    // SmoothedValue ramp at the OVERSAMPLED sample rate (the rate the core sees
+    // inside processBlock). 20 ms is the same constant the fader / pan / bus
+    // gains use.
+    auto seedComp = [prepSr] (dusk::audio::SmoothedValue<float>& sv, float v)
     {
         sv.reset (prepSr, 0.020);
         sv.setCurrentAndTargetValue (v);
@@ -271,46 +259,6 @@ void ChannelStrip::prepare (double sampleRate, int blockSize, int oversamplingFa
 #endif
 }
 
-#if DUSKSTUDIO_HAS_DUSK_DSP
-void ChannelStrip::bindCompParams()
-{
-    auto& apvts = compressor.getParameters();
-    // getRawParameterValue() returns a pointer to the parameter's denormalised
-    // value atomic - the same atomic that UniversalCompressor's processBlock()
-    // reads. Writing here is lock-free and notification-free, suitable for the
-    // audio thread. Stores hold SI-unit / index / 0-or-1 values.
-    compModeAtom        = apvts.getRawParameterValue ("mode");
-    compBypassAtom      = apvts.getRawParameterValue ("bypass");
-    compMixAtom         = apvts.getRawParameterValue ("mix");
-    compAutoMakeupAtom  = apvts.getRawParameterValue ("auto_makeup");
-    compScHpAtom        = apvts.getRawParameterValue ("sidechain_hp");
-    compOptoPeakRedAtom = apvts.getRawParameterValue ("opto_peak_reduction");
-    compOptoGainAtom    = apvts.getRawParameterValue ("opto_gain");
-    compOptoLimitAtom   = apvts.getRawParameterValue ("opto_limit");
-    compFetInputAtom     = apvts.getRawParameterValue ("fet_input");
-    compFetOutputAtom    = apvts.getRawParameterValue ("fet_output");
-    compFetAttackAtom    = apvts.getRawParameterValue ("fet_attack");
-    compFetReleaseAtom   = apvts.getRawParameterValue ("fet_release");
-    compFetRatioAtom     = apvts.getRawParameterValue ("fet_ratio");
-    compFetThresholdAtom = apvts.getRawParameterValue ("fet_threshold");
-    compVcaThreshAtom   = apvts.getRawParameterValue ("vca_threshold");
-    compVcaRatioAtom    = apvts.getRawParameterValue ("vca_ratio");
-    compVcaAttackAtom   = apvts.getRawParameterValue ("vca_attack");
-    compVcaReleaseAtom  = apvts.getRawParameterValue ("vca_release");
-    compVcaOutputAtom   = apvts.getRawParameterValue ("vca_output");
-    compVcaOverEasyAtom = apvts.getRawParameterValue ("vca_overeasy");
-    compVcaDetectorModeAtom = apvts.getRawParameterValue ("vca_detector_mode");
-
-    // Mix=100% wet, auto-makeup off (we control makeup via per-mode output param).
-    storeAtom (compMixAtom,        100.0f);
-    storeAtom (compAutoMakeupAtom,   0.0f);  // Choice index 0 = "Off"
-    // Donor's "Analog Noise" injects ~-80 dB white noise on every analog mode
-    // (FET / Opto / VCA) and defaults ON — force it off so an engaged channel
-    // comp doesn't raise the noise floor. See MasterBus::bindCompParams.
-    storeAtom (apvts.getRawParameterValue ("noise_enable"), 0.0f);
-}
-#endif
-
 void ChannelStrip::updateGainTargets() noexcept
 {
     if (paramsRef == nullptr) return;
@@ -324,13 +272,14 @@ void ChannelStrip::updateGainTargets() noexcept
 
     const float gain = (muted || faderDb <= ChannelStripParams::kFaderInfThreshDb)
                        ? 0.0f
-                       : juce::Decibels::decibelsToGain (faderDb);
+                       : dusk::audio::decibelsToGain (faderDb);
     faderGain.setTargetValue (gain);
 
     // Read livePan (engine routes manual pan or lane value through it),
     // matching the liveFaderDb pattern.
-    const float p     = juce::jlimit (-1.0f, 1.0f, paramsRef->livePan.load (std::memory_order_relaxed));
-    const float angle = (p + 1.0f) * (juce::MathConstants<float>::halfPi * 0.5f);
+    const float p     = std::clamp (paramsRef->livePan.load (std::memory_order_relaxed),
+                                    -1.0f, 1.0f);
+    const float angle = (p + 1.0f) * (kHalfPi * 0.5f);
     panGainL.setTargetValue (std::cos (angle));
     panGainR.setTargetValue (std::sin (angle));
 
@@ -347,7 +296,7 @@ void ChannelStrip::updateGainTargets() noexcept
         const float db = paramsRef->liveAuxSendDb[(size_t) i].load (std::memory_order_relaxed);
         const float g  = (db <= ChannelStripParams::kAuxSendOffDb)
                             ? 0.0f
-                            : juce::Decibels::decibelsToGain (db);
+                            : dusk::audio::decibelsToGain (db);
         auxSendGain[(size_t) i].setTargetValue (g);
         auxSendPre[(size_t) i] =
             paramsRef->auxSendPreFader[(size_t) i].load (std::memory_order_relaxed);
@@ -358,27 +307,30 @@ void ChannelStrip::updateEqParameters() noexcept
 {
 #if DUSKSTUDIO_HAS_DUSK_DSP
     if (paramsRef == nullptr) return;
-    // Value-init so padding bytes are zero - paired with lastEqParams's {}
+    // Plain-float snapshot (no padding) - paired with lastEqParams's {}
     // initializer, this lets memcmp tell us reliably whether the params
-    // actually changed since last block. Skipping setParameters() when they
-    // haven't avoids a full BritishEQProcessor coefficient recompute (8-14
-    // biquads) on every silent block on every channel.
+    // actually changed since last block. Skipping the setter push when they
+    // haven't avoids a full FourKEQDSP coefficient recompute on every silent
+    // block on every channel.
     //
     // The console saturation is the channel's always-on console floor, so the
     // EQ processor runs every block regardless of the EQ bypass. When the EQ
-    // section is bypassed we leave the filter params at their flat value-init
-    // defaults (filters off, every band 0 dB) so only the saturation +
+    // section is bypassed we leave the band / filter params at their flat
+    // value-init zeros (filters off, every band 0 dB) so only the saturation +
     // transformer character is applied — the tone shaping is what bypasses.
-    BritishEQProcessor::Parameters p {};
+    // FourKEQDSP tolerates the zero-freq/zero-Q flat image: the HPF/LPF are
+    // gated by their enable flags (so their freq-0 coeffs never process), and
+    // the parallel bands compute a finite (zero) output scaled by K = 0.
+    EqSnapshot p {};
     if (paramsRef->eqEnabled.load (std::memory_order_relaxed))
     {
-        p.hpfEnabled = paramsRef->hpfEnabled.load (std::memory_order_relaxed);
+        p.hpfEnabled = paramsRef->hpfEnabled.load (std::memory_order_relaxed) ? 1.0f : 0.0f;
         p.hpfFreq    = paramsRef->hpfFreq.load    (std::memory_order_relaxed);
-        p.lpfEnabled = paramsRef->lpfEnabled.load (std::memory_order_relaxed);
+        p.lpfEnabled = paramsRef->lpfEnabled.load (std::memory_order_relaxed) ? 1.0f : 0.0f;
         p.lpfFreq    = paramsRef->lpfFreq.load    (std::memory_order_relaxed);
         p.lfGain     = paramsRef->lfGainDb.load (std::memory_order_relaxed);
         p.lfFreq     = paramsRef->lfFreq.load   (std::memory_order_relaxed);
-        p.lfBell     = false;
+        p.lfBell     = 0.0f;
         p.lmGain     = paramsRef->lmGainDb.load (std::memory_order_relaxed);
         p.lmFreq     = paramsRef->lmFreq.load   (std::memory_order_relaxed);
         p.lmQ        = paramsRef->lmQ.load      (std::memory_order_relaxed);
@@ -387,15 +339,24 @@ void ChannelStrip::updateEqParameters() noexcept
         p.hmQ        = paramsRef->hmQ.load      (std::memory_order_relaxed);
         p.hfGain     = paramsRef->hfGainDb.load (std::memory_order_relaxed);
         p.hfFreq     = paramsRef->hfFreq.load   (std::memory_order_relaxed);
-        p.hfBell     = false;
+        p.hfBell     = 0.0f;
     }
-    p.isBlackMode = paramsRef->eqBlackMode.load (std::memory_order_relaxed);
-    p.saturation  = kConsoleSaturationDrive;
-    p.inputGain   = 0.0f;
-    p.outputGain  = 0.0f;
+    p.eqType     = paramsRef->eqBlackMode.load (std::memory_order_relaxed) ? 1.0f : 0.0f;
+    p.saturation = kConsoleSaturationDrive;
+    p.inputGain  = 0.0f;
+    p.outputGain = 0.0f;
     if (std::memcmp (&p, &lastEqParams, sizeof (p)) != 0)
     {
-        eq.setParameters (p);
+        eq.setHpfEnabled (p.hpfEnabled > 0.5f);  eq.setHpfFreq (p.hpfFreq);
+        eq.setLpfEnabled (p.lpfEnabled > 0.5f);  eq.setLpfFreq (p.lpfFreq);
+        eq.setLfGain (p.lfGain);  eq.setLfFreq (p.lfFreq);  eq.setLfBell (p.lfBell > 0.5f);
+        eq.setLmGain (p.lmGain);  eq.setLmFreq (p.lmFreq);  eq.setLmQ (p.lmQ);
+        eq.setHmGain (p.hmGain);  eq.setHmFreq (p.hmFreq);  eq.setHmQ (p.hmQ);
+        eq.setHfGain (p.hfGain);  eq.setHfFreq (p.hfFreq);  eq.setHfBell (p.hfBell > 0.5f);
+        eq.setEqType ((int) p.eqType);
+        eq.setSaturation (p.saturation);
+        eq.setInputGainDb (p.inputGain);
+        eq.setOutputGainDb (p.outputGain);
         lastEqParams = p;
     }
 #endif
@@ -407,29 +368,25 @@ void ChannelStrip::updateCompParameters() noexcept
     if (paramsRef == nullptr) return;
 
     // Discrete params (no smoothing): bypass + mode + LIMIT toggle + FET
-    // ratio index. Stored directly on the donor atoms.
-    storeAtom (compBypassAtom,
-               paramsRef->compEnabled.load (std::memory_order_relaxed) ? 0.0f : 1.0f);
+    // ratio index. Pushed straight to the core's atomic setters. Mode map:
+    // session compMode 0..2 -> Opto/FET/VCA (setMode 0/1/2).
+    compressor.setBypass (! paramsRef->compEnabled.load (std::memory_order_relaxed));
 
-    const int modeIdx = juce::jlimit (0, 2, paramsRef->compMode.load (std::memory_order_relaxed));
-    storeAtom (compModeAtom, (float) modeIdx);
+    const int modeIdx = std::clamp (paramsRef->compMode.load (std::memory_order_relaxed), 0, 2);
+    compressor.setMode (modeIdx);
 
     // Per-mode sidechain HPF preset. VCA gets 60 Hz to match the SSL G /
     // dbx convention (keeps low-end transients from pumping the mids);
     // Opto and FET stay at 0 Hz so their original feedback-detector
     // character is preserved.
-    const float scHpHz = (modeIdx == 2) ? 60.0f : 0.0f;
-    storeAtom (compScHpAtom, scHpHz);
+    compressor.setSidechainHp ((modeIdx == 2) ? 60.0f : 0.0f);
 
-    storeAtom (compOptoLimitAtom,
-               paramsRef->compOptoLimit.load (std::memory_order_relaxed) ? 1.0f : 0.0f);
-    storeAtom (compFetRatioAtom,
-               (float) paramsRef->compFetRatio.load (std::memory_order_relaxed));
-    storeAtom (compVcaOverEasyAtom,
-               paramsRef->compVcaOverEasy.load (std::memory_order_relaxed) ? 1.0f : 0.0f);
+    compressor.setOptoLimit (paramsRef->compOptoLimit.load (std::memory_order_relaxed));
+    compressor.setFetRatio  (paramsRef->compFetRatio.load  (std::memory_order_relaxed));
+    compressor.setVcaOverEasy (paramsRef->compVcaOverEasy.load (std::memory_order_relaxed));
     // 0 = Adaptive (donor default), 1 = Classic (dbx 160 fixed 10 ms).
-    storeAtom (compVcaDetectorModeAtom,
-               paramsRef->compVcaDetectorClassic.load (std::memory_order_relaxed) ? 1.0f : 0.0f);
+    compressor.setVcaDetectorMode (
+        paramsRef->compVcaDetectorClassic.load (std::memory_order_relaxed) ? 1 : 0);
 
     // Continuous params: set smoother targets. The per-chunk
     // publishSmoothedCompParams() advances the smoothers and writes the
@@ -454,32 +411,25 @@ void ChannelStrip::publishSmoothedCompParams (int numSamples) noexcept
 {
 #if DUSKSTUDIO_HAS_DUSK_DSP
     if (numSamples <= 0) return;
-    // Advance each smoother by N samples then write the end-of-chunk
-    // value to the donor atom. Called once per inner chunk so chunks
-    // shorter than the smoother's 20 ms ramp see a STEPPED-but-fine-
-    // grained param trajectory (one step per 64 samples) rather than
-    // one step per audio block. Donor reads each atom only at the
-    // start of its processBlock call - true per-sample interpolation
-    // would require calling processBlock per-sample.
-    auto step = [numSamples] (juce::SmoothedValue<float>& sv,
-                                 std::atomic<float>* atom)
-    {
-        sv.skip (numSamples);
-        if (atom != nullptr) atom->store (sv.getCurrentValue(),
-                                            std::memory_order_relaxed);
-    };
-    step (smoothedOptoPeakRed, compOptoPeakRedAtom);
-    step (smoothedOptoGain,    compOptoGainAtom);
-    step (smoothedFetInput,    compFetInputAtom);
-    step (smoothedFetOutput,   compFetOutputAtom);
-    step (smoothedFetAttack,   compFetAttackAtom);
-    step (smoothedFetRelease,  compFetReleaseAtom);
-    step (smoothedFetThreshold,compFetThresholdAtom);
-    step (smoothedVcaThresh,   compVcaThreshAtom);
-    step (smoothedVcaRatio,    compVcaRatioAtom);
-    step (smoothedVcaAttack,   compVcaAttackAtom);
-    step (smoothedVcaRelease,  compVcaReleaseAtom);
-    step (smoothedVcaOutput,   compVcaOutputAtom);
+    // Advance each smoother by N samples then push the end-of-chunk value to
+    // the core's atomic setter. Called once per inner chunk so chunks shorter
+    // than the smoother's 20 ms ramp see a STEPPED-but-fine-grained param
+    // trajectory (one step per 64 samples) rather than one step per audio
+    // block. The core reads each atom only at the start of its processBlock
+    // call — true per-sample interpolation would require calling processBlock
+    // per-sample.
+    smoothedOptoPeakRed.skip (numSamples); compressor.setOptoPeakReduction (smoothedOptoPeakRed.getCurrentValue());
+    smoothedOptoGain   .skip (numSamples); compressor.setOptoGain          (smoothedOptoGain   .getCurrentValue());
+    smoothedFetInput   .skip (numSamples); compressor.setFetInput          (smoothedFetInput   .getCurrentValue());
+    smoothedFetOutput  .skip (numSamples); compressor.setFetOutput         (smoothedFetOutput  .getCurrentValue());
+    smoothedFetAttack  .skip (numSamples); compressor.setFetAttack         (smoothedFetAttack  .getCurrentValue());
+    smoothedFetRelease .skip (numSamples); compressor.setFetRelease        (smoothedFetRelease .getCurrentValue());
+    smoothedFetThreshold.skip (numSamples); compressor.setFetThreshold     (smoothedFetThreshold.getCurrentValue());
+    smoothedVcaThresh  .skip (numSamples); compressor.setVcaThreshold      (smoothedVcaThresh  .getCurrentValue());
+    smoothedVcaRatio   .skip (numSamples); compressor.setVcaRatio          (smoothedVcaRatio   .getCurrentValue());
+    smoothedVcaAttack  .skip (numSamples); compressor.setVcaAttack         (smoothedVcaAttack  .getCurrentValue());
+    smoothedVcaRelease .skip (numSamples); compressor.setVcaRelease        (smoothedVcaRelease .getCurrentValue());
+    smoothedVcaOutput  .skip (numSamples); compressor.setVcaOutput         (smoothedVcaOutput  .getCurrentValue());
 #else
     (void) numSamples;
 #endif
@@ -638,7 +588,7 @@ void ChannelStrip::processAndAccumulate (const float* inL,
                                          int   numDeviceOutputs,
                                          bool  isFrozen) noexcept
 {
-    juce::ScopedNoDenormals noDenormals;
+    dusk::audio::ScopedNoDenormals noDenormals;
 
     // Insert-mode crossfade gate. Run once at the top of every block.
     //   - If the user (or session-load) flipped insertMode, ramp the
@@ -718,9 +668,9 @@ void ChannelStrip::processAndAccumulate (const float* inL,
         return;
 
     // Skip the heavy DSP when the strip isn't passing to master and the
-    // recorder doesn't need a processed buffer either. With 16 channels each
-    // hosting a UniversalCompressor (a full juce::AudioProcessor), running
-    // the chain on every silent track was an xrun-class CPU spike.
+    // recorder doesn't need a processed buffer either. With 24 strips each
+    // running a full EQ + comp core, running the chain on every silent track
+    // was an xrun-class CPU spike.
     // A pending hardware-insert ping must still reach the slot (transport
     // stopped + IN off is the normal way to ping): the chirp goes only to
     // the insert's device send pair, and the !passByGate gain targets below
@@ -938,8 +888,8 @@ void ChannelStrip::processAndAccumulate (const float* inL,
             if (pdcAppliedSamples > 0 && freezeCapL == nullptr)
                 for (int i = 0; i < numSamples; ++i)
                 {
-                    pdcDelayL.pushSample (0, tempMono[(size_t) i]);
-                    tempMono[(size_t) i] = pdcDelayL.popSample (0);
+                    pdcDelayL.pushSample (tempMono[(size_t) i]);
+                    tempMono[(size_t) i] = pdcDelayL.popSample();
                 }
         }
 
@@ -955,50 +905,45 @@ void ChannelStrip::processAndAccumulate (const float* inL,
             const int compBufSize = 64 * oversampleFactor;
             for (int offset = 0; offset < total; offset += compBufSize)
             {
-                const int n = juce::jmin (compBufSize, total - offset);
-                float* compView[1] = { base + offset };
-                juce::AudioBuffer<float> compBuf (compView, 1, n);
+                const int n = std::min (compBufSize, total - offset);
+                const float* compIn[1]  = { base + offset };
+                float*       compOut[1] = { base + offset };
                 publishSmoothedCompParams (n);
-                compMidiScratch.clear();
-                compressor.processBlock (compBuf, compMidiScratch);
+                compressor.processBlock (compIn, compOut, 1, n);
             }
         };
 
-        if (oversamplerStages > 0 && oversamplerMono != nullptr)
+        if (oversampleFactor > 1)
         {
             // Oversampled chain: the EQ (carrying the always-on console
             // saturation) and, when engaged, the comp run on the upsampled view,
-            // then downsample back into tempMono. Donor saturation aliasing is
-            // suppressed by the half-band filters inside juce::dsp::Oversampling.
-            const float* readPtrs[1]  = { tempMono.data() };
-            float*       writePtrs[1] = { tempMono.data() };
-            juce::dsp::AudioBlock<const float> nativeIn  (readPtrs,  1, (size_t) numSamples);
-            juce::dsp::AudioBlock<float>       nativeOut (writePtrs, 1, (size_t) numSamples);
-
-            auto upBlock = oversamplerMono->processSamplesUp (nativeIn);
-            const int upN = (int) upBlock.getNumSamples();
-            float* upPtrs[1] = { upBlock.getChannelPointer (0) };
-            juce::AudioBuffer<float> upBuf (upPtrs, 1, upN);
-            eq.process (upBuf);
+            // then downsample back into tempMono. Saturation aliasing is
+            // suppressed by the half-band FIRs inside StereoOversampler. Mono
+            // feeds channel 0; the silent channel 1 (osMonoScratchR) is the
+            // oversampler's throwaway R and is never touched by the EQ / comp.
+            auto up = oversampler.processSamplesUp (tempMono.data(), osMonoScratchR.data(), numSamples);
+            const float* eqIn[1]  = { up.L };
+            float*       eqOut[1] = { up.L };
+            eq.processBlock (eqIn, eqOut, 1, up.numSamples);
             if (compEnabled)
-                runComp (upPtrs[0], upN);
+                runComp (up.L, up.numSamples);
 
-            oversamplerMono->processSamplesDown (nativeOut);
+            oversampler.processSamplesDown (tempMono.data(), osMonoScratchR.data(), numSamples);
         }
         else
         {
             // Native-rate path (factor == 1). The EQ (with the always-on
             // console saturation) always runs; the comp runs when engaged.
-            float* monoChannel[1] = { tempMono.data() };
-            juce::AudioBuffer<float> monoBuf (monoChannel, 1, numSamples);
-            eq.process (monoBuf);
+            const float* eqIn[1]  = { tempMono.data() };
+            float*       eqOut[1] = { tempMono.data() };
+            eq.processBlock (eqIn, eqOut, 1, numSamples);
             if (compEnabled)
                 runComp (tempMono.data(), numSamples);
         }
 
         // When bypassed, force the GR atom to 0 so the meter doesn't hold
-        // the last-computed reduction (the donor's getGainReduction()
-        // returns the cached value from its detector even while bypass=1).
+        // the last-computed reduction (the core's getGainReduction() returns
+        // the cached value from its detector even while bypass=1).
         currentGrDb.store (compEnabled ? compressor.getGainReduction() : 0.0f,
                             std::memory_order_relaxed);
 #endif
@@ -1136,8 +1081,8 @@ void ChannelStrip::processAndAccumulate (const float* inL,
             if (pdcAppliedSamples > 0 && freezeCapL == nullptr)
                 for (int i = 0; i < numSamples; ++i)
                 {
-                    pdcDelayL.pushSample (0, L[i]);  L[i] = pdcDelayL.popSample (0);
-                    pdcDelayR.pushSample (0, R[i]);  R[i] = pdcDelayR.popSample (0);
+                    pdcDelayL.pushSample (L[i]);  L[i] = pdcDelayL.popSample();
+                    pdcDelayR.pushSample (R[i]);  R[i] = pdcDelayR.popSample();
                 }
         }
 
@@ -1150,12 +1095,11 @@ void ChannelStrip::processAndAccumulate (const float* inL,
             const int compBufSize = 64 * oversampleFactor;
             for (int offset = 0; offset < total; offset += compBufSize)
             {
-                const int n = juce::jmin (compBufSize, total - offset);
-                float* compView[2] = { l + offset, r + offset };
-                juce::AudioBuffer<float> compBuf (compView, 2, n);
+                const int n = std::min (compBufSize, total - offset);
+                const float* compIn[2]  = { l + offset, r + offset };
+                float*       compOut[2] = { l + offset, r + offset };
                 publishSmoothedCompParams (n);
-                compMidiScratch.clear();
-                compressor.processBlock (compBuf, compMidiScratch);
+                compressor.processBlock (compIn, compOut, 2, n);
             }
         };
 
@@ -1163,31 +1107,24 @@ void ChannelStrip::processAndAccumulate (const float* inL,
         // during the freeze render, so re-running them would double-process.
         if (! isFrozen)
         {
-            if (oversamplerStages > 0 && oversamplerStereo != nullptr)
+            if (oversampleFactor > 1)
             {
-                const float* readPtrs[2]  = { L, R };
-                float*       writePtrs[2] = { L, R };
-                juce::dsp::AudioBlock<const float> nativeIn  (readPtrs,  2, (size_t) numSamples);
-                juce::dsp::AudioBlock<float>       nativeOut (writePtrs, 2, (size_t) numSamples);
-
-                auto upBlock = oversamplerStereo->processSamplesUp (nativeIn);
-                const int upN = (int) upBlock.getNumSamples();
-                float* upPtrs[2] = { upBlock.getChannelPointer (0),
-                                      upBlock.getChannelPointer (1) };
-                juce::AudioBuffer<float> upBuf (upPtrs, 2, upN);
-                eq.process (upBuf);
+                auto up = oversampler.processSamplesUp (L, R, numSamples);
+                const float* eqIn[2]  = { up.L, up.R };
+                float*       eqOut[2] = { up.L, up.R };
+                eq.processBlock (eqIn, eqOut, 2, up.numSamples);
                 if (compEnabled)
-                    runCompStereo (upPtrs[0], upPtrs[1], upN);
+                    runCompStereo (up.L, up.R, up.numSamples);
 
-                oversamplerStereo->processSamplesDown (nativeOut);
+                oversampler.processSamplesDown (L, R, numSamples);
             }
             else
             {
                 // Native-rate path (factor == 1). EQ (with console saturation)
                 // always runs; comp when engaged.
-                float* stereoChannels[2] = { L, R };
-                juce::AudioBuffer<float> stereoBuf (stereoChannels, 2, numSamples);
-                eq.process (stereoBuf);
+                const float* eqIn[2]  = { L, R };
+                float*       eqOut[2] = { L, R };
+                eq.processBlock (eqIn, eqOut, 2, numSamples);
                 if (compEnabled)
                     runCompStereo (L, R, numSamples);
             }
@@ -1268,9 +1205,9 @@ void ChannelStrip::processAndAccumulate (const float* inL,
     float outPeakL = 0.0f, outPeakR = 0.0f;
     const auto publishOutMeter = [this] (float pL, float pR)
     {
-        currentOutLDb.store (pL > 1e-5f ? juce::Decibels::gainToDecibels (pL, -100.0f) : -100.0f,
+        currentOutLDb.store (pL > 1e-5f ? dusk::audio::gainToDecibels (pL, -100.0f) : -100.0f,
                              std::memory_order_relaxed);
-        currentOutRDb.store (pR > 1e-5f ? juce::Decibels::gainToDecibels (pR, -100.0f) : -100.0f,
+        currentOutRDb.store (pR > 1e-5f ? dusk::audio::gainToDecibels (pR, -100.0f) : -100.0f,
                              std::memory_order_relaxed);
     };
 

--- a/src/dsp/ChannelStrip.h
+++ b/src/dsp/ChannelStrip.h
@@ -1,11 +1,14 @@
 #pragma once
 
 #include <juce_audio_basics/juce_audio_basics.h>
-#include <juce_dsp/juce_dsp.h>
+#include <algorithm>
 #include <array>
 #include <filesystem>
 #include <memory>
 #include <vector>
+#include "../foundation/IntDelayLine.h"
+#include "../foundation/SmoothedValue.h"
+#include "../foundation/StereoOversampler.h"
 #include "../session/Session.h"
 #include "../engine/PluginSlot.h"
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
@@ -20,13 +23,13 @@
 #include "HardwareInsertSlot.h"
 
 #if DUSKSTUDIO_HAS_DUSK_DSP
-  #include "BritishEQProcessor.h"
-  // Use UniversalCompressor directly (not the ChannelComp facade) so
-  // the strip behaves like a DAW hosting the standalone multi-comp:
-  // full feature set with the donor's internal oversampling disabled
-  // because the strip wraps EQ+Comp in its own oversampler — running
-  // both would double-OS.
-  #include "UniversalCompressor.h"
+  // Framework-free donor cores. The strip drives the full comp feature set
+  // (Opto/FET/VCA) with the core's internal oversampling left off because the
+  // strip wraps EQ+Comp in its own StereoOversampler — running both would
+  // double-OS. The EQ likewise runs 1x internally inside that same wrap (its
+  // console saturation is the only saturating stage and the wrap band-limits it).
+  #include <dsp/FourKEQDSP.hpp>
+  #include <core/UniversalCompressorDSP.hpp>
 #endif
 
 namespace duskstudio
@@ -49,7 +52,7 @@ public:
     static constexpr int kMaxPdcSamples = 16384;   // ~340 ms @ 48k, matches HW insert
     void setPdcCompensationSamples (int n) noexcept
     {
-        pdcTargetSamples.store (juce::jlimit (0, kMaxPdcSamples, n), std::memory_order_relaxed);
+        pdcTargetSamples.store (std::clamp (n, 0, kMaxPdcSamples), std::memory_order_relaxed);
     }
     int getPdcCompensationSamples() const noexcept
     {
@@ -229,30 +232,35 @@ public:
 
 private:
     const ChannelStripParams* paramsRef = nullptr;
-    juce::SmoothedValue<float> faderGain  { 0.0f };
-    juce::SmoothedValue<float> panGainL   { 0.7071f };
-    juce::SmoothedValue<float> panGainR   { 0.7071f };
+    dusk::audio::SmoothedValue<float> faderGain  { 0.0f };
+    dusk::audio::SmoothedValue<float> panGainL   { 0.7071f };
+    dusk::audio::SmoothedValue<float> panGainR   { 0.7071f };
     // Binary bus routing smoothed 0..1 to avoid clicks on toggle.
-    std::array<juce::SmoothedValue<float>, kNumBuses> busGain;
-    std::array<juce::SmoothedValue<float>, kNumAuxSends> auxSendGain;
+    std::array<dusk::audio::SmoothedValue<float>, kNumBuses> busGain;
+    std::array<dusk::audio::SmoothedValue<float>, kNumAuxSends> auxSendGain;
     // Sampled at the top of processAndAccumulate so the inner loop
     // avoids per-sample atomic loads.
     std::array<bool, kNumAuxSends> auxSendPre {};
 
     std::vector<float> tempMono;
-    juce::AudioBuffer<float> eqMonoBuffer;
 
     // 2-channel even on mono so a mid-session mono->stereo flip doesn't
-    // fault on missing filter / envelope state.
+    // fault on missing filter / envelope state. Shared with the plugin /
+    // hardware insert hosting path, so it stays a juce::AudioBuffer.
     juce::AudioBuffer<float> tempStereoBuffer;
 
-    // Built once per prepare from Session::oversamplingFactor: nullptr
-    // at 1×, 1 stage at 2×, 2 stages at 4×. Without this the donor's
-    // BritishEQ console saturation and UC saturation alias.
-    std::unique_ptr<juce::dsp::Oversampling<float>> oversamplerMono;
-    std::unique_ptr<juce::dsp::Oversampling<float>> oversamplerStereo;
-    int oversamplerStages = 0;
-    int oversampleFactor  = 1;   // 1 / 2 / 4 — drives the comp sub-chunk size
+    // Per-strip Dusk Studio-side oversampler wrapping (EQ + Comp). The donor
+    // EQ's always-on console saturation and the comp's saturation alias hard at
+    // native rate; the wrap moves the whole per-channel DSP to the oversampled
+    // rate so the half-band FIRs band-limit it before downsampling. One
+    // StereoOversampler serves both track widths: mono feeds channel 0 with a
+    // silent channel 1 (osMonoScratchR) and processes only channel 0 — the
+    // wasted R half-band FIR runs on silence, but avoids doubling the expensive
+    // EQ + comp work a duplicate-mono approach would incur, and no mono-only
+    // primitive exists.
+    dusk::audio::StereoOversampler oversampler;
+    std::vector<float> osMonoScratchR;
+    int oversampleFactor = 1;    // 1 / 2 / 4 — drives the comp sub-chunk size
 
     // Sits between phase invert and the EQ stage.
     PluginSlot pluginSlot;
@@ -304,9 +312,8 @@ private:
     // currently-applied length) so a latency change never clicks. pdcApplied /
     // pdcSilentRun are audio-thread-only; pdcTargetSamples is the cross-thread
     // setpoint.
-    using PdcDelayLine = juce::dsp::DelayLine<float, juce::dsp::DelayLineInterpolationTypes::None>;
-    PdcDelayLine pdcDelayL { kMaxPdcSamples };
-    PdcDelayLine pdcDelayR { kMaxPdcSamples };
+    dusk::audio::IntDelayLine pdcDelayL;
+    dusk::audio::IntDelayLine pdcDelayR;
     std::atomic<int> pdcTargetSamples { 0 };
     int          pdcAppliedSamples = 0;
     std::int64_t  pdcSilentRun = 0;
@@ -316,8 +323,9 @@ private:
     // state). The EQ — which carries the always-on console saturation — runs
     // every block, so the oversampler is never skipped; this value is kept only
     // so the silent-skip can account for the oversampler's tail before dropping
-    // a block (see requiredDrain in processAndAccumulate).
-    static constexpr int kMaxOsLatency = 16;
+    // a block (see requiredDrain in processAndAccumulate). The FIR round trip is
+    // 23 (2x) / lround(26.5)=27 (4x) base-rate samples.
+    static constexpr int kMaxOsLatency = 32;
     int          osLatencySamples = 0;
 
     // Empty buffer for the channel insert plugin; PluginSlot's
@@ -326,69 +334,48 @@ private:
     juce::MidiBuffer pluginMidiScratch;
 
 #if DUSKSTUDIO_HAS_DUSK_DSP
-    BritishEQProcessor eq;
+    duskaudio::FourKEQDSP eq;
     // On false->true we eq.reset() so a disabled-then-re-enabled EQ
     // doesn't emit a transient from stale filter history.
     bool prevEqEnabled { true };
-    // memcmp against last block — only call setParameters when bytes
-    // differ, skipping the 8-14 biquad recompute when no knob moved.
-    // Value-init {} so padding bytes are zeroed.
-    BritishEQProcessor::Parameters lastEqParams {};
 
-    UniversalCompressor compressor;
-    juce::MidiBuffer compMidiScratch;
+    // memcmp against last block — only push the EQ setters when a field
+    // changed, skipping the biquad recompute when no knob moved. Plain-float
+    // struct (no padding) value-init to zero so memcmp is byte-reliable, and
+    // so a bypassed EQ's flat defaults (all bands 0 dB, filters off) are the
+    // literal zero image.
+    struct EqSnapshot
+    {
+        float hpfEnabled = 0, hpfFreq = 0, lpfEnabled = 0, lpfFreq = 0;
+        float lfGain = 0, lfFreq = 0, lfBell = 0;
+        float lmGain = 0, lmFreq = 0, lmQ = 0;
+        float hmGain = 0, hmFreq = 0, hmQ = 0;
+        float hfGain = 0, hfFreq = 0, hfBell = 0;
+        float eqType = 0, saturation = 0, inputGain = 0, outputGain = 0;
+    };
+    EqSnapshot lastEqParams {};
 
-    // Cached APVTS atomic pointers — write here goes directly to the
-    // same std::atomic<float> UniversalCompressor reads each block,
-    // skipping the string lookup. Values stored DENORMALISED (SI / index
-    // / 0-or-1).
-    std::atomic<float>* compModeAtom        = nullptr;
-    std::atomic<float>* compBypassAtom      = nullptr;
-    std::atomic<float>* compMixAtom         = nullptr;
-    std::atomic<float>* compAutoMakeupAtom  = nullptr;
-    // VCA defaults to 60 Hz (SSL/dbx convention — keeps kick pumping at
-    // bay), Opto and FET stay at 0 Hz so their feedback-detector
-    // character is unchanged.
-    std::atomic<float>* compScHpAtom        = nullptr;
-    std::atomic<float>* compOptoPeakRedAtom = nullptr;
-    std::atomic<float>* compOptoGainAtom    = nullptr;
-    std::atomic<float>* compOptoLimitAtom   = nullptr;
-    std::atomic<float>* compFetInputAtom    = nullptr;
-    std::atomic<float>* compFetOutputAtom   = nullptr;
-    std::atomic<float>* compFetAttackAtom   = nullptr;
-    std::atomic<float>* compFetReleaseAtom  = nullptr;
-    std::atomic<float>* compFetRatioAtom    = nullptr;
-    std::atomic<float>* compFetThresholdAtom = nullptr;
-    std::atomic<float>* compVcaThreshAtom   = nullptr;
-    std::atomic<float>* compVcaRatioAtom    = nullptr;
-    std::atomic<float>* compVcaAttackAtom   = nullptr;
-    std::atomic<float>* compVcaReleaseAtom  = nullptr;
-    std::atomic<float>* compVcaOutputAtom   = nullptr;
-    std::atomic<float>* compVcaOverEasyAtom = nullptr;
-    std::atomic<float>* compVcaDetectorModeAtom = nullptr;
+    duskaudio::UniversalCompressorDSP compressor;
 
     // 20 ms ramps for continuous params so knob drags don't zipper.
-    // Discrete params (mode, bypass, LIMIT, FET ratio) bypass.
-    juce::SmoothedValue<float> smoothedOptoPeakRed;
-    juce::SmoothedValue<float> smoothedOptoGain;
-    juce::SmoothedValue<float> smoothedFetInput;
-    juce::SmoothedValue<float> smoothedFetOutput;
-    juce::SmoothedValue<float> smoothedFetAttack;
-    juce::SmoothedValue<float> smoothedFetRelease;
-    juce::SmoothedValue<float> smoothedFetThreshold;
-    juce::SmoothedValue<float> smoothedVcaThresh;
-    juce::SmoothedValue<float> smoothedVcaRatio;
-    juce::SmoothedValue<float> smoothedVcaAttack;
-    juce::SmoothedValue<float> smoothedVcaRelease;
-    juce::SmoothedValue<float> smoothedVcaOutput;
+    // Discrete params (mode, bypass, LIMIT, FET ratio) bypass. Their per-chunk
+    // published values feed the core's atomic setters (no APVTS atoms to cache
+    // — the core does not port the donor's analog-hiss stage, so the old
+    // noise_enable force-off is unnecessary).
+    dusk::audio::SmoothedValue<float> smoothedOptoPeakRed;
+    dusk::audio::SmoothedValue<float> smoothedOptoGain;
+    dusk::audio::SmoothedValue<float> smoothedFetInput;
+    dusk::audio::SmoothedValue<float> smoothedFetOutput;
+    dusk::audio::SmoothedValue<float> smoothedFetAttack;
+    dusk::audio::SmoothedValue<float> smoothedFetRelease;
+    dusk::audio::SmoothedValue<float> smoothedFetThreshold;
+    dusk::audio::SmoothedValue<float> smoothedVcaThresh;
+    dusk::audio::SmoothedValue<float> smoothedVcaRatio;
+    dusk::audio::SmoothedValue<float> smoothedVcaAttack;
+    dusk::audio::SmoothedValue<float> smoothedVcaRelease;
+    dusk::audio::SmoothedValue<float> smoothedVcaOutput;
 
     void publishSmoothedCompParams (int numSamples) noexcept;
-
-    void bindCompParams();
-    static inline void storeAtom (std::atomic<float>* a, float v) noexcept
-    {
-        if (a != nullptr) a->store (v, std::memory_order_relaxed);
-    }
 #endif
 
     std::atomic<float> currentGrDb { 0.0f };

--- a/src/dsp/MasterBus.cpp
+++ b/src/dsp/MasterBus.cpp
@@ -222,8 +222,24 @@ void MasterBus::processInPlace (float* L, float* R, int numSamples) noexcept
     const bool compOn = paramsRef != nullptr
                      && paramsRef->compEnabled.load (std::memory_order_relaxed);
 
-    if (currentOxFactor > 1 && (eqOn || compOn))
+    const bool wrapActive = currentOxFactor > 1 && (eqOn || compOn);
+    if (wrapActive && ! prevWrapActive)
+        oversampler.reset();
+    prevWrapActive = wrapActive;
+
+    if (wrapActive)
     {
+        // Keep the skip ring warm (see header) — push the pre-wrap signal,
+        // discard the pops.
+        if (osLatencySamples > 0)
+        {
+            for (int i = 0; i < numSamples; ++i)
+            {
+                osSkipDelayL.pushSample (L[i]);  osSkipDelayL.popSample();
+                osSkipDelayR.pushSample (R[i]);  osSkipDelayR.popSample();
+            }
+        }
+
         // Oversampled path. Wrap (TubeEQ + busComp) inside the up/down so their
         // saturation is band-limited before downsampling. Both were prepped at
         // oversampled rate / block size in prepare().

--- a/src/dsp/MasterBus.cpp
+++ b/src/dsp/MasterBus.cpp
@@ -1,6 +1,8 @@
 #include "MasterBus.h"
+#include "../foundation/Decibels.h"
+#include "../foundation/ScopedNoDenormals.h"
+#include <algorithm>
 #include <cmath>
-#include <cstring>
 
 namespace duskstudio
 {
@@ -16,7 +18,7 @@ void MasterBus::prepare (double sampleRate, int blockSize, int oversamplingFacto
     sampleRateForMeter = sampleRate > 0.0 ? sampleRate : 44100.0;
     vuRmsLinL = vuRmsLinR = 0.0f;
     {
-        const int bs = juce::jmax (1, blockSize);
+        const int bs = std::max (1, blockSize);
         meterBlockSize = bs;
         meterRmsAlpha  = std::exp (-((float) bs / (float) sampleRateForMeter) / 0.3f);
     }
@@ -83,36 +85,21 @@ void MasterBus::prepare (double sampleRate, int blockSize, int oversamplingFacto
 
     // Master oversampler around (TubeEQ + busComp). Both stages have donor
     // saturation that aliases at native rate; the wrap moves them to
-    // oversampled rate. UC's internal toggle is OFF here because Dusk Studio
-    // does the up/downsample around the chain. TapeMachine has its own
-    // internal oversampling (driven via APVTS above) so it processes at
-    // native rate AFTER this wrap.
-    oversamplerStages = (currentOxFactor == 4) ? 2 : (currentOxFactor == 2) ? 1 : 0;
-    const int bsClamped = juce::jmax (1, blockSize);
-    if (oversamplerStages > 0)
-    {
-        oversampler = std::make_unique<juce::dsp::Oversampling<float>> (
-            2, (size_t) oversamplerStages,
-            juce::dsp::Oversampling<float>::filterHalfBandPolyphaseIIR,
-            /*isMaximumQuality*/ true);
-        oversampler->initProcessing ((size_t) bsClamped);
-        oversampler->reset();
-        osLatencySamples = juce::jmin (kMaxOsLatency,
-            (int) std::lround (oversampler->getLatencyInSamples()));
-    }
-    else
-    {
-        oversampler.reset();
-        osLatencySamples = 0;
-    }
+    // oversampled rate. The comp core's internal oversampling path is never
+    // engaged because Dusk Studio does the up/downsample around the chain.
+    // TapeMachine has its own internal oversampling (driven via APVTS above) so
+    // it processes at native rate AFTER this wrap.
+    const int bsClamped = std::max (1, blockSize);
+    oversampler.setFactor (currentOxFactor);
+    oversampler.prepare (bsClamped);
+    osLatencySamples = (currentOxFactor > 1)
+        ? std::min (kMaxOsLatency, (int) std::lround (oversampler.latency()))
+        : 0;
 
-    const juce::dsp::ProcessSpec osSpec { sampleRate, (std::uint32_t) bsClamped, 1 };
-    osSkipDelayL.prepare (osSpec);
-    osSkipDelayR.prepare (osSpec);
     osSkipDelayL.setMaximumDelayInSamples (kMaxOsLatency);
     osSkipDelayR.setMaximumDelayInSamples (kMaxOsLatency);
-    osSkipDelayL.setDelay ((float) osLatencySamples);
-    osSkipDelayR.setDelay ((float) osLatencySamples);
+    osSkipDelayL.setDelay (osLatencySamples);
+    osSkipDelayR.setDelay (osLatencySamples);
     osSkipDelayL.reset();
     osSkipDelayR.reset();
 
@@ -122,52 +109,24 @@ void MasterBus::prepare (double sampleRate, int blockSize, int oversamplingFacto
     tubeEQ.prepare (prepSr, prepBs, 2);
     tubeEQ.reset();
 
-    busComp.setPlayConfigDetails (2, 2, prepSr, prepBs);
-    busComp.prepareToPlay (prepSr, prepBs);
-    busComp.setInternalOversamplingEnabled (false);  // External wrap handles oversampling.
-    compStereoBuffer.setSize (2, prepBs, false, false, true);
-    compMidi.clear();
-    bindCompParams();
+    busComp.setMode (3);            // Bus mode
+    busComp.setMix (100.0f);
+    busComp.setBusMix (100.0f);
+    busComp.setAutoMakeup (false);
+    // The core does not port the donor's analog-noise stage, so no explicit
+    // force-off is needed — the master chain stays clean under signal.
+    busComp.prepare (prepSr, prepBs);
+    busComp.reset();
+    compMaxBlock = prepBs;
 #endif
-
-    preparedBlockSize = blockSize;
 }
 
 #if DUSKSTUDIO_HAS_DUSK_DSP
-void MasterBus::bindCompParams()
-{
-    auto& apvts = busComp.getParameters();
-    compModeAtom       = apvts.getRawParameterValue ("mode");
-    compBypassAtom     = apvts.getRawParameterValue ("bypass");
-    compMixAtom        = apvts.getRawParameterValue ("mix");
-    compAutoMakeupAtom = apvts.getRawParameterValue ("auto_makeup");
-    compBusThreshAtom  = apvts.getRawParameterValue ("bus_threshold");
-    compBusRatioAtom   = apvts.getRawParameterValue ("bus_ratio");
-    compBusAttackAtom  = apvts.getRawParameterValue ("bus_attack");
-    compBusReleaseAtom = apvts.getRawParameterValue ("bus_release");
-    compBusMakeupAtom  = apvts.getRawParameterValue ("bus_makeup");
-    compBusMixAtom     = apvts.getRawParameterValue ("bus_mix");
-
-    // Lock the comp into Bus mode (CompressorMode::Bus = 3); set wet-only mix.
-    storeAtom (compModeAtom, 3.0f);
-    storeAtom (compMixAtom,         100.0f);
-    storeAtom (compBusMixAtom,      100.0f);
-    storeAtom (compAutoMakeupAtom,    0.0f);  // Off
-    // The donor's "Analog Noise" feature injects ~-80 dB white noise on every
-    // analog mode (Bus included) and defaults ON. The master chain runs the
-    // comp every block whenever it's engaged, so that hiss would sit on the
-    // output continuously (~-67 dB peak, two channels) and print into bounces.
-    // Force it off — Dusk Studio's master bus is meant to be clean.
-    storeAtom (apvts.getRawParameterValue ("noise_enable"), 0.0f);
-}
-
 void MasterBus::updateEqParameters() noexcept
 {
     if (paramsRef == nullptr) return;
 
-    // Value-init padding to zero so the memcmp cache against lastTubeEqParams
-    // is reliable - see ChannelStrip equivalent for full reasoning.
-    TubeEQProcessor::Parameters p {};
+    duskaudio::MultiQTube::Parameters p {};
     p.lfBoostGain      = paramsRef->eqLfBoost.load (std::memory_order_relaxed);
     p.lfBoostFreq      = paramsRef->eqLfFreq.load (std::memory_order_relaxed);
     p.lfAttenGain      = paramsRef->eqLfAtten.load (std::memory_order_relaxed);
@@ -192,57 +151,48 @@ void MasterBus::updateEqParameters() noexcept
     // "warm but not saturated" character, like a real EQP-1A at unity.
     p.tubeDrive  = 0.02f;
     p.bypass     = ! paramsRef->eqEnabled.load (std::memory_order_relaxed);
-    if (std::memcmp (&p, &lastTubeEqParams, sizeof (p)) != 0)
-    {
-        tubeEQ.setParameters (p);
-        lastTubeEqParams = p;
-    }
+    // The core's setParameters self-gates on operator!= (marks filters dirty
+    // only on an actual change), preserving the "updateFilters only on change"
+    // semantics that keep the end-of-block HF inductor-Q remodulation persistent
+    // — no external memcmp cache needed.
+    tubeEQ.setParameters (p);
 }
 
 void MasterBus::updateCompParameters() noexcept
 {
     if (paramsRef == nullptr) return;
 
-    storeAtom (compBypassAtom,
-               paramsRef->compEnabled.load (std::memory_order_relaxed) ? 0.0f : 1.0f);
-    storeAtom (compBusThreshAtom,  paramsRef->compThreshDb.load   (std::memory_order_relaxed));
+    busComp.setBypass (! paramsRef->compEnabled.load (std::memory_order_relaxed));
+    busComp.setBusThreshold (paramsRef->compThreshDb.load (std::memory_order_relaxed));
     // bus_ratio / bus_attack are SSL-style stepped Choice params, NOT
-    // continuous. Storing the raw knob value treated it as an out-of-range
-    // index (ratio 4.0 -> 2:1, attack 10 ms -> 30 ms). Map to the nearest
-    // discrete index.  bus_ratio: 0=2:1 1=4:1 2=10:1.  bus_attack: 0=0.1
-    // 1=0.3 2=1 3=3 4=10 5=30 ms.
+    // continuous. Map the raw knob value to the nearest discrete index.
+    //   bus_ratio: 0=2:1 1=4:1 2=10:1.  bus_attack: 0=0.1 1=0.3 2=1 3=3 4=10
+    //   5=30 ms.
     const float ratio  = paramsRef->compRatio.load (std::memory_order_relaxed);
-    storeAtom (compBusRatioAtom, ratio < 3.0f ? 0.0f : (ratio < 7.0f ? 1.0f : 2.0f));
+    busComp.setBusRatio (ratio < 3.0f ? 0 : (ratio < 7.0f ? 1 : 2));
     const float atkMs  = paramsRef->compAttackMs.load (std::memory_order_relaxed);
-    storeAtom (compBusAttackAtom,
-               atkMs < 0.2f ? 0.0f
-             : (atkMs < 0.65f ? 1.0f
-             : (atkMs < 2.0f ? 2.0f
-             : (atkMs < 6.5f ? 3.0f
-             : (atkMs < 20.0f ? 4.0f : 5.0f)))));
-    // The donor's bus_release is a Choice param indexed 0..4 over
-    // {0.1s, 0.3s, 0.6s, 1.2s, Auto}. Map Dusk Studio's continuous release knob
-    // to the nearest discrete index, or send 4 ("Auto") when the Auto
-    // toggle is engaged so the comp uses its program-dependent envelope.
+    busComp.setBusAttack (atkMs < 0.2f ? 0
+                        : (atkMs < 0.65f ? 1
+                        : (atkMs < 2.0f ? 2
+                        : (atkMs < 6.5f ? 3
+                        : (atkMs < 20.0f ? 4 : 5)))));
+    // bus_release is a Choice indexed 0..4 over {0.1s, 0.3s, 0.6s, 1.2s, Auto}.
+    // Map the continuous release knob to the nearest discrete index, or send 4
+    // ("Auto") when the Auto toggle is engaged so the comp uses its
+    // program-dependent envelope.
     const bool autoRel = paramsRef->compReleaseAuto.load (std::memory_order_relaxed);
     const float relMs  = paramsRef->compReleaseMs.load   (std::memory_order_relaxed);
-    const float relIdx = autoRel ? 4.0f
-                       : (relMs < 200.0f ? 0.0f
-                       : (relMs < 450.0f ? 1.0f
-                       : (relMs < 900.0f ? 2.0f : 3.0f)));
-    storeAtom (compBusReleaseAtom, relIdx);
-    storeAtom (compBusMakeupAtom,  paramsRef->compMakeupDb.load   (std::memory_order_relaxed));
+    busComp.setBusRelease (autoRel ? 4
+                         : (relMs < 200.0f ? 0
+                         : (relMs < 450.0f ? 1
+                         : (relMs < 900.0f ? 2 : 3))));
+    busComp.setBusMakeup (paramsRef->compMakeupDb.load (std::memory_order_relaxed));
 }
 #endif
 
 void MasterBus::processInPlace (float* L, float* R, int numSamples) noexcept
 {
-    juce::ScopedNoDenormals noDenormals;
-
-    // Contract: numSamples must not exceed what was passed to prepare().
-    // If a host violates this, our chunk loop below correctly handles the
-    // comp portion; the assert just makes the violation visible in debug.
-    jassert (numSamples <= preparedBlockSize);
+    dusk::audio::ScopedNoDenormals noDenormals;
 
     const bool tapeOn = paramsRef != nullptr
                        && paramsRef->tapeEnabled.load (std::memory_order_relaxed);
@@ -255,7 +205,7 @@ void MasterBus::processInPlace (float* L, float* R, int numSamples) noexcept
         const float faderDb = paramsRef->liveFaderDb.load (std::memory_order_relaxed);
         const float gain = (faderDb <= ChannelStripParams::kFaderInfThreshDb)
                            ? 0.0f
-                           : juce::Decibels::decibelsToGain (faderDb);
+                           : dusk::audio::decibelsToGain (faderDb);
         faderGain.setTargetValue (gain);
     }
 
@@ -272,75 +222,57 @@ void MasterBus::processInPlace (float* L, float* R, int numSamples) noexcept
     const bool compOn = paramsRef != nullptr
                      && paramsRef->compEnabled.load (std::memory_order_relaxed);
 
-    if (oversamplerStages > 0 && oversampler != nullptr && (eqOn || compOn))
+    if (currentOxFactor > 1 && (eqOn || compOn))
     {
-        // Oversampled path. Wrap (TubeEQ + busComp) inside the up/down so
-        // their saturation is band-limited before downsampling. EQ and UC
-        // were prepped at oversampled rate / block size in prepare().
-        const float* readPtrs[2]  = { L, R };
-        float*       writePtrs[2] = { L, R };
-        juce::dsp::AudioBlock<const float> nativeIn  (readPtrs,  2, (size_t) numSamples);
-        juce::dsp::AudioBlock<float>       nativeOut (writePtrs, 2, (size_t) numSamples);
-
-        auto upBlock = oversampler->processSamplesUp (nativeIn);
-        const int upN = (int) upBlock.getNumSamples();
-        float* upPtrs[2] = { upBlock.getChannelPointer (0),
-                              upBlock.getChannelPointer (1) };
-        juce::AudioBuffer<float> upBuf (upPtrs, 2, upN);
+        // Oversampled path. Wrap (TubeEQ + busComp) inside the up/down so their
+        // saturation is band-limited before downsampling. Both were prepped at
+        // oversampled rate / block size in prepare().
+        auto up = oversampler.processSamplesUp (L, R, numSamples);
         if (eqOn)
-            tubeEQ.process (upBuf);
-
+        {
+            float* eqPtrs[2] = { up.L, up.R };
+            tubeEQ.process (eqPtrs, 2, up.numSamples);
+        }
         if (compOn)
         {
-            const int compBufSize = compStereoBuffer.getNumSamples();
-            for (int offset = 0; offset < upN; offset += compBufSize)
+            for (int offset = 0; offset < up.numSamples; offset += compMaxBlock)
             {
-                const int n = juce::jmin (compBufSize, upN - offset);
-                float* compView[2] = { upPtrs[0] + offset, upPtrs[1] + offset };
-                juce::AudioBuffer<float> compBuf (compView, 2, n);
-                compMidi.clear();
-                busComp.processBlock (compBuf, compMidi);
+                const int n = std::min (compMaxBlock, up.numSamples - offset);
+                const float* compIn[2]  = { up.L + offset, up.R + offset };
+                float*       compOut[2] = { up.L + offset, up.R + offset };
+                busComp.processBlock (compIn, compOut, 2, n);
             }
         }
-
-        oversampler->processSamplesDown (nativeOut);
+        oversampler.processSamplesDown (L, R, numSamples);
     }
     else if (eqOn || compOn)
     {
-        // Native-rate path (factor == 1, or a single active stage). Chunk
-        // both passes to honor preparedBlockSize / compStereoBuffer sizes.
+        // Native-rate path (factor == 1). The tube EQ has no block-size limit;
+        // chunk only the comp to honor compMaxBlock.
         if (eqOn)
         {
-            const int eqBuf = juce::jmax (1, preparedBlockSize);
-            for (int offset = 0; offset < numSamples; offset += eqBuf)
-            {
-                const int n = juce::jmin (eqBuf, numSamples - offset);
-                float* channels[2] = { L + offset, R + offset };
-                juce::AudioBuffer<float> buf (channels, 2, n);
-                tubeEQ.process (buf);
-            }
+            float* eqPtrs[2] = { L, R };
+            tubeEQ.process (eqPtrs, 2, numSamples);
         }
         if (compOn)
         {
-            const int compBuf = compStereoBuffer.getNumSamples();
-            for (int offset = 0; offset < numSamples; offset += compBuf)
+            for (int offset = 0; offset < numSamples; offset += compMaxBlock)
             {
-                const int n = juce::jmin (compBuf, numSamples - offset);
-                float* lrView[2] = { L + offset, R + offset };
-                juce::AudioBuffer<float> cb (lrView, 2, n);
-                compMidi.clear();
-                busComp.processBlock (cb, compMidi);
+                const int n = std::min (compMaxBlock, numSamples - offset);
+                const float* compIn[2]  = { L + offset, R + offset };
+                float*       compOut[2] = { L + offset, R + offset };
+                busComp.processBlock (compIn, compOut, 2, n);
             }
         }
     }
-    else if (oversamplerStages > 0 && osLatencySamples > 0)
+    else if (currentOxFactor > 1 && osLatencySamples > 0)
     {
         // EQ + comp both bypassed → oversampler skipped. Delay by its latency
         // so the master's latency stays invariant to the EQ/comp toggle.
         for (int i = 0; i < numSamples; ++i)
         {
-            osSkipDelayL.pushSample (0, L[i]);  L[i] = osSkipDelayL.popSample (0);
-            osSkipDelayR.pushSample (0, R[i]);  R[i] = osSkipDelayR.popSample (0);
+            osSkipDelayL.pushSample (L[i]);  L[i] = osSkipDelayL.popSample();
+            osSkipDelayR.pushSample (R[i]);  R[i] = osSkipDelayR.popSample();
         }
     }
     // else (factor == 1, both off): signal passes through. TapeMachine still
@@ -357,8 +289,8 @@ void MasterBus::processInPlace (float* L, float* R, int numSamples) noexcept
     // The donor hard-bypasses (early-returns, no ramp), so we own the on/off
     // crossfade here: blend the dry (pre-tape) signal against the wet output
     // over 20 ms. Tape is run only while audible — fully on, or still fading —
-    // so a disengaged tape costs ~nothing. Chunked by preparedBlockSize
-    // because the donor's internal scratch is sized to that.
+    // so a disengaged tape costs ~nothing. Chunked to the tape scratch size
+    // because the donor's internal scratch is sized to the prepared block.
     const float tapeTarget = tapeOn ? 1.0f : 0.0f;
     if (! tapeMixPrimed)
     {
@@ -480,11 +412,11 @@ void MasterBus::processInPlace (float* L, float* R, int numSamples) noexcept
     if (paramsRef != nullptr)
     {
         const auto toDb = [] (float a) { return a > 1.0e-5f
-            ? juce::Decibels::gainToDecibels (a, -100.0f) : -100.0f; };
+            ? dusk::audio::gainToDecibels (a, -100.0f) : -100.0f; };
         paramsRef->meterPostMasterLDb.store (toDb (postPeakL), std::memory_order_relaxed);
         paramsRef->meterPostMasterRDb.store (toDb (postPeakR), std::memory_order_relaxed);
 
-        const float invN    = 1.0f / (float) juce::jmax (1, numSamples);
+        const float invN    = 1.0f / (float) std::max (1, numSamples);
         const float rmsBlkL = std::sqrt (sumSqL * invN);
         const float rmsBlkR = std::sqrt (sumSqR * invN);
         const float alpha   = (numSamples == meterBlockSize)

--- a/src/dsp/MasterBus.h
+++ b/src/dsp/MasterBus.h
@@ -94,6 +94,13 @@ private:
     dusk::audio::IntDelayLine osSkipDelayR;
     int osLatencySamples = 0;
 
+    // The skip ring is fed on EVERY block at OS factors > 1 (wrap-on blocks
+    // push and discard) so toggling EQ+comp off emits continuous delayed dry
+    // instead of a zero-filled gap while the ring refills. The oversampler is
+    // reset on the wrap-on edge so its FIR ramps in from silence, not a stale
+    // tail from the last time the wrap ran.
+    bool prevWrapActive { false };
+
     // juce::dsp integer delay line, retained for the tape crossfade dry-path PDC
     // below (the tape stage keeps its JUCE API).
     using OsDelayLine = juce::dsp::DelayLine<float, juce::dsp::DelayLineInterpolationTypes::None>;

--- a/src/dsp/MasterBus.h
+++ b/src/dsp/MasterBus.h
@@ -4,12 +4,15 @@
 #include <juce_dsp/juce_dsp.h>
 #include <atomic>
 #include <memory>
+#include "../foundation/IntDelayLine.h"
+#include "../foundation/SmoothedValue.h"
+#include "../foundation/StereoOversampler.h"
 #include "../session/Session.h"
 
 #if DUSKSTUDIO_HAS_DUSK_DSP
   #include "PluginProcessor.h"    // TapeMachine/Source - master tape emulation (full plugin processor + editor)
-  #include "TubeEQProcessor.h"    // multi-q - Pultec-style EQ
-  #include "UniversalCompressor.h"// multi-comp - Bus mode for the master comp
+  #include <core/MultiQTube.hpp>             // multi-q - Pultec-style Tube EQ (framework-free donor core)
+  #include <core/UniversalCompressorDSP.hpp> // multi-comp - Bus mode master comp (framework-free donor core)
 #endif
 
 namespace duskstudio
@@ -38,7 +41,7 @@ public:
 
 private:
     const MasterBusParams* paramsRef = nullptr;
-    juce::SmoothedValue<float> faderGain { 1.0f };
+    dusk::audio::SmoothedValue<float> faderGain { 1.0f };
 
 #if DUSKSTUDIO_HAS_DUSK_DSP
     TapeMachineAudioProcessor   tape;
@@ -53,60 +56,47 @@ private:
     juce::SmoothedValue<float>  tapeMix { 0.0f };    // 0 = dry, 1 = wet
     bool                        tapeMixPrimed = false;
     juce::AudioBuffer<float>    tapeDryBuffer;       // pre-allocated; holds dry during the fade
-    TubeEQProcessor             tubeEQ;
-    TubeEQProcessor::Parameters lastTubeEqParams {};   // see ChannelStrip equivalent
-    UniversalCompressor         busComp;
-    juce::MidiBuffer            compMidi;            // unused but required by processBlock
-    juce::AudioBuffer<float>    compStereoBuffer;    // pre-allocated; comp processBlock target
+    duskaudio::MultiQTube             tubeEQ;
+    duskaudio::UniversalCompressorDSP busComp;
+    // Max samples per busComp.processBlock call (the oversampled prepare block
+    // size — the core degrades to dry passthrough beyond it); the process chunk
+    // loop splits anything larger. The tube EQ has no block-size limit.
+    int compMaxBlock = 0;
 
-    // Cached APVTS atoms for the bus compressor - written every block from
-    // session params via direct atomic store (no setValueNotifyingHost), same
-    // lock-free pattern as ChannelStrip.
-    std::atomic<float>* compModeAtom        = nullptr;
-    std::atomic<float>* compBypassAtom      = nullptr;
-    std::atomic<float>* compMixAtom         = nullptr;
-    std::atomic<float>* compAutoMakeupAtom  = nullptr;
-    std::atomic<float>* compBusThreshAtom   = nullptr;
-    std::atomic<float>* compBusRatioAtom    = nullptr;
-    std::atomic<float>* compBusAttackAtom   = nullptr;
-    std::atomic<float>* compBusReleaseAtom  = nullptr;
-    std::atomic<float>* compBusMakeupAtom   = nullptr;
-    std::atomic<float>* compBusMixAtom      = nullptr;
-
-    void bindCompParams();
     void updateEqParameters() noexcept;
     void updateCompParameters() noexcept;
+    // Lock-free atomic store, used for the tape stage's bypass APVTS atom.
     static inline void storeAtom (std::atomic<float>* a, float v) noexcept
     {
         if (a != nullptr) a->store (v, std::memory_order_relaxed);
     }
 #endif
 
-    int preparedBlockSize    = 0;
     int currentOxFactor      = 1;     // 1, 2 or 4 - set in prepare(); drives the
-                                       // Dusk Studio-side oversampler around (TubeEQ +
-                                       // UC) and the TapeMachine "oversampling"
-                                       // APVTS choice atom. UC's internal toggle
-                                       // is OFF on the master bus because the
-                                       // Dusk Studio-side wrap handles oversampling.
+                                       // Dusk Studio-side oversampler around (TubeEQ
+                                       // + comp) and the TapeMachine "oversampling"
+                                       // APVTS choice atom. The comp core's internal
+                                       // oversampling path is never engaged because
+                                       // the Dusk Studio-side wrap handles it.
 
-    // Master oversampler around (TubeEQ + bus comp). Both stages have
-    // saturation (tube + UC) that aliases at native rate; running them at
-    // oversampled rate inside this wrap suppresses it. TapeMachine has
-    // its own internal oversampling (driven via APVTS) so it's processed
-    // at native rate AFTER this wrap.
-    std::unique_ptr<juce::dsp::Oversampling<float>> oversampler;
-    int oversamplerStages    = 0;
+    // Master oversampler around (TubeEQ + bus comp). Both stages saturate (tube
+    // + comp) and alias at native rate; running them at oversampled rate inside
+    // this wrap suppresses it. TapeMachine has its own internal oversampling
+    // (driven via APVTS) so it's processed at native rate AFTER this wrap.
+    dusk::audio::StereoOversampler oversampler;
 
-    // When EQ + comp are both bypassed the oversampler is skipped. It imposes
-    // ~3-4.4 native samples of latency, so delay the skip path by that amount
-    // to keep the master's latency invariant to the EQ/comp toggle. Integer
-    // (None) delay — the sub-sample rounding residual is inaudible.
-    static constexpr int kMaxOsLatency = 16;
-    using OsDelayLine = juce::dsp::DelayLine<float, juce::dsp::DelayLineInterpolationTypes::None>;
-    OsDelayLine osSkipDelayL { kMaxOsLatency };
-    OsDelayLine osSkipDelayR { kMaxOsLatency };
+    // When EQ + comp are both bypassed the oversampler is skipped. Its FIR round
+    // trip imposes 23 (2x) / 26.5 (4x) native samples of latency, so delay the
+    // skip path by that amount to keep the master's latency invariant to the
+    // EQ/comp toggle. Integer delay — the 0.5-sample residual at 4x is inaudible.
+    static constexpr int kMaxOsLatency = 32;
+    dusk::audio::IntDelayLine osSkipDelayL;
+    dusk::audio::IntDelayLine osSkipDelayR;
     int osLatencySamples = 0;
+
+    // juce::dsp integer delay line, retained for the tape crossfade dry-path PDC
+    // below (the tape stage keeps its JUCE API).
+    using OsDelayLine = juce::dsp::DelayLine<float, juce::dsp::DelayLineInterpolationTypes::None>;
 
     // Dry-path PDC for the tape crossfade. Tape adds its own oversampler
     // latency when engaged (0 at 1×); delaying the dry by the same amount keeps

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -299,6 +299,7 @@ if(DUSK_PLUGINS_PATH)
         mastering_chain.cpp
         mastering_digital_eq.cpp
         dsp_stereo_oversampler.cpp
+        eq_british_ab.cpp
         smoke_brickwall_limiter.cpp
         dsp_loudness_meter.cpp
         ${CMAKE_SOURCE_DIR}/src/dsp/BrickwallLimiter.cpp
@@ -306,6 +307,7 @@ if(DUSK_PLUGINS_PATH)
         ${CMAKE_SOURCE_DIR}/src/dsp/MasteringChain.cpp
         ${CMAKE_SOURCE_DIR}/src/dsp/MasteringDigitalEq.cpp
         ${CMAKE_SOURCE_DIR}/src/dsp/LoudnessMeter.cpp
+        "${DUSK_PLUGINS_PATH}/plugins/shared-dpf/dsp/FourKEQDSP.cpp"
         "${DUSK_PLUGINS_PATH}/plugins/multi-comp/multicomp.cpp"
         "${DUSK_PLUGINS_PATH}/plugins/multi-comp/AnalogLookAndFeel.cpp"
         "${DUSK_PLUGINS_PATH}/plugins/multi-comp/EnhancedCompressorEditor.cpp"
@@ -321,7 +323,11 @@ if(DUSK_PLUGINS_PATH)
         PROPERTIES
         COMPILE_DEFINITIONS "AnalogVUMeter=MultiCompAnalogVUMeter")
 
+    # projucer-shim satisfies BritishEQProcessor.h's `#include <JuceHeader.h>`
+    # (the donor EQ under A/B test in eq_british_ab.cpp); the shim pulls in a
+    # few JUCE modules the base test link is missing, added below.
     target_include_directories(dusk-studio-tests SYSTEM PRIVATE
+        "${CMAKE_SOURCE_DIR}/external/projucer-shim"
         "${DUSK_PLUGINS_PATH}/plugins/shared"
         "${DUSK_PLUGINS_PATH}/plugins/shared-dpf"
         "${DUSK_PLUGINS_PATH}/plugins/shared/AnalogEmulation"
@@ -330,6 +336,13 @@ if(DUSK_PLUGINS_PATH)
         "${DUSK_PLUGINS_PATH}/plugins/multi-comp"
         "${DUSK_PLUGINS_PATH}/plugins/multi-comp/HardwareEmulation"
         "${DUSK_PLUGINS_PATH}/plugins/TapeMachine/Source")
+
+    # Modules referenced only transitively by the projucer-shim umbrella header.
+    target_link_libraries(dusk-studio-tests PRIVATE
+        juce::juce_audio_utils
+        juce::juce_data_structures
+        juce::juce_events
+        juce::juce_gui_extra)
 
     target_compile_definitions(dusk-studio-tests PRIVATE
         DUSKSTUDIO_HAS_DUSK_DSP=1

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -300,6 +300,7 @@ if(DUSK_PLUGINS_PATH)
         mastering_digital_eq.cpp
         dsp_stereo_oversampler.cpp
         eq_british_ab.cpp
+        comp_core_ab.cpp
         smoke_brickwall_limiter.cpp
         dsp_loudness_meter.cpp
         ${CMAKE_SOURCE_DIR}/src/dsp/BrickwallLimiter.cpp
@@ -309,6 +310,7 @@ if(DUSK_PLUGINS_PATH)
         ${CMAKE_SOURCE_DIR}/src/dsp/LoudnessMeter.cpp
         "${DUSK_PLUGINS_PATH}/plugins/shared-dpf/dsp/FourKEQDSP.cpp"
         "${DUSK_PLUGINS_PATH}/plugins/multi-comp/multicomp.cpp"
+        "${DUSK_PLUGINS_PATH}/plugins/multi-comp/core/UniversalCompressorDSP.cpp"
         "${DUSK_PLUGINS_PATH}/plugins/multi-comp/AnalogLookAndFeel.cpp"
         "${DUSK_PLUGINS_PATH}/plugins/multi-comp/EnhancedCompressorEditor.cpp"
         "${DUSK_PLUGINS_PATH}/plugins/shared/LEDMeter.cpp")
@@ -334,7 +336,9 @@ if(DUSK_PLUGINS_PATH)
         "${DUSK_PLUGINS_PATH}/plugins/shared/channel-comp"
         "${DUSK_PLUGINS_PATH}/plugins/multi-q"
         "${DUSK_PLUGINS_PATH}/plugins/multi-comp"
+        "${DUSK_PLUGINS_PATH}/plugins/multi-comp/core"
         "${DUSK_PLUGINS_PATH}/plugins/multi-comp/HardwareEmulation"
+        "${DUSK_PLUGINS_PATH}/plugins/shared-dpf/dsp"
         "${DUSK_PLUGINS_PATH}/plugins/TapeMachine/Source")
 
     # Modules referenced only transitively by the projucer-shim umbrella header.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -300,6 +300,7 @@ if(DUSK_PLUGINS_PATH)
         mastering_digital_eq.cpp
         dsp_stereo_oversampler.cpp
         eq_british_ab.cpp
+        tube_multiq_ab.cpp
         comp_core_ab.cpp
         smoke_brickwall_limiter.cpp
         dsp_loudness_meter.cpp

--- a/tests/bus_strip.cpp
+++ b/tests/bus_strip.cpp
@@ -145,7 +145,7 @@ TEST_CASE ("BusStrip: silent input -> silent output", "[BusStrip]")
     }
 
     // No analog noise floor on a silent bus even with EQ + comp engaged
-    // (BusStrip::bindCompParams forces the donor's noise_enable off).
+    // (the framework-free comp core carries no analog-hiss stage).
     REQUIRE (outPeak < 1.0e-4f);
 }
 
@@ -207,7 +207,9 @@ TEST_CASE ("BusStrip: comp-off bus is OS-latency compensated at 4x", "[BusStrip]
     // With comp off, factor 4 skips the comp oversampler but delays the signal
     // by the oversampler's latency so the bus stays aligned with comp-on buses.
     // The EQ is identical (native) in both runs, so the factor-4 stream should
-    // equal the factor-1 stream shifted by a small positive lag.
+    // equal the factor-1 stream shifted by the skip delay: the donor halfband
+    // FIR round trip is 26.5 base samples at 4x, applied as a 27-sample
+    // (lround) integer delay.
     const float amp = juce::Decibels::decibelsToGain (-12.0f);
 
     auto capture = [&] (int factor)
@@ -224,9 +226,8 @@ TEST_CASE ("BusStrip: comp-off bus is OS-latency compensated at 4x", "[BusStrip]
     const auto f1 = capture (1);
     const auto f4 = capture (4);
 
-    const auto [lag, err] = bestLag (f1, f4, 16);   // does f4 == f1 delayed?
-    REQUIRE (lag >= 1);                  // a real compensation delay is applied
-    REQUIRE (lag <= 8);                  // ~4.4 samples at 4× → rounds to 4
+    const auto [lag, err] = bestLag (f1, f4, 40);   // does f4 == f1 delayed?
+    REQUIRE (lag == 27);                 // lround(26.5) — the applied skip delay
     REQUIRE (err < 1.0e-7);              // and at that lag the streams match
 }
 

--- a/tests/bus_strip.cpp
+++ b/tests/bus_strip.cpp
@@ -231,6 +231,38 @@ TEST_CASE ("BusStrip: comp-off bus is OS-latency compensated at 4x", "[BusStrip]
     REQUIRE (err < 1.0e-7);              // and at that lag the streams match
 }
 
+TEST_CASE ("BusStrip: comp-off toggle at 4x leaves no silent gap", "[BusStrip]")
+{
+    // Disabling the comp switches from the oversampled path to the skip-delay
+    // path. The skip ring is fed on comp-on blocks too, so the first comp-off
+    // block emits continuous (delayed) signal — not the zero fill a cold ring
+    // would produce.
+    duskstudio::BusParams params;
+    params.compEnabled.store (true, std::memory_order_relaxed);
+
+    duskstudio::BusStrip strip;
+    strip.prepare (kSr, kBlock, 4);
+    strip.bind (params);
+
+    const float amp = juce::Decibels::decibelsToGain (-12.0f);
+    double phase = driveSine (strip, 0.0, 1000.0, amp, 16);   // settle comp-on
+
+    params.compEnabled.store (false, std::memory_order_relaxed);
+    std::vector<float> outL, outR;
+    driveSine (strip, phase, 1000.0, amp, 1, &outL, &outR, 0);
+
+    // Longest run of near-silent samples in the first comp-off block. A 1 kHz
+    // sine at 48 k crosses zero one sample at a time; a cold ring would emit
+    // ~27 consecutive zeros.
+    int run = 0, maxRun = 0;
+    for (float x : outL)
+    {
+        run    = (std::abs (x) < 1.0e-6f) ? run + 1 : 0;
+        maxRun = std::max (maxRun, run);
+    }
+    REQUIRE (maxRun < 8);
+}
+
 TEST_CASE ("BusStrip: hot input stays finite", "[BusStrip]")
 {
     duskstudio::BusParams params;

--- a/tests/comp_core_ab.cpp
+++ b/tests/comp_core_ab.cpp
@@ -1,0 +1,574 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "UniversalCompressor.h"          // JUCE donor (ground truth)
+#include "UniversalCompressorDSP.hpp"      // duskaudio:: JUCE-free core
+
+#include <cmath>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+// A/B parity: the JUCE-free duskaudio::UniversalCompressorDSP must match the JUCE
+// UniversalCompressor sample-for-sample when both are driven exactly as Dusk
+// Studio's channel strips drive the donor (setMinimalProcessing(false),
+// setInternalOversamplingEnabled(false), oversampling param left at its 2x
+// default, noise forced off, raw APVTS atoms written before every processBlock).
+// JUCE output is the reference; the core is a verbatim transcription, so any
+// nonzero diff is a genuine slip to hunt down.
+
+namespace
+{
+constexpr double kTwoPi = 6.28318530717958647692;
+
+// Per-sample audio tolerance. Transcription is verbatim -> expect 0.0f.
+constexpr float kAudioTol = 1.0e-7f;
+// GR meter is a dB read-back through the same block-delay ring on both sides.
+constexpr float kGrTol = 1.0e-6f;
+
+inline float lin (float db) { return std::pow (10.0f, db * 0.05f); }
+inline int jmaxI (int a, int b) { return a > b ? a : b; }
+
+struct Rng
+{
+    uint32_t s;
+    float next() noexcept
+    {
+        s = s * 1664525u + 1013904223u;
+        return (float) ((s >> 8) & 0xFFFFFF) / (float) 0x1000000 * 2.0f - 1.0f;
+    }
+};
+
+// Deterministic stereo material: sustained multi-tone + 0.18 s level steps
+// (attack/release + voltage-sag territory), periodic transient clicks
+// (delayed-attack / release-memory paths) and a touch of noise. `asym` skews
+// L vs R so the stereo-link paths see a real inter-channel imbalance.
+void makeSignal (std::vector<float>& L, std::vector<float>& R,
+                 int total, double sr, uint32_t seed, bool asym)
+{
+    L.assign ((size_t) total, 0.0f);
+    R.assign ((size_t) total, 0.0f);
+    Rng rng { seed };
+
+    const double f1 = 110.0, f2 = 440.0, f3 = 1730.0;
+    double p1 = 0.0, p2 = 0.0, p3 = 0.0;
+    const int clickPeriod = jmaxI ((int) (sr * 0.13), 1);
+    const int clickLen    = jmaxI ((int) (sr * 0.001), 1);
+    const float segDb[6] = { -18.0f, -3.0f, -9.0f, 0.0f, -24.0f, -6.0f };
+
+    for (int i = 0; i < total; ++i)
+    {
+        const double t = (double) i / sr;
+        const int seg = (int) (t / 0.18) % 6;
+        const float ampL = lin (segDb[seg]);
+        const float ampR = asym ? lin (segDb[(seg + 3) % 6]) * 0.6f : ampL;
+
+        const float sL = 0.6f * (float) std::sin (p1) + 0.3f * (float) std::sin (p2)
+                       + 0.25f * (float) std::sin (p3);
+        const float sR = asym ? (0.6f * (float) std::sin (p1 + 0.5) + 0.3f * (float) std::sin (p2)
+                                 + 0.25f * (float) std::sin (p3 * 1.01))
+                              : sL;
+        p1 += kTwoPi * f1 / sr;
+        p2 += kTwoPi * f2 / sr;
+        p3 += kTwoPi * f3 / sr;
+
+        const float n = 0.02f * rng.next();
+        float clk = 0.0f;
+        if ((i % clickPeriod) < clickLen) clk = rng.next() > 0.0f ? 0.9f : -0.9f;
+
+        L[(size_t) i] = ampL * sL + n + clk;
+        R[(size_t) i] = ampR * sR + n * 0.8f + clk * (asym ? 0.5f : 1.0f);
+    }
+}
+
+// Everything Dusk drives on the donor. Defaults mirror the JUCE APVTS defaults
+// so an unset field is identical on both sides.
+struct CompParams
+{
+    int   mode = 0;
+    bool  bypass = false;
+    float mix = 100.0f;
+    bool  autoMakeup = false;
+    float scHp = 0.0f;
+    float stereoLink = 100.0f;
+    int   stereoLinkMode = 0;
+
+    float optoPeakReduction = 0.0f, optoGain = 50.0f;
+    bool  optoLimit = false;
+
+    float fetInput = 0.0f, fetOutput = 0.0f, fetAttack = 0.2f, fetRelease = 400.0f;
+    float fetThreshold = -10.0f, fetTransient = 0.0f;
+    int   fetRatio = 0, fetCurveMode = 0;
+
+    float vcaThreshold = 0.0f, vcaRatio = 4.0f, vcaAttack = 1.0f, vcaRelease = 100.0f, vcaOutput = 0.0f;
+    bool  vcaOverEasy = false;
+    int   vcaDetectorMode = 0;
+
+    float busThreshold = 0.0f, busMakeup = 0.0f, busMix = 100.0f;
+    int   busRatio = 0, busAttack = 2, busRelease = 1;
+};
+
+void applyJuce (UniversalCompressor& c, const CompParams& p)
+{
+    auto& a = c.getParameters();
+    auto set = [&] (const char* id, float v)
+    {
+        if (auto* atom = a.getRawParameterValue (id))
+            atom->store (v, std::memory_order_relaxed);
+    };
+    set ("mode", (float) p.mode);
+    set ("bypass", p.bypass ? 1.0f : 0.0f);
+    set ("mix", p.mix);
+    set ("auto_makeup", p.autoMakeup ? 1.0f : 0.0f);
+    set ("sidechain_hp", p.scHp);
+    set ("stereo_link", p.stereoLink);
+    set ("stereo_link_mode", (float) p.stereoLinkMode);
+    set ("noise_enable", 0.0f);   // Dusk forces analog noise off
+
+    set ("opto_peak_reduction", p.optoPeakReduction);
+    set ("opto_gain", p.optoGain);
+    set ("opto_limit", p.optoLimit ? 1.0f : 0.0f);
+
+    set ("fet_input", p.fetInput);
+    set ("fet_output", p.fetOutput);
+    set ("fet_attack", p.fetAttack);
+    set ("fet_release", p.fetRelease);
+    set ("fet_ratio", (float) p.fetRatio);
+    set ("fet_threshold", p.fetThreshold);
+    set ("fet_curve_mode", (float) p.fetCurveMode);
+    set ("fet_transient", p.fetTransient);
+
+    set ("vca_threshold", p.vcaThreshold);
+    set ("vca_ratio", p.vcaRatio);
+    set ("vca_attack", p.vcaAttack);
+    set ("vca_release", p.vcaRelease);
+    set ("vca_output", p.vcaOutput);
+    set ("vca_overeasy", p.vcaOverEasy ? 1.0f : 0.0f);
+    set ("vca_detector_mode", (float) p.vcaDetectorMode);
+
+    set ("bus_threshold", p.busThreshold);
+    set ("bus_ratio", (float) p.busRatio);
+    set ("bus_attack", (float) p.busAttack);
+    set ("bus_release", (float) p.busRelease);
+    set ("bus_makeup", p.busMakeup);
+    set ("bus_mix", p.busMix);
+}
+
+void applyCore (duskaudio::UniversalCompressorDSP& c, const CompParams& p)
+{
+    c.setMode (p.mode);
+    c.setBypass (p.bypass);
+    c.setMix (p.mix);
+    c.setAutoMakeup (p.autoMakeup);
+    c.setSidechainHp (p.scHp);
+    c.setStereoLink (p.stereoLink);
+    c.setStereoLinkMode (p.stereoLinkMode);
+
+    c.setOptoPeakReduction (p.optoPeakReduction);
+    c.setOptoGain (p.optoGain);
+    c.setOptoLimit (p.optoLimit);
+
+    c.setFetInput (p.fetInput);
+    c.setFetOutput (p.fetOutput);
+    c.setFetAttack (p.fetAttack);
+    c.setFetRelease (p.fetRelease);
+    c.setFetRatio (p.fetRatio);
+    c.setFetThreshold (p.fetThreshold);
+    c.setFetCurveMode (p.fetCurveMode);
+    c.setFetTransient (p.fetTransient);
+
+    c.setVcaThreshold (p.vcaThreshold);
+    c.setVcaRatio (p.vcaRatio);
+    c.setVcaAttack (p.vcaAttack);
+    c.setVcaRelease (p.vcaRelease);
+    c.setVcaOutput (p.vcaOutput);
+    c.setVcaOverEasy (p.vcaOverEasy);
+    c.setVcaDetectorMode (p.vcaDetectorMode);
+
+    c.setBusThreshold (p.busThreshold);
+    c.setBusRatio (p.busRatio);
+    c.setBusAttack (p.busAttack);
+    c.setBusRelease (p.busRelease);
+    c.setBusMakeup (p.busMakeup);
+    c.setBusMix (p.busMix);
+}
+
+using ParamHook = std::function<void (CompParams&, int /*blockIdx*/)>;
+
+// Drive the JUCE donor exactly like ChannelStrip: 2/2 play config, prepare at
+// prepBlock, then feed `chunk`-sized blocks (params written before each).
+void runJuce (const std::vector<float>& inL, const std::vector<float>& inR,
+              std::vector<float>& outL, std::vector<float>& outR, std::vector<float>& gr,
+              double sr, int prepBlock, int chunk, int nch,
+              const CompParams& base, const ParamHook& hook)
+{
+    UniversalCompressor c;
+    c.setMinimalProcessing (false);
+    c.setInternalOversamplingEnabled (false);
+    c.setPlayConfigDetails (2, 2, sr, prepBlock);
+    c.prepareToPlay (sr, prepBlock);
+    c.reset();
+
+    const int total = (int) inL.size();
+    outL.assign ((size_t) total, 0.0f);
+    outR.assign ((size_t) total, 0.0f);
+    gr.clear();
+
+    juce::MidiBuffer midi;
+    int blk = 0;
+    for (int off = 0; off < total; off += chunk, ++blk)
+    {
+        const int n = std::min (chunk, total - off);
+        CompParams p = base;
+        if (hook) hook (p, blk);
+        applyJuce (c, p);
+
+        juce::AudioBuffer<float> buf (nch, n);
+        for (int i = 0; i < n; ++i)
+        {
+            buf.setSample (0, i, inL[(size_t) (off + i)]);
+            if (nch > 1) buf.setSample (1, i, inR[(size_t) (off + i)]);
+        }
+        midi.clear();
+        c.processBlock (buf, midi);
+
+        for (int i = 0; i < n; ++i)
+        {
+            outL[(size_t) (off + i)] = buf.getSample (0, i);
+            outR[(size_t) (off + i)] = nch > 1 ? buf.getSample (1, i) : buf.getSample (0, i);
+        }
+        gr.push_back (c.getGainReduction());
+    }
+}
+
+void runCore (const std::vector<float>& inL, const std::vector<float>& inR,
+              std::vector<float>& outL, std::vector<float>& outR, std::vector<float>& gr,
+              double sr, int prepBlock, int chunk, int nch,
+              const CompParams& base, const ParamHook& hook)
+{
+    duskaudio::UniversalCompressorDSP c;
+    c.prepare (sr, prepBlock);
+    c.reset();
+
+    const int total = (int) inL.size();
+    outL.assign ((size_t) total, 0.0f);
+    outR.assign ((size_t) total, 0.0f);
+    gr.clear();
+
+    std::vector<float> tL ((size_t) chunk, 0.0f), tR ((size_t) chunk, 0.0f);
+    int blk = 0;
+    for (int off = 0; off < total; off += chunk, ++blk)
+    {
+        const int n = std::min (chunk, total - off);
+        CompParams p = base;
+        if (hook) hook (p, blk);
+        applyCore (c, p);
+
+        const float* inP[2]  = { &inL[(size_t) off], nch > 1 ? &inR[(size_t) off] : &inL[(size_t) off] };
+        float*       outP[2] = { tL.data(), tR.data() };
+        c.processBlock (inP, outP, nch, n);
+
+        for (int i = 0; i < n; ++i)
+        {
+            outL[(size_t) (off + i)] = tL[(size_t) i];
+            outR[(size_t) (off + i)] = nch > 1 ? tR[(size_t) i] : tL[(size_t) i];
+        }
+        gr.push_back (c.getGainReduction());
+    }
+}
+
+float audioMaxDiff (const std::vector<float>& aL, const std::vector<float>& aR,
+                    const std::vector<float>& bL, const std::vector<float>& bR)
+{
+    float d = 0.0f;
+    const size_t n = std::min (aL.size(), bL.size());
+    for (size_t i = 0; i < n; ++i)
+    {
+        d = std::max (d, std::abs (aL[i] - bL[i]));
+        d = std::max (d, std::abs (aR[i] - bR[i]));
+    }
+    return d;
+}
+
+float grMaxDiff (const std::vector<float>& a, const std::vector<float>& b)
+{
+    float d = 0.0f;
+    const size_t n = std::min (a.size(), b.size());
+    for (size_t i = 0; i < n; ++i)
+        d = std::max (d, std::abs (a[i] - b[i]));
+    return d;
+}
+
+// Full A/B for one param set + signal. REQUIREs audio (and GR) parity and
+// surfaces the actual diffs via UNSCOPED_INFO so a slip prints its magnitude.
+void checkAB (const std::string& label, const CompParams& base,
+              double sr, int block, double seconds, int nch,
+              uint32_t seed, bool asym, const ParamHook& hook = nullptr)
+{
+    const int total = (int) (seconds * sr);
+    std::vector<float> inL, inR;
+    makeSignal (inL, inR, total, sr, seed, asym);
+
+    std::vector<float> jL, jR, jGr, cL, cR, cGr;
+    runJuce (inL, inR, jL, jR, jGr, sr, block, block, nch, base, hook);
+    runCore (inL, inR, cL, cR, cGr, sr, block, block, nch, base, hook);
+
+    const float aDiff = audioMaxDiff (jL, jR, cL, cR);
+    const float gDiff = grMaxDiff (jGr, cGr);
+    UNSCOPED_INFO (label << ": audioMaxDiff=" << aDiff << "  grMaxDiff=" << gDiff);
+    REQUIRE (aDiff <= kAudioTol);
+    REQUIRE (gDiff <= kGrTol);
+}
+} // namespace
+
+//==============================================================================
+// 1. Opto (mode 0)
+//==============================================================================
+TEST_CASE ("comp A/B: Opto matches JUCE", "[compab]")
+{
+    CompParams p; p.mode = 0;
+
+    SECTION ("peak-reduction / gain / limit sweep (48k)")
+    {
+        for (float pr : { 20.0f, 60.0f, 90.0f })
+            for (float g : { 50.0f, 65.0f })
+                for (bool lim : { false, true })
+                {
+                    p.optoPeakReduction = pr; p.optoGain = g; p.optoLimit = lim;
+                    checkAB ("opto pr=" + std::to_string ((int) pr) + " g=" + std::to_string ((int) g)
+                             + " lim=" + std::to_string (lim),
+                             p, 48000.0, 512, 3.0, 2, 0xA11CE, false);
+                }
+    }
+
+    SECTION ("release slew across sample rates (sustained)")
+    {
+        p.optoPeakReduction = 80.0f; p.optoGain = 55.0f;
+        for (double sr : { 44100.0, 48000.0, 96000.0 })
+            checkAB ("opto sr=" + std::to_string ((int) sr), p, sr, 512, 3.0, 2, 0x0470, false);
+    }
+}
+
+//==============================================================================
+// 2. FET (mode 1)
+//==============================================================================
+TEST_CASE ("comp A/B: FET matches JUCE", "[compab]")
+{
+    CompParams p; p.mode = 1;
+
+    SECTION ("gain / attack / release / ratio sweep")
+    {
+        for (int ratio : { 0, 1, 2, 3, 4 })
+            for (float atk : { 0.05f, 5.0f })
+                for (float rel : { 80.0f, 600.0f })
+                {
+                    p.fetRatio = ratio; p.fetInput = 12.0f; p.fetOutput = -3.0f;
+                    p.fetAttack = atk; p.fetRelease = rel; p.fetThreshold = -18.0f;
+                    checkAB ("fet ratio=" + std::to_string (ratio) + " atk=" + std::to_string (atk)
+                             + " rel=" + std::to_string (rel),
+                             p, 48000.0, 512, 2.0, 2, 0xFE7, false);
+                }
+    }
+
+    SECTION ("all-buttons (ratio 4) sustained deep GR + transients, across rates")
+    {
+        p.fetRatio = 4; p.fetInput = 24.0f; p.fetOutput = 0.0f;
+        p.fetAttack = 0.1f; p.fetRelease = 300.0f; p.fetThreshold = -30.0f;
+        for (double sr : { 44100.0, 48000.0, 96000.0 })
+            checkAB ("fet allbuttons sr=" + std::to_string ((int) sr), p, sr, 512, 2.5, 2, 0xB77, false);
+    }
+
+    SECTION ("curve mode Measured")
+    {
+        p.fetRatio = 4; p.fetCurveMode = 1; p.fetInput = 20.0f; p.fetThreshold = -28.0f;
+        checkAB ("fet measured curve", p, 48000.0, 512, 2.0, 2, 0xC0FFEE, false);
+    }
+}
+
+//==============================================================================
+// 3. VCA (mode 2)
+//==============================================================================
+TEST_CASE ("comp A/B: VCA matches JUCE", "[compab]")
+{
+    CompParams p; p.mode = 2; p.vcaRatio = 4.0f;
+
+    SECTION ("OverEasy on/off + threshold knee sweep")
+    {
+        for (bool oe : { false, true })
+            for (float toff : { -6.0f, -5.0f, -2.5f, 0.0f, 2.5f, 5.0f, 6.0f })
+            {
+                p.vcaOverEasy = oe; p.vcaThreshold = toff;
+                checkAB ("vca oe=" + std::to_string (oe) + " thr=" + std::to_string (toff),
+                         p, 48000.0, 512, 1.6, 2, 0x0CA, false);
+            }
+    }
+
+    SECTION ("detector mode 0/1 + attack/release banding, across rates")
+    {
+        p.vcaThreshold = -20.0f; p.vcaRatio = 8.0f;
+        for (int det : { 0, 1 })
+            for (double sr : { 44100.0, 48000.0, 96000.0 })
+            {
+                p.vcaDetectorMode = det;
+                checkAB ("vca det=" + std::to_string (det) + " sr=" + std::to_string ((int) sr),
+                         p, sr, 512, 1.6, 2, 0xD37, false);
+            }
+    }
+
+    SECTION ("fast-attack overshoot")
+    {
+        p.vcaThreshold = -28.0f; p.vcaRatio = 20.0f; p.vcaAttack = 0.1f; p.vcaRelease = 30.0f;
+        checkAB ("vca fast attack", p, 48000.0, 512, 1.6, 2, 0xFA57, false);
+    }
+}
+
+//==============================================================================
+// 4. Bus (mode 3)
+//==============================================================================
+TEST_CASE ("comp A/B: Bus matches JUCE", "[compab]")
+{
+    CompParams p; p.mode = 3;
+
+    SECTION ("attack/release indices incl auto-release (transient-dense + sustained)")
+    {
+        for (int atk : { 0, 2, 5 })
+            for (int rel : { 0, 1, 4 })
+            {
+                p.busThreshold = -12.0f; p.busRatio = 1; p.busAttack = atk; p.busRelease = rel;
+                checkAB ("bus atk=" + std::to_string (atk) + " rel=" + std::to_string (rel),
+                         p, 48000.0, 512, 2.0, 2, 0xB5, false);
+            }
+    }
+
+    SECTION ("stereo link default / explicit 0.0 / 0.5 / 1.0 with asymmetric L-R")
+    {
+        p.busThreshold = -15.0f; p.busRatio = 2; p.busAttack = 2; p.busRelease = 1;
+        for (float link : { 0.0f, 50.0f, 100.0f })
+        {
+            p.stereoLink = link;
+            checkAB ("bus link=" + std::to_string ((int) link), p, 48000.0, 512, 2.0, 2, 0xA57, true);
+        }
+    }
+
+    SECTION ("makeup hot input + postGain ordering + bus_mix on linked path")
+    {
+        p.busThreshold = -24.0f; p.busRatio = 2; p.busMakeup = 12.0f;
+        for (float mix : { 40.0f, 100.0f })
+        {
+            p.busMix = mix;
+            checkAB ("bus makeup mix=" + std::to_string ((int) mix), p, 48000.0, 512, 2.0, 2, 0x60, true);
+        }
+    }
+
+    SECTION ("mono 1ch (non-linked path)")
+    {
+        p.busThreshold = -15.0f; p.busRatio = 1;
+        checkAB ("bus mono", p, 48000.0, 512, 1.6, 1, 0x0110, false);
+    }
+}
+
+//==============================================================================
+// 5. Bypass toggle: delayed-dry parity through the transition + un-bypass fade
+//==============================================================================
+TEST_CASE ("comp A/B: bypass toggle + un-bypass fade", "[compab]")
+{
+    CompParams base; base.mode = 1; base.fetRatio = 2; base.fetInput = 12.0f;
+    base.fetThreshold = -20.0f; base.autoMakeup = true;
+
+    // active blocks 0-9, bypass 10-24 (60-sample delayed dry), active again 25+
+    // (5 ms fade + auto-makeup accumulator reset).
+    auto hook = [] (CompParams& p, int blk) { p.bypass = (blk >= 10 && blk < 25); };
+    checkAB ("bypass toggle", base, 48000.0, 512, 3.0, 2, 0xB1FA, false, hook);
+}
+
+//==============================================================================
+// 6. Partial mix (dry-ring parity)
+//==============================================================================
+TEST_CASE ("comp A/B: partial mix dry ring", "[compab]")
+{
+    CompParams p; p.mode = 1; p.fetRatio = 1; p.fetInput = 10.0f; p.fetThreshold = -18.0f;
+    p.mix = 40.0f;
+    checkAB ("fet mix=40", p, 48000.0, 512, 2.0, 2, 0x4140, false);
+}
+
+//==============================================================================
+// 7. Block-size invariance: 64 / 160 / 1024 chunking, both sides, audio only
+//    (GR meter delay is measured in BLOCKS, so it legitimately differs by chunk).
+//==============================================================================
+TEST_CASE ("comp A/B: block-size invariance", "[compab]")
+{
+    CompParams p; p.mode = 1; p.fetRatio = 2; p.fetInput = 14.0f; p.fetThreshold = -20.0f;
+
+    const double sr = 48000.0;
+    const int prepBlock = 1024;
+    const int total = (int) (1.5 * sr);
+    std::vector<float> inL, inR;
+    makeSignal (inL, inR, total, sr, 0xB10C, false);
+
+    std::vector<float> jRefL, jRefR, cRefL, cRefR, dummyGr;
+    runJuce (inL, inR, jRefL, jRefR, dummyGr, sr, prepBlock, prepBlock, 2, p, nullptr);
+    runCore (inL, inR, cRefL, cRefR, dummyGr, sr, prepBlock, prepBlock, 2, p, nullptr);
+
+    for (int chunk : { 64, 160, 1024 })
+    {
+        std::vector<float> jL, jR, cL, cR;
+        runJuce (inL, inR, jL, jR, dummyGr, sr, prepBlock, chunk, 2, p, nullptr);
+        runCore (inL, inR, cL, cR, dummyGr, sr, prepBlock, chunk, 2, p, nullptr);
+
+        const float jSelf = audioMaxDiff (jL, jR, jRefL, jRefR);
+        const float cSelf = audioMaxDiff (cL, cR, cRefL, cRefR);
+        const float cross = audioMaxDiff (jL, jR, cL, cR);
+        UNSCOPED_INFO ("chunk=" << chunk << " jSelf=" << jSelf << " cSelf=" << cSelf << " cross=" << cross);
+        REQUIRE (jSelf <= kAudioTol);
+        REQUIRE (cSelf <= kAudioTol);
+        REQUIRE (cross <= kAudioTol);
+    }
+}
+
+//==============================================================================
+// 8. GR meter parity (block-delay behaviour) — explicit, deep compression.
+//==============================================================================
+TEST_CASE ("comp A/B: GR meter block-delay parity", "[compab]")
+{
+    const double sr = 48000.0;
+    const int block = 500;   // 60/500 -> ceil = 1 block delay
+    const int total = (int) (2.0 * sr);
+    std::vector<float> inL, inR;
+    makeSignal (inL, inR, total, sr, 0x6DAA, false);
+
+    CompParams p; p.mode = 2; p.vcaThreshold = -24.0f; p.vcaRatio = 10.0f;
+
+    std::vector<float> jL, jR, jGr, cL, cR, cGr;
+    runJuce (inL, inR, jL, jR, jGr, sr, block, block, 2, p, nullptr);
+    runCore (inL, inR, cL, cR, cGr, sr, block, block, 2, p, nullptr);
+
+    const float gDiff = grMaxDiff (jGr, cGr);
+    UNSCOPED_INFO ("GR block-delay maxDiff=" << gDiff << " (blocks=" << jGr.size() << ")");
+    REQUIRE (jGr.size() == cGr.size());
+    REQUIRE (gDiff <= kGrTol);
+}
+
+//==============================================================================
+// 9. Auto-makeup on/off (FET + VCA). Opto forces gain internally when on.
+//==============================================================================
+TEST_CASE ("comp A/B: auto-makeup FET + VCA", "[compab]")
+{
+    SECTION ("FET auto-makeup on")
+    {
+        CompParams p; p.mode = 1; p.fetRatio = 3; p.fetInput = 18.0f; p.fetThreshold = -24.0f;
+        p.autoMakeup = true;
+        checkAB ("fet auto-makeup", p, 48000.0, 512, 2.5, 2, 0xA07, false);
+    }
+    SECTION ("VCA auto-makeup on")
+    {
+        CompParams p; p.mode = 2; p.vcaThreshold = -26.0f; p.vcaRatio = 8.0f;
+        p.autoMakeup = true;
+        checkAB ("vca auto-makeup", p, 48000.0, 512, 2.5, 2, 0xA08, false);
+    }
+    SECTION ("Opto auto-makeup on (internal gain)")
+    {
+        CompParams p; p.mode = 0; p.optoPeakReduction = 75.0f; p.autoMakeup = true;
+        checkAB ("opto auto-makeup", p, 48000.0, 512, 3.0, 2, 0xA09, false);
+    }
+}

--- a/tests/eq_british_ab.cpp
+++ b/tests/eq_british_ab.cpp
@@ -1,0 +1,202 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <BritishEQProcessor.h>
+
+#include <dsp/FourKEQDSP.hpp>
+
+#include <cmath>
+#include <random>
+#include <vector>
+
+namespace
+{
+constexpr double kSampleRate = 48000.0;
+constexpr int    kBlock      = 512;
+constexpr int    kBlocks     = 40;
+constexpr int    kTotal      = kBlock * kBlocks;   // 20480 samples
+constexpr int    kWarmup     = kBlock * 16;        // 8192 samples before measuring
+
+// Deterministic stereo excitation: log sine sweep + periodic impulses + noise.
+// L and R differ (offset phase + independent noise stream) so inter-channel
+// paths — FourKEQDSP's -60 dB crosstalk, both processors' independent filter
+// state — are genuinely exercised rather than mirrored.
+void makeInput (std::vector<float>& L, std::vector<float>& R)
+{
+    L.assign ((size_t) kTotal, 0.0f);
+    R.assign ((size_t) kTotal, 0.0f);
+
+    std::mt19937 rng (0x4B455147u);
+    std::uniform_real_distribution<float> noise (-1.0f, 1.0f);
+
+    const double f0 = 50.0, f1 = 15000.0;
+    const double logRatio = std::log (f1 / f0);
+
+    double phaseL = 0.0, phaseR = 1.3;
+    for (int n = 0; n < kTotal; ++n)
+    {
+        const double t = (double) n / (double) kTotal;
+        const double freq = f0 * std::exp (logRatio * t);
+        const double dphase = 2.0 * M_PI * freq / kSampleRate;
+        phaseL += dphase;
+        phaseR += dphase;
+
+        float l = 0.30f * (float) std::sin (phaseL) + 0.10f * noise (rng);
+        float r = 0.30f * (float) std::sin (phaseR) + 0.10f * noise (rng);
+        if ((n % 4096) == 0) { l += 0.5f; r -= 0.5f; }
+
+        L[(size_t) n] = l;
+        R[(size_t) n] = r;
+    }
+}
+
+void runBritish (const BritishEQProcessor::Parameters& p,
+                 const std::vector<float>& Lin, const std::vector<float>& Rin,
+                 std::vector<float>& Lout, std::vector<float>& Rout)
+{
+    BritishEQProcessor eq;
+    eq.prepare (kSampleRate, kBlock, 2);
+    eq.setParameters (p);
+
+    Lout.assign ((size_t) kTotal, 0.0f);
+    Rout.assign ((size_t) kTotal, 0.0f);
+
+    juce::AudioBuffer<float> buf (2, kBlock);
+    for (int off = 0; off < kTotal; off += kBlock)
+    {
+        const int n = std::min (kBlock, kTotal - off);
+        for (int i = 0; i < n; ++i)
+        {
+            buf.setSample (0, i, Lin[(size_t) (off + i)]);
+            buf.setSample (1, i, Rin[(size_t) (off + i)]);
+        }
+        buf.setSize (2, n, true, false, true);
+        eq.process (buf);
+        for (int i = 0; i < n; ++i)
+        {
+            Lout[(size_t) (off + i)] = buf.getSample (0, i);
+            Rout[(size_t) (off + i)] = buf.getSample (1, i);
+        }
+        buf.setSize (2, kBlock, true, false, true);
+    }
+}
+
+// Map BritishEQProcessor::Parameters 1:1 onto FourKEQDSP's atomic setters and
+// pin the JUCE-free extras (oversampling / M-S / auto-gain / bypass) neutral so
+// the comparison isolates the EQ + saturation topology difference.
+void runFourK (const BritishEQProcessor::Parameters& p,
+               const std::vector<float>& Lin, const std::vector<float>& Rin,
+               std::vector<float>& Lout, std::vector<float>& Rout,
+               int& latencyOut)
+{
+    duskaudio::FourKEQDSP eq;
+    eq.setHpfFreq (p.hpfFreq);   eq.setHpfEnabled (p.hpfEnabled);
+    eq.setLpfFreq (p.lpfFreq);   eq.setLpfEnabled (p.lpfEnabled);
+    eq.setLfGain (p.lfGain);     eq.setLfFreq (p.lfFreq);   eq.setLfBell (p.lfBell);
+    eq.setLmGain (p.lmGain);     eq.setLmFreq (p.lmFreq);   eq.setLmQ (p.lmQ);
+    eq.setHmGain (p.hmGain);     eq.setHmFreq (p.hmFreq);   eq.setHmQ (p.hmQ);
+    eq.setHfGain (p.hfGain);     eq.setHfFreq (p.hfFreq);   eq.setHfBell (p.hfBell);
+    eq.setEqType (p.isBlackMode ? 1 : 0);
+    eq.setSaturation (p.saturation);
+    eq.setInputGainDb (p.inputGain);
+    eq.setOutputGainDb (p.outputGain);
+    eq.setOversampling (0);   // 1x — match BritishEQProcessor's base-rate chain
+    eq.setMsMode (false);
+    eq.setAutoGain (false);
+    eq.setBypass (false);
+
+    eq.prepare (kSampleRate, kBlock);
+    latencyOut = eq.getLatencySamples();
+
+    Lout.assign ((size_t) kTotal, 0.0f);
+    Rout.assign ((size_t) kTotal, 0.0f);
+
+    for (int off = 0; off < kTotal; off += kBlock)
+    {
+        const int n = std::min (kBlock, kTotal - off);
+        const float* in[2]  = { Lin.data() + off, Rin.data() + off };
+        float*       out[2] = { Lout.data() + off, Rout.data() + off };
+        eq.processBlock (in, out, 2, n);
+    }
+}
+
+struct DiffResult { float maxAbs; bool finite; };
+
+DiffResult measure (const std::vector<float>& aL, const std::vector<float>& aR,
+                    const std::vector<float>& bL, const std::vector<float>& bR)
+{
+    float maxAbs = 0.0f;
+    bool  finite = true;
+    for (int n = kWarmup; n < kTotal; ++n)
+    {
+        const float dl = aL[(size_t) n] - bL[(size_t) n];
+        const float dr = aR[(size_t) n] - bR[(size_t) n];
+        if (! std::isfinite (aL[(size_t) n]) || ! std::isfinite (aR[(size_t) n]) ||
+            ! std::isfinite (bL[(size_t) n]) || ! std::isfinite (bR[(size_t) n]))
+            finite = false;
+        maxAbs = std::max (maxAbs, std::max (std::abs (dl), std::abs (dr)));
+    }
+    return { maxAbs, finite };
+}
+
+BritishEQProcessor::Parameters flatDefault()
+{
+    return BritishEQProcessor::Parameters {};
+}
+
+BritishEQProcessor::Parameters stripCurve (bool black)
+{
+    BritishEQProcessor::Parameters p;
+    p.hpfEnabled = true; p.hpfFreq = 80.0f;
+    p.lfGain = 4.0f;  p.lfFreq = 100.0f;  p.lfBell = false;
+    p.lmGain = -3.0f; p.lmFreq = 600.0f;  p.lmQ = 0.9f;
+    p.hmGain = 2.5f;  p.hmFreq = 2000.0f; p.hmQ = 0.7f;
+    p.hfGain = 3.0f;  p.hfFreq = 8000.0f; p.hfBell = false;
+    p.saturation = 0.0f;
+    p.isBlackMode = black;
+    return p;
+}
+} // namespace
+
+TEST_CASE ("BritishEQProcessor vs FourKEQDSP A/B parity", "[british][ab]")
+{
+    std::vector<float> Lin, Rin;
+    makeInput (Lin, Rin);
+
+    struct Case { const char* name; BritishEQProcessor::Parameters p; };
+    std::vector<Case> cases;
+    cases.push_back ({ "a_flat_default_brown", flatDefault() });
+    cases.push_back ({ "b_strip_curve_brown", stripCurve (false) });
+    cases.push_back ({ "c_strip_curve_black", stripCurve (true) });
+    {
+        BritishEQProcessor::Parameters p = stripCurve (false);
+        p.saturation = 35.0f;
+        p.lfGain = 3.0f; p.hmGain = 2.0f; p.hfGain = 2.0f;
+        cases.push_back ({ "d_saturation_35pct_brown", p });
+    }
+    {
+        BritishEQProcessor::Parameters p = stripCurve (true);
+        p.lfBell = true; p.hfBell = true;
+        cases.push_back ({ "e_lf_hf_bells_black", p });
+    }
+
+    for (const auto& c : cases)
+    {
+        std::vector<float> bL, bR, fL, fR;
+        runBritish (c.p, Lin, Rin, bL, bR);
+        int fourKLatency = -1;
+        runFourK (c.p, Lin, Rin, fL, fR, fourKLatency);
+
+        const DiffResult d = measure (bL, bR, fL, fR);
+        const bool isNull = d.maxAbs <= 1.0e-6f;
+
+        UNSCOPED_INFO ("config=" << c.name
+                       << "  maxAbsDiff=" << d.maxAbs
+                       << "  null(<=1e-6)=" << (isNull ? "yes" : "no")
+                       << "  FourKEQDSP.latency=" << fourKLatency
+                       << "  (BritishEQProcessor reports no latency)");
+
+        REQUIRE (d.finite);
+        REQUIRE (fourKLatency == 0);          // 1x → no oversampler delay
+        REQUIRE (d.maxAbs < 0.5f);            // sane bound; the real number is in the INFO line
+    }
+}

--- a/tests/eq_british_ab.cpp
+++ b/tests/eq_british_ab.cpp
@@ -15,6 +15,7 @@ constexpr int    kBlock      = 512;
 constexpr int    kBlocks     = 40;
 constexpr int    kTotal      = kBlock * kBlocks;   // 20480 samples
 constexpr int    kWarmup     = kBlock * 16;        // 8192 samples before measuring
+constexpr double kPi         = 3.14159265358979323846;
 
 // Deterministic stereo excitation: log sine sweep + periodic impulses + noise.
 // L and R differ (offset phase + independent noise stream) so inter-channel
@@ -36,7 +37,7 @@ void makeInput (std::vector<float>& L, std::vector<float>& R)
     {
         const double t = (double) n / (double) kTotal;
         const double freq = f0 * std::exp (logRatio * t);
-        const double dphase = 2.0 * M_PI * freq / kSampleRate;
+        const double dphase = 2.0 * kPi * freq / kSampleRate;
         phaseL += dphase;
         phaseR += dphase;
 

--- a/tests/tube_multiq_ab.cpp
+++ b/tests/tube_multiq_ab.cpp
@@ -1,0 +1,212 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <TubeEQProcessor.h>
+
+#include <core/MultiQTube.hpp>
+
+#include <cmath>
+#include <random>
+#include <vector>
+
+// MultiQTube.hpp claims to be a verbatim, framework-free transcription of
+// TubeEQProcessor.h (same magic numbers, same sample-level op order). MasterBus
+// swaps the JUCE TubeEQProcessor for the core, so this pins the swap as null:
+// identical parameter surface driven through both, measured against a ~1e-6
+// bound. The Parameters structs are field-identical, so one templated builder
+// fills both.
+namespace
+{
+constexpr double kSampleRate = 48000.0;
+constexpr int    kBlock      = 512;
+constexpr int    kBlocks     = 40;
+constexpr int    kTotal      = kBlock * kBlocks;   // 20480 samples
+constexpr int    kWarmup     = kBlock * 16;        // 8192 samples before measuring
+
+// Deterministic stereo excitation: log sine sweep + periodic impulses + noise.
+// L and R differ (offset phase + independent noise) so the per-channel HF
+// inductor state and transformer paths are genuinely exercised.
+void makeInput (std::vector<float>& L, std::vector<float>& R)
+{
+    L.assign ((size_t) kTotal, 0.0f);
+    R.assign ((size_t) kTotal, 0.0f);
+
+    std::mt19937 rng (0x54554245u);   // "TUBE"
+    std::uniform_real_distribution<float> noise (-1.0f, 1.0f);
+
+    const double f0 = 50.0, f1 = 15000.0;
+    const double logRatio = std::log (f1 / f0);
+
+    double phaseL = 0.0, phaseR = 1.3;
+    for (int n = 0; n < kTotal; ++n)
+    {
+        const double t = (double) n / (double) kTotal;
+        const double freq = f0 * std::exp (logRatio * t);
+        const double dphase = 2.0 * M_PI * freq / kSampleRate;
+        phaseL += dphase;
+        phaseR += dphase;
+
+        float l = 0.30f * (float) std::sin (phaseL) + 0.10f * noise (rng);
+        float r = 0.30f * (float) std::sin (phaseR) + 0.10f * noise (rng);
+        if ((n % 4096) == 0) { l += 0.5f; r -= 0.5f; }
+
+        L[(size_t) n] = l;
+        R[(size_t) n] = r;
+    }
+}
+
+// The two Parameters structs share every field name, so one template fills both.
+template <typename P>
+P makeParams (float lfBoost, float lfBoostFreq, float lfAtten,
+              float hfBoost, float hfBoostFreq, float hfBw,
+              float hfAtten, float hfAttenFreq,
+              bool midEnabled, float midLowPeak, float midDip, float midHighPeak,
+              float outGain, float tubeDrive)
+{
+    P p {};
+    p.lfBoostGain      = lfBoost;
+    p.lfBoostFreq      = lfBoostFreq;
+    p.lfAttenGain      = lfAtten;
+    p.hfBoostGain      = hfBoost;
+    p.hfBoostFreq      = hfBoostFreq;
+    p.hfBoostBandwidth = hfBw;
+    p.hfAttenGain      = hfAtten;
+    p.hfAttenFreq      = hfAttenFreq;
+    p.midEnabled       = midEnabled;
+    p.midLowFreq  = 500.0f;  p.midLowPeak  = midLowPeak;
+    p.midDipFreq  = 700.0f;  p.midDip      = midDip;
+    p.midHighFreq = 3000.0f; p.midHighPeak = midHighPeak;
+    p.inputGain   = 0.0f;
+    p.outputGain  = outGain;
+    p.tubeDrive   = tubeDrive;
+    p.bypass      = false;
+    return p;
+}
+
+void runTube (const TubeEQProcessor::Parameters& p,
+              const std::vector<float>& Lin, const std::vector<float>& Rin,
+              std::vector<float>& Lout, std::vector<float>& Rout)
+{
+    TubeEQProcessor eq;
+    eq.prepare (kSampleRate, kBlock, 2);
+    eq.setParameters (p);
+
+    Lout.assign ((size_t) kTotal, 0.0f);
+    Rout.assign ((size_t) kTotal, 0.0f);
+
+    juce::AudioBuffer<float> buf (2, kBlock);
+    for (int off = 0; off < kTotal; off += kBlock)
+    {
+        const int n = std::min (kBlock, kTotal - off);
+        for (int i = 0; i < n; ++i)
+        {
+            buf.setSample (0, i, Lin[(size_t) (off + i)]);
+            buf.setSample (1, i, Rin[(size_t) (off + i)]);
+        }
+        buf.setSize (2, n, true, false, true);
+        eq.process (buf);
+        for (int i = 0; i < n; ++i)
+        {
+            Lout[(size_t) (off + i)] = buf.getSample (0, i);
+            Rout[(size_t) (off + i)] = buf.getSample (1, i);
+        }
+        buf.setSize (2, kBlock, true, false, true);
+    }
+}
+
+void runMultiQ (const duskaudio::MultiQTube::Parameters& p,
+                const std::vector<float>& Lin, const std::vector<float>& Rin,
+                std::vector<float>& Lout, std::vector<float>& Rout,
+                int& latencyOut)
+{
+    duskaudio::MultiQTube eq;
+    eq.prepare (kSampleRate, kBlock, 2);   // no setOversampling → 1x, matching
+                                            // MasterBus (its own wrap does OS)
+    eq.setParameters (p);
+    latencyOut = eq.getLatencySamples();
+
+    Lout.assign ((size_t) kTotal, 0.0f);
+    Rout.assign ((size_t) kTotal, 0.0f);
+
+    for (int off = 0; off < kTotal; off += kBlock)
+    {
+        const int n = std::min (kBlock, kTotal - off);
+        float* ch[2] = { Lout.data() + off, Rout.data() + off };
+        for (int i = 0; i < n; ++i)
+        {
+            ch[0][i] = Lin[(size_t) (off + i)];
+            ch[1][i] = Rin[(size_t) (off + i)];
+        }
+        eq.process (ch, 2, n);
+    }
+}
+
+struct DiffResult { float maxAbs; bool finite; };
+
+DiffResult measure (const std::vector<float>& aL, const std::vector<float>& aR,
+                    const std::vector<float>& bL, const std::vector<float>& bR)
+{
+    float maxAbs = 0.0f;
+    bool  finite = true;
+    for (int n = kWarmup; n < kTotal; ++n)
+    {
+        const float dl = aL[(size_t) n] - bL[(size_t) n];
+        const float dr = aR[(size_t) n] - bR[(size_t) n];
+        if (! std::isfinite (aL[(size_t) n]) || ! std::isfinite (aR[(size_t) n]) ||
+            ! std::isfinite (bL[(size_t) n]) || ! std::isfinite (bR[(size_t) n]))
+            finite = false;
+        maxAbs = std::max (maxAbs, std::max (std::abs (dl), std::abs (dr)));
+    }
+    return { maxAbs, finite };
+}
+} // namespace
+
+TEST_CASE ("TubeEQProcessor vs MultiQTube A/B parity", "[tube][ab]")
+{
+    std::vector<float> Lin, Rin;
+    makeInput (Lin, Rin);
+
+    struct Case { const char* name;
+                  float lfBoost, lfBoostFreq, lfAtten,
+                        hfBoost, hfBoostFreq, hfBw, hfAtten, hfAttenFreq;
+                  bool  midEnabled; float midLowPeak, midDip, midHighPeak,
+                        outGain, tubeDrive; };
+
+    std::vector<Case> cases = {
+        // name                     lfB  lfF  lfA  hfB  hfF   bw  hfA  hfAf  midEn low dip high out  drive
+        { "a_flat_default",         0,   60,  0,   0, 8000, 0.5f, 0, 10000, false, 0,  0,  0,   0.0f, 0.0f },
+        { "b_masterbus_tube_02",    0,   60,  0,   0, 8000, 0.5f, 0, 10000, false, 0,  0,  0,   0.0f, 0.02f },
+        { "c_lf_boost_atten",     6.0f, 100, 4.0f, 0, 8000, 0.5f, 0, 10000, false, 0,  0,  0,   0.0f, 0.02f },
+        { "d_hf_boost_atten",       0,   60,  0, 5.0f,5000,0.3f,3.0f,10000, false, 0,  0,  0,   0.0f, 0.02f },
+        { "e_mid_section",          0,   60,  0,   0, 8000, 0.5f, 0, 10000, true,  4.0f,3.0f,2.0f,0.0f,0.02f },
+        { "f_full_curve",         4.0f, 100, 2.0f,4.0f,5000,0.4f,2.0f,10000, true, 3.0f,2.0f,3.0f, 1.5f,0.05f },
+    };
+
+    for (const auto& c : cases)
+    {
+        const auto tp = makeParams<TubeEQProcessor::Parameters> (
+            c.lfBoost, c.lfBoostFreq, c.lfAtten, c.hfBoost, c.hfBoostFreq, c.hfBw,
+            c.hfAtten, c.hfAttenFreq, c.midEnabled, c.midLowPeak, c.midDip,
+            c.midHighPeak, c.outGain, c.tubeDrive);
+        const auto mp = makeParams<duskaudio::MultiQTube::Parameters> (
+            c.lfBoost, c.lfBoostFreq, c.lfAtten, c.hfBoost, c.hfBoostFreq, c.hfBw,
+            c.hfAtten, c.hfAttenFreq, c.midEnabled, c.midLowPeak, c.midDip,
+            c.midHighPeak, c.outGain, c.tubeDrive);
+
+        std::vector<float> tL, tR, mL, mR;
+        runTube (tp, Lin, Rin, tL, tR);
+        int multiQLatency = -1;
+        runMultiQ (mp, Lin, Rin, mL, mR, multiQLatency);
+
+        const DiffResult d = measure (tL, tR, mL, mR);
+        const bool isNull = d.maxAbs <= 1.0e-6f;
+
+        UNSCOPED_INFO ("config=" << c.name
+                       << "  maxAbsDiff=" << d.maxAbs
+                       << "  null(<=1e-6)=" << (isNull ? "yes" : "no")
+                       << "  MultiQTube.latency=" << multiQLatency);
+
+        REQUIRE (d.finite);
+        REQUIRE (multiQLatency == 0);   // 1x → no oversampler delay, matching TubeEQProcessor
+        REQUIRE (isNull);               // verbatim transcription → bit-exact within 1e-6
+    }
+}

--- a/tests/tube_multiq_ab.cpp
+++ b/tests/tube_multiq_ab.cpp
@@ -21,6 +21,7 @@ constexpr int    kBlock      = 512;
 constexpr int    kBlocks     = 40;
 constexpr int    kTotal      = kBlock * kBlocks;   // 20480 samples
 constexpr int    kWarmup     = kBlock * 16;        // 8192 samples before measuring
+constexpr double kPi         = 3.14159265358979323846;
 
 // Deterministic stereo excitation: log sine sweep + periodic impulses + noise.
 // L and R differ (offset phase + independent noise) so the per-channel HF
@@ -41,7 +42,7 @@ void makeInput (std::vector<float>& L, std::vector<float>& R)
     {
         const double t = (double) n / (double) kTotal;
         const double freq = f0 * std::exp (logRatio * t);
-        const double dphase = 2.0 * M_PI * freq / kSampleRate;
+        const double dphase = 2.0 * kPi * freq / kSampleRate;
         phaseL += dphase;
         phaseR += dphase;
 

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -2,8 +2,6 @@ src/DuskStudioApp.cpp
 src/DuskStudioApp.h
 src/dsp/AuxLaneStrip.cpp
 src/dsp/AuxLaneStrip.h
-src/dsp/BusStrip.cpp
-src/dsp/BusStrip.h
 src/dsp/ChannelStrip.cpp
 src/dsp/ChannelStrip.h
 src/dsp/MasterBus.cpp


### PR DESCRIPTION
Flips the strip tower's donor DSP off JUCE. Gate 204 -> 202 (BusStrip.{h,cpp} fully token-clean); ChannelStrip and MasterBus decouple from the donor APVTS but stay allowlisted (native-host layer and TapeMachine respectively — later towers).

**Depends on dusk-audio-plugins#117** (the JUCE-free UniversalCompressorDSP core) merging to the donor main first — CI clones the donor's main.

Commits:
- tests: British EQ vs FourKEQDSP A/B measurement — NOT a null pair (parallel-summing console model vs serial cascade, residuals -66 dB flat to -22 dB at heavy curves, latency 0 both). The strip EQ swap is a deliberate re-voicing onto the newer 4K-EQ-2 core; the test pins the envelope.
- tests: UniversalCompressorDSP vs donor comp A/B harness — drives the JUCE donor exactly as the strips do; bit-exact (0.0 max-abs-diff) across all modes, timing, bypass toggling, partial mix, block sizes, sample rates, GR meter included.
- BusStrip flip — comp core + FourKEQDSP + dusk primitives (StereoOversampler/IntDelayLine/SmoothedValue/Decibels); EQ moves outside the oversampler wrap (linear at saturation 0); comp-off skip delay re-baselined to the FIR round trip (23 @2x, 27 @4x).
- ChannelStrip DSP-layer flip — same recipe; tokens 125 -> 68; one shared StereoOversampler with a silent-R mono path; perf suite improves 8-21% on EQ/comp paths.
- MasterBus flip — comp + TubeEQProcessor -> duskaudio::MultiQTube (bit-exact, new tube_multiq_ab test measures 0.0); TapeMachine path untouched (ported separately).
- Toggle-discontinuity fix — the oversampler skip ring is fed on every block and the FIR resets on the wrap-on edge, so comp/EQ toggles at OS > 1 splice cleanly (regression test included; the gap predated the swap but grew from ~4 to 27 samples with the FIR).

Verification: 360/360 Catch2 tests, selftest 26 PASS / 0 FAIL under Xvfb (incl Parallel-Matches-Serial multicore A/B and Master Tape gain audit), perf suite no regressions, juce-gate exit 0 at 202.

MANUAL.md audited: control surface, ranges and defaults unchanged; the 'no EQ cramping / pre-warping' claim was verified against the FourKEQDSP coeff builders and still holds.