### PR TITLE
CI: MIT mirror for the release arm64 apt

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -82,7 +82,14 @@ jobs:
             echo "Tag ${GITHUB_REF_NAME} != VERSION v$(tr -d '[:space:]' < VERSION)"; exit 1; }
 
       - name: Install Linux build deps + packaging tools
+        # The arm64 matrix arm pulls from ports.ubuntu.com, which is often
+        # unreachable from GitHub's ARM runners on both IPv6 and IPv4; swap it
+        # for the MIT mirror and force IPv4 (a no-op on the amd64 arm, which
+        # uses archive.ubuntu.com). Mirrors raspberry-pi-build.yml.
         run: |
+          sudo find /etc/apt/ -type f \( -name "*.list" -o -name "*.sources" \) \
+            -exec sed -i 's|ports.ubuntu.com|mirrors.mit.edu|g' {} +
+          echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4 >/dev/null
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             build-essential cmake ninja-build pkg-config \

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -82,14 +82,16 @@ jobs:
             echo "Tag ${GITHUB_REF_NAME} != VERSION v$(tr -d '[:space:]' < VERSION)"; exit 1; }
 
       - name: Install Linux build deps + packaging tools
-        # The arm64 matrix arm pulls from ports.ubuntu.com, which is often
-        # unreachable from GitHub's ARM runners on both IPv6 and IPv4; swap it
-        # for the MIT mirror and force IPv4 (a no-op on the amd64 arm, which
-        # uses archive.ubuntu.com). Mirrors raspberry-pi-build.yml.
+        # The aarch64 arm pulls from ports.ubuntu.com, which is often unreachable
+        # from GitHub's ARM runners on both IPv6 and IPv4; swap it for the MIT
+        # mirror and force IPv4 (arm only, so the amd64 arm keeps its stock apt
+        # sources and network behavior). Mirrors raspberry-pi-build.yml.
         run: |
-          sudo find /etc/apt/ -type f \( -name "*.list" -o -name "*.sources" \) \
-            -exec sed -i 's|ports.ubuntu.com|mirrors.mit.edu|g' {} +
-          echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4 >/dev/null
+          if [ "${{ matrix.arch }}" = "aarch64" ]; then
+            sudo find /etc/apt/ -type f \( -name "*.list" -o -name "*.sources" \) \
+              -exec sed -i 's|ports.ubuntu.com|mirrors.mit.edu|g' {} +
+            echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4 >/dev/null
+          fi
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             build-essential cmake ninja-build pkg-config \


### PR DESCRIPTION
The release workflow's aarch64 matrix arm installs deps from `ports.ubuntu.com`, which is regularly unreachable from GitHub's ARM runners (both IPv6 and IPv4) — the same outage that just failed the Raspberry Pi build on PR #79. Swap to the MIT ubuntu-ports mirror and force IPv4, mirroring `raspberry-pi-build.yml`. No-op on the amd64 matrix arm (uses `archive.ubuntu.com`).

Prevents a tag build from failing at dep install. CI-only; runs on tags, so no PR build exercises it directly, but the change is identical to the RPi fix already proven green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Linux builds on ARM environments by updating package mirror configuration and forcing IPv4 connections during dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->