### PR TITLE
Mastering view playback polish and a New Folder button in the file browser

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1763,7 +1763,7 @@ The metronome never prints in any bounce: it is a monitoring aid, mixed in after
 
 ## Where bounces go
 
-By default, bounces are written to the session folder itself (the same directory that holds `session.json`). The bounce dialog opens a file browser there so you can rename or redirect each export. The most-recent bounce in the session folder is what the mastering stage's **Load latest mixdown** button picks up.
+By default, bounces are written to the session folder itself (the same directory that holds `session.json`). The bounce dialog opens a file browser there so you can rename or redirect each export; **New folder…** in its bottom-left corner creates a subfolder and jumps into it, handy for keeping stem sets together. The most-recent bounce in the session folder is what the mastering stage's **Load latest mixdown** button picks up.
 
 \newpage
 

--- a/src/ui/DuskFileBrowser.cpp
+++ b/src/ui/DuskFileBrowser.cpp
@@ -86,6 +86,30 @@ public:
         addAndMakeVisible (okBtn);
         addAndMakeVisible (cancelBtn);
 
+        // New-folder affordance for flows that write somewhere: Save targets
+        // and directory pickers. Plain Open stays uncluttered.
+        if (opts.mode == Mode::Save || opts.selectDirectories)
+        {
+            styleBtn (newFolderBtn, juce::Colour (0xff262630));
+            newFolderBtn.onClick = [this] { toggleNewFolderRow(); };
+            addAndMakeVisible (newFolderBtn);
+
+            newFolderName.setSelectAllWhenFocused (true);
+            newFolderName.onReturnKey = [this] { createNewFolder(); };
+            newFolderName.onEscapeKey = [this] { toggleNewFolderRow(); };
+            newFolderName.onTextChange = [this]
+            {
+                newFolderName.setColour (juce::TextEditor::outlineColourId,
+                                          findColour (juce::TextEditor::outlineColourId));
+                newFolderName.repaint();
+            };
+            addChildComponent (newFolderName);
+
+            styleBtn (createFolderBtn, juce::Colour (0xff385a78));
+            createFolderBtn.onClick = [this] { createNewFolder(); };
+            addChildComponent (createFolderBtn);
+        }
+
         // Comfortable browse size - clamped to parent by EmbeddedModal.
         setSize (820, 560);
     }
@@ -112,7 +136,18 @@ public:
         cancelBtn.setBounds (bottom.removeFromRight (100));
         bottom.removeFromRight (8);
         okBtn    .setBounds (bottom.removeFromRight (100));
+        if (newFolderBtn.isVisible())
+            newFolderBtn.setBounds (bottom.removeFromLeft (110));
         area.removeFromBottom (10);
+
+        if (newFolderName.isVisible())
+        {
+            auto row = area.removeFromBottom (28);
+            createFolderBtn.setBounds (row.removeFromRight (80));
+            row.removeFromRight (8);
+            newFolderName.setBounds (row);
+            area.removeFromBottom (8);
+        }
 
         if (browser != nullptr) browser->setBounds (area);
     }
@@ -186,6 +221,37 @@ private:
         if (multi)  multi  (juce::Array<juce::File>());
     }
 
+    void toggleNewFolderRow()
+    {
+        const bool show = ! newFolderName.isVisible();
+        newFolderName.setVisible (show);
+        createFolderBtn.setVisible (show);
+        resized();
+        if (show)
+        {
+            newFolderName.setText ("New folder", juce::dontSendNotification);
+            newFolderName.grabKeyboardFocus();
+        }
+    }
+
+    void createNewFolder()
+    {
+        if (browser == nullptr) return;
+        const auto name = juce::File::createLegalFileName (newFolderName.getText().trim());
+        if (name.isEmpty()) return;
+
+        const auto dir = browser->getRoot().getChildFile (name);
+        if (! dir.isDirectory() && ! dir.createDirectory())
+        {
+            newFolderName.setColour (juce::TextEditor::outlineColourId,
+                                      juce::Colour (0xffcc4444));
+            newFolderName.repaint();
+            return;
+        }
+        toggleNewFolderRow();
+        browser->setRoot (dir);
+    }
+
     Options opts;
     std::function<void (juce::File)> resultFn;
     std::function<void (juce::Array<juce::File>)> multiResultFn;
@@ -193,6 +259,8 @@ private:
     std::unique_ptr<juce::FileBrowserComponent> browser;
     juce::Label titleLabel;
     juce::TextButton okBtn, cancelBtn;
+    juce::TextButton newFolderBtn { "New folder..." }, createFolderBtn { "Create" };
+    juce::TextEditor newFolderName;
     juce::File chosen;
 };
 } // namespace

--- a/src/ui/MasteringEqEditor.cpp
+++ b/src/ui/MasteringEqEditor.cpp
@@ -76,6 +76,7 @@ MasteringEqEditor::MasteringEqEditor (MasteringParams& p, MasteringChain* c)
     specDb.fill (kSpecFloorDb);
 
     // Spectrum on/off - a small unobtrusive pill in the curve's top-right.
+    specToggle.setMouseClickGrabsKeyboardFocus (false);
     specToggle.setClickingTogglesState (true);
     specToggle.setToggleState (showSpectrum, juce::dontSendNotification);
     specToggle.setColour (juce::TextButton::buttonColourId,   juce::Colour (0xff202028));

