### PR TITLE
De-JUCE: MIDI device seam layer (duskstudio::midi)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,6 +328,7 @@ target_sources(DuskStudio PRIVATE
     src/engine/McuReceiver.cpp
     src/engine/McuController.cpp
     src/engine/MidiTimeCodeEmitter.cpp
+    src/engine/midi/MidiDevices.cpp
     src/engine/PlaybackEngine.cpp
     src/engine/PluginManager.cpp
     src/engine/PluginSlot.cpp

--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -553,7 +553,7 @@ static void runHeadlessPipelineTest (const juce::String& pluginPath)
     // - Otherwise pick index 0 if any MIDI input exists, and force track
     //   0's midiInputIndex to match so the test can inject end-to-end.
     int midiInputIdx = -1;
-    const int numMidiInputs = engine->getMidiInputDevices().size();
+    const int numMidiInputs = (int) engine->getMidiInputDevices().size();
     if (numMidiInputs == 0)
     {
         std::fprintf (stderr, "WARN: no MIDI inputs available; injection will be a no-op.\n");

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -2616,10 +2616,9 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
             std::memset (outputChannelData[ch], 0,
                           sizeof (float) * (size_t) numSamples);
 
-    // Drain each MIDI input's collector into its per-input buffer for this
-    // block. Each removeNextBlockOfMessages is lock-free with respect to
-    // the MIDI thread's addMessageToQueue, so the audio thread never
-    // contends. Empty buffers cost ~nothing.
+    // Drain each MIDI input into its per-input buffer for this block. The
+    // layer's drain is lock-free with respect to the MIDI thread's enqueue,
+    // so the audio thread never contends. Empty buffers cost ~nothing.
     for (int i = 0; i < midiIn.getNumInputs() && i < (int) perInputMidi.size(); ++i)
         midiIn.drainBlock (i, perInputMidi[(size_t) i], numSamples);
 
@@ -2633,7 +2632,7 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
         const int idx = testInjectInputIdx.load (std::memory_order_relaxed);
         if (idx >= 0 && (size_t) idx < perInputMidi.size())
             for (const auto meta : testInjectMidi)
-                if (meta.samplePosition < numSamples)
+                if (meta.samplePosition >= 0 && meta.samplePosition < numSamples)
                     perInputMidi[(size_t) idx].addEvent (meta.data, meta.numBytes,
                                                          meta.samplePosition);
         testInjectMidi.clear();
@@ -4216,13 +4215,19 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
             if (outIdx >= 0)
             {
                 // Bridge the juce per-track buffer into the dusk out-scratch
-                // (pre-reserved) for queueRt's dusk boundary.
+                // (pre-reserved) for queueRt's dusk boundary. Whole-block or
+                // nothing: a partial copy on cap overflow could split paired
+                // events (note on/off), so mirror the pre-flip whole-block
+                // drop semantics.
                 midiOutTrackScratch.clear();
+                bool fits = true;
                 for (const auto meta : perTrackMidiScratch[(size_t) t])
-                    midiOutTrackScratch.addEvent (meta.data, meta.numBytes,
-                                                  meta.samplePosition);
-                midiOut.queueRt (outIdx, midiOutTrackScratch,
-                                 currentSampleRate.load (std::memory_order_relaxed));
+                    if (! midiOutTrackScratch.addEvent (meta.data, meta.numBytes,
+                                                        meta.samplePosition))
+                    { fits = false; break; }
+                if (fits)
+                    midiOut.queueRt (outIdx, midiOutTrackScratch,
+                                     currentSampleRate.load (std::memory_order_relaxed));
             }
         }
 

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -561,6 +561,14 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
     }
    #endif
 
+    // Build both MIDI banks before ANY callback is registered — the audio
+    // callback iterates perInputMidi, so it must not be attachable while
+    // rebuildMidiBanks sizes the vector. Empty deviceIdentifier = every
+    // enabled input fans out to midiIn, routed there by source identifier.
+    midiIn.setDeviceManager (deviceManager);
+    rebuildMidiBanks();
+    midiIn.attachCallback();
+
     deviceManager.addAudioCallback (this);
 
     // H5: subscribe to AudioDeviceManager change broadcasts so we can
@@ -568,14 +576,6 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
     // one). Fires on the message thread per JUCE's ChangeBroadcaster
     // contract.
     deviceManager.addChangeListener (this);
