### PR TITLE
Fail cleanly when no X display is reachable at launch

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -318,7 +318,7 @@ Assign a strip to one of eight fader groups (right-click the strip → **Fader g
 
 ## System requirements
 
-- **Linux**: PipeWire (recommended) or JACK or ALSA. JUCE 8's JACK backend drives PipeWire transparently.
+- **Linux**: PipeWire (recommended) or JACK or ALSA. JUCE 8's JACK backend drives PipeWire transparently. An X11 display is required: on a Wayland desktop this means XWayland (present and enabled by default on GNOME and KDE; compositors like sway, niri and labwc can run without it — enable it there, or Dusk Studio will refuse to start with a message pointing here).
 - **macOS**: 14.4 (Sonoma) or later for the out-of-process plugin sandbox; older macOS still runs plugins in-process.
 - **Windows**: Windows 10 or later, ASIO driver recommended.
 

--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -1338,6 +1338,31 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
         return;
     }
 
+    // Preflight the windowing system before touching anything that opens
+    // a native window (Desktop display enumeration, the main window). Dusk
+    // Studio's Linux UI is X11-only — the main window and every plugin-
+    // editor peer are X11 surfaces, reached via XWayland on a Wayland
+    // session — so a pure-Wayland session with XWayland disabled (sway
+    // without `xwayland enable`, niri/labwc without an XWayland satellite)
+    // has no display we can open. Without this guard JUCE null-derefs deep
+    // inside window creation and the process core-dumps with no usable
+    // message. All headless env-gate paths above have already returned, so
+    // this is only reached by a real GUI launch.
+    if (! duskstudio::platform::hasUsableDisplay())
+    {
+        std::fprintf (stderr,
+            "Dusk Studio needs an X11 display and could not open one.\n"
+            "This is a Wayland session without XWayland. Enable it, then relaunch:\n"
+            "  sway:   add `xwayland enable` to your config and restart sway\n"
+            "  niri:   run `xwayland-satellite` and export the DISPLAY it prints\n"
+            "  labwc:  start labwc with XWayland enabled (the default build)\n"
+            "  river / mango / other wlroots: ensure XWayland is installed and enabled\n");
+        std::fflush (stderr);
+        setApplicationReturnValue (1);
+        quit();
+        return;
+    }
+
     // Install crash handler + FileLogger AFTER every selftest env-gate
     // above has had its chance to quit. Self-test paths don't want
     // stray daily log files littering the user's data dir (or CI

--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -185,6 +185,25 @@ public:
 DuskStudioApp::DuskStudioApp() = default;
 DuskStudioApp::~DuskStudioApp() = default;
 
