### PR TITLE
Single-pass stems, realtime bounce, and hardware inserts on frozen tracks

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -590,6 +590,7 @@ This block is visible in the RECORDING stage, alongside a small **I/O** button t
 - **FREEZE** (MIDI tracks, and audio tracks once recorded): the same button reads **FREEZE**. Click it to render the track to an audio file and bypass the DSP that produced it, to reclaim CPU — the frozen track plays back from the rendered audio with the fader, pan, and aux sends still live so you can keep mixing. The button turns to a snowflake while frozen; click it again to unfreeze (the rendered file is discarded). Frozen state is saved with the session, and a frozen track is locked — unfreeze first to edit, re-record, or change its mode.
   - On a **MIDI track** freeze bakes the instrument plugin plus the channel EQ and compressor — the way to reclaim CPU from a heavy synth or sample library once you're happy with a part.
   - On an **audio track** the PRINT button becomes FREEZE once the track holds a recorded take. Freeze bakes the recorded audio through its insert, EQ, and compressor — a large CPU saving when you run high effect oversampling, since the oversampled processing no longer runs on playback.
+  - A frozen track still accepts a **hardware insert**: the baked audio is a source like any other, so you can route it through outboard gear (its measured loop latency is compensated as usual). The insert picker on a frozen MIDI track offers effects rather than instruments — the instrument is baked into the audio. A plugin insert added while frozen doesn't process until you unfreeze (the frozen audio plays through untouched).
 
 ## Insert slot
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1751,7 +1751,7 @@ The File menu has three bounce commands:
 
   A track stem is that track's post-fader output — its full processed signal, without master-strip processing — so the whole set is mutually sample-aligned and track + bus + aux stems together reconstruct the pre-master mix. A track routed to a bus appears both as its own stem and (processed) inside the bus stem; re-import one or the other, not both. Mute and solo print as heard, so a muted track writes a silent stem.
 
-If a session uses **hardware inserts**, the bounce dialog shows a warning: an offline render is detached from the audio interface, so the external loop cannot run and those inserts print dry.
+If a session uses **hardware inserts**, an offline render cannot run the external loop (it is detached from the audio interface), so those inserts would print dry. Bounce and stem flows therefore ask whether to run a **realtime bounce** instead: the session plays once through the interface at normal speed and the capture streams to disk, printing the hardware exactly as you hear it (minus the monitoring click, which never prints). Realtime bounces are always WAV, render at the device sample rate, and need the transport stopped to start; choosing **Offline** keeps the fast render with the dry-insert warning.
 
 ## Bouncing the master vs the mastering chain
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1508,7 +1508,7 @@ The configuration panel has six controls:
 - **Input volume**: a level trim on the return side, 0.0 to 1.0.
 - **Latency samples**: the round-trip delay through the external gear, in samples. Determines the dry-path delay applied to the rest of the mix so the hardware insert remains time-aligned.
 - **Dry/Wet**: 0.0 plays only the dry signal (insert bypassed), 1.0 plays only the returned wet signal. Useful for parallel processing.
-- **Format**: **Stereo** or **Mid/Side**. Mid/Side encodes the signal so that the hardware EQ processes the mid and side components independently.
+- **Format**: **Stereo** or **Mid/Side**. Mid/Side encodes the signal so that the hardware EQ processes the mid and side components independently. On a **mono track** a third option, **Mono**, patches a single output and a single return — the natural hookup for one-channel outboard like a mono compressor or a pedal — and the channel dropdowns list individual channels instead of pairs.
 
 ## Auto-measuring latency
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1747,7 +1747,11 @@ The File menu has three bounce commands:
 
 - **Bounce…** — render the full master mix to a WAV you choose.
 - **Mixdown** — one-shot render to `mixdown.wav` in the session folder, then automatically switch to the MASTERING stage with that file loaded.
-- **Bounce stems…** — render one WAV per track (named `<base>_<NN>_<track>.wav`); warns before overwriting any existing stem files.
+- **Bounce stems…** — render every stem in a single offline pass: one WAV per track with content (named `<base>_<NN>_<track>.wav`), plus one per bus group any of those tracks route into (`<base>_bus<N>_<name>.wav`) and one per aux lane they send to (`<base>_aux<N>_<name>.wav`). Warns before overwriting any existing stem files.
+
+  A track stem is that track's post-fader output — its full processed signal, without master-strip processing — so the whole set is mutually sample-aligned and track + bus + aux stems together reconstruct the pre-master mix. A track routed to a bus appears both as its own stem and (processed) inside the bus stem; re-import one or the other, not both. Mute and solo print as heard, so a muted track writes a silent stem.
+
+If a session uses **hardware inserts**, the bounce dialog shows a warning: an offline render is detached from the audio interface, so the external loop cannot run and those inserts print dry.
 
 ## Bouncing the master vs the mastering chain
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1747,7 +1747,7 @@ The File menu has three bounce commands:
 
 - **Bounce…** — render the full master mix to a WAV you choose.
 - **Mixdown** — one-shot render to `mixdown.wav` in the session folder, then automatically switch to the MASTERING stage with that file loaded.
-- **Bounce stems…** — render every stem in a single offline pass: one WAV per track with content (named `<base>_<NN>_<track>.wav`), plus one per bus group any of those tracks route into (`<base>_bus<N>_<name>.wav`) and one per aux lane they send to (`<base>_aux<N>_<name>.wav`). Warns before overwriting any existing stem files.
+- **Bounce stems…** — render every stem in a single offline pass: one WAV per track with content (named `<base>_<NN>_<track>.wav`), plus one per bus group any of those tracks route into (`<base>_bus<N>_<name>.wav`) and one per aux lane they send to (`<base>_aux<N>_<name>.wav`). The file browser opens in a `stems/` subfolder of the session so a full set doesn't crowd the session root; pick any other location if you prefer. Warns before overwriting any existing stem files.
 
   A track stem is that track's post-fader output — its full processed signal, without master-strip processing — so the whole set is mutually sample-aligned and track + bus + aux stems together reconstruct the pre-master mix. A track routed to a bus appears both as its own stem and (processed) inside the bus stem; re-import one or the other, not both. Mute and solo print as heard, so a muted track writes a silent stem.
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1751,7 +1751,9 @@ The File menu has three bounce commands:
 
   A track stem is that track's post-fader output — its full processed signal, without master-strip processing — so the whole set is mutually sample-aligned and track + bus + aux stems together reconstruct the pre-master mix. A track routed to a bus appears both as its own stem and (processed) inside the bus stem; re-import one or the other, not both. Mute and solo print as heard, so a muted track writes a silent stem.
 
-If a session uses **hardware inserts**, an offline render cannot run the external loop (it is detached from the audio interface), so those inserts would print dry. Bounce and stem flows therefore ask whether to run a **realtime bounce** instead: the session plays once through the interface at normal speed and the capture streams to disk, printing the hardware exactly as you hear it (minus the monitoring click, which never prints). Realtime bounces are always WAV, render at the device sample rate, and need the transport stopped to start; choosing **Offline** keeps the fast render with the dry-insert warning.
+If a session uses **hardware inserts**, an offline render cannot run the external loop (it is detached from the audio interface), so those inserts would print dry. Bounce and stem flows therefore ask whether to run a **realtime bounce** instead: the session plays once through the interface at normal speed and the capture streams to disk, printing the hardware exactly as you hear it (minus the monitoring click, which never prints). Realtime bounces are always WAV, render at the device sample rate, and need the transport stopped to start; choosing **Offline** keeps the fast render with the dry-insert warning. Because the transport genuinely rolls, MIDI Clock / MTC keep transmitting during a realtime bounce — chase-synced external gear starts with it, which is exactly what you want when that gear is part of the sound.
+
+The metronome never prints in any bounce: it is a monitoring aid, mixed in after the point every render captures.
 
 ## Bouncing the master vs the mastering chain
 

--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -1336,11 +1336,121 @@ private:
                     else
                         exitCode = 1;
                     std::fflush (stdout);
