### PR TITLE
0.12.0 release prep: JUCE pin standardization, Wayland launch fix, workflow hardening

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -47,61 +47,34 @@ jobs:
             libwebkit2gtk-4.0-dev libglu1-mesa-dev xvfb \
             libwayland-dev libxkbcommon-dev libdecor-0-dev
 
-      - name: Clone JUCE 8.0.4 (upstream)
-        # CI uses upstream JUCE. The plugdata-team wayland-juce8 fork
-        # carries 5 local commits (XEmbed mapping, SIMD<int64> alias,
-        # Wayland peer-creation latch, etc.) that exist only on the dev
-        # box — not pushable. The runtime-only fixes (XEmbed, Wayland
-        # peer) don't matter for CI; the SIMD<long long> alias does
-        # because GCC on x86_64 instantiates SIMDRegister<long long>
-        # for jmax<juce::int64>(). Patch it in below.
+      - name: Clone JUCE (Dusk-owned Wayland mirror, pinned)
+        # CI builds against the SAME Dusk-owned mirror snapshot the release
+        # uses (dusk-audio/JUCE-wayland, immutable tag), NOT upstream + a
+        # SIMD patch. The snapshot already carries the SIMDNativeOps<long
+        # long> alias GCC needs for jmax<juce::int64>() on x86_64/arm64,
+        # plus the Wayland/XEmbed runtime fixes — so no separate patch step,
+        # and CI compiles the exact tree a release ships. To bump JUCE, push
+        # a new snapshot tag to the mirror and update JUCE_TAG / JUCE_REV
+        # here + in linux-release.yml. Mac + Windows stay on upstream.
         # JuceCompat.h picks the right addDefaultFormats API via the
         # DUSKSTUDIO_JUCE_HAS_FREE_ADD_FORMATS preprocessor define (CMake
         # detects which surface is present at configure time).
+        env:
+          JUCE_MIRROR: https://github.com/dusk-audio/JUCE-wayland.git
+          JUCE_TAG: dusk-wayland-v2
+          JUCE_REV: 4d85afa175a45e0b5da11f9211de3ba88705588e
         run: |
-          git clone --depth 1 --branch 8.0.4 \
-            https://github.com/juce-framework/JUCE.git \
-            "${RUNNER_TEMP}/JUCE-wayland"
-
-      - name: Patch JUCE — SIMDNativeOps<long long> alias for x86_64 + arm64 Linux
-        # Upstream JUCE 8.0.4's per-arch SIMDNativeOps headers
-        # (juce_SIMDNativeOps_sse.h for x86, _neon.h for arm) define
-        # SIMDNativeOps<int64_t> but not SIMDNativeOps<long long>. On
-        # GCC the two are distinct types (long long is 64-bit; int64_t
-        # is the same width but a different name) and JUCE's template
-        # machinery instantiates SIMDRegister<long long> for any
-        # jmax<juce::int64>() call — incomplete type, hard error.
-        # The plugdata-team JUCE-wayland fork adds these two aliases;
-        # we apply them here on BOTH the SSE and NEON variants so the
-        # build is clean on amd64 + arm64.
-        run: |
-          patch_simd_file() {
-            local file="$1"
-            if [ ! -f "$file" ]; then
-              echo "Skipping $file — not present in this JUCE checkout."
-              return 0
-            fi
-            # Tolerant match: a closing brace then a // comment
-            # mentioning both "juce" and "dsp" — survives upstream
-            # whitespace / comment rewording.
-            awk '
-              /^}[[:space:]]*\/\/.*juce.*dsp/ && !done {
-                print "#if defined (__GNUC__) && defined (__SIZEOF_LONG__) && __SIZEOF_LONG__ == 8 && !defined (_WIN32)"
-                print "template <> struct SIMDNativeOps<long long> : SIMDNativeOps<int64_t> {};"
-                print "template <> struct SIMDNativeOps<unsigned long long> : SIMDNativeOps<uint64_t> {};"
-                print "#endif"
-                done = 1
-              }
-              { print }
-            ' "$file" > "$file.new" && mv "$file.new" "$file"
-            echo "Patched: $file"
-            if ! grep -q "SIMDNativeOps<long long>" "$file"; then
-              echo "ERROR: SIMDNativeOps<long long> alias not present after patching $file." >&2
-              return 1
-            fi
-          }
-          patch_simd_file "${RUNNER_TEMP}/JUCE-wayland/modules/juce_dsp/native/juce_SIMDNativeOps_sse.h"
-          patch_simd_file "${RUNNER_TEMP}/JUCE-wayland/modules/juce_dsp/native/juce_SIMDNativeOps_neon.h"
+          set -euo pipefail
+          git init -q "${RUNNER_TEMP}/JUCE-wayland"
+          cd "${RUNNER_TEMP}/JUCE-wayland"
+          git remote add origin "${JUCE_MIRROR}"
+          git fetch --depth 1 origin "refs/tags/${JUCE_TAG}"
+          git checkout -q FETCH_HEAD
+          [[ "$(git rev-parse HEAD)" == "${JUCE_REV}" ]] || {
+            echo "ERROR: JUCE checkout $(git rev-parse HEAD) != pinned ${JUCE_REV}" >&2; exit 1; }
+          grep -q "SIMDNativeOps<long long>" \
+            modules/juce_dsp/native/juce_SIMDNativeOps_sse.h || {
+            echo "ERROR: pinned JUCE missing the SIMDNativeOps<long long> alias." >&2; exit 1; }
 
       - name: Clone Dusk plugins (donor DSP)
         run: |