-
-    // Build both banks pre-attach (no callback registered yet, so the mutation
-    // is safe without a fence), then attach midiIn as the input callback. Empty
-    // deviceIdentifier = every enabled input fans out to midiIn, routed there
-    // by source identifier.
-    midiIn.setDeviceManager (deviceManager);
-    rebuildMidiBanks();
-    midiIn.attachCallback();
 }
 
 void AudioEngine::refreshMidiInputs()

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -2912,8 +2912,8 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
         {
             // Bridge the dusk event to juce for its message-parsing API (same
             // per-event cost as the pre-flip juce buffer's getMessage()).
-            const juce::MidiMessage m (meta.getMessage().getRawData(),
-                                       meta.getMessage().getRawDataSize());
+            const auto& v = meta.getMessage();
+            const juce::MidiMessage m (v.getRawData(), v.getRawDataSize());
             if (m.isNoteOn() && m.getVelocity() > 0)
             {
                 const int n = m.getNoteNumber();
@@ -2954,8 +2954,8 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
             if (buf.isEmpty()) continue;
             for (const auto meta : buf)
             {
-                const juce::MidiMessage m (meta.getMessage().getRawData(),
-                                           meta.getMessage().getRawDataSize());
+                const auto& v = meta.getMessage();
+                const juce::MidiMessage m (v.getRawData(), v.getRawDataSize());
                 MidiBindingTrigger tg;
                 int dn = 0, val = 0;
                 if      (m.isController())                    { tg = MidiBindingTrigger::CC;         dn = m.getControllerNumber(); val = m.getControllerValue(); }
@@ -4161,11 +4161,19 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
                 for (const auto meta : perInputMidi[(size_t) srcIdx])
                 {
                     // dusk (perInputMidi) -> juce (perTrackMidiScratch, feeds
-                    // the instrument + recorder): bridge each event to juce.
-                    const juce::MidiMessage m (meta.getMessage().getRawData(),
-                                               meta.getMessage().getRawDataSize());
-                    if (chFilter == 0 || m.getChannel() == chFilter)
-                        perTrackMidiScratch[(size_t) t].addEvent (m, meta.samplePosition);
+                    // the instrument + recorder): raw-byte copy, no message
+                    // object. Channel read mirrors the juce getChannel
+                    // convention: 1..16 for channel messages, 0 for system.
+                    const auto& v = meta.getMessage();
+                    if (chFilter != 0)
+                    {
+                        const std::uint8_t status = v.getRawDataSize() > 0 ? v.getRawData()[0] : 0;
+                        const int ch = (status & 0xF0) != 0xF0 ? (int) (status & 0x0F) + 1 : 0;
+                        if (ch != chFilter) continue;
+                    }
+                    perTrackMidiScratch[(size_t) t].addEvent (v.getRawData(),
+                                                              v.getRawDataSize(),
+                                                              meta.samplePosition);
                 }
             };
 

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -366,8 +366,10 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
     mcuController = std::make_unique<McuController> (session);
     mcuController->setSink ([this] (const juce::MidiBuffer& buf)
     {
+        // Message thread (30 Hz MCU tick). The bank's juce send overload keeps
+        // McuController juce-typed (events-tower coupling).
         const int outIdx = session.mcu.resolvedOutputIdx.load (std::memory_order_acquire);
-        if (outIdx >= 0) sendMidiToOutput (outIdx, buf);
+        if (outIdx >= 0) midiOut.send (outIdx, buf);
     });
     mcuController->setTransportProvider ([this] { return &transport; });
     mcuController->setSampleRateProvider ([this] { return getCurrentSampleRate(); });
@@ -395,7 +397,7 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
 
     // High priority so a loaded message thread can't starve clock /
     // note delivery; still below the audio thread.
-    midiOutPump.startThread (juce::Thread::Priority::high);
+    midiOut.startPump();
 
     for (int i = 0; i < Session::kNumTracks; ++i)
     {
@@ -567,11 +569,13 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
     // contract.
     deviceManager.addChangeListener (this);
 
-    // Empty deviceIdentifier = "every enabled input fans out to this
-    // callback"; handleIncomingMidiMessage routes by source pointer.
-    rebuildMidiInputBank();
-    rebuildMidiOutputBank();
-    deviceManager.addMidiInputDeviceCallback ({}, this);
+    // Build both banks pre-attach (no callback registered yet, so the mutation
+    // is safe without a fence), then attach midiIn as the input callback. Empty
+    // deviceIdentifier = every enabled input fans out to midiIn, routed there
+    // by source identifier.
+    midiIn.setDeviceManager (deviceManager);
+    rebuildMidiBanks();
+    midiIn.attachCallback();
 }
 
 void AudioEngine::refreshMidiInputs()
@@ -581,26 +585,24 @@ void AudioEngine::refreshMidiInputs()
     // rare hot-plug event; lock-free vector mutation would cost more
     // throughout the audio path than it's worth.
     deviceManager.removeAudioCallback (this);
-    deviceManager.removeMidiInputDeviceCallback ({}, this);
+    midiIn.detachCallback();
 
     // Disable currently-enabled inputs before rebuilding so the device
     // manager's own bookkeeping releases the OS handles. The new pass
     // re-enables whichever devices are still present.
-    for (const auto& d : midiInputDevices)
-        deviceManager.setMidiInputDeviceEnabled (d.identifier, false);
+    midiIn.disableAllDevices();
 
-    rebuildMidiInputBank();
-    rebuildMidiOutputBank();
+    rebuildMidiBanks();
 
     // The track-side index atoms may now point at moved or removed
     // devices. Re-resolve each track's saved identifier so a refresh
     // doesn't silently break existing routing. Tracks with no saved
     // identifier (very old sessions) keep their raw index, clamped.
-    auto resolveByIdentifier = [] (const juce::Array<juce::MidiDeviceInfo>& devices,
+    auto resolveByIdentifier = [] (const std::vector<duskstudio::midi::MidiDeviceInfo>& devices,
                                     const juce::String& wantedId)
     {
-        for (int i = 0; i < devices.size(); ++i)
-            if (devices[i].identifier == wantedId)
+        for (int i = 0; i < (int) devices.size(); ++i)
+            if (devices[(size_t) i].identifier == wantedId)
                 return i;
         return -1;
     };
@@ -610,34 +612,34 @@ void AudioEngine::refreshMidiInputs()
         if (track.midiInputIdentifier.isNotEmpty())
         {
             track.midiInputIndex.store (
-                resolveByIdentifier (midiInputDevices, track.midiInputIdentifier),
+                resolveByIdentifier (midiIn.getDevices(), track.midiInputIdentifier),
                 std::memory_order_relaxed);
         }
         else
         {
             const int cur = track.midiInputIndex.load (std::memory_order_relaxed);
-            if (cur >= midiInputDevices.size())
+            if (cur >= (int) midiIn.getDevices().size())
                 track.midiInputIndex.store (-1, std::memory_order_relaxed);
         }
         if (track.midiOutputIdentifier.isNotEmpty())
         {
             track.midiOutputIndex.store (
-                resolveByIdentifier (midiOutputDevices, track.midiOutputIdentifier),
+                resolveByIdentifier (midiOut.getDevices(), track.midiOutputIdentifier),
                 std::memory_order_relaxed);
         }
         else
         {
             const int cur = track.midiOutputIndex.load (std::memory_order_relaxed);
-            if (cur >= midiOutputDevices.size())
+            if (cur >= (int) midiOut.getDevices().size())
                 track.midiOutputIndex.store (-1, std::memory_order_relaxed);
         }
     }
 
     // Must run BEFORE re-attaching callbacks — otherwise the audio
-    // thread iterates midiOutputs while ensureMidiOutputOpen mutates it.
+    // thread reads the output bank while ensureOpen mutates it.
     openConfiguredMidiOutputs();
 
-    deviceManager.addMidiInputDeviceCallback ({}, this);
+    midiIn.attachCallback();
     deviceManager.addAudioCallback (this);
 
     sendChangeMessage();
@@ -940,11 +942,11 @@ void AudioEngine::reresolveTrackMidiFromSession()
     // no audio glitch. Cheap enough to run on every session load. (The full
     // refreshMidiInputs hot-plug path would detach/reattach the audio callback
     // and disable/re-enable every MIDI device — seconds of frozen UI on load.)
-    auto resolveByIdentifier = [] (const juce::Array<juce::MidiDeviceInfo>& devices,
+    auto resolveByIdentifier = [] (const std::vector<duskstudio::midi::MidiDeviceInfo>& devices,
                                     const juce::String& wantedId)
     {
-        for (int i = 0; i < devices.size(); ++i)
-            if (devices[i].identifier == wantedId)
+        for (int i = 0; i < (int) devices.size(); ++i)
+            if (devices[(size_t) i].identifier == wantedId)
                 return i;
         return -1;
     };
@@ -953,16 +955,16 @@ void AudioEngine::reresolveTrackMidiFromSession()
         auto& track = session.track (t);
         if (track.midiInputIdentifier.isNotEmpty())
             track.midiInputIndex.store (
-                resolveByIdentifier (midiInputDevices, track.midiInputIdentifier),
+                resolveByIdentifier (midiIn.getDevices(), track.midiInputIdentifier),
                 std::memory_order_relaxed);
-        else if (track.midiInputIndex.load (std::memory_order_relaxed) >= midiInputDevices.size())
+        else if (track.midiInputIndex.load (std::memory_order_relaxed) >= (int) midiIn.getDevices().size())
             track.midiInputIndex.store (-1, std::memory_order_relaxed);
 
         if (track.midiOutputIdentifier.isNotEmpty())
             track.midiOutputIndex.store (
-                resolveByIdentifier (midiOutputDevices, track.midiOutputIdentifier),
+                resolveByIdentifier (midiOut.getDevices(), track.midiOutputIdentifier),
                 std::memory_order_relaxed);
-        else if (track.midiOutputIndex.load (std::memory_order_relaxed) >= midiOutputDevices.size())
+        else if (track.midiOutputIndex.load (std::memory_order_relaxed) >= (int) midiOut.getDevices().size())
             track.midiOutputIndex.store (-1, std::memory_order_relaxed);
     }
 
@@ -972,16 +974,16 @@ void AudioEngine::reresolveTrackMidiFromSession()
     // engine's sync + MCU consumers read stale indices until the user reopens
     // Audio Settings. release-ordered to match their setters in AudioSettingsPanel.
     auto resolveSessionIdx = [&] (std::atomic<int>& idx,
-                                   const juce::Array<juce::MidiDeviceInfo>& devices,
+                                   const std::vector<duskstudio::midi::MidiDeviceInfo>& devices,
                                    const juce::String& wantedId)
     {
         idx.store (wantedId.isNotEmpty() ? resolveByIdentifier (devices, wantedId) : -1,
                    std::memory_order_release);
     };
-    resolveSessionIdx (session.syncSourceInputIdx,    midiInputDevices,  session.syncSourceInputIdentifier);
-    resolveSessionIdx (session.syncOutputIdx,         midiOutputDevices, session.syncOutputIdentifier);
-    resolveSessionIdx (session.mcu.resolvedInputIdx,  midiInputDevices,  session.mcu.inputIdentifier);
-    resolveSessionIdx (session.mcu.resolvedOutputIdx, midiOutputDevices, session.mcu.outputIdentifier);
+    resolveSessionIdx (session.syncSourceInputIdx,    midiIn.getDevices(),  session.syncSourceInputIdentifier);
+    resolveSessionIdx (session.syncOutputIdx,         midiOut.getDevices(), session.syncOutputIdentifier);
+    resolveSessionIdx (session.mcu.resolvedInputIdx,  midiIn.getDevices(),  session.mcu.inputIdentifier);
+    resolveSessionIdx (session.mcu.resolvedOutputIdx, midiOut.getDevices(), session.mcu.outputIdentifier);
 
     // A session load may have replaced the tempo map — republish the audio
     // thread's snapshot so the MIDI scheduler + metronome see the loaded points.
@@ -993,269 +995,48 @@ void AudioEngine::reresolveTrackMidiFromSession()
     // load (same place the per-track outputs open).
 }
 
-void AudioEngine::rebuildMidiInputBank()
+void AudioEngine::rebuildMidiBanks()
 {
-    // Safe to mutate ONLY with both callbacks detached. Ctor's first
-    // call satisfies that (callbacks not yet registered);
-    // refreshMidiInputs does remove-then-call-then-add. Callbacks
-    // active during mutation = UB.
-    midiInputDevices = juce::MidiInput::getAvailableDevices();
-    midiInputCollectors.clear();
-    midiInputCollectors.reserve ((size_t) midiInputDevices.size() + 1);
+    // Safe to mutate ONLY with the input + audio callbacks detached. Ctor's
+    // first call satisfies that (callbacks not yet registered); refreshMidiInputs
+    // does remove-then-call-then-add. Callbacks active during mutation = UB.
     const double sr = currentSampleRate.load (std::memory_order_relaxed);
-    for (int i = 0; i < midiInputDevices.size(); ++i)
-    {
-        auto col = std::make_unique<juce::MidiMessageCollector>();
-        if (sr > 0.0) col->reset (sr);
-        // setMidiInputDeviceEnabled returns void — re-query to verify.
-        // Failure usually = OS denied access (another app exclusively
-        // owns the port). Log so the user can diagnose missing input.
-        const auto& devId = midiInputDevices[i].identifier;
-        deviceManager.setMidiInputDeviceEnabled (devId, true);
-        if (! deviceManager.isMidiInputDeviceEnabled (devId))
-        {
-            std::fprintf (stderr,
-                          "[Dusk Studio/AudioEngine] WARNING: failed to enable MIDI input \"%s\" "
-                          "(id %s). Another application may be holding it open.\n",
-                          midiInputDevices[i].name.toRawUTF8(),
-                          devId.toRawUTF8());
-        }
-        midiInputCollectors.push_back (std::move (col));
-    }
+    midiIn.rebuild (sr);
+    midiOut.rebuild();
 
-    // Appended after real hardware so the VKB's index is stable across
-    // hot-plug. Fixed identifier so saved sessions resolve back to it.
-    // Not bound to any OS device — VKB UI addMessageToQueues directly;
-    // audio drains it as perInputMidi[virtualKeyboardCollectorIndex].
-    juce::MidiDeviceInfo virtualKb { "Virtual Keyboard (Dusk Studio)", "Dusk Studio:virtual-keyboard" };
-    midiInputDevices.add (virtualKb);
-    {
-        auto vkbCol = std::make_unique<juce::MidiMessageCollector>();
-        if (sr > 0.0) vkbCol->reset (sr);
-        midiInputCollectors.push_back (std::move (vkbCol));
-    }
-    virtualKeyboardCollectorIndex = (int) midiInputCollectors.size() - 1;
+    // One drained-block buffer per input, reserved off the RT path so the
+    // per-block drain + test-inject merge never allocate on the audio thread.
+    perInputMidi.assign ((size_t) midiIn.getNumInputs(), dusk::MidiBuffer{});
+    for (auto& m : perInputMidi) m.reserveBytes (4096);
 
-    perInputMidi.assign ((size_t) midiInputDevices.size(), juce::MidiBuffer{});
-    // Pre-reserve like perTrackMidiScratch: removeNextBlockOfMessages grows the
-    // destination on the audio thread if a burst exceeds prior capacity.
-    for (auto& m : perInputMidi) m.ensureSize (4096);
-    syncMidiScratch.reserveBytes (4096);   // same headroom for the juce->dusk bridge
-    mcuMidiScratch .reserveBytes (4096);
-
-    // Re-resolve on every rebuild so a hot-plug doesn't strand the
-    // index at a stale slot. Empty / no match = -1 (no sync).
-    int resolvedSyncIdx = -1;
-    const auto& wantedId = session.syncSourceInputIdentifier;
-    if (wantedId.isNotEmpty())
+    // Re-resolve the session's sync + MCU wiring against the fresh banks so a
+    // hot-plug doesn't strand an index at a stale slot (STAYS in the engine —
+    // the banks don't know session identifiers). Empty / no match = -1. release
+    // pairs with the audio-thread acquires and the AudioSettingsPanel setters.
+    auto resolve = [] (const std::vector<duskstudio::midi::MidiDeviceInfo>& devices,
+                        const juce::String& wantedId)
     {
-        for (int i = 0; i < midiInputDevices.size(); ++i)
-        {
-            if (midiInputDevices[i].identifier == wantedId)
-            {
-                resolvedSyncIdx = i;
-                break;
-            }
-        }
-    }
-    session.syncSourceInputIdx.store (resolvedSyncIdx, std::memory_order_release);
+        if (wantedId.isEmpty()) return -1;
+        for (int i = 0; i < (int) devices.size(); ++i)
+            if (devices[(size_t) i].identifier == wantedId) return i;
+        return -1;
+    };
+    session.syncSourceInputIdx   .store (resolve (midiIn.getDevices(),  session.syncSourceInputIdentifier), std::memory_order_release);
+    session.mcu.resolvedInputIdx .store (resolve (midiIn.getDevices(),  session.mcu.inputIdentifier),       std::memory_order_release);
+    session.syncOutputIdx        .store (resolve (midiOut.getDevices(), session.syncOutputIdentifier),      std::memory_order_release);
+    session.mcu.resolvedOutputIdx.store (resolve (midiOut.getDevices(), session.mcu.outputIdentifier),      std::memory_order_release);
 
-    // Same resolve pattern. -1 = MCU surface off.
-    int resolvedMcuInputIdx = -1;
-    const auto& wantedMcuInputId = session.mcu.inputIdentifier;
-    if (wantedMcuInputId.isNotEmpty())
-    {
-        for (int i = 0; i < midiInputDevices.size(); ++i)
-        {
-            if (midiInputDevices[i].identifier == wantedMcuInputId)
-            {
-                resolvedMcuInputIdx = i;
-                break;
-            }
-        }
-    }
-    session.mcu.resolvedInputIdx.store (resolvedMcuInputIdx, std::memory_order_release);
+    // Eager-open the sync + MCU output ports so the first clock byte / MCU tick
+    // doesn't wait on a synchronous ALSA snd_seq_connect. Per-track outputs open
+    // lazily via openConfiguredMidiOutputs.
+    if (const int i = session.syncOutputIdx.load (std::memory_order_acquire); i >= 0)
+        midiOut.ensureOpen (i);
+    if (const int i = session.mcu.resolvedOutputIdx.load (std::memory_order_acquire); i >= 0)
+        midiOut.ensureOpen (i);
 
     midiSyncReceiver.reset();
     midiTimeCodeReceiver.reset();
-}
-
-juce::MidiMessageCollector* AudioEngine::getVirtualKeyboardCollector() noexcept
-{
-    const int idx = virtualKeyboardCollectorIndex;
-    if (idx < 0 || idx >= (int) midiInputCollectors.size())
-        return nullptr;
-    return midiInputCollectors[(size_t) idx].get();
-}
-
-void AudioEngine::rebuildMidiOutputBank()
-{
-    // Mutating midiOutputs is safe only with audio callback detached
-    // (audio writes port indices into the out-FIFO while running) and
-    // under midiOutBankMutex (the pump thread dereferences the ports).
-    // Enumerate but don't open — eager open at startup blocks the
-    // message thread on each snd_seq_connect_to and spawns one thread
-    // per port; stalls MainWindow::setVisible(true) for seconds on
-    // systems with USB MIDI. Open on demand via ensureMidiOutputOpen.
-    {
-        const std::lock_guard<std::mutex> lock (midiOutBankMutex);
-        // Discard queued-but-unsent blocks first: their port indices were
-        // minted against the OLD device order and could land on a different
-        // physical port after re-enumeration. The callback is detached, so
-        // nothing new is being written; the mutex excludes the pump's drain.
-        const int stale = midiOutFifo.getNumReady();
-        if (stale > 0)
-        {
-            int s1 = 0, n1 = 0, s2 = 0, n2 = 0;
-            midiOutFifo.prepareToRead (stale, s1, n1, s2, n2);
-            midiOutFifo.finishedRead (n1 + n2);
-        }
-        midiOutputs.clear();
-        midiOutputDevices = juce::MidiOutput::getAvailableDevices();
-        midiOutputs.resize ((size_t) midiOutputDevices.size());
-    }
-
-    // Eager-open the chosen sync port so the first clock byte the
-    // audio thread emits doesn't wait on a sync ALSA connect.
-    int resolvedSyncOutIdx = -1;
-    const auto& wantedOutId = session.syncOutputIdentifier;
-    if (wantedOutId.isNotEmpty())
-    {
-        for (int i = 0; i < midiOutputDevices.size(); ++i)
-        {
-            if (midiOutputDevices[i].identifier == wantedOutId)
-            {
-                resolvedSyncOutIdx = i;
-                ensureMidiOutputOpen (i);
-                break;
-            }
-        }
-    }
-    session.syncOutputIdx.store (resolvedSyncOutIdx, std::memory_order_release);
-
-    // Same eager-open pattern — McuController's first 30 Hz tick
-    // doesn't race ALSA's sync connect.
-    int resolvedMcuOutIdx = -1;
-    const auto& wantedMcuOutId = session.mcu.outputIdentifier;
-    if (wantedMcuOutId.isNotEmpty())
-    {
-        for (int i = 0; i < midiOutputDevices.size(); ++i)
-        {
-            if (midiOutputDevices[i].identifier == wantedMcuOutId)
-            {
-                resolvedMcuOutIdx = i;
-                ensureMidiOutputOpen (i);
-                break;
-            }
-        }
-    }
-    session.mcu.resolvedOutputIdx.store (resolvedMcuOutIdx, std::memory_order_release);
-
     midiClockEmitter.reset();
-}
-
-bool AudioEngine::ensureMidiOutputOpen (int index)
-{
-    if (index < 0 || index >= (int) midiOutputs.size())
-        return false;
-    if (midiOutputs[(size_t) index] != nullptr)
-        return true;  // already open
-
-    auto out = juce::MidiOutput::openDevice (midiOutputDevices[index].identifier);
-    if (out == nullptr)
-    {
-        std::fprintf (stderr,
-                      "[Dusk Studio/AudioEngine] WARNING: failed to open MIDI output \"%s\" "
-                      "(id %s). Another application may be holding it open.\n",
-                      midiOutputDevices[index].name.toRawUTF8(),
-                      midiOutputDevices[index].identifier.toRawUTF8());
-        return false;
-    }
-    // Background thread so the pump thread's sendBlockOfMessages
-    // enqueues without blocking on the OS port.
-    out->startBackgroundThread();
-    {
-        // The pump thread may be dereferencing this slot's pointer.
-        const std::lock_guard<std::mutex> lock (midiOutBankMutex);
-        midiOutputs[(size_t) index] = std::move (out);
-    }
-    return true;
-}
-
-void AudioEngine::MidiOutPump::run()
-{
-    while (! threadShouldExit())
-    {
-        engine.drainMidiOutQueue();
-        wait (1);
-    }
-}
-
-void AudioEngine::queueMidiOutBlock (int port, const juce::MidiBuffer& events,
-                                     double sampleRate) noexcept
-{
-    // A block bigger than the slot's pre-allocated capacity would make
-    // addEvents reallocate on the audio thread — drop it instead, same
-    // policy as queue-full.
-    if (events.data.size() > kMidiOutSlotBytes) return;
-
-    int start1 = 0, size1 = 0, start2 = 0, size2 = 0;
-    midiOutFifo.prepareToWrite (1, start1, size1, start2, size2);
-    if (size1 + size2 < 1) return;   // pump stalled — drop the block
-
-    // The lone writable slot lands in the SECOND segment when the write wraps
-    // (size1 == 0, size2 == 1); use start2 then, not the stale start1.
-    auto& slot = midiOutQueue[(size_t) (size1 > 0 ? start1 : start2)];
-    slot.port       = port;
-    slot.timeMs     = juce::Time::getMillisecondCounterHiRes();
-    slot.sampleRate = sampleRate > 0.0 ? sampleRate : 48000.0;
-    slot.events.clear();   // keeps the pre-sized capacity
-    slot.events.addEvents (events, 0, -1, 0);
-    midiOutFifo.finishedWrite (1);
-}
-
-void AudioEngine::drainMidiOutQueue()
-{
-    // The whole read cycle holds midiOutBankMutex — not just the port
-    // dereference — so rebuildMidiOutputBank can discard stale slots
-    // under the same mutex without racing a half-finished drain (the
-    // FIFO's reader side is single-consumer). The audio thread only
-    // touches the writer side and never takes this mutex.
-    const std::lock_guard<std::mutex> lock (midiOutBankMutex);
-
-    const int ready = midiOutFifo.getNumReady();
-    if (ready <= 0) return;
-
-    int start1 = 0, size1 = 0, start2 = 0, size2 = 0;
-    midiOutFifo.prepareToRead (ready, start1, size1, start2, size2);
-    auto send = [this] (int start, int n)
-    {
-        for (int i = 0; i < n; ++i)
-        {
-            auto& slot = midiOutQueue[(size_t) (start + i)];
-            if (slot.port >= 0 && slot.port < (int) midiOutputs.size())
-                if (auto* out = midiOutputs[(size_t) slot.port].get())
-                    out->sendBlockOfMessages (slot.events, slot.timeMs,
-                                               slot.sampleRate);
-        }
-    };
-    send (start1, size1);
-    send (start2, size2);
-    midiOutFifo.finishedRead (size1 + size2);
-}
-
-bool AudioEngine::sendMidiToOutput (int index, const juce::MidiBuffer& events) noexcept
-{
-    if (index < 0 || index >= (int) midiOutputs.size())
-        return false;
-    auto* out = midiOutputs[(size_t) index].get();
-    if (out == nullptr) return false;
-    // Absolute ms-since-epoch base; getMillisecondCounterHiRes = "ASAP".
-    // Lower latency than buffering for the next audio block.
-    out->sendBlockOfMessages (events,
-                                juce::Time::getMillisecondCounterHiRes(),
-                                /* sampleRate for time stamps only */ 48000.0);
-    return true;
 }
 
 void AudioEngine::openConfiguredMidiOutputs()
