### PR TITLE
Monitor live audio input (and its aux sends) during playback

### DIFF
--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -3937,7 +3937,8 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
                 if (stereoTrackInput)
                 {
                     const int rIdxMon = session.resolveInputRForTrack (t);
-                    if (rIdxMon >= 0 && rIdxMon < numInputChannels)
+                    if (rIdxMon >= 0 && rIdxMon < numInputChannels
+                        && inputChannelData[(size_t) rIdxMon] != nullptr)
                         juce::FloatVectorOperations::add (playbackScratchR[(size_t) t].data(),
                                                             inputChannelData[(size_t) rIdxMon],
                                                             numSamples);

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -3921,6 +3921,29 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
             playbackEngine.readForTrack (t, blockStartSamples,
                                           playbackScratch[(size_t) t].data(), outR,
                                           numSamples, loopReadStart, loopReadEnd);
+
+            // Live-audio play-along overlay, the audio twin of the MIDI overlay
+            // below. Playing forces willReadFromDisk, so without this an
+            // IN-monitored audio track hears only the disk take and every send
+            // fed from its live input is silent while rolling. Sum the live input
+            // on top of the take so the strip, and its aux sends, process both,
+            // matching Record. Frozen (baked WAV, no live input), MIDI (served by
+            // its own overlay) and offline renders (deterministic) are excluded.
+            if (monitorEnabled && ! midiTrack && ! isFrozen && ! offlineRender
+                && deviceInput != nullptr)
+            {
+                juce::FloatVectorOperations::add (playbackScratch[(size_t) t].data(),
+                                                    deviceInput, numSamples);
+                if (stereoTrackInput)
+                {
+                    const int rIdxMon = session.resolveInputRForTrack (t);
+                    if (rIdxMon >= 0 && rIdxMon < numInputChannels)
+                        juce::FloatVectorOperations::add (playbackScratchR[(size_t) t].data(),
+                                                            inputChannelData[(size_t) rIdxMon],
+                                                            numSamples);
+                }
+            }
+
             monoIn = playbackScratch[(size_t) t].data();
         }
         else if (deviceInput != nullptr && (armed || monitorEnabled) && ! isFrozen)

--- a/src/engine/AudioPipelineSelfTest.cpp
+++ b/src/engine/AudioPipelineSelfTest.cpp
@@ -1234,6 +1234,102 @@ juce::String AudioPipelineSelfTest::testMidiPlayAlongMonitor()
         pass ? "" : "<-- live MIDI dropped (play-along must sound while rolling)");
 }
 