@@ -174,30 +147,27 @@ jobs:
             libwebkit2gtk-4.0-dev libglu1-mesa-dev \
             libwayland-dev libxkbcommon-dev libdecor-0-dev
 
-      - name: Clone JUCE 8.0.4 (upstream)
-        # See build-job rationale above. Same upstream + same SIMD patch.
+      - name: Clone JUCE (Dusk-owned Wayland mirror, pinned)
+        # Same pinned Dusk-owned mirror snapshot as the build job above; the
+        # snapshot already carries the SIMDNativeOps<long long> alias, so no
+        # patch step. Keep JUCE_TAG / JUCE_REV in lockstep with the build job
+        # and linux-release.yml.
+        env:
+          JUCE_MIRROR: https://github.com/dusk-audio/JUCE-wayland.git
+          JUCE_TAG: dusk-wayland-v2
+          JUCE_REV: 4d85afa175a45e0b5da11f9211de3ba88705588e
         run: |
-          git clone --depth 1 --branch 8.0.4 \
-            https://github.com/juce-framework/JUCE.git \
-            "${RUNNER_TEMP}/JUCE-wayland"
-
-      - name: Patch JUCE — SIMDNativeOps<long long> alias for x86_64 Linux
-        run: |
-          file="${RUNNER_TEMP}/JUCE-wayland/modules/juce_dsp/native/juce_SIMDNativeOps_sse.h"
-          awk '
-            /^}[[:space:]]*\/\/.*juce.*dsp/ && !done {
-              print "#if defined (__GNUC__) && defined (__SIZEOF_LONG__) && __SIZEOF_LONG__ == 8 && !defined (_WIN32)"
-              print "template <> struct SIMDNativeOps<long long> : SIMDNativeOps<int64_t> {};"
-              print "template <> struct SIMDNativeOps<unsigned long long> : SIMDNativeOps<uint64_t> {};"
-              print "#endif"
-              done = 1
-            }
-            { print }
-          ' "$file" > "$file.new" && mv "$file.new" "$file"
-          if ! grep -q "SIMDNativeOps<long long>" "$file"; then
-            echo "ERROR: SIMDNativeOps<long long> alias not present after patch — the awk anchor likely no longer matches upstream JUCE." >&2
-            exit 1
-          fi
+          set -euo pipefail
+          git init -q "${RUNNER_TEMP}/JUCE-wayland"
+          cd "${RUNNER_TEMP}/JUCE-wayland"
+          git remote add origin "${JUCE_MIRROR}"
+          git fetch --depth 1 origin "refs/tags/${JUCE_TAG}"
+          git checkout -q FETCH_HEAD
+          [[ "$(git rev-parse HEAD)" == "${JUCE_REV}" ]] || {
+            echo "ERROR: JUCE checkout $(git rev-parse HEAD) != pinned ${JUCE_REV}" >&2; exit 1; }
+          grep -q "SIMDNativeOps<long long>" \
+            modules/juce_dsp/native/juce_SIMDNativeOps_sse.h || {
+            echo "ERROR: pinned JUCE missing the SIMDNativeOps<long long> alias." >&2; exit 1; }
 
       - name: Clone Dusk plugins (donor DSP)
         run: |

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -110,8 +110,8 @@ jobs:
         # Mac + Windows stay on upstream.
         env:
           JUCE_MIRROR: https://github.com/dusk-audio/JUCE-wayland.git
-          JUCE_TAG: dusk-wayland-v1
-          JUCE_REV: 46ab52f4b6e12acf24309fefb6c349f3f78ed52e
+          JUCE_TAG: dusk-wayland-v2
+          JUCE_REV: 4d85afa175a45e0b5da11f9211de3ba88705588e
         run: |
           set -euo pipefail
           git init -q "${RUNNER_TEMP}/JUCE-wayland"

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -97,9 +97,9 @@ jobs:
         # Linux ships against the Wayland fork, NOT upstream: it carries the
         # XEmbed mapping / X11-on-Wayland / peer-creation-latch commits that
         # plugin-editor hosting on Wayland depends on, plus the
-        # SIMDNativeOps<long long> alias GCC needs for int64 SIMD (so no
-        # separate patch step — re-applying it would duplicate the
-        # specialization and fail to compile).
+        # SIMDNativeOps<long long> alias GCC needs for int64 SIMD (present on
+        # the SSE header, so x86_64 needs no patch; the aarch64 leg patches the
+        # NEON header — see below).
         #
         # Pinned to a Dusk-OWNED mirror (dusk-audio/JUCE-wayland), NOT the
         # upstream plugdata-team fork: that fork rebased + GC'd the exact commit
@@ -108,6 +108,13 @@ jobs:
         # can't be broken by a third-party fork's history rewrite. To bump JUCE,
         # push a new snapshot tag to the mirror and update JUCE_TAG / JUCE_REV.
         # Mac + Windows stay on upstream.
+        #
+        # The snapshot carries the SIMDNativeOps<long long> alias on the SSE
+        # header (x86_64) but NOT the NEON one, so the aarch64 matrix leg patches
+        # the NEON header when the alias is absent (same rationale as
+        # raspberry-pi-build.yml). Applied conditionally, so it is a no-op on
+        # x86_64 (NEON header not compiled) and on any future snapshot that
+        # already ships the alias — double-defining it would fail to compile.
         env:
           JUCE_MIRROR: https://github.com/dusk-audio/JUCE-wayland.git
           JUCE_TAG: dusk-wayland-v2
