### PR TITLE
File browser: error-outline reset and empty-name feedback

### DIFF
--- a/src/ui/DuskFileBrowser.cpp
+++ b/src/ui/DuskFileBrowser.cpp
@@ -99,8 +99,9 @@ public:
             newFolderName.onEscapeKey = [this] { toggleNewFolderRow(); };
             newFolderName.onTextChange = [this]
             {
-                newFolderName.setColour (juce::TextEditor::outlineColourId,
-                                          findColour (juce::TextEditor::outlineColourId));
+                // Drop the error override so the LookAndFeel default applies
+                // again (a copied findColour value would freeze the theme).
+                newFolderName.removeColour (juce::TextEditor::outlineColourId);
                 newFolderName.repaint();
             };
             addChildComponent (newFolderName);
@@ -238,7 +239,15 @@ private:
     {
         if (browser == nullptr) return;
         const auto name = juce::File::createLegalFileName (newFolderName.getText().trim());
-        if (name.isEmpty()) return;
+        if (name.isEmpty())
+        {
+            // Same feedback as a failed create - a silent return reads as a
+            // dead Create button when the name was all whitespace.
+            newFolderName.setColour (juce::TextEditor::outlineColourId,
+                                      juce::Colour (0xffcc4444));
+            newFolderName.repaint();
+            return;
+        }
 
         const auto dir = browser->getRoot().getChildFile (name);
         if (! dir.isDirectory() && ! dir.createDirectory())


### PR DESCRIPTION
Review follow-ups to the New Folder row from #67:

- removeColour restores the LookAndFeel default outline instead of freezing a copied findColour value across theme changes.
- An all-whitespace folder name gets the same red-outline feedback as a failed create instead of returning silently.

Build + Xvfb selftest 27/27.