@@ -1264,47 +1045,28 @@ void AudioEngine::openConfiguredMidiOutputs()
     {
         const int idx = session.track (t).midiOutputIndex.load (std::memory_order_relaxed);
         if (idx >= 0)
-            ensureMidiOutputOpen (idx);
+            midiOut.ensureOpen (idx);
     }
 
     // Sync clock + MCU feedback ports the loaded session resolved (see
     // reresolveTrackMidiFromSession). Opened here so clock / MCU feedback flow
     // without the user reopening Audio Settings, alongside the per-track opens.
     if (const int i = session.syncOutputIdx.load (std::memory_order_acquire); i >= 0)
-        ensureMidiOutputOpen (i);
+        midiOut.ensureOpen (i);
     if (const int i = session.mcu.resolvedOutputIdx.load (std::memory_order_acquire); i >= 0)
-        ensureMidiOutputOpen (i);
+        midiOut.ensureOpen (i);
 }
 
 void AudioEngine::openConfiguredMidiOutputsSafely()
 {
-    // Session-load calls this with the audio callback ATTACHED, but
-    // ensureMidiOutputOpen mutates the midiOutputs bank the audio thread
-    // reads (midiOutputs[idx] in the clock / MCU send paths). Detach the
-    // callback for the brief open pass — same contract refreshMidiInputs()
-    // and rebuildMidiOutputBank() rely on. The startup caller runs pre-attach
-    // and uses openConfiguredMidiOutputs() directly.
+    // Session-load calls this with the audio callback ATTACHED, but ensureOpen
+    // mutates the output bank the audio thread reads (in the clock / MCU send
+    // paths). Detach the callback for the brief open pass — same contract
+    // refreshMidiInputs() relies on. The startup caller runs pre-attach and
+    // uses openConfiguredMidiOutputs() directly.
     deviceManager.removeAudioCallback (this);
     openConfiguredMidiOutputs();
     deviceManager.addAudioCallback (this);
-}
-
-void AudioEngine::handleIncomingMidiMessage (juce::MidiInput* source,
-                                                const juce::MidiMessage& message)
-{
-    if (source == nullptr) return;
-    // JUCE guarantees identifier stability per device per session.
-    const auto& sourceId = source->getIdentifier();
-    for (int i = 0; i < midiInputDevices.size(); ++i)
-    {
-        if (midiInputDevices[(size_t) i].identifier == sourceId)
-        {
-            if (i < (int) midiInputCollectors.size()
-                && midiInputCollectors[(size_t) i] != nullptr)
-                midiInputCollectors[(size_t) i]->addMessageToQueue (message);
-            return;
-        }
-    }
 }
 
 int AudioEngine::getBackendXRunCount() const noexcept
@@ -1358,11 +1120,11 @@ AudioEngine::~AudioEngine()
         recordManager.stopRecording (transport.getPlayhead());
     deviceManager.removeChangeListener (this);
     deviceManager.removeAudioCallback (this);
-    deviceManager.removeMidiInputDeviceCallback ({}, this);
+    midiIn.detachCallback();
     deviceManager.closeAudioDevice();
-    // After the callback is gone — nothing pushes to the out-FIFO, the
-    // pump drains or drops what's left, then midiOutputs can destruct.
-    midiOutPump.stopThread (2000);
+    // After the callback is gone — nothing pushes to the out-queue, the
+    // pump drains or drops what's left, then the output bank can destruct.
+    midiOut.stopPump();
 }
 
 void AudioEngine::drainCallbackDiagnostics()
@@ -2289,15 +2051,9 @@ void AudioEngine::audioDeviceAboutToStart (juce::AudioIODevice* device)
 
     // Reset every MIDI collector with the current sample rate so it can
     // convert the MIDI thread's millisecond timestamps into per-block sample
-    // positions. Without this, removeNextBlockOfMessages would emit
-    // garbage timestamps the first block. Safe to call here — the audio
-    // callback hasn't fired yet for this open.
-    {
-        const double sr = device->getCurrentSampleRate();
-        for (auto& c : midiInputCollectors)
-            if (c != nullptr)
-                c->reset (sr);
-    }
+    // positions. Without this, the first drain would emit garbage timestamps.
+    // Safe to call here — the audio callback hasn't fired yet for this open.
+    midiIn.resetCollectors (device->getCurrentSampleRate());
 
     prepareForSelfTest (device->getCurrentSampleRate(),
                          device->getCurrentBufferSizeSamples());
@@ -2462,16 +2218,8 @@ void AudioEngine::prepareForSelfTest (double sr, int bs)
     for (auto& v : playbackScratch)  v.assign ((size_t) bs, 0.0f);
     for (auto& v : playbackScratchR) v.assign ((size_t) bs, 0.0f);
     for (auto& m : perTrackMidiScratch) m.ensureSize (4096);
-    midiClockOutScratch.ensureSize (4096);
-    mtcOutScratch.reserveBytes (4096);
-    {
-        // Serialize the resize with the MIDI pump: drainMidiOutQueue() reads
-        // slot.events under midiOutBankMutex on the pump thread, which keeps
-        // running across a device re-open. ensureSize() reallocates the buffer,
-        // so it must hold the same lock.
-        const std::lock_guard<std::mutex> lock (midiOutBankMutex);
-        for (auto& q : midiOutQueue) q.events.ensureSize (kMidiOutSlotBytes);
-    }
+    midiClockOutScratch.reserveBytes (4096);
+    midiOutTrackScratch.reserveBytes (4096);
     silentInputScratch.assign ((size_t) bs, 0.0f);
 
     for (auto& a : laneAccum)
@@ -2872,12 +2620,8 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
     // block. Each removeNextBlockOfMessages is lock-free with respect to
     // the MIDI thread's addMessageToQueue, so the audio thread never
     // contends. Empty buffers cost ~nothing.
-    for (size_t i = 0; i < midiInputCollectors.size() && i < perInputMidi.size(); ++i)
-    {
-        perInputMidi[i].clear();
-        if (midiInputCollectors[i] != nullptr)
-            midiInputCollectors[i]->removeNextBlockOfMessages (perInputMidi[i], numSamples);
-    }
+    for (int i = 0; i < midiIn.getNumInputs() && i < (int) perInputMidi.size(); ++i)
+        midiIn.drainBlock (i, perInputMidi[(size_t) i], numSamples);
 
     // Test-hook: if the message thread staged a buffer via
     // stageTestMidiInjection, merge it into the requested input's
@@ -2888,7 +2632,10 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
     {
         const int idx = testInjectInputIdx.load (std::memory_order_relaxed);
         if (idx >= 0 && (size_t) idx < perInputMidi.size())
-            perInputMidi[(size_t) idx].addEvents (testInjectMidi, 0, numSamples, 0);
+            for (const auto meta : testInjectMidi)
+                if (meta.samplePosition < numSamples)
+                    perInputMidi[(size_t) idx].addEvent (meta.data, meta.numBytes,
+                                                         meta.samplePosition);
         testInjectMidi.clear();
         testInjectReady.store (false, std::memory_order_release);
     }