@@ -123,7 +130,22 @@ jobs:
             echo "ERROR: JUCE checkout $(git rev-parse HEAD) != pinned ${JUCE_REV}" >&2; exit 1; }
           grep -q "SIMDNativeOps<long long>" \
             modules/juce_dsp/native/juce_SIMDNativeOps_sse.h || {
-            echo "ERROR: pinned JUCE missing the SIMDNativeOps<long long> alias." >&2; exit 1; }
+            echo "ERROR: pinned JUCE missing the SIMDNativeOps<long long> alias (SSE)." >&2; exit 1; }
+          neon="modules/juce_dsp/native/juce_SIMDNativeOps_neon.h"
+          if ! grep -q "SIMDNativeOps<long long>" "$neon"; then
+            awk '
+              /^}[[:space:]]*\/\/.*juce.*dsp/ && !done {
+                print "#if defined (__GNUC__) && defined (__SIZEOF_LONG__) && __SIZEOF_LONG__ == 8 && !defined (_WIN32)"
+                print "template <> struct SIMDNativeOps<long long> : SIMDNativeOps<int64_t> {};"
+                print "template <> struct SIMDNativeOps<unsigned long long> : SIMDNativeOps<uint64_t> {};"
+                print "#endif"
+                done = 1
+              }
+              { print }
+            ' "$neon" > "$neon.new" && mv "$neon.new" "$neon"
+            grep -q "SIMDNativeOps<long long>" "$neon" || {
+              echo "ERROR: NEON SIMDNativeOps<long long> alias still missing after patch (awk anchor no longer matches the mirror header)." >&2; exit 1; }
+          fi
 
       - name: Clone Dusk plugins (donor DSP, pinned)
         # Pinned to a specific donor SHA, mirroring the JUCE pin above. An

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -66,8 +66,10 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASES_REPO_TOKEN }}
         run: |
           set -euo pipefail
-          if ! gh api "repos/${RELEASES_REPO}" >/dev/null; then
-            echo "::error::RELEASES_REPO_TOKEN cannot access ${RELEASES_REPO} (expired, revoked, or missing contents scope). Rotate the RELEASES_REPO_TOKEN secret with contents:write on that repo, then re-run this workflow." >&2
+          # .permissions.push reflects contents:write for the token; a read-only
+          # token can fetch repo metadata and would pass a bare existence probe.
+          if [[ "$(gh api "repos/${RELEASES_REPO}" --jq '.permissions.push // false' 2>/dev/null)" != "true" ]]; then
+            echo "::error::RELEASES_REPO_TOKEN cannot WRITE to ${RELEASES_REPO} (expired, revoked, or missing contents:write). Rotate the RELEASES_REPO_TOKEN secret with contents:write on that repo, then re-run this workflow." >&2
             exit 1
           fi
 

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -55,6 +55,22 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
+      - name: Preflight - releases-repo token is valid (tag builds only)
+        # Fail fast BEFORE the ~17-minute build if RELEASES_REPO_TOKEN is dead.
+        # A v0.12.0 run once burned a full green build then hit HTTP 401 at the
+        # publish step (expired token), and the `|| echo raced` fallback masked
+        # it as a benign race. Probe the token up front so an expired/revoked
+        # secret stops the run in seconds. Mirrors the publish step's tag guard.
+        if: ${{ github.ref_type == 'tag' }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASES_REPO_TOKEN }}
+        run: |
+          set -euo pipefail
+          if ! gh api "repos/${RELEASES_REPO}" >/dev/null; then
+            echo "::error::RELEASES_REPO_TOKEN cannot access ${RELEASES_REPO} (expired, revoked, or missing contents scope). Rotate the RELEASES_REPO_TOKEN secret with contents:write on that repo, then re-run this workflow." >&2
+            exit 1
+          fi
+
       - name: Verify tag matches VERSION
         # Assets are named from the VERSION file, not the tag — a mismatch
         # would publish wrongly-labelled artifacts silently.
@@ -109,11 +125,23 @@ jobs:
             modules/juce_dsp/native/juce_SIMDNativeOps_sse.h || {
             echo "ERROR: pinned JUCE missing the SIMDNativeOps<long long> alias." >&2; exit 1; }
 
-      - name: Clone Dusk plugins (donor DSP)
+      - name: Clone Dusk plugins (donor DSP, pinned)
+        # Pinned to a specific donor SHA, mirroring the JUCE pin above. An
+        # unpinned `git clone` of main HEAD makes old tags non-reproducible:
+        # a later donor commit would silently change the DSP a past release
+        # was built from. To move the donor forward, bump DONOR_REV.
+        env:
+          DONOR_REPO: https://github.com/dusk-audio/dusk-audio-plugins.git
+          DONOR_REV: 69f04318e3b7063e382c80ac1cde2388170e668b
         run: |
-          git clone --depth 1 \
-            https://github.com/dusk-audio/dusk-audio-plugins.git \
-            "${RUNNER_TEMP}/plugins-main"
+          set -euo pipefail
+          git init -q "${RUNNER_TEMP}/plugins-main"
+          cd "${RUNNER_TEMP}/plugins-main"
+          git remote add origin "${DONOR_REPO}"
+          git fetch --depth 1 origin "${DONOR_REV}"
+          git checkout -q "${DONOR_REV}"
+          [[ "$(git rev-parse HEAD)" == "${DONOR_REV}" ]] || {
+            echo "ERROR: donor checkout $(git rev-parse HEAD) != pinned ${DONOR_REV}" >&2; exit 1; }
 
       - name: Refresh Patreon supporters (best-effort)
         # Bakes the live supporters list into the release binary via
