### PR TITLE
De-JUCE: native PipeWire audio backend

### DIFF
--- a/.github/workflows/raspberry-pi-build.yml
+++ b/.github/workflows/raspberry-pi-build.yml
@@ -28,11 +28,13 @@ jobs:
           persist-credentials: false
 
       - name: Install Linux build deps
-        # ports.ubuntu.com (the arm64 mirror) intermittently drops IPv6
-        # connectivity on GitHub's ARM runners, failing apt with "Network is
-        # unreachable" on the 2620:2d:: addresses. Force IPv4 to skip them and
-        # retry so a transient mirror hiccup doesn't red the whole build.
+        # ports.ubuntu.com (the arm64 archive) is under-resourced and regularly
+        # unreachable from GitHub's ARM runners on both IPv6 and IPv4, redding
+        # the build on an otherwise-clean commit. Swap it for a high-bandwidth
+        # mirror (MIT), force IPv4, and retry so a mirror hiccup doesn't fail CI.
         run: |
+          sudo find /etc/apt/ -type f \( -name "*.list" -o -name "*.sources" \) \
+            -exec sed -i 's|ports.ubuntu.com|mirrors.mit.edu|g' {} +
           echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4 >/dev/null
           ok=0
           for i in 1 2 3; do

--- a/.github/workflows/raspberry-pi-build.yml
+++ b/.github/workflows/raspberry-pi-build.yml
@@ -28,17 +28,26 @@ jobs:
           persist-credentials: false
 
       - name: Install Linux build deps
+        # ports.ubuntu.com (the arm64 mirror) intermittently drops IPv6
+        # connectivity on GitHub's ARM runners, failing apt with "Network is
+        # unreachable" on the 2620:2d:: addresses. Force IPv4 to skip them and
+        # retry so a transient mirror hiccup doesn't red the whole build.
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential cmake ninja-build pkg-config \
-            libasound2-dev libjack-jackd2-dev libmp3lame-dev \
-            ladspa-sdk \
-            libcurl4-openssl-dev libfreetype-dev libfontconfig1-dev \
-            libx11-dev libxcomposite-dev libxcursor-dev libxext-dev \
-            libxinerama-dev libxrandr-dev libxrender-dev libxss-dev \
-            libwebkit2gtk-4.0-dev libglu1-mesa-dev xvfb \
-            libwayland-dev libxkbcommon-dev libdecor-0-dev
+          echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4 >/dev/null
+          ok=0
+          for i in 1 2 3; do
+            sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+              build-essential cmake ninja-build pkg-config \
+              libasound2-dev libjack-jackd2-dev libmp3lame-dev \
+              ladspa-sdk \
+              libcurl4-openssl-dev libfreetype-dev libfontconfig1-dev \
+              libx11-dev libxcomposite-dev libxcursor-dev libxext-dev \
+              libxinerama-dev libxrandr-dev libxrender-dev libxss-dev \
+              libwebkit2gtk-4.0-dev libglu1-mesa-dev xvfb \
+              libwayland-dev libxkbcommon-dev libdecor-0-dev && { ok=1; break; }
+            echo "apt attempt $i failed; retrying in 20s"; sleep 20
+          done
+          [ "$ok" = 1 ] || { echo "apt failed after 3 attempts"; exit 1; }
 
       - name: Clone JUCE (Dusk-owned Wayland mirror, pinned)
         # Same pinned Dusk-owned mirror snapshot as linux-build.yml. The

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         pkg_check_modules(LILV IMPORTED_TARGET GLOBAL lilv-0)
         pkg_check_modules(SUIL IMPORTED_TARGET GLOBAL suil-0)
         pkg_check_modules(LV2  IMPORTED_TARGET GLOBAL lv2)
+        pkg_check_modules(PIPEWIRE IMPORTED_TARGET GLOBAL libpipewire-0.3)
     endif()
     if(LILV_FOUND AND SUIL_FOUND AND LV2_FOUND)
         option(DUSKSTUDIO_NATIVE_LV2 "Build the native LV2 plugin host (Linux, needs lilv/suil)" ON)
@@ -526,6 +527,20 @@ if(UNIX AND NOT APPLE)
         src/ui/KeyboardStateLinux.cpp)
     target_link_libraries(DuskStudio PRIVATE asound X11 ${CMAKE_DL_LIBS})  # X11/dl: clap host + windowing
     target_compile_definitions(DuskStudio PRIVATE DUSKSTUDIO_HAS_ALSA=1)
+endif()
+
+# Dusk Studio-owned native PipeWire backend - a juce::AudioIODevice +
+# AudioIODeviceType pair speaking libpipewire directly (single pw_filter node),
+# replacing JUCE's JACK-over-pipewire-jack path. Correct graph latency, native
+# node naming, one fewer shim on the Linux #1 audio path. Linux-only, and only
+# when the dev libs are present (as with the LV2 host); registration in
+# AudioEngine is guarded by DUSKSTUDIO_HAS_PIPEWIRE.
+if(UNIX AND NOT APPLE AND PIPEWIRE_FOUND)
+    target_sources(DuskStudio PRIVATE
+        src/engine/pipewire/PipeWireAudioIODevice.cpp
+        src/engine/pipewire/PipeWireAudioIODeviceType.cpp)
+    target_link_libraries(DuskStudio PRIVATE PkgConfig::PIPEWIRE)
+    target_compile_definitions(DuskStudio PRIVATE DUSKSTUDIO_HAS_PIPEWIRE=1)
 endif()
 
 # Shared native-host layer (format-agnostic) — compiled whenever any native host

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2018,7 +2018,7 @@ If the disconnect happened during a take, the WAV that was being written is comm
 
 If the interface saved in your settings is held by another application when Dusk Studio launches — PipeWire or the JACK/PipeWire server, another DAW (Ardour, Reaper), a screen recorder, or browser audio holding the device in exclusive mode — Dusk Studio can't open it. Rather than load a silent, dead session, it recovers and tells you what happened:
 
-- It tries the PipeWire backend (which reaches your interface through the graph even while the raw device is held), then the next available device.
+- It tries the PipeWire backend, then the next available device. PipeWire can still reach an interface that another PipeWire client is using, since they share the graph; but if something holds the raw ALSA device exclusively (a JACK server, or an app talking to the hardware directly), PipeWire is locked out too and the fallback moves on to the next device.
 - If that lands on a **different** working device, you keep working and see *"Your saved audio device … could not be opened … audio has switched to …"*. Your saved device is **not** changed — it's tried again on the next launch once you free it.
 - If nothing opens, you get a clear warning: the playhead and meters won't move and recording is disabled until a device is available.
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -73,7 +73,7 @@ Open **Settings → Audio…**. Choose your interface, sample rate, and block si
 
 ![Audio device panel with a real interface selected.](docs/images/qg-02-audio-settings.png)
 
-On Linux, PipeWire and JACK both appear as "JACK"; pick whichever owns your interface. On macOS, both Core Audio devices and any AVB / aggregate devices show up. On Windows, ASIO drivers appear ahead of WASAPI.
+On Linux, the graph appears as "PipeWire" and raw hardware as "ALSA"; pick whichever owns your interface. On macOS, both Core Audio devices and any AVB / aggregate devices show up. On Windows, ASIO drivers appear ahead of WASAPI.
 
 If your interface has more than two inputs, the channel pickers on each track's input block will populate automatically; no extra routing dialog is needed.
 