@@ -2931,29 +2678,15 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
     {
         const int mcuIdx = session.mcu.resolvedInputIdx.load (std::memory_order_acquire);
         if (mcuIdx >= 0 && (size_t) mcuIdx < perInputMidi.size())
-        {
-            mcuMidiScratch.clear();
-            for (const auto meta : perInputMidi[(size_t) mcuIdx])
-                mcuMidiScratch.addEvent (meta.getMessage().getRawData(),
-                                         meta.getMessage().getRawDataSize(),
-                                         meta.samplePosition);
-            mcuReceiver->process (mcuMidiScratch, midiSyncSampleClock);
-        }
+            mcuReceiver->process (perInputMidi[(size_t) mcuIdx], midiSyncSampleClock);
     }
 
     if (syncIdx >= 0 && (size_t) syncIdx < perInputMidi.size())
     {
-        // Bridge the JUCE input block into the dusk buffer the receivers take.
-        // Pre-reserved (and capacity-capped) in rebuildMidiInputBank, so this
-        // refill never allocates — over-cap events are dropped, not grown into.
-        syncMidiScratch.clear();
-        for (const auto meta : perInputMidi[(size_t) syncIdx])
-            syncMidiScratch.addEvent (meta.getMessage().getRawData(),
-                                      meta.getMessage().getRawDataSize(),
-                                      meta.samplePosition);
-
-        midiSyncReceiver.process (syncMidiScratch, midiSyncSampleClock);
-        midiTimeCodeReceiver.process (syncMidiScratch,
+        // The drained input block is already a dusk::MidiBuffer — feed it
+        // straight to the receivers (Clock + MTC multiplex on the same port).
+        midiSyncReceiver.process (perInputMidi[(size_t) syncIdx], midiSyncSampleClock);
+        midiTimeCodeReceiver.process (perInputMidi[(size_t) syncIdx],
                                          midiSyncSampleClock, numSamples);
         // Publish MTC decoded state. Same input port — Clock + MTC
         // multiplex on it; both decoders ignore bytes they don't own.
@@ -3114,16 +2847,15 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
     }
     midiSyncSampleClock += numSamples;
 
-    // MIDI Clock OUTPUT (master mode). Generates F8 + FA/FC bytes into
-    // a scratch MidiBuffer and hands it to the chosen MidiOutput's
-    // background delivery thread. Uses the same monotonic sync clock
-    // so receiver + emitter share a sample-time origin (matters when
-    // a user has Dusk Studio as both slave AND master - rare but possible
-    // via a MIDI thru).
-    // acquire pairs with release stores in AudioEngine::rebuildMidiOutputBank
-    // and AudioSettingsPanel: any state the writer published before flipping
-    // the index (the opened juce::MidiOutput inside midiOutputs[idx] and its
-    // background-thread state) is visible here before we route bytes to it.
+    // MIDI Clock OUTPUT (master mode). Generates F8 + FA/FC (+ MTC) bytes into
+    // a dusk scratch buffer and hands it to the out-bank's RT queue for the
+    // pump thread to deliver. Uses the same monotonic sync clock so receiver +
+    // emitter share a sample-time origin (matters when a user has Dusk Studio
+    // as both slave AND master - rare but possible via a MIDI thru).
+    // acquire pairs with the release stores in rebuildMidiBanks and
+    // AudioSettingsPanel: any state the writer published before flipping the
+    // index (the opened output port + its background-thread state) is visible
+    // here before we route bytes to it.
     const int syncOutIdx = session.syncOutputIdx.load (std::memory_order_acquire);
     if (syncOutIdx != lastSyncOutputIdx)
     {
@@ -3131,9 +2863,7 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
         midiTimeCodeEmitter.reset();
         lastSyncOutputIdx = syncOutIdx;
     }
-    const bool portReady = syncOutIdx >= 0
-                         && (size_t) syncOutIdx < midiOutputs.size()
-                         && midiOutputs[(size_t) syncOutIdx] != nullptr;
+    const bool portReady = syncOutIdx >= 0 && midiOut.isOpen (syncOutIdx);
     const bool emitClock = portReady
                          && session.syncOutputEmitClock.load (std::memory_order_relaxed);
     const bool emitTimeCode = portReady
@@ -3155,32 +2885,20 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
         }
         if (emitTimeCode)
         {
-            // MTC + Clock multiplex onto the same scratch buffer; the
-            // chosen MidiOutput delivers both message types together.
+            // MTC + Clock multiplex onto the same buffer; the emitter appends
+            // its QF/sysex bytes after the clock bytes, delivered together.
             const auto rate = (MidiTimeCodeEmitter::FrameRate)
                 session.syncOutputTimeCodeFrameRate.load (std::memory_order_relaxed);
-            // The emitter writes dusk::MidiBuffer; merge its events into the
-            // shared JUCE output scratch (pre-reserved, so no allocation).
-            mtcOutScratch.clear();
             midiTimeCodeEmitter.generateBlock (midiSyncSampleClock - numSamples,
                                                   numSamples,
                                                   transport.getPlayhead(),
                                                   rolling, rate,
-                                                  mtcOutScratch);
-            for (const auto meta : mtcOutScratch)
-                midiClockOutScratch.addEvent (meta.getMessage().getRawData(),
-                                              meta.getMessage().getRawDataSize(),
-                                              meta.samplePosition);
+                                                  midiClockOutScratch);
         }
 
         if (! midiClockOutScratch.isEmpty())
-        {
-            // Hand off to the pump thread — sendBlockOfMessages locks
-            // the delivery thread's mutex and allocates, neither of
-            // which is audio-thread safe (see midiOutFifo).
-            queueMidiOutBlock (syncOutIdx, midiClockOutScratch,
-                               currentSampleRate.load (std::memory_order_relaxed));
-        }
+            midiOut.queueRt (syncOutIdx, midiClockOutScratch,
+                             currentSampleRate.load (std::memory_order_relaxed));
     }
 
     // Held-MIDI-notes tracking for the chord display. Walk every drained
