### PR TITLE
De-JUCE: String sweep (importers, SF2, self-test, native insert slots)

### DIFF
--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -948,7 +948,7 @@ static void runHeadlessSelfTest()
     AudioPipelineSelfTest test (*engine, engine->getDeviceManager(), *session);
     const auto report = test.runAll();
 
-    std::fprintf (stdout, "%s\n", report.toRawUTF8());
+    std::fprintf (stdout, "%s\n", report.c_str());
     std::fflush (stdout);
 }
 
@@ -1956,7 +1956,7 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
 
         AudioPipelineSelfTest test (*engine, engine->getDeviceManager(), *session);
         const auto report = test.runPerfSuite();
-        std::fprintf (stdout, "%s\n", report.toRawUTF8());
+        std::fprintf (stdout, "%s\n", report.c_str());
         std::fflush (stdout);
 
         quit();

--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -1672,7 +1672,7 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
         duskstudio::platform::preferX11ForNextNativeWindow();   // editor host needs an X11 peer
         lv2EditorTest = std::make_unique<Lv2EditorTest>();
         std::string err;
-        if (! lv2EditorTest->slot.load (juce::File (juce::String (path)), 48000.0, 1024, err))
+        if (! lv2EditorTest->slot.load (std::filesystem::u8path (path), 48000.0, 1024, err))
         {
             std::fprintf (stderr, "[lv2 editor test] load failed: %s\n", err.c_str());
             quit();

--- a/src/dsp/AuxLaneStrip.cpp
+++ b/src/dsp/AuxLaneStrip.cpp
@@ -33,8 +33,9 @@ void AuxLaneStrip::prepare (double sampleRate, int blockSize)
             // set to kInsertPlugin by the engine before it stashed this.
             const juce::File p (pendingClapPath[(size_t) s]);
             std::string err;
-            const bool ok = ncs.load (p, preparedSampleRate, preparedBlockSize, err,
-                                      pendingClapPluginId[(size_t) s]);
+            const bool ok = ncs.load (std::filesystem::u8path (p.getFullPathName().toStdString()),
+                                      preparedSampleRate, preparedBlockSize, err,
+                                      pendingClapPluginId[(size_t) s].toStdString());
             if (ok && ! pendingClapState[(size_t) s].empty())
                 ncs.loadState (pendingClapState[(size_t) s]);
             nativeReloadFailed[(size_t) s].store (! ok, std::memory_order_relaxed);
@@ -60,8 +61,9 @@ void AuxLaneStrip::prepare (double sampleRate, int blockSize)
             {
                 const juce::File p (pendingLv2Path[(size_t) s]);
                 std::string err;
-                const bool ok = nls.load (p, preparedSampleRate, preparedBlockSize, err,
-                                          pendingLv2PluginId[(size_t) s]);
+                const bool ok = nls.load (std::filesystem::u8path (p.getFullPathName().toStdString()),
+                                          preparedSampleRate, preparedBlockSize, err,
+                                          pendingLv2PluginId[(size_t) s].toStdString());
                 if (ok && ! pendingLv2State[(size_t) s].empty())
                 {
                     nls.setStateDirectory (pendingLv2StateDir[(size_t) s]);
@@ -94,8 +96,9 @@ void AuxLaneStrip::prepare (double sampleRate, int blockSize)
             {
                 const juce::File p (pendingVst3Path[(size_t) s]);
                 std::string err;
-                const bool ok = nvs.load (p, preparedSampleRate, preparedBlockSize, err,
-                                          pendingVst3PluginId[(size_t) s]);
+                const bool ok = nvs.load (std::filesystem::u8path (p.getFullPathName().toStdString()),
+                                          preparedSampleRate, preparedBlockSize, err,
+                                          pendingVst3PluginId[(size_t) s].toStdString());
                 if (ok && ! pendingVst3State[(size_t) s].empty())
                     nvs.loadState (pendingVst3State[(size_t) s]);
                 vst3ReloadFailed[(size_t) s].store (! ok, std::memory_order_relaxed);
@@ -153,7 +156,8 @@ bool AuxLaneStrip::loadNativeClap (int slotIdx, const juce::File& path, std::str
     unloadNativeLv2 (slotIdx);
     unloadNativeVst3 (slotIdx);
     slots[(size_t) slotIdx].unload();
-    const bool ok = nativeClapSlots[(size_t) slotIdx].load (path, preparedSampleRate, preparedBlockSize, errorOut, pluginId);
+    const bool ok = nativeClapSlots[(size_t) slotIdx].load (std::filesystem::u8path (path.getFullPathName().toStdString()),
+                                                            preparedSampleRate, preparedBlockSize, errorOut, pluginId.toStdString());
     // User-initiated load always ends any "failed restore" state (see ChannelStrip::
     // loadNativeClap) - clear regardless of outcome so the flag stays caller-independent.
     nativeReloadFailed[(size_t) slotIdx].store (false, std::memory_order_relaxed);
@@ -192,7 +196,8 @@ bool AuxLaneStrip::loadNativeLv2 (int slotIdx, const juce::File& path, std::stri
     unloadNativeClap (slotIdx);
     unloadNativeVst3 (slotIdx);
     slots[(size_t) slotIdx].unload();
-    const bool ok = nativeLv2Slots[(size_t) slotIdx].load (path, preparedSampleRate, preparedBlockSize, errorOut, pluginId);
+    const bool ok = nativeLv2Slots[(size_t) slotIdx].load (std::filesystem::u8path (path.getFullPathName().toStdString()),
+                                                           preparedSampleRate, preparedBlockSize, errorOut, pluginId.toStdString());
     lv2ReloadFailed[(size_t) slotIdx].store (false, std::memory_order_relaxed);
     return ok;
 }
@@ -231,7 +236,8 @@ bool AuxLaneStrip::loadNativeVst3 (int slotIdx, const juce::File& path, std::str
     unloadNativeClap (slotIdx);
     unloadNativeLv2 (slotIdx);
     slots[(size_t) slotIdx].unload();
-    const bool ok = nativeVst3Slots[(size_t) slotIdx].load (path, preparedSampleRate, preparedBlockSize, errorOut, pluginId);
+    const bool ok = nativeVst3Slots[(size_t) slotIdx].load (std::filesystem::u8path (path.getFullPathName().toStdString()),
+                                                            preparedSampleRate, preparedBlockSize, errorOut, pluginId.toStdString());
     vst3ReloadFailed[(size_t) slotIdx].store (false, std::memory_order_relaxed);
     return ok;
 }

--- a/src/dsp/ChannelStrip.cpp
+++ b/src/dsp/ChannelStrip.cpp
@@ -106,8 +106,9 @@ void ChannelStrip::prepare (double sampleRate, int blockSize, int oversamplingFa
     {
         const juce::File p (pendingClapPath);
         std::string err;
-        const bool ok = nativeClapSlot.load (p, preparedSampleRate, preparedBlockSize, err,
-                                             pendingClapPluginId);
+        const bool ok = nativeClapSlot.load (std::filesystem::u8path (p.getFullPathName().toStdString()),
+                                             preparedSampleRate, preparedBlockSize, err,
+                                             pendingClapPluginId.toStdString());
         if (ok && ! pendingClapState.empty())
             nativeClapSlot.loadState (pendingClapState);
         nativeReloadFailed.store (! ok, std::memory_order_relaxed);
@@ -129,8 +130,9 @@ void ChannelStrip::prepare (double sampleRate, int blockSize, int oversamplingFa
         {
             const juce::File p (pendingLv2Path);
             std::string err;
-            const bool ok = nativeLv2Slot.load (p, preparedSampleRate, preparedBlockSize, err,
-                                                pendingLv2PluginId);
+            const bool ok = nativeLv2Slot.load (std::filesystem::u8path (p.getFullPathName().toStdString()),
+                                                preparedSampleRate, preparedBlockSize, err,
+                                                pendingLv2PluginId.toStdString());
             if (ok && ! pendingLv2State.empty())
             {
                 nativeLv2Slot.setStateDirectory (pendingLv2StateDir);
@@ -159,8 +161,9 @@ void ChannelStrip::prepare (double sampleRate, int blockSize, int oversamplingFa
         {
             const juce::File p (pendingVst3Path);
             std::string err;
-            const bool ok = nativeVst3Slot.load (p, preparedSampleRate, preparedBlockSize, err,
-                                                 pendingVst3PluginId);
+            const bool ok = nativeVst3Slot.load (std::filesystem::u8path (p.getFullPathName().toStdString()),
+                                                 preparedSampleRate, preparedBlockSize, err,
+                                                 pendingVst3PluginId.toStdString());
             if (ok && ! pendingVst3State.empty())
                 nativeVst3Slot.loadState (pendingVst3State);
             vst3ReloadFailed.store (! ok, std::memory_order_relaxed);
@@ -452,7 +455,8 @@ bool ChannelStrip::loadNativeClap (const juce::File& path, std::string& errorOut
     unloadNativeLv2();
     unloadNativeVst3();
     pluginSlot.unload();
-    const bool ok = nativeClapSlot.load (path, preparedSampleRate, preparedBlockSize, errorOut, pluginId);
+    const bool ok = nativeClapSlot.load (std::filesystem::u8path (path.getFullPathName().toStdString()),
+                                         preparedSampleRate, preparedBlockSize, errorOut, pluginId.toStdString());
     // A user-initiated load is not a restore, so it always ends any "failed restore"
     // state - whether it succeeds (recovered) or fails (caller clears the persisted
     // refs). Clearing unconditionally keeps the flag's meaning independent of the caller.
@@ -488,7 +492,8 @@ bool ChannelStrip::loadNativeLv2 (const juce::File& path, std::string& errorOut,
     unloadNativeClap();
     unloadNativeVst3();
     pluginSlot.unload();
-    const bool ok = nativeLv2Slot.load (path, preparedSampleRate, preparedBlockSize, errorOut, pluginId);
+    const bool ok = nativeLv2Slot.load (std::filesystem::u8path (path.getFullPathName().toStdString()),
+                                        preparedSampleRate, preparedBlockSize, errorOut, pluginId.toStdString());
     // A user-initiated load always ends any "failed restore" state (see loadNativeClap).
     lv2ReloadFailed.store (false, std::memory_order_relaxed);
     return ok;
@@ -524,7 +529,8 @@ bool ChannelStrip::loadNativeVst3 (const juce::File& path, std::string& errorOut
     unloadNativeClap();
     unloadNativeLv2();
     pluginSlot.unload();
-    const bool ok = nativeVst3Slot.load (path, preparedSampleRate, preparedBlockSize, errorOut, pluginId);
+    const bool ok = nativeVst3Slot.load (std::filesystem::u8path (path.getFullPathName().toStdString()),
+                                         preparedSampleRate, preparedBlockSize, errorOut, pluginId.toStdString());
     // A user-initiated load always ends any "failed restore" state (see loadNativeClap).
     vst3ReloadFailed.store (false, std::memory_order_relaxed);
     return ok;

--- a/src/engine/AudioPipelineSelfTest.cpp
+++ b/src/engine/AudioPipelineSelfTest.cpp
@@ -1,4 +1,5 @@
 #include "AudioPipelineSelfTest.h"
+#include "../foundation/Text.h"
 #if defined(__linux__)
  #include "alsa/AlsaAudioIODevice.h"
 #endif
@@ -22,7 +23,7 @@ float ampToDb (float a, float ref = 1.0f)
     return 20.0f * std::log10 (juce::jmax (1.0e-9f, a) / juce::jmax (1.0e-9f, ref));
 }
 
-juce::String fmtPassFail (bool pass) { return pass ? juce::String ("[PASS]") : juce::String ("[FAIL]"); }
+std::string fmtPassFail (bool pass) { return pass ? "[PASS]" : "[FAIL]"; }
 } // namespace
 
 AudioPipelineSelfTest::AudioPipelineSelfTest (AudioEngine& e,
@@ -243,7 +244,7 @@ AudioPipelineSelfTest::runSynthetic (double sampleRate, int blockSize,
     return m;
 }
 
-juce::String AudioPipelineSelfTest::testPassThroughUnity()
+std::string AudioPipelineSelfTest::testPassThroughUnity()
 {
     prepareCleanState();
     constexpr int bs = 512;
@@ -262,14 +263,14 @@ juce::String AudioPipelineSelfTest::testPassThroughUnity()
                       && std::abs (m.rmsR  - expRms)  < kRmsTol;
     const bool stereoOK = std::abs (m.peakL - m.peakR) < 0.01f;
 
-    return juce::String::formatted (
+    return dusk::text::format (
         "%s Pass-Through Unity (track 0 IN, fader 0 dB, pan center, master 0 dB)\n"
         "      Input -6 dBFS sine @1 kHz, %.0f Hz / %d samples, 16in/2out\n"
         "      Expected peak=%.4f (%+.2f dBFS), RMS=%.4f (%+.2f dBFS)\n"
         "      Measured L peak=%.4f (%+.2f dBFS), RMS=%.4f (%+.2f dBFS) %s\n"
         "      Measured R peak=%.4f (%+.2f dBFS), RMS=%.4f (%+.2f dBFS) %s\n"
         "      L vs R peak delta: %.4f %s",
-        fmtPassFail (peakOK && rmsOK && stereoOK).toRawUTF8(),
+        fmtPassFail (peakOK && rmsOK && stereoOK).c_str(),
         sr, bs,
         expPeak, ampToDb (expPeak), expRms, ampToDb (expRms),
         m.peakL, ampToDb (m.peakL), m.rmsL, ampToDb (m.rmsL),
@@ -280,7 +281,7 @@ juce::String AudioPipelineSelfTest::testPassThroughUnity()
         stereoOK ? "" : "<-- L/R imbalance!");
 }
 
-juce::String AudioPipelineSelfTest::testMuteSilences()
+std::string AudioPipelineSelfTest::testMuteSilences()
 {
     prepareCleanState();
     session.track (0).strip.mute.store (true, std::memory_order_relaxed);
@@ -290,16 +291,16 @@ juce::String AudioPipelineSelfTest::testMuteSilences()
     const bool silentL = m.peakL < 1.0e-4f;
     const bool silentR = m.peakR < 1.0e-4f;
 
-    return juce::String::formatted (
+    return dusk::text::format (
         "%s Mute Silences (track 0 IN + mute on)\n"
         "      Expected peak=0.0 on both channels\n"
         "      Measured L peak=%.6f, R peak=%.6f %s",
-        fmtPassFail (silentL && silentR).toRawUTF8(),
+        fmtPassFail (silentL && silentR).c_str(),
         m.peakL, m.peakR,
         silentL && silentR ? "" : "<-- audio leaking past mute!");
 }
 
-juce::String AudioPipelineSelfTest::testMasterFaderMinusSix()
+std::string AudioPipelineSelfTest::testMasterFaderMinusSix()
 {
     prepareCleanState();
     session.master().faderDb.store (-6.0f, std::memory_order_relaxed);
@@ -311,17 +312,17 @@ juce::String AudioPipelineSelfTest::testMasterFaderMinusSix()
     const float expPeak = kInputAmpMinusSixDb * 0.7071f * 0.5012f;
     const bool peakOK = std::abs (m.peakL - expPeak) < kPeakTol;
 
-    return juce::String::formatted (
+    return dusk::text::format (
         "%s Master Fader -6 dB (track 0 unity + pan center, master -6 dB)\n"
         "      Expected peak=%.4f (%+.2f dBFS)\n"
         "      Measured L peak=%.4f (%+.2f dBFS) %s",
-        fmtPassFail (peakOK).toRawUTF8(),
+        fmtPassFail (peakOK).c_str(),
         expPeak, ampToDb (expPeak),
         m.peakL, ampToDb (m.peakL),
         peakOK ? "" : "<-- master fader not applying expected gain!");
 }
 
-juce::String AudioPipelineSelfTest::testMasterCompNoNoiseFloor()
+std::string AudioPipelineSelfTest::testMasterCompNoNoiseFloor()
 {
     prepareCleanState();
     // Engage the master bus compressor over SILENT input. The donor comp's
@@ -337,16 +338,16 @@ juce::String AudioPipelineSelfTest::testMasterCompNoNoiseFloor()
     const bool silentL = m.peakL < 1.0e-4f;   // -80 dBFS
     const bool silentR = m.peakR < 1.0e-4f;
 
-    return juce::String::formatted (
+    return dusk::text::format (
         "%s Master Comp No Noise Floor (comp ON, silent input)\n"
         "      Expected peak=0.0 on both channels (donor analog-noise disabled)\n"
         "      Measured L peak=%.6f (%+.2f dBFS), R peak=%.6f %s",
-        fmtPassFail (silentL && silentR).toRawUTF8(),
+        fmtPassFail (silentL && silentR).c_str(),
         m.peakL, ampToDb (m.peakL), m.peakR,
         silentL && silentR ? "" : "<-- comp injecting noise into silence!");
 }
 
-juce::String AudioPipelineSelfTest::testBusSoloMutesDirect()
+std::string AudioPipelineSelfTest::testBusSoloMutesDirect()
 {
     prepareCleanState();   // clears track 0's busAssign -> guaranteed direct-to-master
     // Solo bus 0 with NO track routed to it. Track 0 takes the direct-to-master
@@ -364,31 +365,31 @@ juce::String AudioPipelineSelfTest::testBusSoloMutesDirect()
     // clear it here to avoid bleeding into the next test.
     session.setBusSoloed (0, false);
 
-    return juce::String::formatted (
+    return dusk::text::format (
         "%s Bus Solo Mutes Direct (bus 0 soloed + empty, track 0 unassigned)\n"
         "      Expected silence: a direct-to-master track must not bypass bus solo\n"
         "      Measured L peak=%.6f, R peak=%.6f %s",
-        fmtPassFail (silentL && silentR).toRawUTF8(),
+        fmtPassFail (silentL && silentR).c_str(),
         m.peakL, m.peakR,
         silentL && silentR ? "" : "<-- unassigned track leaking past bus solo!");
 }
 
-juce::String AudioPipelineSelfTest::testChannelRoutingTwoOut()
+std::string AudioPipelineSelfTest::testChannelRoutingTwoOut()
 {
     prepareCleanState();
     auto m = runSynthetic (48000.0, 512, 16, 2, kInputAmpMinusSixDb, kToneHz, 8, 4);
 
     // With 2 output channels, both should have signal (pan center).
     const bool bothPresent = m.peakL > 0.05f && m.peakR > 0.05f;
-    return juce::String::formatted (
+    return dusk::text::format (
         "%s Channel Routing 2-out (16in/2out, pan center)\n"
         "      L=%.4f R=%.4f %s",
-        fmtPassFail (bothPresent).toRawUTF8(),
+        fmtPassFail (bothPresent).c_str(),
         m.peakL, m.peakR,
         bothPresent ? "" : "<-- one or both output channels missing signal");
 }
 
-juce::String AudioPipelineSelfTest::testChannelRoutingFourOut()
+std::string AudioPipelineSelfTest::testChannelRoutingFourOut()
 {
     prepareCleanState();
 
@@ -440,17 +441,17 @@ juce::String AudioPipelineSelfTest::testChannelRoutingFourOut()
     const bool ch01HaveSignal = peaks[0] > 0.05f && peaks[1] > 0.05f;
     const bool ch23AreSilent  = peaks[2] < 1.0e-4f && peaks[3] < 1.0e-4f;
 
-    return juce::String::formatted (
+    return dusk::text::format (
         "%s Channel Routing 4-out (16in/4out, only ch 0+1 should have audio)\n"
         "      ch0=%.4f ch1=%.4f ch2=%.6f ch3=%.6f %s",
-        fmtPassFail (ch01HaveSignal && ch23AreSilent).toRawUTF8(),
+        fmtPassFail (ch01HaveSignal && ch23AreSilent).c_str(),
         peaks[0], peaks[1], peaks[2], peaks[3],
         (! ch01HaveSignal) ? "<-- L/R missing"
             : (! ch23AreSilent) ? "<-- ch2/3 should be silent (engine bleeding into extra channels?)"
             : "");
 }
 
-juce::String AudioPipelineSelfTest::testMasterTapeAddsGain()
+std::string AudioPipelineSelfTest::testMasterTapeAddsGain()
 {
     // Audit: characterize the master tape donor's transfer function across
     // its input-gain (drive) parameter, with auto-compensation both ON and
@@ -472,7 +473,7 @@ juce::String AudioPipelineSelfTest::testMasterTapeAddsGain()
     auto* pOut     = apvts.getParameter ("outputGain");
     auto* pAuto    = apvts.getParameter ("autoComp");
    #else
-    return juce::String ("[SKIP] Master Tape gain audit - DUSKSTUDIO_HAS_DUSK_DSP not defined");
+    return std::string ("[SKIP] Master Tape gain audit - DUSKSTUDIO_HAS_DUSK_DSP not defined");
    #endif
 
     auto setNorm = [] (juce::AudioProcessorParameter* p, float n)
@@ -483,8 +484,8 @@ juce::String AudioPipelineSelfTest::testMasterTapeAddsGain()
 
     constexpr float postStripPeak = 0.5012f * 0.7071f;  // 0.3544 = -9.01 dBFS
 
-    juce::String table;
-    table << juce::String::formatted (
+    std::string table;
+    table += dusk::text::format (
         "      Pre-tape peak (track 0 -> pan center): %.4f (%+.2f dBFS)\n",
         postStripPeak, ampToDb (postStripPeak));
 
@@ -499,14 +500,14 @@ juce::String AudioPipelineSelfTest::testMasterTapeAddsGain()
         setNorm (pAuto, ac ? 1.0f : 0.0f);   // Choice "Off"/"On" -> 0 / 1
         setNorm (pOut,  normFromGainDb (0.0f));
 
-        table << juce::String::formatted ("      autoComp=%s\n", ac ? "ON " : "OFF");
+        table += dusk::text::format ("      autoComp=%s\n", ac ? "ON " : "OFF");
         for (float drDb : drives)
         {
             setNorm (pIn, normFromGainDb (drDb));
             auto m = runSynthetic (48000.0, 512, 16, 2,
                                     kInputAmpMinusSixDb, kToneHz, 24, 8);
             const float deltaDb = ampToDb (m.peakL / postStripPeak);
-            table << juce::String::formatted (
+            table += dusk::text::format (
                 "        drive=%+6.1f dB -> post-tape L=%.4f (%+.2f dBFS), "
                 "delta=%+.2f dB\n",
                 drDb, m.peakL, ampToDb (m.peakL), deltaDb);
@@ -527,13 +528,13 @@ juce::String AudioPipelineSelfTest::testMasterTapeAddsGain()
 
     const bool pass = autoCompOnWithinHalfDb;
 
-    return juce::String::formatted (
+    return dusk::text::format (
         "%s Master Tape gain audit (sweep)\n%s"
         "      Default (autoComp ON, drive 0 dB): %+.2f dB vs unity\n"
         "      autoComp ON worst |delta| over -12..+12 dB: %.2f dB "
         "(pass if < 0.5 dB at every drive point)",
-        fmtPassFail (pass).toRawUTF8(),
-        table.toRawUTF8(),
+        fmtPassFail (pass).c_str(),
+        table.c_str(),
         deltaAtDefault,
         worstAutoOnDelta);
 }
@@ -617,7 +618,7 @@ void captureToneOutput (AudioEngine& engine, double sr, int blockSize,
 }
 } // namespace
 
-juce::String AudioPipelineSelfTest::testCompEachMode()
+std::string AudioPipelineSelfTest::testCompEachMode()
 {
     // -18 dBFS @ 1 kHz through each comp mode on track 0. Goertzel measures
     // fundamental + first 4 harmonics; the 17 kHz bin acts as a "no-signal-
@@ -640,7 +641,7 @@ juce::String AudioPipelineSelfTest::testCompEachMode()
         { 0, "Opto" }, { 1, "FET" }, { 2, "VCA" }
     };
 
-    juce::String table;
+    std::string table;
     bool allPass = true;
 
     for (const auto& m : modes)
@@ -685,7 +686,7 @@ juce::String AudioPipelineSelfTest::testCompEachMode()
         const bool pass    = fundOk && aliasOk;
         if (! pass) allPass = false;
 
-        table << juce::String::formatted (
+        table += dusk::text::format (
             "      %s  fund=%+6.2f dBFS  H2=%+6.2f  H3=%+6.2f  H4=%+6.2f  "
             "H5=%+6.2f  THD=%5.2f%%  alias17k=%+7.2f dBFS  %s\n",
             m.label,
@@ -699,13 +700,13 @@ juce::String AudioPipelineSelfTest::testCompEachMode()
             pass ? "OK" : "FAIL");
     }
 
-    return juce::String::formatted (
+    return dusk::text::format (
         "%s Channel comp (Opto / FET / VCA) on -18 dBFS @ 1 kHz\n%s",
-        fmtPassFail (allPass).toRawUTF8(),
-        table.toRawUTF8());
+        fmtPassFail (allPass).c_str(),
+        table.c_str());
 }
 
-juce::String AudioPipelineSelfTest::testCompHeavyGR()
+std::string AudioPipelineSelfTest::testCompHeavyGR()
 {
     // Heavy gain-reduction stress: push each mode to its aggressive corner
     // and measure how much harmonic + alias energy comes out. This run is
@@ -746,7 +747,7 @@ juce::String AudioPipelineSelfTest::testCompHeavyGR()
                                  -36.0f, 20.0f, 1.0f, 50.0f, 12.0f }
     };
 
-    juce::String table;
+    std::string table;
     for (const auto& s : specs)
     {
         prepareCleanState();
@@ -782,7 +783,7 @@ juce::String AudioPipelineSelfTest::testCompHeavyGR()
         float peak = 0.0f;
         for (float v : buf) if (std::abs (v) > peak) peak = std::abs (v);
 
-        table << juce::String::formatted (
+        table += dusk::text::format (
             "      %s  peak=%+6.2f  fund=%+6.2f  H2=%+6.2f  H3=%+6.2f  "
             "H4=%+6.2f  H5=%+6.2f  THD=%6.2f%%  alias17k=%+7.2f\n",
             s.label,
@@ -796,15 +797,15 @@ juce::String AudioPipelineSelfTest::testCompHeavyGR()
             ampToDb (alias));
     }
 
-    return juce::String::formatted (
+    return dusk::text::format (
         "[INFO] Channel comp heavy-GR characterization (-6 dBFS in, extreme settings)\n%s"
         "      Heavy-GR distortion is partly intrinsic (envelope chatter,\n"
         "      asymmetric saturation) and partly side-effect (donor clip if\n"
         "      makeup pushes hot). 17 kHz floor < -50 dBFS = OS doing its job.",
-        table.toRawUTF8());
+        table.c_str());
 }
 
-juce::String AudioPipelineSelfTest::testCompPerTrack()
+std::string AudioPipelineSelfTest::testCompPerTrack()
 {
     // Wiring uniformity: run the same Opto-comp config on each of the 16
     // tracks one at a time. Output peaks must agree within tolerance,
@@ -867,25 +868,25 @@ juce::String AudioPipelineSelfTest::testCompPerTrack()
                               : 999.0f;
     const bool pass = spreadDb < 0.5f && minP > 0.01f;
 
-    return juce::String::formatted (
+    return dusk::text::format (
         "%s Comp wiring uniformity across 16 tracks (Opto)\n"
         "      peak min=%+6.2f dBFS  max=%+6.2f dBFS  spread=%.3f dB "
         "(pass if spread < 0.5 dB AND min > -40 dBFS)",
-        fmtPassFail (pass).toRawUTF8(),
+        fmtPassFail (pass).c_str(),
         ampToDb (minP),
         ampToDb (maxP),
         spreadDb);
 }
 
-juce::String AudioPipelineSelfTest::probeUMC1820AlsaFormat()
+std::string AudioPipelineSelfTest::probeUMC1820AlsaFormat()
 {
     // Explicitly open the UMC1820 front: device on the ALSA backend so the
     // device-open stderr line shows what format/access mode plug negotiated
     // for THAT specific PCM. Verifies the format-pin patch (S24_3LE first
     // for non-hw: devices) is taking effect on the actual hardware the user
     // selects in the dialog.
-    juce::String out;
-    out << "--- UMC1820 ALSA Direct Open Probe ---\n";
+    std::string out;
+    out += "--- UMC1820 ALSA Direct Open Probe ---\n";
 
     const auto origType  = deviceManager.getCurrentAudioDeviceType();
     const auto origSetup = deviceManager.getAudioDeviceSetup();
@@ -909,13 +910,13 @@ juce::String AudioPipelineSelfTest::probeUMC1820AlsaFormat()
         const auto err = deviceManager.setAudioDeviceSetup (setup, /*treatAsChosen*/ true);
         if (err.isNotEmpty())
         {
-            out << "  " << name << ": ERROR " << err << "\n";
+            out += "  " + name.toStdString() + ": ERROR " + err.toStdString() + "\n";
             continue;
         }
 
         if (auto* dev = deviceManager.getCurrentAudioDevice())
         {
-            out << juce::String::formatted (
+            out += dusk::text::format (
                 "  %s\n      OPENED rate=%.0f buf=%d in=%d out=%d "
                 "(see [Dusk Studio/JUCE-ALSA] line in stderr for format/access)\n",
                 name.toRawUTF8(),
@@ -926,7 +927,7 @@ juce::String AudioPipelineSelfTest::probeUMC1820AlsaFormat()
         }
         else
         {
-            out << "  " << name << ": OPEN-FAILED (getCurrentAudioDevice() == nullptr)\n";
+            out += "  " + name.toStdString() + ": OPEN-FAILED (getCurrentAudioDevice() == nullptr)\n";
         }
     }
 
@@ -935,10 +936,10 @@ juce::String AudioPipelineSelfTest::probeUMC1820AlsaFormat()
     return out;
 }
 
-juce::String AudioPipelineSelfTest::testBackendsOpenCleanly()
+std::string AudioPipelineSelfTest::testBackendsOpenCleanly()
 {
-    juce::String out;
-    out << "--- Backend Open Tests ---\n";
+    std::string out;
+    out += "--- Backend Open Tests ---\n";
 
     // Capture the user's current setup so we can restore.
     const auto origType  = deviceManager.getCurrentAudioDeviceType();
@@ -953,16 +954,17 @@ juce::String AudioPipelineSelfTest::testBackendsOpenCleanly()
         const auto outDevs = type->getDeviceNames (false);
         const auto inDevs  = type->getDeviceNames (true);
 
-        out << "  Backend: " << type->getTypeName()
-            << " | " << outDevs.size() << " out devs, " << inDevs.size() << " in devs\n";
-        for (const auto& d : outDevs) out << "      out: " << d << "\n";
-        for (const auto& d : inDevs)  out << "      in:  " << d << "\n";
+        out += dusk::text::format ("  Backend: %s | %d out devs, %d in devs\n",
+                                   type->getTypeName().toRawUTF8(),
+                                   outDevs.size(), inDevs.size());
+        for (const auto& d : outDevs) out += "      out: " + d.toStdString() + "\n";
+        for (const auto& d : inDevs)  out += "      in:  " + d.toStdString() + "\n";
 
         // Try opening the type's default device.
         deviceManager.setCurrentAudioDeviceType (type->getTypeName(), /*treatAsChosenDevice*/ true);
         if (auto* dev = deviceManager.getCurrentAudioDevice())
         {
-            out << juce::String::formatted (
+            out += dusk::text::format (
                 "      OPENED  rate=%.0f buf=%d in=%d out=%d\n",
                 dev->getCurrentSampleRate(),
                 dev->getCurrentBufferSizeSamples(),
@@ -971,18 +973,18 @@ juce::String AudioPipelineSelfTest::testBackendsOpenCleanly()
         }
         else
         {
-            out << "      OPEN-FAILED (deviceManager.getCurrentAudioDevice() returned nullptr)\n";
+            out += "      OPEN-FAILED (deviceManager.getCurrentAudioDevice() returned nullptr)\n";
         }
     }
 
     // Restore.
     deviceManager.setCurrentAudioDeviceType (origType, /*treatAsChosenDevice*/ true);
     deviceManager.setAudioDeviceSetup (origSetup, /*treatAsChosenDevice*/ true);
-    out << "  (restored original setup: " << origType << ")\n";
+    out += "  (restored original setup: " + origType.toStdString() + ")\n";
     return out;
 }
 
-juce::String AudioPipelineSelfTest::testParallelMatchesSerial()
+std::string AudioPipelineSelfTest::testParallelMatchesSerial()
 {
     using juce::jmax;
     using juce::jmin;
@@ -1108,10 +1110,10 @@ juce::String AudioPipelineSelfTest::testParallelMatchesSerial()
     const bool matchOK   = testWorkers == 0 || parallelDiff <= serialDiff + kReassocTol;
     const bool pass      = sizeOK && signalOK && matchOK;
 
-    return juce::String::formatted (
+    return dusk::text::format (
         "%s Parallel Matches Serial (%d active tracks, %d workers vs serial)\n"
         "      serial-vs-serial = %.3e   serial-vs-parallel = %.3e   (reassoc tol %.1e, peak %.4f)%s",
-        fmtPassFail (pass).toRawUTF8(),
+        fmtPassFail (pass).c_str(),
         activeTracks, testWorkers,
         (double) serialDiff, (double) parallelDiff, (double) kReassocTol, (double) peak,
         testWorkers == 0 ? "  [host < 3 cores: parallel == serial by construction]"
@@ -1120,7 +1122,7 @@ juce::String AudioPipelineSelfTest::testParallelMatchesSerial()
                           : "");
 }
 
-juce::String AudioPipelineSelfTest::testMidiPlayAlongMonitor()
+std::string AudioPipelineSelfTest::testMidiPlayAlongMonitor()
 {
     // Regression guard: an armed, input-monitored MIDI track must sound the
     // live controller in ALL transport states - Stopped, Playing, and Stopped
@@ -1144,8 +1146,8 @@ juce::String AudioPipelineSelfTest::testMidiPlayAlongMonitor()
 
     if (vkbIdx < 0)
     {
-        return juce::String ("[PASS] MIDI play-along monitor: SKIPPED "
-                             "(no virtual-keyboard input available headlessly)");
+        return std::string ("[PASS] MIDI play-along monitor: SKIPPED "
+                            "(no virtual-keyboard input available headlessly)");
     }
 
     const double sr = 48000.0;
@@ -1223,10 +1225,10 @@ juce::String AudioPipelineSelfTest::testMidiPlayAlongMonitor()
     t0.midiActivity.store   (savedActivity, std::memory_order_relaxed);
 
     const bool pass = stoppedBefore && playing && stoppedAfter && flushInert;
-    return juce::String::formatted (
+    return dusk::text::format (
         "%s MIDI play-along monitor (armed + IN MIDI track, live note each state)\n"
         "      stopped=%s  playing=%s  stopped-again=%s  flush-inert=%s %s",
-        fmtPassFail (pass).toRawUTF8(),
+        fmtPassFail (pass).c_str(),
         stoppedBefore ? "sound" : "SILENT",
         playing       ? "sound" : "SILENT",
         stoppedAfter  ? "sound" : "SILENT",
@@ -1234,14 +1236,14 @@ juce::String AudioPipelineSelfTest::testMidiPlayAlongMonitor()
         pass ? "" : "<-- live MIDI dropped (play-along must sound while rolling)");
 }
 
-juce::String AudioPipelineSelfTest::runAll()
+std::string AudioPipelineSelfTest::runAll()
 {
-    juce::StringArray report;
-    report.add ("=== Dusk Studio Audio Pipeline Self-Test ===");
-    report.add ("Time: " + juce::Time::getCurrentTime().toString (true, true));
+    std::vector<std::string> report;
+    report.push_back ("=== Dusk Studio Audio Pipeline Self-Test ===");
+    report.push_back ("Time: " + juce::Time::getCurrentTime().toString (true, true).toStdString());
     {
         const auto& setup = deviceManager.getAudioDeviceSetup();
-        report.add (juce::String::formatted (
+        report.push_back (dusk::text::format (
             "Active backend: %s, %s out, %s in, %.0f Hz, %d-sample buffer",
             deviceManager.getCurrentAudioDeviceType().toRawUTF8(),
             setup.outputDeviceName.toRawUTF8(),
@@ -1249,27 +1251,27 @@ juce::String AudioPipelineSelfTest::runAll()
             setup.sampleRate,
             setup.bufferSize));
     }
-    report.add ("");
+    report.push_back ("");
 
     // Save state, detach engine.
     const auto savedSession = saveState();
     deviceManager.removeAudioCallback (&engine);
 
-    report.add ("--- Synthetic Engine Pipeline Tests (no hardware) ---");
-    report.add (testPassThroughUnity());
-    report.add (testMuteSilences());
-    report.add (testMasterFaderMinusSix());
-    report.add (testMasterCompNoNoiseFloor());
-    report.add (testBusSoloMutesDirect());
-    report.add (testChannelRoutingTwoOut());
-    report.add (testChannelRoutingFourOut());
-    report.add (testMasterTapeAddsGain());
-    report.add (testCompEachMode());
-    report.add (testCompHeavyGR());
-    report.add (testCompPerTrack());
-    report.add (testParallelMatchesSerial());
-    report.add (testMidiPlayAlongMonitor());
-    report.add ("");
+    report.push_back ("--- Synthetic Engine Pipeline Tests (no hardware) ---");
+    report.push_back (testPassThroughUnity());
+    report.push_back (testMuteSilences());
+    report.push_back (testMasterFaderMinusSix());
+    report.push_back (testMasterCompNoNoiseFloor());
+    report.push_back (testBusSoloMutesDirect());
+    report.push_back (testChannelRoutingTwoOut());
+    report.push_back (testChannelRoutingFourOut());
+    report.push_back (testMasterTapeAddsGain());
+    report.push_back (testCompEachMode());
+    report.push_back (testCompHeavyGR());
+    report.push_back (testCompPerTrack());
+    report.push_back (testParallelMatchesSerial());
+    report.push_back (testMidiPlayAlongMonitor());
+    report.push_back ("");
 
    #if defined(__linux__)
     // Pure-logic self-test for the Dusk Studio-owned ALSA backend. Covers the
@@ -1277,8 +1279,8 @@ juce::String AudioPipelineSelfTest::runAll()
     // periods-knob clamping. Real-device opens of the backend are
     // exercised by the backend cycle below alongside the JUCE-stock
     // ALSA / JACK paths.
-    report.add (AlsaAudioIODevice::runSelfTest());
-    report.add ("");
+    report.push_back (AlsaAudioIODevice::runSelfTest().toStdString());
+    report.push_back ("");
    #endif
 
     // Re-attach the engine BEFORE the backend cycle. Without an audio callback
@@ -1322,21 +1324,21 @@ juce::String AudioPipelineSelfTest::runAll()
     engine.applyDesiredWorkers();
     deviceManager.addAudioCallback (&engine);
 
-    report.add (testBackendsOpenCleanly());
-    report.add ("");
-    report.add (probeUMC1820AlsaFormat());
+    report.push_back (testBackendsOpenCleanly());
+    report.push_back ("");
+    report.push_back (probeUMC1820AlsaFormat());
 
     // Probe done (devices opened/closed) - reinstate the user's real session.
     restoreState (savedSession);
     for (int a = 0; a < Session::kNumAuxLanes; ++a)
         session.auxLane (a).params.mute.store (savedAuxMute[(size_t) a], std::memory_order_relaxed);
 
-    report.add ("");
-    report.add ("=== End of Self-Test ===");
-    return report.joinIntoString ("\n");
+    report.push_back ("");
+    report.push_back ("=== End of Self-Test ===");
+    return dusk::text::joinIntoString (report, "\n");
 }
 
-juce::String AudioPipelineSelfTest::runPerfBenchmark (const juce::String& label,
+std::string AudioPipelineSelfTest::runPerfBenchmark (const std::string& label,
                                                       double sampleRate, int blockSize,
                                                       int numActiveTracks,
                                                       bool eqEnabled, bool compEnabled,
@@ -1453,25 +1455,25 @@ juce::String AudioPipelineSelfTest::runPerfBenchmark (const juce::String& label,
     for (auto v : times) if (v > budgetUs) ++overruns;
     const double headroomPctMedian = 100.0 * (1.0 - median / budgetUs);
 
-    return juce::String::formatted (
+    return dusk::text::format (
         "%s %s  median=%.1f us  p95=%.1f us  p99=%.1f us  max=%.1f us  min=%.1f us  "
         "(budget=%.1f us, headroom@median=%.1f%%, overruns=%d/%d)",
         overruns > 0 ? "[OVER]" : "[OK]",
-        label.toRawUTF8(),
+        label.c_str(),
         median, p95, p99, maxV, minV,
         budgetUs, headroomPctMedian,
         overruns, (int) times.size());
 }
 
-juce::String AudioPipelineSelfTest::runPerfSuite()
+std::string AudioPipelineSelfTest::runPerfSuite()
 {
-    juce::StringArray report;
-    report.add ("=== Dusk Studio Engine Perf Benchmark ===");
-    report.add (juce::String ("Time: ") + juce::Time::getCurrentTime().toString (true, true));
-    report.add ("Measures pure-engine callback wall time across configs.");
-    report.add ("All callbacks driven directly via audioDeviceIOCallbackWithContext;");
-    report.add ("no audio device, no PipeWire, no ALSA - engine DSP only.");
-    report.add ("");
+    std::vector<std::string> report;
+    report.push_back ("=== Dusk Studio Engine Perf Benchmark ===");
+    report.push_back ("Time: " + juce::Time::getCurrentTime().toString (true, true).toStdString());
+    report.push_back ("Measures pure-engine callback wall time across configs.");
+    report.push_back ("All callbacks driven directly via audioDeviceIOCallbackWithContext;");
+    report.push_back ("no audio device, no PipeWire, no ALSA - engine DSP only.");
+    report.push_back ("");
 
     const auto saved = saveState();
     deviceManager.removeAudioCallback (&engine);
@@ -1496,32 +1498,32 @@ juce::String AudioPipelineSelfTest::runPerfSuite()
 
     for (const auto& cfg : configs)
     {
-        report.add (juce::String ("--- ") + cfg.label + " ---");
-        report.add (runPerfBenchmark ("idle (1 track, EQ off, comp off)            ",
+        report.push_back (std::string ("--- ") + cfg.label + " ---");
+        report.push_back (runPerfBenchmark ("idle (1 track, EQ off, comp off)            ",
                                        cfg.sr, cfg.bs, 1, false, false, false, /*ox*/ 1,
                                        warm, meas));
         // EQ-only and comp-only on 16ch isolates where the per-channel cost lives.
-        report.add (runPerfBenchmark ("16ch EQ only  (comp off)                    ",
+        report.push_back (runPerfBenchmark ("16ch EQ only  (comp off)                    ",
                                        cfg.sr, cfg.bs, 16, true,  false, false, /*ox*/ 1,
                                        warm, meas));
-        report.add (runPerfBenchmark ("16ch comp only (EQ off)                     ",
+        report.push_back (runPerfBenchmark ("16ch comp only (EQ off)                     ",
                                        cfg.sr, cfg.bs, 16, false, true,  false, /*ox*/ 1,
                                        warm, meas));
         // ASCII-only labels - these go straight into a TextEditor display
         // and would mojibake without UTF-8 wrapping. "x" reads naturally.
-        report.add (runPerfBenchmark ("16ch + EQ + comp (full mixer) @1x           ",
+        report.push_back (runPerfBenchmark ("16ch + EQ + comp (full mixer) @1x           ",
                                        cfg.sr, cfg.bs, 16, true,  true,  false, /*ox*/ 1,
                                        warm, meas));
-        report.add (runPerfBenchmark ("16ch + EQ + comp + tape on    @1x           ",
+        report.push_back (runPerfBenchmark ("16ch + EQ + comp + tape on    @1x           ",
                                        cfg.sr, cfg.bs, 16, true,  true,  true,  /*ox*/ 1,
                                        warm, meas));
-        report.add (runPerfBenchmark ("16ch + EQ + comp + tape on    @2x           ",
+        report.push_back (runPerfBenchmark ("16ch + EQ + comp + tape on    @2x           ",
                                        cfg.sr, cfg.bs, 16, true,  true,  true,  /*ox*/ 2,
                                        warm, meas));
-        report.add (runPerfBenchmark ("16ch + EQ + comp + tape on    @4x           ",
+        report.push_back (runPerfBenchmark ("16ch + EQ + comp + tape on    @4x           ",
                                        cfg.sr, cfg.bs, 16, true,  true,  true,  /*ox*/ 4,
                                        warm, meas));
-        report.add ("");
+        report.push_back ("");
     }
 
     // Multicore scaling: the heavy full-mixer config (the one that actually
@@ -1532,24 +1534,24 @@ juce::String AudioPipelineSelfTest::runPerfSuite()
     const int parW = juce::jmax (0, juce::jmin (juce::SystemStats::getNumCpus() - 2, 15));
     if (parW > 0)
     {
-        report.add ("--- Multicore scaling (48k/256, 16ch + EQ + comp @1x) ---");
-        report.add (runPerfBenchmark ("serial (0 workers)                          ",
+        report.push_back ("--- Multicore scaling (48k/256, 16ch + EQ + comp @1x) ---");
+        report.push_back (runPerfBenchmark ("serial (0 workers)                          ",
                                        48000.0, 256, 16, true, true, false, /*ox*/ 1,
                                        warm, meas, /*workers*/ 0));
-        report.add (runPerfBenchmark (juce::String (parW) + " worker"
+        report.push_back (runPerfBenchmark (std::to_string (parW) + " worker"
                                           + (parW == 1 ? "" : "s")
-                                          + " (cores-2)" + juce::String::repeatedString (" ", 22),
+                                          + " (cores-2)" + std::string (22, ' '),
                                        48000.0, 256, 16, true, true, false, /*ox*/ 1,
                                        warm, meas, /*workers*/ parW));
-        report.add ("  (divide serial median by parallel median for the speedup)");
-        report.add ("");
+        report.push_back ("  (divide serial median by parallel median for the speedup)");
+        report.push_back ("");
         // Leave the engine serial for any later use.
         engine.setWorkerCountForTest (0);
     }
     else
     {
-        report.add ("--- Multicore scaling: host has < 3 cores; serial only ---");
-        report.add ("");
+        report.push_back ("--- Multicore scaling: host has < 3 cores; serial only ---");
+        report.push_back ("");
     }
 
     restoreState (saved);
@@ -1557,7 +1559,7 @@ juce::String AudioPipelineSelfTest::runPerfSuite()
     engine.applyDesiredWorkers();
     deviceManager.addAudioCallback (&engine);
 
-    report.add ("=== End of Engine Perf Benchmark ===");
-    return report.joinIntoString ("\n");
+    report.push_back ("=== End of Engine Perf Benchmark ===");
+    return dusk::text::joinIntoString (report, "\n");
 }
 } // namespace duskstudio

--- a/src/engine/AudioPipelineSelfTest.h
+++ b/src/engine/AudioPipelineSelfTest.h
@@ -2,6 +2,7 @@
 
 #include <juce_audio_devices/juce_audio_devices.h>
 #include <array>
+#include <string>
 #include <vector>
 #include "AudioEngine.h"
 #include "../session/Session.h"
@@ -29,7 +30,7 @@ public:
     // Runs the full suite, returns a multi-line formatted report suitable for
     // pasting into bug reports. Safe to call from the message thread; takes
     // a few hundred milliseconds to a few seconds depending on backend count.
-    juce::String runAll();
+    std::string runAll();
 
     // Headless engine-CPU benchmark: configures the engine for a given load
     // (number of active tracks, EQ on/off, comp on/off, tape on/HQ), drives
@@ -37,7 +38,7 @@ public:
     // wall-clock timings vs. the buffer budget. Independent from any audio
     // device - measures the engine's pure DSP cost, exactly the figure you
     // compare against Reaper / Bitwig / Ardour at the same load.
-    juce::String runPerfSuite();
+    std::string runPerfSuite();
 
 private:
     struct Measurements
@@ -103,26 +104,26 @@ private:
                                 int numMeasureBlocks);
 
     // Test cases - each formats a "[PASS]/[FAIL] name: details" string.
-    juce::String testPassThroughUnity();
-    juce::String testMuteSilences();
-    juce::String testMasterFaderMinusSix();
-    juce::String testMasterCompNoNoiseFloor(); // comp ON + silent in stays silent (donor analog-noise off)
-    juce::String testBusSoloMutesDirect();      // SIP bus solo: unassigned/direct track muted when a bus is soloed
-    juce::String testChannelRoutingTwoOut();
-    juce::String testChannelRoutingFourOut();
-    juce::String testMasterTapeAddsGain();   // sanity: tape ON should not silently drop signal
-    juce::String testCompEachMode();         // -18 dBFS sine through Opto/FET/VCA; THD + alias floor
-    juce::String testCompHeavyGR();          // extreme settings: characterize harmonics at heavy GR
-    juce::String testCompPerTrack();         // all 16 tracks under Opto produce identical output
-    juce::String testParallelMatchesSerial(); // worker-pool mix == serial mix within float-reassoc tol
-    juce::String testMidiPlayAlongMonitor();   // armed+IN MIDI track sounds live notes in Stopped AND Playing
-    juce::String testBackendsOpenCleanly();
-    juce::String probeUMC1820AlsaFormat();   // explicitly open UMC1820 ALSA & report format
+    std::string testPassThroughUnity();
+    std::string testMuteSilences();
+    std::string testMasterFaderMinusSix();
+    std::string testMasterCompNoNoiseFloor(); // comp ON + silent in stays silent (donor analog-noise off)
+    std::string testBusSoloMutesDirect();      // SIP bus solo: unassigned/direct track muted when a bus is soloed
+    std::string testChannelRoutingTwoOut();
+    std::string testChannelRoutingFourOut();
+    std::string testMasterTapeAddsGain();   // sanity: tape ON should not silently drop signal
+    std::string testCompEachMode();         // -18 dBFS sine through Opto/FET/VCA; THD + alias floor
+    std::string testCompHeavyGR();          // extreme settings: characterize harmonics at heavy GR
+    std::string testCompPerTrack();         // all 16 tracks under Opto produce identical output
+    std::string testParallelMatchesSerial(); // worker-pool mix == serial mix within float-reassoc tol
+    std::string testMidiPlayAlongMonitor();   // armed+IN MIDI track sounds live notes in Stopped AND Playing
+    std::string testBackendsOpenCleanly();
+    std::string probeUMC1820AlsaFormat();   // explicitly open UMC1820 ALSA & report format
 
     // Per-config benchmark cell. Drives `numBlocks` callbacks and returns one
     // formatted line "[OK]/[OVER]  config  -> median X us / p95 Y us / max Z us
     // (budget B us, overruns N/total)". budget = blockSize * 1e6 / sampleRate.
-    juce::String runPerfBenchmark (const juce::String& label,
+    std::string runPerfBenchmark (const std::string& label,
                                     double sampleRate, int blockSize,
                                     int numActiveTracks,
                                     bool eqEnabled, bool compEnabled,

--- a/src/engine/DpImporter.cpp
+++ b/src/engine/DpImporter.cpp
@@ -540,7 +540,7 @@ SongScan scanSongFolder (const juce::File& folder)
                                              scan.deviceModel);
     const int nFrag = (int) scan.tracks.size();
     if (scan.deviceTrackLimit > 0 && nFrag > scan.deviceTrackLimit)
-        warn.add (juce::String::formatted (
+        warn.add (dusk::text::format (
             "%d audio fragments found, but a %s has only %d tracks. The extra "
             "fragments are virtual takes / punch clips / cut regions. Without the "
             "(undecoded) placement table they can't be grouped, so each fragment "

--- a/src/engine/DpImporter.cpp
+++ b/src/engine/DpImporter.cpp
@@ -1,5 +1,6 @@
 #include "DpImporter.h"
 
+#include "../foundation/Text.h"
 #include <cmath>
 #include <cstring>
 #include <map>
@@ -148,7 +149,7 @@ float panByteToNorm (std::uint8_t v) noexcept
 // carries a constant "DP-24   " magic on both models - but edltable.sys
 // records the real model ("DP-24"/"DP-32" at 0x08, "DP-24_EDL"/"DP-32_EDL"
 // at 0x18). Returns the physical track count (18 / 20) or 0 if unknown.
-int readDeviceModel (const juce::File& edl, juce::String& modelOut)
+int readDeviceModel (const juce::File& edl, std::string& modelOut)
 {
     juce::FileInputStream in (edl);
     if (! in.openedOk()) return 0;
@@ -515,7 +516,7 @@ SongScan scanSongFolder (const juce::File& folder)
         }
 
         ImportedTrack t;
-        t.name     = juce::String::formatted ("DP %04d", idx);   // ZZ fragment id, not a track number
+        t.name     = dusk::text::format ("DP %04d", idx);   // ZZ fragment id, not a track number
         t.fragment = frag;
         scan.tracks.push_back (std::move (t));
         if (frag.stereo) ++scan.stereoPairs;
@@ -523,8 +524,8 @@ SongScan scanSongFolder (const juce::File& folder)
 
     if (scan.tracks.empty())
     {
-        scan.warnings = warn.joinIntoString ("\n");
-        if (scan.warnings.isEmpty()) scan.warnings = "No importable fragments.";
+        scan.warnings = warn.joinIntoString ("\n").toStdString();
+        if (scan.warnings.empty()) scan.warnings = "No importable fragments.";
         return scan;
     }
 
@@ -544,7 +545,7 @@ SongScan scanSongFolder (const juce::File& folder)
             "fragments are virtual takes / punch clips / cut regions. Without the "
             "(undecoded) placement table they can't be grouped, so each fragment "
             "is imported onto its own track for you to sort manually.",
-            nFrag, scan.deviceModel.toRawUTF8(), scan.deviceTrackLimit));
+            nFrag, scan.deviceModel.c_str(), scan.deviceTrackLimit));
     else
         warn.add ("Each audio fragment is imported onto its own track; fragments "
                   "are not grouped into their original device tracks.");
@@ -628,7 +629,7 @@ SongScan scanSongFolder (const juce::File& folder)
     else
         warn.add ("All clips start at song start (no stored offsets).");
 
-    scan.warnings = warn.joinIntoString ("\n");
+    scan.warnings = warn.joinIntoString ("\n").toStdString();
     scan.ok = true;
     return scan;
 }

--- a/src/engine/DpImporter.h
+++ b/src/engine/DpImporter.h
@@ -2,6 +2,7 @@
 
 #include <juce_audio_formats/juce_audio_formats.h>
 #include <juce_core/juce_core.h>
+#include <string>
 #include <vector>
 
 // Importer for raw song folders written by a hardware SD-card multitrack
@@ -52,7 +53,7 @@ struct MixerStrip
 // is decoded each fragment is surfaced separately and named by its ZZ id.
 struct ImportedTrack
 {
-    juce::String name;               // "DP 0006" (the ZZ fragment id)
+    std::string  name;               // "DP 0006" (the ZZ fragment id)
     Fragment     fragment;
     std::int64_t  timelineStart = 0;  // 0 until the placement table is solved
     MixerStrip   mixer;
@@ -74,7 +75,7 @@ struct SongScan
     std::vector<ImportedTrack> tracks;  // one entry per audio fragment (NOT per device track)
     int          stereoPairs = 0;
     int          discardedTakes = 0;       // on-disk fragments excluded as not-in-arrangement (File-List)
-    juce::String deviceModel;              // "DP-24" / "DP-32" from edltable.sys, or empty
+    std::string  deviceModel;              // "DP-24" / "DP-32" from edltable.sys, or empty
     int          deviceTrackLimit = 0;     // physical track faders: 18 (DP-24), 20 (DP-32), 0 unknown
     int          tempoBpm = 0;             // song.sys 0x6d8 (u8 BPM); 0 = not decoded/default
     int          timeSigNum = 0;           // song.sys 0x6d9 numerator (1..12); 0 = not decoded
@@ -84,7 +85,7 @@ struct SongScan
     bool         hasMixdown = false;       // an in-folder master WAV is present (enables alignment)
     juce::File   mixdownFile;              // the detected master mixdown, if any
     std::vector<DpMarker> markers;         // song.sys locate marks -> session markers
-    juce::String warnings;                 // human-readable caveats for the dialog
+    std::string  warnings;                 // human-readable caveats for the dialog
 };
 
 // Scan a song folder. Never throws; bad/short WAV headers and garbage

--- a/src/engine/FileImporter.cpp
+++ b/src/engine/FileImporter.cpp
@@ -1,5 +1,6 @@
 #include "FileImporter.h"
 
+#include "../foundation/Text.h"
 #include <juce_audio_basics/juce_audio_basics.h>
 #include <algorithm>
 #include <array>
@@ -17,16 +18,14 @@ namespace
 // "track{NN}_{timestamp}.wav" so imports sit next to recordings in the
 // session's audio directory and aren't visually distinct in the file
 // listing. "import_" prefix is the only differentiator.
-juce::String makeImportedFilename (int trackIndex, const juce::String& extension = ".wav")
+std::string makeImportedFilename (int trackIndex, const juce::String& extension = ".wav")
 {
     const auto now = juce::Time::getCurrentTime();
-    const auto stamp = juce::String::formatted ("%04d%02d%02d-%02d%02d%02d",
-                                                  now.getYear(), now.getMonth() + 1, now.getDayOfMonth(),
-                                                  now.getHours(), now.getMinutes(), now.getSeconds());
-    // No %s through String::formatted: MSVC's wide printf reads a char* as
-    // wchar_t* and garbles the name into invalid filename characters.
-    return "import_track" + juce::String (trackIndex + 1).paddedLeft ('0', 2)
-             + "_" + stamp + extension;
+    return dusk::text::format ("import_track%02d_%04d%02d%02d-%02d%02d%02d%s",
+                               trackIndex + 1,
+                               now.getYear(), now.getMonth() + 1, now.getDayOfMonth(),
+                               now.getHours(), now.getMinutes(), now.getSeconds(),
+                               extension.toRawUTF8());
 }
 
 // Channel-conform the first `numSamples` of `src` into `dst` (both pre-sized
@@ -71,7 +70,7 @@ AudioImportResult importAudio (const AudioImportRequest& req)
 
     if (! req.source.existsAsFile())
     {
-        result.errorMessage = "Source file does not exist: " + req.source.getFullPathName();
+        result.errorMessage = ("Source file does not exist: " + req.source.getFullPathName()).toStdString();
         return result;
     }
     // Session sample rate can legitimately be zero at import time when
@@ -91,8 +90,8 @@ AudioImportResult importAudio (const AudioImportRequest& req)
         const auto created = req.audioDir.createDirectory();
         if (created.failed())
         {
-            result.errorMessage = "Could not create audio directory: "
-                                + created.getErrorMessage();
+            result.errorMessage = ("Could not create audio directory: "
+                                + created.getErrorMessage()).toStdString();
             return result;
         }
     }
@@ -112,8 +111,8 @@ AudioImportResult importAudio (const AudioImportRequest& req)
     }
     if (reader == nullptr)
     {
-        result.errorMessage = "Unsupported or unreadable audio file: "
-                            + req.source.getFileName();
+        result.errorMessage = ("Unsupported or unreadable audio file: "
+                            + req.source.getFileName()).toStdString();
         return result;
     }
 
@@ -165,8 +164,8 @@ AudioImportResult importAudio (const AudioImportRequest& req)
         if (! copied)
         {
             outFile.deleteFile();   // drop any partial copy (matches the slow path)
-            result.errorMessage = "Could not copy the file into the session audio folder: "
-                                + outFile.getFullPathName();
+            result.errorMessage = ("Could not copy the file into the session audio folder: "
+                                + outFile.getFullPathName()).toStdString();
             return result;
         }
 
@@ -217,8 +216,8 @@ AudioImportResult importAudio (const AudioImportRequest& req)
     }
     if (stream == nullptr || ! stream->openedOk())
     {
-        result.errorMessage = "Could not open output file for writing: "
-                            + outFile.getFullPathName();
+        result.errorMessage = ("Could not open output file for writing: "
+                            + outFile.getFullPathName()).toStdString();
         return result;
     }
 
@@ -385,7 +384,7 @@ MidiImportResult importMidi (const MidiImportRequest& req)
 
     if (! req.source.existsAsFile())
     {
-        result.errorMessage = "MIDI file does not exist: " + req.source.getFullPathName();
+        result.errorMessage = ("MIDI file does not exist: " + req.source.getFullPathName()).toStdString();
         return result;
     }
     // MIDI has no inherent sample rate - the importer only needs one to

--- a/src/engine/FileImporter.h
+++ b/src/engine/FileImporter.h
@@ -3,6 +3,7 @@
 #include <juce_audio_formats/juce_audio_formats.h>
 #include <juce_core/juce_core.h>
 #include "../session/Session.h"
+#include <string>
 
 namespace duskstudio::fileimport
 {
@@ -35,7 +36,7 @@ struct AudioImportRequest
 struct AudioImportResult
 {
     bool         ok = false;
-    juce::String errorMessage;
+    std::string  errorMessage;
     AudioRegion  region;
 };
 
@@ -52,7 +53,7 @@ struct MidiImportRequest
 struct MidiImportResult
 {
     bool         ok = false;
-    juce::String errorMessage;
+    std::string  errorMessage;
     MidiRegion   region;
 };
 

--- a/src/engine/McuController.cpp
+++ b/src/engine/McuController.cpp
@@ -3,6 +3,10 @@
 #include "McuFaderTaper.h"
 #include "Transport.h"
 #include "../session/Session.h"
+#include "../foundation/Text.h"
+
+#include <algorithm>
+#include <string>
 
 namespace duskstudio
 {
@@ -14,16 +18,15 @@ namespace
 constexpr int kLcdCharsPerStrip = mcu::sysex::kLcdCharsPerStrip;   // 7
 
 void writeStripField (std::array<char, mcu::sysex::kLcdRowBytes>& row,
-                      int strip, const juce::String& text)
+                      int strip, const std::string& text)
 {
     const int base = strip * kLcdCharsPerStrip;
     if (base + kLcdCharsPerStrip > (int) row.size()) return;
     // Truncate or right-pad to exactly kLcdCharsPerStrip. Skip non-
     // ASCII runs (utf-8 multi-byte glyphs would otherwise emit two
     // garbage characters before the rest shifts).
-    const auto utf = text.toRawUTF8();
     int written = 0;
-    for (const char* p = utf; *p && written < kLcdCharsPerStrip; ++p)
+    for (const char* p = text.c_str(); *p && written < kLcdCharsPerStrip; ++p)
     {
         const unsigned char c = (unsigned char) *p;
         row[(size_t) (base + written++)] = (c >= 0x20 && c < 0x7F)
@@ -71,20 +74,20 @@ void emitTimecode (juce::MidiBuffer& buf,
     buf.addEvent (juce::MidiMessage (bytes.data(), (int) n), 0);
 }
 
-juce::String formatFaderDbForLcd (float db)
+std::string formatFaderDbForLcd (float db)
 {
-    if (db <= ChannelStripParams::kFaderInfThreshDb) return juce::String ("  -inf");
+    if (db <= ChannelStripParams::kFaderInfThreshDb) return "  -inf";
     // 1 decimal, max width 6 chars including sign. " +3.0 " etc.
-    if (db >= 0.0f) return "+" + juce::String (db, 1);
-    return juce::String (db, 1);
+    if (db >= 0.0f) return "+" + dusk::text::format ("%.1f", db);
+    return dusk::text::format ("%.1f", db);
 }
 
-juce::String formatPanForLcd (float pan)
+std::string formatPanForLcd (float pan)
 {
-    if (std::abs (pan) < 0.01f) return juce::String ("  C   ");
+    if (std::abs (pan) < 0.01f) return "  C   ";
     const int magnitude = (int) std::round (std::abs (pan) * 100.0f);
-    return (pan < 0.0f ? juce::String ("L") : juce::String ("R"))
-         + juce::String (magnitude);
+    return (pan < 0.0f ? std::string ("L") : std::string ("R"))
+         + std::to_string (magnitude);
 }
 } // namespace
 
@@ -276,13 +279,13 @@ juce::MidiBuffer McuController::buildEmitBuffer (bool forceAll)
 
         // Row 0: track name. Empty / default-numeric -> "TRK N".
         const auto rawName = trk.name.trim();
-        const juce::String displayName = rawName.isNotEmpty()
-                                            ? rawName
-                                            : "TRK " + juce::String (t + 1);
+        const std::string displayName = rawName.isNotEmpty()
+                                            ? rawName.toStdString()
+                                            : "TRK " + std::to_string (t + 1);
         writeStripField (row0, strip, displayName);
 
         // Row 1: value depends on assign mode.
-        juce::String value;
+        std::string value;
         switch (assign)
         {
             case 0:   value = formatPanForLcd (trk.strip.pan.load (std::memory_order_relaxed)); break;
@@ -291,8 +294,8 @@ juce::MidiBuffer McuController::buildEmitBuffer (bool forceAll)
                             trk.strip.auxSendDb[(size_t) (assign - 1)]
                                 .load (std::memory_order_relaxed));
                 break;
-            case 5:   value = juce::String ("EQ");   break;
-            case 6:   value = juce::String ("COMP"); break;
+            case 5:   value = "EQ";   break;
+            case 6:   value = "COMP"; break;
             default:  value = formatFaderDbForLcd (
                             trk.strip.liveFaderDb.load (std::memory_order_relaxed));
                 break;
@@ -316,7 +319,7 @@ juce::MidiBuffer McuController::buildEmitBuffer (bool forceAll)
             const auto& trk = session.track (t);
             const float dbL = trk.meterInputDb .load (std::memory_order_relaxed);
             const float dbR = trk.meterInputRDb.load (std::memory_order_relaxed);
-            const float peakDb = juce::jmax (dbL, dbR);
+            const float peakDb = std::max (dbL, dbR);
             // Map -60..0 dB to 0..14, clip > 0 dB to 15.
             int level;
             if (peakDb >= 0.0f) level = mcu::meter::kClipLevel;
@@ -422,27 +425,28 @@ juce::MidiBuffer McuController::buildEmitBuffer (bool forceAll)
         if (auto* transport = transportProvider())
             playhead = transport->getPlayhead();
     const float bpm   = session.tempoBpm.load (std::memory_order_relaxed);
-    const int bpb     = juce::jmax (1, session.beatsPerBar.load (std::memory_order_relaxed));
+    const int bpb     = std::max (1, session.beatsPerBar.load (std::memory_order_relaxed));
     double sr = sampleRateProvider ? sampleRateProvider() : 0.0;
     if (sr <= 0.0) sr = 48000.0;
     const double samplesPerBeat = (bpm > 0.0f)
                                     ? sr * 60.0 / (double) bpm : sr;
     const double samplesPerBar  = samplesPerBeat * (double) bpb;
-    const int bar  = (int) ((double) playhead / juce::jmax (1.0, samplesPerBar));
-    const int beat = (int) (((double) playhead - bar * samplesPerBar) / juce::jmax (1.0, samplesPerBeat));
+    const int bar  = (int) ((double) playhead / std::max (1.0, samplesPerBar));
+    const int beat = (int) (((double) playhead - bar * samplesPerBar) / std::max (1.0, samplesPerBeat));
     const int subdiv = (int) (((double) playhead
                                 - bar * samplesPerBar
                                 - beat * samplesPerBeat)
                                 * 4.0
-                                / juce::jmax (1.0, samplesPerBeat));
+                                / std::max (1.0, samplesPerBeat));
     auto pad = [] (int v, int width)
     {
-        return juce::String (juce::jmax (0, v) + 1).paddedLeft ('0', width);
+        return dusk::text::paddedLeft (std::to_string (std::max (0, v) + 1), '0', width);
     };
-    const auto tcStr = (pad (bar, 3) + pad (beat, 2) + pad (subdiv, 2) + "  0")
-                          .substring (0, mcu::sysex::kTimecodeDigits);
+    const auto tcStr = dusk::text::substring (
+                           pad (bar, 3) + pad (beat, 2) + pad (subdiv, 2) + "  0",
+                           0, mcu::sysex::kTimecodeDigits);
     for (int i = 0; i < mcu::sysex::kTimecodeDigits
-                    && i < tcStr.length(); ++i)
+                    && i < (int) tcStr.length(); ++i)
         tc[(size_t) i] = (char) tcStr[i];
 
     const bool transportRolling = lastTransportState

--- a/src/engine/McuController.cpp
+++ b/src/engine/McuController.cpp
@@ -29,8 +29,9 @@ void writeStripField (std::array<char, mcu::sysex::kLcdRowBytes>& row,
     for (const char* p = text.c_str(); *p && written < kLcdCharsPerStrip; ++p)
     {
         const unsigned char c = (unsigned char) *p;
-        row[(size_t) (base + written++)] = (c >= 0x20 && c < 0x7F)
-                                             ? (char) c : ' ';
+        if (c >= 0x7F)
+            continue;   // drop UTF-8 bytes without spending LCD columns on them
+        row[(size_t) (base + written++)] = (c >= 0x20) ? (char) c : ' ';
     }
     while (written < kLcdCharsPerStrip)
         row[(size_t) (base + written++)] = ' ';

--- a/src/engine/PluginBackingCheck.h
+++ b/src/engine/PluginBackingCheck.h
@@ -9,18 +9,27 @@ namespace duskstudio
 {
 namespace detail
 {
-// Mirrors JUCE File::isAbsolutePath: a leading separator, a Windows drive
-// colon, or a leading '~' on POSIX. std::filesystem::path::is_absolute would
-// reject the tilde form, so classify by hand to keep the same verdicts.
+// A leading separator, a Windows drive colon or forward slash, or a leading
+// '~' on POSIX. std::filesystem::path::is_absolute would reject the tilde
+// form, so classify by hand.
 inline bool pathLooksAbsolute (const std::string& path) noexcept
 {
     if (path.empty()) return false;
     const char first = path[0];
 #if defined(_WIN32)
-    return first == '\\' || (path.size() > 1 && path[1] == ':');
+    return first == '\\' || first == '/' || (path.size() > 1 && path[1] == ':');
 #else
     return first == '/' || first == '~';
 #endif
+}
+
+// JUCE's File(String) expanded a leading tilde; std::filesystem takes it
+// literally, which would misread every home-relative entry as dead.
+inline std::filesystem::path expandedPath (const std::string& p)
+{
+    if (! p.empty() && p[0] == '~' && (p.size() == 1 || p[1] == '/'))
+        return dusk::fs::userHomeDir() / std::filesystem::u8path (p.substr (p.size() == 1 ? 1 : 2));
+    return std::filesystem::u8path (p);
 }
 } // namespace detail
 
@@ -41,7 +50,7 @@ inline bool pluginBackingLooksDead (const std::string& fileOrIdentifier)
         return false;
 
     namespace stdfs = std::filesystem;
-    const auto path = stdfs::u8path (fileOrIdentifier);
+    const auto path = detail::expandedPath (fileOrIdentifier);
 
     std::error_code ec;
     if (! stdfs::exists (path, ec))         return true;

--- a/src/engine/PluginBackingCheck.h
+++ b/src/engine/PluginBackingCheck.h
@@ -1,9 +1,29 @@
 #pragma once
 
-#include <juce_core/juce_core.h>
+#include "../foundation/Fs.h"
+
+#include <filesystem>
+#include <string>
 
 namespace duskstudio
 {
+namespace detail
+{
+// Mirrors JUCE File::isAbsolutePath: a leading separator, a Windows drive
+// colon, or a leading '~' on POSIX. std::filesystem::path::is_absolute would
+// reject the tilde form, so classify by hand to keep the same verdicts.
+inline bool pathLooksAbsolute (const std::string& path) noexcept
+{
+    if (path.empty()) return false;
+    const char first = path[0];
+#if defined(_WIN32)
+    return first == '\\' || (path.size() > 1 && path[1] == ':');
+#else
+    return first == '/' || first == '~';
+#endif
+}
+} // namespace detail
+
 // True when a cached plugin entry's backing is gone or hollowed out (a broken /
 // half-removed install) and should be pruned so the picker never offers an entry
 // that can't load. Pure filesystem heuristic - never instantiates a plugin:
@@ -15,14 +35,17 @@ namespace duskstudio
 //     symptom. Any file inside (the binary on any platform - no extension on
 //     macOS - moduleinfo.json, resources) counts as intact enough to attempt.
 //   - a path that no longer exists -> dead.
-inline bool pluginBackingLooksDead (const juce::String& fileOrIdentifier)
+inline bool pluginBackingLooksDead (const std::string& fileOrIdentifier)
 {
-    if (! juce::File::isAbsolutePath (fileOrIdentifier))
+    if (! detail::pathLooksAbsolute (fileOrIdentifier))
         return false;
 
-    const juce::File f (fileOrIdentifier);
-    if (! f.exists())     return true;
-    if (f.existsAsFile()) return false;
-    return f.findChildFiles (juce::File::findFiles, true).isEmpty();
+    namespace stdfs = std::filesystem;
+    const auto path = stdfs::u8path (fileOrIdentifier);
+
+    std::error_code ec;
+    if (! stdfs::exists (path, ec))         return true;
+    if (stdfs::is_regular_file (path, ec))  return false;
+    return dusk::fs::findChildFiles (path, "*", true).empty();
 }
 } // namespace duskstudio

--- a/src/engine/PluginManager.cpp
+++ b/src/engine/PluginManager.cpp
@@ -373,7 +373,7 @@ int PluginManager::scanInstalledPlugins (
         // mutating the live list inside this loop can't invalidate the iteration.
         for (const auto& desc : knownPluginList.getTypes())
         {
-            bool dead = pluginBackingLooksDead (desc.fileOrIdentifier);
+            bool dead = pluginBackingLooksDead (desc.fileOrIdentifier.toStdString());
 
             if (! dead && ! juce::File::isAbsolutePath (desc.fileOrIdentifier))
             {

--- a/src/engine/hosting/NativeInsertSlot.h
+++ b/src/engine/hosting/NativeInsertSlot.h
@@ -1,12 +1,13 @@
 #pragma once
 
-#include <juce_core/juce_core.h>
+#include <juce_audio_basics/juce_audio_basics.h>   // JUCE MidiBuffer (audio path)
 
 #include "InsertAdapter.h"
 #include "SpscRing.h"
 
 #include <atomic>
 #include <cstring>
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <vector>
@@ -44,19 +45,19 @@ public:
     // Message thread: load the bundle at `path` and instantiate `pluginId` (empty =
     // the format's default pick - the first effect), replacing any prior load.
     // False (+ errorOut) on failure.
-    bool load (const juce::File& path, double sampleRate, int maxBlock, std::string& errorOut,
-               const juce::String& pluginId = {})
+    bool load (const std::filesystem::path& path, double sampleRate, int maxBlock,
+               std::string& errorOut, const std::string& pluginId = {})
     {
         unload();
         bindingRing.clear();   // writes queued against the previous occupant
 
         auto b = std::make_unique<Bundle>();
         std::string err;
-        if (! b->load (path.getFullPathName().toStdString(), err))
+        if (! b->load (path.u8string(), err))
         { errorOut = std::string (Traits::bundleNoun) + ": " + err; return false; }
 
         std::string pickedId;
-        if (! Traits::pickPlugin (*b, pluginId.toStdString(), pickedId, errorOut))
+        if (! Traits::pickPlugin (*b, pluginId, pickedId, errorOut))
             return false;
 
         auto inst = std::make_unique<Instance>();
@@ -70,8 +71,8 @@ public:
         bundle     = std::move (b);
         instance   = std::move (inst);
         adapter.prepare (instance->portLayout(), maxBlock);   // size the fold scratch
-        loadedPath     = path.getFullPathName();
-        loadedPluginId = juce::String (pickedId);
+        loadedPath     = path.u8string();
+        loadedPluginId = pickedId;
         ready.store (true, std::memory_order_release);
         return true;
     }
@@ -112,10 +113,10 @@ public:
     }
 
     bool isLoaded() const noexcept { return ready.load (std::memory_order_acquire); }
-    const juce::String& getPath() const noexcept { return loadedPath; }
+    const std::string& getPath() const noexcept { return loadedPath; }
     // The instantiated plugin's id within its bundle (class UID / URI / CLAP id) -
     // resolved even when load() defaulted, so sessions persist the actual pick.
-    const juce::String& getPluginId() const noexcept { return loadedPluginId; }
+    const std::string& getPluginId() const noexcept { return loadedPluginId; }
 
     // Bypass: processStereo passes audio through untouched (the plugin stays loaded).
     void setBypassed (bool b) noexcept { bypassed.store (b, std::memory_order_relaxed); }
@@ -229,8 +230,8 @@ protected:
     InsertAdapter     adapter;
     std::atomic<bool> ready    { false };
     std::atomic<bool> bypassed { false };
-    juce::String      loadedPath;
-    juce::String      loadedPluginId;
+    std::string       loadedPath;
+    std::string       loadedPluginId;
 
 private:
     struct ParamBinding { uint32_t paramIndex; float frac; };

--- a/src/engine/multisample/DuskMultisampleProcessor.cpp
+++ b/src/engine/multisample/DuskMultisampleProcessor.cpp
@@ -278,7 +278,7 @@ bool DuskMultisampleProcessor::applySf2Preset (const juce::File& sf2,
     // sfizz roots relative sample= names at the SFZ path's parent dir,
     // so point the virtual SFZ inside the temp dir holding the WAVs.
     const auto virtualSfz = newDir.getChildFile ("preset.sfz");
-    const auto body       = conv.sfzText.toStdString();
+    const auto body       = conv.sfzText;
     const auto pathStr    = virtualSfz.getFullPathName().toStdString();
     // Only the sfizz call itself is serialised against processBlock - the
     // expensive conversion above runs unlocked so the audio thread keeps

--- a/src/engine/multisample/Sf2Reader.cpp
+++ b/src/engine/multisample/Sf2Reader.cpp
@@ -1,5 +1,7 @@
 #include "Sf2Reader.h"
 
+#include "../../foundation/Text.h"
+
 namespace duskstudio
 {
 const Sf2Generator* Sf2Zone::find(uint16_t oper) const noexcept
@@ -44,13 +46,13 @@ struct Cursor
         pos += 4;
         return v;
     }
-    juce::String fixedStr(int n)
+    std::string fixedStr(int n)
     {
         // SF2 name fields are NUL-padded ASCII up to n bytes.
         const char* s = (const char*) (p + pos);
         int len = 0;
         while (len < n && s[len] != '\0') ++len;
-        juce::String out (juce::CharPointer_UTF8 (s), (size_t) len);
+        std::string out (s, (size_t) len);
         pos += (size_t) n;
         return out;
     }
@@ -106,7 +108,7 @@ Sf2File readSf2(const juce::File& file)
     juce::FileInputStream in (file);
     if (! in.openedOk())
     {
-        out.error = "Could not open " + file.getFileName();
+        out.error = ("Could not open " + file.getFileName()).toStdString();
         return out;
     }
 
@@ -250,7 +252,7 @@ Sf2File readSf2(const juce::File& file)
             s.sampleLink      = c.u16();
             s.sampleType      = c.u16();
             // Last record is the "EOS" terminal sentinel - drop it.
-            if (i == n - 1 && s.name.startsWith("EOS")) break;
+            if (i == n - 1 && dusk::text::startsWith(s.name, "EOS")) break;
             out.samples.push_back(std::move(s));
         }
     }
@@ -279,7 +281,7 @@ Sf2File readSf2(const juce::File& file)
     {
         const int n = (int) (inst.size / kInstSize);
         Cursor c { inst.data, inst.size, 0 };
-        std::vector<juce::String> names;
+        std::vector<std::string>  names;
         std::vector<int>          bagNdx;
         for (int i = 0; i < n; ++i)
         {
@@ -321,7 +323,7 @@ Sf2File readSf2(const juce::File& file)
     {
         const int n = (int) (phdr.size / kPhdrSize);
         Cursor c { phdr.data, phdr.size, 0 };
-        std::vector<juce::String> names;
+        std::vector<std::string>  names;
         std::vector<uint16_t>     progs, banks;
         std::vector<int>          bagNdx;
         for (int i = 0; i < n; ++i)

--- a/src/engine/multisample/Sf2Reader.h
+++ b/src/engine/multisample/Sf2Reader.h
@@ -3,6 +3,7 @@
 #include <juce_core/juce_core.h>
 
 #include <cstdint>
+#include <string>
 #include <vector>
 
 namespace duskstudio
@@ -72,13 +73,13 @@ struct Sf2Zone
 
 struct Sf2Instrument
 {
-    juce::String         name;
+    std::string          name;
     std::vector<Sf2Zone> zones;   // first zone may be a global zone (no sampleID)
 };
 
 struct Sf2Preset
 {
-    juce::String         name;
+    std::string          name;
     uint16_t             preset { 0 };   // MIDI program
     uint16_t             bank   { 0 };
     std::vector<Sf2Zone> zones;          // first zone may be global; others ref instruments
@@ -86,7 +87,7 @@ struct Sf2Preset
 
 struct Sf2Sample
 {
-    juce::String name;
+    std::string  name;
     uint32_t     start          { 0 };   // sample frames into the smpl chunk
     uint32_t     end            { 0 };
     uint32_t     startLoop      { 0 };
@@ -113,7 +114,7 @@ struct Sf2File
     std::int64_t sm24Size   { 0 };
 
     bool         ok    { false };
-    juce::String error;
+    std::string  error;
 };
 
 // Parse an .sf2 file. On failure returns an Sf2File with ok=false and a

--- a/src/engine/multisample/Sf2ToSfz.cpp
+++ b/src/engine/multisample/Sf2ToSfz.cpp
@@ -55,11 +55,14 @@ std::string sanitize(const std::string& s)
 }
 
 // Fixed decimal-place formatting with trailing-zero padding for the SFZ
-// numeric fields.
+// numeric fields. snprintf's decimal separator follows the C locale (which
+// hosted plugins are known to flip); SFZ requires '.', so normalize.
 std::string fmtF(double v, int dp)
 {
     char buf[64];
     std::snprintf(buf, sizeof(buf), "%.*f", dp, v);
+    for (char* c = buf; *c != '\0'; ++c)
+        if (*c == ',') *c = '.';
     return std::string(buf);
 }
 

--- a/src/engine/multisample/Sf2ToSfz.cpp
+++ b/src/engine/multisample/Sf2ToSfz.cpp
@@ -2,7 +2,11 @@
 
 #include <juce_audio_formats/juce_audio_formats.h>
 
+#include <cctype>
+#include <cmath>
+#include <cstdio>
 #include <map>
+#include <string>
 
 namespace duskstudio
 {
@@ -34,20 +38,29 @@ bool hasGen(const Sf2Zone& z, uint16_t oper)
 // absence of instrument (41).
 constexpr uint16_t kGenInstrument = 41;
 
-juce::String sanitize(const juce::String& s)
+std::string sanitize(const std::string& s)
 {
-    juce::String out;
-    for (auto c : s)
+    std::string out;
+    for (const char ch : s)
     {
-        // Cast the fallback to juce_wchar so both ternary branches share a
-        // single type. Without the cast, arm64 GCC sees juce_wchar (uint32)
-        // + int and flags the operator+= overload set as ambiguous; amd64
-        // GCC is more permissive but the cast is correct on both.
-        const juce::juce_wchar pick = juce::CharacterFunctions::isLetterOrDigit (c)
-                                          ? c : (juce::juce_wchar) '_';
-        out += pick;
+        const auto c = (unsigned char) ch;
+        if (c >= 0x80)                 // pass UTF-8 continuation/lead bytes through
+            out += (char) c;
+        else if (std::isalnum(c))
+            out += (char) c;
+        else
+            out += '_';
     }
-    return out.isEmpty() ? juce::String("s") : out;
+    return out.empty() ? std::string("s") : out;
+}
+
+// Fixed decimal-place formatting with trailing-zero padding for the SFZ
+// numeric fields.
+std::string fmtF(double v, int dp)
+{
+    char buf[64];
+    std::snprintf(buf, sizeof(buf), "%.*f", dp, v);
+    return std::string(buf);
 }
 
 // Extract one mono sample [start,end) of 16-bit PCM from the smpl chunk
@@ -142,8 +155,8 @@ Sf2Conversion convertSf2Preset(const juce::File& sf2,
         firstInstZone = 1;
     }
 
-    juce::StringArray regions;
-    std::map<int, juce::String> extracted;   // sampleIndex -> wav filename
+    std::vector<std::string> regions;
+    std::map<int, std::string> extracted;   // sampleIndex -> wav filename
 
     for (size_t pz = firstInstZone; pz < preset.zones.size(); ++pz)
     {
@@ -240,24 +253,24 @@ Sf2Conversion convertSf2Preset(const juce::File& sf2,
 
             // Volume envelope (timecents -> seconds; cB -> % sustain)
             auto tcToSec = [](int tc) { return std::pow(2.0, (double) tc / 1200.0); };
-            juce::String env;
+            std::string env;
             if (auto it = eff.find(kGenDelayVolEnv);   it != eff.end())
-                env << " ampeg_delay="   << juce::String(tcToSec(it->second), 4);
+                env += " ampeg_delay="   + fmtF(tcToSec(it->second), 4);
             if (auto it = eff.find(kGenAttackVolEnv);  it != eff.end())
-                env << " ampeg_attack="  << juce::String(tcToSec(it->second), 4);
+                env += " ampeg_attack="  + fmtF(tcToSec(it->second), 4);
             if (auto it = eff.find(kGenHoldVolEnv);    it != eff.end())
-                env << " ampeg_hold="    << juce::String(tcToSec(it->second), 4);
+                env += " ampeg_hold="    + fmtF(tcToSec(it->second), 4);
             if (auto it = eff.find(kGenDecayVolEnv);   it != eff.end())
-                env << " ampeg_decay="   << juce::String(tcToSec(it->second), 4);
+                env += " ampeg_decay="   + fmtF(tcToSec(it->second), 4);
             if (auto it = eff.find(kGenSustainVolEnv); it != eff.end())
             {
                 // SF2 sustain is centibels of attenuation from full level.
                 const double pct = juce::jlimit(0.0, 100.0,
                                                  100.0 * std::pow(10.0, -((double) it->second) / 200.0));
-                env << " ampeg_sustain=" << juce::String(pct, 2);
+                env += " ampeg_sustain=" + fmtF(pct, 2);
             }
             if (auto it = eff.find(kGenReleaseVolEnv); it != eff.end())
-                env << " ampeg_release=" << juce::String(tcToSec(it->second), 4);
+                env += " ampeg_release=" + fmtF(tcToSec(it->second), 4);
 
             // Lowpass filter
             // initialFilterFc is absolute cents (8.176 Hz reference);
@@ -267,29 +280,29 @@ Sf2Conversion convertSf2Preset(const juce::File& sf2,
             if (fcCents < 13500)
             {
                 const double hz = 8.176 * std::pow(2.0, (double) fcCents / 1200.0);
-                env << " cutoff=" << juce::String(juce::jlimit(20.0, 22000.0, hz), 1)
-                    << " fil_type=lpf_2p";
+                env += " cutoff=" + fmtF(juce::jlimit(20.0, 22000.0, hz), 1)
+                     + " fil_type=lpf_2p";
             }
             const int resCb = genOr(eff, kGenInitialFilterQ, 0)
                             + genOr(presetLayer, kGenInitialFilterQ, 0);
             if (resCb > 0)
-                env << " resonance=" << juce::String((double) resCb / 10.0, 2);
+                env += " resonance=" + fmtF((double) resCb / 10.0, 2);
 
             // Key tracking (scaleTuning, cents/key; default 100)
             if (auto it = eff.find(kGenScaleTuning); it != eff.end() && it->second != 100)
-                env << " pitch_keytrack=" << (int) it->second;
+                env += " pitch_keytrack=" + std::to_string((int) it->second);
 
             // Exclusive class -> self-choking group (drum hi-hats)
             if (auto it = eff.find(kGenExclusiveClass); it != eff.end() && it->second != 0)
-                env << " group=" << (int) it->second
-                    << " off_by=" << (int) it->second;
+                env += " group=" + std::to_string((int) it->second)
+                     + " off_by=" + std::to_string((int) it->second);
 
             // Extract the sample once, reuse the WAV across regions.
             auto exIt = extracted.find(sampleIdx);
             if (exIt == extracted.end())
             {
-                const auto fname = "s" + juce::String(sampleIdx) + "_"
-                                 + sanitize(smp.name) + ".wav";
+                const std::string fname = "s" + std::to_string(sampleIdx) + "_"
+                                        + sanitize(smp.name) + ".wav";
                 const auto wav = outDir.getChildFile(fname);
                 if (! writeSampleWav(in, parsed.smplOffset, parsed.smplSize, smp, wav))
                     continue;
@@ -298,40 +311,38 @@ Sf2Conversion convertSf2Preset(const juce::File& sf2,
             const auto& wavName = exIt->second;
 
             // Emit region
-            juce::String r;
-            r << "<region> sample=" << wavName
-              << " lokey=" << loKey << " hikey=" << hiKey
-              << " lovel=" << loVel << " hivel=" << hiVel
-              << " pitch_keycenter=" << rootKey;
-            if (coarse != 0) r << " transpose=" << coarse;
-            if (fine   != 0) r << " tune=" << juce::jlimit(-100, 100, fine);
-            if (std::abs(volumeDb) > 0.01) r << " volume=" << juce::String(volumeDb, 2);
-            if (std::abs(pan) > 0.01)      r << " pan=" << juce::String(pan, 1);
+            std::string r = "<region> sample=" + wavName
+                          + " lokey=" + std::to_string(loKey) + " hikey=" + std::to_string(hiKey)
+                          + " lovel=" + std::to_string(loVel) + " hivel=" + std::to_string(hiVel)
+                          + " pitch_keycenter=" + std::to_string(rootKey);
+            if (coarse != 0) r += " transpose=" + std::to_string(coarse);
+            if (fine   != 0) r += " tune=" + std::to_string(juce::jlimit(-100, 100, fine));
+            if (std::abs(volumeDb) > 0.01) r += " volume=" + fmtF(volumeDb, 2);
+            if (std::abs(pan) > 0.01)      r += " pan=" + fmtF(pan, 1);
             if (loops && smp.endLoop > smp.startLoop && smp.startLoop >= smp.start
                 && smp.endLoop <= smp.end)
             {
-                r << " loop_mode=loop_continuous"
-                  << " loop_start=" << (int) (smp.startLoop - smp.start)
-                  << " loop_end="   << (int) (smp.endLoop   - smp.start - 1);
+                r += " loop_mode=loop_continuous";
+                r += " loop_start=" + std::to_string((int) (smp.startLoop - smp.start));
+                r += " loop_end="   + std::to_string((int) (smp.endLoop   - smp.start - 1));
             }
-            r << env;
-            regions.add(r);
+            r += env;
+            regions.push_back(r);
         }
     }
 
-    if (regions.isEmpty())
+    if (regions.empty())
     {
         conv.error = "SF2 preset \"" + preset.name + "\" produced no playable regions";
         return conv;
     }
 
-    juce::String sfz;
-    sfz << "// Auto-generated from " << sf2.getFileName()
-        << " preset \"" << preset.name << "\"\n"
-        << "<control>\n"
-        << "<global>\n";
+    std::string sfz = "// Auto-generated from " + sf2.getFileName().toStdString()
+                    + " preset \"" + preset.name + "\"\n"
+                    + "<control>\n"
+                    + "<global>\n";
     for (const auto& r : regions)
-        sfz << r << "\n";
+        sfz += r + "\n";
 
     conv.sfzText   = sfz;
     conv.sampleDir = outDir;

--- a/src/engine/multisample/Sf2ToSfz.h
+++ b/src/engine/multisample/Sf2ToSfz.h
@@ -3,6 +3,8 @@
 #include <juce_core/juce_core.h>
 #include "Sf2Reader.h"
 
+#include <string>
+
 namespace duskstudio
 {
 // Converts one preset of a SoundFont 2 file into an SFZ text body plus a
@@ -18,10 +20,10 @@ namespace duskstudio
 struct Sf2Conversion
 {
     bool         ok { false };
-    juce::String error;
-    juce::String sfzText;     // synthetic SFZ body for sfizz_load_string
+    std::string  error;
+    std::string  sfzText;     // synthetic SFZ body for sfizz_load_string
     juce::File   sampleDir;   // dir holding the extracted WAVs (sfizz root path)
-    juce::String presetName;  // human-readable, for the editor's file label
+    std::string  presetName;  // human-readable, for the editor's file label
 };
 
 // Convert preset `presetIndex` of `sf2` into SFZ + WAVs under `outDir`

--- a/src/foundation/Text.h
+++ b/src/foundation/Text.h
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdarg>
+#include <cstdio>
 #include <cstdlib>
 #include <string>
 #include <string_view>
@@ -189,5 +191,40 @@ inline std::vector<std::string> split (std::string_view s, char delim)
             start = i + 1;
         }
     return out;
+}
+
+// Narrow vsnprintf-based printf replacement for JUCE's String::formatted. Unlike
+// that one (wide printf on MSVC, where %s reads char* as wchar_t*), %s with a
+// char* argument is correct on every platform here.
+#if defined(__GNUC__)
+__attribute__((format (printf, 1, 2)))
+#endif
+inline std::string format (const char* fmt, ...)
+{
+    va_list args;
+    va_start (args, fmt);
+
+    char stackBuf[256];
+    va_list argsCopy;
+    va_copy (argsCopy, args);
+    const int n = std::vsnprintf (stackBuf, sizeof (stackBuf), fmt, argsCopy);
+    va_end (argsCopy);
+
+    if (n < 0)
+    {
+        va_end (args);
+        return {};
+    }
+
+    if ((size_t) n < sizeof (stackBuf))
+    {
+        va_end (args);
+        return std::string (stackBuf, (size_t) n);
+    }
+
+    std::string heap ((size_t) n, '\0');
+    std::vsnprintf (&heap[0], (size_t) n + 1, fmt, args);
+    va_end (args);
+    return heap;
 }
 } // namespace dusk::text

--- a/src/ui/DpImportDialog.h
+++ b/src/ui/DpImportDialog.h
@@ -58,9 +58,9 @@ public:
         warnings.setColour (juce::TextEditor::textColourId, juce::Colour (0xffd0a060));
         warnings.setColour (juce::TextEditor::outlineColourId, juce::Colour (0xff35404a));
         warnings.setFont (juce::Font (juce::FontOptions (13.0f)));
-        warnings.setText (scan.warnings.isEmpty()
+        warnings.setText (scan.warnings.empty()
                               ? juce::String ("Ready to import.")
-                              : scan.warnings,
+                              : juce::String (scan.warnings),
                           juce::dontSendNotification);
         addAndMakeVisible (warnings);
 

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -3830,9 +3830,9 @@ void MainComponent::importDpSongPrompt()
         if (! scan.ok)
         {
             showImportError ("Import DP Song",
-                             scan.warnings.isEmpty()
+                             scan.warnings.empty()
                                  ? juce::String ("No DP song folder found at that location.")
-                                 : scan.warnings);
+                                 : juce::String (scan.warnings));
             return;
         }
 

--- a/src/util/CrashHandler.cpp
+++ b/src/util/CrashHandler.cpp
@@ -9,7 +9,7 @@ namespace duskstudio::crash_handler
 namespace
 {
 std::atomic<bool>             installed { false };
-juce::String                  cachedAppVersion;
+std::string                   cachedAppVersion;
 juce::File                    cachedCrashDir;
 juce::File                    cachedLogFile;
 std::unique_ptr<juce::FileLogger> ownedLogger;
@@ -49,7 +49,7 @@ void crashCallback (void* /*platformSpecific*/)
     stream << "Dusk Studio crash report\n"
            << "==================\n"
            << "Time:         " << juce::Time::getCurrentTime().toString (true, true) << "\n"
-           << "App version:  " << cachedAppVersion << "\n"
+           << "App version:  " << cachedAppVersion.c_str() << "\n"
            << "JUCE version: " << juce::SystemStats::getJUCEVersion() << "\n"
            << "OS:           " << juce::SystemStats::getOperatingSystemName() << "\n"
            << "CPU:          " << juce::SystemStats::getCpuModel()
@@ -98,7 +98,7 @@ void crashCallback (void* /*platformSpecific*/)
 }
 } // namespace
 
-void install (const juce::String& appVersion)
+void install (const std::string& appVersion)
 {
     // Always refresh version - a second install() call from a future
     // hot-reload / test harness updates the crash report header even
@@ -118,7 +118,7 @@ void install (const juce::String& appVersion)
     // from the date in the filename - next-day startup picks a new file.
     ownedLogger = std::make_unique<juce::FileLogger> (
         cachedLogFile,
-        "Dusk Studio " + appVersion + " - "
+        "Dusk Studio " + juce::String (appVersion) + " - "
             + juce::Time::getCurrentTime().toString (true, true));
     juce::Logger::setCurrentLogger (ownedLogger.get());
 

--- a/src/util/CrashHandler.h
+++ b/src/util/CrashHandler.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <juce_core/juce_core.h>
+#include <string>
 
 namespace duskstudio::crash_handler
 {
@@ -16,7 +17,7 @@ namespace duskstudio::crash_handler
 // Patreon support flow: ask user to attach the most recent file from
 // each folder to their DM. With the --version output (see DuskStudioApp),
 // that's enough to triage 90% of reports without back-and-forth.
-void install (const juce::String& appVersion);
+void install (const std::string& appVersion);
 
 // Detach + delete the FileLogger so JUCE's leak detector stays quiet at
 // shutdown. The crash callback registered via SystemStats stays put

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -120,6 +120,7 @@ target_include_directories(dusk-studio-tests SYSTEM PRIVATE ${CMAKE_SOURCE_DIR}/
 # JUCE-free foundation helpers (dusk::text / dusk::fs / dusk::json) — no external deps.
 target_sources(dusk-studio-tests PRIVATE
     foundation_text.cpp
+    foundation_text_format.cpp
     foundation_fs.cpp
     foundation_special_locations.cpp
     foundation_json.cpp

--- a/tests/clap_native_slot.cpp
+++ b/tests/clap_native_slot.cpp
@@ -10,6 +10,8 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
+#include <filesystem>
+#include <string>
 #include <vector>
 
 TEST_CASE ("NativeClapSlot loads, processes, and unloads cleanly", "[clap][slot]")
@@ -25,7 +27,7 @@ TEST_CASE ("NativeClapSlot loads, processes, and unloads cleanly", "[clap][slot]
     duskstudio::clap::NativeClapSlot slot;
     std::string err;
 
-    REQUIRE (slot.load (juce::File (juce::String (path)), 48000.0, kBlock, err));
+    REQUIRE (slot.load (std::filesystem::u8path (path), 48000.0, kBlock, err));
     REQUIRE (slot.isLoaded());
     REQUIRE (slot.getInstance() != nullptr);
 
@@ -35,15 +37,15 @@ TEST_CASE ("NativeClapSlot loads, processes, and unloads cleanly", "[clap][slot]
 
     SECTION ("explicit plugin id: round-trips, bogus id refuses to load")
     {
-        const juce::String pickedId = slot.getPluginId();
-        REQUIRE (pickedId.isNotEmpty());
+        const std::string pickedId = slot.getPluginId();
+        REQUIRE (! pickedId.empty());
 
         slot.unload();
-        REQUIRE (slot.load (juce::File (juce::String (path)), 48000.0, kBlock, err, pickedId));
+        REQUIRE (slot.load (std::filesystem::u8path (path), 48000.0, kBlock, err, pickedId));
         REQUIRE (slot.getPluginId() == pickedId);
 
         slot.unload();
-        REQUIRE_FALSE (slot.load (juce::File (juce::String (path)), 48000.0, kBlock, err,
+        REQUIRE_FALSE (slot.load (std::filesystem::u8path (path), 48000.0, kBlock, err,
                                   "urn:duskstudio:no-such-plugin"));
         REQUIRE_FALSE (slot.isLoaded());
     }
@@ -131,7 +133,7 @@ TEST_CASE ("NativeClapSlot reactivate keeps the same instance (no destroy)", "[c
 
     duskstudio::clap::NativeClapSlot slot;
     std::string err;
-    REQUIRE (slot.load (juce::File (juce::String (path)), 48000.0, 512, err));
+    REQUIRE (slot.load (std::filesystem::u8path (path), 48000.0, 512, err));
     auto* before = slot.getInstance();
     REQUIRE (before != nullptr);
 
@@ -172,7 +174,7 @@ TEST_CASE ("NativeClapSlot state round-trips into a fresh slot", "[clap][slot][s
     }
 
     constexpr int kBlock = 512;
-    const juce::File bundle { juce::String (path) };
+    const std::filesystem::path bundle = std::filesystem::u8path (path);
 
     duskstudio::clap::NativeClapSlot a;
     std::string err;

--- a/tests/clap_params.cpp
+++ b/tests/clap_params.cpp
@@ -8,6 +8,7 @@
 
 #include <cmath>
 #include <cstdlib>
+#include <filesystem>
 #include <vector>
 
 using duskstudio::clap::NativeClapSlot;
@@ -25,7 +26,7 @@ TEST_CASE ("CLAP params enumerate, read, and round-trip a change through process
     constexpr int kBlock = 512;
     NativeClapSlot slot;
     std::string err;
-    REQUIRE (slot.load (juce::File (juce::String (path)), 48000.0, kBlock, err));
+    REQUIRE (slot.load (std::filesystem::u8path (path), 48000.0, kBlock, err));
 
     const int n = slot.paramCount();
     // A valid effect can legitimately expose zero parameters — skip rather than fail.

--- a/tests/dp_importer_parse.cpp
+++ b/tests/dp_importer_parse.cpp
@@ -6,6 +6,7 @@
 #include <juce_core/juce_core.h>
 
 #include "engine/DpImporter.h"
+#include "foundation/Text.h"
 
 #include <cstring>
 #include <memory>
@@ -165,7 +166,7 @@ TEST_CASE ("DpImporter: lone _2 imported as mono with warning", "[DpImporter]")
     REQUIRE (scan.tracks.size() == 1);
     REQUIRE_FALSE (scan.tracks[0].fragment.stereo);
     REQUIRE (scan.tracks[0].fragment.lengthSamples == 2000);
-    REQUIRE (scan.warnings.containsIgnoreCase ("right channel without left"));
+    REQUIRE (dusk::text::containsIgnoreCase (scan.warnings, "right channel without left"));
 }
 
 TEST_CASE ("DpImporter: empty folder and garbage never throw", "[DpImporter]")

--- a/tests/file_importer_audio.cpp
+++ b/tests/file_importer_audio.cpp
@@ -122,7 +122,7 @@ TEST_CASE ("FileImporter: 44.1k mono -> 48k session preserves length", "[FileImp
 
     const auto res = duskstudio::fileimport::importAudio (req);
     REQUIRE (res.ok);
-    REQUIRE (res.errorMessage.isEmpty());
+    REQUIRE (res.errorMessage.empty());
 
     const auto rb = readWav (res.region.file);
     REQUIRE (rb.sampleRate == 48000.0);

--- a/tests/foundation_text_format.cpp
+++ b/tests/foundation_text_format.cpp
@@ -1,0 +1,81 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "foundation/Text.h"
+
+#include <juce_core/juce_core.h>
+
+#include <cstdint>
+#include <string>
+
+using namespace dusk;
+
+TEST_CASE ("dusk::text::format matches juce::String::formatted (numeric)", "[foundation][text]")
+{
+    for (int v : { 0, 7, 42, -5, 1234, -999999 })
+    {
+        REQUIRE (text::format ("%d", v)   == juce::String::formatted ("%d", v).toStdString());
+        REQUIRE (text::format ("%04d", v) == juce::String::formatted ("%04d", v).toStdString());
+        REQUIRE (text::format ("%02d", v) == juce::String::formatted ("%02d", v).toStdString());
+        REQUIRE (text::format ("%x", v)   == juce::String::formatted ("%x", v).toStdString());
+    }
+
+    for (double v : { 0.0, 3.14159, -2.5, 1000.0, 0.001, -0.0009 })
+    {
+        REQUIRE (text::format ("%.1f", v) == juce::String::formatted ("%.1f", v).toStdString());
+        REQUIRE (text::format ("%.2f", v) == juce::String::formatted ("%.2f", v).toStdString());
+        REQUIRE (text::format ("%.3f", v) == juce::String::formatted ("%.3f", v).toStdString());
+        REQUIRE (text::format ("%g", v)   == juce::String::formatted ("%g", v).toStdString());
+    }
+
+    for (std::int64_t v : { std::int64_t (0), std::int64_t (42), std::int64_t (-1),
+                            std::int64_t (9000000000LL), std::int64_t (-9000000000LL) })
+    {
+        REQUIRE (text::format ("%lld", (long long) v)
+                     == juce::String::formatted ("%lld", (long long) v).toStdString());
+    }
+
+    for (std::uint64_t v : { std::uint64_t (0), std::uint64_t (255),
+                             std::uint64_t (18000000000ULL) })
+    {
+        REQUIRE (text::format ("%llu", (unsigned long long) v)
+                     == juce::String::formatted ("%llu", (unsigned long long) v).toStdString());
+    }
+
+    REQUIRE (text::format ("%04d%02d%02d-%02d%02d%02d", 2026, 7, 13, 9, 5, 30)
+                 == juce::String::formatted ("%04d%02d%02d-%02d%02d%02d",
+                                             2026, 7, 13, 9, 5, 30).toStdString());
+}
+
+TEST_CASE ("dusk::text::format direct expectations", "[foundation][text]")
+{
+    SECTION ("%s with char*")
+    {
+        const std::string name = "kick";
+        REQUIRE (text::format ("track: %s", name.c_str()) == "track: kick");
+        REQUIRE (text::format ("%s.wav", "master") == "master.wav");
+        REQUIRE (text::format ("%s/%s", "a", "b") == "a/b");
+    }
+
+    SECTION ("mixed patterns")
+    {
+        REQUIRE (text::format ("%s %d %.1f dB", "gain", 3, -6.0) == "gain 3 -6.0 dB");
+    }
+
+    SECTION ("empty format")
+    {
+        REQUIRE (text::format ("") == "");
+    }
+
+    SECTION ("literal with no conversions")
+    {
+        REQUIRE (text::format ("no percents here") == "no percents here");
+    }
+
+    SECTION ("heap path - output longer than the 256-byte stack buffer")
+    {
+        const std::string chunk (300, 'x');
+        const std::string expected = "[" + chunk + "]";
+        REQUIRE (text::format ("[%s]", chunk.c_str()) == expected);
+        REQUIRE (text::format ("[%s]", chunk.c_str()).size() == 302);
+    }
+}

--- a/tests/lv2_native_slot.cpp
+++ b/tests/lv2_native_slot.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
+#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -56,7 +57,7 @@ TEST_CASE ("NativeLv2Slot loads, processes, and unloads cleanly", "[lv2][slot]")
     std::string err;
     constexpr int kBlock = 256;
 
-    if (! slot.load (juce::File (juce::String (path)), 48000.0, kBlock, err))
+    if (! slot.load (std::filesystem::u8path (path), 48000.0, kBlock, err))
     {
         SUCCEED ("bundle has no loadable audio effect (" + err + ") — skipping");
         return;
@@ -97,15 +98,15 @@ TEST_CASE ("NativeLv2Slot loads, processes, and unloads cleanly", "[lv2][slot]")
 
     SECTION ("explicit plugin id: round-trips, bogus id refuses to load")
     {
-        const juce::String pickedId = slot.getPluginId();
-        REQUIRE (pickedId.isNotEmpty());
+        const std::string pickedId = slot.getPluginId();
+        REQUIRE (! pickedId.empty());
 
         slot.unload();
-        REQUIRE (slot.load (juce::File (juce::String (path)), 48000.0, kBlock, err, pickedId));
+        REQUIRE (slot.load (std::filesystem::u8path (path), 48000.0, kBlock, err, pickedId));
         REQUIRE (slot.getPluginId() == pickedId);
 
         slot.unload();
-        REQUIRE_FALSE (slot.load (juce::File (juce::String (path)), 48000.0, kBlock, err,
+        REQUIRE_FALSE (slot.load (std::filesystem::u8path (path), 48000.0, kBlock, err,
                                   "urn:duskstudio:no-such-plugin"));
         REQUIRE_FALSE (slot.isLoaded());
     }

--- a/tests/native_instrument_process.cpp
+++ b/tests/native_instrument_process.cpp
@@ -18,6 +18,8 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
+#include <filesystem>
+#include <string>
 #include <vector>
 
 namespace
@@ -85,7 +87,7 @@ TEST_CASE ("Native CLAP instrument produces audio from notes", "[clap][instrumen
 
     duskstudio::clap::NativeClapSlot slot;
     std::string err;
-    REQUIRE (slot.load (juce::File (juce::String (path)), 48000.0, kBlock, err));
+    REQUIRE (slot.load (std::filesystem::u8path (path), 48000.0, kBlock, err));
     REQUIRE (slot.isLoadedInstrument());
 
     driveSilence (slot, 188);   // ~2 s warmup: sample libraries stream their kits
@@ -105,14 +107,14 @@ TEST_CASE ("Native VST3 instrument produces audio from notes", "[vst3][instrumen
     duskstudio::vst3::Vst3Bundle bundle;
     std::string err;
     REQUIRE (bundle.load (path, err));
-    juce::String classId;
+    std::string classId;
     for (const auto& d : bundle.plugins())
-        if (d.isInstrument) { classId = juce::String (juce::CharPointer_UTF8 (d.id.c_str())); break; }
-    if (classId.isEmpty())
+        if (d.isInstrument) { classId = d.id; break; }
+    if (classId.empty())
     { SUCCEED ("module advertises no instrument class — skipping"); return; }
 
     duskstudio::vst3::NativeVst3Slot slot;
-    REQUIRE (slot.load (juce::File (juce::String (path)), 48000.0, kBlock, err, classId));
+    REQUIRE (slot.load (std::filesystem::u8path (path), 48000.0, kBlock, err, classId));
     // No isLoadedInstrument assert: instrument-flagged hybrids with an audio
     // input bus exist (drum-replacement tools). Notes making sound is the test.
 
@@ -136,7 +138,7 @@ TEST_CASE ("Native LV2 instrument produces audio from notes", "[lv2][instrument]
 
     duskstudio::lv2::NativeLv2Slot slot;
     std::string err;
-    REQUIRE (slot.load (juce::File (juce::String (path)), 48000.0, kBlock, err));
+    REQUIRE (slot.load (std::filesystem::u8path (path), 48000.0, kBlock, err));
     // No isLoadedInstrument assert: JUCE-built LV2 instruments expose an audio
     // input bus, so the layout legitimately isn't input-less. The strip's MIDI
     // branch only needs isLoaded — what matters is that notes make sound.

--- a/tests/plugin_backing_check.cpp
+++ b/tests/plugin_backing_check.cpp
@@ -34,14 +34,14 @@ TEST_CASE ("pluginBackingLooksDead classifies filesystem backings")
     {
         auto gone = root.getChildFile ("ghost.vst3");
         REQUIRE_FALSE (gone.exists());
-        REQUIRE (pluginBackingLooksDead (gone.getFullPathName()));
+        REQUIRE (pluginBackingLooksDead (gone.getFullPathName().toStdString()));
     }
 
     SECTION ("a present single-file backing is alive")
     {
         auto f = root.getChildFile ("plugin.so");
         f.replaceWithText ("ELF");
-        REQUIRE_FALSE (pluginBackingLooksDead (f.getFullPathName()));
+        REQUIRE_FALSE (pluginBackingLooksDead (f.getFullPathName().toStdString()));
     }
 
     SECTION ("an empty bundle directory is dead (hollow / broken install)")
@@ -51,7 +51,7 @@ TEST_CASE ("pluginBackingLooksDead classifies filesystem backings")
         auto bundle = root.getChildFile ("Hollow.vst3");
         bundle.getChildFile ("Contents/x86_64-linux").createDirectory();
         REQUIRE (bundle.isDirectory());
-        REQUIRE (pluginBackingLooksDead (bundle.getFullPathName()));
+        REQUIRE (pluginBackingLooksDead (bundle.getFullPathName().toStdString()));
     }
 
     SECTION ("a bundle directory holding any file is alive")
@@ -61,7 +61,7 @@ TEST_CASE ("pluginBackingLooksDead classifies filesystem backings")
         auto bundle = root.getChildFile ("Valid.vst3");
         bundle.getChildFile ("Contents/x86_64-linux").createDirectory();
         bundle.getChildFile ("Contents/x86_64-linux/Valid.so").replaceWithText ("ELF");
-        REQUIRE_FALSE (pluginBackingLooksDead (bundle.getFullPathName()));
+        REQUIRE_FALSE (pluginBackingLooksDead (bundle.getFullPathName().toStdString()));
     }
 
     root.deleteRecursively();

--- a/tests/sf2_reader_parse.cpp
+++ b/tests/sf2_reader_parse.cpp
@@ -18,7 +18,7 @@ TEST_CASE("Sf2Reader: rejects a non-SF2 file", "[sf2]")
     tmp.replaceWithText("this is not a soundfont");
     auto sf = duskstudio::readSf2(tmp);
     REQUIRE_FALSE(sf.ok);
-    REQUIRE(sf.error.isNotEmpty());
+    REQUIRE_FALSE(sf.error.empty());
     tmp.deleteFile();
 }
 
@@ -26,7 +26,7 @@ TEST_CASE("Sf2Reader: missing file errors cleanly", "[sf2]")
 {
     auto sf = duskstudio::readSf2(juce::File("/no/such/file.sf2"));
     REQUIRE_FALSE(sf.ok);
-    REQUIRE(sf.error.isNotEmpty());
+    REQUIRE_FALSE(sf.error.empty());
 }
 
 TEST_CASE("Sf2Reader: parses FluidR3 GM structure", "[sf2][.fixture]")
@@ -39,7 +39,7 @@ TEST_CASE("Sf2Reader: parses FluidR3 GM structure", "[sf2][.fixture]")
 
     auto sf = duskstudio::readSf2(kFluidR3);
     REQUIRE(sf.ok);
-    REQUIRE(sf.error.isEmpty());
+    REQUIRE(sf.error.empty());
 
     // GM bank: 128 melodic + percussion + GS extras. Exact count varies
     // by FluidR3 revision; assert a sane lower bound rather than ==.
@@ -54,7 +54,7 @@ TEST_CASE("Sf2Reader: parses FluidR3 GM structure", "[sf2][.fixture]")
     // Every preset has a name and at least one zone.
     for (const auto& p : sf.presets)
     {
-        REQUIRE(p.name.isNotEmpty());
+        REQUIRE_FALSE(p.name.empty());
         REQUIRE_FALSE(p.zones.empty());
     }
 

--- a/tests/sf2_to_sfz_convert.cpp
+++ b/tests/sf2_to_sfz_convert.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "engine/multisample/Sf2ToSfz.h"
+#include "foundation/Text.h"
 
 #include <juce_core/juce_core.h>
 
@@ -24,7 +25,7 @@ TEST_CASE("Sf2ToSfz: missing file fails cleanly", "[sf2conv]")
     auto dir = freshTempDir();
     auto conv = duskstudio::convertSf2Preset(juce::File("/no/such.sf2"), 0, dir);
     REQUIRE_FALSE(conv.ok);
-    REQUIRE(conv.error.isNotEmpty());
+    REQUIRE_FALSE(conv.error.empty());
     dir.deleteRecursively();
 }
 
@@ -40,14 +41,14 @@ TEST_CASE("Sf2ToSfz: converts FluidR3 preset 0 to SFZ + WAVs", "[sf2conv][.fixtu
     auto conv = duskstudio::convertSf2Preset(kFluidR3, 0, dir);
 
     REQUIRE(conv.ok);
-    REQUIRE(conv.error.isEmpty());
-    REQUIRE(conv.presetName.isNotEmpty());
+    REQUIRE(conv.error.empty());
+    REQUIRE_FALSE(conv.presetName.empty());
 
     // SFZ body has the expected scaffolding + at least one region.
-    REQUIRE(conv.sfzText.contains("<region>"));
-    REQUIRE(conv.sfzText.contains("sample="));
-    REQUIRE(conv.sfzText.contains("pitch_keycenter="));
-    REQUIRE(conv.sfzText.contains("lokey="));
+    REQUIRE(dusk::text::contains(conv.sfzText, "<region>"));
+    REQUIRE(dusk::text::contains(conv.sfzText, "sample="));
+    REQUIRE(dusk::text::contains(conv.sfzText, "pitch_keycenter="));
+    REQUIRE(dusk::text::contains(conv.sfzText, "lokey="));
 
     // At least one WAV was extracted into the sample dir, and each
     // sample= name in the SFZ resolves to a real file there.
@@ -55,10 +56,10 @@ TEST_CASE("Sf2ToSfz: converts FluidR3 preset 0 to SFZ + WAVs", "[sf2conv][.fixtu
     REQUIRE(wavs.size() > 0);
 
     // Spot-check the first region's sample resolves on disk.
-    const int regionIdx = conv.sfzText.indexOf("sample=");
-    REQUIRE(regionIdx >= 0);
-    auto afterEq = conv.sfzText.substring(regionIdx + 7);
-    const auto name = afterEq.upToFirstOccurrenceOf(" ", false, false).trim();
+    const auto regionIdx = conv.sfzText.find("sample=");
+    REQUIRE(regionIdx != std::string::npos);
+    const auto afterEq = conv.sfzText.substr(regionIdx + 7);
+    const auto name = dusk::text::trim(afterEq.substr(0, afterEq.find(' ')));
     REQUIRE(dir.getChildFile(name).existsAsFile());
 
     dir.deleteRecursively();

--- a/tests/vst3_native_slot.cpp
+++ b/tests/vst3_native_slot.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
+#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -56,7 +57,7 @@ TEST_CASE ("NativeVst3Slot loads, processes, and unloads cleanly", "[vst3][slot]
     std::string err;
     constexpr int kBlock = 256;
 
-    if (! slot.load (juce::File (juce::String (path)), 48000.0, kBlock, err))
+    if (! slot.load (std::filesystem::u8path (path), 48000.0, kBlock, err))
     {
         SUCCEED ("module has no loadable audio effect (" + err + ") — skipping");
         return;
@@ -119,15 +120,15 @@ TEST_CASE ("NativeVst3Slot loads, processes, and unloads cleanly", "[vst3][slot]
 
     SECTION ("explicit plugin id: round-trips, bogus id refuses to load")
     {
-        const juce::String pickedId = slot.getPluginId();
-        REQUIRE (pickedId.isNotEmpty());
+        const std::string pickedId = slot.getPluginId();
+        REQUIRE (! pickedId.empty());
 
         slot.unload();
-        REQUIRE (slot.load (juce::File (juce::String (path)), 48000.0, kBlock, err, pickedId));
+        REQUIRE (slot.load (std::filesystem::u8path (path), 48000.0, kBlock, err, pickedId));
         REQUIRE (slot.getPluginId() == pickedId);
 
         slot.unload();
-        REQUIRE_FALSE (slot.load (juce::File (juce::String (path)), 48000.0, kBlock, err,
+        REQUIRE_FALSE (slot.load (std::filesystem::u8path (path), 48000.0, kBlock, err,
                                   "urn:duskstudio:no-such-plugin"));
         REQUIRE_FALSE (slot.isLoaded());
     }

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -30,7 +30,6 @@ src/engine/McuController.h
 src/engine/NativeScanRows.h
 src/engine/PlaybackEngine.cpp
 src/engine/PlaybackEngine.h
-src/engine/PluginBackingCheck.h
 src/engine/PluginManager.cpp
 src/engine/PluginManager.h
 src/engine/PluginSlot.cpp


### PR DESCRIPTION
## What this is

The next de-JUCE tower: juce::String off the engine's internal surfaces, onto std::string + dusk::text. Ratchet moves 202 -> 201.

## Commits

1. dusk::text::format - narrow vsnprintf printf-style helper replacing String::formatted. Unlike JUCE's (wide printf on MSVC, where %s reads char* as wchar_t*), %s with .c_str() is safe on every platform; the FileImporter workaround that avoided %s is deleted. A/B-tested against juce::String::formatted for numeric patterns.
2. PluginBackingCheck.h fully JUCE-free (the ratchet mover): std::string + std::filesystem, with a hand-rolled absolute-path check that reproduces JUCE's exact rule.
3. SF2 reader/converter: names, errors, and sfz text as std::string. RIFF name bytes copied verbatim; sanitize keeps UTF-8 lead/continuation bytes intact.
4. NativeInsertSlot: load/getPath/getPluginId on std::string + filesystem::path (the instance layer underneath was already std, so this deletes conversions). juce::MidiBuffer stays - that boundary belongs to the MIDI tower.
5. Importers, self-test, crash handler: error/report/name surfaces to std::string. BounceEngine deliberately keeps its juce::String surfaces - it was rewritten by the stems/realtime work (#66) after this sweep started, so its flip rides a later pass rather than a rebase-resolution rewrite.
6. McuController LCD formatters.

Scope notes: only files whose String use is internal or engine-facing; Session.h (UI writes its String members), the ALSA backend (JUCE virtual signatures), and the hosting/device layers (String dies with their own towers) are deliberately excluded.

## Verification

- Full ctest green including new foundation_text_format A/B tests; gate 202 -> 201 with nothing added.
- DUSKSTUDIO_BOUNCE_TEST harness (real CLAP insert): ALL PASS.
- Xvfb selftest 27/27. Rebased onto the merged #66/#67/#68 line and fully re-verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when loading CLAP, LV2, and VST3 plugins, including plugin identifiers and filesystem paths.
  * Improved detection of unavailable or incomplete plugin files and bundles.
  * Improved DP song import warnings and error messages.
  * Improved reliability of SF2/SFZ conversion and native instrument loading.

* **Diagnostics**
  * Audio self-test and performance reports now display consistently across supported platforms.

* **Tests**
  * Expanded coverage for text formatting, plugin loading, file importing, and sound-font conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->