+// True when a native window can be created; on failure prints the XWayland
+// guidance. Called before the main window AND at the top of each *_EDITOR_TEST
+// gate (those open real X11 windows too) — but never on the headless paths,
+// which must keep running without any display.
+static bool displayUsableOrExplain()
+{
+    if (duskstudio::platform::hasUsableDisplay())
+        return true;
+    std::fprintf (stderr,
+        "Dusk Studio needs an X11 display and could not open one.\n"
+        "This is a Wayland session without XWayland. Enable it, then relaunch:\n"
+        "  sway:   add `xwayland enable` to your config and restart sway\n"
+        "  niri:   run `xwayland-satellite` and export the DISPLAY it prints\n"
+        "  labwc:  start labwc with XWayland enabled (the default build)\n"
+        "  river / mango / other wlroots: ensure XWayland is installed and enabled\n");
+    std::fflush (stderr);
+    return false;
+}
+
 #if JUCE_LINUX
 static void primeRealtimeAudio()
 {
@@ -1006,6 +1025,7 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
     if (const char* path = std::getenv ("DUSKSTUDIO_CLAP_EDITOR_TEST"); path != nullptr && *path)
     {
+        if (! displayUsableOrExplain()) { setApplicationReturnValue (1); quit(); return; }
         duskstudio::platform::preferX11ForNextNativeWindow();   // editor host needs an X11 peer
         auto comp = std::make_unique<duskstudio::ClapPluginEditorComponent>();
         juce::String err;
@@ -1045,6 +1065,7 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
 #if DUSKSTUDIO_HAS_NATIVE_LV2
     if (const char* path = std::getenv ("DUSKSTUDIO_LV2_EDITOR_TEST"); path != nullptr && *path)
     {
+        if (! displayUsableOrExplain()) { setApplicationReturnValue (1); quit(); return; }
         duskstudio::platform::preferX11ForNextNativeWindow();   // editor host needs an X11 peer
         lv2EditorTest = std::make_unique<Lv2EditorTest>();
         std::string err;
@@ -1088,6 +1109,7 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
 #if DUSKSTUDIO_HAS_NATIVE_VST3
     if (const char* path = std::getenv ("DUSKSTUDIO_VST3_EDITOR_TEST"); path != nullptr && *path)
     {
+        if (! displayUsableOrExplain()) { setApplicationReturnValue (1); quit(); return; }
         duskstudio::platform::preferX11ForNextNativeWindow();   // editor host needs an X11 peer
         vst3EditorTest = std::make_unique<Vst3EditorTest>();
         std::string err;
@@ -1348,16 +1370,8 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
     // inside window creation and the process core-dumps with no usable
     // message. All headless env-gate paths above have already returned, so
     // this is only reached by a real GUI launch.
-    if (! duskstudio::platform::hasUsableDisplay())
+    if (! displayUsableOrExplain())
     {
-        std::fprintf (stderr,
-            "Dusk Studio needs an X11 display and could not open one.\n"
-            "This is a Wayland session without XWayland. Enable it, then relaunch:\n"
-            "  sway:   add `xwayland enable` to your config and restart sway\n"
-            "  niri:   run `xwayland-satellite` and export the DISPLAY it prints\n"
-            "  labwc:  start labwc with XWayland enabled (the default build)\n"
-            "  river / mango / other wlroots: ensure XWayland is installed and enabled\n");
-        std::fflush (stderr);
         setApplicationReturnValue (1);
         quit();
         return;

--- a/src/ui/PlatformWindowing.h
+++ b/src/ui/PlatformWindowing.h
@@ -27,6 +27,18 @@ namespace duskstudio::platform
 // Linux, so the platform asymmetry of past bug reports does NOT mean
 // the other platforms are bug-free.
 
+// Preflight, before any window is created: true when a native display
+// connection can actually be opened. Dusk Studio's Linux UI is X11-only
+// (the main window and every plugin-editor peer are X11 surfaces, via
+// XWayland on a Wayland session), so this reports whether an X server /
+// XWayland is reachable. A pure-Wayland session with XWayland disabled
+// returns false; the caller prints guidance and exits cleanly instead of
+// letting JUCE null-deref deep inside window creation and core-dump.
+//
+// macOS / Windows: always true — their native windowing is present once
+// the process has a GUI session.
+bool hasUsableDisplay();
+
 // Bring the given window's native peer to the foreground and grant it
 // focus. Used after creating a fresh top-level window (main window,
 // plugin editor) so the WM doesn't bury it under existing windows or

--- a/src/ui/PlatformWindowing_Linux.cpp
+++ b/src/ui/PlatformWindowing_Linux.cpp
@@ -104,6 +104,21 @@ juce::ComponentPeer* pickSiblingFocusTargetPeer (juce::Component& departing)
 }
 } // namespace
 
+bool hasUsableDisplay()
+{
+    // JUCE's XWindowSystem is lazy and not yet created at preflight time,
+    // so we can't reuse its ::Display*; open a throwaway connection.
+    // XOpenDisplay(nullptr) reads $DISPLAY itself and returns null when no
+    // X server / XWayland is reachable — the "pure Wayland, no XWayland"
+    // case that otherwise crashes deep in JUCE window creation.
+    if (::Display* d = ::XOpenDisplay (nullptr))
+    {
+        ::XCloseDisplay (d);
+        return true;
+    }
+    return false;
+}
+
 void installNonFatalXErrorHandler()
 {
     // Install once. XSetErrorHandler returns the previously-installed handler

--- a/src/ui/PlatformWindowing_Mac.mm
+++ b/src/ui/PlatformWindowing_Mac.mm
@@ -104,6 +104,7 @@ private:
 } // namespace
 
 
+bool hasUsableDisplay()                                   { return true; }
 void bringWindowToFront (juce::ComponentPeer&)             {}
 void flushWindowOperations()                                {}
 void prepareNativePeerForChildAttach (juce::ComponentPeer&) {}

--- a/src/ui/PlatformWindowing_Windows.cpp
+++ b/src/ui/PlatformWindowing_Windows.cpp
@@ -115,6 +115,7 @@ void prepareForTopLevelDestruction (juce::Component& topLevel)
     juce::Component::unfocusAllComponents();
     topLevel.giveAwayKeyboardFocus();
 }
+bool hasUsableDisplay() { return true; }   // native windowing always present
 void clearXInputFocus() {}                 // X-only; no-op on Windows
 void requestFocusOnMainWaylandSurface() {} // Wayland-only; no-op on Windows
 void preferX11ForNextNativeWindow() {}     // Linux-only; no-op on Windows


### PR DESCRIPTION
Fixes the crash from #56 (0.11.1 core dump on pure-Wayland sessions).

Root cause: on a Wayland session without XWayland, JUCE's X11 backend records the failed XOpenDisplay but window creation dereferences the null display anyway — SIGSEGV in ResizableWindow::restoreWindowStateFromString during MainWindow construction. All four compositors in the report (sway, niri, mango, labwc) can run without XWayland.

Fix: a pre-GUI preflight (platformwindowing::hasUsableDisplay, a throwaway XOpenDisplay probe on Linux, trivially true on macOS/Windows) runs after every headless env-gate path and before the crash handler + main window. On failure it prints per-compositor XWayland guidance to stderr and exits 1 instead of core dumping. The X11/XWayland requirement itself stands until the GUI moves off JUCE, and is now stated in MANUAL.md's system requirements.

Verified: dead-display and no-display runs print the guidance and exit 1; Xvfb selftest 26 PASS / 0 FAIL (headless paths unaffected); 364/364 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability on Linux systems using Wayland.
  * The application now checks for a usable display before launching and exits with a clear error instead of crashing when XWayland is unavailable.

* **Documentation**
  * Updated Linux system requirements to clarify XWayland requirements for Wayland desktops.
  * Added notes about compositor-specific behavior and the need for XWayland to be enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->