@@ -209,17 +237,26 @@ jobs:
           fi
           ASSETS=( "${TARBALLS[@]}" "SHA256SUMS.linux-${ARCH}" )
 
-          # The amd64 + arm64 matrix jobs publish to the SAME tag in parallel, so
-          # the release may be absent when we look yet created by the sibling a
-          # moment later. Create best-effort (tolerate the race), then always
-          # upload our arch's assets with --clobber. Asset names carry the arch,
-          # so the two jobs never overwrite each other's tarballs.
+          # The amd64 + arm64 matrix jobs publish to the SAME tag in parallel,
+          # so the release may be absent when we look yet created by the sibling
+          # a moment later. That race is benign; a real create failure (e.g. a
+          # dead token) is NOT. Distinguish them: if `create` fails, re-check
+          # existence - only a still-absent release is fatal, and we surface the
+          # actual create error before exiting. Asset names carry the arch, so
+          # the two jobs never overwrite each other's tarballs on upload.
           if ! gh release view "$TAG" --repo "$RELEASES_REPO" >/dev/null 2>&1; then
-            gh release create "$TAG" \
+            if ! create_err=$(gh release create "$TAG" \
               --repo "$RELEASES_REPO" \
               --title "Dusk Studio $TAG" \
-              --notes "$NOTES" \
-              || echo "release create raced with the sibling arch job; uploading instead."
+              --notes "$NOTES" 2>&1); then
+              if gh release view "$TAG" --repo "$RELEASES_REPO" >/dev/null 2>&1; then
+                echo "release create raced with the sibling arch job; the release now exists, uploading."
+              else
+                echo "::error::gh release create failed for ${TAG} and no release exists:" >&2
+                echo "${create_err}" >&2
+                exit 1
+              fi
+            fi
           fi
           gh release upload "$TAG" --repo "$RELEASES_REPO" --clobber "${ASSETS[@]}"
           echo "Published ${#ASSETS[@]} ${ARCH} asset(s) to ${RELEASES_REPO} @ ${TAG}"

--- a/.github/workflows/linux-sanitizer.yml
+++ b/.github/workflows/linux-sanitizer.yml
@@ -63,31 +63,27 @@ jobs:
             libwebkit2gtk-4.0-dev libglu1-mesa-dev xvfb \
             libwayland-dev libxkbcommon-dev libdecor-0-dev
 
-      - name: Clone JUCE 8.0.4 (upstream)
-        # Same upstream + same SIMD<long long> patch as linux-build.yml.
-        # See that workflow's clone step for the rationale.
+      - name: Clone JUCE (Dusk-owned Wayland mirror, pinned)
+        # Same pinned Dusk-owned mirror snapshot as linux-build.yml; the
+        # snapshot already carries the SIMDNativeOps<long long> alias, so no
+        # patch step. Keep JUCE_TAG / JUCE_REV in lockstep with the other
+        # Linux workflows.
+        env:
+          JUCE_MIRROR: https://github.com/dusk-audio/JUCE-wayland.git
+          JUCE_TAG: dusk-wayland-v2
+          JUCE_REV: 4d85afa175a45e0b5da11f9211de3ba88705588e
         run: |
-          git clone --depth 1 --branch 8.0.4 \
-            https://github.com/juce-framework/JUCE.git \
-            "${RUNNER_TEMP}/JUCE-wayland"
-
-      - name: Patch JUCE — SIMDNativeOps<long long> alias for x86_64 Linux
-        run: |
-          file="${RUNNER_TEMP}/JUCE-wayland/modules/juce_dsp/native/juce_SIMDNativeOps_sse.h"
-          awk '
-            /^}[[:space:]]*\/\/.*juce.*dsp/ && !done {
-              print "#if defined (__GNUC__) && defined (__SIZEOF_LONG__) && __SIZEOF_LONG__ == 8 && !defined (_WIN32)"
-              print "template <> struct SIMDNativeOps<long long> : SIMDNativeOps<int64_t> {};"
-              print "template <> struct SIMDNativeOps<unsigned long long> : SIMDNativeOps<uint64_t> {};"
-              print "#endif"
-              done = 1
-            }
-            { print }
-          ' "$file" > "$file.new" && mv "$file.new" "$file"
-          if ! grep -q "SIMDNativeOps<long long>" "$file"; then
-            echo "ERROR: SIMDNativeOps<long long> alias not present after patch — the awk anchor likely no longer matches upstream JUCE." >&2
-            exit 1
-          fi
+          set -euo pipefail
+          git init -q "${RUNNER_TEMP}/JUCE-wayland"
+          cd "${RUNNER_TEMP}/JUCE-wayland"
+          git remote add origin "${JUCE_MIRROR}"
+          git fetch --depth 1 origin "refs/tags/${JUCE_TAG}"
+          git checkout -q FETCH_HEAD
+          [[ "$(git rev-parse HEAD)" == "${JUCE_REV}" ]] || {
+            echo "ERROR: JUCE checkout $(git rev-parse HEAD) != pinned ${JUCE_REV}" >&2; exit 1; }
+          grep -q "SIMDNativeOps<long long>" \
+            modules/juce_dsp/native/juce_SIMDNativeOps_sse.h || {
+            echo "ERROR: pinned JUCE missing the SIMDNativeOps<long long> alias." >&2; exit 1; }
 
       - name: Clone Dusk plugins (donor DSP)
         run: |

--- a/.github/workflows/raspberry-pi-build.yml
+++ b/.github/workflows/raspberry-pi-build.yml
@@ -41,11 +41,16 @@ jobs:
             libwayland-dev libxkbcommon-dev libdecor-0-dev
 
       - name: Clone JUCE (Dusk-owned Wayland mirror, pinned)