--- a/src/ui/MasteringLimiterEditor.cpp
+++ b/src/ui/MasteringLimiterEditor.cpp
@@ -119,6 +119,7 @@ MasteringLimiterEditor::MasteringLimiterEditor (MasteringParams& p,
     lookaheadLabel.setColour (juce::Label::textColourId, juce::Colour (0xffa0a0a8));
     addAndMakeVisible (lookaheadLabel);
 
+    stereoLinkToggle.setMouseClickGrabsKeyboardFocus (false);
     stereoLinkToggle.setColour (juce::ToggleButton::textColourId, juce::Colour (0xffd0d0d0));
     stereoLinkToggle.setToggleState (params.limiterStereoLink.load (std::memory_order_relaxed),
                                       juce::dontSendNotification);

--- a/src/ui/MasteringView.cpp
+++ b/src/ui/MasteringView.cpp
@@ -72,13 +72,24 @@ void WaveformDisplay::paint (juce::Graphics& g)
     g.drawHorizontalLine (bounds.getCentreY(), (float) bounds.getX(), (float) bounds.getRight());
 
     // Played portion bright, unplayed dim - position reads at a glance.
-    if (total > 0.0 && frac > 0.0f)
+    // Both passes draw the FULL time range into the FULL rect and let a clip
+    // region do the split: drawChannels re-derives its time-to-pixel mapping
+    // from the rect it's given, so drawing the two halves into two rects that
+    // resize every frame makes the rendered wave shimmer during playback.
+    if (splitX > bounds.getX())
     {
+        juce::Graphics::ScopedSaveState ss (g);
+        g.reduceClipRegion (bounds.withRight (splitX));
         g.setColour (juce::Colour (0xff7ab0ee));
-        thumbnail.drawChannels (g, bounds.withRight (splitX), 0.0, playSec, 1.0f);
+        thumbnail.drawChannels (g, bounds, 0.0, total, 1.0f);
     }
-    g.setColour (juce::Colour (0xff3c5c84));
-    thumbnail.drawChannels (g, bounds.withLeft (splitX), playSec, total, 1.0f);
+    if (splitX < bounds.getRight())
+    {
+        juce::Graphics::ScopedSaveState ss (g);
+        g.reduceClipRegion (bounds.withLeft (splitX));
+        g.setColour (juce::Colour (0xff3c5c84));
+        thumbnail.drawChannels (g, bounds, 0.0, total, 1.0f);
+    }
 
     // Time ruler along the bottom - a handful of mm:ss ticks.
     if (total > 0.0)
@@ -148,6 +159,17 @@ constexpr int kNumMasteringTargets = (int) (sizeof (kMasteringTargets) / sizeof 
 MasteringView::MasteringView (Session& s, AudioEngine& e)
     : session (s), engine (e)
 {
+    // A clicked button would otherwise take keyboard focus and eat Space
+    // (juce::Button triggers on it), so the global play/stop toggle in
+    // MainComponent::keyPressed would go dead after any click in here.
+    loadButton.setMouseClickGrabsKeyboardFocus (false);
+    loadLatestMixdown.setMouseClickGrabsKeyboardFocus (false);
+    playButton.setMouseClickGrabsKeyboardFocus (false);
+    stopButton.setMouseClickGrabsKeyboardFocus (false);
+    rewindButton.setMouseClickGrabsKeyboardFocus (false);
+    resetLoudness.setMouseClickGrabsKeyboardFocus (false);
+    exportButton.setMouseClickGrabsKeyboardFocus (false);
+
     // header
     sourceFileLabel.setText ("No mix loaded", juce::dontSendNotification);
     sourceFileLabel.setColour (juce::Label::textColourId, juce::Colour (0xffd0d0d0));


### PR DESCRIPTION
## Mastering view

- The rendered waveform no longer jitters during playback. The played/unplayed halves were drawn as two thumbnail renders whose rects resize every frame, so each half's time-to-pixel mapping shifted as the playhead advanced. Both passes now draw the full range into the full rect with a clip region doing the split - the mapping is identical every frame.
- Spacebar reaches the transport again. MainComponent already routed Space to the mastering player in the Mastering stage, but every button in the view grabbed keyboard focus on click and consumed Space as a re-trigger. The view's buttons (and the EQ FFT / limiter stereo-link toggles) no longer take focus from a click, matching the toolbar convention.

## File browser

- Save dialogs and directory pickers get a New folder... button (bottom-left): inline name row, creates the folder and navigates into it. Failure keeps the row open with a red outline. Keeps stem sets and exports organized without leaving the app.

## Verification

Xvfb screenshot review of the mastering view (byte-identical figures - no visual regression) and the browser with the folder row open; full ctest green; gate unchanged; rebased onto the merged bounce tower and re-verified (build, ctest, selftest 27/27).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **“New folder…”** option when choosing bounce destinations, allowing folders to be created directly in the file browser.
  * Updated the manual with guidance for organizing stem sets in subfolders.

* **Bug Fixes**
  * Reduced waveform shimmer during playback.
  * Improved keyboard shortcuts by preventing control clicks from unexpectedly changing keyboard focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->