### PR TITLE
Pin donor DSP checkout across all CI workflows

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -76,11 +76,22 @@ jobs:
             modules/juce_dsp/native/juce_SIMDNativeOps_sse.h || {
             echo "ERROR: pinned JUCE missing the SIMDNativeOps<long long> alias." >&2; exit 1; }
 
-      - name: Clone Dusk plugins (donor DSP)
+      - name: Clone Dusk plugins (donor DSP, pinned)
+        # Pinned donor SHA (mirrors linux-release.yml). main consumes source
+        # files the donor's main HEAD has since relocated, so an unpinned
+        # clone breaks configure. Bump every workflow's DONOR_REV together.
+        env:
+          DONOR_REPO: https://github.com/dusk-audio/dusk-audio-plugins.git
+          DONOR_REV: 69f04318e3b7063e382c80ac1cde2388170e668b
         run: |
-          git clone --depth 1 \
-            https://github.com/dusk-audio/dusk-audio-plugins.git \
-            "${RUNNER_TEMP}/plugins-main"
+          set -euo pipefail
+          git init -q "${RUNNER_TEMP}/plugins-main"
+          cd "${RUNNER_TEMP}/plugins-main"
+          git remote add origin "${DONOR_REPO}"
+          git fetch --depth 1 origin "${DONOR_REV}"
+          git checkout -q "${DONOR_REV}"
+          [[ "$(git rev-parse HEAD)" == "${DONOR_REV}" ]] || {
+            echo "ERROR: donor checkout $(git rev-parse HEAD) != pinned ${DONOR_REV}" >&2; exit 1; }
 
       - name: Configure (Release)
         run: |
@@ -169,11 +180,22 @@ jobs:
             modules/juce_dsp/native/juce_SIMDNativeOps_sse.h || {
             echo "ERROR: pinned JUCE missing the SIMDNativeOps<long long> alias." >&2; exit 1; }
 
-      - name: Clone Dusk plugins (donor DSP)
+      - name: Clone Dusk plugins (donor DSP, pinned)
+        # Pinned donor SHA (mirrors linux-release.yml). main consumes source
+        # files the donor's main HEAD has since relocated, so an unpinned
+        # clone breaks configure. Bump every workflow's DONOR_REV together.
+        env:
+          DONOR_REPO: https://github.com/dusk-audio/dusk-audio-plugins.git
+          DONOR_REV: 69f04318e3b7063e382c80ac1cde2388170e668b
         run: |
-          git clone --depth 1 \
-            https://github.com/dusk-audio/dusk-audio-plugins.git \
-            "${RUNNER_TEMP}/plugins-main"
+          set -euo pipefail
+          git init -q "${RUNNER_TEMP}/plugins-main"
+          cd "${RUNNER_TEMP}/plugins-main"
+          git remote add origin "${DONOR_REPO}"
+          git fetch --depth 1 origin "${DONOR_REV}"
+          git checkout -q "${DONOR_REV}"
+          [[ "$(git rev-parse HEAD)" == "${DONOR_REV}" ]] || {
+            echo "ERROR: donor checkout $(git rev-parse HEAD) != pinned ${DONOR_REV}" >&2; exit 1; }
 
       - name: Configure tests
         run: |

--- a/.github/workflows/linux-sanitizer.yml
+++ b/.github/workflows/linux-sanitizer.yml
@@ -85,11 +85,22 @@ jobs:
             modules/juce_dsp/native/juce_SIMDNativeOps_sse.h || {
             echo "ERROR: pinned JUCE missing the SIMDNativeOps<long long> alias." >&2; exit 1; }
 
-      - name: Clone Dusk plugins (donor DSP)
+      - name: Clone Dusk plugins (donor DSP, pinned)
+        # Pinned donor SHA (mirrors linux-release.yml). main consumes source
+        # files the donor's main HEAD has since relocated, so an unpinned
+        # clone breaks configure. Bump every workflow's DONOR_REV together.
+        env:
+          DONOR_REPO: https://github.com/dusk-audio/dusk-audio-plugins.git
+          DONOR_REV: 69f04318e3b7063e382c80ac1cde2388170e668b
         run: |
