### PR TITLE
De-JUCE: BounceEngine error and naming surfaces onto std::string

### DIFF
--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -1042,7 +1042,7 @@ struct DuskStudioApp::BounceTest : private juce::Timer
                              BounceEngine::Format::Wav))
         {
             std::fprintf (stdout, "[FAIL] MasterMix bounce start() returned false: %s\n",
-                          bounce->getLastError().toRawUTF8());
+                          bounce->getLastError().c_str());
             exitCode = 1;
             return false;
         }
@@ -1316,7 +1316,7 @@ private:
                 else if (++freezeAttempts > 40)
                 {
                     std::fprintf (stdout, "[FAIL] Freeze: startFreeze() would not start: %s\n",
-                                  bounce->getLastError().toRawUTF8());
+                                  bounce->getLastError().c_str());
                     exitCode = 1;
                     finish();
                 }
@@ -1383,7 +1383,7 @@ private:
                 else if (++stemsAttempts > 40)
                 {
                     std::fprintf (stdout, "[FAIL] Stems: start() would not start: %s\n",
-                                  bounce->getLastError().toRawUTF8());
+                                  bounce->getLastError().c_str());
                     exitCode = 1;
                     finish();
                 }

--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -1028,7 +1028,7 @@ struct DuskStudioApp::BounceTest : private juce::Timer
 
         bounce = std::make_unique<BounceEngine> (*engine, *session,
                                                  engine->getDeviceManager());