-        # Same pinned Dusk-owned mirror snapshot as linux-build.yml; the
-        # snapshot already carries the SIMDNativeOps<long long> alias (on both
-        # the SSE and NEON headers), so no patch step. arm64 compiles the NEON
-        # variant, so the sanity grep targets that header. Keep JUCE_TAG /
-        # JUCE_REV in lockstep with the other Linux workflows.
+        # Same pinned Dusk-owned mirror snapshot as linux-build.yml. The
+        # snapshot carries the SIMDNativeOps<long long> alias on the SSE header
+        # but NOT the NEON one, so arm64 (which compiles the NEON variant) must
+        # patch it in: GCC instantiates SIMDRegister<long long> for
+        # jmax<juce::int64>(), and int64_t is a distinct type from long long —
+        # an incomplete-type hard error without the alias. Applied only when
+        # absent, so a future snapshot that already ships the NEON alias makes
+        # this a no-op (double-defining the specialisation would fail to
+        # compile). Keep JUCE_TAG / JUCE_REV in lockstep with the other Linux
+        # workflows.
         env:
           JUCE_MIRROR: https://github.com/dusk-audio/JUCE-wayland.git
           JUCE_TAG: dusk-wayland-v2
@@ -59,9 +64,21 @@ jobs:
           git checkout -q FETCH_HEAD
           [[ "$(git rev-parse HEAD)" == "${JUCE_REV}" ]] || {
             echo "ERROR: JUCE checkout $(git rev-parse HEAD) != pinned ${JUCE_REV}" >&2; exit 1; }
-          grep -q "SIMDNativeOps<long long>" \
-            modules/juce_dsp/native/juce_SIMDNativeOps_neon.h || {
-            echo "ERROR: pinned JUCE missing the SIMDNativeOps<long long> alias (NEON)." >&2; exit 1; }
+          neon="modules/juce_dsp/native/juce_SIMDNativeOps_neon.h"
+          if ! grep -q "SIMDNativeOps<long long>" "$neon"; then
+            awk '
+              /^}[[:space:]]*\/\/.*juce.*dsp/ && !done {
+                print "#if defined (__GNUC__) && defined (__SIZEOF_LONG__) && __SIZEOF_LONG__ == 8 && !defined (_WIN32)"
+                print "template <> struct SIMDNativeOps<long long> : SIMDNativeOps<int64_t> {};"
+                print "template <> struct SIMDNativeOps<unsigned long long> : SIMDNativeOps<uint64_t> {};"
+                print "#endif"
+                done = 1
+              }
+              { print }
+            ' "$neon" > "$neon.new" && mv "$neon.new" "$neon"
+            grep -q "SIMDNativeOps<long long>" "$neon" || {
+              echo "ERROR: NEON SIMDNativeOps<long long> alias still missing after patch (awk anchor no longer matches the mirror header)." >&2; exit 1; }
+          fi
 
       - name: Clone Dusk plugins (donor DSP)
         run: |

--- a/.github/workflows/raspberry-pi-build.yml
+++ b/.github/workflows/raspberry-pi-build.yml
@@ -40,40 +40,28 @@ jobs:
             libwebkit2gtk-4.0-dev libglu1-mesa-dev xvfb \
             libwayland-dev libxkbcommon-dev libdecor-0-dev
 
-      - name: Clone JUCE 8.0.4 (upstream)
+      - name: Clone JUCE (Dusk-owned Wayland mirror, pinned)
+        # Same pinned Dusk-owned mirror snapshot as linux-build.yml; the
+        # snapshot already carries the SIMDNativeOps<long long> alias (on both
+        # the SSE and NEON headers), so no patch step. arm64 compiles the NEON
+        # variant, so the sanity grep targets that header. Keep JUCE_TAG /
+        # JUCE_REV in lockstep with the other Linux workflows.
+        env:
+          JUCE_MIRROR: https://github.com/dusk-audio/JUCE-wayland.git
+          JUCE_TAG: dusk-wayland-v2
+          JUCE_REV: 4d85afa175a45e0b5da11f9211de3ba88705588e
         run: |