-          git clone --depth 1 \
-            https://github.com/dusk-audio/dusk-audio-plugins.git \
-            "${RUNNER_TEMP}/plugins-main"
+          set -euo pipefail
+          git init -q "${RUNNER_TEMP}/plugins-main"
+          cd "${RUNNER_TEMP}/plugins-main"
+          git remote add origin "${DONOR_REPO}"
+          git fetch --depth 1 origin "${DONOR_REV}"
+          git checkout -q "${DONOR_REV}"
+          [[ "$(git rev-parse HEAD)" == "${DONOR_REV}" ]] || {
+            echo "ERROR: donor checkout $(git rev-parse HEAD) != pinned ${DONOR_REV}" >&2; exit 1; }
 
       - name: Configure tests (TSan, RelWithDebInfo)
         # RelWithDebInfo preserves -O2 (so the optimiser-driven memory

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -60,11 +60,22 @@ jobs:
             https://github.com/juce-framework/JUCE.git \
             "${RUNNER_TEMP}/JUCE"
 
-      - name: Clone Dusk plugins (donor DSP)
+      - name: Clone Dusk plugins (donor DSP, pinned)
+        # Pinned donor SHA (mirrors linux-release.yml). main consumes source
+        # files the donor's main HEAD has since relocated, so an unpinned
+        # clone breaks configure. Bump every workflow's DONOR_REV together.
+        env:
+          DONOR_REPO: https://github.com/dusk-audio/dusk-audio-plugins.git
+          DONOR_REV: 69f04318e3b7063e382c80ac1cde2388170e668b
         run: |
-          git clone --depth 1 \
-            https://github.com/dusk-audio/dusk-audio-plugins.git \
-            "${RUNNER_TEMP}/plugins-main"
+          set -euo pipefail
+          git init -q "${RUNNER_TEMP}/plugins-main"
+          cd "${RUNNER_TEMP}/plugins-main"
+          git remote add origin "${DONOR_REPO}"
+          git fetch --depth 1 origin "${DONOR_REV}"
+          git checkout -q "${DONOR_REV}"
+          [[ "$(git rev-parse HEAD)" == "${DONOR_REV}" ]] || {
+            echo "ERROR: donor checkout $(git rev-parse HEAD) != pinned ${DONOR_REV}" >&2; exit 1; }
 
       - name: Configure (Release)
         run: |

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -78,11 +78,24 @@ jobs:
             https://github.com/juce-framework/JUCE.git \
             "${RUNNER_TEMP}/JUCE"
 
-      - name: Clone Dusk plugins (donor DSP)
+      - name: Clone Dusk plugins (donor DSP, pinned)
+        # Pinned to the same donor SHA linux-release.yml uses. An unpinned
+        # clone of main HEAD makes old tags non-reproducible and breaks the
+        # build outright once the donor relocates a consumed source file.
+        # To move the donor forward, bump DONOR_REV here and in the other
+        # release workflows together.
+        env:
+          DONOR_REPO: https://github.com/dusk-audio/dusk-audio-plugins.git
+          DONOR_REV: 69f04318e3b7063e382c80ac1cde2388170e668b
         run: |
-          git clone --depth 1 \
-            https://github.com/dusk-audio/dusk-audio-plugins.git \
-            "${RUNNER_TEMP}/plugins-main"
+          set -euo pipefail
+          git init -q "${RUNNER_TEMP}/plugins-main"
+          cd "${RUNNER_TEMP}/plugins-main"
+          git remote add origin "${DONOR_REPO}"
+          git fetch --depth 1 origin "${DONOR_REV}"
+          git checkout -q "${DONOR_REV}"
+          [[ "$(git rev-parse HEAD)" == "${DONOR_REV}" ]] || {
+            echo "ERROR: donor checkout $(git rev-parse HEAD) != pinned ${DONOR_REV}" >&2; exit 1; }
 
       - name: Refresh Patreon supporters (best-effort)
         # See linux-release.yml for the rationale. Bakes the live list into the

--- a/.github/workflows/raspberry-pi-build.yml
+++ b/.github/workflows/raspberry-pi-build.yml
@@ -80,11 +80,22 @@ jobs:
               echo "ERROR: NEON SIMDNativeOps<long long> alias still missing after patch (awk anchor no longer matches the mirror header)." >&2; exit 1; }
           fi
 
-      - name: Clone Dusk plugins (donor DSP)
+      - name: Clone Dusk plugins (donor DSP, pinned)
+        # Pinned donor SHA (mirrors linux-release.yml). main consumes source
+        # files the donor's main HEAD has since relocated, so an unpinned
+        # clone breaks configure. Bump every workflow's DONOR_REV together.
+        env:
+          DONOR_REPO: https://github.com/dusk-audio/dusk-audio-plugins.git
+          DONOR_REV: 69f04318e3b7063e382c80ac1cde2388170e668b
         run: |