-        bounce->onFinished = [this] (bool ok, juce::String err)
+        bounce->onFinished = [this] (bool ok, std::string err)
         {
             // Worker thread. Record + let the poll timer pick it up on the message
             // thread. masterDone is the release fence.
@@ -1265,10 +1265,10 @@ private:
                     if (! cb)
                         std::fprintf (stdout, "[FAIL] MasterMix: engine produced non-finite output "
                                               "on the post-bounce callback\n");
-                    const bool ok = masterOk && masterErr.isEmpty() && wav && cb;
-                    if (! masterOk || masterErr.isNotEmpty())
+                    const bool ok = masterOk && masterErr.empty() && wav && cb;
+                    if (! masterOk || ! masterErr.empty())
                         std::fprintf (stdout, "[FAIL] MasterMix: worker reported ok=%d err=\"%s\"\n",
-                                      (int) masterOk, masterErr.toRawUTF8());
+                                      (int) masterOk, masterErr.c_str());
                     if (ok)
                         std::fprintf (stdout,
                                       "[PASS] MasterMix render OK (peak=%.4f, engine reattached + "
@@ -1301,7 +1301,7 @@ private:
                 // startFreeze() starts on the first tick.
                 bounce = std::make_unique<BounceEngine> (*engine, *session,
                                                          engine->getDeviceManager());
-                bounce->onFinished = [this] (bool ok, juce::String err)
+                bounce->onFinished = [this] (bool ok, std::string err)
                 {
                     freezeOk  = ok;
                     freezeErr = err;
@@ -1329,10 +1329,10 @@ private:
                 {
                     float peak = 0.0f;
                     const bool wav = validateWav (freezeFile, "Freeze", peak);
-                    const bool ok  = freezeOk && freezeErr.isEmpty() && wav;
-                    if (! freezeOk || freezeErr.isNotEmpty())
+                    const bool ok  = freezeOk && freezeErr.empty() && wav;
+                    if (! freezeOk || ! freezeErr.empty())
                         std::fprintf (stdout, "[FAIL] Freeze: worker reported ok=%d err=\"%s\"\n",
-                                      (int) freezeOk, freezeErr.toRawUTF8());
+                                      (int) freezeOk, freezeErr.c_str());
                     if (ok)
                         std::fprintf (stdout,
                                       "[PASS] Freeze render OK (peak=%.4f, plugin processed through "
@@ -1368,7 +1368,7 @@ private:
 
                 bounce = std::make_unique<BounceEngine> (*engine, *session,
                                                          engine->getDeviceManager());
-                bounce->onFinished = [this] (bool ok, juce::String err)
+                bounce->onFinished = [this] (bool ok, std::string err)
                 {
                     stemsOk  = ok;
                     stemsErr = err;
@@ -1394,10 +1394,10 @@ private:
             {
                 if (stemsDone.load (std::memory_order_acquire))
                 {
-                    bool ok = stemsOk && stemsErr.isEmpty();
+                    bool ok = stemsOk && stemsErr.empty();
                     if (! ok)
                         std::fprintf (stdout, "[FAIL] Stems: worker reported ok=%d err=\"%s\"\n",
-                                      (int) stemsOk, stemsErr.toRawUTF8());
+                                      (int) stemsOk, stemsErr.c_str());
 
                     const auto targets = BounceEngine::collectStemTargets (*session, stemsBase);
                     int trackStems = 0, busStems = 0, auxStems = 0;
@@ -1505,7 +1505,7 @@ private:
     std::atomic<bool> freezeDone { false };
     std::atomic<bool> stemsDone  { false };
     bool masterOk = false, freezeOk = false, stemsOk = false;
-    juce::String masterErr, freezeErr, stemsErr;
+    std::string  masterErr, freezeErr, stemsErr;
 };
 
 // Resolve a session path passed on the command line / by the file manager.

--- a/src/engine/BounceEngine.cpp
+++ b/src/engine/BounceEngine.cpp
@@ -81,7 +81,7 @@ bool BounceEngine::runOnMessageThread (std::function<void()> fn)
 
 std::unique_ptr<juce::AudioFormatWriter>
 BounceEngine::makeWriter (std::unique_ptr<juce::FileOutputStream> outStream,
-                            juce::String& errOut) const
+                            std::string& errOut) const
 {
     constexpr unsigned kNumChannels = 2;   // bounce is always stereo
 
@@ -249,7 +249,7 @@ void BounceEngine::run()
     {
         const bool ok = runRealtimeMode();
         rendering.store (false, std::memory_order_relaxed);
-        juce::String errSnapshot;
+        std::string errSnapshot;
         {
             const juce::ScopedLock lock (lastErrorLock);
             errSnapshot = lastError;
@@ -262,7 +262,7 @@ void BounceEngine::run()
     {
         const bool ok = runStemsMode();
         rendering.store (false, std::memory_order_relaxed);
-        juce::String errSnapshot;
+        std::string errSnapshot;
         {
             const juce::ScopedLock lock (lastErrorLock);
             errSnapshot = lastError;
@@ -277,7 +277,7 @@ void BounceEngine::run()
                                             freezeLenSamples, renderSampleRate,
                                             renderBlockSize);
         rendering.store (false, std::memory_order_relaxed);
-        juce::String errSnapshot;
+        std::string errSnapshot;
         {
             const juce::ScopedLock lock (lastErrorLock);
             errSnapshot = lastError;
@@ -291,7 +291,7 @@ void BounceEngine::run()
     std::unique_ptr<juce::FileOutputStream> outStream (outputFile.createOutputStream());
     if (outStream == nullptr)
     {
-        juce::String err = "Could not open output file " + outputFile.getFullPathName();
+        const std::string err = ("Could not open output file " + outputFile.getFullPathName()).toStdString();
         {
             const juce::ScopedLock lock (lastErrorLock);
             lastError = err;
@@ -304,7 +304,7 @@ void BounceEngine::run()
     outStream->truncate();
 
     constexpr int kNumChannels = 2;   // bounce is always stereo
-    juce::String writerErr;
+    std::string writerErr;
     std::unique_ptr<juce::AudioFormatWriter> writer = makeWriter (std::move (outStream), writerErr);
     if (writer == nullptr)
     {
@@ -451,7 +451,7 @@ void BounceEngine::run()
             if (! writer->writeFromFloatArrays (offPtrs.data(), kNumChannels, writeCount))
             {
                 const juce::ScopedLock lock (lastErrorLock);
-                lastError = "Writer failed mid-render at " + juce::String (written) + " samples";
+                lastError = "Writer failed mid-render at " + std::to_string (written) + " samples";
                 succeeded = false;
                 break;
             }
@@ -512,7 +512,7 @@ void BounceEngine::run()
     });
 
     rendering.store (false, std::memory_order_relaxed);
-    juce::String errSnapshot;
+    std::string errSnapshot;
     {
         const juce::ScopedLock lock (lastErrorLock);
         errSnapshot = lastError;
@@ -521,19 +521,19 @@ void BounceEngine::run()
 }
 
 std::unique_ptr<juce::AudioFormatWriter>
-BounceEngine::openWriterFor (const juce::File& outFile, juce::String& errOut) const
+BounceEngine::openWriterFor (const juce::File& outFile, std::string& errOut) const
 {
     std::unique_ptr<juce::FileOutputStream> outStream (outFile.createOutputStream());
     if (outStream == nullptr)
     {
-        errOut = "Could not open output file " + outFile.getFullPathName();
+        errOut = ("Could not open output file " + outFile.getFullPathName()).toStdString();
         return nullptr;
     }
     outStream->setPosition (0);
     outStream->truncate();
     auto writer = makeWriter (std::move (outStream), errOut);
     if (writer == nullptr)
-        errOut += " (" + outFile.getFileName() + ")";
+        errOut += (" (" + outFile.getFileName() + ")").toStdString();
     return writer;
 }
 
@@ -617,7 +617,7 @@ bool BounceEngine::runStemsMode()
     writers.reserve ((size_t) numStems);
     for (const auto& tgt : targets)
     {
-        juce::String writerErr;
+        std::string writerErr;
         auto writer = openWriterFor (tgt.file, writerErr);
         if (writer == nullptr)
         {
@@ -708,8 +708,8 @@ bool BounceEngine::runStemsMode()
                     {
                         const juce::ScopedLock lock (lastErrorLock);
                         lastError = "Writer failed mid-stem at "
-                                    + juce::String (writtenFor[(size_t) i]) + " samples in "
-                                    + targets[(size_t) i].file.getFileName();
+                                    + std::to_string (writtenFor[(size_t) i]) + " samples in "
+                                    + targets[(size_t) i].file.getFileName().toStdString();
                         succeeded = false;
                         break;
                     }
@@ -812,7 +812,7 @@ bool BounceEngine::runRealtimeMode()
     writers.reserve ((size_t) numFiles);
     for (const auto& f : files)
     {
-        juce::String writerErr;
+        std::string writerErr;
         auto writer = openWriterFor (f.file, writerErr);
         if (writer == nullptr)
         {
@@ -1050,14 +1050,14 @@ bool BounceEngine::renderFreezeTrack (int trackIndex, const juce::File& outFile,
     if (outStream == nullptr)
     {
         const juce::ScopedLock lock (lastErrorLock);
-        lastError = "Could not open freeze file " + outFile.getFullPathName();
+        lastError = ("Could not open freeze file " + outFile.getFullPathName()).toStdString();
         return false;
     }
     outStream->setPosition (0);
     outStream->truncate();
 
     constexpr int kNumChannels = 2;
-    juce::String writerErr;
+    std::string writerErr;
     std::unique_ptr<juce::AudioFormatWriter> writer = makeWriter (std::move (outStream), writerErr);
     if (writer == nullptr)
     {
@@ -1165,7 +1165,7 @@ bool BounceEngine::renderFreezeTrack (int trackIndex, const juce::File& outFile,
             if (! writer->writeFromFloatArrays (capPtrs, kNumChannels, writeCount))
             {
                 const juce::ScopedLock lock (lastErrorLock);
-                lastError = "Writer failed mid-freeze at " + juce::String (written) + " samples";
+                lastError = "Writer failed mid-freeze at " + std::to_string (written) + " samples";
                 ok = false;
                 break;
             }

--- a/src/engine/BounceEngine.h
+++ b/src/engine/BounceEngine.h
@@ -3,6 +3,7 @@
 #include <juce_audio_devices/juce_audio_devices.h>
 #include <juce_audio_formats/juce_audio_formats.h>
 #include "../session/Session.h"
+#include "../foundation/Text.h"
 #include <array>
 #include <atomic>
 #include <functional>
@@ -53,39 +54,40 @@ public:
     // AudioEngine + Session + the bounce loop.
     static juce::File stemOutputFile (const juce::File& base,
                                         int trackIndexZeroBased,
-                                        const juce::String& trackName)
+                                        const std::string& trackName)
     {
         auto dir  = base.getParentDirectory();
         auto stem = base.getFileNameWithoutExtension();
         if (stem.isEmpty()) stem = "bounce";
 
-        auto safeName = trackName.trim();
-        if (safeName.isEmpty() || safeName == juce::String (trackIndexZeroBased + 1))
+        auto safeName = dusk::text::trim (trackName);
+        if (safeName.empty() || safeName == std::to_string (trackIndexZeroBased + 1))
             safeName = "track";
 
-        safeName = juce::File::createLegalFileName (safeName);
-        if (safeName.isEmpty()) safeName = "track";
+        safeName = juce::File::createLegalFileName (safeName).toStdString();
+        if (safeName.empty()) safeName = "track";
 
         // Stems are always WAV regardless of the base file's extension: start()
         // forces Format::Wav for Stems mode (MP3 encoder delay + frame padding
         // would shift each stem and break the sample-accurate alignment a
         // re-import needs).
-        const auto idx = juce::String (trackIndexZeroBased + 1).paddedLeft ('0', 2);
+        const auto idx = dusk::text::paddedLeft (std::to_string (trackIndexZeroBased + 1), '0', 2);
         return dir.getChildFile (stem + "_" + idx + "_" + safeName + ".wav");
     }
 
     // <dir>/<base>_<tag>_<safe>.wav for bus / aux stems (tag = "bus1".."aux4").
     // Falls back to the tag alone when the unit has no usable name.
     static juce::File namedStemOutputFile (const juce::File& base,
-                                             const juce::String& tag,
-                                             const juce::String& unitName)
+                                             const std::string& tag,
+                                             const std::string& unitName)
     {
         auto dir  = base.getParentDirectory();
         auto stem = base.getFileNameWithoutExtension();
         if (stem.isEmpty()) stem = "bounce";
 
-        auto safeName = juce::File::createLegalFileName (unitName.trim());
-        return dir.getChildFile (safeName.isEmpty()
+        const auto safeName =
+            juce::File::createLegalFileName (dusk::text::trim (unitName)).toStdString();
+        return dir.getChildFile (safeName.empty()
                                     ? stem + "_" + tag + ".wav"
                                     : stem + "_" + tag + "_" + safeName + ".wav");
     }
@@ -125,7 +127,7 @@ public:
             if (! (hasContent || armed)) continue;
 
             targets.push_back ({ StemTarget::Kind::Track, t,
-                                 stemOutputFile (base, t, tr.name) });
+                                 stemOutputFile (base, t, tr.name.toStdString()) });
 
             for (int a = 0; a < Session::kNumBuses; ++a)
                 if (tr.strip.busAssign[(size_t) a].load (std::memory_order_relaxed))
@@ -149,13 +151,13 @@ public:
         for (int a = 0; a < Session::kNumBuses; ++a)
             if (busActive[(size_t) a])
                 targets.push_back ({ StemTarget::Kind::Bus, a,
-                                     namedStemOutputFile (base, "bus" + juce::String (a + 1),
-                                                            session.bus (a).name) });
+                                     namedStemOutputFile (base, "bus" + std::to_string (a + 1),
+                                                            session.bus (a).name.toStdString()) });
         for (int a = 0; a < Session::kNumAuxLanes; ++a)
             if (auxActive[(size_t) a])
                 targets.push_back ({ StemTarget::Kind::Aux, a,
-                                     namedStemOutputFile (base, "aux" + juce::String (a + 1),
-                                                            session.auxLane (a).name) });
+                                     namedStemOutputFile (base, "aux" + std::to_string (a + 1),
+                                                            session.auxLane (a).name.toStdString()) });
         return targets;
     }
 
@@ -233,9 +235,10 @@ public:
     float        getProgress() const noexcept { return progress.load (std::memory_order_relaxed); }
     int          getTotalStemsToRender() const noexcept
         { return totalStemsToRender.load (std::memory_order_relaxed); }
-    juce::String getLastError() const
+    std::string getLastError() const
     {
-        // juce::String is refcounted; concurrent copy races the refcount.
+        // A std::string copy concurrent with a writer is UB; the lock is
+        // load-bearing.
         const juce::ScopedLock lock (lastErrorLock);
         return lastError;
     }
@@ -244,7 +247,7 @@ public:
     // Called on the worker thread. Use MessageManager::callAsync for UI.
     std::function<void()>                  onStarted;
     std::function<void(float)>             onProgressUpdated;
-    std::function<void(bool, juce::String)> onFinished;
+    std::function<void(bool, std::string)> onFinished;
 
 private:
     void run() override;
@@ -288,7 +291,7 @@ private:
     std::atomic<float> progress         { 0.0f };
     std::atomic<std::int64_t> renderedSamples { 0 };
     std::atomic<int>   totalStemsToRender { 0 };
-    juce::String lastError;
+    std::string lastError;
     juce::CriticalSection lastErrorLock;
 
     std::int64_t computeBounceLength (double sampleRate, double tail) const;
@@ -297,13 +300,13 @@ private:
     // (truncated) output stream. Returns null + sets errOut on failure. Takes
     // ownership of outStream on success; on failure outStream is freed.
     std::unique_ptr<juce::AudioFormatWriter>
-        makeWriter (std::unique_ptr<juce::FileOutputStream> outStream, juce::String& errOut) const;
+        makeWriter (std::unique_ptr<juce::FileOutputStream> outStream, std::string& errOut) const;
 
     // Open + truncate outFile, then wrap it in the configured format writer.
     // Null + errOut on failure - the file may already be truncated by then,
     // so failure paths that must preserve prior content delete it.
     std::unique_ptr<juce::AudioFormatWriter>
-        openWriterFor (const juce::File& outFile, juce::String& errOut) const;
+        openWriterFor (const juce::File& outFile, std::string& errOut) const;
 
     // Stem-tap registry plumbing shared by the offline and realtime stem
     // renders. Arm and clear must cover the same tap set or a render leaves

--- a/src/ui/BounceDialog.cpp
+++ b/src/ui/BounceDialog.cpp
@@ -180,7 +180,7 @@ void BounceDialog::finalizeIfStopped()
 
     finished = true;
     const auto err = bounceEngine->getLastError();
-    succeeded = err.isEmpty();
+    succeeded = err.empty();
 
     if (succeeded)
     {

--- a/src/ui/FreezeDialog.cpp
+++ b/src/ui/FreezeDialog.cpp
@@ -74,8 +74,8 @@ FreezeDialog::FreezeDialog (AudioEngine& e, Session& s,
         // freeze render thread"); only fall back to the generic message if it's empty.
         const auto startErr = bounceEngine->getLastError();
         failBeforeStart ("Freeze failed",
-                         startErr.isNotEmpty() ? startErr
-                                               : juce::String ("A render is already in progress."));
+                         ! startErr.empty() ? juce::String (startErr)
+                                            : juce::String ("A render is already in progress."));
         return;
     }
 
@@ -129,7 +129,7 @@ void FreezeDialog::finalizeIfStopped()
 
     finished = true;
     const auto err = bounceEngine->getLastError();
-    succeeded = err.isEmpty();
+    succeeded = err.empty();
 
     if (succeeded)
     {


### PR DESCRIPTION
The piece deferred from the String sweep (#69): BounceEngine was rewritten by the stems/realtime work mid-sweep, so its flip waited for the merged code.

- stemOutputFile / namedStemOutputFile take std::string names (dusk::text trim/paddedLeft inside; juce::File only at the filesystem boundary).
- getLastError / lastError / onFinished / makeWriter and openWriterFor error-outs carry std::string. The lastError lock stays - a std::string copy racing a writer is UB, the lock is load-bearing.
- Error messages assemble via std::to_string with toStdString bridges at juce::File name reads.
- Bridges re-flipped in BounceDialog, FreezeDialog, MainComponent, and the DUSKSTUDIO_BOUNCE_TEST harness.

BounceEngine keeps its allowlist line (Thread, File, audio-format layer are other towers), so the gate holds at 201 with nothing added.

Verification: full ctest green, bounce harness (real CLAP insert) ALL PASS, Xvfb selftest 27/27.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when audio bounce, freeze, or stem rendering fails.
  * Corrected completion checks so successful renders, cancellations, and failures are identified more reliably.
  * Improved handling and display of freeze failure messages.
  * Preserved existing rendering behavior and pass/fail outcomes while making failure details clearer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->