@@ -318,7 +318,7 @@ Assign a strip to one of eight fader groups (right-click the strip → **Fader g
 
 ## System requirements
 
-- **Linux**: PipeWire (recommended) or JACK or ALSA. JUCE 8's JACK backend drives PipeWire transparently. An X11 display is required: on a Wayland desktop this means XWayland (present and enabled by default on GNOME and KDE; compositors like sway, niri and labwc can run without it — enable it there, or Dusk Studio will refuse to start with a message pointing here).
+- **Linux**: PipeWire (recommended) or ALSA. Dusk Studio talks to the PipeWire graph directly through its own backend, so the client shows up as "Dusk Studio" with correct latency reporting; ALSA reaches the raw hardware for exclusive low-latency use. An X11 display is required: on a Wayland desktop this means XWayland (present and enabled by default on GNOME and KDE; compositors like sway, niri and labwc can run without it — enable it there, or Dusk Studio will refuse to start with a message pointing here).
 - **macOS**: 14.4 (Sonoma) or later for the out-of-process plugin sandbox; older macOS still runs plugins in-process.
 - **Windows**: Windows 10 or later, ASIO driver recommended.
 
@@ -422,7 +422,7 @@ Open **Settings → Audio…** to choose your audio device. The panel is divided
 
 ### Audio
 
-- **Device**: lists every backend driver Dusk Studio detected. On Linux, PipeWire and JACK appear as "JACK"; ALSA devices appear separately. On Windows, ASIO is preferred and selected by default when an ASIO driver is present; if none is installed, Dusk Studio falls back to "Windows Audio (Exclusive Mode)" for low latency, then shared "Windows Audio", then "DirectSound". Install your interface's ASIO driver (or ASIO4ALL) for best latency. Changes apply immediately — there is no Save button — and the device you pick is remembered across restarts (per machine, not per session).
+- **Device**: lists every backend driver Dusk Studio detected. On Linux, PipeWire graph nodes appear under "PipeWire"; ALSA devices appear separately. On Windows, ASIO is preferred and selected by default when an ASIO driver is present; if none is installed, Dusk Studio falls back to "Windows Audio (Exclusive Mode)" for low latency, then shared "Windows Audio", then "DirectSound". Install your interface's ASIO driver (or ASIO4ALL) for best latency. Changes apply immediately — there is no Save button — and the device you pick is remembered across restarts (per machine, not per session).
 - **Sample rate**: any rate the device supports. 44.1 kHz, 48 kHz, 88.2 kHz, 96 kHz are common. A session remembers the rate its audio was made at: opening it tries to switch the device to that rate automatically, and Dusk Studio warns if it can't (or if you change the rate mid-session) — recorded tracks play at the wrong speed and pitch until the device runs at the session's rate.
 - **Block size**: smaller blocks give lower latency but cost more CPU per sample. 256 or 512 samples is a good starting point.
 - **Periods (Linux/ALSA only)**: how many buffers the ALSA driver keeps in flight. Two is the lowest-latency safe value; three or more is more robust on a busy machine.
@@ -2018,7 +2018,7 @@ If the disconnect happened during a take, the WAV that was being written is comm
 
 If the interface saved in your settings is held by another application when Dusk Studio launches — PipeWire or the JACK/PipeWire server, another DAW (Ardour, Reaper), a screen recorder, or browser audio holding the device in exclusive mode — Dusk Studio can't open it. Rather than load a silent, dead session, it recovers and tells you what happened:
 
-- It tries the JACK / PipeWire backend (which reaches your interface even while the raw device is held), then the next available device.
+- It tries the PipeWire backend (which reaches your interface through the graph even while the raw device is held), then the next available device.
 - If that lands on a **different** working device, you keep working and see *"Your saved audio device … could not be opened … audio has switched to …"*. Your saved device is **not** changed — it's tried again on the next launch once you free it.
 - If nothing opens, you get a clear warning: the playhead and meters won't move and recording is disabled until a device is available.
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -318,7 +318,7 @@ Assign a strip to one of eight fader groups (right-click the strip → **Fader g
 
 ## System requirements
 
-- **Linux**: PipeWire (recommended) or ALSA. Dusk Studio talks to the PipeWire graph directly through its own backend, so the client shows up as "Dusk Studio" with correct latency reporting; ALSA reaches the raw hardware for exclusive low-latency use. An X11 display is required: on a Wayland desktop this means XWayland (present and enabled by default on GNOME and KDE; compositors like sway, niri and labwc can run without it — enable it there, or Dusk Studio will refuse to start with a message pointing here).
+- **Linux**: PipeWire (recommended) or ALSA. Dusk Studio talks to the PipeWire graph directly through its own backend, so the client shows up as "Dusk Studio" and reports its node latency to the graph; ALSA reaches the raw hardware for exclusive low-latency use. An X11 display is required: on a Wayland desktop this means XWayland (present and enabled by default on GNOME and KDE; compositors like sway, niri and labwc can run without it — enable it there, or Dusk Studio will refuse to start with a message pointing here).
 - **macOS**: 14.4 (Sonoma) or later for the out-of-process plugin sandbox; older macOS still runs plugins in-process.
 - **Windows**: Windows 10 or later, ASIO driver recommended.
 

--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -29,6 +29,9 @@
  #include "engine/alsa/AlsaAudioIODeviceType.h"
  #include "engine/alsa/AlsaPerformanceTest.h"
 #endif
+#if defined(DUSKSTUDIO_HAS_PIPEWIRE)
+ #include "engine/pipewire/PipeWireAudioIODeviceType.h"
+#endif
 #include "session/Session.h"
 
 #include <algorithm>
@@ -274,7 +277,7 @@ static bool envFlagSet (const char* name)
 // Test button at low buffer sizes on ALSA + USB interfaces.
 //
 // Env vars (all optional, sensible defaults):
-//   DUSKSTUDIO_TONE_BACKEND     "ALSA" | "JACK"           (default "ALSA")
+//   DUSKSTUDIO_TONE_BACKEND     "ALSA" | "PipeWire"       (default "ALSA")
 //   DUSKSTUDIO_TONE_DEVICE      output device name        (default "" = backend default)
 //   DUSKSTUDIO_TONE_RATE        sample rate in Hz         (default 48000)
 //   DUSKSTUDIO_TONE_BUFFER      buffer size in samples    (default 128)
@@ -302,16 +305,19 @@ static void runHeadlessToneTest()
                   backendName.toRawUTF8(), deviceName.toRawUTF8(),
                   targetRate, targetBuf, durationMs);
 
-    // Linux: pre-register Dusk Studio's ALSA backend + JACK before init, same
-    // pattern AudioEngine uses. Stops JUCE's createDeviceTypesIfNeeded
-    // from auto-registering its stock ALSA path (which would collide on
-    // the type-name "ALSA" with ours). Pre-scanning lets init's
+    // Linux: pre-register Dusk Studio's own backends before init, same pattern
+    // (and preference order) AudioEngine uses - native PipeWire first, native
+    // ALSA fallback, no JUCE JACK. Stops JUCE's createDeviceTypesIfNeeded from
+    // auto-registering its stock ALSA path. Pre-scanning lets init's
     // pickCurrentDeviceTypeWithDevices read device counts without tripping
     // hasScanned assertions.
+   #if defined(DUSKSTUDIO_HAS_PIPEWIRE)
+    dm.addAudioDeviceType (std::make_unique<duskstudio::PipeWireAudioIODeviceType>());
+   #endif
    #if defined(__linux__)
-    if (auto* jackType = juce::AudioIODeviceType::createAudioIODeviceType_JACK())
-        dm.addAudioDeviceType (std::unique_ptr<juce::AudioIODeviceType> (jackType));
     dm.addAudioDeviceType (std::make_unique<duskstudio::AlsaAudioIODeviceType>());
+   #endif
+   #if defined(__linux__)
     for (auto* type : dm.getAvailableDeviceTypes())
         if (type != nullptr) type->scanForDevices();
    #endif

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -12,6 +12,9 @@
   #include "alsa/AlsaAudioIODeviceType.h"
 #endif
 #include <algorithm>
+#if defined(DUSKSTUDIO_HAS_PIPEWIRE)
+  #include "pipewire/PipeWireAudioIODeviceType.h"
+#endif
 #include <array>
 #include <cstdlib>
 #include <cstring>
@@ -427,20 +430,25 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
     master.bind (session.master());
     masteringChain.bind (session.mastering());
 
-    // Linux: pre-register Dusk Studio's ALSA + JACK BEFORE
-    // initialiseWithDefaultDevices so JUCE's createDeviceTypesIfNeeded
-    // branch is a no-op (it only auto-registers defaults when the type
-    // list is empty, which would re-add the stock ALSA path). Explicit
-    // scanForDevices so init's pickCurrentDeviceTypeWithDevices doesn't
-    // trip hasScanned assertions. Dropdown ends up with "ALSA" (ours)
-    // + "JACK", no double-listing.
-    // macOS / Windows let JUCE auto-register natives - DUSKSTUDIO_HAS_ALSA
-    // isn't defined there.
+    // Linux: pre-register Dusk Studio's own backends BEFORE
+    // initialiseWithDefaultDevices so JUCE's createDeviceTypesIfNeeded branch is
+    // a no-op (it only auto-registers defaults when the type list is empty,
+    // which would re-add the stock ALSA path). Explicit scanForDevices so init's
+    // pickCurrentDeviceTypeWithDevices doesn't trip hasScanned assertions.
+    //
+    // Registration order = default-backend preference (the pick lands on the
+    // first registered type that has devices): native PipeWire first (correct
+    // graph latency, native node naming, no pipewire-jack shim), native ALSA as
+    // the hardware-direct fallback. JUCE's JACK backend is intentionally NOT
+    // registered - talking to libpipewire directly replaces it.
+    // macOS / Windows let JUCE auto-register natives - these gates aren't defined there.
+   #if defined(DUSKSTUDIO_HAS_PIPEWIRE)
+    deviceManager.addAudioDeviceType (std::make_unique<PipeWireAudioIODeviceType>());
+   #endif
    #if defined(DUSKSTUDIO_HAS_ALSA)
-    if (auto* jackType = juce::AudioIODeviceType::createAudioIODeviceType_JACK())
-        deviceManager.addAudioDeviceType (std::unique_ptr<juce::AudioIODeviceType> (jackType));
     deviceManager.addAudioDeviceType (std::make_unique<AlsaAudioIODeviceType>());
-
+   #endif
+   #if defined(DUSKSTUDIO_HAS_PIPEWIRE) || defined(DUSKSTUDIO_HAS_ALSA)
     for (auto* t : deviceManager.getAvailableDeviceTypes())
         if (t != nullptr) t->scanForDevices();
    #endif
@@ -498,10 +506,10 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
     // The saved setup can pin an ALSA hw: device that another app (PipeWire,
     // JACK, another DAW) holds exclusively. JUCE's selectDefaultDeviceOnFailure
     // only re-picks another device NAME on the same ALSA type - the same hw
-    // conflict - so it never falls through to JACK. Recover explicitly: JACK
-    // (routes through PipeWire and reaches the interface even while the raw hw
-    // handle is held) -> the first ALSA device that opens -> give up and tell the
-    // user. This runs BEFORE addAudioCallback / addChangeListener: the audio
+    // conflict - so it never falls through to the graph. Recover explicitly: the
+    // native PipeWire backend (reaches the interface through the graph even while
+    // the raw hw handle is held) -> the first ALSA device that opens -> give up
+    // and tell the user. This runs BEFORE addAudioCallback / addChangeListener: the audio
     // thread isn't attached and the engine isn't a change listener yet, so the
     // setup-switch broadcasts reach no one (no re-entrancy, no fallback loop).
     {
@@ -539,8 +547,11 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
                 deviceManager.setAudioDeviceSetup (s, /*treatAsChosen*/ true);
             };
 
-            // 1) JACK / PipeWire default.
-            openDefaultOnType ("JACK", juce::String());
+            // 1) Native PipeWire default (the graph reaches the interface even
+            //    while another app holds the raw ALSA hw handle).
+           #if defined(DUSKSTUDIO_HAS_PIPEWIRE)
+            openDefaultOnType ("PipeWire", juce::String());
+           #endif
 
             // 2) Walk ALSA device names; the busy one fails, the next (Built-in
             //    / HDMI / other interface) opens.

--- a/src/engine/AudioPipelineSelfTest.cpp
+++ b/src/engine/AudioPipelineSelfTest.cpp
@@ -4,6 +4,9 @@
  #include "alsa/AlsaAudioIODevice.h"
 #endif
 #include <algorithm>
+#if defined(DUSKSTUDIO_HAS_PIPEWIRE)
+ #include "pipewire/PipeWireAudioIODevice.h"
+#endif
 #include <cmath>
 
 namespace duskstudio
@@ -1378,6 +1381,14 @@ std::string AudioPipelineSelfTest::runAll()
     // exercised by the backend cycle below alongside the JUCE-stock
     // ALSA / JACK paths.
     report.push_back (AlsaAudioIODevice::runSelfTest().toStdString());
+    report.push_back ("");
+   #endif
+
+   #if defined(DUSKSTUDIO_HAS_PIPEWIRE)
+    // Pure-logic self-test for the native PipeWire backend: active-channel
+    // counting (drives port creation) and node.latency string formatting. No
+    // live graph needed; a real-device open is exercised by the backend cycle.
+    report.push_back (PipeWireAudioIODevice::runSelfTest().toStdString());
     report.push_back ("");
    #endif
 

--- a/src/engine/pipewire/PipeWireAudioIODevice.cpp
+++ b/src/engine/pipewire/PipeWireAudioIODevice.cpp
@@ -32,6 +32,12 @@ void onProcessTrampoline (void* data, struct spa_io_position* position)
     static_cast<PipeWireAudioIODevice*> (data)->onProcess (position);
 }
 