-          git clone --depth 1 \
-            https://github.com/dusk-audio/dusk-audio-plugins.git \
-            "${RUNNER_TEMP}/plugins-main"
+          set -euo pipefail
+          git init -q "${RUNNER_TEMP}/plugins-main"
+          cd "${RUNNER_TEMP}/plugins-main"
+          git remote add origin "${DONOR_REPO}"
+          git fetch --depth 1 origin "${DONOR_REV}"
+          git checkout -q "${DONOR_REV}"
+          [[ "$(git rev-parse HEAD)" == "${DONOR_REV}" ]] || {
+            echo "ERROR: donor checkout $(git rev-parse HEAD) != pinned ${DONOR_REV}" >&2; exit 1; }
 
       - name: Configure (Release)
         run: |

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -70,12 +70,25 @@ jobs:
             https://github.com/juce-framework/JUCE.git \
             "${RUNNER_TEMP}/JUCE"
 
-      - name: Clone Dusk plugins (donor DSP)
+      - name: Clone Dusk plugins (donor DSP, pinned)
+        # Pinned to the same donor SHA linux-release.yml uses. An unpinned
+        # clone of main HEAD makes old tags non-reproducible and breaks the
+        # build outright once the donor relocates a consumed source file.
+        # To move the donor forward, bump DONOR_REV here and in the other
+        # release workflows together.
         shell: bash
+        env:
+          DONOR_REPO: https://github.com/dusk-audio/dusk-audio-plugins.git
+          DONOR_REV: 69f04318e3b7063e382c80ac1cde2388170e668b
         run: |
-          git clone --depth 1 \
-            https://github.com/dusk-audio/dusk-audio-plugins.git \
-            "${RUNNER_TEMP}/plugins"
+          set -euo pipefail
+          git init -q "${RUNNER_TEMP}/plugins"
+          cd "${RUNNER_TEMP}/plugins"
+          git remote add origin "${DONOR_REPO}"
+          git fetch --depth 1 origin "${DONOR_REV}"
+          git checkout -q "${DONOR_REV}"
+          [[ "$(git rev-parse HEAD)" == "${DONOR_REV}" ]] || {
+            echo "ERROR: donor checkout $(git rev-parse HEAD) != pinned ${DONOR_REV}" >&2; exit 1; }
 
       - name: Refresh Patreon supporters (best-effort)
         # See linux-release.yml for the rationale. Bakes the live list into the

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -51,12 +51,23 @@ jobs:
             https://github.com/juce-framework/JUCE.git \
             "${RUNNER_TEMP}/JUCE"
 
-      - name: Clone Dusk plugins (donor DSP)
+      - name: Clone Dusk plugins (donor DSP, pinned)
+        # Pinned donor SHA (mirrors linux-release.yml). main consumes source
+        # files the donor's main HEAD has since relocated, so an unpinned
+        # clone breaks configure. Bump every workflow's DONOR_REV together.
         shell: bash
+        env:
+          DONOR_REPO: https://github.com/dusk-audio/dusk-audio-plugins.git
+          DONOR_REV: 69f04318e3b7063e382c80ac1cde2388170e668b
         run: |
-          git clone --depth 1 \
-            https://github.com/dusk-audio/dusk-audio-plugins.git \
-            "${RUNNER_TEMP}/plugins"
+          set -euo pipefail
+          git init -q "${RUNNER_TEMP}/plugins"
+          cd "${RUNNER_TEMP}/plugins"
+          git remote add origin "${DONOR_REPO}"
+          git fetch --depth 1 origin "${DONOR_REV}"
+          git checkout -q "${DONOR_REV}"
+          [[ "$(git rev-parse HEAD)" == "${DONOR_REV}" ]] || {
+            echo "ERROR: donor checkout $(git rev-parse HEAD) != pinned ${DONOR_REV}" >&2; exit 1; }
 
       - name: Fetch Steinberg ASIO SDK
         # Test binary itself doesn't use ASIO, but the top-level CMake


### PR DESCRIPTION
Every workflow except linux-release.yml cloned dusk-audio-plugins main HEAD unpinned. The donor relocated a consumed source file (UniversalCompressorDSP.cpp) on its main, so those unpinned clones now fail configure - this reddened the ENTIRE build/test matrix on every PR (not just releases; that's why this PR's own checks failed).

Pins all eight donor-consuming workflows (linux/macos/windows/raspberry-pi builds, windows/TSan tests, macos/windows release) to 69f04318 - the SHA linux-release.yml already used and that main builds against locally and shipped v0.12.3 with. Bump DONOR_REV everywhere together to move the donor forward.

Fixes the main CI breakage.