-                    finish();
+                    phase = Phase::StartStems;
+                    phaseStartMs = now;
                 }
                 else if (timedOut)
                 {
                     std::fprintf (stdout, "[FAIL] Freeze render did not finish within %d ms\n",
+                                  kTimeoutMs);
+                    exitCode = 1;
+                    finish();
+                }
+                break;
+            }
+
+            case Phase::StartStems:
+            {
+                // Route track 1 into bus 1 and send it to aux 1 so the single
+                // pass has to produce every stem kind: two track stems, a bus
+                // stem, and an aux stem. Master leg already ran, so mutating
+                // the routing here can't disturb its output.
+                session->track (1).strip.busAssign[0].store (true);
+                session->track (1).strip.auxSendDb[0].store (0.0f);
+
+                stemsBase = tmpDir.getChildFile ("stems.wav");
+                for (const auto& tgt : BounceEngine::collectStemTargets (*session, stemsBase))
+                    tgt.file.deleteFile();
+
+                bounce = std::make_unique<BounceEngine> (*engine, *session,
+                                                         engine->getDeviceManager());
+                bounce->onFinished = [this] (bool ok, juce::String err)
+                {
+                    stemsOk  = ok;
+                    stemsErr = err;
+                    stemsDone.store (true, std::memory_order_release);
+                };
+                if (bounce->start (stemsBase, sr, bs, 1.0, BounceEngine::Mode::Stems,
+                                   BounceEngine::Format::Wav))
+                {
+                    phase = Phase::WaitStems;
+                    phaseStartMs = now;
+                }
+                else if (++stemsAttempts > 40)
+                {
+                    std::fprintf (stdout, "[FAIL] Stems: start() would not start: %s\n",
+                                  bounce->getLastError().toRawUTF8());
+                    exitCode = 1;
+                    finish();
+                }
+                break;
+            }
+
+            case Phase::WaitStems:
+            {
+                if (stemsDone.load (std::memory_order_acquire))
+                {
+                    bool ok = stemsOk && stemsErr.isEmpty();
+                    if (! ok)
+                        std::fprintf (stdout, "[FAIL] Stems: worker reported ok=%d err=\"%s\"\n",
+                                      (int) stemsOk, stemsErr.toRawUTF8());
+
+                    const auto targets = BounceEngine::collectStemTargets (*session, stemsBase);
+                    int trackStems = 0, busStems = 0, auxStems = 0;
+                    for (const auto& tgt : targets)
+                        switch (tgt.kind)
+                        {
+                            case BounceEngine::StemTarget::Kind::Track: ++trackStems; break;
+                            case BounceEngine::StemTarget::Kind::Bus:   ++busStems;   break;
+                            case BounceEngine::StemTarget::Kind::Aux:   ++auxStems;   break;
+                        }
+                    if (trackStems != 2 || busStems != 1 || auxStems != 1)
+                    {
+                        std::fprintf (stdout, "[FAIL] Stems: expected 2 track + 1 bus + 1 aux "
+                                              "targets, got %d/%d/%d\n",
+                                      trackStems, busStems, auxStems);
+                        ok = false;
+                    }
+
+                    std::int64_t commonLen = -1;
+                    for (const auto& tgt : targets)
+                    {
+                        float peak = 0.0f;
+                        const auto label = "Stems: " + tgt.file.getFileName();
+                        if (! validateWav (tgt.file, label.toRawUTF8(), peak))
+                        {
+                            ok = false;
+                            continue;
+                        }
+                        juce::WavAudioFormat wav;
+                        if (auto reader = std::unique_ptr<juce::AudioFormatReader> (
+                                wav.createReaderFor (tgt.file.createInputStream().release(), true)))
+                        {
+                            if (commonLen < 0) commonLen = reader->lengthInSamples;
+                            else if (reader->lengthInSamples != commonLen)
+                            {
+                                std::fprintf (stdout, "[FAIL] Stems: %s length %lld != %lld - "
+                                                      "set is not sample-aligned\n",
+                                              tgt.file.getFileName().toRawUTF8(),
+                                              (long long) reader->lengthInSamples,
+                                              (long long) commonLen);
+                                ok = false;
+                            }
+                        }
+                    }
+
+                    if (ok)
+                        std::fprintf (stdout,
+                                      "[PASS] Stems single-pass render OK (%d files, equal length, "
+                                      "all nonzero + finite)\n", (int) targets.size());
+                    else
+                        exitCode = 1;
+                    std::fflush (stdout);
+                    finish();
+                }
+                else if (timedOut)
+                {
+                    std::fprintf (stdout, "[FAIL] Stems render did not finish within %d ms\n",
                                   kTimeoutMs);
                     exitCode = 1;
                     finish();
@@ -1370,7 +1480,7 @@ private:
     static constexpr double kContentSeconds = 2.0;
     static constexpr int    kTimeoutMs = 60000;
 
-    enum class Phase { WaitMaster, StartFreeze, WaitFreeze, Done };
+    enum class Phase { WaitMaster, StartFreeze, WaitFreeze, StartStems, WaitStems, Done };
 
     DuskStudioApp& app;
     juce::String   pluginPath;
@@ -1380,19 +1490,21 @@ private:
     std::unique_ptr<AudioEngine>  engine;
     std::unique_ptr<BounceEngine> bounce;
 
-    juce::File tmpDir, mixFile, freezeFile;
+    juce::File tmpDir, mixFile, freezeFile, stemsBase;
     double sr = 48000.0;
     int    bs = 1024;
 
     Phase        phase = Phase::WaitMaster;
     juce::uint32 phaseStartMs = 0;
     int          freezeAttempts = 0;
+    int          stemsAttempts = 0;
     int          exitCode = 0;
 
     std::atomic<bool> masterDone { false };
     std::atomic<bool> freezeDone { false };
-    bool masterOk = false, freezeOk = false;
-    juce::String masterErr, freezeErr;
+    std::atomic<bool> stemsDone  { false };
+    bool masterOk = false, freezeOk = false, stemsOk = false;
+    juce::String masterErr, freezeErr, stemsErr;
 };
 
 // Resolve a session path passed on the command line / by the file manager.

--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -1170,23 +1170,27 @@ private:
 
     // Read a rendered WAV back and report nonzero + finite. peakOut set to the
     // linear peak. Returns false with a printed [FAIL] reason on any problem.
-    bool validateWav (const juce::File& file, const char* label, float& peakOut)
+    bool validateWav (const juce::File& file, const char* label, float& peakOut,
+                      std::int64_t* lengthOut = nullptr)
     {
         peakOut = 0.0f;
+        if (lengthOut != nullptr) *lengthOut = 0;
         if (! file.existsAsFile())
         {
             std::fprintf (stdout, "[FAIL] %s: output file not written: %s\n",
                           label, file.getFullPathName().toRawUTF8());
             return false;
         }
+        auto stream = file.createInputStream();
         juce::WavAudioFormat wav;
         std::unique_ptr<juce::AudioFormatReader> reader (
-            wav.createReaderFor (file.createInputStream().release(), true));
+            stream != nullptr ? wav.createReaderFor (stream.release(), true) : nullptr);
         if (reader == nullptr)
         {
             std::fprintf (stdout, "[FAIL] %s: could not open output WAV for readback\n", label);
             return false;
         }
+        if (lengthOut != nullptr) *lengthOut = reader->lengthInSamples;
         const int n = (int) reader->lengthInSamples;
         if (n <= 0)
         {
@@ -1403,6 +1407,7 @@ private:
                             case BounceEngine::StemTarget::Kind::Track: ++trackStems; break;
                             case BounceEngine::StemTarget::Kind::Bus:   ++busStems;   break;
                             case BounceEngine::StemTarget::Kind::Aux:   ++auxStems;   break;
+                            case BounceEngine::StemTarget::Kind::Mix:   break;
                         }
                     if (trackStems != 2 || busStems != 1 || auxStems != 1)
                     {
@@ -1416,26 +1421,22 @@ private:
                     for (const auto& tgt : targets)
                     {
                         float peak = 0.0f;
+                        std::int64_t len = 0;
                         const auto label = "Stems: " + tgt.file.getFileName();
-                        if (! validateWav (tgt.file, label.toRawUTF8(), peak))
+                        if (! validateWav (tgt.file, label.toRawUTF8(), peak, &len))
                         {
                             ok = false;
                             continue;
                         }
-                        juce::WavAudioFormat wav;
-                        if (auto reader = std::unique_ptr<juce::AudioFormatReader> (
-                                wav.createReaderFor (tgt.file.createInputStream().release(), true)))
+                        if (commonLen < 0) commonLen = len;
+                        else if (len != commonLen)
                         {
-                            if (commonLen < 0) commonLen = reader->lengthInSamples;
-                            else if (reader->lengthInSamples != commonLen)
-                            {
-                                std::fprintf (stdout, "[FAIL] Stems: %s length %lld != %lld - "
-                                                      "set is not sample-aligned\n",
-                                              tgt.file.getFileName().toRawUTF8(),
-                                              (long long) reader->lengthInSamples,
-                                              (long long) commonLen);
-                                ok = false;
-                            }
+                            std::fprintf (stdout, "[FAIL] Stems: %s length %lld != %lld - "
+                                                  "set is not sample-aligned\n",
+                                          tgt.file.getFileName().toRawUTF8(),
+                                          (long long) len,
+                                          (long long) commonLen);
+                            ok = false;
                         }
                     }
 

--- a/src/dsp/ChannelStrip.cpp
+++ b/src/dsp/ChannelStrip.cpp
@@ -1203,6 +1203,12 @@ void ChannelStrip::processAndAccumulate (const float* inL,
     // during playback). It's the level BEFORE the master/bus routing split, so
     // it reflects the track's contribution regardless of where it's routed.
     float outPeakL = 0.0f, outPeakR = 0.0f;
+    // Both sides or neither: a live disarm (realtime bounce) nulls the pair
+    // non-atomically, so one load can land each side of it.
+    float* scL = stemCapL.load (std::memory_order_acquire);
+    float* scR = stemCapR.load (std::memory_order_acquire);
+    if (scL == nullptr || scR == nullptr)
+        scL = scR = nullptr;
     const auto publishOutMeter = [this] (float pL, float pR)
     {
         currentOutLDb.store (pL > 1e-5f ? dusk::audio::gainToDecibels (pL, -100.0f) : -100.0f,
@@ -1227,7 +1233,7 @@ void ChannelStrip::processAndAccumulate (const float* inL,
             const float oR = srcR[i] * gR;
             masterL[i] += oL;
             masterR[i] += oR;
-            if (stemCapL != nullptr) { stemCapL[i] += oL; stemCapR[i] += oR; }
+            if (scL != nullptr) { scL[i] += oL; scR[i] += oR; }
             outPeakL = juce::jmax (outPeakL, std::abs (oL));
             outPeakR = juce::jmax (outPeakR, std::abs (oR));
         }
@@ -1252,7 +1258,7 @@ void ChannelStrip::processAndAccumulate (const float* inL,
         const float wetRPre = sR * pR;
         const float wetL = sL * gL;
         const float wetR = sR * gR;
-        if (stemCapL != nullptr) { stemCapL[i] += wetL; stemCapR[i] += wetR; }
+        if (scL != nullptr) { scL[i] += wetL; scR[i] += wetR; }
         outPeakL = juce::jmax (outPeakL, std::abs (wetL));
         outPeakR = juce::jmax (outPeakR, std::abs (wetR));
 

--- a/src/dsp/ChannelStrip.cpp
+++ b/src/dsp/ChannelStrip.cpp
@@ -1227,6 +1227,7 @@ void ChannelStrip::processAndAccumulate (const float* inL,
             const float oR = srcR[i] * gR;
             masterL[i] += oL;
             masterR[i] += oR;
+            if (stemCapL != nullptr) { stemCapL[i] += oL; stemCapR[i] += oR; }
             outPeakL = juce::jmax (outPeakL, std::abs (oL));
             outPeakR = juce::jmax (outPeakR, std::abs (oR));
         }
@@ -1251,6 +1252,7 @@ void ChannelStrip::processAndAccumulate (const float* inL,
         const float wetRPre = sR * pR;
         const float wetL = sL * gL;
         const float wetR = sR * gR;
+        if (stemCapL != nullptr) { stemCapL[i] += wetL; stemCapR[i] += wetR; }
         outPeakL = juce::jmax (outPeakL, std::abs (wetL));
         outPeakR = juce::jmax (outPeakR, std::abs (wetR));
 

--- a/src/dsp/ChannelStrip.cpp
+++ b/src/dsp/ChannelStrip.cpp
@@ -966,16 +966,40 @@ void ChannelStrip::processAndAccumulate (const float* inL,
         if (isFrozen)
         {
             // Frozen track: inL/inR are the pre-rendered (instrument + EQ +
-            // comp) audio. Copy it in as the source; the instrument plugin and
-            // the EQ/comp stage below are skipped (baked into the WAV). PDC and
-            // fader/pan/sends still run. Keep the insert-gate smoother ticking
-            // so an un-freeze mid-session resumes click-free.
+            // comp) audio. Copy it in as the source; the baked plugin and the
+            // EQ/comp stage below stay skipped. A HARDWARE insert still runs -
+            // it is only ever engaged by an explicit post-freeze user action,
+            // and the frozen WAV is an audio source like any other. A plugin
+            // slot cannot run here: the strip can't tell a newly added effect
+            // from a still-loaded baked native instrument, which would render
+            // silence over the WAV. PDC and fader/pan/sends still run.
             if (inL != nullptr) std::memcpy (L, inL, sizeof (float) * (size_t) numSamples);
             else                juce::FloatVectorOperations::clear (L, numSamples);
             if (inR != nullptr) std::memcpy (R, inR, sizeof (float) * (size_t) numSamples);
             else                std::memcpy (R, L,   sizeof (float) * (size_t) numSamples);
-            for (int i = 0; i < numSamples; ++i)
-                activeInsertGain.getNextValue();
+
+            if (activeInsertMode == kInsertHardware)
+            {
+                jassert (numSamples <= (int) insertScratchL.size());
+                std::memcpy (insertScratchL.data(), L, sizeof (float) * (size_t) numSamples);
+                std::memcpy (insertScratchR.data(), R, sizeof (float) * (size_t) numSamples);
+                hardwareSlot.processStereoBlock (L, R, numSamples,
+                                                  deviceInputs, numDeviceInputs,
+                                                  deviceOutputs, numDeviceOutputs);
+                for (int i = 0; i < numSamples; ++i)
+                {
+                    const float g = activeInsertGain.getNextValue();
+                    L[i] = (1.0f - g) * insertScratchL[(size_t) i] + g * L[i];
+                    R[i] = (1.0f - g) * insertScratchR[(size_t) i] + g * R[i];
+                }
+            }
+            else
+            {
+                // Keep the insert-gate smoother ticking so an un-freeze or a
+                // hardware engage mid-session resumes click-free.
+                for (int i = 0; i < numSamples; ++i)
+                    activeInsertGain.getNextValue();
+            }
         }
         else if (isMidi)
         {

--- a/src/dsp/ChannelStrip.h
+++ b/src/dsp/ChannelStrip.h
@@ -230,14 +230,19 @@ public:
     // engine is detached for the offline render - never during live audio.
     void setFreezeCapture (float* l, float* r) noexcept { freezeCapL = l; freezeCapR = r; }
 
-    // setStemCapture points the strip at a stereo scratch the offline stems
-    // render reads each block: the post-fader / post-pan output (the track's
-    // full wet contribution, BEFORE the master-vs-bus routing split) is
-    // accumulated there. The caller clears the scratch each block, so a strip
-    // whose processing is skipped leaves silence. Same contract as
-    // setFreezeCapture: nullptr disables, message thread only, set while the
-    // engine is detached.
-    void setStemCapture (float* l, float* r) noexcept { stemCapL = l; stemCapR = r; }
+    // setStemCapture points the strip at a stereo scratch the stems render
+    // reads each block: the post-fader / post-pan output (the track's full
+    // wet contribution, BEFORE the master-vs-bus routing split) is
+    // accumulated there. The caller clears the scratch each block, so a
+    // strip whose processing is skipped leaves silence. Message thread;
+    // atomic (unlike the freeze tap) because a REALTIME bounce arms it while
+    // the live callback is running.
+    void setStemCapture (float* l, float* r) noexcept
+    {
+        // R first: the audio thread gates on L, so L's release-store publishes R.
+        stemCapR.store (r, std::memory_order_relaxed);
+        stemCapL.store (l, std::memory_order_release);
+    }
 
 private:
     const ChannelStripParams* paramsRef = nullptr;
@@ -400,10 +405,10 @@ private:
     float* freezeCapL = nullptr;
     float* freezeCapR = nullptr;
 
-    // Post-fader capture destinations for the offline stems render (see
-    // setStemCapture). nullptr on the live path.
-    float* stemCapL = nullptr;
-    float* stemCapR = nullptr;
+    // Post-fader capture destinations for the stems render (see
+    // setStemCapture). nullptr when no stems bounce is running.
+    std::atomic<float*> stemCapL { nullptr };
+    std::atomic<float*> stemCapR { nullptr };
 
     void updateGainTargets() noexcept;
     void updateEqParameters() noexcept;

--- a/src/dsp/ChannelStrip.h
+++ b/src/dsp/ChannelStrip.h
@@ -230,6 +230,15 @@ public:
     // engine is detached for the offline render - never during live audio.
     void setFreezeCapture (float* l, float* r) noexcept { freezeCapL = l; freezeCapR = r; }
 
+    // setStemCapture points the strip at a stereo scratch the offline stems
+    // render reads each block: the post-fader / post-pan output (the track's
+    // full wet contribution, BEFORE the master-vs-bus routing split) is
+    // accumulated there. The caller clears the scratch each block, so a strip
+    // whose processing is skipped leaves silence. Same contract as
+    // setFreezeCapture: nullptr disables, message thread only, set while the
+    // engine is detached.
+    void setStemCapture (float* l, float* r) noexcept { stemCapL = l; stemCapR = r; }
+
 private:
     const ChannelStripParams* paramsRef = nullptr;
     dusk::audio::SmoothedValue<float> faderGain  { 0.0f };
@@ -390,6 +399,11 @@ private:
     // setFreezeCapture). nullptr on the live path.
     float* freezeCapL = nullptr;
     float* freezeCapR = nullptr;
+
+    // Post-fader capture destinations for the offline stems render (see
+    // setStemCapture). nullptr on the live path.
+    float* stemCapL = nullptr;
+    float* stemCapR = nullptr;
 
     void updateGainTargets() noexcept;
     void updateEqParameters() noexcept;

--- a/src/dsp/HardwareInsertSlot.cpp
+++ b/src/dsp/HardwareInsertSlot.cpp
@@ -234,24 +234,30 @@ void HardwareInsertSlot::processStereoBlock (float* L, float* R, int numSamples,
     }
     // -------------------------------------------------------------------
 
-    // Bounds-check the device channel indices. An out-of-range routing
-    // (e.g. user picked output 7-8 but then switched to a 2-out device)
-    // falls through to a dry-only path so the user hears something
-    // sensible instead of silence + a crashed audio thread.
-    const bool outValid = routing.outputChL >= 0
-                       && routing.outputChR >= 0
-                       && routing.outputChL < numDeviceOutputs
-                       && routing.outputChR < numDeviceOutputs
-                       && deviceOutputs != nullptr
-                       && deviceOutputs[routing.outputChL] != nullptr
-                       && deviceOutputs[routing.outputChR] != nullptr;
-    const bool inValid  = routing.inputChL >= 0
-                       && routing.inputChR >= 0
-                       && routing.inputChL < numDeviceInputs
-                       && routing.inputChR < numDeviceInputs
-                       && deviceInputs != nullptr
-                       && deviceInputs[routing.inputChL] != nullptr
-                       && deviceInputs[routing.inputChR] != nullptr;
+    // Bounds-check the device channel indices per side. An out-of-range
+    // routing (e.g. user picked output 7-8 but then switched to a 2-out
+    // device) falls through to a dry-only path so the user hears something
+    // sensible instead of silence + a crashed audio thread. A -1 on the R
+    // side is MONO routing (single-channel outboard): the send goes out on
+    // L alone and the single return feeds both sides.
+    const bool outLValid = routing.outputChL >= 0
+                        && routing.outputChL < numDeviceOutputs
+                        && deviceOutputs != nullptr
+                        && deviceOutputs[routing.outputChL] != nullptr;
+    const bool outRValid = routing.outputChR >= 0
+                        && routing.outputChR < numDeviceOutputs
+                        && deviceOutputs != nullptr
+                        && deviceOutputs[routing.outputChR] != nullptr;
+    const bool inLValid  = routing.inputChL >= 0
+                        && routing.inputChL < numDeviceInputs
+                        && deviceInputs != nullptr
+                        && deviceInputs[routing.inputChL] != nullptr;
+    const bool inRValid  = routing.inputChR >= 0
+                        && routing.inputChR < numDeviceInputs
+                        && deviceInputs != nullptr
+                        && deviceInputs[routing.inputChR] != nullptr;
+    const bool outValid = outLValid || outRValid;
+    const bool inValid  = inLValid  || inRValid;
 
     for (int i = 0; i < numSamples; ++i)
     {
@@ -313,21 +319,23 @@ void HardwareInsertSlot::processStereoBlock (float* L, float* R, int numSamples,
         // (Phase 2), so multiple inserts sharing an output pair sum
         // naturally and the master overwrites its assigned channels
         // via memcpy at the end of the callback regardless.
-        if (outValid)
-        {
+        if (outLValid)
             deviceOutputs[routing.outputChL][i] += sendL;
+        if (outRValid)
             deviceOutputs[routing.outputChR][i] += sendR;
-        }
 
         // Read the RETURN. With invalid routing, the wet path is
         // silent - the user gets the dry signal back through the
         // dry/wet mix and a visible empty input dropdown in the
-        // editor modal.
+        // editor modal. A single-sided (mono) return feeds both
+        // channels, so the strip's mono fold-down stays at unity.
         float retL = 0.0f, retR = 0.0f;
         if (inValid)
         {
-            retL = deviceInputs[routing.inputChL][i];
-            retR = deviceInputs[routing.inputChR][i];
+            retL = inLValid ? deviceInputs[routing.inputChL][i]
+                            : deviceInputs[routing.inputChR][i];
+            retR = inRValid ? deviceInputs[routing.inputChR][i]
+                            : retL;
 
             // Ping capture: store the L-channel return into the ring.
             // We correlate against L only - the M/S decode hasn't run

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -3945,9 +3945,8 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
         {
             monoIn = deviceInput;
         }
-        else if (! isFrozen
-                 && (strips[(size_t) t].getPluginSlot().isLoaded()
-                     || session.track (t).hardwareInsert.pingPending.load (std::memory_order_acquire)))
+        else if ((! isFrozen && strips[(size_t) t].getPluginSlot().isLoaded())
+                 || session.track (t).hardwareInsert.pingPending.load (std::memory_order_acquire))
         {
             // Generator-style insert with no input source: feed a
             // pre-zeroed buffer so the chain runs and the plugin can
@@ -3956,7 +3955,9 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
             // Same feed while a hardware-insert ping is in flight -
             // with transport stopped and IN off the track has no
             // source, and the slot needs to be serviced to run the
-            // chirp + capture.
+            // chirp + capture. The ping feed ignores frozen state: the
+            // frozen strip path runs the hardware slot too, and a
+            // stopped frozen track otherwise has no input at all.
             monoIn = silentInputScratch.data();
         }
 

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -703,13 +703,19 @@ void AudioEngine::recomputePdc() noexcept
         // their output is timeline-aligned as if zero-latency.
         const bool midi = session.track (t).mode.load (std::memory_order_relaxed)
                               == (int) Track::Mode::Midi;
-        // A frozen track plays its baked WAV with the insert bypassed, so its
-        // plugin / hardware latency must not count toward PDC - it's a zero-latency
-        // disk source (the bake was captured pre-PDC; see ChannelStrip freeze tap).
+        // A frozen track plays its baked WAV with the baked plugin bypassed, so
+        // PLUGIN latency must not count toward PDC - it's a zero-latency disk
+        // source (the bake was captured pre-PDC; see ChannelStrip freeze tap).
+        // A HARDWARE insert is different: the frozen strip path still runs it
+        // on the WAV audio, so its measured loop latency counts.
         const bool frozen = session.track (t).frozen.load (std::memory_order_relaxed);
-        if (! midi && ! frozen)
+        const int  mode   = strip.insertMode.load (std::memory_order_relaxed);
+        if (mode == ChannelStrip::kInsertHardware && (frozen || ! midi))
         {
-            const int mode = strip.insertMode.load (std::memory_order_relaxed);
+            lat = strip.getHardwareInsertSlot().getLatencySamples();
+        }
+        else if (! midi && ! frozen)
+        {
             if (mode == ChannelStrip::kInsertPlugin)
             {
                 lat = strip.getPluginSlot().getLatencySamples();
@@ -733,8 +739,6 @@ void AudioEngine::recomputePdc() noexcept
                         lat = inst->getLatencySamples();
 #endif
             }
-            else if (mode == ChannelStrip::kInsertHardware)
-                lat = strip.getHardwareInsertSlot().getLatencySamples();
         }
         latency[t] = juce::jlimit (0, ChannelStrip::kMaxPdcSamples, lat);
     }

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -4921,6 +4921,12 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
         else if (isPlaying)
             clickRolling = wantWhilePlay;
 
+        // The click is a monitoring aid and must never print: an offline
+        // bounce captures the mix it is about to be added to, so suppress it
+        // for the render. (Realtime bounces capture pre-click, upstream.)
+        if (offlineRenderActive.load (std::memory_order_relaxed))
+            clickRolling = false;
+
         // The click mixes post-master, AFTER the master-stage aux PDC delayed
         // the program by masterDryPdcApplied - reference the click to the
         // delayed position or it leads everything it's supposed to mark.

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -4575,6 +4575,13 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
         busStrips[(size_t) a].processInPlace (busL[(size_t) a].data(),
                                               busR[(size_t) a].data(),
                                               numSamples);
+        if (stemBusCapL[(size_t) a] != nullptr)
+        {
+            juce::FloatVectorOperations::add (stemBusCapL[(size_t) a],
+                                                busL[(size_t) a].data(), numSamples);
+            juce::FloatVectorOperations::add (stemBusCapR[(size_t) a],
+                                                busR[(size_t) a].data(), numSamples);
+        }
         // SIMD'd mix accumulate - hot inner loop, runs once per active aux
         // per callback. JUCE picks the right SSE/NEON path based on the
         // platform; cheaper than scalar [i]+= even with -O3.
@@ -4767,6 +4774,13 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
                 wL[i] = dL.popSample (0);
                 wR[i] = dR.popSample (0);
             }
+        }
+        if (stemAuxCapL[(size_t) a] != nullptr)
+        {
+            juce::FloatVectorOperations::add (stemAuxCapL[(size_t) a],
+                                                auxLaneL[(size_t) a].data(), numSamples);
+            juce::FloatVectorOperations::add (stemAuxCapR[(size_t) a],
+                                                auxLaneR[(size_t) a].data(), numSamples);
         }
         juce::FloatVectorOperations::add (mixL.data(),
                                             auxLaneL[(size_t) a].data(),

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -4575,11 +4575,13 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
         busStrips[(size_t) a].processInPlace (busL[(size_t) a].data(),
                                               busR[(size_t) a].data(),
                                               numSamples);
-        if (stemBusCapL[(size_t) a] != nullptr)
+        auto* capBusL = stemBusCapL[(size_t) a].load (std::memory_order_acquire);
+        auto* capBusR = stemBusCapR[(size_t) a].load (std::memory_order_relaxed);
+        if (capBusL != nullptr && capBusR != nullptr)
         {
-            juce::FloatVectorOperations::add (stemBusCapL[(size_t) a],
+            juce::FloatVectorOperations::add (capBusL,
                                                 busL[(size_t) a].data(), numSamples);
-            juce::FloatVectorOperations::add (stemBusCapR[(size_t) a],
+            juce::FloatVectorOperations::add (capBusR,
                                                 busR[(size_t) a].data(), numSamples);
         }
         // SIMD'd mix accumulate - hot inner loop, runs once per active aux
@@ -4775,11 +4777,13 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
                 wR[i] = dR.popSample (0);
             }
         }
-        if (stemAuxCapL[(size_t) a] != nullptr)
+        auto* capAuxL = stemAuxCapL[(size_t) a].load (std::memory_order_acquire);
+        auto* capAuxR = stemAuxCapR[(size_t) a].load (std::memory_order_relaxed);
+        if (capAuxL != nullptr && capAuxR != nullptr)
         {
-            juce::FloatVectorOperations::add (stemAuxCapL[(size_t) a],
+            juce::FloatVectorOperations::add (capAuxL,
                                                 auxLaneL[(size_t) a].data(), numSamples);
-            juce::FloatVectorOperations::add (stemAuxCapR[(size_t) a],
+            juce::FloatVectorOperations::add (capAuxR,
                                                 auxLaneR[(size_t) a].data(), numSamples);
         }
         juce::FloatVectorOperations::add (mixL.data(),
@@ -4805,6 +4809,47 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
     perfLap (PerfSections::kAuxes);
 
     master.processInPlace (mixL.data(), mixR.data(), numSamples);
+
+    // Realtime bounce: push each armed sink's block to its disk writer.
+    // Post-master, pre-metronome, so the monitoring click never prints.
+    // Gated on the transport actually rolling - the sinks are armed while
+    // stopped, and capturing the pre-roll would front-pad every file with
+    // silence. ThreadedWriter::write is a lock-free FIFO push (its
+    // TimeSliceThread drains to disk), so this stays RT-safe.
+    if (const int nSinks = rtBounceSinkCount.load (std::memory_order_acquire);
+        nSinks > 0 && isPlaying)
+    {
+        auto* sinks = rtBounceSinks.load (std::memory_order_relaxed);
+        for (int s = 0; sinks != nullptr && s < nSinks; ++s)
+        {
+            auto& sink = sinks[s];
+            const float* srcL = sink.srcL != nullptr ? sink.srcL : mixL.data();
+            const float* srcR = sink.srcR != nullptr ? sink.srcR : mixR.data();
+
+            int offset = 0;
+            if (sink.leadRemaining > 0)
+            {
+                offset = (int) juce::jmin ((std::int64_t) numSamples, sink.leadRemaining);
+                sink.leadRemaining -= offset;
+            }
+            const auto already = sink.written.load (std::memory_order_relaxed);
+            const int n = (int) juce::jmin ((std::int64_t) (numSamples - offset),
+                                              sink.cap - already);
+            if (n > 0)
+            {
+                const float* chans[2] = { srcL + offset, srcR + offset };
+                if (sink.writer->write (chans, n))
+                    sink.written.store (already + n, std::memory_order_release);
+                else
+                    sink.writeFailed.store (true, std::memory_order_release);
+            }
+            if (sink.wipeL != nullptr)
+            {
+                juce::FloatVectorOperations::clear (sink.wipeL, numSamples);
+                juce::FloatVectorOperations::clear (sink.wipeR, numSamples);
+            }
+        }
+    }
 
     // Metronome - push session BPM + enable into the click generator each
     // block (cheap atomic loads), then mix the click into the post-master

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -2125,6 +2125,20 @@ void AudioEngine::prepareForSelfTest (double sr, int bs)
     };
     const ResumeGuard resumeGuard { *this };
 
+    // A re-prepare invalidates an armed realtime bounce: its capture
+    // scratches were sized for the old block, so a grown one would overrun
+    // them from the audio thread (the mixL guard tracks the NEW size and
+    // passes). The gate above guarantees no callback is mid-sink-loop; kill
+    // the arming here and let the bounce worker fail the render cleanly.
+    if (rtBounceSinkCount.load (std::memory_order_relaxed) > 0)
+    {
+        rtBounceSinkCount.store (0, std::memory_order_relaxed);
+        rtBounceAborted.store (true, std::memory_order_release);
+        for (auto& s : strips) s.setStemCapture (nullptr, nullptr);
+        for (int a = 0; a < Session::kNumBuses; ++a)    setBusStemCapture (a, nullptr, nullptr);
+        for (int a = 0; a < Session::kNumAuxLanes; ++a) setAuxStemCapture (a, nullptr, nullptr);
+    }
+
     currentSampleRate.store (sr, std::memory_order_relaxed);
     currentBlockSize.store  (bs, std::memory_order_relaxed);
 
@@ -4812,36 +4826,42 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
 
     // Realtime bounce: push each armed sink's block to its disk writer.
     // Post-master, pre-metronome, so the monitoring click never prints.
-    // Gated on the transport actually rolling - the sinks are armed while
-    // stopped, and capturing the pre-roll would front-pad every file with
-    // silence. ThreadedWriter::write is a lock-free FIFO push (its
-    // TimeSliceThread drains to disk), so this stays RT-safe.
+    // Writes are gated on the transport actually rolling - the sinks are
+    // armed while stopped, and capturing the pre-roll would front-pad every
+    // file with silence. The scratch WIPES are not gated: the taps
+    // accumulate during stopped callbacks too (input monitoring runs the
+    // strips), and an unwiped pre-roll prints as a summed burst at sample 0.
+    // ThreadedWriter::write is a lock-free FIFO push (its TimeSliceThread
+    // drains to disk), so this stays RT-safe.
     if (const int nSinks = rtBounceSinkCount.load (std::memory_order_acquire);
-        nSinks > 0 && isPlaying)
+        nSinks > 0)
     {
         auto* sinks = rtBounceSinks.load (std::memory_order_relaxed);
         for (int s = 0; sinks != nullptr && s < nSinks; ++s)
         {
             auto& sink = sinks[s];
-            const float* srcL = sink.srcL != nullptr ? sink.srcL : mixL.data();
-            const float* srcR = sink.srcR != nullptr ? sink.srcR : mixR.data();
+            if (isPlaying)
+            {
+                const float* srcL = sink.srcL != nullptr ? sink.srcL : mixL.data();
+                const float* srcR = sink.srcR != nullptr ? sink.srcR : mixR.data();
 
-            int offset = 0;
-            if (sink.leadRemaining > 0)
-            {
-                offset = (int) juce::jmin ((std::int64_t) numSamples, sink.leadRemaining);
-                sink.leadRemaining -= offset;
-            }
-            const auto already = sink.written.load (std::memory_order_relaxed);
-            const int n = (int) juce::jmin ((std::int64_t) (numSamples - offset),
-                                              sink.cap - already);
-            if (n > 0)
-            {
-                const float* chans[2] = { srcL + offset, srcR + offset };
-                if (sink.writer->write (chans, n))
-                    sink.written.store (already + n, std::memory_order_release);
-                else
-                    sink.writeFailed.store (true, std::memory_order_release);
+                int offset = 0;
+                if (sink.leadRemaining > 0)
+                {
+                    offset = (int) juce::jmin ((std::int64_t) numSamples, sink.leadRemaining);
+                    sink.leadRemaining -= offset;
+                }
+                const auto already = sink.written.load (std::memory_order_relaxed);
+                const int n = (int) juce::jmin ((std::int64_t) (numSamples - offset),
+                                                  sink.cap - already);
+                if (n > 0)
+                {
+                    const float* chans[2] = { srcL + offset, srcR + offset };
+                    if (sink.writer->write (chans, n))
+                        sink.written.store (already + n, std::memory_order_release);
+                    else
+                        sink.writeFailed.store (true, std::memory_order_release);
+                }
             }
             if (sink.wipeL != nullptr)
             {

--- a/src/engine/AudioEngine.h
+++ b/src/engine/AudioEngine.h
@@ -281,6 +281,24 @@ public:
     void setOfflineRenderActive (bool active) noexcept
         { offlineRenderActive.store (active, std::memory_order_relaxed); }
 
+    // Offline-render stem capture for bus groups and aux lanes (the per-track
+    // taps live on ChannelStrip::setStemCapture). When set, the audio path
+    // accumulates the named unit's processed output - the exact signal it
+    // sums into the mix - into the given scratch each block. The caller
+    // clears the scratch per block, so a skipped (silent) bus or aux leaves
+    // silence. Same contract as the strip taps: nullptr disables, message
+    // thread only, set while the engine is detached for an offline render.
+    void setBusStemCapture (int bus, float* l, float* r) noexcept
+    {
+        stemBusCapL[(size_t) bus] = l;
+        stemBusCapR[(size_t) bus] = r;
+    }
+    void setAuxStemCapture (int lane, float* l, float* r) noexcept
+    {
+        stemAuxCapL[(size_t) lane] = l;
+        stemAuxCapR[(size_t) lane] = r;
+    }
+
     // Cross-track Plugin Delay Compensation. Reads each track's reported insert
     // latency (plugin OR hardware, gated by mode; MIDI tracks count 0 because
     // their instrument latency is already absorbed by the MIDI scheduling
@@ -540,6 +558,13 @@ private:
     // True only while an offline render drives the callback. See
     // setOfflineRenderActive.
     std::atomic<bool> offlineRenderActive { false };
+
+    // Stem-capture destinations for bus groups / aux lanes (see
+    // setBusStemCapture / setAuxStemCapture). nullptr on the live path.
+    std::array<float*, Session::kNumBuses>    stemBusCapL {};
+    std::array<float*, Session::kNumBuses>    stemBusCapR {};
+    std::array<float*, Session::kNumAuxLanes> stemAuxCapL {};
+    std::array<float*, Session::kNumAuxLanes> stemAuxCapR {};
 
     std::array<ChannelStrip, Session::kNumTracks> strips;
     std::array<BusStrip,  Session::kNumBuses> busStrips;

--- a/src/engine/AudioEngine.h
+++ b/src/engine/AudioEngine.h
@@ -327,8 +327,17 @@ public:
     };
     void armRealtimeBounce (RtBounceSink* sinks, int count) noexcept
     {
+        rtBounceAborted.store (false, std::memory_order_relaxed);
         rtBounceSinks.store (sinks, std::memory_order_relaxed);
         rtBounceSinkCount.store (count, std::memory_order_release);
+    }
+    // True when a re-prepare (device change, buffer-size renegotiation) killed
+    // an armed realtime bounce: the capture scratches are sized at arm time,
+    // so a grown block would overrun them - prepare disarms instead and the
+    // bounce worker fails the render.
+    bool wasRealtimeBounceAborted() const noexcept
+    {
+        return rtBounceAborted.load (std::memory_order_acquire);
     }
     void disarmRealtimeBounce() noexcept
     {
@@ -611,6 +620,7 @@ private:
     // when nonzero.
     std::atomic<AudioEngine::RtBounceSink*> rtBounceSinks { nullptr };
     std::atomic<int> rtBounceSinkCount { 0 };
+    std::atomic<bool> rtBounceAborted { false };
 
     std::array<ChannelStrip, Session::kNumTracks> strips;
     std::array<BusStrip,  Session::kNumBuses> busStrips;

--- a/src/engine/AudioEngine.h
+++ b/src/engine/AudioEngine.h
@@ -281,22 +281,61 @@ public:
     void setOfflineRenderActive (bool active) noexcept
         { offlineRenderActive.store (active, std::memory_order_relaxed); }
 
-    // Offline-render stem capture for bus groups and aux lanes (the per-track
-    // taps live on ChannelStrip::setStemCapture). When set, the audio path
-    // accumulates the named unit's processed output - the exact signal it
-    // sums into the mix - into the given scratch each block. The caller
-    // clears the scratch per block, so a skipped (silent) bus or aux leaves
-    // silence. Same contract as the strip taps: nullptr disables, message
-    // thread only, set while the engine is detached for an offline render.
+    // Stem capture for bus groups and aux lanes (the per-track taps live on
+    // ChannelStrip::setStemCapture). When set, the audio path accumulates the
+    // named unit's processed output - the exact signal it sums into the mix -
+    // into the given scratch each block. The caller clears the scratch per
+    // block, so a skipped (silent) bus or aux leaves silence. Message thread;
+    // atomic because a realtime bounce arms these against the live callback.
     void setBusStemCapture (int bus, float* l, float* r) noexcept
     {
-        stemBusCapL[(size_t) bus] = l;
-        stemBusCapR[(size_t) bus] = r;
+        // R first: the audio thread gates on L, so L's release-store publishes R.
+        stemBusCapR[(size_t) bus].store (r, std::memory_order_relaxed);
+        stemBusCapL[(size_t) bus].store (l, std::memory_order_release);
     }
     void setAuxStemCapture (int lane, float* l, float* r) noexcept
     {
-        stemAuxCapL[(size_t) lane] = l;
-        stemAuxCapR[(size_t) lane] = r;
+        stemAuxCapR[(size_t) lane].store (r, std::memory_order_relaxed);
+        stemAuxCapL[(size_t) lane].store (l, std::memory_order_release);
+    }
+
+    // Realtime bounce: the live callback pushes each armed sink's source
+    // block into its ThreadedWriter after the mix is complete (post-master,
+    // pre-metronome, so the monitoring click never prints). srcL == nullptr
+    // means "the master mix bus". leadRemaining samples are dropped from the
+    // head on the audio thread (per-kind PDC trim); writing stops at cap so
+    // every file ends up exactly cap samples long. The sink array is owned by
+    // the caller and must stay alive until disarm + one poll interval after
+    // the transport has stopped (the callback may be mid-block at disarm).
+    struct RtBounceSink
+    {
+        juce::AudioFormatWriter::ThreadedWriter* writer = nullptr;
+        const float* srcL = nullptr;
+        const float* srcR = nullptr;
+        // Stem taps ACCUMULATE into their scratch, so after consuming a block
+        // the callback wipes it for the next one (offline renders clear from
+        // their drive loop instead). Null for the master-mix sink.
+        float* wipeL = nullptr;
+        float* wipeR = nullptr;
+        std::int64_t leadRemaining = 0;                 // audio thread only
+        std::int64_t cap = 0;
+        std::atomic<std::int64_t> written { 0 };
+        // Set when the FIFO push fails (disk can't keep up); the bounce
+        // worker fails the render instead of reporting dropped samples as
+        // written.
+        std::atomic<bool> writeFailed { false };
+    };
+    void armRealtimeBounce (RtBounceSink* sinks, int count) noexcept
+    {
+        rtBounceSinks.store (sinks, std::memory_order_relaxed);
+        rtBounceSinkCount.store (count, std::memory_order_release);
+    }
+    void disarmRealtimeBounce() noexcept
+    {
+        // Count alone is the gate; the pointer stays set so a callback that
+        // read a stale nonzero count never pairs it with a null pointer (the
+        // caller keeps the sink array alive past disarm - see above).
+        rtBounceSinkCount.store (0, std::memory_order_release);
     }
 
     // Cross-track Plugin Delay Compensation. Reads each track's reported insert
@@ -560,11 +599,18 @@ private:
     std::atomic<bool> offlineRenderActive { false };
 
     // Stem-capture destinations for bus groups / aux lanes (see
-    // setBusStemCapture / setAuxStemCapture). nullptr on the live path.
-    std::array<float*, Session::kNumBuses>    stemBusCapL {};
-    std::array<float*, Session::kNumBuses>    stemBusCapR {};
-    std::array<float*, Session::kNumAuxLanes> stemAuxCapL {};
-    std::array<float*, Session::kNumAuxLanes> stemAuxCapR {};
+    // setBusStemCapture / setAuxStemCapture). nullptr when no stems bounce
+    // is running.
+    std::array<std::atomic<float*>, Session::kNumBuses>    stemBusCapL {};
+    std::array<std::atomic<float*>, Session::kNumBuses>    stemBusCapR {};
+    std::array<std::atomic<float*>, Session::kNumAuxLanes> stemAuxCapL {};
+    std::array<std::atomic<float*>, Session::kNumAuxLanes> stemAuxCapR {};
+
+    // Realtime-bounce sink array (see armRealtimeBounce). Count is the
+    // publish gate: the callback reads it acquire and touches the sinks only
+    // when nonzero.
+    std::atomic<AudioEngine::RtBounceSink*> rtBounceSinks { nullptr };
+    std::atomic<int> rtBounceSinkCount { 0 };
 
     std::array<ChannelStrip, Session::kNumTracks> strips;
     std::array<BusStrip,  Session::kNumBuses> busStrips;

--- a/src/engine/BounceEngine.cpp
+++ b/src/engine/BounceEngine.cpp
@@ -143,7 +143,7 @@ std::int64_t BounceEngine::computeBounceLength (double sampleRate, double tail) 
 
 bool BounceEngine::start (const juce::File& outFile, double sr, int bs, double tail,
                             Mode mode, Format format, int mp3BitrateKbps,
-                            int wavBitDepth)
+                            int wavBitDepth, bool realtimeCapture)
 {
     if (rendering.load (std::memory_order_relaxed)) return false;
 
@@ -157,6 +157,21 @@ bool BounceEngine::start (const juce::File& outFile, double sr, int bs, double t
         return false;
     }
 
+    renderRealtime = realtimeCapture
+                       && (mode == Mode::MasterMix || mode == Mode::Stems);
+    if (renderRealtime)
+    {
+        // The live callback IS the render clock: it runs at the device rate,
+        // and a rolling transport would print from wherever it happens to be.
+        sr = 0.0;
+        if (! engine.getTransport().isStopped())
+        {
+            const juce::ScopedLock lock (lastErrorLock);
+            lastError = "Stop the transport before a realtime bounce";
+            return false;
+        }
+    }
+
     outputFile  = outFile;
     renderSampleRate = (sr > 0.0) ? sr : engine.getCurrentSampleRate();
     if (renderSampleRate <= 0.0) renderSampleRate = 48000.0;
@@ -165,9 +180,11 @@ bool BounceEngine::start (const juce::File& outFile, double sr, int bs, double t
     renderMode      = mode;
     // Stems must stay WAV: MP3 encoder delay + frame padding shift each stem by
     // a different amount and change its length, breaking the sample-accurate
-    // alignment stems need for re-import. Force WAV at the engine boundary
-    // regardless of what the caller requested.
-    renderFormat    = (mode == Mode::Stems) ? Format::Wav : format;
+    // alignment stems need for re-import. Realtime is WAV too: the disk path
+    // is ThreadedWriter, which owns its writer outright, so the MP3 encoder's
+    // explicit finalize flush has no place to run. Force WAV at the engine
+    // boundary regardless of what the caller requested.
+    renderFormat    = (mode == Mode::Stems || renderRealtime) ? Format::Wav : format;
     renderBitrateKbps = mp3BitrateKbps;
     // Stems keep 24-bit regardless: they exist for re-import, not delivery.
     renderWavBitDepth = (mode != Mode::Stems && wavBitDepth == 16) ? 16 : 24;
@@ -223,6 +240,19 @@ bool BounceEngine::start (const juce::File& outFile, double sr, int bs, double t
 void BounceEngine::run()
 {
     if (onStarted) onStarted();
+
+    if (renderRealtime)
+    {
+        const bool ok = runRealtimeMode();
+        rendering.store (false, std::memory_order_relaxed);
+        juce::String errSnapshot;
+        {
+            const juce::ScopedLock lock (lastErrorLock);
+            errSnapshot = lastError;
+        }
+        if (onFinished) onFinished (ok, errSnapshot);
+        return;
+    }
 
     if (renderMode == Mode::Stems)
     {
@@ -720,6 +750,229 @@ bool BounceEngine::runStemsMode()
         lastError = kCancelledError;
         succeeded = false;
     }
+    return succeeded;
+}
+
+bool BounceEngine::runRealtimeMode()
+{
+    // Realtime capture: the engine stays attached and the session PLAYS.
+    // The audio callback pushes the capture taps (or the master mix) into
+    // ThreadedWriters (see AudioEngine::RtBounceSink); this worker only
+    // orchestrates transport state and polls progress. Hardware inserts run
+    // their external loop for real - the whole point of this mode.
+    struct Target { StemTarget::Kind kind; int index; juce::File file; };
+    std::vector<Target> files;
+    if (renderMode == Mode::Stems)
+    {
+        for (const auto& tgt : collectStemTargets (session, outputFile))
+            files.push_back ({ tgt.kind, tgt.index, tgt.file });
+        if (files.empty())
+        {
+            const juce::ScopedLock lock (lastErrorLock);
+            lastError = "No tracks with content or armed for recording";
+            return false;
+        }
+        totalStemsToRender.store ((int) files.size(), std::memory_order_relaxed);
+    }
+    else
+    {
+        // Master mix: one sink fed straight off the mix bus (srcL == nullptr).
+        files.push_back ({ StemTarget::Kind::Track, -1, outputFile });
+    }
+    const int numFiles = (int) files.size();
+
+    juce::TimeSliceThread diskThread ("Dusk Studio bounce disk");
+    diskThread.startThread();
+
+    // Capture scratches sized to the live block; the callback never hands the
+    // strips more than the prepared block size (oversized host blocks are
+    // guarded upstream).
+    const int scratchLen = juce::jmax (engine.getCurrentBlockSize(), 4096);
+    std::vector<std::vector<float>> capL, capR;
+    if (renderMode == Mode::Stems)
+    {
+        capL.assign ((size_t) numFiles, std::vector<float> ((size_t) scratchLen, 0.0f));
+        capR.assign ((size_t) numFiles, std::vector<float> ((size_t) scratchLen, 0.0f));
+    }
+
+    const auto clearAllTaps = [this]
+    {
+        for (int t = 0; t < Session::kNumTracks; ++t)
+            engine.getStrip (t).setStemCapture (nullptr, nullptr);
+        for (int a = 0; a < Session::kNumBuses; ++a)
+            engine.setBusStemCapture (a, nullptr, nullptr);
+        for (int a = 0; a < Session::kNumAuxLanes; ++a)
+            engine.setAuxStemCapture (a, nullptr, nullptr);
+    };
+
+    bool succeeded = true;
+    std::vector<std::unique_ptr<juce::AudioFormatWriter::ThreadedWriter>> writers;
+    writers.reserve ((size_t) numFiles);
+    for (const auto& f : files)
+    {
+        std::unique_ptr<juce::FileOutputStream> outStream (f.file.createOutputStream());
+        std::unique_ptr<juce::AudioFormatWriter> writer;
+        juce::String writerErr;
+        if (outStream == nullptr)
+            writerErr = "Could not open output file " + f.file.getFullPathName();
+        else
+        {
+            outStream->setPosition (0);
+            outStream->truncate();
+            writer = makeWriter (std::move (outStream), writerErr);
+        }
+        if (writer == nullptr)
+        {
+            {
+                const juce::ScopedLock lock (lastErrorLock);
+                lastError = writerErr;
+            }
+            succeeded = false;
+            break;
+        }
+        writers.push_back (std::make_unique<juce::AudioFormatWriter::ThreadedWriter> (
+            writer.release(), diskThread, 1 << 17));
+    }
+
+    auto& transport = engine.getTransport();
+    const auto savedPlayhead = transport.getPlayhead();
+    const bool savedLoop     = transport.isLoopEnabled();
+
+    if (succeeded)
+    {
+        // Per-kind PDC lead-in, exactly as the offline stems path: track /
+        // bus taps sit before the master-stage dry delay, aux taps and the
+        // mix carry it too.
+        const std::int64_t trackLead = (std::int64_t) engine.getAggregatePdcLatencySamples();
+        const std::int64_t mixLead   = trackLead
+                                        + (std::int64_t) engine.getMasterDryPdcTargetSamples();
+
+        auto sinks = std::make_unique<AudioEngine::RtBounceSink[]> ((size_t) numFiles);
+        for (int i = 0; i < numFiles; ++i)
+        {
+            auto& sink = sinks[(size_t) i];
+            sink.writer = writers[(size_t) i].get();
+            sink.cap    = totalSamples;
+            if (renderMode == Mode::Stems)
+            {
+                auto* l = capL[(size_t) i].data();
+                auto* r = capR[(size_t) i].data();
+                sink.srcL = l;
+                sink.srcR = r;
+                sink.wipeL = l;
+                sink.wipeR = r;
+                sink.leadRemaining = files[(size_t) i].kind == StemTarget::Kind::Aux
+                                       ? mixLead : trackLead;
+                switch (files[(size_t) i].kind)
+                {
+                    case StemTarget::Kind::Track:
+                        engine.getStrip (files[(size_t) i].index).setStemCapture (l, r); break;
+                    case StemTarget::Kind::Bus:
+                        engine.setBusStemCapture (files[(size_t) i].index, l, r); break;
+                    case StemTarget::Kind::Aux:
+                        engine.setAuxStemCapture (files[(size_t) i].index, l, r); break;
+                }
+            }
+            else
+            {
+                sink.leadRemaining = mixLead;   // srcL stays null = master mix
+            }
+        }
+
+        engine.armRealtimeBounce (sinks.get(), numFiles);
+
+        if (! runOnMessageThread ([this, &transport]
+            {
+                transport.setLoopEnabled (false);
+                transport.setPlayhead (0);
+                engine.play();
+            }))
+        {
+            engine.disarmRealtimeBounce();
+            succeeded = false;
+        }
+
+        if (succeeded)
+        {
+            // Poll until every sink has its full length, the user cancels, or
+            // the transport stops from under us (device change, user Stop).
+            std::int64_t minWritten = 0;
+            std::int64_t lastProgressCount = -1;
+            juce::uint32 lastProgressMs = juce::Time::getMillisecondCounter();
+            while (! cancelRequested.load (std::memory_order_relaxed))
+            {
+                minWritten = totalSamples;
+                bool anyWriteFailed = false;
+                for (int i = 0; i < numFiles; ++i)
+                {
+                    minWritten = juce::jmin (minWritten,
+                                             sinks[(size_t) i].written.load (std::memory_order_acquire));
+                    anyWriteFailed = anyWriteFailed
+                                   || sinks[(size_t) i].writeFailed.load (std::memory_order_acquire);
+                }
+                if (anyWriteFailed)
+                {
+                    const juce::ScopedLock lock (lastErrorLock);
+                    lastError = "Realtime bounce overran the disk writer (disk too slow)";
+                    succeeded = false;
+                    break;
+                }
+                renderedSamples.store (minWritten, std::memory_order_relaxed);
+                const float p = (float) ((double) minWritten / (double) totalSamples);
+                progress.store (p, std::memory_order_relaxed);
+                if (onProgressUpdated) onProgressUpdated (p);
+
+                if (minWritten >= totalSamples) break;
+
+                const auto nowMs = juce::Time::getMillisecondCounter();
+                if (minWritten != lastProgressCount)
+                {
+                    lastProgressCount = minWritten;
+                    lastProgressMs = nowMs;
+                }
+                else if (nowMs - lastProgressMs > 5000)
+                {
+                    const juce::ScopedLock lock (lastErrorLock);
+                    lastError = transport.isPlaying()
+                                  ? "Realtime bounce stalled (no audio callbacks)"
+                                  : "Transport stopped during the realtime bounce";
+                    succeeded = false;
+                    break;
+                }
+                wait (50);
+            }
+
+            runOnMessageThread ([this] { engine.stop(); });
+            // The callback gates capture on a rolling transport; give the
+            // block in flight at stop time a chance to drain before the
+            // sinks and scratches go away.
+            wait (150);
+        }
+
+        engine.disarmRealtimeBounce();
+        clearAllTaps();
+    }
+
+    // ThreadedWriter destructors flush their queues to disk.
+    writers.clear();
+    diskThread.stopThread (2000);
+
+    runOnMessageThread ([&transport, savedPlayhead, savedLoop]
+    {
+        transport.setLoopEnabled (savedLoop);
+        transport.setPlayhead (savedPlayhead);
+    });
+
+    if (cancelRequested.load (std::memory_order_relaxed))
+    {
+        succeeded = false;
+        const juce::ScopedLock lock (lastErrorLock);
+        lastError = kCancelledError;
+    }
+    if (! succeeded)
+        for (const auto& f : files)
+            f.file.deleteFile();
+
     return succeeded;
 }
 

--- a/src/engine/BounceEngine.cpp
+++ b/src/engine/BounceEngine.cpp
@@ -516,6 +516,52 @@ void BounceEngine::run()
     if (onFinished) onFinished (succeeded, errSnapshot);
 }
 
+std::unique_ptr<juce::AudioFormatWriter>
+BounceEngine::openWriterFor (const juce::File& outFile, juce::String& errOut) const
+{
+    std::unique_ptr<juce::FileOutputStream> outStream (outFile.createOutputStream());
+    if (outStream == nullptr)
+    {
+        errOut = "Could not open output file " + outFile.getFullPathName();
+        return nullptr;
+    }
+    outStream->setPosition (0);
+    outStream->truncate();
+    auto writer = makeWriter (std::move (outStream), errOut);
+    if (writer == nullptr)
+        errOut += " (" + outFile.getFileName() + ")";
+    return writer;
+}
+
+void BounceEngine::armStemTap (const StemTarget& target, float* l, float* r)
+{
+    switch (target.kind)
+    {
+        case StemTarget::Kind::Track: engine.getStrip (target.index).setStemCapture (l, r); break;
+        case StemTarget::Kind::Bus:   engine.setBusStemCapture (target.index, l, r);        break;
+        case StemTarget::Kind::Aux:   engine.setAuxStemCapture (target.index, l, r);        break;
+        case StemTarget::Kind::Mix:   break;   // fed straight off the mix bus, no tap
+    }
+}
+
+void BounceEngine::clearAllStemTaps()
+{
+    for (int t = 0; t < Session::kNumTracks; ++t)
+        engine.getStrip (t).setStemCapture (nullptr, nullptr);
+    for (int a = 0; a < Session::kNumBuses; ++a)
+        engine.setBusStemCapture (a, nullptr, nullptr);
+    for (int a = 0; a < Session::kNumAuxLanes; ++a)
+        engine.setAuxStemCapture (a, nullptr, nullptr);
+}
+
+std::int64_t BounceEngine::leadInFor (StemTarget::Kind kind) const
+{
+    const auto trackLead = (std::int64_t) engine.getAggregatePdcLatencySamples();
+    if (kind == StemTarget::Kind::Track || kind == StemTarget::Kind::Bus)
+        return trackLead;
+    return trackLead + (std::int64_t) engine.getMasterDryPdcTargetSamples();
+}
+
 bool BounceEngine::runStemsMode()
 {
     const auto targets = collectStemTargets (session, outputFile);
@@ -560,36 +606,15 @@ bool BounceEngine::runStemsMode()
     std::vector<std::vector<float>> capR ((size_t) numStems,
                                             std::vector<float> ((size_t) renderBlockSize, 0.0f));
 
-    const auto clearAllTaps = [this]
-    {
-        for (int t = 0; t < Session::kNumTracks; ++t)
-            engine.getStrip (t).setStemCapture (nullptr, nullptr);
-        for (int a = 0; a < Session::kNumBuses; ++a)
-            engine.setBusStemCapture (a, nullptr, nullptr);
-        for (int a = 0; a < Session::kNumAuxLanes; ++a)
-            engine.setAuxStemCapture (a, nullptr, nullptr);
-    };
-
     // Open every writer up front so a full disk / bad path fails before any
-    // rendering. Track which files exist so a failure can remove them all.
+    // rendering.
     bool succeeded = true;
     std::vector<std::unique_ptr<juce::AudioFormatWriter>> writers;
     writers.reserve ((size_t) numStems);
     for (const auto& tgt : targets)
     {
-        std::unique_ptr<juce::FileOutputStream> outStream (tgt.file.createOutputStream());
-        std::unique_ptr<juce::AudioFormatWriter> writer;
         juce::String writerErr;
-        if (outStream == nullptr)
-            writerErr = "Could not open stem output file " + tgt.file.getFullPathName();
-        else
-        {
-            outStream->setPosition (0);
-            outStream->truncate();
-            writer = makeWriter (std::move (outStream), writerErr);
-            if (writer == nullptr)
-                writerErr += " (stem " + tgt.file.getFileName() + ")";
-        }
+        auto writer = openWriterFor (tgt.file, writerErr);
         if (writer == nullptr)
         {
             {
@@ -605,17 +630,8 @@ bool BounceEngine::runStemsMode()
     if (succeeded)
     {
         for (int i = 0; i < numStems; ++i)
-        {
-            const auto& tgt = targets[(size_t) i];
-            auto* l = capL[(size_t) i].data();
-            auto* r = capR[(size_t) i].data();
-            switch (tgt.kind)
-            {
-                case StemTarget::Kind::Track: engine.getStrip (tgt.index).setStemCapture (l, r); break;
-                case StemTarget::Kind::Bus:   engine.setBusStemCapture (tgt.index, l, r);        break;
-                case StemTarget::Kind::Aux:   engine.setAuxStemCapture (tgt.index, l, r);        break;
-            }
-        }
+            armStemTap (targets[(size_t) i],
+                        capL[(size_t) i].data(), capR[(size_t) i].data());
 
         constexpr int kNumChannels = 2;
         constexpr int kNumIn = 16;
@@ -635,25 +651,16 @@ bool BounceEngine::runStemsMode()
         transport.setState (Transport::State::Playing);
         engine.getPlaybackEngine().preparePlayback();
 
-        // Per-kind PDC lead-in trim. Track and bus taps sit BEFORE the
-        // master-stage dry delay (the strip's own cross-track PDC is inside
-        // the strip, so their content is offset by the deepest track latency
-        // only); aux taps are captured after the aux-return PDC, so they
-        // carry the master-stage delay on top. Trimming each stem by its own
-        // offset keeps the whole set mutually sample-aligned at sample 0
-        // without cutting real head content off the track / bus stems.
-        const std::int64_t trackLead = (std::int64_t) engine.getAggregatePdcLatencySamples();
-        const std::int64_t auxLead   = trackLead
-                                        + (std::int64_t) engine.getMasterDryPdcTargetSamples();
-
-        std::vector<std::int64_t> leadIn     ((size_t) numStems, trackLead);
+        // Per-kind PDC lead-in trim (see leadInFor). Trimming each stem by
+        // its own offset keeps the whole set mutually sample-aligned at
+        // sample 0 without cutting real head content off track / bus stems.
+        std::vector<std::int64_t> leadIn     ((size_t) numStems, 0);
         std::vector<std::int64_t> droppedFor ((size_t) numStems, 0);
         std::vector<std::int64_t> writtenFor ((size_t) numStems, 0);
         std::int64_t maxLead = 0;
         for (int i = 0; i < numStems; ++i)
         {
-            if (targets[(size_t) i].kind == StemTarget::Kind::Aux)
-                leadIn[(size_t) i] = auxLead;
+            leadIn[(size_t) i] = leadInFor (targets[(size_t) i].kind);
             maxLead = juce::jmax (maxLead, leadIn[(size_t) i]);
         }
         const std::int64_t toRender = totalSamples + maxLead;
@@ -718,7 +725,8 @@ bool BounceEngine::runStemsMode()
         engine.getPlaybackEngine().stopPlayback();
     }
 
-    clearAllTaps();
+    clearAllStemTaps();
+    const size_t writersOpened = writers.size();
     writers.clear();  // flush + close before any delete below
 
     if (cancelRequested.load (std::memory_order_relaxed))
@@ -726,9 +734,12 @@ bool BounceEngine::runStemsMode()
     if (! succeeded)
     {
         // Drop the partial set - half-rendered files are more confusing than
-        // no files when the user cancels or a writer fails mid-render.
-        for (const auto& tgt : targets)
-            tgt.file.deleteFile();
+        // no files when the user cancels or a writer fails mid-render. Only
+        // files this run actually opened (truncated): targets past a failed
+        // open still hold the previous bounce's good stems.
+        const size_t touched = juce::jmin (targets.size(), writersOpened + 1);
+        for (size_t i = 0; i < touched; ++i)
+            targets[i].file.deleteFile();
     }
 
     // Restore everything - transport, stage, device callback.
@@ -760,12 +771,10 @@ bool BounceEngine::runRealtimeMode()
     // ThreadedWriters (see AudioEngine::RtBounceSink); this worker only
     // orchestrates transport state and polls progress. Hardware inserts run
     // their external loop for real - the whole point of this mode.
-    struct Target { StemTarget::Kind kind; int index; juce::File file; };
-    std::vector<Target> files;
+    std::vector<StemTarget> files;
     if (renderMode == Mode::Stems)
     {
-        for (const auto& tgt : collectStemTargets (session, outputFile))
-            files.push_back ({ tgt.kind, tgt.index, tgt.file });
+        files = collectStemTargets (session, outputFile);
         if (files.empty())
         {
             const juce::ScopedLock lock (lastErrorLock);
@@ -776,8 +785,7 @@ bool BounceEngine::runRealtimeMode()
     }
     else
     {
-        // Master mix: one sink fed straight off the mix bus (srcL == nullptr).
-        files.push_back ({ StemTarget::Kind::Track, -1, outputFile });
+        files.push_back ({ StemTarget::Kind::Mix, -1, outputFile });
     }
     const int numFiles = (int) files.size();
 
@@ -795,32 +803,13 @@ bool BounceEngine::runRealtimeMode()
         capR.assign ((size_t) numFiles, std::vector<float> ((size_t) scratchLen, 0.0f));
     }
 
-    const auto clearAllTaps = [this]
-    {
-        for (int t = 0; t < Session::kNumTracks; ++t)
-            engine.getStrip (t).setStemCapture (nullptr, nullptr);
-        for (int a = 0; a < Session::kNumBuses; ++a)
-            engine.setBusStemCapture (a, nullptr, nullptr);
-        for (int a = 0; a < Session::kNumAuxLanes; ++a)
-            engine.setAuxStemCapture (a, nullptr, nullptr);
-    };
-
     bool succeeded = true;
     std::vector<std::unique_ptr<juce::AudioFormatWriter::ThreadedWriter>> writers;
     writers.reserve ((size_t) numFiles);
     for (const auto& f : files)
     {
-        std::unique_ptr<juce::FileOutputStream> outStream (f.file.createOutputStream());
-        std::unique_ptr<juce::AudioFormatWriter> writer;
         juce::String writerErr;
-        if (outStream == nullptr)
-            writerErr = "Could not open output file " + f.file.getFullPathName();
-        else
-        {
-            outStream->setPosition (0);
-            outStream->truncate();
-            writer = makeWriter (std::move (outStream), writerErr);
-        }
+        auto writer = openWriterFor (f.file, writerErr);
         if (writer == nullptr)
         {
             {
@@ -840,20 +829,14 @@ bool BounceEngine::runRealtimeMode()
 
     if (succeeded)
     {
-        // Per-kind PDC lead-in, exactly as the offline stems path: track /
-        // bus taps sit before the master-stage dry delay, aux taps and the
-        // mix carry it too.
-        const std::int64_t trackLead = (std::int64_t) engine.getAggregatePdcLatencySamples();
-        const std::int64_t mixLead   = trackLead
-                                        + (std::int64_t) engine.getMasterDryPdcTargetSamples();
-
         auto sinks = std::make_unique<AudioEngine::RtBounceSink[]> ((size_t) numFiles);
         for (int i = 0; i < numFiles; ++i)
         {
             auto& sink = sinks[(size_t) i];
             sink.writer = writers[(size_t) i].get();
             sink.cap    = totalSamples;
-            if (renderMode == Mode::Stems)
+            sink.leadRemaining = leadInFor (files[(size_t) i].kind);
+            if (files[(size_t) i].kind != StemTarget::Kind::Mix)
             {
                 auto* l = capL[(size_t) i].data();
                 auto* r = capR[(size_t) i].data();
@@ -861,34 +844,40 @@ bool BounceEngine::runRealtimeMode()
                 sink.srcR = r;
                 sink.wipeL = l;
                 sink.wipeR = r;
-                sink.leadRemaining = files[(size_t) i].kind == StemTarget::Kind::Aux
-                                       ? mixLead : trackLead;
-                switch (files[(size_t) i].kind)
-                {
-                    case StemTarget::Kind::Track:
-                        engine.getStrip (files[(size_t) i].index).setStemCapture (l, r); break;
-                    case StemTarget::Kind::Bus:
-                        engine.setBusStemCapture (files[(size_t) i].index, l, r); break;
-                    case StemTarget::Kind::Aux:
-                        engine.setAuxStemCapture (files[(size_t) i].index, l, r); break;
-                }
+                armStemTap (files[(size_t) i], l, r);
             }
-            else
-            {
-                sink.leadRemaining = mixLead;   // srcL stays null = master mix
-            }
+            // Mix sinks keep srcL null - the callback feeds them the mix bus.
         }
 
         engine.armRealtimeBounce (sinks.get(), numFiles);
 
-        if (! runOnMessageThread ([this, &transport]
+        // Re-check the transport INSIDE the marshaled start: start()'s
+        // stopped-gate ran when the dialog opened, but MCU / MIDI-binding
+        // transport commands can start playback in the gap - yanking a live
+        // take to sample 0 here would corrupt it.
+        bool transportWasBusy = false;
+        if (! runOnMessageThread ([this, &transport, &transportWasBusy]
             {
+                if (! transport.isStopped())
+                {
+                    transportWasBusy = true;
+                    return;
+                }
                 transport.setLoopEnabled (false);
                 transport.setPlayhead (0);
                 engine.play();
             }))
         {
             engine.disarmRealtimeBounce();
+            succeeded = false;
+        }
+        else if (transportWasBusy)
+        {
+            engine.disarmRealtimeBounce();
+            {
+                const juce::ScopedLock lock (lastErrorLock);
+                lastError = "Transport started before the realtime bounce could begin";
+            }
             succeeded = false;
         }
 
@@ -914,6 +903,15 @@ bool BounceEngine::runRealtimeMode()
                 {
                     const juce::ScopedLock lock (lastErrorLock);
                     lastError = "Realtime bounce overran the disk writer (disk too slow)";
+                    succeeded = false;
+                    break;
+                }
+                if (engine.wasRealtimeBounceAborted())
+                {
+                    // A re-prepare (device change, buffer renegotiation)
+                    // invalidated the armed scratches; the engine disarmed.
+                    const juce::ScopedLock lock (lastErrorLock);
+                    lastError = "Audio device changed during the realtime bounce";
                     succeeded = false;
                     break;
                 }
@@ -943,17 +941,24 @@ bool BounceEngine::runRealtimeMode()
             }
 
             runOnMessageThread ([this] { engine.stop(); });
-            // The callback gates capture on a rolling transport; give the
-            // block in flight at stop time a chance to drain before the
-            // sinks and scratches go away.
-            wait (150);
         }
 
         engine.disarmRealtimeBounce();
-        clearAllTaps();
+        clearAllStemTaps();
+        // A callback that loaded the sink count before the disarm can still
+        // be mid-loop over the sinks; the process gate waits for in-flight
+        // callbacks to drain, so after this fence nothing references the
+        // sink array or the scratches. A fixed sleep can't guarantee that -
+        // a device period or scheduler stall can exceed any constant.
+        runOnMessageThread ([this]
+        {
+            engine.suspendProcessing();
+            engine.resumeProcessing();
+        });
     }
 
     // ThreadedWriter destructors flush their queues to disk.
+    const size_t writersOpened = writers.size();
     writers.clear();
     diskThread.stopThread (2000);
 
@@ -970,8 +975,13 @@ bool BounceEngine::runRealtimeMode()
         lastError = kCancelledError;
     }
     if (! succeeded)
-        for (const auto& f : files)
-            f.file.deleteFile();
+    {
+        // Only files this run actually opened (truncated): targets past a
+        // failed open still hold the previous bounce's good stems.
+        const size_t touched = juce::jmin (files.size(), writersOpened + 1);
+        for (size_t i = 0; i < touched; ++i)
+            files[i].file.deleteFile();
+    }
 
     return succeeded;
 }

--- a/src/engine/BounceEngine.cpp
+++ b/src/engine/BounceEngine.cpp
@@ -191,22 +191,13 @@ bool BounceEngine::start (const juce::File& outFile, double sr, int bs, double t
         if (totalSamples <= 0) return false;  // no file loaded
     }
 
-    // Pre-compute stem count so the UI's "track N of M" label has its
+    // Pre-compute the stem-file count so the UI's "N stems" label has its
     // total available immediately (otherwise the dialog flashes 0 until
-    // the worker thread enters its loop). Tracks render only when they
-    // have audio / MIDI regions or are armed for recording - empty
-    // unarmed tracks would write silent stems.
+    // the worker thread enters its loop).
     int stems = 0;
     if (renderMode == Mode::Stems)
     {
-        for (int t = 0; t < Session::kNumTracks; ++t)
-        {
-            const auto& tr = session.track (t);
-            const bool hasContent = ! tr.regions.empty()
-                                  || ! tr.midiRegions.current().empty();
-            const bool armed = tr.recordArmed.load (std::memory_order_relaxed);
-            if (hasContent || armed) ++stems;
-        }
+        stems = (int) collectStemTargets (session, outputFile).size();
         if (stems == 0)
         {
             const juce::ScopedLock lock (lastErrorLock);
@@ -215,7 +206,6 @@ bool BounceEngine::start (const juce::File& outFile, double sr, int bs, double t
         }
     }
     totalStemsToRender.store (stems, std::memory_order_relaxed);
-    currentStemIndex  .store (0,     std::memory_order_relaxed);
 
     cancelRequested.store (false, std::memory_order_relaxed);
     progress.store (0.0f, std::memory_order_relaxed);
@@ -496,148 +486,17 @@ void BounceEngine::run()
     if (onFinished) onFinished (succeeded, errSnapshot);
 }
 
-bool BounceEngine::renderOneStem (const juce::File& outFile,
-                                    std::int64_t lenSamples,
-                                    float stemFractionStart,
-                                    float stemFractionWidth)
-{
-    std::unique_ptr<juce::FileOutputStream> outStream (outFile.createOutputStream());
-    if (outStream == nullptr)
-    {
-        const juce::ScopedLock lock (lastErrorLock);
-        lastError = "Could not open stem output file " + outFile.getFullPathName();
-        return false;
-    }
-    outStream->setPosition (0);
-    outStream->truncate();
-
-    constexpr int kNumChannels = 2;
-    juce::String writerErr;
-    std::unique_ptr<juce::AudioFormatWriter> writer = makeWriter (std::move (outStream), writerErr);
-    if (writer == nullptr)
-    {
-        // Writer failed AFTER we truncated the file above - drop the now-zeroed
-        // file so we don't leave a 0-byte stem on disk.
-        outFile.deleteFile();
-        const juce::ScopedLock lock (lastErrorLock);
-        lastError = writerErr + " (stem " + outFile.getFileName() + ")";
-        return false;
-    }
-
-    constexpr int kNumIn = 16;
-    std::vector<std::vector<float>> inputs (kNumIn,
-                                              std::vector<float> ((size_t) renderBlockSize, 0.0f));
-    std::vector<const float*> inputPtrs (kNumIn);
-    for (int c = 0; c < kNumIn; ++c) inputPtrs[(size_t) c] = inputs[(size_t) c].data();
-
-    std::vector<std::vector<float>> outputs (kNumChannels,
-                                               std::vector<float> ((size_t) renderBlockSize, 0.0f));
-    std::vector<float*> outputPtrs (kNumChannels);
-    for (int c = 0; c < kNumChannels; ++c) outputPtrs[(size_t) c] = outputs[(size_t) c].data();
-
-    juce::AudioIODeviceCallbackContext ctx {};
-
-    auto& transport = engine.getTransport();
-    transport.setPlayhead (0);
-    transport.setState (Transport::State::Playing);
-    engine.getPlaybackEngine().preparePlayback();
-
-    // Same PDC lead-in trim as the master render: each stem runs the full strip
-    // path, so it's delayed by the deepest track latency plus the
-    // master-stage aux PDC. Drop those leading samples so all stems stay
-    // mutually aligned and start at sample 0.
-    const std::int64_t leadIn  = (std::int64_t) engine.getAggregatePdcLatencySamples()
-                                  + (std::int64_t) engine.getMasterDryPdcTargetSamples();
-    const std::int64_t toRender = lenSamples + leadIn;
-
-    std::int64_t done    = 0;
-    std::int64_t written = 0;
-    std::int64_t dropped = 0;
-    bool ok = true;
-    while (done < toRender && ! cancelRequested.load (std::memory_order_relaxed))
-    {
-        const int remaining = (int) juce::jmin ((std::int64_t) renderBlockSize,
-                                                  toRender - done);
-
-        for (auto& o : outputs) std::fill (o.begin(), o.end(), 0.0f);
-
-        engine.audioDeviceIOCallbackWithContext (inputPtrs.data(), kNumIn,
-                                                   outputPtrs.data(), kNumChannels,
-                                                   remaining, ctx);
-
-        int writeStart = 0;
-        if (dropped < leadIn)
-        {
-            writeStart = (int) juce::jmin ((std::int64_t) remaining, leadIn - dropped);
-            dropped += writeStart;
-        }
-        const int writeCount = remaining - writeStart;
-        std::array<float*, kNumChannels> offPtrs {};
-        for (int c = 0; c < kNumChannels; ++c) offPtrs[(size_t) c] = outputPtrs[(size_t) c] + writeStart;
-        if (writeCount > 0 && ! writer->writeFromFloatArrays (offPtrs.data(), kNumChannels, writeCount))
-        {
-            const juce::ScopedLock lock (lastErrorLock);
-            lastError = "Writer failed mid-stem at "
-                        + juce::String (written) + " samples in "
-                        + outFile.getFileName();
-            ok = false;
-            break;
-        }
-        written += juce::jmax (0, writeCount);
-
-        done += remaining;
-        renderedSamples.store (written, std::memory_order_relaxed);
-        const float withinStem = (float) ((double) written / (double) lenSamples);
-        const float overall    = stemFractionStart + withinStem * stemFractionWidth;
-        progress.store (overall, std::memory_order_relaxed);
-        if (onProgressUpdated) onProgressUpdated (overall);
-    }
-
-    engine.getPlaybackEngine().stopPlayback();
-    writer.reset();  // flush + close
-
-    if (cancelRequested.load (std::memory_order_relaxed) || ! ok)
-    {
-        // Drop the partial stem - a half-rendered file is more
-        // confusing than no file when the user cancels or the writer
-        // fails mid-render. Delete is performed AFTER writer.reset()
-        // above so the file handle is closed before we unlink.
-        outFile.deleteFile();
-        return false;
-    }
-    return ok;
-}
-
 bool BounceEngine::runStemsMode()
 {
-    // Build the list of tracks to render. Mirrors the predicate in
-    // start()'s pre-count so we render exactly the same set.
-    std::vector<int> tracksToRender;
-    tracksToRender.reserve ((size_t) Session::kNumTracks);
-    for (int t = 0; t < Session::kNumTracks; ++t)
-    {
-        const auto& tr = session.track (t);
-        const bool hasContent = ! tr.regions.empty()
-                              || ! tr.midiRegions.current().empty();
-        const bool armed = tr.recordArmed.load (std::memory_order_relaxed);
-        if (hasContent || armed) tracksToRender.push_back (t);
-    }
-    if (tracksToRender.empty())
+    const auto targets = collectStemTargets (session, outputFile);
+    if (targets.empty())
     {
         const juce::ScopedLock lock (lastErrorLock);
         lastError = "No tracks with content or armed for recording";
         return false;
     }
+    totalStemsToRender.store ((int) targets.size(), std::memory_order_relaxed);
 
-    // Snapshot solo state so we can restore EXACTLY what the user had
-    // before the bounce, regardless of how we exit.
-    std::array<bool, (size_t) Session::kNumTracks> savedSolo {};
-    for (int t = 0; t < Session::kNumTracks; ++t)
-        savedSolo[(size_t) t] = session.track (t).strip.solo
-                                  .load (std::memory_order_relaxed);
-
-    // Detach engine + prepare for offline rate just once. Each stem
-    // re-uses the same prepared state.
     ScopedOfflineRender offlineGuard (engine);
     // Detach + re-prepare on the message thread (plugin (de)activate must not run
     // on this worker - see runOnMessageThread). Stems render through the full
@@ -661,40 +520,188 @@ bool BounceEngine::runStemsMode()
     // master-stage aux PDC - latch it while the callback is detached.
     engine.applyMasterPdcTargetsNow();
 
-    bool succeeded = true;
-    const int  numStems = (int) tracksToRender.size();
-    const float widthPerStem = (numStems > 0) ? (1.0f / (float) numStems) : 1.0f;
+    const int numStems = (int) targets.size();
 
-    for (int i = 0; i < numStems; ++i)
+    // One stereo capture scratch per stem, registered as taps below. The
+    // strips / engine accumulate into them; we clear them before each driven
+    // block, so a skipped (silent) unit leaves silence.
+    std::vector<std::vector<float>> capL ((size_t) numStems,
+                                            std::vector<float> ((size_t) renderBlockSize, 0.0f));
+    std::vector<std::vector<float>> capR ((size_t) numStems,
+                                            std::vector<float> ((size_t) renderBlockSize, 0.0f));
+
+    const auto clearAllTaps = [this]
     {
-        if (cancelRequested.load (std::memory_order_relaxed)) { succeeded = false; break; }
-
-        const int trackIdx = tracksToRender[(size_t) i];
-
-        // Solo exclusively: clear every track's solo, then engage the
-        // current one. Using setTrackSoloed keeps soloTrackCount in
-        // sync so the audio thread's anyTrackSoloed check fires right
-        // away on the next block.
         for (int t = 0; t < Session::kNumTracks; ++t)
-            if (t != trackIdx) session.setTrackSoloed (t, false);
-        session.setTrackSoloed (trackIdx, true);
+            engine.getStrip (t).setStemCapture (nullptr, nullptr);
+        for (int a = 0; a < Session::kNumBuses; ++a)
+            engine.setBusStemCapture (a, nullptr, nullptr);
+        for (int a = 0; a < Session::kNumAuxLanes; ++a)
+            engine.setAuxStemCapture (a, nullptr, nullptr);
+    };
 
-        currentStemIndex.store (i + 1, std::memory_order_relaxed);
-
-        const auto outFile = stemOutputFile (outputFile, trackIdx,
-                                               session.track (trackIdx).name);
-        if (! renderOneStem (outFile, totalSamples,
-                             (float) i * widthPerStem,
-                             widthPerStem))
+    // Open every writer up front so a full disk / bad path fails before any
+    // rendering. Track which files exist so a failure can remove them all.
+    bool succeeded = true;
+    std::vector<std::unique_ptr<juce::AudioFormatWriter>> writers;
+    writers.reserve ((size_t) numStems);
+    for (const auto& tgt : targets)
+    {
+        std::unique_ptr<juce::FileOutputStream> outStream (tgt.file.createOutputStream());
+        std::unique_ptr<juce::AudioFormatWriter> writer;
+        juce::String writerErr;
+        if (outStream == nullptr)
+            writerErr = "Could not open stem output file " + tgt.file.getFullPathName();
+        else
         {
+            outStream->setPosition (0);
+            outStream->truncate();
+            writer = makeWriter (std::move (outStream), writerErr);
+            if (writer == nullptr)
+                writerErr += " (stem " + tgt.file.getFileName() + ")";
+        }
+        if (writer == nullptr)
+        {
+            {
+                const juce::ScopedLock lock (lastErrorLock);
+                lastError = writerErr;
+            }
             succeeded = false;
             break;
         }
+        writers.push_back (std::move (writer));
     }
 
-    // Restore everything - solo, transport, stage, device callback.
-    for (int t = 0; t < Session::kNumTracks; ++t)
-        session.setTrackSoloed (t, savedSolo[(size_t) t]);
+    if (succeeded)
+    {
+        for (int i = 0; i < numStems; ++i)
+        {
+            const auto& tgt = targets[(size_t) i];
+            auto* l = capL[(size_t) i].data();
+            auto* r = capR[(size_t) i].data();
+            switch (tgt.kind)
+            {
+                case StemTarget::Kind::Track: engine.getStrip (tgt.index).setStemCapture (l, r); break;
+                case StemTarget::Kind::Bus:   engine.setBusStemCapture (tgt.index, l, r);        break;
+                case StemTarget::Kind::Aux:   engine.setAuxStemCapture (tgt.index, l, r);        break;
+            }
+        }
+
+        constexpr int kNumChannels = 2;
+        constexpr int kNumIn = 16;
+        std::vector<std::vector<float>> inputs (kNumIn,
+                                                  std::vector<float> ((size_t) renderBlockSize, 0.0f));
+        std::vector<const float*> inputPtrs (kNumIn);
+        for (int c = 0; c < kNumIn; ++c) inputPtrs[(size_t) c] = inputs[(size_t) c].data();
+
+        std::vector<std::vector<float>> outputs (kNumChannels,
+                                                   std::vector<float> ((size_t) renderBlockSize, 0.0f));
+        std::vector<float*> outputPtrs (kNumChannels);
+        for (int c = 0; c < kNumChannels; ++c) outputPtrs[(size_t) c] = outputs[(size_t) c].data();
+
+        juce::AudioIODeviceCallbackContext ctx {};
+
+        transport.setPlayhead (0);
+        transport.setState (Transport::State::Playing);
+        engine.getPlaybackEngine().preparePlayback();
+
+        // Per-kind PDC lead-in trim. Track and bus taps sit BEFORE the
+        // master-stage dry delay (the strip's own cross-track PDC is inside
+        // the strip, so their content is offset by the deepest track latency
+        // only); aux taps are captured after the aux-return PDC, so they
+        // carry the master-stage delay on top. Trimming each stem by its own
+        // offset keeps the whole set mutually sample-aligned at sample 0
+        // without cutting real head content off the track / bus stems.
+        const std::int64_t trackLead = (std::int64_t) engine.getAggregatePdcLatencySamples();
+        const std::int64_t auxLead   = trackLead
+                                        + (std::int64_t) engine.getMasterDryPdcTargetSamples();
+
+        std::vector<std::int64_t> leadIn     ((size_t) numStems, trackLead);
+        std::vector<std::int64_t> droppedFor ((size_t) numStems, 0);
+        std::vector<std::int64_t> writtenFor ((size_t) numStems, 0);
+        std::int64_t maxLead = 0;
+        for (int i = 0; i < numStems; ++i)
+        {
+            if (targets[(size_t) i].kind == StemTarget::Kind::Aux)
+                leadIn[(size_t) i] = auxLead;
+            maxLead = juce::jmax (maxLead, leadIn[(size_t) i]);
+        }
+        const std::int64_t toRender = totalSamples + maxLead;
+
+        std::int64_t done = 0;
+        while (done < toRender && ! cancelRequested.load (std::memory_order_relaxed))
+        {
+            const int remaining = (int) juce::jmin ((std::int64_t) renderBlockSize,
+                                                      toRender - done);
+
+            for (auto& o : outputs) std::fill (o.begin(), o.end(), 0.0f);
+            for (int i = 0; i < numStems; ++i)
+            {
+                juce::FloatVectorOperations::clear (capL[(size_t) i].data(), remaining);
+                juce::FloatVectorOperations::clear (capR[(size_t) i].data(), remaining);
+            }
+
+            engine.audioDeviceIOCallbackWithContext (inputPtrs.data(), kNumIn,
+                                                       outputPtrs.data(), kNumChannels,
+                                                       remaining, ctx);
+
+            std::int64_t minWritten = totalSamples;
+            for (int i = 0; i < numStems; ++i)
+            {
+                int writeStart = 0;
+                if (droppedFor[(size_t) i] < leadIn[(size_t) i])
+                {
+                    writeStart = (int) juce::jmin ((std::int64_t) remaining,
+                                                     leadIn[(size_t) i] - droppedFor[(size_t) i]);
+                    droppedFor[(size_t) i] += writeStart;
+                }
+                // Shorter-lead stems run out of file before the render loop
+                // ends; cap each writer at totalSamples so lengths stay equal.
+                const int writeCount = (int) juce::jmin ((std::int64_t) (remaining - writeStart),
+                                                           totalSamples - writtenFor[(size_t) i]);
+                if (writeCount > 0)
+                {
+                    const float* ptrs[kNumChannels] = { capL[(size_t) i].data() + writeStart,
+                                                        capR[(size_t) i].data() + writeStart };
+                    if (! writers[(size_t) i]->writeFromFloatArrays (ptrs, kNumChannels, writeCount))
+                    {
+                        const juce::ScopedLock lock (lastErrorLock);
+                        lastError = "Writer failed mid-stem at "
+                                    + juce::String (writtenFor[(size_t) i]) + " samples in "
+                                    + targets[(size_t) i].file.getFileName();
+                        succeeded = false;
+                        break;
+                    }
+                    writtenFor[(size_t) i] += writeCount;
+                }
+                minWritten = juce::jmin (minWritten, writtenFor[(size_t) i]);
+            }
+            if (! succeeded) break;
+
+            done += remaining;
+            renderedSamples.store (minWritten, std::memory_order_relaxed);
+            const float overall = (float) ((double) minWritten / (double) totalSamples);
+            progress.store (overall, std::memory_order_relaxed);
+            if (onProgressUpdated) onProgressUpdated (overall);
+        }
+
+        engine.getPlaybackEngine().stopPlayback();
+    }
+
+    clearAllTaps();
+    writers.clear();  // flush + close before any delete below
+
+    if (cancelRequested.load (std::memory_order_relaxed))
+        succeeded = false;
+    if (! succeeded)
+    {
+        // Drop the partial set - half-rendered files are more confusing than
+        // no files when the user cancels or a writer fails mid-render.
+        for (const auto& tgt : targets)
+            tgt.file.deleteFile();
+    }
+
+    // Restore everything - transport, stage, device callback.
     transport.setState (savedTransportState);
     transport.setPlayhead (savedPlayhead);
     engine.setStage (savedStage);

--- a/src/engine/BounceEngine.cpp
+++ b/src/engine/BounceEngine.cpp
@@ -187,7 +187,11 @@ bool BounceEngine::start (const juce::File& outFile, double sr, int bs, double t
     renderFormat    = (mode == Mode::Stems || renderRealtime) ? Format::Wav : format;
     renderBitrateKbps = mp3BitrateKbps;
     // Stems keep 24-bit regardless: they exist for re-import, not delivery.
-    renderWavBitDepth = (mode != Mode::Stems && wavBitDepth == 16) ? 16 : 24;
+    // Realtime does too: its disk path streams through ThreadedWriter with no
+    // dither stage, so a 16-bit realtime file would truncate undithered (the
+    // offline loop is where the TPDF dither lives).
+    renderWavBitDepth = (mode != Mode::Stems && ! renderRealtime && wavBitDepth == 16)
+                          ? 16 : 24;
 
     if (renderMode == Mode::MasterMix || renderMode == Mode::Stems)
     {

--- a/src/engine/BounceEngine.h
+++ b/src/engine/BounceEngine.h
@@ -130,7 +130,7 @@ public:
                     busActive[(size_t) a] = true;
             for (int a = 0; a < ChannelStripParams::kNumAuxSends; ++a)
                 if (tr.strip.auxSendDb[(size_t) a].load (std::memory_order_relaxed)
-                        > ChannelStripParams::kFaderInfThreshDb)
+                        > ChannelStripParams::kAuxSendOffDb)
                     auxActive[(size_t) a] = true;
         }
 
@@ -179,6 +179,13 @@ public:
     // realtime. tail = silence appended so reverb/comp tails decay.
     // wavBitDepth: 24 (default) or 16 - 16 gets TPDF dither at ±1 LSB
     // before the truncation (CD / distribution target).
+    //
+    // realtimeCapture (MasterMix / Stems only): instead of detaching the
+    // engine, the session PLAYS live and the callback streams the capture
+    // taps to disk - the only path that prints hardware inserts, since the
+    // external loop needs the device rolling. Renders at the device rate,
+    // always WAV, at the user's live oversampling (it prints what you hear,
+    // minus the monitoring click). The transport must be stopped to start.
     bool start (const juce::File& outputFile,
                 double sampleRate = 0.0,
                 int blockSize = 1024,
@@ -186,7 +193,8 @@ public:
                 Mode mode = Mode::MasterMix,
                 Format format = Format::Wav,
                 int mp3BitrateKbps = 320,
-                int wavBitDepth = 24);
+                int wavBitDepth = 24,
+                bool realtimeCapture = false);
 
     void cancel() noexcept { cancelRequested.store (true, std::memory_order_relaxed); }
 
@@ -257,6 +265,7 @@ private:
     std::int64_t  totalSamples     = 0;
     Mode         renderMode       = Mode::MasterMix;
     Format       renderFormat     = Format::Wav;
+    bool         renderRealtime   = false;
     int          renderBitrateKbps = 320;
     int          renderWavBitDepth = 24;
     int          freezeTrackIndex = -1;   // Mode::FreezeTrack target
@@ -279,5 +288,6 @@ private:
         makeWriter (std::unique_ptr<juce::FileOutputStream> outStream, juce::String& errOut) const;
 
     bool runStemsMode();
+    bool runRealtimeMode();
 };
 } // namespace duskstudio

--- a/src/engine/BounceEngine.h
+++ b/src/engine/BounceEngine.h
@@ -97,9 +97,11 @@ public:
     // overwrite-conflict check so the two can't drift.
     struct StemTarget
     {
-        enum class Kind { Track, Bus, Aux };
+        // Mix is never produced by collectStemTargets; the realtime
+        // master-mix bounce uses it so its sink is not mistaken for a track.
+        enum class Kind { Track, Bus, Aux, Mix };
         Kind kind;
-        int  index;        // track / bus / aux index, zero-based
+        int  index;        // track / bus / aux index, zero-based (-1 for Mix)
         juce::File file;
     };
     static std::vector<StemTarget> collectStemTargets (const Session& session,
@@ -129,9 +131,19 @@ public:
                 if (tr.strip.busAssign[(size_t) a].load (std::memory_order_relaxed))
                     busActive[(size_t) a] = true;
             for (int a = 0; a < ChannelStripParams::kNumAuxSends; ++a)
-                if (tr.strip.auxSendDb[(size_t) a].load (std::memory_order_relaxed)
-                        > ChannelStripParams::kAuxSendOffDb)
+            {
+                // The audio thread follows liveAuxSendDb, which automation
+                // can raise even when the knob rests at the off sentinel -
+                // a send lane with points makes the aux potentially audible.
+                const bool manualOn =
+                    tr.strip.auxSendDb[(size_t) a].load (std::memory_order_relaxed)
+                        > ChannelStripParams::kAuxSendOffDb;
+                const auto param = (AutomationParam) ((int) AutomationParam::AuxSend1 + a);
+                const bool automated =
+                    ! tr.automationLanes[(size_t) param].pointsForRead().empty();
+                if (manualOn || automated)
                     auxActive[(size_t) a] = true;
+            }
         }
 
         for (int a = 0; a < Session::kNumBuses; ++a)
@@ -286,6 +298,22 @@ private:
     // ownership of outStream on success; on failure outStream is freed.
     std::unique_ptr<juce::AudioFormatWriter>
         makeWriter (std::unique_ptr<juce::FileOutputStream> outStream, juce::String& errOut) const;
+
+    // Open + truncate outFile, then wrap it in the configured format writer.
+    // Null + errOut on failure - the file may already be truncated by then,
+    // so failure paths that must preserve prior content delete it.
+    std::unique_ptr<juce::AudioFormatWriter>
+        openWriterFor (const juce::File& outFile, juce::String& errOut) const;
+
+    // Stem-tap registry plumbing shared by the offline and realtime stem
+    // renders. Arm and clear must cover the same tap set or a render leaves
+    // the audio thread accumulating into a freed scratch.
+    void armStemTap (const StemTarget& target, float* l, float* r);
+    void clearAllStemTaps();
+
+    // Per-kind PDC lead-in: track / bus taps sit before the master-stage dry
+    // delay; aux taps and the mix carry it too.
+    std::int64_t leadInFor (StemTarget::Kind kind) const;
 
     bool runStemsMode();
     bool runRealtimeMode();

--- a/src/engine/BounceEngine.h
+++ b/src/engine/BounceEngine.h
@@ -2,13 +2,15 @@
 
 #include <juce_audio_devices/juce_audio_devices.h>
 #include <juce_audio_formats/juce_audio_formats.h>
+#include "../session/Session.h"
+#include <array>
 #include <atomic>
 #include <functional>
+#include <vector>
 
 namespace duskstudio
 {
 class AudioEngine;
-class Session;
 
 // Offline bounce. Detaches the engine from AudioDeviceManager and drives
 // audioDeviceIOCallbackWithContext in a tight loop on its own worker
@@ -19,16 +21,17 @@ class BounceEngine final : private juce::Thread
 public:
     // MasterMix   : full track / aux / master path. Length = longest
     //               region end + tail.
-    // Stems       : one WAV per track with content or armed. Each
-    //               renders through the full chain with every other
-    //               track soloed-off, so a stem carries the same
-    //               per-track processing as the mix. Nonlinear master
-    //               stages (bus comp, tape) react to the soloed track
-    //               alone, so stems are NOT guaranteed to null-sum
-    //               against the master mix. Files written as
-    //               `<base>_<NN>_<sanitized-name>.wav` next to base.
-    //               Original solo state restored on finish / cancel /
-    //               error.
+    // Stems       : single offline pass, one WAV per stem target. A track
+    //               stem is the track's post-fader / post-pan output (its
+    //               full wet contribution, before the master-vs-bus routing
+    //               split); bus groups and aux lanes with anything routed /
+    //               sent print as additional stems of their own processed
+    //               output. Mute / solo state prints as heard. Stems carry
+    //               no master-strip processing, so track+bus+aux stems sum
+    //               to the PRE-master mix; a bus-routed track appears both
+    //               in its own stem and (processed) in the bus stem. Track
+    //               files: `<base>_<NN>_<name>.wav`; units:
+    //               `<base>_bus<N>_<name>.wav` / `<base>_aux<N>_<name>.wav`.
     // MasteringChain : MasteringPlayer -> MasteringChain. Length =
     //               player's source file + tail. Engine stage forced
     //               to Mastering for the render.
@@ -69,6 +72,102 @@ public:
         // re-import needs).
         const auto idx = juce::String (trackIndexZeroBased + 1).paddedLeft ('0', 2);
         return dir.getChildFile (stem + "_" + idx + "_" + safeName + ".wav");
+    }
+
+    // <dir>/<base>_<tag>_<safe>.wav for bus / aux stems (tag = "bus1".."aux4").
+    // Falls back to the tag alone when the unit has no usable name.
+    static juce::File namedStemOutputFile (const juce::File& base,
+                                             const juce::String& tag,
+                                             const juce::String& unitName)
+    {
+        auto dir  = base.getParentDirectory();
+        auto stem = base.getFileNameWithoutExtension();
+        if (stem.isEmpty()) stem = "bounce";
+
+        auto safeName = juce::File::createLegalFileName (unitName.trim());
+        return dir.getChildFile (safeName.isEmpty()
+                                    ? stem + "_" + tag + ".wav"
+                                    : stem + "_" + tag + "_" + safeName + ".wav");
+    }
+
+    // The stem files a Stems bounce against `base` would write, in render
+    // order: tracks with content or armed, then buses any of those tracks
+    // route into, then aux lanes any of them send to. Message-thread safe
+    // (atomic reads only). Used by the render itself and by the UI's
+    // overwrite-conflict check so the two can't drift.
+    struct StemTarget
+    {
+        enum class Kind { Track, Bus, Aux };
+        Kind kind;
+        int  index;        // track / bus / aux index, zero-based
+        juce::File file;
+    };
+    static std::vector<StemTarget> collectStemTargets (const Session& session,
+                                                         const juce::File& base)
+    {
+        std::vector<StemTarget> targets;
+
+        // The per-track send fan-out indexes the per-lane array below.
+        static_assert (ChannelStripParams::kNumAuxSends == Session::kNumAuxLanes,
+                       "aux-send count must match the aux-lane count");
+
+        std::array<bool, (size_t) Session::kNumBuses>    busActive {};
+        std::array<bool, (size_t) Session::kNumAuxLanes> auxActive {};
+
+        for (int t = 0; t < Session::kNumTracks; ++t)
+        {
+            const auto& tr = session.track (t);
+            const bool hasContent = ! tr.regions.empty()
+                                  || ! tr.midiRegions.current().empty();
+            const bool armed = tr.recordArmed.load (std::memory_order_relaxed);
+            if (! (hasContent || armed)) continue;
+
+            targets.push_back ({ StemTarget::Kind::Track, t,
+                                 stemOutputFile (base, t, tr.name) });
+
+            for (int a = 0; a < Session::kNumBuses; ++a)
+                if (tr.strip.busAssign[(size_t) a].load (std::memory_order_relaxed))
+                    busActive[(size_t) a] = true;
+            for (int a = 0; a < ChannelStripParams::kNumAuxSends; ++a)
+                if (tr.strip.auxSendDb[(size_t) a].load (std::memory_order_relaxed)
+                        > ChannelStripParams::kFaderInfThreshDb)
+                    auxActive[(size_t) a] = true;
+        }
+
+        for (int a = 0; a < Session::kNumBuses; ++a)
+            if (busActive[(size_t) a])
+                targets.push_back ({ StemTarget::Kind::Bus, a,
+                                     namedStemOutputFile (base, "bus" + juce::String (a + 1),
+                                                            session.bus (a).name) });
+        for (int a = 0; a < Session::kNumAuxLanes; ++a)
+            if (auxActive[(size_t) a])
+                targets.push_back ({ StemTarget::Kind::Aux, a,
+                                     namedStemOutputFile (base, "aux" + juce::String (a + 1),
+                                                            session.auxLane (a).name) });
+        return targets;
+    }
+
+    // True when any rendered track's strip or any aux lane has a hardware
+    // insert routed. Offline renders can't run the external loop (the device
+    // callback is detached), so the insert returns dry or silence - the UI
+    // warns before an offline bounce of such a session.
+    static bool anyHardwareInsertActive (const Session& session)
+    {
+        for (int t = 0; t < Session::kNumTracks; ++t)
+        {
+            const auto& tr = session.track (t);
+            const bool hasContent = ! tr.regions.empty()
+                                  || ! tr.midiRegions.current().empty();
+            const bool armed = tr.recordArmed.load (std::memory_order_relaxed);
+            if ((hasContent || armed)
+                && tr.hardwareInsert.enabled.load (std::memory_order_relaxed))
+                return true;
+        }
+        for (int a = 0; a < Session::kNumAuxLanes; ++a)
+            for (const auto& hw : session.auxLane (a).hardwareInserts)
+                if (hw.enabled.load (std::memory_order_relaxed))
+                    return true;
+        return false;
     }
 
     BounceEngine (AudioEngine& engine, Session& session,
@@ -112,10 +211,6 @@ public:
 
     bool         isRendering() const noexcept { return rendering.load (std::memory_order_relaxed); }
     float        getProgress() const noexcept { return progress.load (std::memory_order_relaxed); }
-    // Stems mode: 1-based current stem (1..total). 0 before first stem
-    // or in Master / Mastering modes.
-    int          getCurrentStemIndex() const noexcept
-        { return currentStemIndex.load (std::memory_order_relaxed); }
     int          getTotalStemsToRender() const noexcept
         { return totalStemsToRender.load (std::memory_order_relaxed); }
     juce::String getLastError() const
@@ -171,7 +266,6 @@ private:
     std::atomic<bool>  cancelRequested  { false };
     std::atomic<float> progress         { 0.0f };
     std::atomic<std::int64_t> renderedSamples { 0 };
-    std::atomic<int>   currentStemIndex   { 0 };
     std::atomic<int>   totalStemsToRender { 0 };
     juce::String lastError;
     juce::CriticalSection lastErrorLock;
@@ -184,13 +278,6 @@ private:
     std::unique_ptr<juce::AudioFormatWriter>
         makeWriter (std::unique_ptr<juce::FileOutputStream> outStream, juce::String& errOut) const;
 
-    // Always restores original solo state before returning.
     bool runStemsMode();
-    // stemFractionStart + stemFractionWidth slice the progress bar so
-    // the UI sees monotonic 0..1 across all stems.
-    bool renderOneStem (const juce::File& outFile,
-                          std::int64_t lenSamples,
-                          float stemFractionStart,
-                          float stemFractionWidth);
 };
 } // namespace duskstudio

--- a/src/ui/BounceDialog.cpp
+++ b/src/ui/BounceDialog.cpp
@@ -41,18 +41,23 @@ BounceDialog::BounceDialog (AudioEngine& e,
     // external hardware-insert loop can't run: those inserts print dry (or
     // silent at full wet). Mastering renders skip the strips, and a realtime
     // bounce runs the loop for real, so only the offline strip-driven modes
-    // warn. Components are visible by default, so hide first - resized()
-    // reserves the warning row off isVisible().
+    // warn. A live solo gets its own note: stems print as heard, so a
+    // forgotten solo writes a mostly-silent set that still reports success.
+    // Components are visible by default, so hide first - resized() reserves
+    // the warning row off isVisible().
     hwWarnLabel.setVisible (false);
+    juce::String warn;
     if (! renderRealtime
         && renderMode != BounceEngine::Mode::MasteringChain
         && BounceEngine::anyHardwareInsertActive (session))
+        warn = "Hardware inserts are bypassed in an offline render and will print dry.";
+    else if (renderMode == BounceEngine::Mode::Stems && session.anyTrackSoloed())
+        warn = "Solo is active - unsoloed tracks will print silent stems.";
+    if (warn.isNotEmpty())
     {
         hwWarnLabel.setJustificationType (juce::Justification::centredLeft);
         hwWarnLabel.setColour (juce::Label::textColourId, juce::Colour (0xffe0b050));
-        hwWarnLabel.setText ("Hardware inserts are bypassed in an offline render "
-                             "and will print dry.",
-                             juce::dontSendNotification);
+        hwWarnLabel.setText (warn, juce::dontSendNotification);
         addAndMakeVisible (hwWarnLabel);
     }
 
@@ -145,11 +150,13 @@ void BounceDialog::timerCallback()
     progressValue = (double) bounceEngine->getProgress();
     progressBar.repaint();
 
-    if (renderMode == BounceEngine::Mode::Stems && bounceEngine->isRendering())
+    if (renderMode == BounceEngine::Mode::Stems && bounceEngine->isRendering()
+        && ! stemsStatusShown)
     {
         const int total = bounceEngine->getTotalStemsToRender();
         if (total > 0)
         {
+            stemsStatusShown = true;
             statusLabel.setText ("Rendering " + juce::String (total) + " stem"
                                   + juce::String (total == 1 ? "" : "s")
                                   + " -> " + outputFile.getParentDirectory().getFullPathName(),

--- a/src/ui/BounceDialog.cpp
+++ b/src/ui/BounceDialog.cpp
@@ -12,20 +12,23 @@ BounceDialog::BounceDialog (AudioEngine& e,
                               BounceEngine::Format format,
                               int mp3BitrateKbps,
                               double sampleRate,
-                              int bitDepth)
+                              int bitDepth,
+                              bool realtime)
     : engine (e), session (s), deviceManager (dm), outputFile (f),
       renderMode (mode), renderFormat (format), mp3Bitrate (mp3BitrateKbps),
       renderSampleRate (sampleRate), wavBitDepth (bitDepth),
+      renderRealtime (realtime),
       progressBar (progressValue)
 {
     titleLabel.setJustificationType (juce::Justification::centredLeft);
     titleLabel.setFont (juce::Font (juce::FontOptions (14.0f, juce::Font::bold)));
     titleLabel.setColour (juce::Label::textColourId, juce::Colour (0xffe8e8e8));
     titleLabel.setText (renderMode == BounceEngine::Mode::MasteringChain
-                          ? "Exporting master..."
-                          : (renderMode == BounceEngine::Mode::Stems
-                              ? "Bouncing stems..."
-                              : "Bouncing master mix..."),
+                          ? juce::String ("Exporting master...")
+                          : juce::String (renderMode == BounceEngine::Mode::Stems
+                                            ? "Bouncing stems"
+                                            : "Bouncing master mix")
+                              + (renderRealtime ? " (realtime)..." : "..."),
                          juce::dontSendNotification);
     addAndMakeVisible (titleLabel);
 
@@ -36,9 +39,13 @@ BounceDialog::BounceDialog (AudioEngine& e,
 
     // Offline renders drive the engine detached from the audio device, so an
     // external hardware-insert loop can't run: those inserts print dry (or
-    // silent at full wet). Mastering renders skip the strips, so only the
-    // strip-driven modes warn.
-    if (renderMode != BounceEngine::Mode::MasteringChain
+    // silent at full wet). Mastering renders skip the strips, and a realtime
+    // bounce runs the loop for real, so only the offline strip-driven modes
+    // warn. Components are visible by default, so hide first - resized()
+    // reserves the warning row off isVisible().
+    hwWarnLabel.setVisible (false);
+    if (! renderRealtime
+        && renderMode != BounceEngine::Mode::MasteringChain
         && BounceEngine::anyHardwareInsertActive (session))
     {
         hwWarnLabel.setJustificationType (juce::Justification::centredLeft);
@@ -74,7 +81,8 @@ BounceDialog::BounceDialog (AudioEngine& e,
     // complexity of marshalling callbacks back to a Component that might be
     // closing.
     if (! bounceEngine->start (outputFile, renderSampleRate, 1024, 5.0,
-                                renderMode, renderFormat, mp3Bitrate, wavBitDepth))
+                                renderMode, renderFormat, mp3Bitrate, wavBitDepth,
+                                renderRealtime))
     {
         finished = true;
         succeeded = false;

--- a/src/ui/BounceDialog.cpp
+++ b/src/ui/BounceDialog.cpp
@@ -34,6 +34,21 @@ BounceDialog::BounceDialog (AudioEngine& e,
     statusLabel.setText (outputFile.getFullPathName(), juce::dontSendNotification);
     addAndMakeVisible (statusLabel);
 
+    // Offline renders drive the engine detached from the audio device, so an
+    // external hardware-insert loop can't run: those inserts print dry (or
+    // silent at full wet). Mastering renders skip the strips, so only the
+    // strip-driven modes warn.
+    if (renderMode != BounceEngine::Mode::MasteringChain
+        && BounceEngine::anyHardwareInsertActive (session))
+    {
+        hwWarnLabel.setJustificationType (juce::Justification::centredLeft);
+        hwWarnLabel.setColour (juce::Label::textColourId, juce::Colour (0xffe0b050));
+        hwWarnLabel.setText ("Hardware inserts are bypassed in an offline render "
+                             "and will print dry.",
+                             juce::dontSendNotification);
+        addAndMakeVisible (hwWarnLabel);
+    }
+
     progressBar.setColour (juce::ProgressBar::backgroundColourId, juce::Colour (0xff101012));
     progressBar.setColour (juce::ProgressBar::foregroundColourId, juce::Colour (0xff5fa8ff));
     addAndMakeVisible (progressBar);
@@ -101,6 +116,11 @@ void BounceDialog::resized()
     titleLabel.setBounds (area.removeFromTop (24));
     area.removeFromTop (4);
     statusLabel.setBounds (area.removeFromTop (20));
+    if (hwWarnLabel.isVisible())
+    {
+        area.removeFromTop (2);
+        hwWarnLabel.setBounds (area.removeFromTop (18));
+    }
     area.removeFromTop (12);
     progressBar.setBounds (area.removeFromTop (24));
     area.removeFromTop (16);
@@ -119,12 +139,11 @@ void BounceDialog::timerCallback()
 
     if (renderMode == BounceEngine::Mode::Stems && bounceEngine->isRendering())
     {
-        const int idx   = bounceEngine->getCurrentStemIndex();
         const int total = bounceEngine->getTotalStemsToRender();
-        if (idx > 0 && total > 0)
+        if (total > 0)
         {
-            statusLabel.setText ("Rendering stem " + juce::String (idx)
-                                  + " of " + juce::String (total)
+            statusLabel.setText ("Rendering " + juce::String (total) + " stem"
+                                  + juce::String (total == 1 ? "" : "s")
                                   + " -> " + outputFile.getParentDirectory().getFullPathName(),
                                   juce::dontSendNotification);
         }

--- a/src/ui/BounceDialog.h
+++ b/src/ui/BounceDialog.h
@@ -72,6 +72,7 @@ private:
 
     juce::Label       titleLabel;
     juce::Label       statusLabel;
+    juce::Label       hwWarnLabel;
     juce::ProgressBar progressBar;
     juce::TextButton  cancelButton { "Cancel" };
     juce::TextButton  closeButton  { "Close" };

--- a/src/ui/BounceDialog.h
+++ b/src/ui/BounceDialog.h
@@ -84,5 +84,6 @@ private:
     double progressValue = 0.0;  // bound to ProgressBar
     bool   finished      = false;
     bool   succeeded     = false;
+    bool   stemsStatusShown = false;
 };
 } // namespace duskstudio

--- a/src/ui/BounceDialog.h
+++ b/src/ui/BounceDialog.h
@@ -27,6 +27,8 @@ class BounceDialog final : public juce::Component,
 public:
     // renderSampleRate 0 = the engine's current rate; wavBitDepth 16 dithers
     // (see BounceEngine::start). The mastering export presets drive both.
+    // realtime plays the session live and captures it (hardware inserts
+    // print); MasterMix / Stems only.
     BounceDialog (AudioEngine& engine,
                    Session& session,
                    juce::AudioDeviceManager& deviceManager,
@@ -35,7 +37,8 @@ public:
                    BounceEngine::Format format = BounceEngine::Format::Wav,
                    int mp3BitrateKbps = 320,
                    double renderSampleRate = 0.0,
-                   int wavBitDepth = 24);
+                   int wavBitDepth = 24,
+                   bool realtime = false);
     ~BounceDialog() override;
 
     void resized() override;
@@ -67,6 +70,7 @@ private:
     int mp3Bitrate;
     double renderSampleRate;
     int wavBitDepth;
+    bool renderRealtime;
 
     std::unique_ptr<BounceEngine> bounceEngine;
 

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -1838,7 +1838,10 @@ void ChannelStripComponent::openHardwareInsertEditor()
                 self->hardwareInsertModal.close();
                 self->refreshPluginSlotButton();
             }
-        });
+        },
+        /*embedded*/ false,
+        /*allowMono*/ track.mode.load (std::memory_order_relaxed)
+                          == (int) Track::Mode::Mono);
 
     auto* parent = findParentComponentOfClass<juce::Component>();
     if (parent == nullptr) parent = this;

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -1654,15 +1654,20 @@ void ChannelStripComponent::setMixingMode (bool mixing)
 //   - Click while the OTHER popup is open -> close the other, open this one
 // The mutual-exclusion path lets the user move quickly between EQ and COMP
 // without first having to dismiss the open dialog manually.
-void ChannelStripComponent::openPluginPicker (bool useChooser)
+void ChannelStripComponent::openPluginPicker()
 {
     // MIDI tracks need an instrument plugin (synth / sampler) - the strip
     // routes per-track MIDI events into the slot. Mono / Stereo tracks
     // route audio through the slot, which only makes sense for effect
     // plugins; instrument plugins ignore the audio input entirely and
     // (in the case of some VSTGUI-based instruments) fail to render
-    // their UI when loaded as an audio insert.
-    const auto kind = (track.mode.load (std::memory_order_relaxed) == (int) Track::Mode::Midi)
+    // their UI when loaded as an audio insert. A FROZEN MIDI track is an
+    // audio source (the baked WAV), so its slot takes effects and the
+    // hardware insert - the instrument is baked in and stays bypassed.
+    const bool isMidiTrack =
+        track.mode.load (std::memory_order_relaxed) == (int) Track::Mode::Midi;
+    const bool frozenNow = track.frozen.load (std::memory_order_relaxed);
+    const auto kind = (isMidiTrack && ! frozenNow)
                         ? pluginpicker::PluginKind::Instruments
                         : pluginpicker::PluginKind::Effects;
 
@@ -1676,9 +1681,7 @@ void ChannelStripComponent::openPluginPicker (bool useChooser)
     // Two-step flow: chooser modal first (Hardware / Soundfont / Plugin)
     // so the plugin list isn't the user's only path. Picking "Plugin"
     // from the chooser routes to the existing openPickerMenu - same
-    // callbacks below. The right-click "Replace plugin..." path passes
-    // useChooser=false: the user is already committed to a plugin, so
-    // skip the chooser and jump straight to the plugin list.
+    // callbacks below.
     auto onChange = [safe]
                                     {
                                         auto* self = safe.getComponent();
@@ -1803,33 +1806,14 @@ void ChannelStripComponent::openPluginPicker (bool useChooser)
     };
 #endif
 
-    if (useChooser)
-    {
-        pluginpicker::openInsertChooser (pluginSlot,
-                                          pluginSlotButton,
-                                          std::move (onChange),
-                                          kind,
-                                          std::move (openHwEditor),
-                                          std::move (onClap),
-                                          std::move (onLv2),
-                                          std::move (onVst3));
-    }
-    else
-    {
-        // Replace-plugin path: skip the chooser, suppress the picker's
-        // own secondary buttons (HW + Soundfont) since the user has
-        // already committed to "this is a plugin".
-        pluginpicker::openPickerMenu (pluginSlot,
-                                       pluginSlotButton,
-                                       std::move (onChange),
-                                       kind,
-                                       { -1, -1 },
-                                       /*onPickHardwareInsert*/ {},
-                                       /*suppressSecondaryButtons*/ true,
-                                       std::move (onClap),
-                                       std::move (onLv2),
-                                       std::move (onVst3));
-    }
+    pluginpicker::openInsertChooser (pluginSlot,
+                                      pluginSlotButton,
+                                      std::move (onChange),
+                                      kind,
+                                      std::move (openHwEditor),
+                                      std::move (onClap),
+                                      std::move (onLv2),
+                                      std::move (onVst3));
 }
 
 void ChannelStripComponent::openHardwareInsertEditor()
@@ -1859,6 +1843,16 @@ void ChannelStripComponent::openHardwareInsertEditor()
     auto* parent = findParentComponentOfClass<juce::Component>();
     if (parent == nullptr) parent = this;
     hardwareInsertModal.show (*parent, std::move (editor));
+}
+
+void ChannelStripComponent::removeHardwareInsert()
+{
+    // The crossfade gate ramps the insert out click-free on the mode flip;
+    // enabled=false parks the params so a later re-engage starts clean.
+    engine.getChannelStrip (trackIndex)
+        .insertMode.store (ChannelStrip::kInsertEmpty, std::memory_order_release);
+    track.hardwareInsert.enabled.store (false, std::memory_order_relaxed);
+    refreshPluginSlotButton();
 }
 
 void ChannelStripComponent::unloadPluginSlot()
@@ -1940,7 +1934,7 @@ void ChannelStripComponent::showPluginSlotMenu()
         const bool editorOpen = isPluginEditorOpen();
         menu.addItem (2001, editorOpen ? "Close editor" : "Open editor");
         menu.addSeparator();
-        menu.addItem (2002, "Replace plugin...");
+        menu.addItem (2002, "Replace insert...");
         menu.addItem (2003, "Remove plugin");
         // Crash/auto-bypass recovery is a JUCE-slot concept (native hosts run
         // in-process without the watchdog).
@@ -1964,9 +1958,17 @@ void ChannelStripComponent::showPluginSlotMenu()
                            lastParam >= 0);
         }
     }
+    else if (engine.getChannelStrip (trackIndex).insertMode.load (std::memory_order_acquire)
+                 == ChannelStrip::kInsertHardware)
+    {
+        menu.addItem (2006, "Edit hardware insert...");
+        menu.addSeparator();
+        menu.addItem (2002, "Replace insert...");
+        menu.addItem (2007, "Remove hardware insert");
+    }
     else
     {
-        menu.addItem (2010, "Pick plugin...");
+        menu.addItem (2010, "Add insert...");
     }
 
     juce::Component::SafePointer<ChannelStripComponent> safe (this);
@@ -1978,8 +1980,10 @@ void ChannelStripComponent::showPluginSlotMenu()
             switch (result)
             {
                 case 2001: self->togglePluginEditor();             break;
-                case 2002: self->openPluginPicker (/*useChooser*/ false); break;
+                case 2002: self->openPluginPicker(); break;
                 case 2003: self->unloadPluginSlot();               break;
+                case 2006: self->openHardwareInsertEditor();       break;
+                case 2007: self->removeHardwareInsert();           break;
                 case 2004: self->pluginSlot.clearAutoBypass();     break;
                 case 2005:
                     // Fire the MIDI Learn workflow targeting THIS
@@ -1994,7 +1998,7 @@ void ChannelStripComponent::showPluginSlotMenu()
                         MidiBindingTarget::TrackPluginParam,
                         self->trackIndex);
                     break;
-                case 2010: self->openPluginPicker (/*useChooser*/ false); break;
+                case 2010: self->openPluginPicker(); break;
                 default: break;
             }
         });
@@ -4197,17 +4201,15 @@ void ChannelStripComponent::showColourMenu()
     menu.addSeparator();
     menu.addItem (1001, "Rename track...");
 
-    // Plugin slot menu items, only meaningful when a plugin is loaded.
-    // Replace/Remove live here (rather than on the slot button itself) so
-    // the slot button's primary click stays as a toggle for the editor.
-    if (pluginSlot.isLoaded()
-        || engine.getChannelStrip (trackIndex).isNativeClapLoaded()
-        || engine.getChannelStrip (trackIndex).isNativeLv2Loaded()
-        || engine.getChannelStrip (trackIndex).isNativeVst3Loaded())
+    // Insert slot menu items, only meaningful when the slot is occupied
+    // (plugin, native, or hardware). Replace/Remove live here (rather than
+    // on the slot button itself) so the slot button's primary click stays
+    // as a toggle for the editor.
+    if (insertSlotOccupied())
     {
         menu.addSeparator();
-        menu.addItem (1010, "Replace plugin...");
-        menu.addItem (1011, "Remove plugin");
+        menu.addItem (1010, "Replace insert...");
+        menu.addItem (1011, "Remove insert");
         if (pluginSlot.wasCrashed())
             menu.addItem (1012, "Re-enable plugin (crashed)");
         else if (pluginSlot.wasAutoBypassed())
@@ -4259,8 +4261,16 @@ void ChannelStripComponent::showColourMenu()
                 self->nameLabel.showEditor();
                 return;
             }
-            if (result == 1010) { self->openPluginPicker (/*useChooser*/ false); return; }
-            if (result == 1011) { self->unloadPluginSlot();      return; }
+            if (result == 1010) { self->openPluginPicker(); return; }
+            if (result == 1011)
+            {
+                const bool hw = self->engine.getChannelStrip (self->trackIndex)
+                                    .insertMode.load (std::memory_order_acquire)
+                                        == ChannelStrip::kInsertHardware;
+                if (hw) self->removeHardwareInsert();
+                else    self->unloadPluginSlot();
+                return;
+            }
             if (result == 1012) { self->pluginSlot.clearAutoBypass(); return; }
             if (result >= 2000 && result < 2000 + Session::kNumTracks)
             {

--- a/src/ui/ChannelStripComponent.h
+++ b/src/ui/ChannelStripComponent.h
@@ -320,8 +320,9 @@ private:
     // useChooser=true: shows 3-button Add Insert chooser (Hardware /
     // Soundfont / Plugin) first. false: jump to plugin list (used by
     // Replace plugin... where the user already committed to plugin).
-    void openPluginPicker (bool useChooser = true);
+    void openPluginPicker();
     void unloadPluginSlot();
+    void removeHardwareInsert();
     void refreshPluginSlotButton();
 
     // Flips insertMode to Hardware and shows HardwareInsertEditor in

--- a/src/ui/HardwareInsertEditor.cpp
+++ b/src/ui/HardwareInsertEditor.cpp
@@ -9,14 +9,20 @@ using outputpair::encodePair;
 using outputpair::decodePairL;
 using outputpair::decodePairR;
 
+// Combo ids for Mono format's single-channel rows; offset clear of every
+// encodePair id (chL * 1000 + chR + 1 with device channel counts far below).
+constexpr int kMonoChannelIdBase = 1000000;
+
 HardwareInsertEditor::HardwareInsertEditor (HardwareInsertParams& paramsRef,
                                                 juce::AudioDeviceManager& dm,
                                                 std::function<void()> onDone,
-                                                bool embedded)
+                                                bool embedded,
+                                                bool allowMono)
     : params (paramsRef),
       deviceManager (dm),
       onDoneCallback (std::move (onDone)),
-      isEmbedded (embedded)
+      isEmbedded (embedded),
+      monoAllowed (allowMono)
 {
     setSize (kPanelW, kPanelH);
 
@@ -136,15 +142,22 @@ HardwareInsertEditor::HardwareInsertEditor (HardwareInsertParams& paramsRef,
 
     formatStereoButton.setRadioGroupId (8001);
     formatMidSideButton.setRadioGroupId (8001);
+    formatMonoButton.setRadioGroupId (8001);
     {
         const auto routing = currentRouting();
         formatStereoButton .setToggleState (routing.format == 0, juce::dontSendNotification);
         formatMidSideButton.setToggleState (routing.format == 1, juce::dontSendNotification);
+        formatMonoButton   .setToggleState (routing.format == 2, juce::dontSendNotification);
     }
-    formatStereoButton .onClick = [this] { publishRoutingFromUi(); };
-    formatMidSideButton.onClick = [this] { publishRoutingFromUi(); };
+    // Flipping to or from Mono changes the channel lists from pairs to
+    // singles, so the dropdowns rebuild along with the publish.
+    formatStereoButton .onClick = [this] { populateDropdowns(); publishRoutingFromUi(); };
+    formatMidSideButton.onClick = [this] { populateDropdowns(); publishRoutingFromUi(); };
+    formatMonoButton   .onClick = [this] { populateDropdowns(); publishRoutingFromUi(); };
     addAndMakeVisible (formatStereoButton);
     addAndMakeVisible (formatMidSideButton);
+    if (monoAllowed)
+        addAndMakeVisible (formatMonoButton);
 
     // Cancel + Done are popup-modal vestiges. When embedded inline in
     // the AUX lane, the X (remove) button on the slot header handles
@@ -245,6 +258,7 @@ void HardwareInsertEditor::populateDropdowns()
     const auto inNames  = device->getInputChannelNames();
     const auto routing = currentRouting();
 
+    const bool monoFormat = formatMonoButton.getToggleState();
     auto addPairs = [] (juce::ComboBox& cb, const juce::StringArray& names)
     {
         // Pair adjacent channels - typical interface convention is
@@ -258,19 +272,35 @@ void HardwareInsertEditor::populateDropdowns()
             cb.addItem (label, encodePair (i, i + 1));
         }
     };
-    addPairs (outChCombo, outNames);
-    addPairs (inChCombo,  inNames);
+    auto addSingles = [] (juce::ComboBox& cb, const juce::StringArray& names)
+    {
+        cb.addItem ("(none)", 1);
+        for (int i = 0; i < names.size(); ++i)
+            cb.addItem (juce::String (i + 1) + "  " + names[i],
+                        kMonoChannelIdBase + i);
+    };
+    if (monoFormat)
+    {
+        addSingles (outChCombo, outNames);
+        addSingles (inChCombo,  inNames);
+    }
+    else
+    {
+        addPairs (outChCombo, outNames);
+        addPairs (inChCombo,  inNames);
+    }
 
     // Preselect the routing the params currently hold. Falls back to
     // "(none)" if the stored pair isn't in the menu (device hot-swap).
-    auto selectMatching = [] (juce::ComboBox& cb, int chL, int chR)
+    auto selectMatching = [monoFormat] (juce::ComboBox& cb, int chL, int chR)
     {
-        if (chL < 0 || chR < 0)
+        if (chL < 0 || (chR < 0 && ! monoFormat))
         {
             cb.setSelectedId (1, juce::dontSendNotification);
             return;
         }
-        const int targetId = encodePair (chL, chR);
+        const int targetId = monoFormat ? kMonoChannelIdBase + chL
+                                        : encodePair (chL, chR);
         for (int i = 0; i < cb.getNumItems(); ++i)
         {
             if (cb.getItemId (i) == targetId)
@@ -294,32 +324,18 @@ void HardwareInsertEditor::publishRoutingFromUi()
 {
     auto fresh = std::make_unique<HardwareInsertRouting> (currentRouting());
 
-    const int outId = outChCombo.getSelectedId();
-    if (outId == 1 || outId == 0)
+    auto decodeSelection = [] (int id, int& chL, int& chR)
     {
-        fresh->outputChL = -1;
-        fresh->outputChR = -1;
-    }
-    else
-    {
-        fresh->outputChL = decodePairL (outId);
-        fresh->outputChR = decodePairR (outId);
-    }
-
-    const int inId = inChCombo.getSelectedId();
-    if (inId == 1 || inId == 0)
-    {
-        fresh->inputChL = -1;
-        fresh->inputChR = -1;
-    }
-    else
-    {
-        fresh->inputChL = decodePairL (inId);
-        fresh->inputChR = decodePairR (inId);
-    }
+        if (id == 1 || id == 0)          { chL = -1; chR = -1; }
+        else if (id >= kMonoChannelIdBase) { chL = id - kMonoChannelIdBase; chR = -1; }
+        else                              { chL = decodePairL (id); chR = decodePairR (id); }
+    };
+    decodeSelection (outChCombo.getSelectedId(), fresh->outputChL, fresh->outputChR);
+    decodeSelection (inChCombo.getSelectedId(),  fresh->inputChL,  fresh->inputChR);
 
     fresh->latencySamples = (int) latencySlider.getValue();
-    fresh->format = formatMidSideButton.getToggleState() ? 1 : 0;
+    fresh->format = formatMonoButton.getToggleState() ? 2
+                   : formatMidSideButton.getToggleState() ? 1 : 0;
 
     params.routing.publish (std::move (fresh));
 }
@@ -379,6 +395,11 @@ void HardwareInsertEditor::resized()
         formatStereoButton .setBounds (row.removeFromLeft (110));
         row.removeFromLeft (8);
         formatMidSideButton.setBounds (row.removeFromLeft (110));
+        if (monoAllowed)
+        {
+            row.removeFromLeft (8);
+            formatMonoButton.setBounds (row.removeFromLeft (90));
+        }
     }
 
     // Footer row, pinned to the bottom. Skip layout when embedded -

--- a/src/ui/HardwareInsertEditor.h
+++ b/src/ui/HardwareInsertEditor.h
@@ -28,10 +28,14 @@ class HardwareInsertEditor final : public juce::Component,
                                        private juce::Timer
 {
 public:
+    // allowMono adds a Mono format (single-channel send + return) to the
+    // format row - offered on mono tracks, where single-channel outboard
+    // (a mono compressor, a guitar pedal) is the natural patch.
     HardwareInsertEditor (HardwareInsertParams& params,
                           juce::AudioDeviceManager& deviceManager,
                           std::function<void()> onDone,
-                          bool embedded = false);
+                          bool embedded = false,
+                          bool allowMono = false);
     ~HardwareInsertEditor() override;
 
     void paint (juce::Graphics&) override;
@@ -50,6 +54,7 @@ private:
     juce::AudioDeviceManager& deviceManager;
     std::function<void()> onDoneCallback;
     bool isEmbedded = false;
+    bool monoAllowed = false;
 
     juce::Label headerLabel;
 
@@ -79,6 +84,7 @@ private:
     juce::Label       formatLabel;
     juce::ToggleButton formatStereoButton  { "Stereo" };
     juce::ToggleButton formatMidSideButton { "Mid/Side" };
+    juce::ToggleButton formatMonoButton    { "Mono" };
 
     juce::TextButton cancelButton { "Cancel" };
     juce::TextButton doneButton   { "Done" };

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -3387,22 +3387,14 @@ void MainComponent::openBounceStemsDialog()
             outFile = outFile.withFileExtension ("wav");
 
         // Preflight: the base WAV is never written for stems - the real
-        // targets are the derived <base>_<NN>_<track>.wav files. Compute
-        // them for the tracks that will actually render (same predicate
-        // as BounceEngine) and warn if any already exist, so the file
-        // browser's base-file overwrite check doesn't give false comfort.
+        // targets are the derived stem files. Ask BounceEngine for the exact
+        // set it would write (tracks + bus / aux stems) and warn if any
+        // already exist, so the file browser's base-file overwrite check
+        // doesn't give false comfort.
         juce::StringArray conflicts;
-        for (int t = 0; t < Session::kNumTracks; ++t)
-        {
-            const auto& tr = session.track (t);
-            const bool hasContent = ! tr.regions.empty()
-                                  || ! tr.midiRegions.current().empty();
-            const bool armed = tr.recordArmed.load (std::memory_order_relaxed);
-            if (! (hasContent || armed)) continue;
-            const auto sf = BounceEngine::stemOutputFile (outFile, t, tr.name);
-            if (sf.existsAsFile())
-                conflicts.add (sf.getFileName());
-        }
+        for (const auto& tgt : BounceEngine::collectStemTargets (session, outFile))
+            if (tgt.file.existsAsFile())
+                conflicts.add (tgt.file.getFileName());
 
         auto launch = [this, outFile]
         {

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -3381,14 +3381,34 @@ void MainComponent::openBounceDialog()
             // is WAV data under an .mp3 extension.
             const auto target = realtime ? outFile.withFileExtension ("wav") : outFile;
             const auto format = realtime ? BounceEngine::Format::Wav : fmt;
-            auto panel = std::make_unique<BounceDialog> (engine, session,
-                                                           engine.getDeviceManager(), target,
-                                                           BounceEngine::Mode::MasterMix, format,
-                                                           320, 0.0, 24, realtime);
-            panel->setSize (520, 200);
-            juce::Component::SafePointer<MainComponent> safeThis (this);
-            panel->onRequestClose = [safeThis] { if (safeThis != nullptr) safeThis->bounceModal.close(); };
-            bounceModal.show (*this, std::move (panel), {}, false, false);
+
+            auto launchBounce = [this, target, format, realtime]
+            {
+                auto panel = std::make_unique<BounceDialog> (engine, session,
+                                                               engine.getDeviceManager(), target,
+                                                               BounceEngine::Mode::MasterMix, format,
+                                                               320, 0.0, 24, realtime);
+                panel->setSize (520, 200);
+                juce::Component::SafePointer<MainComponent> safeThis (this);
+                panel->onRequestClose = [safeThis] { if (safeThis != nullptr) safeThis->bounceModal.close(); };
+                bounceModal.show (*this, std::move (panel), {}, false, false);
+            };
+
+            // The .mp3 -> .wav retarget skips the file browser's overwrite
+            // check (it inspected the .mp3 name), so re-check the real target.
+            if (target != outFile && target.existsAsFile())
+            {
+                juce::Component::SafePointer<MainComponent> safe (this);
+                showDuskConfirm (*this, "Overwrite file?",
+                                 target.getFileName()
+                                   + " already exists (realtime bounces are written as WAV). "
+                                     "Overwrite it?",
+                                 "Overwrite",
+                                 [safe, launchBounce] { if (safe != nullptr) launchBounce(); },
+                                 "Cancel", {}, /*destructive*/ true);
+                return;
+            }
+            launchBounce();
         });
     });
 }

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -2060,6 +2060,25 @@ void MainComponent::syncStageUi (AudioEngine::Stage s)
     masteringStageBtn.setToggleState (s == AudioEngine::Stage::Mastering, juce::dontSendNotification);
 }
 
+void MainComponent::askBounceRealtime (std::function<void (bool realtime)> launch)
+{
+    if (! BounceEngine::anyHardwareInsertActive (session))
+    {
+        launch (false);
+        return;
+    }
+    // The confirm's callbacks fire later from the shared alert modal; launch
+    // captures raw `this` at every call site, so gate it on this component
+    // still being alive.
+    juce::Component::SafePointer<MainComponent> safe (this);
+    showDuskConfirm (*this, "Hardware inserts in session",
+                     "An offline bounce cannot run external gear, so hardware "
+                     "inserts print dry. A realtime bounce plays the session "
+                     "once through the interface and prints them.",
+                     "Realtime", [safe, launch] { if (safe != nullptr) launch (true); },
+                     "Offline",  [safe, launch] { if (safe != nullptr) launch (false); });
+}
+
 void MainComponent::doMixdown()
 {
     // One-shot bounce of the master mix to <sessionDir>/mixdown.wav, then
@@ -2068,29 +2087,35 @@ void MainComponent::doMixdown()
     // the explicit dialog flow for ad-hoc renders.
     auto target = session.getSessionDirectory().getChildFile ("mixdown.wav");
 
-    auto panel = std::make_unique<BounceDialog> (engine, session,
-                                                   engine.getDeviceManager(), target);
-    panel->setSize (520, 200);
-
-    // Close the modal, then hand off to Mastering once the bounce finishes
-    // successfully. The handoff is deferred so the heavy stage swap does not
-    // run re-entrantly from inside the dialog's close-button callback.
-    juce::Component::SafePointer<MainComponent> safeThis (this);
-    panel->onRequestClose = [safeThis] { if (safeThis != nullptr) safeThis->mixdownModal.close(); };
-    panel->onSuccessfulFinish = [safeThis] (juce::File rendered)
+    askBounceRealtime ([this, target] (bool realtime)
     {
-        juce::MessageManager::callAsync ([safeThis, rendered]
-        {
-            if (safeThis == nullptr) return;
-            safeThis->switchToStage (AudioEngine::Stage::Mastering);
-            if (safeThis->masteringView != nullptr)
-                safeThis->masteringView->loadFile (rendered);
-        });
-    };
+        auto panel = std::make_unique<BounceDialog> (engine, session,
+                                                       engine.getDeviceManager(), target,
+                                                       BounceEngine::Mode::MasterMix,
+                                                       BounceEngine::Format::Wav, 320, 0.0, 24,
+                                                       realtime);
+        panel->setSize (520, 200);
 
-    // A render in progress must not be dismissed by a stray click / Escape -
-    // only the dialog's own Cancel / Close buttons drive teardown.
-    mixdownModal.show (*this, std::move (panel), {}, false, false);
+        // Close the modal, then hand off to Mastering once the bounce finishes
+        // successfully. The handoff is deferred so the heavy stage swap does not
+        // run re-entrantly from inside the dialog's close-button callback.
+        juce::Component::SafePointer<MainComponent> safeThis (this);
+        panel->onRequestClose = [safeThis] { if (safeThis != nullptr) safeThis->mixdownModal.close(); };
+        panel->onSuccessfulFinish = [safeThis] (juce::File rendered)
+        {
+            juce::MessageManager::callAsync ([safeThis, rendered]
+            {
+                if (safeThis == nullptr) return;
+                safeThis->switchToStage (AudioEngine::Stage::Mastering);
+                if (safeThis->masteringView != nullptr)
+                    safeThis->masteringView->loadFile (rendered);
+            });
+        };
+
+        // A render in progress must not be dismissed by a stray click / Escape -
+        // only the dialog's own Cancel / Close buttons drive teardown.
+        mixdownModal.show (*this, std::move (panel), {}, false, false);
+    });
 }
 
 void MainComponent::launchStartupDialog()
@@ -3349,13 +3374,22 @@ void MainComponent::openBounceDialog()
             outFile = outFile.withFileExtension ("wav");
         const auto fmt = mp3 ? BounceEngine::Format::Mp3 : BounceEngine::Format::Wav;
 
-        auto panel = std::make_unique<BounceDialog> (engine, session,
-                                                       engine.getDeviceManager(), outFile,
-                                                       BounceEngine::Mode::MasterMix, fmt);
-        panel->setSize (520, 200);
-        juce::Component::SafePointer<MainComponent> safeThis (this);
-        panel->onRequestClose = [safeThis] { if (safeThis != nullptr) safeThis->bounceModal.close(); };
-        bounceModal.show (*this, std::move (panel), {}, false, false);
+        askBounceRealtime ([this, outFile, fmt] (bool realtime)
+        {
+            // A realtime capture is always WAV (BounceEngine forces the
+            // format), so a typed .mp3 name must follow - otherwise the file
+            // is WAV data under an .mp3 extension.
+            const auto target = realtime ? outFile.withFileExtension ("wav") : outFile;
+            const auto format = realtime ? BounceEngine::Format::Wav : fmt;
+            auto panel = std::make_unique<BounceDialog> (engine, session,
+                                                           engine.getDeviceManager(), target,
+                                                           BounceEngine::Mode::MasterMix, format,
+                                                           320, 0.0, 24, realtime);
+            panel->setSize (520, 200);
+            juce::Component::SafePointer<MainComponent> safeThis (this);
+            panel->onRequestClose = [safeThis] { if (safeThis != nullptr) safeThis->bounceModal.close(); };
+            bounceModal.show (*this, std::move (panel), {}, false, false);
+        });
     });
 }
 
@@ -3396,11 +3430,13 @@ void MainComponent::openBounceStemsDialog()
             if (tgt.file.existsAsFile())
                 conflicts.add (tgt.file.getFileName());
 
-        auto launch = [this, outFile]
+        auto launch = [this, outFile] (bool realtime)
         {
             auto panel = std::make_unique<BounceDialog> (engine, session,
                                                            engine.getDeviceManager(), outFile,
-                                                           BounceEngine::Mode::Stems);
+                                                           BounceEngine::Mode::Stems,
+                                                           BounceEngine::Format::Wav,
+                                                           320, 0.0, 24, realtime);
             panel->setSize (520, 200);
             juce::Component::SafePointer<MainComponent> safeThis (this);
             panel->onRequestClose = [safeThis] { if (safeThis != nullptr) safeThis->bounceModal.close(); };
@@ -3409,7 +3445,7 @@ void MainComponent::openBounceStemsDialog()
 
         if (conflicts.isEmpty())
         {
-            launch();
+            askBounceRealtime (launch);
             return;
         }
 
@@ -3422,7 +3458,7 @@ void MainComponent::openBounceStemsDialog()
                          [safe, launch]() mutable
                          {
                              if (safe.getComponent() != nullptr)
-                                 launch();
+                                 safe->askBounceRealtime (launch);
                          },
                          "Cancel", {}, /*destructive*/ true);
     });

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -3397,10 +3397,15 @@ void MainComponent::openBounceStemsDialog()
 {
     // Pick a base WAV; per-stem filenames derive from it via
     // BounceEngine::stemOutputFile (<base>_<NN>_<sanitized-track>.wav).
-    // Sit alongside the master mix so the user can find them together.
+    // Default into a stems/ subfolder - a full set is 20+ files and would
+    // bury session.json and mixdown.wav in the session root. The browser can
+    // still navigate anywhere.
     auto defaultDir = session.getSessionDirectory();
     if (! defaultDir.isDirectory())
         defaultDir = juce::File::getSpecialLocation (juce::File::userMusicDirectory);
+    else
+        defaultDir = defaultDir.getChildFile ("stems");
+    defaultDir.createDirectory();
     const auto defaultFile = defaultDir.getChildFile ("stems.wav");
 
     // Stems are WAV-only - MP3 encoder delay/padding would misalign them for

--- a/src/ui/MainComponent.h
+++ b/src/ui/MainComponent.h
@@ -71,6 +71,9 @@ private:
     void openAudioSettings();
     void openBounceDialog();
     void openBounceStemsDialog();
+    // Hardware inserts print dry offline; when the session has any, ask
+    // whether to bounce in realtime instead. launch receives the choice.
+    void askBounceRealtime (std::function<void (bool realtime)> launch);
     void cleanOutUnreferencedFiles();
     void launchStartupDialog();
     void switchToStage (AudioEngine::Stage);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,6 +73,7 @@ add_executable(dusk-studio-tests
     ${CMAKE_SOURCE_DIR}/src/engine/McuController.cpp
     multisample_state_roundtrip.cpp
     bounce_stem_filename.cpp
+    bounce_stem_targets.cpp
     dp_importer_parse.cpp
     dp_aligner_align.cpp
     metronome_click.cpp

--- a/tests/bounce_stem_filename.cpp
+++ b/tests/bounce_stem_filename.cpp
@@ -68,3 +68,22 @@ TEST_CASE ("stemOutputFile builds <dir>/<base>_<NN>_<safe>.wav", "[bounce][stems
                   == "master_01_kick.wav");
     }
 }
+
+TEST_CASE ("namedStemOutputFile builds <dir>/<base>_<tag>_<safe>.wav", "[bounce][stems]")
+{
+    const auto temp = juce::File::getSpecialLocation (juce::File::tempDirectory);
+    const auto base = temp.getChildFile ("mix.wav");
+
+    REQUIRE (BounceEngine::namedStemOutputFile (base, "bus1", "Rhythm").getFileName()
+              == "mix_bus1_Rhythm.wav");
+    REQUIRE (BounceEngine::namedStemOutputFile (base, "aux3", "Plate  ").getFileName()
+              == "mix_aux3_Plate.wav");
+
+    SECTION ("empty or all-whitespace names fall back to the tag alone")
+    {
+        REQUIRE (BounceEngine::namedStemOutputFile (base, "aux2", "").getFileName()
+                  == "mix_aux2.wav");
+        REQUIRE (BounceEngine::namedStemOutputFile (base, "bus4", "   ").getFileName()
+                  == "mix_bus4.wav");
+    }
+}

--- a/tests/bounce_stem_targets.cpp
+++ b/tests/bounce_stem_targets.cpp
@@ -67,15 +67,20 @@ TEST_CASE ("collectStemTargets: tracks then buses then auxes, gated on routing",
     REQUIRE (targets[3].file.getFileName() == "mix_aux2_Plate.wav");
 }
 
-TEST_CASE ("collectStemTargets: send at the -inf floor stays inactive", "[bounce][stems]")
+TEST_CASE ("collectStemTargets: send at the off sentinel stays inactive", "[bounce][stems]")
 {
     Session s;
     s.track (0).recordArmed.store (true);
-    s.track (0).strip.auxSendDb[0].store (duskstudio::ChannelStripParams::kFaderInfThreshDb);
+    s.track (0).strip.auxSendDb[0].store (duskstudio::ChannelStripParams::kAuxSendOffDb);
 
     const auto targets = BounceEngine::collectStemTargets (s, baseFile());
     REQUIRE (targets.size() == 1);
     REQUIRE (targets[0].kind == BounceEngine::StemTarget::Kind::Track);
+
+    // Anything above the sentinel is audible on the audio thread, however
+    // faint, so it must produce an aux stem.
+    s.track (0).strip.auxSendDb[0].store (-90.0f);
+    REQUIRE (BounceEngine::collectStemTargets (s, baseFile()).size() == 2);
 }
 
 TEST_CASE ("anyHardwareInsertActive follows rendered tracks and aux lanes",

--- a/tests/bounce_stem_targets.cpp
+++ b/tests/bounce_stem_targets.cpp
@@ -1,0 +1,100 @@
+// Unit tests for BounceEngine::collectStemTargets and
+// BounceEngine::anyHardwareInsertActive - the message-thread planning side
+// of the single-pass stems bounce. The render itself is integration scope
+// (DUSKSTUDIO_BOUNCE_TEST harness).
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/BounceEngine.h"
+#include "session/Session.h"
+
+#include <juce_core/juce_core.h>
+
+using duskstudio::BounceEngine;
+using duskstudio::Session;
+
+namespace
+{
+juce::File baseFile()
+{
+    return juce::File::getSpecialLocation (juce::File::tempDirectory)
+             .getChildFile ("mix.wav");
+}
+}
+
+TEST_CASE ("collectStemTargets: empty session yields no targets", "[bounce][stems]")
+{
+    Session s;
+    REQUIRE (BounceEngine::collectStemTargets (s, baseFile()).empty());
+}
+
+TEST_CASE ("collectStemTargets: tracks then buses then auxes, gated on routing",
+           "[bounce][stems]")
+{
+    Session s;
+    s.track (2).name = "drums";
+    s.track (2).recordArmed.store (true);
+
+    s.track (5).name = "gtr";
+    s.track (5).recordArmed.store (true);
+    s.track (5).strip.busAssign[0].store (true);
+    s.track (5).strip.auxSendDb[1].store (-12.0f);
+
+    // Routing on a track that is NOT rendered must not activate its units.
+    s.track (7).strip.busAssign[3].store (true);
+    s.track (7).strip.auxSendDb[3].store (0.0f);
+
+    s.bus (0).name = "Rhythm";
+    s.auxLane (1).name = "Plate";
+
+    const auto targets = BounceEngine::collectStemTargets (s, baseFile());
+    REQUIRE (targets.size() == 4);
+
+    REQUIRE (targets[0].kind == BounceEngine::StemTarget::Kind::Track);
+    REQUIRE (targets[0].index == 2);
+    REQUIRE (targets[0].file.getFileName() == "mix_03_drums.wav");
+
+    REQUIRE (targets[1].kind == BounceEngine::StemTarget::Kind::Track);
+    REQUIRE (targets[1].index == 5);
+    REQUIRE (targets[1].file.getFileName() == "mix_06_gtr.wav");
+
+    REQUIRE (targets[2].kind == BounceEngine::StemTarget::Kind::Bus);
+    REQUIRE (targets[2].index == 0);
+    REQUIRE (targets[2].file.getFileName() == "mix_bus1_Rhythm.wav");
+
+    REQUIRE (targets[3].kind == BounceEngine::StemTarget::Kind::Aux);
+    REQUIRE (targets[3].index == 1);
+    REQUIRE (targets[3].file.getFileName() == "mix_aux2_Plate.wav");
+}
+
+TEST_CASE ("collectStemTargets: send at the -inf floor stays inactive", "[bounce][stems]")
+{
+    Session s;
+    s.track (0).recordArmed.store (true);
+    s.track (0).strip.auxSendDb[0].store (duskstudio::ChannelStripParams::kFaderInfThreshDb);
+
+    const auto targets = BounceEngine::collectStemTargets (s, baseFile());
+    REQUIRE (targets.size() == 1);
+    REQUIRE (targets[0].kind == BounceEngine::StemTarget::Kind::Track);
+}
+
+TEST_CASE ("anyHardwareInsertActive follows rendered tracks and aux lanes",
+           "[bounce][stems]")
+{
+    Session s;
+    REQUIRE_FALSE (BounceEngine::anyHardwareInsertActive (s));
+
+    // An insert on a track that won't render doesn't count.
+    s.track (3).hardwareInsert.enabled.store (true);
+    REQUIRE_FALSE (BounceEngine::anyHardwareInsertActive (s));
+
+    s.track (3).recordArmed.store (true);
+    REQUIRE (BounceEngine::anyHardwareInsertActive (s));
+
+    s.track (3).hardwareInsert.enabled.store (false);
+    REQUIRE_FALSE (BounceEngine::anyHardwareInsertActive (s));
+
+    // Aux-lane inserts count regardless of track content.
+    s.auxLane (2).hardwareInserts[0].enabled.store (true);
+    REQUIRE (BounceEngine::anyHardwareInsertActive (s));
+}

--- a/tests/bounce_stem_targets.cpp
+++ b/tests/bounce_stem_targets.cpp
@@ -83,6 +83,21 @@ TEST_CASE ("collectStemTargets: send at the off sentinel stays inactive", "[boun
     REQUIRE (BounceEngine::collectStemTargets (s, baseFile()).size() == 2);
 }
 
+TEST_CASE ("collectStemTargets: automated send activates its aux even at the off sentinel",
+           "[bounce][stems]")
+{
+    Session s;
+    s.track (0).recordArmed.store (true);
+    s.track (0).strip.auxSendDb[2].store (duskstudio::ChannelStripParams::kAuxSendOffDb);
+    s.track (0).automationLanes[(size_t) duskstudio::AutomationParam::AuxSend3]
+        .publishPoints ({ { 0, 0.5f } });
+
+    const auto targets = BounceEngine::collectStemTargets (s, baseFile());
+    REQUIRE (targets.size() == 2);
+    REQUIRE (targets[1].kind == BounceEngine::StemTarget::Kind::Aux);
+    REQUIRE (targets[1].index == 2);
+}
+
 TEST_CASE ("anyHardwareInsertActive follows rendered tracks and aux lanes",
            "[bounce][stems]")
 {


### PR DESCRIPTION
## What this is

The hardware/bounce workstream: stem bouncing rebuilt as a single offline pass, a realtime bounce mode so hardware inserts can print, and the insert-slot work that makes hardware inserts usable on frozen and mono tracks.

## Stems in one pass (was N full renders)

- One offline render captures every stem via per-strip taps (post-fader/post-pan, same contract as the freeze tap) plus bus and aux captures at their engine sum points. 22 stems now cost roughly one mixdown.
- Semantics match commercial DAWs: track stems carry no master-strip processing, mute/solo prints as heard, and track + bus + aux stems reconstruct the pre-master mix. Aux lanes and bus groups print as their own stems (send automation counts as active).
- Per-kind PDC lead-ins keep the whole set mutually sample-aligned; every writer is capped to equal length.
- The file browser defaults into a stems/ subfolder; the overwrite check covers the exact target set the render will write.

## Realtime bounce

- When a session uses hardware inserts, Bounce / Mixdown / Bounce stems ask Realtime or Offline. Realtime plays the session once through the interface while the callback streams each sink to a ThreadedWriter (lock-free push); the external loop prints for real. Offline keeps the fast render with a dry-insert warning.
- Capture sits post-master, pre-metronome (the monitoring click never prints; the offline paths now suppress it too). Pre-roll accumulation is wiped, a mid-bounce device change aborts cleanly instead of corrupting heap, disarm is fenced through the process gate, and a too-slow disk fails the render rather than writing a silently short file.

## Hardware inserts: frozen + mono

- A frozen track runs its hardware insert on the baked audio (crossfade-gated), and PDC counts the measured loop latency. The bake stays dry of hardware, which keeps running live - hardware costs no CPU. A plugin cannot run on a frozen strip (indistinguishable from a still-loaded baked native instrument).
- Ping works with the transport stopped on frozen tracks.
- Mono tracks get a Mono format in the I/O editor: single output channel, single return (fed to both sides so the mono fold-down stays at unity).
- "Replace plugin..." / "Pick plugin..." are now "Replace insert..." / "Add insert..." and always open the kind chooser; hardware-occupied slots get real edit/replace/remove menus.

## Verification

- 379 Catch2 tests green (new: stem target collection, naming, aux automation gating).
- DUSKSTUDIO_BOUNCE_TEST harness gained a stems leg (real CLAP insert, all three stem kinds, equal length): ALL PASS.
- Xvfb selftest 27/27; de-JUCE gate unchanged at 202.
- Field-validated: 22-stem session bounced single-pass.
- Owed on the bench: one realtime bounce through a live hardware loop (Out 3 -> In 3) to sign off the realtime path end to end.

MANUAL.md updated throughout (stems folder + semantics, realtime bounce, click-never-prints, frozen/mono hardware inserts).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Mono hardware-insert format for mono tracks with single-channel routing.
  * Introduced enhanced “Bounce stems” rendering for tracks, buses, and aux lanes, including consistent naming and sample-aligned, non-silent output.
  * Added realtime bounce support for sessions with hardware inserts, with updated UI messaging and prompts.
* **Bug Fixes**
  * Fixed frozen-track hardware-insert processing so inserted audio is handled correctly.
  * Improved prevention/validation of silent or invalid stems during bounce.
* **Documentation**
  * Expanded MANUAL guidance for recording/freeze behavior, hardware-insert formats, and stems rules.
* **Tests**
  * Added coverage for stem target selection and stem filename generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->