+void onStateChangedTrampoline (void* data, enum pw_filter_state /*old*/,
+                                enum pw_filter_state /*state*/, const char* /*error*/)
+{
+    static_cast<PipeWireAudioIODevice*> (data)->onFilterStateChanged();
+}
+
 // Zero-init + assignment rather than C99 designated initializers (a C++20
 // feature; the project is C++17 -Werror).
 pw_filter_events makeFilterEvents()
@@ -39,6 +45,7 @@ pw_filter_events makeFilterEvents()
     pw_filter_events e {};
     e.version = PW_VERSION_FILTER_EVENTS;
     e.process = onProcessTrampoline;
+    e.state_changed = onStateChangedTrampoline;
     return e;
 }
 
@@ -182,7 +189,7 @@ juce::String PipeWireAudioIODevice::open (const juce::BigInteger& inputChannels,
                                     "Dusk Studio", props, &kFilterEvents, this);
     if (filter == nullptr)
     {
-        pw_properties_free (props);   // ownership only transfers on success
+        // props ownership is taken by pw_filter_new_simple even on failure.
         lastError = "pw_filter_new_simple failed";
         close();
         return lastError;
@@ -203,7 +210,7 @@ juce::String PipeWireAudioIODevice::open (const juce::BigInteger& inputChannels,
                                           0, pp, nullptr, 0);
         if (port == nullptr)
         {
-            pw_properties_free (pp);   // ownership only transfers on success
+            // pp ownership is taken by pw_filter_add_port even on failure.
             lastError = "pw_filter_add_port (output) failed";
             close();
             return lastError;
@@ -223,7 +230,7 @@ juce::String PipeWireAudioIODevice::open (const juce::BigInteger& inputChannels,
                                           0, pp, nullptr, 0);
         if (port == nullptr)
         {
-            pw_properties_free (pp);   // ownership only transfers on success
+            // pp ownership is taken by pw_filter_add_port even on failure.
             lastError = "pw_filter_add_port (input) failed";
             close();
             return lastError;
@@ -237,21 +244,61 @@ juce::String PipeWireAudioIODevice::open (const juce::BigInteger& inputChannels,
     outputLatency = wantOutput ? quantum : 0;
     inputLatency  = wantInput  ? quantum : 0;
 
-    if (pw_filter_connect (filter, PW_FILTER_FLAG_RT_PROCESS, nullptr, 0) < 0)
+    // Initialise the RT-thread state before the data thread can run - once
+    // started, onProcess may read these on the very first cycle.
+    lastXrun = 0;
+    xrunCount.store (0, std::memory_order_relaxed);
+
+    if (const int rc = pw_thread_loop_start (threadLoop); rc < 0)
     {
-        lastError = "pw_filter_connect failed";
+        lastError = "pw_thread_loop_start failed (" + juce::String (rc) + ")";
         close();
         return lastError;
     }
-
-    // Start the RT data thread. All object creation above happened before start,
-    // so no thread-loop lock was needed; post-start pw_* calls (close) stop the
-    // loop first.
-    pw_thread_loop_start (threadLoop);
     threadLoopRunning = true;
 
-    lastXrun = 0;
-    xrunCount.store (0, std::memory_order_relaxed);
+    // Connect and wait for the async handshake to resolve, under the loop lock so
+    // no state_changed is missed. pw_filter_connect is scheduled on the loop and
+    // completes asynchronously - returning success before it lands would report a
+    // dead device as open when the target vanished or the server disconnected.
+    {
+        pw_thread_loop_lock (threadLoop);
+        if (pw_filter_connect (filter, PW_FILTER_FLAG_RT_PROCESS, nullptr, 0) < 0)
+        {
+            pw_thread_loop_unlock (threadLoop);
+            lastError = "pw_filter_connect failed";
+            close();
+            return lastError;
+        }
+
+        // A functioning graph resolves in milliseconds; the timeout backstops a
+        // wedged server so open() never blocks indefinitely. Each iteration is
+        // woken by state_changed (onFilterStateChanged signals the loop) or by
+        // the per-wait timeout.
+        const char* stateError = nullptr;
+        pw_filter_state state = pw_filter_get_state (filter, &stateError);
+        for (int tries = 0;
+             state != PW_FILTER_STATE_PAUSED
+             && state != PW_FILTER_STATE_STREAMING
+             && state != PW_FILTER_STATE_ERROR
+             && tries < 10;
+             ++tries)
+        {
+            if (pw_thread_loop_timed_wait (threadLoop, 2) != 0)
+                break;
+            state = pw_filter_get_state (filter, &stateError);
+        }
+        pw_thread_loop_unlock (threadLoop);
+
+        if (state != PW_FILTER_STATE_PAUSED && state != PW_FILTER_STATE_STREAMING)
+        {
+            lastError = juce::String ("PipeWire filter did not connect: ")
+                        + (stateError != nullptr ? stateError : "timeout");
+            close();
+            return lastError;
+        }
+    }
+
     isDeviceOpen.store (true, std::memory_order_release);
     lastError.clear();
 
@@ -371,6 +418,13 @@ void PipeWireAudioIODevice::onProcess (struct spa_io_position* position) noexcep
             callbackInPointers.getRawDataPointer(),  numInputChannels,
             callbackOutPointers.getRawDataPointer(), numOutputChannels,
             (int) n, {});
+}
+
+void PipeWireAudioIODevice::onFilterStateChanged() noexcept
+{
+    // Wake open()'s bounded wait; it re-reads pw_filter_get_state for the truth.
+    if (threadLoop != nullptr)
+        pw_thread_loop_signal (threadLoop, false);
 }
 
 // ----- self-test -------------------------------------------------------------

--- a/src/engine/pipewire/PipeWireAudioIODevice.cpp
+++ b/src/engine/pipewire/PipeWireAudioIODevice.cpp
@@ -184,6 +184,10 @@ juce::String PipeWireAudioIODevice::open (const juce::BigInteger& inputChannels,
     // port target, older policy the node target, so we set both.
     if (wantOutput)      pw_properties_set (props, PW_KEY_TARGET_OBJECT, outputId.toRawUTF8());
     else if (wantInput)  pw_properties_set (props, PW_KEY_TARGET_OBJECT, inputId.toRawUTF8());
+    // Strict target: don't let the session manager fall back to a different node
+    // when the requested one is unavailable. The connect then fails to reach
+    // PAUSED (see open()'s wait below) instead of silently linking elsewhere.
+    pw_properties_set (props, PW_KEY_NODE_DONT_RECONNECT, "true");
 
     filter = pw_filter_new_simple (pw_thread_loop_get_loop (threadLoop),
                                     "Dusk Studio", props, &kFilterEvents, this);
@@ -246,7 +250,7 @@ juce::String PipeWireAudioIODevice::open (const juce::BigInteger& inputChannels,
 
     // Initialise the RT-thread state before the data thread can run - once
     // started, onProcess may read these on the very first cycle.
-    lastXrun = 0;
+    lastXrunRecovering = false;
     xrunCount.store (0, std::memory_order_relaxed);
 
     if (const int rc = pw_thread_loop_start (threadLoop); rc < 0)
@@ -379,11 +383,16 @@ void PipeWireAudioIODevice::onProcess (struct spa_io_position* position) noexcep
     if (n == 0)
         return;
 
-    // Surface the graph's accumulated xrun as an event count for the UI.
+    // Count one xrun per recovery episode: increment on the rising edge of the
+    // XRUN_RECOVER flag, not on every cycle it stays set (a recovery can span
+    // several cycles). clock.xrun is only an estimated duration, so the flag is
+    // the reliable event signal.
     if (position != nullptr)
     {
-        const juce::uint64 x = position->clock.xrun;
-        if (x > lastXrun) { xrunCount.fetch_add (1, std::memory_order_relaxed); lastXrun = x; }
+        const bool recovering = (position->clock.flags & SPA_IO_CLOCK_FLAG_XRUN_RECOVER) != 0;
+        if (recovering && ! lastXrunRecovering)
+            xrunCount.fetch_add (1, std::memory_order_relaxed);
+        lastXrunRecovering = recovering;
     }
 
     // A cycle larger than our scratch ceiling can't be serviced safely without

--- a/src/engine/pipewire/PipeWireAudioIODevice.cpp
+++ b/src/engine/pipewire/PipeWireAudioIODevice.cpp
@@ -1,0 +1,398 @@
+#include "PipeWireAudioIODevice.h"
+
+#include <pipewire/pipewire.h>
+#include <pipewire/filter.h>
+#include <spa/node/io.h>
+
+#include <algorithm>
+#include <mutex>
+#include <cstdio>
+#include <cstring>
+
+namespace duskstudio
+{
+namespace
+{
+// PipeWire's default graph clock.max-quantum. A cycle larger than this is
+// pathological (another client forced a huge quantum); we drop it rather than
+// grow scratch on the RT thread. Sizing the unlinked-port scratch to this keeps
+// the data thread allocation-free across any legal quantum.
+constexpr int kMaxQuantum = 8192;
+
+// pw_init refcounts internally; the once-flag just keeps a first-use race
+// between the type ctor, a device open and a bare runSelfTest() off the global.
+void ensurePipeWireInit()
+{
+    static std::once_flag once;
+    std::call_once (once, [] { pw_init (nullptr, nullptr); });
+}
+
+void onProcessTrampoline (void* data, struct spa_io_position* position)
+{
+    static_cast<PipeWireAudioIODevice*> (data)->onProcess (position);
+}
+
+// Zero-init + assignment rather than C99 designated initializers (a C++20
+// feature; the project is C++17 -Werror).
+pw_filter_events makeFilterEvents()
+{
+    pw_filter_events e {};
+    e.version = PW_VERSION_FILTER_EVENTS;
+    e.process = onProcessTrampoline;
+    return e;
+}
+
+const pw_filter_events kFilterEvents = makeFilterEvents();
+} // namespace
+
+// ----- pure helpers (shared with the self-test) ------------------------------
+int PipeWireAudioIODevice::countActiveChannels (const juce::BigInteger& mask)
+{
+    int n = 0;
+    for (int i = 0; i <= mask.getHighestBit(); ++i)
+        if (mask[i]) ++n;
+    return n;
+}
+
+juce::String PipeWireAudioIODevice::formatNodeLatency (int quantum, int sampleRate)
+{
+    return juce::String (quantum) + "/" + juce::String (sampleRate);
+}
+
+// ----- construction ----------------------------------------------------------
+PipeWireAudioIODevice::PipeWireAudioIODevice (const juce::String& deviceName,
+                                              const juce::String& inId,
+                                              const juce::String& outId,
+                                              int numInChannels,
+                                              int numOutChannels)
+    : juce::AudioIODevice (deviceName, "PipeWire"),
+      inputId (inId), outputId (outId), displayName (deviceName),
+      deviceInChannels (std::max (0, numInChannels)),
+      deviceOutChannels (std::max (0, numOutChannels))
+{
+}
+
+PipeWireAudioIODevice::~PipeWireAudioIODevice()
+{
+    close();
+}
+
+// ----- capability queries ----------------------------------------------------
+juce::StringArray PipeWireAudioIODevice::getOutputChannelNames()
+{
+    // Report the node's real channel count (from enumeration's audio.channels)
+    // so a multichannel interface isn't capped at stereo. Fall back to a stereo
+    // pair when the node didn't advertise a count.
+    juce::StringArray names;
+    const int n = deviceOutChannels > 0 ? deviceOutChannels : 2;
+    for (int i = 1; i <= n; ++i) names.add ("Out " + juce::String (i));
+    return names;
+}
+
+juce::StringArray PipeWireAudioIODevice::getInputChannelNames()
+{
+    juce::StringArray names;
+    const int n = deviceInChannels > 0 ? deviceInChannels : 2;
+    for (int i = 1; i <= n; ++i) names.add ("In " + juce::String (i));
+    return names;
+}
+
+juce::Array<double> PipeWireAudioIODevice::getAvailableSampleRates()
+{
+    // PipeWire resamples transparently around the graph rate, so any common rate
+    // is usable regardless of the underlying device.
+    return { 44100.0, 48000.0, 88200.0, 96000.0, 176400.0, 192000.0 };
+}
+
+juce::Array<int> PipeWireAudioIODevice::getAvailableBufferSizes()
+{
+    return { 32, 64, 128, 256, 512, 1024, 2048 };
+}
+
+int PipeWireAudioIODevice::getDefaultBufferSize() { return 512; }
+
+// ----- open / close ----------------------------------------------------------
+juce::String PipeWireAudioIODevice::open (const juce::BigInteger& inputChannels,
+                                          const juce::BigInteger& outputChannels,
+                                          double sampleRate, int bufferSizeSamples)
+{
+    if (isDeviceOpen.load (std::memory_order_acquire))
+        close();
+
+    currentInputChannels  = inputChannels;
+    currentOutputChannels = outputChannels;
+
+    numOutputChannels = countActiveChannels (outputChannels);
+    numInputChannels  = countActiveChannels (inputChannels);
+
+    const bool wantOutput = numOutputChannels > 0 && outputId.isNotEmpty();
+    const bool wantInput  = numInputChannels  > 0 && inputId.isNotEmpty();
+    if (! wantOutput && ! wantInput)
+    {
+        lastError = "no input or output channels selected";
+        return lastError;
+    }
+    if (! wantOutput) numOutputChannels = 0;
+    if (! wantInput)  numInputChannels  = 0;
+
+    const int rate    = (int) sampleRate;
+    const int quantum = std::max (32, bufferSizeSamples);
+    openedSampleRate  = sampleRate;
+    currentBlockSize  = quantum;
+    maxQuantum        = kMaxQuantum;
+
+    // Unlinked-port scratch. silenceIn stays zeroed (read by the callback for a
+    // port the graph hasn't linked); dumpOut absorbs writes to an unlinked output.
+    silenceIn.allocate ((size_t) maxQuantum, true);
+    dumpOut  .allocate ((size_t) maxQuantum, true);
+
+    callbackInPointers.resize (numInputChannels);
+    callbackOutPointers.resize (numOutputChannels);
+
+    ensurePipeWireInit();
+
+    threadLoop = pw_thread_loop_new ("Dusk Studio PipeWire", nullptr);
+    if (threadLoop == nullptr)
+    {
+        lastError = "pw_thread_loop_new failed";
+        close();
+        return lastError;
+    }
+
+    const char* category = (wantOutput && wantInput) ? "Duplex"
+                          : wantOutput                ? "Playback"
+                          :                             "Capture";
+    const auto latency = formatNodeLatency (quantum, rate);
+
+    auto* props = pw_properties_new (
+        PW_KEY_MEDIA_TYPE,     "Audio",
+        PW_KEY_MEDIA_CATEGORY, category,
+        PW_KEY_MEDIA_ROLE,     "Production",
+        PW_KEY_APP_NAME,       "Dusk Studio",
+        PW_KEY_NODE_NAME,      "Dusk Studio",
+        PW_KEY_NODE_LATENCY,   latency.toRawUTF8(),
+        nullptr);
+    // Node-level target links the primary direction to the chosen device. Ports
+    // also carry a per-direction target below; recent WirePlumber honours the
+    // port target, older policy the node target, so we set both.
+    if (wantOutput)      pw_properties_set (props, PW_KEY_TARGET_OBJECT, outputId.toRawUTF8());
+    else if (wantInput)  pw_properties_set (props, PW_KEY_TARGET_OBJECT, inputId.toRawUTF8());
+
+    filter = pw_filter_new_simple (pw_thread_loop_get_loop (threadLoop),
+                                    "Dusk Studio", props, &kFilterEvents, this);
+    if (filter == nullptr)
+    {
+        pw_properties_free (props);   // ownership only transfers on success
+        lastError = "pw_filter_new_simple failed";
+        close();
+        return lastError;
+    }
+
+    inPorts.clearQuick();
+    outPorts.clearQuick();
+
+    for (int i = 0; i < numOutputChannels; ++i)
+    {
+        const auto portName = "playback_" + juce::String (i + 1);
+        auto* pp = pw_properties_new (PW_KEY_FORMAT_DSP, "32 bit float mono audio",
+                                       PW_KEY_PORT_NAME,  portName.toRawUTF8(),
+                                       nullptr);
+        pw_properties_set (pp, PW_KEY_TARGET_OBJECT, outputId.toRawUTF8());
+        void* port = pw_filter_add_port (filter, PW_DIRECTION_OUTPUT,
+                                          PW_FILTER_PORT_FLAG_MAP_BUFFERS,
+                                          0, pp, nullptr, 0);
+        if (port == nullptr)
+        {
+            pw_properties_free (pp);   // ownership only transfers on success
+            lastError = "pw_filter_add_port (output) failed";
+            close();
+            return lastError;
+        }
+        outPorts.add (port);
+    }
+
+    for (int i = 0; i < numInputChannels; ++i)
+    {
+        const auto portName = "capture_" + juce::String (i + 1);
+        auto* pp = pw_properties_new (PW_KEY_FORMAT_DSP, "32 bit float mono audio",
+                                       PW_KEY_PORT_NAME,  portName.toRawUTF8(),
+                                       nullptr);
+        pw_properties_set (pp, PW_KEY_TARGET_OBJECT, inputId.toRawUTF8());
+        void* port = pw_filter_add_port (filter, PW_DIRECTION_INPUT,
+                                          PW_FILTER_PORT_FLAG_MAP_BUFFERS,
+                                          0, pp, nullptr, 0);
+        if (port == nullptr)
+        {
+            pw_properties_free (pp);   // ownership only transfers on success
+            lastError = "pw_filter_add_port (input) failed";
+            close();
+            return lastError;
+        }
+        inPorts.add (port);
+    }
+
+    // The graph's real port latency isn't known until links are made; report one
+    // quantum as the estimate. (Graph-accurate latency via the port latency
+    // param is a refinement.)
+    outputLatency = wantOutput ? quantum : 0;
+    inputLatency  = wantInput  ? quantum : 0;
+
+    if (pw_filter_connect (filter, PW_FILTER_FLAG_RT_PROCESS, nullptr, 0) < 0)
+    {
+        lastError = "pw_filter_connect failed";
+        close();
+        return lastError;
+    }
+
+    // Start the RT data thread. All object creation above happened before start,
+    // so no thread-loop lock was needed; post-start pw_* calls (close) stop the
+    // loop first.
+    pw_thread_loop_start (threadLoop);
+    threadLoopRunning = true;
+
+    lastXrun = 0;
+    xrunCount.store (0, std::memory_order_relaxed);
+    isDeviceOpen.store (true, std::memory_order_release);
+    lastError.clear();
+
+    std::fprintf (stderr,
+                  "[Dusk Studio/PipeWire] opened \"%s\" rate=%d quantum=%d out=%dch in=%dch "
+                  "target-out=\"%s\" target-in=\"%s\"\n",
+                  displayName.toRawUTF8(), rate, quantum,
+                  numOutputChannels, numInputChannels,
+                  wantOutput ? outputId.toRawUTF8() : "-",
+                  wantInput  ? inputId.toRawUTF8()  : "-");
+
+    return {};
+}
+
+void PipeWireAudioIODevice::close()
+{
+    stop();
+
+    // pw_thread_loop_stop must be called WITHOUT the lock held; it joins the RT
+    // thread, after which teardown races nothing. Only stop a loop we actually
+    // started - an open() that failed before pw_thread_loop_start leaves the
+    // loop created-but-not-running.
+    if (threadLoop != nullptr && threadLoopRunning)
+    {
+        pw_thread_loop_stop (threadLoop);
+        threadLoopRunning = false;
+    }
+
+    if (filter != nullptr)     { pw_filter_destroy (filter);      filter = nullptr; }
+    if (threadLoop != nullptr) { pw_thread_loop_destroy (threadLoop); threadLoop = nullptr; }
+
+    inPorts.clearQuick();
+    outPorts.clearQuick();
+    silenceIn.free();
+    dumpOut.free();
+
+    isDeviceOpen.store (false, std::memory_order_release);
+}
+
+// ----- start / stop ----------------------------------------------------------
+void PipeWireAudioIODevice::start (juce::AudioIODeviceCallback* newCallback)
+{
+    if (! isDeviceOpen.load (std::memory_order_acquire) || newCallback == nullptr)
+        return;
+    if (isStarted.load (std::memory_order_acquire))
+        return;
+
+    newCallback->audioDeviceAboutToStart (this);
+
+    {
+        const juce::ScopedLock sl (callbackLock);
+        callback = newCallback;
+    }
+
+    isStarted.store (true, std::memory_order_release);
+}
+
+void PipeWireAudioIODevice::stop()
+{
+    if (! isStarted.load (std::memory_order_acquire))
+        return;
+
+    isStarted.store (false, std::memory_order_release);
+
+    juce::AudioIODeviceCallback* cb = nullptr;
+    {
+        const juce::ScopedLock sl (callbackLock);
+        std::swap (cb, callback);
+    }
+    if (cb != nullptr)
+        cb->audioDeviceStopped();
+}
+
+// ----- RT process ------------------------------------------------------------
+void PipeWireAudioIODevice::onProcess (struct spa_io_position* position) noexcept
+{
+    const juce::uint32 n = position != nullptr ? (juce::uint32) position->clock.duration : 0;
+    if (n == 0)
+        return;
+
+    // Surface the graph's accumulated xrun as an event count for the UI.
+    if (position != nullptr)
+    {
+        const juce::uint64 x = position->clock.xrun;
+        if (x > lastXrun) { xrunCount.fetch_add (1, std::memory_order_relaxed); lastXrun = x; }
+    }
+
+    // A cycle larger than our scratch ceiling can't be serviced safely without
+    // allocating; clear any real output buffers and skip the callback.
+    if (n > (juce::uint32) maxQuantum)
+    {
+        for (int i = 0; i < numOutputChannels; ++i)
+            if (auto* b = (float*) pw_filter_get_dsp_buffer (outPorts.getUnchecked (i), n))
+                std::memset (b, 0, (size_t) n * sizeof (float));
+        return;
+    }
+
+    for (int i = 0; i < numOutputChannels; ++i)
+    {
+        auto* b = (float*) pw_filter_get_dsp_buffer (outPorts.getUnchecked (i), n);
+        callbackOutPointers.setUnchecked (i, b != nullptr ? b : dumpOut.getData());
+    }
+    for (int i = 0; i < numInputChannels; ++i)
+    {
+        auto* b = (const float*) pw_filter_get_dsp_buffer (inPorts.getUnchecked (i), n);
+        callbackInPointers.setUnchecked (i, b != nullptr ? b : silenceIn.getData());
+    }
+
+    // Clear the output buffers up front so channels the callback leaves untouched
+    // (or every channel when stopped) are silence, not stale graph memory.
+    for (int i = 0; i < numOutputChannels; ++i)
+        std::memset (callbackOutPointers.getUnchecked (i), 0, (size_t) n * sizeof (float));
+
+    const juce::ScopedLock sl (callbackLock);
+    if (callback != nullptr)
+        callback->audioDeviceIOCallbackWithContext (
+            callbackInPointers.getRawDataPointer(),  numInputChannels,
+            callbackOutPointers.getRawDataPointer(), numOutputChannels,
+            (int) n, {});
+}
+
+// ----- self-test -------------------------------------------------------------
+juce::String PipeWireAudioIODevice::runSelfTest()
+{
+    juce::StringArray out;
+    auto check = [&out] (bool ok, const juce::String& what)
+    { out.add ((ok ? "[PASS] " : "[FAIL] ") + what); };
+
+    // Active-channel counting from a mask (drives port creation).
+    {
+        juce::BigInteger m;
+        m.setBit (0); m.setBit (1); m.setBit (5);
+        check (countActiveChannels (m) == 3, "PipeWire: countActiveChannels stereo+1 = 3");
+        juce::BigInteger empty;
+        check (countActiveChannels (empty) == 0, "PipeWire: countActiveChannels empty = 0");
+    }
+
+    // node.latency string formatting (quantum/rate).
+    check (formatNodeLatency (512, 48000) == "512/48000", "PipeWire: node.latency format 512/48000");
+    check (formatNodeLatency (64, 44100)  == "64/44100",  "PipeWire: node.latency format 64/44100");
+
+    return out.joinIntoString ("\n");
+}
+} // namespace duskstudio

--- a/src/engine/pipewire/PipeWireAudioIODevice.h
+++ b/src/engine/pipewire/PipeWireAudioIODevice.h
@@ -1,0 +1,150 @@
+#pragma once
+
+#include <juce_audio_devices/juce_audio_devices.h>
+#include <juce_core/juce_core.h>
+#include <atomic>
+
+// libpipewire types kept out of this header - forward-declared so callers that
+// only need the juce::AudioIODevice interface don't pull <pipewire/pipewire.h>.
+struct pw_thread_loop;
+struct pw_filter;
+struct spa_io_position;
+
+namespace duskstudio
+{
+// Native PipeWire audio I/O. One instance per open device (a Sink, a Source,
+// or a Source+Sink pair driven as one duplex client). Implements
+// juce::AudioIODevice so AudioEngine's callback, AudioDeviceManager and the
+// selector UI use it interchangeably with the ALSA backend.
+//
+// Design choices, for new readers:
+//   - ONE pw_filter node with N input ports + M output ports, all processed in
+//     a single graph cycle. This is the JACK model JUCE's single duplex
+//     callback expects - capture and playback are inherently sample-aligned
+//     because they share the cycle. (pw_stream would need two nodes with no
+//     cross-node sync guarantee.)
+//   - Ports carry SPA_AUDIO_FORMAT_F32P (planar float) - PipeWire's native
+//     working format, so no per-sample int<->float conversion and no format
+//     negotiation guessing. The graph resamples around us if the device rate
+//     differs.
+//   - pw_thread_loop owns the RT thread; on_process fires on it and calls
+//     straight into the JUCE callback. No separate SCHED_RR thread (PipeWire
+//     already runs its data thread at RT priority).
+//   - Target node chosen via PW_KEY_TARGET_OBJECT = the node name captured at
+//     enumeration; the session manager links our ports to it.
+//   - Quantum (block size) requested via PW_KEY_NODE_LATENCY; the graph may
+//     round it. getCurrentBufferSizeSamples reports the value actually used.
+class PipeWireAudioIODevice final : public juce::AudioIODevice
+{
+public:
+    PipeWireAudioIODevice (const juce::String& deviceName,
+                           const juce::String& inputId,
+                           const juce::String& outputId,
+                           int numInputChannels,
+                           int numOutputChannels);
+    ~PipeWireAudioIODevice() override;
+
+    // Identifiers (PW_KEY_NODE_NAME) the type uses to look this instance up.
+    const juce::String inputId, outputId;
+
+    // juce::AudioIODevice ------------------------------------------------------
+    juce::StringArray  getOutputChannelNames() override;
+    juce::StringArray  getInputChannelNames()  override;
+    juce::Array<double> getAvailableSampleRates() override;
+    juce::Array<int>    getAvailableBufferSizes() override;
+    int                 getDefaultBufferSize()    override;
+
+    juce::String open (const juce::BigInteger& inputChannels,
+                        const juce::BigInteger& outputChannels,
+                        double sampleRate, int bufferSizeSamples) override;
+    void  close()  override;
+    bool  isOpen() override                    { return isDeviceOpen.load (std::memory_order_acquire); }
+
+    void  start (juce::AudioIODeviceCallback* newCallback) override;
+    void  stop() override;
+    bool  isPlaying() override                 { return isStarted.load (std::memory_order_acquire); }
+
+    juce::String getLastError() override        { return lastError; }
+
+    int    getCurrentBufferSizeSamples() override { return currentBlockSize; }
+    double getCurrentSampleRate()        override { return openedSampleRate; }
+    int    getCurrentBitDepth()          override { return 32; }  // F32 float throughout
+
+    juce::BigInteger getActiveOutputChannels() const override { return currentOutputChannels; }
+    juce::BigInteger getActiveInputChannels()  const override { return currentInputChannels; }
+
+    int getOutputLatencyInSamples() override    { return outputLatency; }
+    int getInputLatencyInSamples()  override    { return inputLatency; }
+
+    int getXRunCount() const noexcept override  { return xrunCount.load (std::memory_order_relaxed); }
+
+    // Synthetic backend self-test - exercises the pure-logic surfaces that need
+    // no live graph (active-channel counting from a mask, node.latency string
+    // formatting). Returns a multi-line "[PASS]/[FAIL]" report;
+    // AudioPipelineSelfTest::runAll() picks it up under DUSKSTUDIO_RUN_SELFTEST=1.
+    static juce::String runSelfTest();
+
+    // Pure helpers shared by open() and the self-test (no live graph needed).
+    static int         countActiveChannels (const juce::BigInteger& mask);
+    static juce::String formatNodeLatency (int quantum, int sampleRate);
+
+    // pw_filter process entry point. Public only so the C trampoline in the .cpp
+    // can reach it; not part of the juce::AudioIODevice contract. Runs on
+    // PipeWire's RT data thread; allocation-free, lock-free bar the uncontended
+    // callback lock.
+    void onProcess (struct spa_io_position* position) noexcept;
+
+private:
+    const juce::String displayName;
+
+    // Device channel counts from enumeration (the node's audio.channels). Bound
+    // the reported channel-name lists so a multichannel interface isn't capped
+    // at stereo. numInput/OutputChannels below are the ACTIVE counts at open().
+    const int deviceInChannels;
+    const int deviceOutChannels;
+
+    // libpipewire objects (owned; torn down in close()). pw_filter_new_simple
+    // manages its own context/core internally, so we hold only the thread loop
+    // (owns the RT data thread) and the filter node.
+    pw_thread_loop* threadLoop = nullptr;
+    pw_filter*      filter     = nullptr;
+    bool            threadLoopRunning = false;  // gate stop() - only stop a started loop
+
+    // Port userdata blocks (one per active channel, dense). Opaque void* -
+    // pw_filter owns the port lifetime; we pass these to pw_filter_get_dsp_buffer.
+    juce::Array<void*> inPorts;
+    juce::Array<void*> outPorts;
+
+    double openedSampleRate = 0.0;
+    int    currentBlockSize = 0;
+    int    maxQuantum       = 0;      // scratch ceiling; cycles above this are dropped
+    int    outputLatency    = 0;
+    int    inputLatency     = 0;
+    int    numInputChannels  = 0;
+    int    numOutputChannels = 0;
+    juce::uint64 lastXrun    = 0;     // last-seen clock.xrun (RT thread only)
+
+    juce::BigInteger currentOutputChannels, currentInputChannels;
+
+    juce::CriticalSection callbackLock;
+    juce::AudioIODeviceCallback* callback = nullptr;
+
+    // Pointer arrays handed to the JUCE callback (sized on open, only indexed on
+    // the RT thread). For an unlinked port the slot points at the shared scratch.
+    juce::Array<const float*> callbackInPointers;
+    juce::Array<float*>       callbackOutPointers;
+
+    // Read-only silence for unlinked input ports; write-only dump for unlinked
+    // output ports. Sized to maxQuantum at open, never reallocated on the RT thread.
+    juce::HeapBlock<float> silenceIn;
+    juce::HeapBlock<float> dumpOut;
+
+    std::atomic<bool> isDeviceOpen { false };
+    std::atomic<bool> isStarted    { false };
+    std::atomic<int>  xrunCount    { 0 };
+
+    juce::String lastError;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (PipeWireAudioIODevice)
+};
+} // namespace duskstudio

--- a/src/engine/pipewire/PipeWireAudioIODevice.h
+++ b/src/engine/pipewire/PipeWireAudioIODevice.h
@@ -126,7 +126,7 @@ private:
     int    inputLatency     = 0;
     int    numInputChannels  = 0;
     int    numOutputChannels = 0;
-    juce::uint64 lastXrun    = 0;     // last-seen clock.xrun (RT thread only)
+    bool         lastXrunRecovering = false;  // XRUN_RECOVER edge state (RT thread only)
 
     juce::BigInteger currentOutputChannels, currentInputChannels;
 

--- a/src/engine/pipewire/PipeWireAudioIODevice.h
+++ b/src/engine/pipewire/PipeWireAudioIODevice.h
@@ -94,6 +94,10 @@ public:
     // callback lock.
     void onProcess (struct spa_io_position* position) noexcept;
 
+    // pw_filter state-change entry point (C trampoline in the .cpp). Runs on the
+    // thread loop; wakes open()'s bounded wait so it can read the resolved state.
+    void onFilterStateChanged() noexcept;
+
 private:
     const juce::String displayName;
 

--- a/src/engine/pipewire/PipeWireAudioIODeviceType.cpp
+++ b/src/engine/pipewire/PipeWireAudioIODeviceType.cpp
@@ -70,6 +70,15 @@ void onCoreDone (void* data, uint32_t id, int seq)
         pw_main_loop_quit (r.loop);
 }
 
+void onCoreError (void* data, uint32_t /*id*/, int /*seq*/, int /*res*/, const char* /*message*/)
+{
+    // A fatal core error means no matching done will arrive; quit the loop so the
+    // synchronous roundtrip can't hang waiting for a sync it will never get.
+    auto& r = *static_cast<ScanResult*> (data);
+    if (r.loop != nullptr)
+        pw_main_loop_quit (r.loop);
+}
+
 // Zero-init + field assignment rather than C99 designated initializers, which
 // are a C++20 feature (the project is C++17 -Werror).
 pw_registry_events makeRegistryEvents()
@@ -85,6 +94,7 @@ pw_core_events makeCoreEvents()
     pw_core_events e {};
     e.version = PW_VERSION_CORE_EVENTS;
     e.done    = onCoreDone;
+    e.error   = onCoreError;
     return e;
 }
 
@@ -109,6 +119,14 @@ void enumerateNodes (ScanResult& result)
     if (core == nullptr) { pw_context_destroy (context); pw_main_loop_destroy (result.loop); result.loop = nullptr; return; }
 
     auto* registry = pw_core_get_registry (core, PW_VERSION_REGISTRY, 0);
+    if (registry == nullptr)
+    {
+        pw_core_disconnect (core);
+        pw_context_destroy (context);
+        pw_main_loop_destroy (result.loop);
+        result.loop = nullptr;
+        return;
+    }
 
     spa_hook registryHook {};
     spa_hook coreHook {};

--- a/src/engine/pipewire/PipeWireAudioIODeviceType.cpp
+++ b/src/engine/pipewire/PipeWireAudioIODeviceType.cpp
@@ -6,6 +6,7 @@
 
 #include <mutex>
 #include <cstring>
+#include <ctime>
 
 namespace duskstudio
 {
@@ -79,6 +80,15 @@ void onCoreError (void* data, uint32_t /*id*/, int /*seq*/, int /*res*/, const c
         pw_main_loop_quit (r.loop);
 }
 
+void onEnumTimeout (void* data, uint64_t /*expirations*/)
+{
+    // Backstop the roundtrip: a server that neither answers our sync nor errors
+    // would otherwise block the message thread forever.
+    auto& r = *static_cast<ScanResult*> (data);
+    if (r.loop != nullptr)
+        pw_main_loop_quit (r.loop);
+}
+
 // Zero-init + field assignment rather than C99 designated initializers, which
 // are a C++20 feature (the project is C++17 -Werror).
 pw_registry_events makeRegistryEvents()
@@ -136,8 +146,15 @@ void enumerateNodes (ScanResult& result)
     result.syncSeq  = pw_core_sync (core, PW_ID_CORE, 0);
     result.haveSync = true;
 
+    auto* pwLoop = pw_main_loop_get_loop (result.loop);
+    auto* timer  = pw_loop_add_timer (pwLoop, onEnumTimeout, &result);
+    struct timespec timeout {};
+    timeout.tv_sec = 2;
+    pw_loop_update_timer (pwLoop, timer, &timeout, nullptr, false);
+
     pw_main_loop_run (result.loop);
 
+    pw_loop_destroy_source (pwLoop, timer);
     spa_hook_remove (&registryHook);
     spa_hook_remove (&coreHook);
     pw_proxy_destroy ((pw_proxy*) registry);

--- a/src/engine/pipewire/PipeWireAudioIODeviceType.cpp
+++ b/src/engine/pipewire/PipeWireAudioIODeviceType.cpp
@@ -1,0 +1,212 @@
+#include "PipeWireAudioIODeviceType.h"
+#include "PipeWireAudioIODevice.h"
+
+#include <pipewire/pipewire.h>
+#include <spa/utils/dict.h>
+
+#include <mutex>
+#include <cstring>
+
+namespace duskstudio
+{
+namespace
+{
+// pw_init refcounts internally, but guard it so concurrent first-use from the
+// type ctor and a bare runSelfTest() can't race the global init.
+void ensurePipeWireInit()
+{
+    static std::once_flag once;
+    std::call_once (once, [] { pw_init (nullptr, nullptr); });
+}
+
+// Collected during a single synchronous registry roundtrip. The *Chans arrays
+// are index-aligned with the corresponding *Names / *Ids arrays.
+struct ScanResult
+{
+    juce::StringArray inNames, outNames, inIds, outIds;
+    juce::Array<int>  inChans, outChans;
+    pw_main_loop*     loop = nullptr;
+    int               syncSeq = 0;
+    bool              haveSync = false;
+};
+
+void onRegistryGlobal (void* data, uint32_t /*id*/, uint32_t /*permissions*/,
+                        const char* type, uint32_t /*version*/,
+                        const struct spa_dict* props)
+{
+    auto& r = *static_cast<ScanResult*> (data);
+    if (props == nullptr || std::strcmp (type, PW_TYPE_INTERFACE_Node) != 0)
+        return;
+
+    const char* mediaClass = spa_dict_lookup (props, PW_KEY_MEDIA_CLASS);
+    const char* nodeName    = spa_dict_lookup (props, PW_KEY_NODE_NAME);
+    if (mediaClass == nullptr || nodeName == nullptr)
+        return;
+
+    const char* desc = spa_dict_lookup (props, PW_KEY_NODE_DESCRIPTION);
+    const juce::String label = desc != nullptr ? juce::String::fromUTF8 (desc)
+                                               : juce::String::fromUTF8 (nodeName);
+    const juce::String id = juce::String::fromUTF8 (nodeName);
+
+    // audio.channels is the node's channel count; absent on some nodes, in which
+    // case 0 -> the device falls back to a stereo pair.
+    const char* chanStr = spa_dict_lookup (props, PW_KEY_AUDIO_CHANNELS);
+    const int chans = chanStr != nullptr ? juce::String (chanStr).getIntValue() : 0;
+
+    const bool isSink   = std::strcmp (mediaClass, "Audio/Sink")   == 0;
+    const bool isSource = std::strcmp (mediaClass, "Audio/Source") == 0;
+    const bool isDuplex = std::strcmp (mediaClass, "Audio/Duplex") == 0;
+
+    if (isSink || isDuplex)   { r.outNames.add (label); r.outIds.add (id); r.outChans.add (chans); }
+    if (isSource || isDuplex) { r.inNames.add  (label); r.inIds.add  (id); r.inChans.add  (chans); }
+}
+
+void onCoreDone (void* data, uint32_t id, int seq)
+{
+    auto& r = *static_cast<ScanResult*> (data);
+    // The graph delivers every existing registry global BEFORE answering our
+    // sync, so once this matching done arrives the enumeration is complete.
+    if (id == PW_ID_CORE && r.haveSync && seq == r.syncSeq)
+        pw_main_loop_quit (r.loop);
+}
+
+// Zero-init + field assignment rather than C99 designated initializers, which
+// are a C++20 feature (the project is C++17 -Werror).
+pw_registry_events makeRegistryEvents()
+{
+    pw_registry_events e {};
+    e.version = PW_VERSION_REGISTRY_EVENTS;
+    e.global  = onRegistryGlobal;
+    return e;
+}
+
+pw_core_events makeCoreEvents()
+{
+    pw_core_events e {};
+    e.version = PW_VERSION_CORE_EVENTS;
+    e.done    = onCoreDone;
+    return e;
+}
+
+const pw_registry_events kRegistryEvents = makeRegistryEvents();
+const pw_core_events     kCoreEvents     = makeCoreEvents();
+
+// Enumerate the graph's audio nodes synchronously: spin up a throwaway
+// context/core/registry, run one roundtrip, tear it all down. Message-thread
+// only (matches AlsaAudioIODeviceType::scanForDevices).
+void enumerateNodes (ScanResult& result)
+{
+    ensurePipeWireInit();
+
+    result.loop = pw_main_loop_new (nullptr);
+    if (result.loop == nullptr)
+        return;
+
+    auto* context = pw_context_new (pw_main_loop_get_loop (result.loop), nullptr, 0);
+    if (context == nullptr) { pw_main_loop_destroy (result.loop); result.loop = nullptr; return; }
+
+    auto* core = pw_context_connect (context, nullptr, 0);
+    if (core == nullptr) { pw_context_destroy (context); pw_main_loop_destroy (result.loop); result.loop = nullptr; return; }
+
+    auto* registry = pw_core_get_registry (core, PW_VERSION_REGISTRY, 0);
+
+    spa_hook registryHook {};
+    spa_hook coreHook {};
+    pw_registry_add_listener (registry, &registryHook, &kRegistryEvents, &result);
+    pw_core_add_listener (core, &coreHook, &kCoreEvents, &result);
+
+    result.syncSeq  = pw_core_sync (core, PW_ID_CORE, 0);
+    result.haveSync = true;
+
+    pw_main_loop_run (result.loop);
+
+    spa_hook_remove (&registryHook);
+    spa_hook_remove (&coreHook);
+    pw_proxy_destroy ((pw_proxy*) registry);
+    pw_core_disconnect (core);
+    pw_context_destroy (context);
+    pw_main_loop_destroy (result.loop);
+    result.loop = nullptr;
+}
+} // namespace
+
+PipeWireAudioIODeviceType::PipeWireAudioIODeviceType()
+    : juce::AudioIODeviceType ("PipeWire")
+{
+    ensurePipeWireInit();
+}
+
+void PipeWireAudioIODeviceType::scanForDevices()
+{
+    ScanResult r;
+    enumerateNodes (r);
+
+    inputNames  = r.inNames;
+    outputNames = r.outNames;
+    inputIds    = r.inIds;
+    outputIds   = r.outIds;
+    inputChans  = r.inChans;
+    outputChans = r.outChans;
+
+    inputNames.appendNumbersToDuplicates  (false, true);
+    outputNames.appendNumbersToDuplicates (false, true);
+
+    hasScanned = true;
+}
+
+juce::StringArray PipeWireAudioIODeviceType::getDeviceNames (bool wantInputNames) const
+{
+    jassert (hasScanned);
+    return wantInputNames ? inputNames : outputNames;
+}
+
+int PipeWireAudioIODeviceType::getDefaultDeviceIndex (bool forInput) const
+{
+    jassert (hasScanned);
+    // Skip monitor sources and HDMI sinks - the same "don't default to the
+    // thing the user didn't mean" heuristic the ALSA backend uses. A saved
+    // selection, once resolved, always takes precedence over this.
+    const auto& names = forInput ? inputNames : outputNames;
+    for (int i = 0; i < names.size(); ++i)
+    {
+        const auto& n = names[i];
+        if (n.containsIgnoreCase ("Monitor")) continue;
+        if (n.containsIgnoreCase ("HDMI"))    continue;
+        return i;
+    }
+    return names.isEmpty() ? -1 : 0;
+}
+
+int PipeWireAudioIODeviceType::getIndexOfDevice (juce::AudioIODevice* device, bool asInput) const
+{
+    jassert (hasScanned);
+    if (auto* pw = dynamic_cast<PipeWireAudioIODevice*> (device))
+        return (asInput ? inputIds : outputIds).indexOf (asInput ? pw->inputId : pw->outputId);
+    return -1;
+}
+
+juce::AudioIODevice* PipeWireAudioIODeviceType::createDevice (const juce::String& outputDeviceName,
+                                                               const juce::String& inputDeviceName)
+{
+    jassert (hasScanned);
+    const int outIdx = outputNames.indexOf (outputDeviceName);
+    const int inIdx  = inputNames .indexOf (inputDeviceName);
+
+    if (outIdx < 0 && inIdx < 0)
+        return nullptr;
+
+    const juce::String outId = outIdx >= 0 ? outputIds[outIdx] : juce::String();
+    const juce::String inId  = inIdx  >= 0 ? inputIds [inIdx]  : juce::String();
+    const juce::String name  = outIdx >= 0 ? outputDeviceName : inputDeviceName;
+    const int outChans = outIdx >= 0 ? outputChans[outIdx] : 0;
+    const int inChans  = inIdx  >= 0 ? inputChans [inIdx]  : 0;
+
+    return new PipeWireAudioIODevice (name, inId, outId, inChans, outChans);
+}
+
+void PipeWireAudioIODeviceType::rescan()
+{
+    scanForDevices();
+    callDeviceChangeListeners();
+}
+} // namespace duskstudio

--- a/src/engine/pipewire/PipeWireAudioIODeviceType.h
+++ b/src/engine/pipewire/PipeWireAudioIODeviceType.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <juce_audio_devices/juce_audio_devices.h>
+
+namespace duskstudio
+{
+// Dusk Studio-owned native PipeWire backend. Enumerates the graph's audio
+// Sink / Source nodes as individual devices (device-per-node, mirroring the
+// ALSA backend's model so the existing AudioDeviceSelector UI works unchanged)
+// and hands each one to a PipeWireAudioIODevice that speaks libpipewire
+// directly via a single pw_filter node.
+//
+// Why native, not JUCE-JACK-over-pipewire-jack: the pipewire-jack shim adds a
+// translation layer, mis-reports latency, and names our client generically.
+// Talking to libpipewire directly gives correct graph latency, proper node
+// naming ("Dusk Studio"), and one fewer moving part on the Linux #1 path.
+//
+// media.class "Audio/Sink"  -> output device (we send audio TO it)
+// media.class "Audio/Source"-> input device  (we read audio FROM it)
+// media.class "Audio/Duplex" contributes to BOTH lists.
+//
+// The node's PW_KEY_NODE_NAME is the stable identifier (used as the
+// PW_KEY_TARGET_OBJECT link target at connect time); PW_KEY_NODE_DESCRIPTION
+// (falling back to the name) is the human-readable dropdown label.
+class PipeWireAudioIODeviceType final : public juce::AudioIODeviceType
+{
+public:
+    PipeWireAudioIODeviceType();
+
+    void               scanForDevices() override;
+    juce::StringArray  getDeviceNames (bool wantInputNames) const override;
+    int                getDefaultDeviceIndex (bool forInput) const override;
+    int                getIndexOfDevice (juce::AudioIODevice* device, bool asInput) const override;
+    bool               hasSeparateInputsAndOutputs() const override { return true; }
+    juce::AudioIODevice* createDevice (const juce::String& outputDeviceName,
+                                        const juce::String& inputDeviceName) override;
+
+    // Re-run enumeration and notify listeners (repopulates the dropdown after a
+    // node appears / disappears). Mirrors AlsaAudioIODeviceType::rescan().
+    void rescan();
+
+private:
+    juce::StringArray inputNames, outputNames;
+    juce::StringArray inputIds, outputIds;      // PW_KEY_NODE_NAME, index-aligned with the *Names arrays
+    juce::Array<int>  inputChans, outputChans;  // audio.channels, index-aligned with the *Names arrays
+    bool hasScanned = false;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (PipeWireAudioIODeviceType)
+};
+} // namespace duskstudio

--- a/src/ui/AudioSettingsPanel.cpp
+++ b/src/ui/AudioSettingsPanel.cpp
@@ -675,7 +675,7 @@ void AudioSettingsPanel::applyRescan()
     // AudioDeviceSelectorComponent to re-query and rebuild its dropdowns.
     //
     // We iterate every type rather than only the current one so that
-    // switching backend (e.g. ALSA -> JACK) after a hot-plug still sees
+    // switching backend (e.g. ALSA -> PipeWire) after a hot-plug still sees
     // the freshly-enumerated devices on the new backend.
     const auto& types = deviceManager.getAvailableDeviceTypes();
     for (auto* type : types)

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -69,6 +69,10 @@ src/engine/multisample/Sf2Reader.cpp
 src/engine/multisample/Sf2Reader.h
 src/engine/multisample/Sf2ToSfz.cpp
 src/engine/multisample/Sf2ToSfz.h
+src/engine/pipewire/PipeWireAudioIODevice.cpp
+src/engine/pipewire/PipeWireAudioIODevice.h
+src/engine/pipewire/PipeWireAudioIODeviceType.cpp
+src/engine/pipewire/PipeWireAudioIODeviceType.h
 src/session/MarkerEditActions.h
 src/session/MidiBindings.cpp
 src/session/MidiBindings.h


### PR DESCRIPTION
Replaces JUCE's JACK-over-pipewire-jack path with a Dusk Studio-owned `juce::AudioIODevice` + `AudioIODeviceType` pair speaking libpipewire directly. Layer 5 of the de-JUCE roadmap; Linux #1 audio path.

## What

- **`PipeWireAudioIODevice`** — one `pw_filter` node, N input + M output ports processed in a single graph cycle (the JACK model JUCE's duplex callback expects, so capture/playback stay sample-aligned). Planar F32 throughout (no per-sample conversion). `pw_thread_loop` RT thread runs the JUCE callback directly, allocation-free, unlinked-port scratch sized to the max quantum. Target node via `PW_KEY_TARGET_OBJECT` (node + port), quantum via `PW_KEY_NODE_LATENCY`, xrun surfaced from `clock.xrun`.
- **`PipeWireAudioIODeviceType`** — enumerates `Audio/Sink|Source|Duplex` nodes as devices over one synchronous registry roundtrip (device-per-node, mirroring the ALSA backend so the existing selector UI works unchanged).
- Registered ahead of native ALSA in `AudioEngine` + the headless tone test; JUCE's JACK backend is no longer registered, and the busy-device recovery path falls back through PipeWire.
- Gated by `DUSKSTUDIO_HAS_PIPEWIRE` (CMake pkg-checks `libpipewire-0.3`), Linux-only, present-or-stub like the LV2 host.

## Connection correctness

`open()` starts the loop, then connects and waits under the thread-loop lock for the filter to reach `PAUSED`/`STREAMING` (or `ERROR`/timeout) via a `state_changed` handler, rather than reporting success while the async connection is still pending. A vanished target or disconnected server fails `open()` with a message instead of leaving a dead device marked open.

## Testing

Pure helpers (active-channel counting, `node.latency` formatting) covered by the backend self-test under `DUSKSTUDIO_RUN_SELFTEST=1`. Verified locally: app build 0 new warnings, 382/382 ctest, Xvfb selftest opens the backend at 44100/512 and 48000/128.

## Deferred (need live hardware)

Negotiated-quantum readback (reports requested, not graph-rounded), graph-accurate port latency (1-quantum estimate now), live registry hotplug listeners (rescan is manual). Bench pass on a real interface + live Wayland still owed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native PipeWire audio support on Linux.
  * PipeWire devices are detected, listed, and preferred for audio initialization.
  * Audio latency is reported from the PipeWire graph, with improved device recovery when ALSA devices are busy.
  * Headless tone tests now support selecting the PipeWire backend.

* **Documentation**
  * Updated Linux audio setup, device selection, system requirements, and troubleshooting guidance for PipeWire and ALSA.

* **Chores**
  * Improved Raspberry Pi build dependency installation reliability with retries and network fallback handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->