-          git clone --depth 1 --branch 8.0.4 \
-            https://github.com/juce-framework/JUCE.git \
-            "${RUNNER_TEMP}/JUCE-wayland"
-
-      - name: Patch JUCE — SIMDNativeOps<long long> alias (NEON)
-        # Upstream JUCE 8.0.4 defines SIMDNativeOps<int64_t> but not
-        # SIMDNativeOps<long long>; on GCC those are distinct types and JUCE
-        # instantiates SIMDRegister<long long> for jmax<juce::int64>() — an
-        # incomplete-type hard error. The plugdata-team JUCE-wayland fork adds
-        # the aliases; we apply them to the NEON header here so the arm64 build
-        # is clean. (The SSE header is patched the same way in linux-build.yml;
-        # it isn't compiled on arm64.)
-        run: |
-          file="${RUNNER_TEMP}/JUCE-wayland/modules/juce_dsp/native/juce_SIMDNativeOps_neon.h"
-          if [ ! -f "$file" ]; then
-            echo "ERROR: $file not present in this JUCE checkout." >&2
-            exit 1
-          fi
-          awk '
-            /^}[[:space:]]*\/\/.*juce.*dsp/ && !done {
-              print "#if defined (__GNUC__) && defined (__SIZEOF_LONG__) && __SIZEOF_LONG__ == 8 && !defined (_WIN32)"
-              print "template <> struct SIMDNativeOps<long long> : SIMDNativeOps<int64_t> {};"
-              print "template <> struct SIMDNativeOps<unsigned long long> : SIMDNativeOps<uint64_t> {};"
-              print "#endif"
-              done = 1
-            }
-            { print }
-          ' "$file" > "$file.new" && mv "$file.new" "$file"
-          if ! grep -q "SIMDNativeOps<long long>" "$file"; then
-            echo "ERROR: SIMDNativeOps<long long> alias not present after patch — the awk anchor likely no longer matches upstream JUCE." >&2
-            exit 1
-          fi
+          set -euo pipefail
+          git init -q "${RUNNER_TEMP}/JUCE-wayland"
+          cd "${RUNNER_TEMP}/JUCE-wayland"
+          git remote add origin "${JUCE_MIRROR}"
+          git fetch --depth 1 origin "refs/tags/${JUCE_TAG}"
+          git checkout -q FETCH_HEAD
+          [[ "$(git rev-parse HEAD)" == "${JUCE_REV}" ]] || {
+            echo "ERROR: JUCE checkout $(git rev-parse HEAD) != pinned ${JUCE_REV}" >&2; exit 1; }
+          grep -q "SIMDNativeOps<long long>" \
+            modules/juce_dsp/native/juce_SIMDNativeOps_neon.h || {
+            echo "ERROR: pinned JUCE missing the SIMDNativeOps<long long> alias (NEON)." >&2; exit 1; }
 
       - name: Clone Dusk plugins (donor DSP)
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,16 @@ All notable changes to Dusk Studio. Format loosely follows
 back-filled from `git log`; once tags exist this file is the
 canonical source.
 
-## [0.12.0] - 2026-07-05
+## [0.12.0] - 2026-07-11
 
 Beta. The biggest release so far: Linux-native plugin hosting across CLAP,
 LV2 and VST3 (effects and instruments), a production-readiness pass over the
 whole engine — sample-rate safety, seamless looping, Save As that takes your
 audio with it, latency compensation across every path — and new delivery
-options for the master.
+options for the master. This cut also brings the console EQ on every channel
+and bus onto the new-generation EQ core (a subtle, deliberate re-voicing —
+see Changed) with a lighter CPU footprint, and fails with clear instructions
+instead of a core dump when launched on Wayland without XWayland.
 
 ### Added
 
@@ -111,6 +114,21 @@ options for the master.
 
 ### Changed
 