+juce::String AudioPipelineSelfTest::testAudioPlayAlongSends()
+{
+    // Regression guard for the audio twin of the MIDI play-along fix: an
+    // input-monitored (IN) audio track must feed its aux sends in every
+    // transport state. Playing forces the disk-playback source branch; the
+    // live-audio overlay merges the input on top of the disk take so the strip,
+    // and its sends, process both while rolling.
+    //
+    // Observable: aux lane 0's post meter. The lane is left empty (no plugin),
+    // so it dry-passes whatever the strip sends into it; a silent send makes
+    // the lane's input-silent skip engage and pin the meter at -100 dBFS, while
+    // any real send drives it well above the floor.
+    prepareCleanState();
+
+    const double sr = 48000.0;
+    const int    bs = 256;
+    const int    numIn = 2, numOut = 2;
+
+    engine.prepareForSelfTest (sr, bs);
+
+    auto& t0 = session.track (0);
+    auto& ts0 = t0.strip;
+    auto& aux0 = session.auxLane (0).params;
+
+    // Snapshot the atoms the outer runAll restore doesn't cover.
+    const float savedSend   = ts0.auxSendDb[0].load (std::memory_order_relaxed);
+    const bool  savedAuxMute = aux0.mute.load (std::memory_order_relaxed);
+
+    // Track 0: mono, input-monitored, listening to input channel 0, sending to
+    // aux lane 0 at unity. Other tracks muted so only track 0 can drive aux 0.
+    t0.mode.store         ((int) Track::Mode::Mono, std::memory_order_relaxed);
+    t0.inputSource.store  (0, std::memory_order_relaxed);
+    t0.inputMonitor.store (true, std::memory_order_relaxed);
+    t0.recordArmed.store  (false, std::memory_order_relaxed);
+    ts0.mute.store        (false, std::memory_order_relaxed);
+    ts0.faderDb.store     (0.0f, std::memory_order_relaxed);
+    ts0.auxSendDb[0].store (0.0f, std::memory_order_relaxed);
+    aux0.mute.store       (false, std::memory_order_relaxed);
+    for (int t = 1; t < Session::kNumTracks; ++t)
+    {
+        session.track (t).inputMonitor.store (false, std::memory_order_relaxed);
+        session.track (t).strip.mute.store (true, std::memory_order_relaxed);
+    }
+    session.recomputeRtCounters();
+
+    std::vector<std::vector<float>> inb ((size_t) numIn, std::vector<float> ((size_t) bs, 0.0f));
+    std::vector<const float*> inp ((size_t) numIn, nullptr);
+    for (int c = 0; c < numIn; ++c) inp[(size_t) c] = inb[(size_t) c].data();
+    std::vector<std::vector<float>> outb ((size_t) numOut, std::vector<float> ((size_t) bs, 0.0f));
+    std::vector<float*> outp ((size_t) numOut, nullptr);
+    for (int c = 0; c < numOut; ++c) outp[(size_t) c] = outb[(size_t) c].data();
+    juce::AudioIODeviceCallbackContext ctx {};
+
+    const double inc = 2.0 * juce::MathConstants<double>::pi * 1000.0 / sr;
+    double phase = 0.0;
+
+    auto probe = [&] (Transport::State st) -> float
+    {
+        engine.getTransport().setPlayhead (0);
+        engine.getTransport().setState (st);
+        // A few settle blocks so the send-gain / return smoothers reach the
+        // steady state before the meter is read.
+        for (int b = 0; b < 8; ++b)
+        {
+            for (int s = 0; s < bs; ++s)
+            {
+                inb[0][(size_t) s] = 0.5f * (float) std::sin (phase);
+                phase += inc;
+            }
+            for (auto& o : outb) std::fill (o.begin(), o.end(), 0.0f);
+            engine.audioDeviceIOCallbackWithContext (inp.data(), numIn, outp.data(),
+                                                      numOut, bs, ctx);
+        }
+        return aux0.meterPostL.load (std::memory_order_relaxed);
+    };
+
+    const float stoppedDb = probe (Transport::State::Stopped);
+    const float playingDb  = probe (Transport::State::Playing);
+
+    // Restore.
+    engine.getTransport().setState (Transport::State::Stopped);
+    ts0.auxSendDb[0].store (savedSend, std::memory_order_relaxed);
+    aux0.mute.store        (savedAuxMute, std::memory_order_relaxed);
+
+    constexpr float kFloorDb = -60.0f;
+    const bool stoppedOK = stoppedDb > kFloorDb;
+    const bool playingOK = playingDb  > kFloorDb;
+    const bool pass = stoppedOK && playingOK;
+    return juce::String::formatted (
+        "%s Audio play-along sends (IN audio track feeds aux 0 each state)\n"
+        "      stopped=%.1f dB  playing=%.1f dB  (floor %.0f dB) %s",
+        fmtPassFail (pass).toRawUTF8(),
+        (double) stoppedDb, (double) playingDb, (double) kFloorDb,
+        pass ? "" : "<-- monitored send dropped (must feed aux while rolling)");
+}
+
 juce::String AudioPipelineSelfTest::runAll()
 {
     juce::StringArray report;
@@ -1269,6 +1365,7 @@ juce::String AudioPipelineSelfTest::runAll()
     report.add (testCompPerTrack());
     report.add (testParallelMatchesSerial());
     report.add (testMidiPlayAlongMonitor());
+    report.add (testAudioPlayAlongSends());
     report.add ("");
 
    #if defined(__linux__)

--- a/src/engine/AudioPipelineSelfTest.h
+++ b/src/engine/AudioPipelineSelfTest.h
@@ -116,6 +116,7 @@ private:
     juce::String testCompPerTrack();         // all 16 tracks under Opto produce identical output
     juce::String testParallelMatchesSerial(); // worker-pool mix == serial mix within float-reassoc tol
     juce::String testMidiPlayAlongMonitor();   // armed+IN MIDI track sounds live notes in Stopped AND Playing
+    juce::String testAudioPlayAlongSends();    // IN audio track feeds its aux send in Stopped AND Playing
     juce::String testBackendsOpenCleanly();
     juce::String probeUMC1820AlsaFormat();   // explicitly open UMC1820 ALSA & report format
 


### PR DESCRIPTION
Playing forces the disk-playback source branch for every track, so an input-monitored (IN) audio track heard only the disk take: its live input and every send fed from it went silent the moment PLAY was pressed and returned on Record/Stop. This is the audio twin of the MIDI play-along bug fixed in #62, which only overlaid live MIDI.

Overlay the live device input on top of the disk take inside the disk-read branch when the track is monitoring, so the strip - and its aux sends - process both, matching Record. Frozen tracks (baked WAV), MIDI tracks (served by their own overlay) and offline renders (deterministic) are excluded.

Self-test testAudioPlayAlongSends drives an IN audio track with an aux send in Stopped and Playing and asserts aux lane 0 sees signal in both. Without the overlay it reads stopped=-9 dB, playing=-75 dB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live audio play-along during disk-based track playback when input monitoring is enabled.
  * Live input now continues through auxiliary sends during both stopped and playing transport states.

* **Tests**
  * Added automated coverage to verify monitored audio reaches auxiliary sends consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->