### PR TITLE
Model 12 / MCU: fader taper, Windows scan sandbox, binding taper (#45)

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1585,6 +1585,17 @@ Once connected:
 - **Jog wheel** scrubs the playhead.
 - **Touch sense** drives Touch automation: touching a fader on the surface puts it into touch-write mode while you hold it.
 
+**Prefer MCU mode over manual MIDI mapping.** Mixer-style controllers with an
+MCU or "Mackie Control" emulation mode (Tascam Model 12, Behringer X-Touch,
+and similar) should be switched to that mode and selected here — not
+hand-mapped through MIDI bindings. MIDI bindings are one-way: they can drive
+Dusk Studio, but Dusk Studio cannot light the controller's Mute/Solo/Record
+LEDs, move its motor faders, or reach transport features like Rewind/Forward
+— those exist only in MCU mode. On the transport: **Rewind/Forward tap to
+jump between markers and hold to scrub**; they are not a continuous tape
+shuttle. The fader scale follows the Mackie taper, so the printed **0**
+position on the surface matches 0 dB on screen.
+
 \newpage
 
 # MIDI bindings

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -5,6 +5,7 @@
 #include "../dsp/OutputPairRouting.h"
 #include "McuReceiver.h"
 #include "McuController.h"
+#include "FaderBindingMap.h"
 #include "../session/RegionEditActions.h"
 #include "DeviceFallbackMessage.h"
 #if defined(DUSKSTUDIO_HAS_ALSA)
@@ -38,8 +39,9 @@ static float currentFracForTarget (Session& session, const MidiBinding& b) noexc
     {
         case MidiBindingTarget::TrackFader:
             if (b.targetIndex < 0 || b.targetIndex >= Session::kNumTracks) return -1.0f;
-            return inv (session.track (b.targetIndex).strip.faderDb.load (std::memory_order_relaxed),
-                        -90.0f, 12.0f);
+            return faderBindingDbToFrac (
+                session.track (b.targetIndex).strip.faderDb.load (std::memory_order_relaxed),
+                b.trigger == MidiBindingTrigger::PitchBend);
         case MidiBindingTarget::TrackPan:
             if (b.targetIndex < 0 || b.targetIndex >= Session::kNumTracks) return -1.0f;
             return inv (session.track (b.targetIndex).strip.pan.load (std::memory_order_relaxed),
@@ -133,8 +135,9 @@ static float currentFracForTarget (Session& session, const MidiBinding& b) noexc
         }
         case MidiBindingTarget::BusFader:
             if (b.targetIndex < 0 || b.targetIndex >= Session::kNumBuses) return -1.0f;
-            return inv (session.bus (b.targetIndex).strip.faderDb.load (std::memory_order_relaxed),
-                        -90.0f, 12.0f);
+            return faderBindingDbToFrac (
+                session.bus (b.targetIndex).strip.faderDb.load (std::memory_order_relaxed),
+                b.trigger == MidiBindingTrigger::PitchBend);
         case MidiBindingTarget::BusPan:
             if (b.targetIndex < 0 || b.targetIndex >= Session::kNumBuses) return -1.0f;
             return inv (session.bus (b.targetIndex).strip.pan.load (std::memory_order_relaxed),
@@ -152,10 +155,13 @@ static float currentFracForTarget (Session& session, const MidiBinding& b) noexc
         }
         case MidiBindingTarget::AuxLaneFader:
             if (b.targetIndex < 0 || b.targetIndex >= Session::kNumAuxLanes) return -1.0f;
-            return inv (session.auxLane (b.targetIndex).params.returnLevelDb
-                            .load (std::memory_order_relaxed), -90.0f, 12.0f);
+            return faderBindingDbToFrac (
+                session.auxLane (b.targetIndex).params.returnLevelDb.load (std::memory_order_relaxed),
+                b.trigger == MidiBindingTrigger::PitchBend);
         case MidiBindingTarget::MasterFader:
-            return inv (session.master().faderDb.load (std::memory_order_relaxed), -90.0f, 12.0f);
+            return faderBindingDbToFrac (
+                session.master().faderDb.load (std::memory_order_relaxed),
+                b.trigger == MidiBindingTrigger::PitchBend);
         case MidiBindingTarget::MasterEqLfBoost:
             return inv (session.master().eqLfBoost.load (std::memory_order_relaxed), 0.0f, 10.0f);
         case MidiBindingTarget::MasterEqHfBoost:
@@ -3152,12 +3158,13 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
                         case MidiBindingTarget::TrackFader:
                             if (b.targetIndex >= 0 && b.targetIndex < Session::kNumTracks)
                             {
-                                // 0..1 fraction maps to -90..+12 dB linearly. -90
-                                // sits below the kFaderInfThreshDb hard-mute floor
-                                // so a zero-position fader cleanly silences the
-                                // strip. Pitch-bend's 14-bit resolution gives a
-                                // ~128x finer dB step than 7-bit CC.
-                                const float db = -90.0f + frac * (12.0f + 90.0f);
+                                // CC/Note: linear -90..+12 dB. PitchBend: the
+                                // Mackie taper (faderBindingFracToDb) so an
+                                // MCU-style motor fader tracks its printed
+                                // scale — 0 dB at ~3/4 throw, bottom at -100 dB
+                                // (below kFaderInfThreshDb, hard-muted).
+                                const float db = faderBindingFracToDb (
+                                    frac, b.trigger == MidiBindingTrigger::PitchBend);
                                 session.setTrackFaderGrouped (b.targetIndex, db);
                             }
                             break;
@@ -3354,7 +3361,8 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
                         case MidiBindingTarget::BusFader:
                             if (b.targetIndex >= 0 && b.targetIndex < Session::kNumBuses)
                             {
-                                const float db = -90.0f + frac * (12.0f + 90.0f);
+                                const float db = faderBindingFracToDb (
+                                    frac, b.trigger == MidiBindingTrigger::PitchBend);
                                 session.bus (b.targetIndex).strip.faderDb.store (
                                     db, std::memory_order_relaxed);
                             }
@@ -3474,7 +3482,8 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
                         case MidiBindingTarget::AuxLaneFader:
                             if (b.targetIndex >= 0 && b.targetIndex < Session::kNumAuxLanes)
                             {
-                                const float db = -90.0f + frac * (12.0f + 90.0f);
+                                const float db = faderBindingFracToDb (
+                                    frac, b.trigger == MidiBindingTrigger::PitchBend);
                                 session.auxLane (b.targetIndex).params.returnLevelDb
                                     .store (db, std::memory_order_relaxed);
                             }
@@ -3490,7 +3499,8 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
 
                         case MidiBindingTarget::MasterFader:
                         {
-                            const float db = -90.0f + frac * (12.0f + 90.0f);
+                            const float db = faderBindingFracToDb (
+                                frac, b.trigger == MidiBindingTrigger::PitchBend);
                             session.master().faderDb.store (db, std::memory_order_relaxed);
                             break;
                         }

--- a/src/engine/FaderBindingMap.h
+++ b/src/engine/FaderBindingMap.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "McuFaderTaper.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace duskstudio
+{
+// Frac <-> dB mapping shared by the fader-dB MIDI-binding targets: TrackFader,
+// BusFader, AuxLaneFader, MasterFader (and TrackFaderBank, which resolves to
+// TrackFader before apply).
+//
+// CC / Note sources are generic 7-bit knobs with no printed scale, so they map
+// linearly across -90..+12 dB. PitchBend sources are MCU-style motor faders
+// whose silkscreened scale follows the Mackie taper (the same curve
+// McuController / McuReceiver ride), so a PB-bound fader maps through it: 0 dB
+// lands at ~3/4 of throw, matching the print, not the ~89% a linear-in-dB map
+// produced. Bottom of a PB throw is -100 dB, below
+// ChannelStripParams::kFaderInfThreshDb (-90), so a zeroed motor fader still
+// hard-mutes the strip; the linear path bottoms at exactly -90 (also muted).
+//
+// The two directions must stay exact inverses: apply uses faderBindingFracToDb,
+// soft-takeover pickup read-back uses faderBindingDbToFrac. Change one, change
+// the other or pickup latches at the wrong position.
+inline float faderBindingFracToDb (float frac, bool pitchBend) noexcept
+{
+    if (pitchBend)
+        return mcu::pitchBend14ToFaderDb (
+            (int) std::lround (frac * (float) mcu::kPitchBendMaxValue));
+    return -90.0f + frac * (12.0f + 90.0f);
+}
+
+inline float faderBindingDbToFrac (float db, bool pitchBend) noexcept
+{
+    const float frac = pitchBend
+        ? (float) mcu::faderDbToPitchBend14 (db) / (float) mcu::kPitchBendMaxValue
+        : (db + 90.0f) / (12.0f + 90.0f);
+    return std::clamp (frac, 0.0f, 1.0f);
+}
+
+} // namespace duskstudio

--- a/src/engine/McuController.cpp
+++ b/src/engine/McuController.cpp
@@ -1,5 +1,6 @@
 #include "McuController.h"
 #include "McuProtocol.h"
+#include "McuFaderTaper.h"
 #include "Transport.h"
 #include "../session/Session.h"
 
@@ -101,16 +102,6 @@ McuController::~McuController()
     stopTimer();
 }
 
-int McuController::faderDbToPitchBend (float db) const noexcept
-{
-    constexpr float kMin = ChannelStripParams::kFaderMinDb;
-    constexpr float kMax = ChannelStripParams::kFaderMaxDb;
-    if (db < kMin) db = kMin;
-    if (db > kMax) db = kMax;
-    const float norm = (db - kMin) / (kMax - kMin);
-    return (int) (norm * (float) mcu::kPitchBendMaxValue);
-}
-
 juce::MidiBuffer McuController::buildEmitBuffer (bool forceAll)
 {
     juce::MidiBuffer buf;
@@ -127,7 +118,7 @@ juce::MidiBuffer McuController::buildEmitBuffer (bool forceAll)
 
         // Fader. liveFaderDb (post-automation) so motors track Read mode.
         const float liveDb = trk.strip.liveFaderDb.load (std::memory_order_relaxed);
-        const int pb14 = faderDbToPitchBend (liveDb);
+        const int pb14 = mcu::faderDbToPitchBend14 (liveDb);
         if (forceAll || pb14 != lastFader[(size_t) strip])
         {
             // MidiMessage::pitchWheel uses 1-based channels.
@@ -165,7 +156,7 @@ juce::MidiBuffer McuController::buildEmitBuffer (bool forceAll)
 
     // ── Master fader ──
     const float masterDb = session.master().liveFaderDb.load (std::memory_order_relaxed);
-    const int masterPb = faderDbToPitchBend (masterDb);
+    const int masterPb = mcu::faderDbToPitchBend14 (masterDb);
     if (forceAll || masterPb != lastMasterFader)
     {
         buf.addEvent (juce::MidiMessage::pitchWheel (mcu::kMasterFaderIndex + 1, masterPb), 0);

--- a/src/engine/McuController.h
+++ b/src/engine/McuController.h
@@ -67,7 +67,6 @@ private:
     void timerCallback() override;
 
     juce::MidiBuffer buildEmitBuffer (bool forceAll);
-    int faderDbToPitchBend (float db) const noexcept;
 
     Session&     session;
     SinkFn       sink;

--- a/src/engine/McuFaderTaper.h
+++ b/src/engine/McuFaderTaper.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "McuProtocol.h"   // kPitchBendMaxValue
+
+#include <array>
+#include <cstddef>
+
+namespace duskstudio::mcu
+{
+// Fader taper for MCU-mode motorised faders (Mackie / Logic Control).
+//
+// Real MCU-compatible surfaces (Tascam Model 12, Mackie MCU / C4, Behringer
+// X-Touch) silkscreen a fader scale with 0 dB near three-quarters of throw,
+// fine resolution around unity, and a long compressed tail toward -inf. A
+// straight linear-in-dB map lands 0 dB at ~89% of throw, so the printed
+// scale and the motor position disagree everywhere but the endpoints.
+//
+// Below unity the breakpoints are sampled from Ardour's Mackie-surface fader
+// law (`gain_to_slider_position`, pbd/dB.h: ((6*log2(g)+192)/198)^8), the
+// de-facto open-source MCU calibration — it lands 0 dB at position 0.782.
+// Above unity, 0..+12 dB maps linearly across the remaining top of throw so
+// the surface spans the full ChannelStripParams fader range (kFaderMinDb
+// = -100 .. kFaderMaxDb = +12) rather than the +6 dB Logic Control ceiling.
+//
+// The table is shared by McuController (dB -> pitch-bend, emit) and
+// McuReceiver (pitch-bend -> dB, decode) so motor feedback and touch input
+// ride one curve. Linear interpolation over shared, strictly-increasing
+// breakpoints makes the two directions exact inverses within pitch-bend
+// quantisation.
+struct FaderTaperPoint { float db; int pb14; };
+
+inline constexpr std::array<FaderTaperPoint, 21> kFaderTaper { {
+    { -100.0f,     0 },
+    {  -84.0f,   131 },
+    {  -72.0f,   303 },
+    {  -60.0f,   647 },
+    {  -54.0f,   922 },
+    {  -48.0f,  1294 },
+    {  -42.0f,  1791 },
+    {  -36.0f,  2448 },
+    {  -30.0f,  3307 },
+    {  -24.0f,  4418 },
+    {  -18.0f,  5844 },
+    {  -15.0f,  6697 },
+    {  -12.0f,  7657 },
+    {   -9.0f,  8735 },
+    {   -6.0f,  9944 },
+    {   -3.0f, 11297 },
+    {    0.0f, 12808 },
+    {    3.0f, 13702 },
+    {    6.0f, 14596 },
+    {    9.0f, 15489 },
+    {   12.0f, 16383 },
+} };
+
+// dB -> 14-bit pitch-bend (0..kPitchBendMaxValue). Clamped to the taper's
+// dB endpoints.
+inline int faderDbToPitchBend14 (float db) noexcept
+{
+    const auto& t = kFaderTaper;
+    if (db <= t.front().db) return t.front().pb14;
+    if (db >= t.back().db)  return t.back().pb14;
+    for (std::size_t i = 1; i < t.size(); ++i)
+    {
+        if (db <= t[i].db)
+        {
+            const float frac = (db - t[i - 1].db) / (t[i].db - t[i - 1].db);
+            const float pb   = (float) t[i - 1].pb14
+                             + frac * (float) (t[i].pb14 - t[i - 1].pb14);
+            return (int) (pb + 0.5f);
+        }
+    }
+    return t.back().pb14;
+}
+
+// 14-bit pitch-bend -> dB. Clamped to [0, kPitchBendMaxValue].
+inline float pitchBend14ToFaderDb (int pb14) noexcept
+{
+    const auto& t = kFaderTaper;
+    if (pb14 < 0) pb14 = 0;
+    if (pb14 > kPitchBendMaxValue) pb14 = kPitchBendMaxValue;
+    if (pb14 <= t.front().pb14) return t.front().db;
+    if (pb14 >= t.back().pb14)  return t.back().db;
+    for (std::size_t i = 1; i < t.size(); ++i)
+    {
+        if (pb14 <= t[i].pb14)
+        {
+            const float frac = (float) (pb14 - t[i - 1].pb14)
+                             / (float) (t[i].pb14 - t[i - 1].pb14);
+            return t[i - 1].db + frac * (t[i].db - t[i - 1].db);
+        }
+    }
+    return t.back().db;
+}
+
+} // namespace duskstudio::mcu

--- a/src/engine/McuReceiver.cpp
+++ b/src/engine/McuReceiver.cpp
@@ -1,5 +1,6 @@
 #include "McuReceiver.h"
 #include "McuProtocol.h"
+#include "McuFaderTaper.h"
 #include "../session/Session.h"
 
 #include <algorithm>
@@ -15,9 +16,6 @@ inline T jlimit (T lo, T hi, T value) noexcept { return std::clamp (value, lo, h
 
 namespace mcu_local
 {
-constexpr float kFaderMinDb = ChannelStripParams::kFaderMinDb;   // -100
-constexpr float kFaderMaxDb = ChannelStripParams::kFaderMaxDb;   //  +12
-
 // MCU V-pot encoder ticks divided by this many to convert one tick into
 // a "musical" delta. Logic uses ~64 ticks per full sweep; we want a knob
 // turn (10..20 ticks for a deliberate move) to be a noticeable change
@@ -31,24 +29,6 @@ void McuReceiver::reset() noexcept
     // No accumulator state today - V-pot deltas are stateless per
     // event. If a future change adds a multi-byte sysex decode
     // (e.g. MCU device-info handshake) this is where to clear it.
-}
-
-float McuReceiver::pitchBendToFaderDb (int pb14) const noexcept
-{
-    if (pb14 < 0) pb14 = 0;
-    if (pb14 > mcu::kPitchBendMaxValue) pb14 = mcu::kPitchBendMaxValue;
-    const float norm = (float) pb14 / (float) mcu::kPitchBendMaxValue;
-    return mcu_local::kFaderMinDb
-         + norm * (mcu_local::kFaderMaxDb - mcu_local::kFaderMinDb);
-}
-
-int McuReceiver::faderDbToPitchBend (float db) const noexcept
-{
-    if (db < mcu_local::kFaderMinDb) db = mcu_local::kFaderMinDb;
-    if (db > mcu_local::kFaderMaxDb) db = mcu_local::kFaderMaxDb;
-    const float norm = (db - mcu_local::kFaderMinDb)
-                     / (mcu_local::kFaderMaxDb - mcu_local::kFaderMinDb);
-    return (int) (norm * (float) mcu::kPitchBendMaxValue);
 }
 
 void McuReceiver::resetVpotTarget (int stripIndex) noexcept
@@ -439,7 +419,7 @@ void McuReceiver::process (const dusk::MidiBuffer& events,
             const int lsb = raw[1] & 0x7F;
             const int msb = raw[2] & 0x7F;
             const int pb14 = lsb | (msb << 7);
-            const float db = pitchBendToFaderDb (pb14);
+            const float db = mcu::pitchBend14ToFaderDb (pb14);
             if (channel == mcu::kMasterFaderIndex)
             {
                 session.master().faderDb.store (db, std::memory_order_relaxed);

--- a/src/engine/McuReceiver.h
+++ b/src/engine/McuReceiver.h
@@ -65,17 +65,6 @@ public:
 private:
     Session& session;
 
-    // Convert a 14-bit MCU pitch-bend value (0..16383) into the
-    // session's faderDb range. Linear-in-dB for v1; MCU's hardware
-    // fader curve is actually log-derived but matches Logic's
-    // calibration only - a future commit can swap in the proper
-    // curve when motorized-fader users complain about feel.
-    float pitchBendToFaderDb (int pb14) const noexcept;
-
-    // Reverse mapping (used by McuController emit). Kept here so the
-    // receiver + controller share the same curve constants.
-    int faderDbToPitchBend (float db) const noexcept;
-
     // Dispatch a V-pot delta (signed -63..+63) through the current
     // assign-mode atom to the right strip parameter.
     void applyVpotDelta (int stripIndex, int delta) noexcept;

--- a/src/engine/PluginManager.cpp
+++ b/src/engine/PluginManager.cpp
@@ -41,18 +41,32 @@ class OutOfProcessPluginScanner final : public juce::KnownPluginList::CustomScan
 {
 public:
     OutOfProcessPluginScanner (juce::String hostExe, juce::KnownPluginList& list,
-                               const std::atomic<bool>* abortFlag)
-        : hostExecutable (std::move (hostExe)), knownList (list), abort (abortFlag) {}
+                               const std::atomic<bool>* abortFlag, int* skipCounter)
+        : hostExecutable (std::move (hostExe)), knownList (list), abort (abortFlag),
+          sandboxSkips (skipCounter),
+          hostPresent (juce::File (hostExecutable).existsAsFile()) {}
 
     bool findPluginTypesFor (juce::AudioPluginFormat& format,
                              juce::OwnedArray<juce::PluginDescription>& result,
                              const juce::String& fileOrIdentifier) override
     {
-        // Native (in-house) formats are our own code and can't crash the host,
-        // so scan them in-process. Only third-party binary formats get sandboxed.
-        if (! isSandboxedFormat (format))
+        // In-house formats are our own code and can't crash the host, so scan
+        // them in-process. Third-party binary formats are sandboxed — and for
+        // those we NEVER fall back to in-process: an unauthorized or crashy
+        // plugin scanned in-process takes down the whole app (issue #45).
+        if (! scanproto::formatRequiresSandbox (format.getName()))
         {
             format.findAllTypesForFile (result, fileOrIdentifier);
+            return true;
+        }
+
+        if (! hostPresent)
+        {
+            // No sandbox binary to isolate the scan with. Skip rather than probe
+            // in-process. Returning true with an empty result marks the plugin
+            // UNSCANNED (JUCE blacklists only on a false return) — it did nothing
+            // wrong, and a later scan with the host present re-probes it.
+            noteSandboxUnavailable (fileOrIdentifier);
             return true;
         }
 
@@ -62,9 +76,9 @@ public:
 
         if (! proc.start (args, juce::ChildProcess::wantStdOut))
         {
-            // Couldn't even spawn the sandbox — fall back to in-process rather
-            // than silently dropping a plugin the user has installed.
-            format.findAllTypesForFile (result, fileOrIdentifier);
+            // Host present but wouldn't spawn (AV block, transient OS limit).
+            // Same rule as above: skip, don't scan in-process, don't blacklist.
+            noteSandboxUnavailable (fileOrIdentifier);
             return true;
         }
 
@@ -74,7 +88,8 @@ public:
         // single getMillisecondCounter() wrap (every ~49 days of uptime), so
         // compare the interval rather than an absolute deadline.
         const std::uint32_t startMs = juce::Time::getMillisecondCounter();
-        bool aborted = false;
+        bool aborted  = false;
+        bool timedOut = false;
 
         for (;;)
         {
@@ -101,43 +116,57 @@ public:
 
             if (juce::Time::getMillisecondCounter() - startMs >= (std::uint32_t) kScanTimeoutMs)
             {
-                proc.kill();
-                proc.waitForProcessToFinish (200);  // reap the SIGKILLed child, no zombie
+                proc.kill();                         // TerminateProcess on Windows — unblocks a modal dialog
+                proc.waitForProcessToFinish (200);   // reap the SIGKILLed child, no zombie
+                timedOut = true;
                 break;
             }
             juce::Thread::sleep (5);
         }
 
-        if (aborted) return false;
+        // Abort tears the whole scan down; leave the in-flight file UNSCANNED
+        // (return true) rather than blacklisting a plugin the user cancelled on.
+        if (aborted) return true;
 
         const juce::String payload = scanproto::extractPayload (captured.toString());
 
-        if (payload.isEmpty())
+        if (timedOut || payload.isEmpty())
         {
-            // No clean payload => the child crashed or hung. Quarantine the
-            // file so the next scan skips it instead of re-crashing.
+            // A hang (timed out) or a crash (child died with no clean payload):
+            // quarantine so the next scan skips it instead of re-hanging /
+            // re-crashing. A hung scan is most often a plugin blocking on a
+            // license / authorization dialog it cannot show during discovery.
             knownList.addToBlacklist (fileOrIdentifier);
+            std::fprintf (stderr, timedOut
+                ? "[Dusk Studio/scan] quarantined \"%s\": timed out (possible license dialog)\n"
+                : "[Dusk Studio/scan] quarantined \"%s\": scan crashed (no payload)\n",
+                fileOrIdentifier.toRawUTF8());
+            std::fflush (stderr);
             return false;
         }
 
         // A clean payload means the child completed the scan without crashing,
         // so this is a successful scan even when the file legitimately yields
-        // zero descriptions. Returning false here would re-probe / quarantine a
-        // perfectly-good file. Only the empty-payload (crash/hang) case fails.
+        // zero descriptions. Only the crash (empty payload) / timeout cases fail.
         scanproto::parsePayload (payload, result);
         return true;
     }
 
 private:
-    static bool isSandboxedFormat (const juce::AudioPluginFormat& f)
+    void noteSandboxUnavailable (const juce::String& fileOrIdentifier)
     {
-        const auto n = f.getName();
-        return n == "VST3" || n == "LV2" || n == "AudioUnit" || n == "VST";
+        if (sandboxSkips != nullptr) ++(*sandboxSkips);
+        std::fprintf (stderr,
+                      "[Dusk Studio/scan] sandbox unavailable — left unscanned: %s\n",
+                      fileOrIdentifier.toRawUTF8());
+        std::fflush (stderr);
     }
 
     juce::String                 hostExecutable;
     juce::KnownPluginList&        knownList;
-    const std::atomic<bool>*      abort;   // polled mid-file; null = never aborts
+    const std::atomic<bool>*      abort;         // polled mid-file; null = never aborts
+    int*                          sandboxSkips;   // ++ per third-party file left unscanned; may be null
+    const bool                    hostPresent;    // sandbox child binary exists at construction
 };
 } // namespace
 #endif // DUSKSTUDIO_HAS_OOP_PLUGINS
@@ -217,16 +246,17 @@ int PluginManager::scanInstalledPlugins (
     const auto deadMansPedalFile = getDeadMansPedalFile();
 
    #if DUSKSTUDIO_HAS_OOP_PLUGINS
-    // Sandbox third-party plugin discovery in the child process when the host
-    // binary is present. A plugin that crashes its scan kills only the child;
-    // we blacklist it and continue. Falls through to in-process scanning if
-    // the binary is missing (e.g. a stripped build).
+    // Sandbox third-party plugin discovery in the child process. A plugin that
+    // crashes/hangs its scan kills only the child; we quarantine it and carry on.
+    // The custom scanner is installed UNCONDITIONALLY: if the child binary is
+    // missing or won't spawn, third-party formats are left UNSCANNED (and counted
+    // here) rather than scanned in-process, so an unauthorized/crashy plugin can
+    // never take down the app. First-party formats always scan in-process.
+    int sandboxSkips = 0;
     const juce::File hostExe (getHostExecutablePath());
-    const bool sandboxScan = hostExe.existsAsFile();
-    if (sandboxScan)
-        knownPluginList.setCustomScanner (
-            std::make_unique<OutOfProcessPluginScanner> (hostExe.getFullPathName(),
-                                                         knownPluginList, abort));
+    knownPluginList.setCustomScanner (
+        std::make_unique<OutOfProcessPluginScanner> (hostExe.getFullPathName(),
+                                                     knownPluginList, abort, &sandboxSkips));
    #else
     juce::ignoreUnused (abort);
    #endif
@@ -302,8 +332,8 @@ int PluginManager::scanInstalledPlugins (
    #if DUSKSTUDIO_HAS_OOP_PLUGINS
     // Release the child-launching scanner — load-time instantiation must stay
     // in-process and doesn't go through the custom scanner anyway.
-    if (sandboxScan)
-        knownPluginList.setCustomScanner (nullptr);
+    knownPluginList.setCustomScanner (nullptr);
+    lastScanSandboxSkips.store (sandboxSkips, std::memory_order_relaxed);
    #endif
 
     // Prune dead entries so the picker never offers a plugin that can't load.

--- a/src/engine/PluginManager.h
+++ b/src/engine/PluginManager.h
@@ -25,6 +25,13 @@ public:
     void setOopEnabled (bool enable) noexcept { oopEnabled = enable; }
     bool isOopEnabled() const noexcept       { return oopEnabled; }
 
+    // Number of third-party plugins the most recent scan left UNSCANNED because
+    // the OOP sandbox host was unavailable (missing binary / spawn failure).
+    // Zero on a healthy scan; surfaced by the scan-complete UI so the user knows
+    // some plugins were skipped rather than silently dropped.
+    int getLastScanSandboxSkips() const noexcept
+    { return lastScanSandboxSkips.load (std::memory_order_relaxed); }
+
     // Path to the OOP child binary, alongside the running app. Empty when
     // OOP isn't compiled in for this platform.
     juce::String getHostExecutablePath() const;
@@ -116,6 +123,10 @@ private:
     juce::Array<juce::PluginDescription> lv2Descriptions;        // native LV2 (scanned separately)
     juce::Array<juce::PluginDescription> vst3NativeDescriptions; // native VST3 (scanned separately)
     bool                           oopEnabled { false };
+    // Written on the scan (background) thread at the end of scanInstalledPlugins,
+    // read on the message thread by the scan-complete UI. The read is fenced by
+    // the modal's scanDone release/acquire; atomic keeps it race-free regardless.
+    std::atomic<int>               lastScanSandboxSkips { 0 };
 
     juce::Array<juce::PluginDescription> filterByInstrumentFlag (
         const juce::Array<juce::PluginDescription>& source, bool wantInstrument) const;
@@ -145,7 +156,16 @@ inline juce::String PluginManager::getHostExecutablePath() const
 {
    #if DUSKSTUDIO_HAS_OOP_PLUGINS
     auto exe = juce::File::getSpecialLocation (juce::File::currentExecutableFile);
-    return exe.getParentDirectory().getChildFile ("dusk-studio-plugin-host").getFullPathName();
+   #if JUCE_WINDOWS
+    // CreateProcess (lpApplicationName) and File::existsAsFile both require the
+    // explicit .exe on Windows — without it the sandbox host is never found and
+    // third-party scanning silently falls through to the crash-prone in-process
+    // path (issue #45).
+    const char* const childName = "dusk-studio-plugin-host.exe";
+   #else
+    const char* const childName = "dusk-studio-plugin-host";
+   #endif
+    return exe.getParentDirectory().getChildFile (childName).getFullPathName();
    #else
     return {};
    #endif

--- a/src/engine/ipc/PluginScanProtocol.h
+++ b/src/engine/ipc/PluginScanProtocol.h
@@ -19,6 +19,19 @@ namespace duskstudio::scanproto
 inline constexpr const char* kPayloadBegin = "==DUSK_SCAN_BEGIN==";
 inline constexpr const char* kPayloadEnd   = "==DUSK_SCAN_END==";
 
+// Scan-sandbox policy: which formats load third-party binary code and therefore
+// MUST be probed out-of-process — an unauthorized or crashy plugin scanned
+// in-process takes down the whole app. Our own in-house formats (e.g.
+// DuskMultisample) are trusted and scan in-process. Centralised here so the
+// scanner's routing and its unit test read from one list.
+inline bool formatRequiresSandbox (const juce::String& formatName)
+{
+    return formatName == "VST3"
+        || formatName == "LV2"
+        || formatName == "AudioUnit"
+        || formatName == "VST";
+}
+
 // Child side: serialise the discovered descriptions into the stdout payload.
 // The plugin's own stdout chatter (if any) is emitted by its init code, which
 // runs BEFORE this is printed, so it lands ahead of kPayloadBegin and the

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -1586,6 +1586,10 @@ void MainComponent::maybeStartStartupPluginScan()
             std::fprintf (stderr,
                           "[Dusk Studio] Scan-on-startup: added %d new plugins (%d total).\n",
                           added, total);
+            if (const int skipped = m.getLastScanSandboxSkips(); skipped > 0)
+                std::fprintf (stderr,
+                              "[Dusk Studio] Scan-on-startup: sandbox unavailable — %d plugin(s) left unscanned.\n",
+                              skipped);
             std::fflush (stderr);
         });
 

--- a/src/ui/PluginPickerHelpers.cpp
+++ b/src/ui/PluginPickerHelpers.cpp
@@ -203,6 +203,13 @@ void runScanModal (PluginManager& manager, juce::Component* parent,
                 added, added == 1 ? "" : "s",
                 manager.getKnownPluginList().getNumTypes());
 
+            if (const int skipped = manager.getLastScanSandboxSkips(); skipped > 0)
+                message << juce::String::formatted (
+                    "\n\nWarning: the plugin scanning sandbox was unavailable — "
+                    "%d plugin%s skipped (left unscanned). Rescan once the plugin "
+                    "host is present.",
+                    skipped, skipped == 1 ? "" : "s");
+
             if (auto* h = safeHost.getComponent())
                 showDuskAlert (*h, "Plugin scan complete", std::move (message),
                                   std::move (onAlertDismiss));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,6 +68,7 @@ add_executable(dusk-studio-tests
     session_mcu_roundtrip.cpp
     mcu_receiver_decode.cpp
     mcu_controller_emit.cpp
+    mcu_fader_taper.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/McuReceiver.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/McuController.cpp
     multisample_state_roundtrip.cpp

--- a/tests/mcu_controller_emit.cpp
+++ b/tests/mcu_controller_emit.cpp
@@ -68,16 +68,17 @@ TEST_CASE ("McuController: initial resync emits faders + LED state for 8 banked 
 
     auto buf = controller.buildBufferForTest();
 
-    // Track 0 fader: live -6 dB on a -100..+12 range -> norm ~= 0.839
-    // -> pb14 ~= 13746. Allow a small rounding band.
+    // Track 0 fader: live -6 dB on the Mackie taper -> pb14 == 9944
+    // (position 0.607). Allow a small rounding band.
     const int pb0 = findPitchBend14 (buf, 0);
-    REQUIRE (pb0 >= 13000);
-    REQUIRE (pb0 <= 14000);
+    REQUIRE (pb0 >= 9850);
+    REQUIRE (pb0 <= 10050);
 
-    // Master fader: 0 dB -> norm = 100/112 -> pb14 ~= 14627.
+    // Master fader: 0 dB -> the taper's unity anchor, pb14 == 12808
+    // (position 0.782, ~3/4 throw).
     const int pbMaster = findPitchBend14 (buf, mcu::kMasterFaderIndex);
-    REQUIRE (pbMaster >= 14000);
-    REQUIRE (pbMaster <= 15500);
+    REQUIRE (pbMaster >= 12700);
+    REQUIRE (pbMaster <= 12900);
 
     // Mute LED on track 3 lit, others dark (vel 0x00).
     REQUIRE (findValueForNote (buf, 0x90, mcu::btn::MuteBase + 3) == 0x7F);

--- a/tests/mcu_fader_taper.cpp
+++ b/tests/mcu_fader_taper.cpp
@@ -1,0 +1,94 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "engine/McuFaderTaper.h"
+#include "engine/McuProtocol.h"
+
+using Catch::Matchers::WithinAbs;
+using namespace duskstudio;
+
+// The taper is the shared Mackie/Logic Control fader curve used by both
+// McuController (dB -> pitch-bend) and McuReceiver (pitch-bend -> dB). The
+// bug it fixes: a linear-in-dB map lands 0 dB at ~89% of throw, so the
+// motor position disagreed with the surface's printed scale everywhere but
+// the endpoints.
+
+TEST_CASE ("McuFaderTaper: endpoints are exact", "[mcu][taper]")
+{
+    // Top of throw = kFaderMaxDb (+12) -> full-scale pitch-bend.
+    REQUIRE (mcu::faderDbToPitchBend14 (12.0f) == mcu::kPitchBendMaxValue);
+    // Bottom of throw = kFaderMinDb (-100, the -inf floor) -> 0.
+    REQUIRE (mcu::faderDbToPitchBend14 (-100.0f) == 0);
+
+    REQUIRE_THAT (mcu::pitchBend14ToFaderDb (mcu::kPitchBendMaxValue),
+                  WithinAbs (12.0f, 1e-4f));
+    REQUIRE_THAT (mcu::pitchBend14ToFaderDb (0),
+                  WithinAbs (-100.0f, 1e-4f));
+}
+
+TEST_CASE ("McuFaderTaper: 0 dB sits at the printed unity position (~3/4 throw)",
+           "[mcu][taper]")
+{
+    const int unity = mcu::faderDbToPitchBend14 (0.0f);
+
+    // The Mackie/Logic taper anchors 0 dB at position 0.782 of full 14-bit
+    // throw, i.e. pitch-bend 12808 — three-quarters up, not 89% as the old
+    // linear-in-dB map produced.
+    REQUIRE (unity == 12808);
+    const float frac = (float) unity / (float) mcu::kPitchBendMaxValue;
+    REQUIRE_THAT (frac, WithinAbs (0.782f, 0.01f));
+
+    // The linear-in-dB map that this replaces would have put 0 dB near 0.89.
+    REQUIRE (frac < 0.85f);
+
+    // Exact round-trip back to unity.
+    REQUIRE_THAT (mcu::pitchBend14ToFaderDb (unity), WithinAbs (0.0f, 1e-4f));
+}
+
+TEST_CASE ("McuFaderTaper: pitch-bend -> dB is monotonic over all 16384 codes",
+           "[mcu][taper]")
+{
+    float prev = mcu::pitchBend14ToFaderDb (0);
+    for (int pb = 1; pb <= mcu::kPitchBendMaxValue; ++pb)
+    {
+        const float db = mcu::pitchBend14ToFaderDb (pb);
+        REQUIRE (db >= prev - 1e-6f);   // non-decreasing
+        prev = db;
+    }
+}
+
+TEST_CASE ("McuFaderTaper: pitch-bend round-trips through dB exactly for every code",
+           "[mcu][taper]")
+{
+    // pb -> dB -> pb must be the identity: the two maps share breakpoints,
+    // so a decoded fader value re-encodes to the same motor position (no
+    // fight between incoming touch and outgoing motor feedback).
+    for (int pb = 0; pb <= mcu::kPitchBendMaxValue; ++pb)
+    {
+        const float db  = mcu::pitchBend14ToFaderDb (pb);
+        const int   rtp = mcu::faderDbToPitchBend14 (db);
+        REQUIRE (rtp == pb);
+    }
+}
+
+TEST_CASE ("McuFaderTaper: dB round-trips through pitch-bend within one code",
+           "[mcu][taper]")
+{
+    // dB -> pb -> dB is limited only by 14-bit quantisation. Even at the
+    // coarsest point (the compressed tail) one pitch-bend step spans a
+    // fraction of a dB, so the error stays small.
+    for (float db = -100.0f; db <= 12.0f; db += 0.05f)
+    {
+        const int   pb  = mcu::faderDbToPitchBend14 (db);
+        const float rtd = mcu::pitchBend14ToFaderDb (pb);
+        REQUIRE_THAT (rtd, WithinAbs (db, 0.2f));
+    }
+}
+
+TEST_CASE ("McuFaderTaper: values clamp beyond the fader range", "[mcu][taper]")
+{
+    REQUIRE (mcu::faderDbToPitchBend14 (200.0f)  == mcu::kPitchBendMaxValue);
+    REQUIRE (mcu::faderDbToPitchBend14 (-500.0f) == 0);
+    REQUIRE (mcu::pitchBend14ToFaderDb (99999) == mcu::pitchBend14ToFaderDb (mcu::kPitchBendMaxValue));
+    REQUIRE (mcu::pitchBend14ToFaderDb (-5)    == mcu::pitchBend14ToFaderDb (0));
+}

--- a/tests/mcu_fader_taper.cpp
+++ b/tests/mcu_fader_taper.cpp
@@ -3,6 +3,7 @@
 
 #include "engine/McuFaderTaper.h"
 #include "engine/McuProtocol.h"
+#include "engine/FaderBindingMap.h"
 
 using Catch::Matchers::WithinAbs;
 using namespace duskstudio;
@@ -82,6 +83,59 @@ TEST_CASE ("McuFaderTaper: dB round-trips through pitch-bend within one code",
         const int   pb  = mcu::faderDbToPitchBend14 (db);
         const float rtd = mcu::pitchBend14ToFaderDb (pb);
         REQUIRE_THAT (rtd, WithinAbs (db, 0.2f));
+    }
+}
+
+// The MIDI-bindings apply/pickup path (AudioEngine) shares these two helpers
+// for its fader-dB targets: TrackFader, BusFader, AuxLaneFader, MasterFader.
+// A PitchBend-triggered binding rides the Mackie taper; a CC/Note binding
+// stays linear (generic 7-bit knob, no printed scale).
+
+TEST_CASE ("FaderBindingMap: PitchBend fader binds ride the Mackie taper",
+           "[mcu][taper][bindings]")
+{
+    // Unity (pb 12808) is what a Model-12-style motor fader sends at its
+    // printed 0 dB — the taper must land it on 0 dB, not the ~-10 dB the old
+    // linear-in-dB binding map produced. Consumed through the shared helper.
+    const float unityFrac = 12808.0f / (float) mcu::kPitchBendMaxValue;
+    REQUIRE_THAT (faderBindingFracToDb (unityFrac, /*pitchBend*/ true),
+                  WithinAbs (0.0f, 1e-3f));
+
+    // Top of throw = +12 dB; bottom = -100 dB, which sits below the
+    // ChannelStripParams hard-mute floor (-90) so a zeroed motor fader still
+    // silences the strip.
+    REQUIRE_THAT (faderBindingFracToDb (1.0f, true), WithinAbs (12.0f, 1e-3f));
+    REQUIRE_THAT (faderBindingFracToDb (0.0f, true), WithinAbs (-100.0f, 1e-3f));
+    REQUIRE (faderBindingFracToDb (0.0f, true) < -90.0f);
+}
+
+TEST_CASE ("FaderBindingMap: CC/Note fader binds stay linear -90..+12 dB",
+           "[mcu][taper][bindings]")
+{
+    REQUIRE_THAT (faderBindingFracToDb (0.0f, /*pitchBend*/ false), WithinAbs (-90.0f, 1e-4f));
+    REQUIRE_THAT (faderBindingFracToDb (1.0f, false), WithinAbs (12.0f, 1e-4f));
+    REQUIRE_THAT (faderBindingFracToDb (0.5f, false), WithinAbs (-39.0f, 1e-4f));
+
+    // A 7-bit CC lands 0 dB at ~0.882 of throw — the deliberately different
+    // behaviour from the PB taper (0 dB at ~0.782).
+    REQUIRE_THAT (faderBindingFracToDb (90.0f / 102.0f, false), WithinAbs (0.0f, 1e-3f));
+}
+
+TEST_CASE ("FaderBindingMap: apply and pickup inverse agree (soft-takeover symmetry)",
+           "[mcu][taper][bindings]")
+{
+    // faderBindingDbToFrac is the pickup read-back; it must invert
+    // faderBindingFracToDb for the SAME trigger or takeover latches at the
+    // wrong spot. Quantisation-limited on the PB side (14-bit codes).
+    for (bool pb : { false, true })
+    {
+        for (int i = 0; i <= 100; ++i)
+        {
+            const float frac = (float) i / 100.0f;
+            const float db   = faderBindingFracToDb (frac, pb);
+            const float back = faderBindingDbToFrac (db, pb);
+            REQUIRE_THAT (back, WithinAbs (frac, 2e-3f));
+        }
     }
 }
 

--- a/tests/mcu_receiver_decode.cpp
+++ b/tests/mcu_receiver_decode.cpp
@@ -47,22 +47,23 @@ TEST_CASE ("McuReceiver: fader pitch-bend writes faderDb on banked strip",
     McuReceiver r (s);
 
     // Bank 0 -> channels 0..7 = tracks 0..7. Pitch-bend on channel 3
-    // (zero-indexed = MCU strip 4) at full scale = 0 dB (top of fader).
-    // Linear-in-dB mapping: 16383 -> +12 dB.
+    // (zero-indexed = MCU strip 4) at full scale = top of throw = +12 dB.
     r.process (makePitchBend (3, mcu::kPitchBendMaxValue), 0);
     REQUIRE_THAT (s.track (3).strip.faderDb.load (std::memory_order_relaxed),
                   WithinAbs (12.0f, 0.1f));
 
-    // Bottom of fader: 0 -> -100 dB.
+    // Bottom of fader: 0 -> -100 dB (-inf floor).
     r.process (makePitchBend (3, 0), 0);
     REQUIRE_THAT (s.track (3).strip.faderDb.load (std::memory_order_relaxed),
                   WithinAbs (-100.0f, 0.1f));
 
     // Bank 1 -> channels 0..7 = tracks 8..15. Strip 0 moves track 8.
+    // Half the 14-bit range (8191) sits on the Mackie taper between the
+    // -12 dB (7657) and -9 dB (8735) breakpoints -> ~-10.5 dB.
     s.mcu.bank.store (1, std::memory_order_relaxed);
     r.process (makePitchBend (0, mcu::kPitchBendMaxValue / 2), 0);
     REQUIRE_THAT (s.track (8).strip.faderDb.load (std::memory_order_relaxed),
-                  WithinAbs (-44.0f, 1.0f));   // midway in -100..+12 -> -44
+                  WithinAbs (-10.5f, 0.3f));
 }
 
 TEST_CASE ("McuReceiver: master fader pitch-bend (channel 8) targets MasterBusParams",

--- a/tests/plugin_scan_protocol.cpp
+++ b/tests/plugin_scan_protocol.cpp
@@ -104,3 +104,22 @@ TEST_CASE ("scan protocol: malformed payload XML parses to nothing", "[scanproto
     parsePayload ("<PLUGINS><PLUGIN garbled", out);   // not well-formed
     CHECK (out.isEmpty());
 }
+
+TEST_CASE ("scan sandbox policy: third-party formats are sandboxed, in-house is not",
+           "[scanproto]")
+{
+    // Third-party binary formats load foreign code and MUST be scanned
+    // out-of-process — this is the decision that keeps an unauthorized / crashy
+    // plugin from taking down the app (issue #45).
+    CHECK (formatRequiresSandbox ("VST3"));
+    CHECK (formatRequiresSandbox ("VST"));
+    CHECK (formatRequiresSandbox ("LV2"));
+    CHECK (formatRequiresSandbox ("AudioUnit"));
+
+    // In-house / trusted formats scan in-process. DuskMultisample is our own
+    // soundfont player; an unknown name defaults to in-process (never sandboxed
+    // by accident — but also never a third-party crash vector).
+    CHECK_FALSE (formatRequiresSandbox ("DuskMultisample"));
+    CHECK_FALSE (formatRequiresSandbox (""));
+    CHECK_FALSE (formatRequiresSandbox ("CLAP"));   // native CLAP has its own sandbox path
+}


### PR DESCRIPTION
Fixes the two real bugs from #45 plus a third instance the reporter's bindings file exposed.

**MCU fader taper.** The dB-to-pitchbend map was linear across -100..+12 dB, putting unity at 89% of fader throw instead of the printed 0 near 3/4 travel. New shared taper (src/engine/McuFaderTaper.h, breakpoints from the de-facto Mackie fader law, 0 dB at pitchbend 12808) used symmetrically by the controller send and receiver decode, with exact pb-to-dB-to-pb identity over all 16384 codes so motor feedback never fights touch. MANUAL gains a controller-setup section (prefer MCU mode over one-way MIDI bindings; Rewind/Forward are marker-jump/scrub).

**Windows scan crash.** Root cause: getHostExecutablePath lacked the .exe suffix, so the out-of-process scan sandbox never engaged on Windows and every third-party plugin scanned in-process - one unauthorized VST3 took down the app. Fixed the name; the custom scanner installs unconditionally; sandbox-spawn failure now SKIPS third-party plugins (unscanned, not quarantined) and reports the count in the scan-complete alert; hung scans (license dialogs) quarantine with a distinct 'timed out' reason; user abort no longer blacklists the in-flight plugin.

**Pitchbend binding taper.** The reporter's hand-made bindings route the Model 12's pitchbend faders through the manual-bindings path, which had the same linear map (printed 0 read about -10 dB). PitchBend-triggered Track/Bus/AuxLane/Master fader bindings now ride the Mackie taper on apply AND soft-takeover pickup (exact inverse); CC/Note fader bindings stay linear (generic knobs). Aux sends stay linear by design.

Verified: 374/374 tests (9 new), Xvfb selftest 26 PASS / 0 FAIL, juce-gate 202 (both new headers token-clean).

Windows manual checks owed (no Win box here): dusk-studio-plugin-host.exe children visible during rescan; license-dialog plugin quarantines after ~30s as 'timed out (possible license dialog)'; crashy plugin kills only the child; renaming the host exe yields skip-and-report, not a crash. Model 12 hardware checks: printed fader 0 reads 0.0 dB (both MCU mode and pitchbend bindings), mute/solo/record LEDs in MCU mode, transport tap/hold semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved Mackie Control fader response and synchronization, including more accurate unity-gain positioning and consistent soft takeover.
  * Enhanced pitch-bend fader behavior across channel, bus, auxiliary, and master controls.

* **Plugin Scanning**
  * Third-party plugins are now scanned in a safer isolated process.
  * Scan results clearly warn when plugins could not be scanned and indicate when to retry.

* **Documentation**
  * Added guidance recommending MCU mode over manual MIDI mapping, including transport and fader behavior details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->