+- **Console EQ engine.** The channel-strip and bus EQ moved to the
+  new-generation parallel-summing console core (the engine behind 4K EQ
+  version 2). Band interaction and the brown/black voicings track the
+  hardware model more closely, and an engaged EQ carries a trace of
+  transformer character even when flat. Existing sessions will sound
+  slightly different on the strip EQ at the same settings; the compressors
+  are bit-identical. The channel EQ/compressor path also costs roughly
+  10-20% less CPU.
+- **Launching without a display.** On a Wayland session without XWayland,
+  Dusk Studio now prints instructions for enabling it and exits cleanly
+  instead of crashing (#56). An X11 display (XWayland on Wayland desktops)
+  remains a requirement — now stated in the manual.
+- **MIDI engine internals.** Device enumeration, input routing and the
+  clock/MTC output path were modernised. Behavior is intended to be
+  identical; report any regression, especially external clock/MTC timing.
 - **Dusk-native UI sweep.** The remaining stock-JUCE dialogs and pickers
   (including the last native alert on the stem-overwrite prompt) now use
   Dusk Studio's in-window equivalents — no more separate OS windows fighting

--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -15,7 +15,7 @@ VENDORED DEPENDENCIES (compiled into the Dusk Studio binary)
 ------------------------------------------------------
 
 JUCE (audio framework)
-  Version  : 8.x  (Linux pin: plugdata-team/JUCE wayland-juce8;
+  Version  : 8.x  (Linux pin: dusk-audio/JUCE-wayland tag dusk-wayland-v2;
                    macOS/Win: upstream juce-framework/JUCE)
   License  : Dual-licensed — GPL-3.0 (used here) OR JUCE Commercial
   Path     : ../JUCE-wayland (Linux), ../JUCE (macOS/Windows)

--- a/packaging/DuskStudio.appdata.xml
+++ b/packaging/DuskStudio.appdata.xml
@@ -30,9 +30,16 @@
   <content_rating type="oars-1.1"/>
   <releases>
     <!-- scripts/bump-version.sh prepends new <release> entries here. -->
-    <release version="0.12.0" date="2026-07-05">
+    <release version="0.12.0" date="2026-07-11">
       <description>
-        <p>Beta: native CLAP/LV2/VST3 hosting on Linux, session sample-rate safety, seamless looping, Save As consolidation, send-effect latency compensation, mastering delivery presets, MIDI soft takeover.</p>
+        <p>Beta. Workflow: session sample-rate policy, seamless loop playback,
+        Save As consolidation, aux return latency compensation, MIDI soft
+        takeover, LV2 file state in sessions, delivery presets, and background
+        audio imports. Sound: the console EQ on every channel and bus moves to
+        a new-generation core with a subtle re-voicing, and the channel EQ and
+        compressor path is lighter on the CPU. Launching on Wayland without
+        XWayland now shows a clear message explaining how to enable it instead
+        of crashing, and the MIDI engine internals have been modernised.</p>
       </description>
     </release>
     <release version="0.11.1" date="2026-06-24">

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -48,6 +48,49 @@ elif ! grep -qF "## [$NEW_VERSION]" CHANGELOG.md; then
     exit 1
 fi
 
+# Anti-drift gate: sibling JUCE-wayland dev fork vs the release snapshot.
+# linux-release.yml pins the Linux build to a Dusk-owned mirror snapshot
+# (JUCE_REV under an immutable dusk-wayland-vN tag). If a maintainer keeps a
+# sibling ../JUCE-wayland dev checkout, make sure a release can't be cut from a
+# fork state that no snapshot captures:
+#   (a) HARD FAIL if that checkout is dirty - uncommitted fork changes are in no
+#       snapshot and would silently not ship.
+#   (b) WARN if the fork HEAD tree differs from the snapshot the release pins -
+#       the dev fork has moved on and a new dusk-wayland-vN tag is due.
+JUCE_FORK_DIR="$REPO_DIR/../JUCE-wayland"
+RELEASE_WORKFLOW=".github/workflows/linux-release.yml"
+if [[ -e "$JUCE_FORK_DIR/.git" ]]; then
+    if [[ -n "$(git -C "$JUCE_FORK_DIR" status --porcelain 2>/dev/null)" ]]; then
+        echo "error: sibling JUCE fork at $JUCE_FORK_DIR has uncommitted changes." >&2
+        echo "       Commit + snapshot to the mirror before cutting a release -" >&2
+        echo "       a dirty working tree is in no dusk-wayland-vN snapshot." >&2
+        exit 1
+    fi
+
+    JUCE_REV="$(sed -n 's/^[[:space:]]*JUCE_REV:[[:space:]]*//p' "$RELEASE_WORKFLOW" | head -n1)"
+    JUCE_TAG="$(sed -n 's/^[[:space:]]*JUCE_TAG:[[:space:]]*//p' "$RELEASE_WORKFLOW" | head -n1)"
+    JUCE_MIRROR="$(sed -n 's/^[[:space:]]*JUCE_MIRROR:[[:space:]]*//p' "$RELEASE_WORKFLOW" | head -n1)"
+
+    if [[ -z "$JUCE_REV" ]]; then
+        echo "warning: could not read JUCE_REV from $RELEASE_WORKFLOW; skipping the fork-drift check." >&2
+    elif ! git -C "$JUCE_FORK_DIR" cat-file -e "$JUCE_REV" 2>/dev/null; then
+        # The snapshot commit may exist only on the mirror, not in this checkout.
+        echo "note: release snapshot $JUCE_REV is not present in $JUCE_FORK_DIR; skipping the fork-drift check." >&2
+        echo "      To enable it, fetch the snapshot first:" >&2
+        echo "        git -C $JUCE_FORK_DIR fetch $JUCE_MIRROR tag $JUCE_TAG" >&2
+    else
+        FORK_TREE="$(git -C "$JUCE_FORK_DIR" rev-parse 'HEAD^{tree}')"
+        SNAP_TREE="$(git -C "$JUCE_FORK_DIR" rev-parse "${JUCE_REV}^{tree}")"
+        if [[ "$FORK_TREE" != "$SNAP_TREE" ]]; then
+            echo "warning: sibling JUCE fork HEAD tree ($FORK_TREE)" >&2
+            echo "         != release snapshot ${JUCE_TAG} tree ($SNAP_TREE)." >&2
+            echo "         The dev fork has moved past the pinned snapshot - push a new" >&2
+            echo "         dusk-wayland-vN tag to the mirror and bump JUCE_TAG / JUCE_REV" >&2
+            echo "         in $RELEASE_WORKFLOW before releasing." >&2
+        fi
+    fi
+fi
+
 TODAY="$(date -u +%Y-%m-%d)"
 
 echo "$NEW_VERSION" > VERSION

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -3,10 +3,6 @@
 #if defined (__linux__)
 #include <cstdlib>
 
-// Hand-rolled START_JUCE_APPLICATION expansion (JUCE_CREATE_APPLICATION_DEFINE
-// + JUCE_MAIN_FUNCTION_DEFINITION) so the environment can be staged before any
-// JUCE code runs.
-//
 // Dusk Studio is an X11/XWayland client on Linux: every window (main UI and
 // plugin-editor peers) is forced to an X11 peer, so the JUCE fork's hybrid
 // Wayland connection is never used for windowing. Leaving it open is not
@@ -15,19 +11,21 @@
 // (wlroots/smithay families — GitHub issue #56) before any window exists.
 // JUCE_XWAYLAND makes the fork skip the Wayland connection entirely — the
 // behavior every 0.9.x release had. DUSKSTUDIO_NATIVE_WAYLAND=1 re-enables
-// the hybrid backend for development.
-juce::JUCEApplicationBase* juce_CreateApplication();
-juce::JUCEApplicationBase* juce_CreateApplication() { return new duskstudio::DuskStudioApp(); }
-
-int main (int argc, char* argv[])
+// the hybrid backend for development. Static initializer so it runs before
+// the app framework touches the window system, without replacing the
+// framework's entry-point macro.
+namespace
 {
-    if (std::getenv ("DUSKSTUDIO_NATIVE_WAYLAND") == nullptr)
-        setenv ("JUCE_XWAYLAND", "1", 0);
-
-    juce::JUCEApplicationBase::createInstance = &juce_CreateApplication;
-    return juce::JUCEApplicationBase::main (argc, (const char**) argv);
-}
-
-#else
-START_JUCE_APPLICATION (duskstudio::DuskStudioApp)
+struct ForceXWaylandByDefault
+{
+    ForceXWaylandByDefault()
+    {
+        if (std::getenv ("DUSKSTUDIO_NATIVE_WAYLAND") == nullptr)
+            setenv ("JUCE_XWAYLAND", "1", 0);
+    }
+};
+const ForceXWaylandByDefault forceXWaylandByDefault;
+} // namespace
 #endif
+
+START_JUCE_APPLICATION (duskstudio::DuskStudioApp)

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -1,3 +1,33 @@
 #include "DuskStudioApp.h"
 
+#if defined (__linux__)
+#include <cstdlib>
+
+// Hand-rolled START_JUCE_APPLICATION expansion (JUCE_CREATE_APPLICATION_DEFINE
+// + JUCE_MAIN_FUNCTION_DEFINITION) so the environment can be staged before any
+// JUCE code runs.
+//
+// Dusk Studio is an X11/XWayland client on Linux: every window (main UI and
+// plugin-editor peers) is forced to an X11 peer, so the JUCE fork's hybrid
+// Wayland connection is never used for windowing. Leaving it open is not
+// harmless: its startup handshake (registry binds at the compositor's
+// advertised versions, libdecor init) aborts on some compositors
+// (wlroots/smithay families — GitHub issue #56) before any window exists.
+// JUCE_XWAYLAND makes the fork skip the Wayland connection entirely — the
+// behavior every 0.9.x release had. DUSKSTUDIO_NATIVE_WAYLAND=1 re-enables
+// the hybrid backend for development.
+juce::JUCEApplicationBase* juce_CreateApplication();
+juce::JUCEApplicationBase* juce_CreateApplication() { return new duskstudio::DuskStudioApp(); }
+
+int main (int argc, char* argv[])
+{
+    if (std::getenv ("DUSKSTUDIO_NATIVE_WAYLAND") == nullptr)
+        setenv ("JUCE_XWAYLAND", "1", 0);
+
+    juce::JUCEApplicationBase::createInstance = &juce_CreateApplication;
+    return juce::JUCEApplicationBase::main (argc, (const char**) argv);
+}
+
+#else
 START_JUCE_APPLICATION (duskstudio::DuskStudioApp)
+#endif

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -2,6 +2,7 @@
 
 #if defined (__linux__)
 #include <cstdlib>
+#include <strings.h>
 
 // Dusk Studio is an X11/XWayland client on Linux: every window (main UI and
 // plugin-editor peers) is forced to an X11 peer, so the JUCE fork's hybrid
@@ -20,7 +21,13 @@ struct ForceXWaylandByDefault
 {
     ForceXWaylandByDefault()
     {
-        if (std::getenv ("DUSKSTUDIO_NATIVE_WAYLAND") == nullptr)
+        // Truthy per the DUSKSTUDIO_* env-flag convention (envFlagSet): a
+        // non-zero integer or "true". Unset, "0" or junk keep the XWayland
+        // default — setting the flag to 0 must not enable the native path.
+        const char* v = std::getenv ("DUSKSTUDIO_NATIVE_WAYLAND");
+        const bool nativeWayland = v != nullptr
+                                    && (std::atoi (v) != 0 || strcasecmp (v, "true") == 0);
+        if (! nativeWayland)
             setenv ("JUCE_XWAYLAND", "1", 0);
     }
 };


### PR DESCRIPTION
Prepares the 0.12.0 re-tag and fixes the #56 root cause.

The crash (#56): releases since 0.11.0 ship the hybrid-Wayland JUCE fork, whose startup handshake aborts on wlroots/smithay-family compositors before any window exists (registry binds at compositor-advertised versions, libdecor init). 0.9.x shipped stock upstream JUCE and worked everywhere as a plain XWayland client. Since Dusk Studio forces every window to an X11 peer, the Wayland connection was never used for windowing. Main.cpp now hand-rolls the JUCE entry point and sets JUCE_XWAYLAND by default on Linux — the fork's own skip path — restoring 0.9.x behavior on every compositor. DUSKSTUDIO_NATIVE_WAYLAND=1 re-enables the hybrid backend for development. (The earlier preflight from #59 still covers genuinely-missing X displays.)

JUCE standardization: dev, CI and releases now build one JUCE. All Linux CI jobs (build, tests, TSan, Raspberry Pi) clone the pinned dusk-audio/JUCE-wayland mirror snapshot instead of upstream 8.0.4 plus an inline SIMD patch; the release pin bumps to dusk-wayland-v2, content-identical to the dev fork HEAD including the previously-uncommitted ALSA endpoint seeding and XEmbed defer-mapping fixes; bump-version.sh gains an anti-drift gate (dirty fork fails, drifted tree warns that a new mirror tag is due).

Release plumbing: donor plugins clone pinned to a SHA like the JUCE pin; a fail-fast token preflight on tag runs (the v0.12.0 attempt burned a 17-minute green build on an expired RELEASES_REPO_TOKEN); the publish step distinguishes the benign sibling-arch race from real failures instead of masking both. appdata + CHANGELOG entries refreshed for the re-tag covering the July production wave and the newer work.

Verified: 364/364 tests, Xvfb selftest 26 PASS / 0 FAIL, dead-display launch prints guidance and exits 1, all four Linux workflows converted and YAML-validated, fork HEAD tree verified identical to the v2 snapshot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Linux now defaults to XWayland for improved compatibility, with an option to enable native Wayland.
  * Added clearer guidance when launching without XWayland.
  * Updated release information with console EQ improvements, MIDI modernization, workflow and session enhancements, and other 0.12.0 changes.

* **Documentation**
  * Updated third-party licensing references and release metadata.
  * Corrected the 0.12.0 release date to July 11, 2026.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->