@@ -3193,7 +2911,10 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
         if (buf.isEmpty()) continue;
         for (const auto meta : buf)
         {
-            const auto m = meta.getMessage();
+            // Bridge the dusk event to juce for its message-parsing API (same
+            // per-event cost as the pre-flip juce buffer's getMessage()).
+            const juce::MidiMessage m (meta.getMessage().getRawData(),
+                                       meta.getMessage().getRawDataSize());
             if (m.isNoteOn() && m.getVelocity() > 0)
             {
                 const int n = m.getNoteNumber();
@@ -3234,7 +2955,8 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
             if (buf.isEmpty()) continue;
             for (const auto meta : buf)
             {
-                const auto m = meta.getMessage();
+                const juce::MidiMessage m (meta.getMessage().getRawData(),
+                                           meta.getMessage().getRawDataSize());
                 MidiBindingTrigger tg;
                 int dn = 0, val = 0;
                 if      (m.isController())                    { tg = MidiBindingTrigger::CC;         dn = m.getControllerNumber(); val = m.getControllerValue(); }
@@ -4439,7 +4161,10 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
                 if (perInputMidi[(size_t) srcIdx].isEmpty()) return;
                 for (const auto meta : perInputMidi[(size_t) srcIdx])
                 {
-                    const auto m = meta.getMessage();
+                    // dusk (perInputMidi) -> juce (perTrackMidiScratch, feeds
+                    // the instrument + recorder): bridge each event to juce.
+                    const juce::MidiMessage m (meta.getMessage().getRawData(),
+                                               meta.getMessage().getRawDataSize());
                     if (chFilter == 0 || m.getChannel() == chFilter)
                         perTrackMidiScratch[(size_t) t].addEvent (m, meta.samplePosition);
                 }
@@ -4457,8 +4182,9 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
             // virtual keyboard. Skip when the explicit input already IS
             // the VK so events aren't doubled.
             const bool trackArmed = session.track (t).recordArmed.load (std::memory_order_relaxed);
-            if (trackArmed && virtualKeyboardCollectorIndex != midiIdx)
-                pullInput (virtualKeyboardCollectorIndex);
+            const int vkbIdx = midiIn.getVirtualKeyboardIndex();
+            if (trackArmed && vkbIdx != midiIdx)
+                pullInput (vkbIdx);
 
             if (! perTrackMidiScratch[(size_t) t].isEmpty())
                 session.track (t).midiActivity.store (true, std::memory_order_relaxed);
@@ -4480,17 +4206,24 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
         // External MIDI output. When this MIDI track has a hardware port
         // selected, mirror the just-built per-track buffer to that port
         // so an external synth/drum machine receives the same notes the
-        // loaded instrument plugin (if any) does. Handed to the pump
-        // thread via the lock-free out-FIFO (see midiOutFifo) — the
-        // pump validates the port index against the bank under its
-        // mutex. Empty buffer skipped to avoid pointless slot use.
+        // loaded instrument plugin (if any) does. Handed to the pump thread
+        // via the out-bank's lock-free RT queue, which validates the port
+        // under its mutex. Empty buffer skipped to avoid pointless slot use.
         if (midiTrack && ! perTrackMidiScratch[(size_t) t].isEmpty())
         {
             const int outIdx = session.track (t).midiOutputIndex.load (
                                   std::memory_order_relaxed);
             if (outIdx >= 0)
-                queueMidiOutBlock (outIdx, perTrackMidiScratch[(size_t) t],
-                                   currentSampleRate.load (std::memory_order_relaxed));
+            {
+                // Bridge the juce per-track buffer into the dusk out-scratch
+                // (pre-reserved) for queueRt's dusk boundary.
+                midiOutTrackScratch.clear();
+                for (const auto meta : perTrackMidiScratch[(size_t) t])
+                    midiOutTrackScratch.addEvent (meta.data, meta.numBytes,
+                                                  meta.samplePosition);
+                midiOut.queueRt (outIdx, midiOutTrackScratch,
+                                 currentSampleRate.load (std::memory_order_relaxed));
+            }
         }
 
         // Tell the strip whether the recorder is going to ask for the

--- a/src/engine/AudioEngine.h
+++ b/src/engine/AudioEngine.h
@@ -173,7 +173,7 @@ public:
 
     // Same, but for live callers (session load) where the audio callback is
     // attached: detaches it around the bank mutation so the audio thread
-    // never reads midiOutputs mid-open. Message-thread only.
+    // never reads the output bank mid-open. Message-thread only.
     void openConfiguredMidiOutputsSafely();
 
     juce::UndoManager& getUndoManager() noexcept { return undoManager; }

--- a/src/engine/AudioEngine.h
+++ b/src/engine/AudioEngine.h
@@ -17,6 +17,7 @@
 #include "MidiTimeCodeReceiver.h"
 #include "MidiClockEmitter.h"
 #include "MidiTimeCodeEmitter.h"
+#include "midi/MidiDevices.h"
 #include "../session/Session.h"
 #include "AudioWorkerPool.h"
 #include "MasteringPlayer.h"
@@ -31,7 +32,6 @@ namespace duskstudio
 // input -> channel strip (live or playback source) -> aux/master.
 // Owns Transport, recording, playback, plugin host.
 class AudioEngine final : public juce::AudioIODeviceCallback,
-                            public juce::MidiInputCallback,
                             public juce::ChangeBroadcaster,
                             public juce::ChangeListener
 {
@@ -140,34 +140,31 @@ public:
     // openConfiguredMidiOutputs. Message-thread only.
     void reresolveTrackMidiFromSession();
 
-    const juce::Array<juce::MidiDeviceInfo>& getMidiInputDevices() const noexcept
+    const std::vector<duskstudio::midi::MidiDeviceInfo>& getMidiInputDevices() const noexcept
     {
-        return midiInputDevices;
+        return midiIn.getDevices();
     }
-    const juce::Array<juce::MidiDeviceInfo>& getMidiOutputDevices() const noexcept
+    const std::vector<duskstudio::midi::MidiDeviceInfo>& getMidiOutputDevices() const noexcept
     {
-        return midiOutputDevices;
+        return midiOut.getDevices();
     }
 
-    // Synthetic "Virtual Keyboard (Dusk Studio)" collector appended to
-    // midiInputDevices. nullptr until rebuildMidiInputBank has run.
-    juce::MidiMessageCollector* getVirtualKeyboardCollector() noexcept;
+    // Synthetic "Virtual Keyboard (Dusk Studio)" collector appended to the
+    // input bank. nullptr until the input bank has been built.
+    juce::MidiMessageCollector* getVirtualKeyboardCollector() noexcept
+    {
+        return midiIn.getVirtualKeyboardCollector();
+    }
 
-    // Index of the virtual keyboard inside midiInputDevices, or -1 if
-    // the bank hasn't been built yet. Used by UI flows that auto-route
-    // the on-screen keyboard to a freshly loaded instrument track.
-    int getVirtualKeyboardInputIndex() const noexcept { return virtualKeyboardCollectorIndex; }
+    // Index of the virtual keyboard inside the input bank, or -1 if the bank
+    // hasn't been built yet. Used by UI flows that auto-route the on-screen
+    // keyboard to a freshly loaded instrument track.
+    int getVirtualKeyboardInputIndex() const noexcept { return midiIn.getVirtualKeyboardIndex(); }
 
     // Lazy-open + start delivery thread. Opening every available output
     // at startup blocks the main thread (snd_seq_connect_to is sync).
     // Message-thread only.
-    bool ensureMidiOutputOpen (int index);
-
-    // No implicit ensure — caller checks state first. Message thread
-    // only (MCU feedback sink). The audio thread routes MIDI out through
-    // queueMidiOutBlock instead — sendBlockOfMessages locks and
-    // allocates, so it must never run in the callback.
-    bool sendMidiToOutput (int index, const juce::MidiBuffer& events) noexcept;
+    bool ensureMidiOutputOpen (int index) { return midiOut.ensureOpen (index); }
 
     // Open the MIDI output every track is routed to. Called once after
     // SessionSerializer::load resolves identifiers. Message-thread only.
@@ -259,12 +256,6 @@ public:
     // guarantee a follow-up audioDeviceStopped, so we do the same
     // flush-record-and-stop dance to keep recordings recoverable.
     void audioDeviceError (const juce::String& errorMessage) override;
-
-    // Bound via addMidiInputDeviceCallback("", this). Fires from JUCE's
-    // MIDI input thread (NOT the audio thread); routes to per-input
-    // collectors that the audio thread drains lock-free.
-    void handleIncomingMidiMessage (juce::MidiInput* source,
-                                       const juce::MidiMessage& message) override;
 
     // Prepare without a real AudioIODevice. The self-test detaches the
     // engine and drives audioDeviceIOCallbackWithContext directly with
@@ -464,21 +455,15 @@ private:
     PitchDetector    pitchDetector;
     MidiSyncReceiver       midiSyncReceiver;
     MidiTimeCodeReceiver   midiTimeCodeReceiver;
-    // Scratch the sync/MTC and MCU input blocks are bridged into: the receivers
-    // take a dusk::MidiBuffer, so each block the JUCE input buffer is walked
-    // into these (pre-reserved so the fill never allocates on the audio thread;
-    // MCU and sync can be different input ports, hence two buffers).
-    dusk::MidiBuffer       syncMidiScratch;
-    dusk::MidiBuffer       mcuMidiScratch;
     std::unique_ptr<class McuReceiver>   mcuReceiver;
     std::unique_ptr<class McuController> mcuController;
 
     MidiClockEmitter     midiClockEmitter;
     MidiTimeCodeEmitter  midiTimeCodeEmitter;
-    juce::MidiBuffer midiClockOutScratch;
-    // MTC emitter writes dusk::MidiBuffer; its events are merged into
-    // midiClockOutScratch each block (pre-reserved, allocation-free).
-    dusk::MidiBuffer mtcOutScratch;
+    // Clock + MTC multiplex onto this one dusk buffer each block (Clock bytes
+    // first, MTC appended); the out-bank's queueRt converts + timestamps it.
+    // Pre-reserved so the emitters never allocate on the audio thread.
+    dusk::MidiBuffer midiClockOutScratch;
     int              lastSyncOutputIdx = -1;
 
     // Monotonic sample clock the sync receiver timestamps clock ticks
@@ -631,68 +616,33 @@ private:
     void processStripLane (int lane) noexcept;            // one worker lane
     void reduceLaneAccum (int numSamples) noexcept;       // sum lanes → mix
 
-    // One MidiMessageCollector per registered input. MIDI thread
-    // addMessageToQueue's; audio thread drains per-block into
-    // perInputMidi[i]. Both sides lock-free per JUCE contract.
-    juce::Array<juce::MidiDeviceInfo> midiInputDevices;
-    std::vector<std::unique_ptr<juce::MidiMessageCollector>> midiInputCollectors;
-    std::vector<juce::MidiBuffer> perInputMidi;
-    std::array<juce::MidiBuffer, Session::kNumTracks> perTrackMidiScratch;
+    // The single JUCE-device seam. midiIn owns the per-input collector bank and
+    // is itself the input callback; midiOut owns the output-port bank + RT
+    // out-queue + pump thread. The audio thread only calls midiIn.drainBlock /
+    // midiOut.queueRt (both take dusk::MidiBuffer). The detach-rebuild-reattach
+    // fence around a hot-plug is orchestrated by rebuildMidiBanks below.
+    duskstudio::midi::MidiInputClient  midiIn;
+    duskstudio::midi::MidiOutputBank   midiOut;
 
-    // Recomputed every rebuildMidiInputBank so hot-plug doesn't invalidate.
-    int virtualKeyboardCollectorIndex { -1 };
+    // Per-input drained block. midiIn.drainBlock fills each every block
+    // (destructive per collector). Sized to midiIn.getNumInputs() and
+    // reserveBytes'd off the RT path in rebuildMidiBanks so the drain and the
+    // test-inject merge never allocate on the audio thread.
+    std::vector<dusk::MidiBuffer> perInputMidi;
+    // Per-track routing buffer feeding the strip's instrument + the recorder —
+    // both take juce::MidiBuffer, so this stays juce-typed.
+    std::array<juce::MidiBuffer, Session::kNumTracks> perTrackMidiScratch;
+    // juce->dusk bridge for a MIDI track's external output: perTrackMidiScratch
+    // (juce) is copied into this before midiOut.queueRt (dusk). Pre-reserved.
+    dusk::MidiBuffer midiOutTrackScratch;
 
     // SPSC handoff. Producer must not touch testInjectMidi while
     // testInjectReady==true. Single relaxed load + branch per block in
-    // production.
+    // production. Staged as juce (the test builds a juce buffer); merged into
+    // the dusk perInputMidi slot on the audio thread.
     juce::MidiBuffer  testInjectMidi;
     std::atomic<int>  testInjectInputIdx { -1 };
     std::atomic<bool> testInjectReady    { false };
-
-    juce::Array<juce::MidiDeviceInfo> midiOutputDevices;
-    std::vector<std::unique_ptr<juce::MidiOutput>> midiOutputs;
-
-    // MIDI-out handoff. juce::MidiOutput::sendBlockOfMessages is NOT
-    // audio-thread safe: it takes the delivery thread's mutex (which
-    // that thread holds across waits of up to ~20 ms) and inserts into
-    // a heap-allocating multiset under it. The audio thread instead
-    // writes whole per-port event blocks into this lock-free FIFO; the
-    // pump thread drains it every millisecond and does the
-    // sendBlockOfMessages call where blocking is harmless. Slot
-    // MidiBuffers are pre-sized in prepareForSelfTest so the audio-
-    // thread copy never allocates. Queue-full drops the block —
-    // dropping clock bytes beats an xrun.
-    static constexpr int kMidiOutQueueSlots = 64;
-    static constexpr int kMidiOutSlotBytes  = 4096;
-    struct QueuedMidiOut
-    {
-        int    port       = -1;
-        double timeMs     = 0.0;
-        double sampleRate = 48000.0;
-        juce::MidiBuffer events;
-    };
-    juce::AbstractFifo midiOutFifo { kMidiOutQueueSlots };
-    std::array<QueuedMidiOut, kMidiOutQueueSlots> midiOutQueue;
-
-    // Serialises the pump thread's port access against message-thread
-    // bank mutation (rebuildMidiOutputBank / ensureMidiOutputOpen). The
-    // audio thread never takes it — it only touches the FIFO.
-    std::mutex midiOutBankMutex;
-
-    class MidiOutPump final : public juce::Thread
-    {
-    public:
-        explicit MidiOutPump (AudioEngine& e)
-            : juce::Thread ("Dusk Studio MIDI out"), engine (e) {}
-        void run() override;
-    private:
-        AudioEngine& engine;
-    };
-    MidiOutPump midiOutPump { *this };
-
-    void queueMidiOutBlock (int port, const juce::MidiBuffer& events,
-                            double sampleRate) noexcept;
-    void drainMidiOutQueue();
 
     // Previous block's midiInputIndex per track — detects mid-play
     // input swaps so we can fire All-Notes-Off + Sustain-Off on the
@@ -700,11 +650,12 @@ private:
     // keep ringing (Note Off never arrives on the now-unrouted source).
     std::array<int, Session::kNumTracks> lastMidiInputIndex {};
 
-    // Called from ctor BEFORE callbacks register, and from
-    // refreshMidiInputs WHILE callbacks are detached. The detach-rebuild-
-    // reattach fence is what makes vector mutation safe.
-    void rebuildMidiInputBank();
-    void rebuildMidiOutputBank();
+    // Rebuild both device banks (message thread, input+audio callbacks
+    // DETACHED by the caller). Enumerates hardware, sizes perInputMidi,
+    // re-resolves the session sync/MCU identifiers to indices, eager-opens the
+    // sync + MCU output ports, and resets the receivers/clock emitter. Called
+    // from the ctor and refreshMidiInputs inside their detach fences.
+    void rebuildMidiBanks();
 
     // Write the finished master mix (mixL/mixR) to its configured device output
     // pair. Accumulates, so an aux lane routed to the same pair sums in rather

--- a/src/engine/MidiClockEmitter.cpp
+++ b/src/engine/MidiClockEmitter.cpp
@@ -1,12 +1,14 @@
 #include "MidiClockEmitter.h"
 
+#include <cmath>
+
 namespace duskstudio
 {
 void MidiClockEmitter::generateBlock (std::int64_t blockStartSample,
                                        int numSamples,
                                        float bpm,
                                        bool isRolling,
-                                       juce::MidiBuffer& out) noexcept
+                                       dusk::MidiBuffer& out) noexcept
 {
     if (numSamples <= 0 || sr <= 0.0) return;
 
@@ -18,7 +20,7 @@ void MidiClockEmitter::generateBlock (std::int64_t blockStartSample,
     {
         const std::uint8_t statusByte = isRolling ? (std::uint8_t) 0xFA   // Start
                                                   : (std::uint8_t) 0xFC; // Stop
-        out.addEvent (juce::MidiMessage (statusByte), 0);
+        out.addEvent (&statusByte, 1, 0);
         lastRolling = isRolling;
         if (isRolling)
         {
@@ -48,7 +50,10 @@ void MidiClockEmitter::generateBlock (std::int64_t blockStartSample,
         const int offset = (int) ((std::int64_t) std::llround (clockPhase)
                                    - blockStartSample);
         if (offset >= 0 && offset < numSamples)
-            out.addEvent (juce::MidiMessage ((std::uint8_t) 0xF8), offset);
+        {
+            const std::uint8_t clockByte = 0xF8;
+            out.addEvent (&clockByte, 1, offset);
+        }
         clockPhase += samplesPerClock;
     }
 }

--- a/src/engine/MidiClockEmitter.h
+++ b/src/engine/MidiClockEmitter.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include <juce_audio_basics/juce_audio_basics.h>
+#include "../foundation/MidiBuffer.h"
+#include <cstdint>
 
 namespace duskstudio
 {
 // Generates MIDI Clock (F8) + transport (FA / FC) bytes for a per-block
-// MidiBuffer. The caller routes the buffer to a juce::MidiOutput via
-// sendBlockOfMessages so delivery happens on JUCE's background thread.
-// Audio-thread safe - the emitter holds only POD state and writes
-// timestamped bytes into a pre-allocated MidiBuffer.
+// MidiBuffer. The caller routes the buffer to a MIDI output port for
+// delivery on its background thread. Audio-thread safe - the emitter holds
+// only POD state and writes timestamped bytes into a pre-allocated MidiBuffer.
 //
 // Sample-accurate placement: F8 ticks fire on a monotonic sample clock
 // that advances independent of the transport playhead. This means a
@@ -48,7 +48,7 @@ public:
                         int numSamples,
                         float bpm,
                         bool isRolling,
-                        juce::MidiBuffer& out) noexcept;
+                        dusk::MidiBuffer& out) noexcept;
 
 private:
     double sr = 48000.0;

--- a/src/engine/midi/MidiDevices.cpp
+++ b/src/engine/midi/MidiDevices.cpp
@@ -46,9 +46,10 @@ void MidiInputClient::rebuild (double sampleRate)
     }
     virtualKeyboardIndex = (int) collectors.size() - 1;
 
-    // Pre-size the RT drain scratch like the pre-flip perInputMidi: a burst past
-    // this grows the destination on the audio thread (rare) — same property.
-    drainScratch.ensureSize (4096);
+    // Pre-size the RT drain scratch well past the 4096-byte dusk copy cap so a
+    // dense burst drops downstream (bounded) instead of reallocating here on
+    // the audio thread.
+    drainScratch.ensureSize (16384);
 }
 
 void MidiInputClient::detachCallback()
@@ -228,13 +229,6 @@ bool MidiOutputBank::send (int index, const juce::MidiBuffer& events) noexcept
 {
     // sampleRate is for time stamps only — the direct send carries no offsets.
     return sendJuce (index, events, 48000.0);
-}
-
-bool MidiOutputBank::send (int index, const dusk::MidiBuffer& events, double sampleRate)
-{
-    juce::MidiBuffer juceEvents;
-    toJuceBuffer (events, juceEvents);
-    return sendJuce (index, juceEvents, sampleRate);
 }
 
 void MidiOutputBank::queueRt (int port, const dusk::MidiBuffer& events, double sampleRate) noexcept

--- a/src/engine/midi/MidiDevices.cpp
+++ b/src/engine/midi/MidiDevices.cpp
@@ -1,0 +1,319 @@
+#include "MidiDevices.h"
+#include <cstdio>
+
+namespace duskstudio::midi
+{
+// ── MidiInputClient ─────────────────────────────────────────────────────────
+
+void MidiInputClient::rebuild (double sampleRate)
+{
+    jassert (deviceManager != nullptr);
+
+    const auto avail = juce::MidiInput::getAvailableDevices();
+    devices.clear();
+    devices.reserve ((size_t) avail.size() + 1);
+    collectors.clear();
+    collectors.reserve ((size_t) avail.size() + 1);
+
+    for (const auto& d : avail)
+    {
+        devices.push_back ({ d.name, d.identifier });
+
+        auto col = std::make_unique<juce::MidiMessageCollector>();
+        if (sampleRate > 0.0) col->reset (sampleRate);
+
+        // setMidiInputDeviceEnabled returns void — re-query to verify. Failure
+        // usually = OS denied access (another app exclusively owns the port).
+        deviceManager->setMidiInputDeviceEnabled (d.identifier, true);
+        if (! deviceManager->isMidiInputDeviceEnabled (d.identifier))
+            std::fprintf (stderr,
+                          "[Dusk Studio/MidiDevices] WARNING: failed to enable MIDI input \"%s\" "
+                          "(id %s). Another application may be holding it open.\n",
+                          d.name.toRawUTF8(), d.identifier.toRawUTF8());
+
+        collectors.push_back (std::move (col));
+    }
+
+    // Appended after real hardware so the VKB's index is stable across hot-plug.
+    // Not bound to any OS device — the on-screen keyboard addMessageToQueues into
+    // its collector directly; the audio thread drains it like any other input.
+    devices.push_back ({ juce::String ("Virtual Keyboard (Dusk Studio)"),
+                         juce::String (kVirtualKeyboardIdentifier) });
+    {
+        auto vkb = std::make_unique<juce::MidiMessageCollector>();
+        if (sampleRate > 0.0) vkb->reset (sampleRate);
+        collectors.push_back (std::move (vkb));
+    }
+    virtualKeyboardIndex = (int) collectors.size() - 1;
+
+    // Pre-size the RT drain scratch like the pre-flip perInputMidi: a burst past
+    // this grows the destination on the audio thread (rare) — same property.
+    drainScratch.ensureSize (4096);
+}
+
+void MidiInputClient::detachCallback()
+{
+    if (deviceManager != nullptr)
+        deviceManager->removeMidiInputDeviceCallback ({}, this);
+}
+
+void MidiInputClient::disableAllDevices()
+{
+    if (deviceManager == nullptr) return;
+    for (const auto& d : devices)
+        deviceManager->setMidiInputDeviceEnabled (d.identifier, false);
+}
+
+void MidiInputClient::attachCallback()
+{
+    if (deviceManager != nullptr)
+        deviceManager->addMidiInputDeviceCallback ({}, this);
+}
+
+void MidiInputClient::resetCollectors (double sampleRate)
+{
+    for (auto& c : collectors)
+        if (c != nullptr) c->reset (sampleRate);
+}
+
+juce::MidiMessageCollector* MidiInputClient::getVirtualKeyboardCollector() noexcept
+{
+    if (virtualKeyboardIndex < 0 || virtualKeyboardIndex >= (int) collectors.size())
+        return nullptr;
+    return collectors[(size_t) virtualKeyboardIndex].get();
+}
+
+void MidiInputClient::drainBlock (int inputIndex, dusk::MidiBuffer& out, int numSamples) noexcept
+{
+    out.clear();
+    if (inputIndex < 0 || inputIndex >= (int) collectors.size()) return;
+    auto* col = collectors[(size_t) inputIndex].get();
+    if (col == nullptr) return;
+
+    drainScratch.clear();
+    col->removeNextBlockOfMessages (drainScratch, numSamples);
+    for (const auto meta : drainScratch)
+        out.addEvent (meta.data, meta.numBytes, meta.samplePosition);
+}
+
+void MidiInputClient::handleIncomingMidiMessage (juce::MidiInput* source,
+                                                 const juce::MidiMessage& message)
+{
+    if (source == nullptr) return;
+    // JUCE guarantees identifier stability per device per session.
+    const auto sourceId = source->getIdentifier();
+    for (int i = 0; i < (int) devices.size(); ++i)
+    {
+        if (devices[(size_t) i].identifier == sourceId)
+        {
+            if (i < (int) collectors.size() && collectors[(size_t) i] != nullptr)
+                collectors[(size_t) i]->addMessageToQueue (message);
+            return;
+        }
+    }
+}
+
+// ── MidiOutputBank ──────────────────────────────────────────────────────────
+
+MidiOutputBank::MidiOutputBank()
+{
+    // Pre-size every slot buffer so the audio-thread copy in queueRt never
+    // allocates (kSlotBytes matches the drop-on-oversize cap there).
+    for (auto& slot : queue)
+        slot.events.ensureSize (kSlotBytes);
+}
+
+MidiOutputBank::~MidiOutputBank()
+{
+    stopPump();
+}
+
+std::vector<MidiDeviceInfo> MidiOutputBank::enumerate()
+{
+    std::vector<MidiDeviceInfo> result;
+    const auto avail = juce::MidiOutput::getAvailableDevices();
+    result.reserve ((size_t) avail.size());
+    for (const auto& d : avail)
+        result.push_back ({ d.name, d.identifier });
+    return result;
+}
+
+void MidiOutputBank::rebuild()
+{
+    // Mutating outputs is safe only with the audio callback detached (the audio
+    // thread writes port indices into the FIFO while running) and under
+    // bankMutex (the pump dereferences the ports).
+    const std::lock_guard<std::mutex> lock (bankMutex);
+
+    // Discard queued-but-unsent blocks first: their port indices were minted
+    // against the OLD device order and could land on a different physical port
+    // after re-enumeration. The callback is detached, so nothing new is being
+    // written; the mutex excludes the pump's drain.
+    const int stale = fifo.getNumReady();
+    if (stale > 0)
+    {
+        int s1 = 0, n1 = 0, s2 = 0, n2 = 0;
+        fifo.prepareToRead (stale, s1, n1, s2, n2);
+        fifo.finishedRead (n1 + n2);
+    }
+
+    outputs.clear();
+    devices = enumerate();
+    outputs.resize (devices.size());
+}
+
+bool MidiOutputBank::ensureOpen (int index)
+{
+    if (index < 0 || index >= (int) outputs.size())
+        return false;
+    if (outputs[(size_t) index] != nullptr)
+        return true;  // already open
+
+    auto out = juce::MidiOutput::openDevice (devices[(size_t) index].identifier);
+    if (out == nullptr)
+    {
+        std::fprintf (stderr,
+                      "[Dusk Studio/MidiDevices] WARNING: failed to open MIDI output \"%s\" "
+                      "(id %s). Another application may be holding it open.\n",
+                      devices[(size_t) index].name.toRawUTF8(),
+                      devices[(size_t) index].identifier.toRawUTF8());
+        return false;
+    }
+    // Background thread so the pump's sendBlockOfMessages enqueues without
+    // blocking on the OS port.
+    out->startBackgroundThread();
+    {
+        // The pump may be dereferencing this slot's pointer.
+        const std::lock_guard<std::mutex> lock (bankMutex);
+        outputs[(size_t) index] = std::move (out);
+    }
+    return true;
+}
+
+void MidiOutputBank::closeAll()
+{
+    const std::lock_guard<std::mutex> lock (bankMutex);
+    outputs.clear();
+}
+
+bool MidiOutputBank::isOpen (int index) const noexcept
+{
+    return index >= 0 && index < (int) outputs.size() && outputs[(size_t) index] != nullptr;
+}
+
+void MidiOutputBank::toJuceBuffer (const dusk::MidiBuffer& in, juce::MidiBuffer& out)
+{
+    out.clear();
+    for (const auto meta : in)
+    {
+        const auto& m = meta.getMessage();
+        out.addEvent (m.getRawData(), m.getRawDataSize(), meta.samplePosition);
+    }
+}
+
+bool MidiOutputBank::sendJuce (int index, const juce::MidiBuffer& events, double sampleRate) noexcept
+{
+    if (index < 0 || index >= (int) outputs.size())
+        return false;
+    auto* out = outputs[(size_t) index].get();
+    if (out == nullptr) return false;
+    // Absolute ms-since-epoch base; getMillisecondCounterHiRes = "ASAP".
+    out->sendBlockOfMessages (events,
+                              juce::Time::getMillisecondCounterHiRes(),
+                              sampleRate > 0.0 ? sampleRate : 48000.0);
+    return true;
+}
+
+bool MidiOutputBank::send (int index, const juce::MidiBuffer& events) noexcept
+{
+    // sampleRate is for time stamps only — the direct send carries no offsets.
+    return sendJuce (index, events, 48000.0);
+}
+
+bool MidiOutputBank::send (int index, const dusk::MidiBuffer& events, double sampleRate)
+{
+    juce::MidiBuffer juceEvents;
+    toJuceBuffer (events, juceEvents);
+    return sendJuce (index, juceEvents, sampleRate);
+}
+
+void MidiOutputBank::queueRt (int port, const dusk::MidiBuffer& events, double sampleRate) noexcept
+{
+    int start1 = 0, size1 = 0, start2 = 0, size2 = 0;
+    fifo.prepareToWrite (1, start1, size1, start2, size2);
+    if (size1 + size2 < 1) return;   // pump stalled — drop the block
+
+    // The lone writable slot lands in the SECOND segment when the write wraps
+    // (size1 == 0, size2 == 1); use start2 then, not the stale start1.
+    auto& slot = queue[(size_t) (size1 > 0 ? start1 : start2)];
+    slot.events.clear();   // keeps the pre-sized capacity
+
+    // Convert dusk -> juce directly into the slot, stopping before the pre-sized
+    // cap so the copy never reallocates on the audio thread. A block past the cap
+    // is dropped whole (same policy as queue-full) rather than realloc'd; the
+    // reserved slot is simply left uncommitted (no finishedWrite).
+    for (const auto meta : events)
+    {
+        const auto& m = meta.getMessage();
+        const int nb = m.getRawDataSize();
+        if ((int) slot.events.data.size() + kJuceEventHeaderBytes + nb > kSlotBytes)
+        {
+            slot.events.clear();
+            return;
+        }
+        slot.events.addEvent (m.getRawData(), nb, meta.samplePosition);
+    }
+
+    slot.port       = port;
+    slot.timeMs     = juce::Time::getMillisecondCounterHiRes();
+    slot.sampleRate = sampleRate > 0.0 ? sampleRate : 48000.0;
+    fifo.finishedWrite (1);
+}
+
+void MidiOutputBank::drainQueue()
+{
+    // The whole read cycle holds bankMutex — not just the port dereference — so
+    // rebuild can discard stale slots under the same mutex without racing a
+    // half-finished drain (the FIFO's reader side is single-consumer). The audio
+    // thread only touches the writer side and never takes this mutex.
+    const std::lock_guard<std::mutex> lock (bankMutex);
+
+    const int ready = fifo.getNumReady();
+    if (ready <= 0) return;
+
+    int start1 = 0, size1 = 0, start2 = 0, size2 = 0;
+    fifo.prepareToRead (ready, start1, size1, start2, size2);
+    auto sendSlots = [this] (int start, int n)
+    {
+        for (int i = 0; i < n; ++i)
+        {
+            auto& slot = queue[(size_t) (start + i)];
+            if (slot.port >= 0 && slot.port < (int) outputs.size())
+                if (auto* out = outputs[(size_t) slot.port].get())
+                    out->sendBlockOfMessages (slot.events, slot.timeMs, slot.sampleRate);
+        }
+    };
+    sendSlots (start1, size1);
+    sendSlots (start2, size2);
+    fifo.finishedRead (size1 + size2);
+}
+
+void MidiOutputBank::Pump::run()
+{
+    while (! threadShouldExit())
+    {
+        bank.drainQueue();
+        wait (1);
+    }
+}
+
+void MidiOutputBank::startPump()
+{
+    pump.startThread (juce::Thread::Priority::high);
+}
+
+void MidiOutputBank::stopPump()
+{
+    pump.stopThread (2000);
+}
+} // namespace duskstudio::midi

--- a/src/engine/midi/MidiDevices.h
+++ b/src/engine/midi/MidiDevices.h
@@ -1,0 +1,182 @@
+#pragma once
+
+#include <juce_audio_devices/juce_audio_devices.h>
+#include "../../foundation/MidiBuffer.h"
+#include <array>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+// The single seam between Dusk Studio's engine and JUCE's MIDI device backend.
+// Its BOUNDARY type is dusk::MidiBuffer — the RT drain hands the audio thread
+// dusk events, and the RT out-queue takes them — so a future native ALSA-
+// sequencer backend can replace this file pair without touching the engine.
+// Internal storage stays juce-typed (collectors, outputs, the SPSC slots); only
+// the API is dusk. This is the only JUCE-device-touching code, hence the
+// deliberate juce-allowlist entry.
+namespace duskstudio::midi
+{
+struct MidiDeviceInfo
+{
+    juce::String name;
+    juce::String identifier;
+};
+
+// Owns the per-input MidiMessageCollector bank and is itself the juce callback
+// bound to every enabled input; routes by source identifier. The detach-rebuild-
+// reattach fence around a hot-plug is orchestrated by the engine (which also
+// detaches its own audio callback) — this class only exposes the pieces.
+class MidiInputClient final : public juce::MidiInputCallback
+{
+public:
+    // Fixed identifier for the synthetic Virtual-Keyboard slot so saved sessions
+    // resolve back to it across hot-plug (its index is otherwise re-derived).
+    static constexpr const char* kVirtualKeyboardIdentifier = "Dusk Studio:virtual-keyboard";
+
+    // Message thread. Stash the device manager the enable/disable lifecycle and
+    // callback (un)registration run against. Call once before rebuild().
+    void setDeviceManager (juce::AudioDeviceManager& dm) noexcept { deviceManager = &dm; }
+
+    // Message thread, input callback DETACHED. Enumerate the hardware inputs,
+    // enable each on the device manager, build a per-input MidiMessageCollector,
+    // then append the synthetic Virtual-Keyboard slot last (fixed identifier, no
+    // OS device). Mutating the bank with the callback active is UB — see the
+    // detach/attach fence.
+    void rebuild (double sampleRate);
+
+    // Detach half of the fence: unregister the input callback (JUCE's remove
+    // joins the MIDI dispatch side before returning) and disable every device so
+    // the OS handles are released before a rebuild.
+    void detachCallback();
+    void disableAllDevices();
+
+    // Reattach: empty identifier = every enabled input fans out to
+    // handleIncomingMidiMessage, routed there by source identifier.
+    void attachCallback();
+
+    // Re-arm every collector to a new sample rate so the MIDI thread's ms
+    // timestamps convert to per-block sample offsets (audioDeviceAboutToStart).
+    void resetCollectors (double sampleRate);
+
+    const std::vector<MidiDeviceInfo>& getDevices() const noexcept { return devices; }
+    int getNumInputs() const noexcept { return (int) collectors.size(); }
+
+    int getVirtualKeyboardIndex() const noexcept { return virtualKeyboardIndex; }
+    juce::MidiMessageCollector* getVirtualKeyboardCollector() noexcept;
+
+    // Audio thread. Pull this input's block out of its collector and copy the
+    // events into the dusk boundary buffer. RT-safe provided (a) `out` was
+    // reserveBytes()'d off the RT path by the caller and (b) the incoming burst
+    // fits the collector's pre-sized scratch — a rare overflow grows it, exactly
+    // as the pre-flip perInputMidi drain did. Call once per input index per
+    // block: the collector drain is destructive.
+    void drainBlock (int inputIndex, dusk::MidiBuffer& out, int numSamples) noexcept;
+
+    // juce::MidiInputCallback. Fires on JUCE's MIDI input thread (NOT the audio
+    // thread); routes by source identifier to the matching collector, which the
+    // audio thread later drains lock-free (JUCE contract).
+    void handleIncomingMidiMessage (juce::MidiInput* source,
+                                    const juce::MidiMessage& message) override;
+
+private:
+    juce::AudioDeviceManager* deviceManager = nullptr;
+    std::vector<MidiDeviceInfo> devices;
+    std::vector<std::unique_ptr<juce::MidiMessageCollector>> collectors;
+    int virtualKeyboardIndex = -1;
+
+    // Single reused juce scratch the RT drain removes into before copying to the
+    // dusk boundary buffer. drainBlock runs sequentially per input on the audio
+    // thread, so one instance suffices.
+    juce::MidiBuffer drainScratch;
+};
+
+// Owns the output-port bank plus the whole RT out-queue apparatus: the SPSC
+// FIFO the audio thread pushes per-port blocks into and the 1 ms pump thread
+// that drains it into sendBlockOfMessages where blocking is harmless.
+class MidiOutputBank
+{
+public:
+    MidiOutputBank();
+    ~MidiOutputBank();
+
+    // Message thread, audio callback DETACHED. Discard queued blocks (their port
+    // indices were minted against the old device order), close open outputs, and
+    // re-enumerate. Does NOT eager-open: opening every port at startup blocks the
+    // message thread on each snd_seq_connect_to and spawns a thread per port,
+    // stalling MainWindow::setVisible for seconds on USB-MIDI systems. Open on
+    // demand via ensureOpen. Session sync/MCU eager-opens stay with the engine.
+    void rebuild();
+
+    // Lazy open + start the port's background delivery thread so the pump's
+    // sendBlockOfMessages enqueues without blocking on the OS port. Message
+    // thread.
+    bool ensureOpen (int index);
+
+    void closeAll();
+
+    const std::vector<MidiDeviceInfo>& getDevices() const noexcept { return devices; }
+    int  getNumOutputs() const noexcept { return (int) outputs.size(); }
+    bool isOpen (int index) const noexcept;
+
+    // Message thread. Direct send with an ms-since-epoch base
+    // (getMillisecondCounterHiRes = "ASAP", lower latency than buffering for the
+    // next block). The juce overload is kept because McuController still builds
+    // juce buffers (events-tower coupling).
+    bool send (int index, const juce::MidiBuffer& events) noexcept;
+    // dusk overload: convert locally (alloc fine on the message thread) then send
+    // with the caller's sample rate as the timestamp base.
+    bool send (int index, const dusk::MidiBuffer& events, double sampleRate);
+
+    // Audio thread. sendBlockOfMessages is NOT audio-thread safe (it takes the
+    // delivery thread's mutex and heap-allocates under it). The audio thread
+    // instead pushes whole per-port blocks into the lock-free FIFO; the pump
+    // drains them. Slot buffers are pre-sized so the copy never allocates; a
+    // block past the slot cap OR a full queue drops the block (dropping clock
+    // bytes beats an xrun). timeMs/sampleRate carry the sample-offset→ms math.
+    void queueRt (int port, const dusk::MidiBuffer& events, double sampleRate) noexcept;
+
+    // Pump lifecycle (message thread). High priority so a loaded message thread
+    // can't starve clock / note delivery; still below the audio thread.
+    void startPump();
+    void stopPump();
+
+    // Convert a dusk event buffer into a juce one. Factored out so the send +
+    // queue conversions are unit-testable without a real output device.
+    static void toJuceBuffer (const dusk::MidiBuffer& in, juce::MidiBuffer& out);
+
+private:
+    void drainQueue();     // pump thread
+    bool sendJuce (int index, const juce::MidiBuffer& events, double sampleRate) noexcept;
+    static std::vector<MidiDeviceInfo> enumerate();
+
+    std::vector<MidiDeviceInfo> devices;
+    std::vector<std::unique_ptr<juce::MidiOutput>> outputs;
+
+    // Serialises the pump thread's port access against message-thread bank
+    // mutation (rebuild / ensureOpen). The audio thread never takes it — it only
+    // touches the FIFO writer side.
+    std::mutex bankMutex;
+
+    static constexpr int kQueueSlots = 64;
+    static constexpr int kSlotBytes  = 4096;
+    // juce::MidiBuffer per-event overhead: int32 samplePosition + uint16 length.
+    static constexpr int kJuceEventHeaderBytes = 6;
+    struct QueuedMidiOut
+    {
+        int    port       = -1;
+        double timeMs     = 0.0;
+        double sampleRate = 48000.0;
+        juce::MidiBuffer events;
+    };
+    juce::AbstractFifo fifo { kQueueSlots };
+    std::array<QueuedMidiOut, kQueueSlots> queue;
+
+    struct Pump final : juce::Thread
+    {
+        explicit Pump (MidiOutputBank& b) : juce::Thread ("Dusk Studio MIDI out"), bank (b) {}
+        void run() override;
+        MidiOutputBank& bank;
+    };
+    Pump pump { *this };
+};
+} // namespace duskstudio::midi

--- a/src/engine/midi/MidiDevices.h
+++ b/src/engine/midi/MidiDevices.h
@@ -120,12 +120,9 @@ public:
 
     // Message thread. Direct send with an ms-since-epoch base
     // (getMillisecondCounterHiRes = "ASAP", lower latency than buffering for the
-    // next block). The juce overload is kept because McuController still builds
-    // juce buffers (events-tower coupling).
+    // next block). juce-typed because McuController still builds juce buffers
+    // (events-tower coupling).
     bool send (int index, const juce::MidiBuffer& events) noexcept;
-    // dusk overload: convert locally (alloc fine on the message thread) then send
-    // with the caller's sample rate as the timestamp base.
-    bool send (int index, const dusk::MidiBuffer& events, double sampleRate);
 
     // Audio thread. sendBlockOfMessages is NOT audio-thread safe (it takes the
     // delivery thread's mutex and heap-allocates under it). The audio thread

--- a/src/foundation/MidiBuffer.h
+++ b/src/foundation/MidiBuffer.h
@@ -54,16 +54,20 @@ public:
     // freely like a plain vector.
     void reserveBytes (std::size_t n) { data.reserve (n); capBytes = n; }
 
-    void addEvent (const std::uint8_t* bytes, int numBytes, int samplePosition)
+    // Returns false when the event was dropped (invalid, or over the reserved
+    // cap) so RT callers can keep whole-block semantics instead of splitting
+    // paired events at the cap.
+    bool addEvent (const std::uint8_t* bytes, int numBytes, int samplePosition)
     {
-        if (numBytes <= 0 || bytes == nullptr) return;
+        if (numBytes <= 0 || bytes == nullptr) return false;
         const std::size_t base = data.size();
         const std::size_t need = kHeader + (std::size_t) numBytes;
-        if (base + need > capBytes) return;   // over the reserved cap: drop, never realloc
+        if (base + need > capBytes) return false;   // over the reserved cap: drop, never realloc
         data.resize (base + need);
         std::memcpy (data.data() + base,               &samplePosition, sizeof (int));
         std::memcpy (data.data() + base + sizeof (int), &numBytes,       sizeof (int));
         std::memcpy (data.data() + base + kHeader, bytes, (std::size_t) numBytes);
+        return true;
     }
 
     class Iterator

--- a/src/ui/AudioSettingsPanel.cpp
+++ b/src/ui/AudioSettingsPanel.cpp
@@ -834,7 +834,7 @@ void AudioSettingsPanel::applyMainOutputChange()
 
 void AudioSettingsPanel::populateSyncSourceCombo()
 {
-    // ID 1 = "(none)"; IDs 2..N+1 map to engine.midiInputDevices[i-2].
+    // ID 1 = "(none)"; IDs 2..N+1 map to engine.getMidiInputDevices()[i-2].
     // Identifier-based selection because indices shift on hot-plug.
     syncSourceCombo.clear (juce::dontSendNotification);
     syncSourceCombo.addItem ("(none)", 1);

--- a/src/ui/AudioSettingsPanel.cpp
+++ b/src/ui/AudioSettingsPanel.cpp
@@ -840,7 +840,7 @@ void AudioSettingsPanel::populateSyncSourceCombo()
     syncSourceCombo.addItem ("(none)", 1);
     const auto& devices = engine.getMidiInputDevices();
     int matchId = 1;
-    for (int i = 0; i < devices.size(); ++i)
+    for (int i = 0; i < (int) devices.size(); ++i)
     {
         syncSourceCombo.addItem (devices[i].name, i + 2);
         if (devices[i].identifier == session.syncSourceInputIdentifier)
@@ -860,7 +860,7 @@ void AudioSettingsPanel::applySyncSourceChange()
     }
     const auto& devices = engine.getMidiInputDevices();
     const int idx = id - 2;
-    if (idx < 0 || idx >= devices.size()) return;
+    if (idx < 0 || idx >= (int) devices.size()) return;
     session.syncSourceInputIdentifier = devices[idx].identifier;
     session.syncSourceInputIdx.store (idx, std::memory_order_release);
 }
@@ -873,7 +873,7 @@ void AudioSettingsPanel::populateSyncOutputCombo()
     syncOutputCombo.addItem ("(none)", 1);
     const auto& devices = engine.getMidiOutputDevices();
     int matchId = 1;
-    for (int i = 0; i < devices.size(); ++i)
+    for (int i = 0; i < (int) devices.size(); ++i)
     {
         syncOutputCombo.addItem (devices[i].name, i + 2);
         if (devices[i].identifier == session.syncOutputIdentifier)
@@ -893,7 +893,7 @@ void AudioSettingsPanel::applySyncOutputChange()
     }
     const auto& devices = engine.getMidiOutputDevices();
     const int idx = id - 2;
-    if (idx < 0 || idx >= devices.size()) return;
+    if (idx < 0 || idx >= (int) devices.size()) return;
     session.syncOutputIdentifier = devices[idx].identifier;
     session.syncOutputIdx.store (idx, std::memory_order_release);
     // Eagerly open the port so the first audio-thread emission doesn't
@@ -907,7 +907,7 @@ void AudioSettingsPanel::populateMcuInputCombo()
     mcuInputCombo.addItem ("(none)", 1);
     const auto& devices = engine.getMidiInputDevices();
     int matchId = 1;
-    for (int i = 0; i < devices.size(); ++i)
+    for (int i = 0; i < (int) devices.size(); ++i)
     {
         mcuInputCombo.addItem (devices[i].name, i + 2);
         if (devices[i].identifier == session.mcu.inputIdentifier)
@@ -922,7 +922,7 @@ void AudioSettingsPanel::populateMcuOutputCombo()
     mcuOutputCombo.addItem ("(none)", 1);
     const auto& devices = engine.getMidiOutputDevices();
     int matchId = 1;
-    for (int i = 0; i < devices.size(); ++i)
+    for (int i = 0; i < (int) devices.size(); ++i)
     {
         mcuOutputCombo.addItem (devices[i].name, i + 2);
         if (devices[i].identifier == session.mcu.outputIdentifier)
@@ -942,7 +942,7 @@ void AudioSettingsPanel::applyMcuInputChange()
     }
     const auto& devices = engine.getMidiInputDevices();
     const int idx = id - 2;
-    if (idx < 0 || idx >= devices.size()) return;
+    if (idx < 0 || idx >= (int) devices.size()) return;
     session.mcu.inputIdentifier = devices[idx].identifier;
     session.mcu.resolvedInputIdx.store (idx, std::memory_order_release);
 }
@@ -958,7 +958,7 @@ void AudioSettingsPanel::applyMcuOutputChange()
     }
     const auto& devices = engine.getMidiOutputDevices();
     const int idx = id - 2;
-    if (idx < 0 || idx >= devices.size()) return;
+    if (idx < 0 || idx >= (int) devices.size()) return;
     session.mcu.outputIdentifier = devices[idx].identifier;
     session.mcu.resolvedOutputIdx.store (idx, std::memory_order_release);
     // Eagerly open so the first 30 Hz emit doesn't race with ALSA's

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -1203,7 +1203,7 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
         if (idx >= 0)
         {
             const auto& inputs = engine.getMidiInputDevices();
-            track.midiInputIdentifier = (idx < inputs.size())
+            track.midiInputIdentifier = (idx < (int) inputs.size())
                                           ? inputs[idx].identifier
                                           : juce::String();
         }
@@ -1246,7 +1246,7 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
         if (idx >= 0)
         {
             const auto& outs = engine.getMidiOutputDevices();
-            track.midiOutputIdentifier = (idx < outs.size())
+            track.midiOutputIdentifier = (idx < (int) outs.size())
                                            ? outs[idx].identifier
                                            : juce::String();
             // Eagerly open the port so the first audio-thread emission
@@ -1567,7 +1567,7 @@ void ChannelStripComponent::rebuildMidiInputDropdown()
     midiInputSelector.clear (juce::dontSendNotification);
     midiInputSelector.addItem ("(none)", 1);
     const auto& inputs = engine.getMidiInputDevices();
-    for (int i = 0; i < inputs.size(); ++i)
+    for (int i = 0; i < (int) inputs.size(); ++i)
         midiInputSelector.addItem (inputs[i].name, 2 + i);
 
     // Prefer identifier-based selection when we have one - it survives
@@ -1576,7 +1576,7 @@ void ChannelStripComponent::rebuildMidiInputDropdown()
     int idx = -1;
     if (track.midiInputIdentifier.isNotEmpty())
     {
-        for (int i = 0; i < inputs.size(); ++i)
+        for (int i = 0; i < (int) inputs.size(); ++i)
         {
             if (inputs[i].identifier == track.midiInputIdentifier)
             {
@@ -1587,7 +1587,7 @@ void ChannelStripComponent::rebuildMidiInputDropdown()
     else
     {
         idx = track.midiInputIndex.load (std::memory_order_relaxed);
-        if (idx >= inputs.size()) idx = -1;
+        if (idx >= (int) inputs.size()) idx = -1;
     }
     track.midiInputIndex.store (idx, std::memory_order_relaxed);
     midiInputSelector.setSelectedId (idx >= 0 ? (2 + idx) : 1,
@@ -1601,13 +1601,13 @@ void ChannelStripComponent::rebuildMidiOutputDropdown()
     midiOutputSelector.clear (juce::dontSendNotification);
     midiOutputSelector.addItem ("(none)", 1);
     const auto& outs = engine.getMidiOutputDevices();
-    for (int i = 0; i < outs.size(); ++i)
+    for (int i = 0; i < (int) outs.size(); ++i)
         midiOutputSelector.addItem (outs[i].name, 2 + i);
 
     int idx = -1;
     if (track.midiOutputIdentifier.isNotEmpty())
     {
-        for (int i = 0; i < outs.size(); ++i)
+        for (int i = 0; i < (int) outs.size(); ++i)
         {
             if (outs[i].identifier == track.midiOutputIdentifier)
             {
@@ -1618,7 +1618,7 @@ void ChannelStripComponent::rebuildMidiOutputDropdown()
     else
     {
         idx = track.midiOutputIndex.load (std::memory_order_relaxed);
-        if (idx >= outs.size()) idx = -1;
+        if (idx >= (int) outs.size()) idx = -1;
     }
     track.midiOutputIndex.store (idx, std::memory_order_relaxed);
     midiOutputSelector.setSelectedId (idx >= 0 ? (2 + idx) : 1,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,6 +51,8 @@ add_executable(dusk-studio-tests
     pitch_detector.cpp
     recording_byte_accuracy.cpp
     midi_fifo_overflow.cpp
+    midi_device_layer.cpp
+    ${CMAKE_SOURCE_DIR}/src/engine/midi/MidiDevices.cpp
     midi_time_code_decode.cpp
     midi_time_code_emit.cpp
     midi_clock_drift.cpp

--- a/tests/midi_clock_drift.cpp
+++ b/tests/midi_clock_drift.cpp
@@ -3,9 +3,9 @@
 
 #include "engine/MidiClockEmitter.h"
 
-#include <juce_audio_basics/juce_audio_basics.h>
-
+#include <algorithm>
 #include <cmath>
+#include <cstdint>
 
 using duskstudio::MidiClockEmitter;
 using Catch::Matchers::WithinAbs;
@@ -15,8 +15,8 @@ namespace
 struct ClockRun
 {
     long long count = 0;
-    juce::int64 firstSample = -1;
-    juce::int64 lastSample  = -1;
+    std::int64_t firstSample = -1;
+    std::int64_t lastSample  = -1;
 };
 
 // Drive the emitter for `seconds` of audio in fixed blocks, counting F8 ticks
@@ -27,12 +27,12 @@ ClockRun runClock (double sr, float bpm, double seconds, int blockSize = 512)
     MidiClockEmitter e;
     e.prepare (sr);
 
-    const juce::int64 total = (juce::int64) (sr * seconds);
+    const std::int64_t total = (std::int64_t) (sr * seconds);
     ClockRun r;
-    juce::MidiBuffer buf;
-    for (juce::int64 start = 0; start < total; start += blockSize)
+    dusk::MidiBuffer buf;
+    for (std::int64_t start = 0; start < total; start += blockSize)
     {
-        const int n = (int) juce::jmin ((juce::int64) blockSize, total - start);
+        const int n = (int) std::min ((std::int64_t) blockSize, total - start);
         buf.clear();
         e.generateBlock (start, n, bpm, /*isRolling*/ true, buf);
         for (const auto m : buf)
@@ -40,7 +40,7 @@ ClockRun runClock (double sr, float bpm, double seconds, int blockSize = 512)
             const auto& msg = m.getMessage();
             if (msg.getRawDataSize() == 1 && msg.getRawData()[0] == 0xF8)
             {
-                const juce::int64 abs = start + m.samplePosition;
+                const std::int64_t abs = start + m.samplePosition;
                 if (r.firstSample < 0) r.firstSample = abs;
                 r.lastSample = abs;
                 ++r.count;
@@ -93,9 +93,9 @@ TEST_CASE ("MidiClockEmitter: transport edges emit Start / Stop", "[midiclock]")
 {
     MidiClockEmitter e;
     e.prepare (48000.0);
-    juce::MidiBuffer buf;
+    dusk::MidiBuffer buf;
 
-    auto countStatus = [] (const juce::MidiBuffer& b, juce::uint8 s)
+    auto countStatus = [] (const dusk::MidiBuffer& b, std::uint8_t s)
     {
         int n = 0;
         for (const auto m : b)

--- a/tests/midi_device_layer.cpp
+++ b/tests/midi_device_layer.cpp
@@ -1,0 +1,123 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <juce_audio_devices/juce_audio_devices.h>
+#include "engine/midi/MidiDevices.h"
+#include "foundation/MidiBuffer.h"
+#include <array>
+#include <cstdint>
+#include <vector>
+
+using duskstudio::midi::MidiInputClient;
+using duskstudio::midi::MidiOutputBank;
+
+TEST_CASE ("MidiInputClient appends a stable Virtual-Keyboard slot", "[midi][devices]")
+{
+    juce::AudioDeviceManager dm;
+    MidiInputClient client;
+    client.setDeviceManager (dm);
+    client.rebuild (48000.0);
+
+    const int vkb = client.getVirtualKeyboardIndex();
+    REQUIRE (vkb >= 0);
+    REQUIRE (client.getVirtualKeyboardCollector() != nullptr);
+
+    // VKB is always the last slot, carrying the fixed identifier.
+    const auto& devs = client.getDevices();
+    REQUIRE (vkb == (int) devs.size() - 1);
+    REQUIRE (client.getNumInputs() == (int) devs.size());
+    REQUIRE (devs[(size_t) vkb].identifier
+             == juce::String (MidiInputClient::kVirtualKeyboardIdentifier));
+}
+
+TEST_CASE ("MidiInputClient VKB feed round-trips through the dusk boundary", "[midi][devices]")
+{
+    juce::AudioDeviceManager dm;
+    MidiInputClient client;
+    client.setDeviceManager (dm);
+    client.rebuild (48000.0);
+
+    const int vkb = client.getVirtualKeyboardIndex();
+    auto* col = client.getVirtualKeyboardCollector();
+    REQUIRE (col != nullptr);
+
+    // Feed a note-on the way the on-screen keyboard does: an ms-since-epoch
+    // timestamp (the collector asserts on a zero stamp and derives the sample
+    // offset from it).
+    auto noteOn = juce::MidiMessage::noteOn (1, 60, (juce::uint8) 100);
+    noteOn.setTimeStamp (juce::Time::getMillisecondCounterHiRes() * 0.001);
+    col->addMessageToQueue (noteOn);
+
+    constexpr int numSamples = 512;
+    dusk::MidiBuffer out;
+    out.reserveBytes (4096);
+    client.drainBlock (vkb, out, numSamples);
+
+    int count = 0;
+    for (const auto meta : out)
+    {
+        ++count;
+        const auto& m = meta.getMessage();
+        REQUIRE (m.getRawDataSize() == 3);
+        const auto* b = m.getRawData();
+        REQUIRE ((b[0] & 0xf0) == 0x90);   // note-on
+        REQUIRE ((b[0] & 0x0f) == 0x00);   // channel 1
+        REQUIRE (b[1] == 60);
+        REQUIRE (b[2] == 100);
+        // The collector clamps the offset into the requested block.
+        REQUIRE (meta.samplePosition >= 0);
+        REQUIRE (meta.samplePosition < numSamples);
+    }
+    REQUIRE (count == 1);
+}
+
+TEST_CASE ("MidiInputClient drainBlock clears and bounds-checks", "[midi][devices]")
+{
+    juce::AudioDeviceManager dm;
+    MidiInputClient client;
+    client.setDeviceManager (dm);
+    client.rebuild (48000.0);
+
+    dusk::MidiBuffer out;
+    out.reserveBytes (256);
+
+    // Out-of-range index just clears the destination.
+    const std::uint8_t junk[3] = { 0x90, 1, 1 };
+    out.addEvent (junk, 3, 0);
+    client.drainBlock (9999, out, 256);
+    REQUIRE (out.isEmpty());
+
+    // Empty collector -> empty out.
+    client.drainBlock (client.getVirtualKeyboardIndex(), out, 256);
+    REQUIRE (out.isEmpty());
+}
+
+TEST_CASE ("MidiOutputBank dusk->juce conversion preserves bytes + offsets", "[midi][devices]")
+{
+    dusk::MidiBuffer in;
+    in.reserveBytes (256);
+    const std::uint8_t noteOn[3]  = { 0x90, 60, 100 };
+    const std::uint8_t cc[3]      = { 0xB0, 7, 127 };
+    const std::uint8_t noteOff[3] = { 0x80, 60, 0 };
+    in.addEvent (noteOn,  3, 0);
+    in.addEvent (cc,      3, 128);
+    in.addEvent (noteOff, 3, 400);
+
+    juce::MidiBuffer juceOut;
+    MidiOutputBank::toJuceBuffer (in, juceOut);
+
+    struct Ev { int pos; std::array<std::uint8_t, 3> b; };
+    std::vector<Ev> got;
+    for (const auto meta : juceOut)
+    {
+        REQUIRE (meta.numBytes == 3);
+        got.push_back ({ meta.samplePosition,
+                         { meta.data[0], meta.data[1], meta.data[2] } });
+    }
+
+    REQUIRE (got.size() == 3);
+    // juce::MidiBuffer keeps events sorted by sample position; the inputs were
+    // already ascending, so the order carries over 1:1.
+    REQUIRE (got[0].pos == 0);   REQUIRE (got[0].b[0] == 0x90);
+    REQUIRE (got[1].pos == 128); REQUIRE (got[1].b[0] == 0xB0);
+    REQUIRE (got[2].pos == 400); REQUIRE (got[2].b[0] == 0x80);
+}

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -58,6 +58,8 @@ src/engine/ipc/PluginIpc.h
 src/engine/ipc/PluginScanProtocol.h
 src/engine/ipc/RemotePluginConnection.cpp
 src/engine/ipc/RemotePluginConnection.h
+src/engine/midi/MidiDevices.cpp
+src/engine/midi/MidiDevices.h
 src/engine/multisample/AriaBank.cpp
 src/engine/multisample/AriaBank.h
 src/engine/multisample/AriaGui.cpp

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -27,8 +27,6 @@ src/engine/MasteringPlayer.cpp
 src/engine/MasteringPlayer.h
 src/engine/McuController.cpp
 src/engine/McuController.h
-src/engine/MidiClockEmitter.cpp
-src/engine/MidiClockEmitter.h
 src/engine/NativeScanRows.h
 src/engine/PlaybackEngine.cpp
 src/engine/PlaybackEngine.h


### PR DESCRIPTION
Moves AudioEngine's JUCE MIDI device plumbing behind a seam layer whose boundary type is dusk::MidiBuffer — the slot a native ALSA-sequencer backend later drops into.

- New src/engine/midi/MidiDevices.{h,cpp}: MidiInputClient (enumeration, per-input lock-free collectors, the virtual-keyboard synthetic slot, RT drainBlock into dusk buffers) and MidiOutputBank (lazy open, message-thread send, the RT SPSC queue + 1 ms pump moved verbatim from the engine).
- AudioEngine flip: engine-side banks/input-callback/out-FIFO/pump deleted (net -313 lines); perInputMidi and the clock-out scratch unify on dusk::MidiBuffer; the sync/MCU/MTC receiver bridges collapse to direct passes; per-track routing keeps one dusk-to-JUCE bridge (PluginSlot + RecordManager stay JUCE-typed). MIDI banks now build before any callback registration (closes a ctor-window race on perInputMidi).
- MidiClockEmitter emits raw bytes into the shared dusk scratch and leaves the allowlist with its cpp. Ratchet nets zero for the tower (the seam pair replaces the emitter pair); the payoff is the framework-free boundary.
- Review round applied: 16 KB drain scratch (no RT realloc), addEvent drop reporting + whole-block-or-nothing per-track out bridge, test-inject lower bound, dead overload removed.

Verification: 364/364 Catch2 (4 new device-layer tests + clock-drift suite rewritten dusk-side), selftest 26 PASS / 0 FAIL under Xvfb including live device enumeration (Midi-Bridge, BLE MIDI), juce-gate exit 0 at 202.

Hardware note for the bench pass: MIDI clock / MTC output timing now flows through the moved pump — worth a check against external gear before the 0.12 tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated MIDI device layer supporting MIDI input, output, virtual keyboard input, and reliable device refresh.
  * Improved MIDI clock, controller, and track output delivery with more dependable real-time processing.
  * MIDI device selections now remain correctly associated when devices are refreshed.

* **Bug Fixes**
  * Improved validation for MIDI device selections and prevented invalid device access.

* **Tests**
  * Added coverage for virtual keyboard input, MIDI event conversion, device handling, and clock timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->