### PR TITLE
Fix: PipeWire backend actually streams (manual linking + channel counts)

### DIFF
--- a/src/engine/pipewire/PipeWireAudioIODevice.cpp
+++ b/src/engine/pipewire/PipeWireAudioIODevice.cpp
@@ -291,6 +291,24 @@ juce::String PipeWireAudioIODevice::open (const juce::BigInteger& inputChannels,
     numOutputChannels = countActiveChannels (outputChannels);
     numInputChannels  = countActiveChannels (inputChannels);
 
+    // The device selector activates a fixed wide channel mask; clamp to the
+    // interface's real port count (from enumeration) so we don't create dead
+    // ports the graph can't link, and the active set the callback/UI see matches
+    // what actually exists. deviceOutChannels == 0 means the count is unknown
+    // (leave the request as-is).
+    if (deviceOutChannels > 0 && numOutputChannels > deviceOutChannels)
+    {
+        currentOutputChannels.setRange (deviceOutChannels,
+            currentOutputChannels.getHighestBit() + 1 - deviceOutChannels, false);
+        numOutputChannels = countActiveChannels (currentOutputChannels);
+    }
+    if (deviceInChannels > 0 && numInputChannels > deviceInChannels)
+    {
+        currentInputChannels.setRange (deviceInChannels,
+            currentInputChannels.getHighestBit() + 1 - deviceInChannels, false);
+        numInputChannels = countActiveChannels (currentInputChannels);
+    }
+
     const bool wantOutput = numOutputChannels > 0 && outputId.isNotEmpty();
     const bool wantInput  = numInputChannels  > 0 && inputId.isNotEmpty();
     if (! wantOutput && ! wantInput)
@@ -610,8 +628,14 @@ int PipeWireAudioIODevice::linkToHardware()
     const auto srcOut = sourceNode != (juce::uint32) SPA_ID_INVALID ? orderedPortIds (s, sourceNode, true)
                                                                     : juce::Array<juce::uint32>();
 
-    const int wantLinks = std::min (ourOut.size(), sinkIn.size())
-                        + std::min (srcOut.size(), ourIn.size());
+    // Every port we created must have a matching device port, or routing would
+    // be partial. numOut/InChannels were clamped to the device's real port count
+    // in open(), so this holds exactly unless the device changed between the
+    // enumeration and now - in which case fail rather than half-wire it.
+    if (sinkIn.size() < ourOut.size() || srcOut.size() < ourIn.size())
+        return -1;
+
+    const int wantLinks = ourOut.size() + ourIn.size();
 
     int made = 0;
     pw_thread_loop_lock (threadLoop);
@@ -631,16 +655,15 @@ int PipeWireAudioIODevice::linkToHardware()
             pw_properties_free (lp);
             if (proxy != nullptr) { linkProxies.add (proxy); ++made; }
         };
-        for (int i = 0; i < std::min (ourOut.size(), sinkIn.size()); ++i)
+        for (int i = 0; i < ourOut.size(); ++i)
             makeLink (ourNode, ourOut.getUnchecked (i), sinkNode,   sinkIn.getUnchecked (i));
-        for (int j = 0; j < std::min (srcOut.size(), ourIn.size()); ++j)
+        for (int j = 0; j < ourIn.size(); ++j)
             makeLink (sourceNode, srcOut.getUnchecked (j), ourNode, ourIn.getUnchecked (j));
     }
     pw_thread_loop_unlock (threadLoop);
 
-    // A partial link set (a proxy failed, or no ports matched) would route only
-    // some channels; signal failure so open() rejects it rather than opening a
-    // half-wired device.
+    // A partial link set (a proxy failed to create) would route only some
+    // channels; signal failure so open() rejects it rather than half-wiring.
     return (wantLinks > 0 && made == wantLinks) ? made : -1;
 }
 

--- a/src/engine/pipewire/PipeWireAudioIODevice.cpp
+++ b/src/engine/pipewire/PipeWireAudioIODevice.cpp
@@ -182,8 +182,9 @@ pw_core_events makeGraphCoreEvents()
 const pw_registry_events kGraphRegistryEvents = makeGraphRegistryEvents();
 const pw_core_events     kGraphCoreEvents     = makeGraphCoreEvents();
 
-// Registry ids of a node's ports in one direction, ordered by port id (which
-// follows creation / channel order), so link N maps our channel N to theirs.
+// Registry ids of a node's ports in one direction, ordered by channelOrderKey
+// (semantic audio.channel, else port-name index) so link N maps our channel N
+// to the device's channel N regardless of registry id assignment.
 juce::Array<juce::uint32> orderedPortIds (const GraphScan& s, juce::uint32 nodeId, bool isOutput)
 {
     juce::Array<GraphPort> matching;
@@ -325,7 +326,10 @@ juce::String PipeWireAudioIODevice::open (const juce::BigInteger& inputChannels,
         PW_KEY_APP_NAME,         "Dusk Studio",
         PW_KEY_NODE_NAME,        "Dusk Studio",
         PW_KEY_NODE_LATENCY,     latency.toRawUTF8(),
-        PW_KEY_NODE_AUTOCONNECT, "true",
+        // We link to the target ourselves (linkToHardware), so keep the session
+        // manager's auto-link policy out of it - autoconnect would also try to
+        // link the node to the DEFAULT device, routing audio to the wrong place.
+        PW_KEY_NODE_AUTOCONNECT, "false",
         // A duplex filter is not a driver and, unlinked, is never scheduled -
         // it sits at PAUSED and on_process never fires. want-driver asks the
         // graph to group it with the hardware driver node so the cycle runs.

--- a/src/engine/pipewire/PipeWireAudioIODevice.cpp
+++ b/src/engine/pipewire/PipeWireAudioIODevice.cpp
@@ -127,13 +127,24 @@ void onGraphGlobal (void* data, uint32_t id, uint32_t /*perm*/, const char* type
         const char* dir       = spa_dict_lookup (props, PW_KEY_PORT_DIRECTION);
         if (nodeIdStr == nullptr || dir == nullptr)
             return;
+        const bool isOut = std::strcmp (dir, "out") == 0;
+        const bool isIn  = std::strcmp (dir, "in")  == 0;
+        if (! isOut && ! isIn)
+            return;
+        const char* ch = spa_dict_lookup (props, PW_KEY_AUDIO_CHANNEL);
+        const char* nm = spa_dict_lookup (props, PW_KEY_PORT_NAME);
+        const juce::String name = nm != nullptr ? juce::String::fromUTF8 (nm) : juce::String();
+        // Link only audio ports: device audio ports carry audio.channel; our own
+        // DSP ports don't but are named playback_/capture_. Everything else
+        // (MIDI / control / notify ports) must not be linked.
+        if (ch == nullptr && ! name.startsWith ("playback_") && ! name.startsWith ("capture_"))
+            return;
         GraphPort p;
         p.nodeId   = (juce::uint32) juce::String (nodeIdStr).getLargeIntValue();
         p.portId   = id;
-        p.isOutput = std::strcmp (dir, "out") == 0;
-        if (const char* nm = spa_dict_lookup (props, PW_KEY_PORT_NAME))
-            p.name = juce::String::fromUTF8 (nm);
-        if (const char* ch = spa_dict_lookup (props, PW_KEY_AUDIO_CHANNEL))
+        p.isOutput = isOut;
+        p.name     = name;
+        if (ch != nullptr)
             p.channel = juce::String::fromUTF8 (ch);
         s.ports.add (p);
     }
@@ -470,6 +481,12 @@ juce::String PipeWireAudioIODevice::open (const juce::BigInteger& inputChannels,
     // chosen device ourselves. Once linked, the graph drives the node (STREAMING)
     // and onProcess starts firing.
     const int nLinks = linkToHardware();
+    if (nLinks <= 0)
+    {
+        lastError = "PipeWire: could not link all device ports";
+        close();
+        return lastError;
+    }
 
     // Wait for the links to drive the node to STREAMING - that state IS the
     // confirmation the links bound and the graph is running. If it never reaches
@@ -532,7 +549,12 @@ juce::String PipeWireAudioIODevice::open (const juce::BigInteger& inputChannels,
 
 int PipeWireAudioIODevice::linkToHardware()
 {
+    // Filter accessors touch objects on the thread loop; briefly lock for them
+    // (but NOT across the registry roundtrip below, which would stall the RT
+    // thread for the whole sync).
+    pw_thread_loop_lock (threadLoop);
     const juce::uint32 ourNode = pw_filter_get_node_id (filter);
+    pw_thread_loop_unlock (threadLoop);
     if (ourNode == (juce::uint32) SPA_ID_INVALID)
         return 0;
 
@@ -588,31 +610,38 @@ int PipeWireAudioIODevice::linkToHardware()
     const auto srcOut = sourceNode != (juce::uint32) SPA_ID_INVALID ? orderedPortIds (s, sourceNode, true)
                                                                     : juce::Array<juce::uint32>();
 
-    auto* filterCore = pw_filter_get_core (filter);
-    if (filterCore == nullptr)
-        return 0;
+    const int wantLinks = std::min (ourOut.size(), sinkIn.size())
+                        + std::min (srcOut.size(), ourIn.size());
 
     int made = 0;
     pw_thread_loop_lock (threadLoop);
-    auto makeLink = [&] (juce::uint32 outNode, juce::uint32 outPort,
-                         juce::uint32 inNode,  juce::uint32 inPort)
+    auto* filterCore = pw_filter_get_core (filter);
+    if (filterCore != nullptr)
     {
-        auto* lp = pw_properties_new (nullptr, nullptr);
-        pw_properties_setf (lp, PW_KEY_LINK_OUTPUT_NODE, "%u", outNode);
-        pw_properties_setf (lp, PW_KEY_LINK_OUTPUT_PORT, "%u", outPort);
-        pw_properties_setf (lp, PW_KEY_LINK_INPUT_NODE,  "%u", inNode);
-        pw_properties_setf (lp, PW_KEY_LINK_INPUT_PORT,  "%u", inPort);
-        auto* proxy = (pw_proxy*) pw_core_create_object (filterCore, "link-factory",
-            PW_TYPE_INTERFACE_Link, PW_VERSION_LINK, &lp->dict, 0);
-        pw_properties_free (lp);
-        if (proxy != nullptr) { linkProxies.add (proxy); ++made; }
-    };
-    for (int i = 0; i < std::min (ourOut.size(), sinkIn.size()); ++i)
-        makeLink (ourNode, ourOut.getUnchecked (i), sinkNode,   sinkIn.getUnchecked (i));
-    for (int j = 0; j < std::min (srcOut.size(), ourIn.size()); ++j)
-        makeLink (sourceNode, srcOut.getUnchecked (j), ourNode, ourIn.getUnchecked (j));
+        auto makeLink = [&] (juce::uint32 outNode, juce::uint32 outPort,
+                             juce::uint32 inNode,  juce::uint32 inPort)
+        {
+            auto* lp = pw_properties_new (nullptr, nullptr);
+            pw_properties_setf (lp, PW_KEY_LINK_OUTPUT_NODE, "%u", outNode);
+            pw_properties_setf (lp, PW_KEY_LINK_OUTPUT_PORT, "%u", outPort);
+            pw_properties_setf (lp, PW_KEY_LINK_INPUT_NODE,  "%u", inNode);
+            pw_properties_setf (lp, PW_KEY_LINK_INPUT_PORT,  "%u", inPort);
+            auto* proxy = (pw_proxy*) pw_core_create_object (filterCore, "link-factory",
+                PW_TYPE_INTERFACE_Link, PW_VERSION_LINK, &lp->dict, 0);
+            pw_properties_free (lp);
+            if (proxy != nullptr) { linkProxies.add (proxy); ++made; }
+        };
+        for (int i = 0; i < std::min (ourOut.size(), sinkIn.size()); ++i)
+            makeLink (ourNode, ourOut.getUnchecked (i), sinkNode,   sinkIn.getUnchecked (i));
+        for (int j = 0; j < std::min (srcOut.size(), ourIn.size()); ++j)
+            makeLink (sourceNode, srcOut.getUnchecked (j), ourNode, ourIn.getUnchecked (j));
+    }
     pw_thread_loop_unlock (threadLoop);
-    return made;
+
+    // A partial link set (a proxy failed, or no ports matched) would route only
+    // some channels; signal failure so open() rejects it rather than opening a
+    // half-wired device.
+    return (wantLinks > 0 && made == wantLinks) ? made : -1;
 }
 
 void PipeWireAudioIODevice::close()

--- a/src/engine/pipewire/PipeWireAudioIODevice.cpp
+++ b/src/engine/pipewire/PipeWireAudioIODevice.cpp
@@ -291,24 +291,6 @@ juce::String PipeWireAudioIODevice::open (const juce::BigInteger& inputChannels,
     numOutputChannels = countActiveChannels (outputChannels);
     numInputChannels  = countActiveChannels (inputChannels);
 
-    // The device selector activates a fixed wide channel mask; clamp to the
-    // interface's real port count (from enumeration) so we don't create dead
-    // ports the graph can't link, and the active set the callback/UI see matches
-    // what actually exists. deviceOutChannels == 0 means the count is unknown
-    // (leave the request as-is).
-    if (deviceOutChannels > 0 && numOutputChannels > deviceOutChannels)
-    {
-        currentOutputChannels.setRange (deviceOutChannels,
-            currentOutputChannels.getHighestBit() + 1 - deviceOutChannels, false);
-        numOutputChannels = countActiveChannels (currentOutputChannels);
-    }
-    if (deviceInChannels > 0 && numInputChannels > deviceInChannels)
-    {
-        currentInputChannels.setRange (deviceInChannels,
-            currentInputChannels.getHighestBit() + 1 - deviceInChannels, false);
-        numInputChannels = countActiveChannels (currentInputChannels);
-    }
-
     const bool wantOutput = numOutputChannels > 0 && outputId.isNotEmpty();
     const bool wantInput  = numInputChannels  > 0 && inputId.isNotEmpty();
     if (! wantOutput && ! wantInput)
@@ -628,14 +610,8 @@ int PipeWireAudioIODevice::linkToHardware()
     const auto srcOut = sourceNode != (juce::uint32) SPA_ID_INVALID ? orderedPortIds (s, sourceNode, true)
                                                                     : juce::Array<juce::uint32>();
 
-    // Every port we created must have a matching device port, or routing would
-    // be partial. numOut/InChannels were clamped to the device's real port count
-    // in open(), so this holds exactly unless the device changed between the
-    // enumeration and now - in which case fail rather than half-wire it.
-    if (sinkIn.size() < ourOut.size() || srcOut.size() < ourIn.size())
-        return -1;
-
-    const int wantLinks = ourOut.size() + ourIn.size();
+    const int wantLinks = std::min (ourOut.size(), sinkIn.size())
+                        + std::min (srcOut.size(), ourIn.size());
 
     int made = 0;
     pw_thread_loop_lock (threadLoop);
@@ -655,15 +631,16 @@ int PipeWireAudioIODevice::linkToHardware()
             pw_properties_free (lp);
             if (proxy != nullptr) { linkProxies.add (proxy); ++made; }
         };
-        for (int i = 0; i < ourOut.size(); ++i)
+        for (int i = 0; i < std::min (ourOut.size(), sinkIn.size()); ++i)
             makeLink (ourNode, ourOut.getUnchecked (i), sinkNode,   sinkIn.getUnchecked (i));
-        for (int j = 0; j < ourIn.size(); ++j)
+        for (int j = 0; j < std::min (srcOut.size(), ourIn.size()); ++j)
             makeLink (sourceNode, srcOut.getUnchecked (j), ourNode, ourIn.getUnchecked (j));
     }
     pw_thread_loop_unlock (threadLoop);
 
-    // A partial link set (a proxy failed to create) would route only some
-    // channels; signal failure so open() rejects it rather than half-wiring.
+    // A partial link set (a proxy failed, or no ports matched) would route only
+    // some channels; signal failure so open() rejects it rather than opening a
+    // half-wired device.
     return (wantLinks > 0 && made == wantLinks) ? made : -1;
 }
 

--- a/src/engine/pipewire/PipeWireAudioIODevice.cpp
+++ b/src/engine/pipewire/PipeWireAudioIODevice.cpp
@@ -2,12 +2,17 @@
 
 #include <pipewire/pipewire.h>
 #include <pipewire/filter.h>
+#include <pipewire/link.h>
 #include <spa/node/io.h>
+#include <spa/utils/dict.h>
 
 #include <algorithm>
 #include <mutex>
 #include <cstdio>
 #include <cstring>
+#include <thread>
+#include <chrono>
+#include <ctime>
 
 namespace duskstudio
 {
@@ -50,6 +55,148 @@ pw_filter_events makeFilterEvents()
 }
 
 const pw_filter_events kFilterEvents = makeFilterEvents();
+
+// ----- graph port discovery (for manual linking) -----------------------------
+// A single node's audio port, collected from the registry so we can reference
+// its global id in a link. Direction is the graph's ("out" produces).
+struct GraphPort
+{
+    juce::uint32 nodeId = 0;
+    juce::uint32 portId = 0;
+    bool         isOutput = false;
+    juce::String name;      // "playback_1", "capture_2", device port names...
+    juce::String channel;   // audio.channel: "FL"/"FR"/"AUX0".., or empty
+};
+
+// A stable per-node channel ordering key. Prefer the semantic audio.channel
+// position (survives graph recreation, unlike registry ids); fall back to the
+// trailing index in our own DSP port names ("playback_3"), then the port id.
+// Only used to order ports WITHIN one node, so the key scales need not align
+// across the named/aux/fallback groups.
+int channelOrderKey (const GraphPort& p)
+{
+    if (p.channel.isNotEmpty())
+    {
+        if (p.channel.startsWith ("AUX"))
+            return 100 + p.channel.substring (3).getIntValue();
+        static const char* const canonical[] =
+            { "MONO", "FL", "FR", "FC", "LFE", "RL", "RR", "FLC", "FRC", "RC", "SL", "SR" };
+        for (int i = 0; i < (int) (sizeof (canonical) / sizeof (canonical[0])); ++i)
+            if (p.channel == canonical[i]) return i;
+    }
+    const auto digits = p.name.retainCharacters ("0123456789");
+    if (digits.isNotEmpty())
+        return digits.getIntValue();
+    return (int) p.portId;
+}
+
+struct GraphScan
+{
+    juce::Array<GraphPort> ports;
+    juce::StringArray      nodeNames;   // index-aligned with nodeIds
+    juce::Array<juce::uint32> nodeIds;
+    pw_main_loop* loop = nullptr;
+    int  syncSeq = 0;
+    bool haveSync = false;
+
+    juce::uint32 resolveNode (const juce::String& name) const
+    {
+        const int i = nodeNames.indexOf (name);
+        return i >= 0 ? nodeIds.getUnchecked (i) : (juce::uint32) SPA_ID_INVALID;
+    }
+};
+
+void onGraphGlobal (void* data, uint32_t id, uint32_t /*perm*/, const char* type,
+                     uint32_t /*version*/, const struct spa_dict* props)
+{
+    auto& s = *static_cast<GraphScan*> (data);
+    if (props == nullptr)
+        return;
+
+    if (std::strcmp (type, PW_TYPE_INTERFACE_Node) == 0)
+    {
+        if (const char* nm = spa_dict_lookup (props, PW_KEY_NODE_NAME))
+        {
+            s.nodeNames.add (juce::String::fromUTF8 (nm));
+            s.nodeIds.add (id);
+        }
+    }
+    else if (std::strcmp (type, PW_TYPE_INTERFACE_Port) == 0)
+    {
+        const char* nodeIdStr = spa_dict_lookup (props, PW_KEY_NODE_ID);
+        const char* dir       = spa_dict_lookup (props, PW_KEY_PORT_DIRECTION);
+        if (nodeIdStr == nullptr || dir == nullptr)
+            return;
+        GraphPort p;
+        p.nodeId   = (juce::uint32) juce::String (nodeIdStr).getLargeIntValue();
+        p.portId   = id;
+        p.isOutput = std::strcmp (dir, "out") == 0;
+        if (const char* nm = spa_dict_lookup (props, PW_KEY_PORT_NAME))
+            p.name = juce::String::fromUTF8 (nm);
+        if (const char* ch = spa_dict_lookup (props, PW_KEY_AUDIO_CHANNEL))
+            p.channel = juce::String::fromUTF8 (ch);
+        s.ports.add (p);
+    }
+}
+
+void onGraphDone (void* data, uint32_t id, int seq)
+{
+    auto& s = *static_cast<GraphScan*> (data);
+    if (id == PW_ID_CORE && s.haveSync && seq == s.syncSeq)
+        pw_main_loop_quit (s.loop);
+}
+
+void onGraphError (void* data, uint32_t /*id*/, int /*seq*/, int /*res*/, const char* /*msg*/)
+{
+    // No matching done will arrive after a fatal core error; quit so discovery
+    // can't block the open() path forever.
+    auto& s = *static_cast<GraphScan*> (data);
+    if (s.loop != nullptr)
+        pw_main_loop_quit (s.loop);
+}
+
+void onGraphTimeout (void* data, uint64_t /*expirations*/)
+{
+    auto& s = *static_cast<GraphScan*> (data);
+    if (s.loop != nullptr)
+        pw_main_loop_quit (s.loop);
+}
+
+pw_registry_events makeGraphRegistryEvents()
+{
+    pw_registry_events e {};
+    e.version = PW_VERSION_REGISTRY_EVENTS;
+    e.global  = onGraphGlobal;
+    return e;
+}
+
+pw_core_events makeGraphCoreEvents()
+{
+    pw_core_events e {};
+    e.version = PW_VERSION_CORE_EVENTS;
+    e.done    = onGraphDone;
+    e.error   = onGraphError;
+    return e;
+}
+
+const pw_registry_events kGraphRegistryEvents = makeGraphRegistryEvents();
+const pw_core_events     kGraphCoreEvents     = makeGraphCoreEvents();
+
+// Registry ids of a node's ports in one direction, ordered by port id (which
+// follows creation / channel order), so link N maps our channel N to theirs.
+juce::Array<juce::uint32> orderedPortIds (const GraphScan& s, juce::uint32 nodeId, bool isOutput)
+{
+    juce::Array<GraphPort> matching;
+    for (const auto& p : s.ports)
+        if (p.nodeId == nodeId && p.isOutput == isOutput)
+            matching.add (p);
+    std::sort (matching.begin(), matching.end(),
+               [] (const GraphPort& a, const GraphPort& b)
+               { return channelOrderKey (a) < channelOrderKey (b); });
+    juce::Array<juce::uint32> ids;
+    for (const auto& p : matching) ids.add (p.portId);
+    return ids;
+}
 } // namespace
 
 // ----- pure helpers (shared with the self-test) ------------------------------
@@ -172,13 +319,24 @@ juce::String PipeWireAudioIODevice::open (const juce::BigInteger& inputChannels,
     const auto latency = formatNodeLatency (quantum, rate);
 
     auto* props = pw_properties_new (
-        PW_KEY_MEDIA_TYPE,     "Audio",
-        PW_KEY_MEDIA_CATEGORY, category,
-        PW_KEY_MEDIA_ROLE,     "Production",
-        PW_KEY_APP_NAME,       "Dusk Studio",
-        PW_KEY_NODE_NAME,      "Dusk Studio",
-        PW_KEY_NODE_LATENCY,   latency.toRawUTF8(),
+        PW_KEY_MEDIA_TYPE,       "Audio",
+        PW_KEY_MEDIA_CATEGORY,   category,
+        PW_KEY_MEDIA_ROLE,       "Production",
+        PW_KEY_APP_NAME,         "Dusk Studio",
+        PW_KEY_NODE_NAME,        "Dusk Studio",
+        PW_KEY_NODE_LATENCY,     latency.toRawUTF8(),
+        PW_KEY_NODE_AUTOCONNECT, "true",
+        // A duplex filter is not a driver and, unlinked, is never scheduled -
+        // it sits at PAUSED and on_process never fires. want-driver asks the
+        // graph to group it with the hardware driver node so the cycle runs.
+        PW_KEY_NODE_WANT_DRIVER,  "true",
         nullptr);
+    // Drive the graph to the session's rate + block size (PipeWire otherwise
+    // runs at its own quantum/rate and resamples, so our callback would get a
+    // different block size than the engine prepared for). force-* holds them
+    // while our node is active - this is the DAW acting as the graph's clock.
+    pw_properties_setf (props, PW_KEY_NODE_FORCE_RATE,    "%d", rate);
+    pw_properties_setf (props, PW_KEY_NODE_FORCE_QUANTUM, "%d", quantum);
     // Node-level target links the primary direction to the chosen device. Ports
     // also carry a per-direction target below; recent WirePlumber honours the
     // port target, older policy the node target, so we set both.
@@ -252,6 +410,7 @@ juce::String PipeWireAudioIODevice::open (const juce::BigInteger& inputChannels,
     // started, onProcess may read these on the very first cycle.
     lastXrunRecovering = false;
     xrunCount.store (0, std::memory_order_relaxed);
+    negotiatedQuantum.store (0, std::memory_order_relaxed);
 
     if (const int rc = pw_thread_loop_start (threadLoop); rc < 0)
     {
@@ -303,23 +462,160 @@ juce::String PipeWireAudioIODevice::open (const juce::BigInteger& inputChannels,
         }
     }
 
+    // The session manager won't link a duplex filter, so link our ports to the
+    // chosen device ourselves. Once linked, the graph drives the node (STREAMING)
+    // and onProcess starts firing.
+    const int nLinks = linkToHardware();
+
+    // Wait for the links to drive the node to STREAMING - that state IS the
+    // confirmation the links bound and the graph is running. If it never reaches
+    // STREAMING (no links bound, or the driver didn't start), the device would
+    // play silence with a frozen transport, so fail the open instead.
+    bool streaming = false;
+    {
+        pw_thread_loop_lock (threadLoop);
+        const char* se = nullptr;
+        pw_filter_state st = pw_filter_get_state (filter, &se);
+        for (int t = 0; st != PW_FILTER_STATE_STREAMING && st != PW_FILTER_STATE_ERROR && t < 10; ++t)
+        {
+            if (pw_thread_loop_timed_wait (threadLoop, 1) != 0)
+                break;
+            st = pw_filter_get_state (filter, &se);
+        }
+        streaming = (st == PW_FILTER_STATE_STREAMING);
+        pw_thread_loop_unlock (threadLoop);
+    }
+    if (! streaming)
+    {
+        lastError = "PipeWire node did not start streaming ("
+                    + juce::String (nLinks) + " link(s) created)";
+        close();
+        return lastError;
+    }
+
+    // Adopt the graph's real quantum: PipeWire runs the graph at its own block
+    // size (our request is only advisory), so the engine must prepare for what
+    // onProcess actually delivers - otherwise its oversized-block guard clears
+    // every block to silence.
+    for (int t = 0; t < 100 && negotiatedQuantum.load (std::memory_order_relaxed) == 0; ++t)
+        std::this_thread::sleep_for (std::chrono::milliseconds (2));
+    if (const int nq = negotiatedQuantum.load (std::memory_order_relaxed); nq > 0)
+        currentBlockSize = nq;
+
     isDeviceOpen.store (true, std::memory_order_release);
     lastError.clear();
 
     std::fprintf (stderr,
                   "[Dusk Studio/PipeWire] opened \"%s\" rate=%d quantum=%d out=%dch in=%dch "
-                  "target-out=\"%s\" target-in=\"%s\"\n",
-                  displayName.toRawUTF8(), rate, quantum,
-                  numOutputChannels, numInputChannels,
+                  "links=%d target-out=\"%s\" target-in=\"%s\"\n",
+                  displayName.toRawUTF8(), rate, currentBlockSize,
+                  numOutputChannels, numInputChannels, linkProxies.size(),
                   wantOutput ? outputId.toRawUTF8() : "-",
                   wantInput  ? inputId.toRawUTF8()  : "-");
 
     return {};
 }
 
+int PipeWireAudioIODevice::linkToHardware()
+{
+    const juce::uint32 ourNode = pw_filter_get_node_id (filter);
+    if (ourNode == (juce::uint32) SPA_ID_INVALID)
+        return 0;
+
+    // Throwaway registry roundtrip to discover the global port ids of our node
+    // and the target device nodes. Object ids are graph-global, so ids found on
+    // this scratch connection are valid to reference from the filter's core.
+    GraphScan s;
+    s.loop = pw_main_loop_new (nullptr);
+    if (s.loop == nullptr) return 0;
+    auto* ctx = pw_context_new (pw_main_loop_get_loop (s.loop), nullptr, 0);
+    if (ctx == nullptr) { pw_main_loop_destroy (s.loop); return 0; }
+    auto* core = pw_context_connect (ctx, nullptr, 0);
+    if (core == nullptr) { pw_context_destroy (ctx); pw_main_loop_destroy (s.loop); return 0; }
+    auto* registry = pw_core_get_registry (core, PW_VERSION_REGISTRY, 0);
+    if (registry == nullptr)
+    {
+        pw_core_disconnect (core); pw_context_destroy (ctx); pw_main_loop_destroy (s.loop);
+        return 0;
+    }
+
+    spa_hook rHook {}, cHook {};
+    pw_registry_add_listener (registry, &rHook, &kGraphRegistryEvents, &s);
+    pw_core_add_listener (core, &cHook, &kGraphCoreEvents, &s);
+    s.syncSeq  = pw_core_sync (core, PW_ID_CORE, 0);
+    s.haveSync = true;
+
+    auto* pwLoop = pw_main_loop_get_loop (s.loop);
+    auto* timer  = pw_loop_add_timer (pwLoop, onGraphTimeout, &s);
+    struct timespec timeout {};
+    timeout.tv_sec = 2;
+    pw_loop_update_timer (pwLoop, timer, &timeout, nullptr, false);
+
+    pw_main_loop_run (s.loop);
+
+    pw_loop_destroy_source (pwLoop, timer);
+    spa_hook_remove (&rHook);
+    spa_hook_remove (&cHook);
+    pw_proxy_destroy ((pw_proxy*) registry);
+    pw_core_disconnect (core);
+    pw_context_destroy (ctx);
+    pw_main_loop_destroy (s.loop);
+    s.loop = nullptr;
+
+    const bool wantOut = numOutputChannels > 0 && outputId.isNotEmpty();
+    const bool wantIn  = numInputChannels  > 0 && inputId.isNotEmpty();
+    const juce::uint32 sinkNode   = wantOut ? s.resolveNode (outputId) : (juce::uint32) SPA_ID_INVALID;
+    const juce::uint32 sourceNode = wantIn  ? s.resolveNode (inputId)  : (juce::uint32) SPA_ID_INVALID;
+
+    const auto ourOut = orderedPortIds (s, ourNode, true);
+    const auto ourIn  = orderedPortIds (s, ourNode, false);
+    const auto sinkIn = sinkNode   != (juce::uint32) SPA_ID_INVALID ? orderedPortIds (s, sinkNode,   false)
+                                                                    : juce::Array<juce::uint32>();
+    const auto srcOut = sourceNode != (juce::uint32) SPA_ID_INVALID ? orderedPortIds (s, sourceNode, true)
+                                                                    : juce::Array<juce::uint32>();
+
+    auto* filterCore = pw_filter_get_core (filter);
+    if (filterCore == nullptr)
+        return 0;
+
+    int made = 0;
+    pw_thread_loop_lock (threadLoop);
+    auto makeLink = [&] (juce::uint32 outNode, juce::uint32 outPort,
+                         juce::uint32 inNode,  juce::uint32 inPort)
+    {
+        auto* lp = pw_properties_new (nullptr, nullptr);
+        pw_properties_setf (lp, PW_KEY_LINK_OUTPUT_NODE, "%u", outNode);
+        pw_properties_setf (lp, PW_KEY_LINK_OUTPUT_PORT, "%u", outPort);
+        pw_properties_setf (lp, PW_KEY_LINK_INPUT_NODE,  "%u", inNode);
+        pw_properties_setf (lp, PW_KEY_LINK_INPUT_PORT,  "%u", inPort);
+        auto* proxy = (pw_proxy*) pw_core_create_object (filterCore, "link-factory",
+            PW_TYPE_INTERFACE_Link, PW_VERSION_LINK, &lp->dict, 0);
+        pw_properties_free (lp);
+        if (proxy != nullptr) { linkProxies.add (proxy); ++made; }
+    };
+    for (int i = 0; i < std::min (ourOut.size(), sinkIn.size()); ++i)
+        makeLink (ourNode, ourOut.getUnchecked (i), sinkNode,   sinkIn.getUnchecked (i));
+    for (int j = 0; j < std::min (srcOut.size(), ourIn.size()); ++j)
+        makeLink (sourceNode, srcOut.getUnchecked (j), ourNode, ourIn.getUnchecked (j));
+    pw_thread_loop_unlock (threadLoop);
+    return made;
+}
+
 void PipeWireAudioIODevice::close()
 {
     stop();
+
+    // Destroy the links we created (on the filter's core) before stopping the
+    // loop - proxy destruction touches the loop, so it needs the lock and a
+    // running loop.
+    if (threadLoop != nullptr && threadLoopRunning && ! linkProxies.isEmpty())
+    {
+        pw_thread_loop_lock (threadLoop);
+        for (auto* p : linkProxies)
+            if (p != nullptr) pw_proxy_destroy ((pw_proxy*) p);
+        pw_thread_loop_unlock (threadLoop);
+    }
+    linkProxies.clearQuick();
 
     // pw_thread_loop_stop must be called WITHOUT the lock held; it joins the RT
     // thread, after which teardown races nothing. Only stop a loop we actually
@@ -382,6 +678,8 @@ void PipeWireAudioIODevice::onProcess (struct spa_io_position* position) noexcep
     const juce::uint32 n = position != nullptr ? (juce::uint32) position->clock.duration : 0;
     if (n == 0)
         return;
+
+    negotiatedQuantum.store ((int) n, std::memory_order_relaxed);
 
     // Count one xrun per recovery episode: increment on the rising edge of the
     // XRUN_RECOVER flag, not on every cycle it stays set (a recovery can span
@@ -455,6 +753,19 @@ juce::String PipeWireAudioIODevice::runSelfTest()
     // node.latency string formatting (quantum/rate).
     check (formatNodeLatency (512, 48000) == "512/48000", "PipeWire: node.latency format 512/48000");
     check (formatNodeLatency (64, 44100)  == "64/44100",  "PipeWire: node.latency format 64/44100");
+
+    // Channel ordering key that maps our ports to the device's ports for
+    // manual linking. Hardware ports order by audio.channel; our DSP ports by
+    // the trailing index in their name.
+    {
+        auto hw = [] (const char* ch) { GraphPort p; p.channel = ch; return channelOrderKey (p); };
+        check (hw ("FL") < hw ("FR"),     "PipeWire: channel order FL before FR");
+        check (hw ("AUX0") < hw ("AUX1"), "PipeWire: channel order AUX0 before AUX1");
+        check (hw ("AUX2") < hw ("AUX10"),"PipeWire: channel order AUX2 before AUX10");
+        auto ours = [] (const char* nm) { GraphPort p; p.name = nm; return channelOrderKey (p); };
+        check (ours ("playback_2") < ours ("playback_10"),
+               "PipeWire: our port order playback_2 before playback_10");
+    }
 
     return out.joinIntoString ("\n");
 }

--- a/src/engine/pipewire/PipeWireAudioIODevice.cpp
+++ b/src/engine/pipewire/PipeWireAudioIODevice.cpp
@@ -500,11 +500,21 @@ juce::String PipeWireAudioIODevice::open (const juce::BigInteger& inputChannels,
     // Adopt the graph's real quantum: PipeWire runs the graph at its own block
     // size (our request is only advisory), so the engine must prepare for what
     // onProcess actually delivers - otherwise its oversized-block guard clears
-    // every block to silence.
+    // every block to silence. A quantum above maxQuantum is itself dropped by
+    // onProcess, so treat "no usable quantum" as a failed open rather than
+    // silently keeping the requested size.
     for (int t = 0; t < 100 && negotiatedQuantum.load (std::memory_order_relaxed) == 0; ++t)
         std::this_thread::sleep_for (std::chrono::milliseconds (2));
-    if (const int nq = negotiatedQuantum.load (std::memory_order_relaxed); nq > 0)
-        currentBlockSize = nq;
+    const int nq = negotiatedQuantum.load (std::memory_order_relaxed);
+    if (nq <= 0 || nq > maxQuantum)
+    {
+        lastError = "PipeWire delivered no usable quantum (" + juce::String (nq) + ")";
+        close();
+        return lastError;
+    }
+    currentBlockSize = nq;
+    if (wantOutput) outputLatency = nq;
+    if (wantInput)  inputLatency  = nq;
 
     isDeviceOpen.store (true, std::memory_order_release);
     lastError.clear();

--- a/src/engine/pipewire/PipeWireAudioIODevice.h
+++ b/src/engine/pipewire/PipeWireAudioIODevice.h
@@ -119,6 +119,12 @@ private:
     juce::Array<void*> inPorts;
     juce::Array<void*> outPorts;
 
+    // Link proxies we create from our ports to the target device's ports. A
+    // duplex pw_filter is not auto-linked by the session manager (it keys off
+    // media.class, which a dual-direction node can't carry), so we link to the
+    // hardware ourselves - see linkToHardware(). Owned; destroyed in close().
+    juce::Array<void*> linkProxies;
+
     double openedSampleRate = 0.0;
     int    currentBlockSize = 0;
     int    maxQuantum       = 0;      // scratch ceiling; cycles above this are dropped
@@ -146,8 +152,18 @@ private:
     std::atomic<bool> isDeviceOpen { false };
     std::atomic<bool> isStarted    { false };
     std::atomic<int>  xrunCount    { 0 };
+    // The graph's real quantum, captured from the first process cycle. PipeWire
+    // runs the graph at its own block size (often not the value we requested),
+    // so open() adopts this as currentBlockSize before the engine prepares.
+    std::atomic<int>  negotiatedQuantum { 0 };
 
     juce::String lastError;
+
+    // After the filter connects, link our ports to the chosen sink/source ports
+    // (the session manager won't). Discovers the global port ids via a registry
+    // roundtrip and creates link objects on the filter's core. Returns the number
+    // of links created. Message-thread only.
+    int linkToHardware();
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (PipeWireAudioIODevice)
 };

--- a/src/engine/pipewire/PipeWireAudioIODeviceType.cpp
+++ b/src/engine/pipewire/PipeWireAudioIODeviceType.cpp
@@ -20,46 +20,88 @@ void ensurePipeWireInit()
     std::call_once (once, [] { pw_init (nullptr, nullptr); });
 }
 
-// Collected during a single synchronous registry roundtrip. The *Chans arrays
-// are index-aligned with the corresponding *Names / *Ids arrays.
-struct ScanResult
+// Collected during a single synchronous registry roundtrip. Nodes and their
+// audio ports arrive as separate globals; channel counts come from counting the
+// ports (audio.channels is not in the node's registry props - it lives in the
+// node info, which the registry roundtrip doesn't fetch). Finalised into the
+// index-aligned *Names / *Ids / *Chans arrays by finalizeScan().
+struct NodeRec
 {
-    juce::StringArray inNames, outNames, inIds, outIds;
-    juce::Array<int>  inChans, outChans;
-    pw_main_loop*     loop = nullptr;
-    int               syncSeq = 0;
-    bool              haveSync = false;
+    juce::uint32 gid = 0;
+    juce::String name, label;
+    bool isSink = false, isSource = false;
 };
 
-void onRegistryGlobal (void* data, uint32_t /*id*/, uint32_t /*permissions*/,
+struct ScanResult
+{
+    juce::Array<NodeRec>      nodes;
+    juce::Array<juce::uint32> portNodeId;   // parallel with portIsOutput
+    juce::Array<bool>         portIsOutput;
+
+    juce::StringArray inNames, outNames, inIds, outIds;
+    juce::Array<int>  inChans, outChans;
+
+    pw_main_loop* loop = nullptr;
+    int  syncSeq = 0;
+    bool haveSync = false;
+};
+
+void onRegistryGlobal (void* data, uint32_t id, uint32_t /*permissions*/,
                         const char* type, uint32_t /*version*/,
                         const struct spa_dict* props)
 {
     auto& r = *static_cast<ScanResult*> (data);
-    if (props == nullptr || std::strcmp (type, PW_TYPE_INTERFACE_Node) != 0)
+    if (props == nullptr)
         return;
 
-    const char* mediaClass = spa_dict_lookup (props, PW_KEY_MEDIA_CLASS);
-    const char* nodeName    = spa_dict_lookup (props, PW_KEY_NODE_NAME);
-    if (mediaClass == nullptr || nodeName == nullptr)
-        return;
+    if (std::strcmp (type, PW_TYPE_INTERFACE_Node) == 0)
+    {
+        const char* mediaClass = spa_dict_lookup (props, PW_KEY_MEDIA_CLASS);
+        const char* nodeName   = spa_dict_lookup (props, PW_KEY_NODE_NAME);
+        if (mediaClass == nullptr || nodeName == nullptr)
+            return;
+        const bool isSink   = std::strcmp (mediaClass, "Audio/Sink")   == 0;
+        const bool isSource = std::strcmp (mediaClass, "Audio/Source") == 0;
+        const bool isDuplex = std::strcmp (mediaClass, "Audio/Duplex") == 0;
+        if (! (isSink || isSource || isDuplex))
+            return;
+        const char* desc = spa_dict_lookup (props, PW_KEY_NODE_DESCRIPTION);
+        NodeRec n;
+        n.gid      = id;
+        n.name     = juce::String::fromUTF8 (nodeName);
+        n.label    = desc != nullptr ? juce::String::fromUTF8 (desc) : n.name;
+        n.isSink   = isSink   || isDuplex;
+        n.isSource = isSource || isDuplex;
+        r.nodes.add (n);
+    }
+    else if (std::strcmp (type, PW_TYPE_INTERFACE_Port) == 0)
+    {
+        const char* nodeIdStr = spa_dict_lookup (props, PW_KEY_NODE_ID);
+        const char* dir       = spa_dict_lookup (props, PW_KEY_PORT_DIRECTION);
+        // Audio channels carry audio.channel; skip control / non-audio ports so
+        // the count reflects real channels.
+        if (nodeIdStr == nullptr || dir == nullptr
+            || spa_dict_lookup (props, PW_KEY_AUDIO_CHANNEL) == nullptr)
+            return;
+        r.portNodeId.add ((juce::uint32) juce::String (nodeIdStr).getLargeIntValue());
+        r.portIsOutput.add (std::strcmp (dir, "out") == 0);
+    }
+}
 
-    const char* desc = spa_dict_lookup (props, PW_KEY_NODE_DESCRIPTION);
-    const juce::String label = desc != nullptr ? juce::String::fromUTF8 (desc)
-                                               : juce::String::fromUTF8 (nodeName);
-    const juce::String id = juce::String::fromUTF8 (nodeName);
+// A sink's channel count is its INPUT ports (audio we send to it); a source's
+// is its OUTPUT ports. Build the index-aligned device lists from the port tally.
+void finalizeScan (ScanResult& r)
+{
+    for (const auto& n : r.nodes)
+    {
+        int inPorts = 0, outPorts = 0;
+        for (int k = 0; k < r.portNodeId.size(); ++k)
+            if (r.portNodeId.getUnchecked (k) == n.gid)
+                (r.portIsOutput.getUnchecked (k) ? outPorts : inPorts) += 1;
 
-    // audio.channels is the node's channel count; absent on some nodes, in which
-    // case 0 -> the device falls back to a stereo pair.
-    const char* chanStr = spa_dict_lookup (props, PW_KEY_AUDIO_CHANNELS);
-    const int chans = chanStr != nullptr ? juce::String (chanStr).getIntValue() : 0;
-
-    const bool isSink   = std::strcmp (mediaClass, "Audio/Sink")   == 0;
-    const bool isSource = std::strcmp (mediaClass, "Audio/Source") == 0;
-    const bool isDuplex = std::strcmp (mediaClass, "Audio/Duplex") == 0;
-
-    if (isSink || isDuplex)   { r.outNames.add (label); r.outIds.add (id); r.outChans.add (chans); }
-    if (isSource || isDuplex) { r.inNames.add  (label); r.inIds.add  (id); r.inChans.add  (chans); }
+        if (n.isSink)   { r.outNames.add (n.label); r.outIds.add (n.name); r.outChans.add (inPorts); }
+        if (n.isSource) { r.inNames.add  (n.label); r.inIds.add  (n.name); r.inChans.add  (outPorts); }
+    }
 }
 
 void onCoreDone (void* data, uint32_t id, int seq)
@@ -162,6 +204,8 @@ void enumerateNodes (ScanResult& result)
     pw_context_destroy (context);
     pw_main_loop_destroy (result.loop);
     result.loop = nullptr;
+
+    finalizeScan (result);
 }
 } // namespace
 

--- a/src/engine/pipewire/PipeWireAudioIODeviceType.cpp
+++ b/src/engine/pipewire/PipeWireAudioIODeviceType.cpp
@@ -44,6 +44,7 @@ struct ScanResult
     pw_main_loop* loop = nullptr;
     int  syncSeq = 0;
     bool haveSync = false;
+    bool completed = false;   // the matching core.done arrived (scan is complete)
 };
 
 void onRegistryGlobal (void* data, uint32_t id, uint32_t /*permissions*/,
@@ -110,7 +111,10 @@ void onCoreDone (void* data, uint32_t id, int seq)
     // The graph delivers every existing registry global BEFORE answering our
     // sync, so once this matching done arrives the enumeration is complete.
     if (id == PW_ID_CORE && r.haveSync && seq == r.syncSeq)
+    {
+        r.completed = true;
         pw_main_loop_quit (r.loop);
+    }
 }
 
 void onCoreError (void* data, uint32_t /*id*/, int /*seq*/, int /*res*/, const char* /*message*/)
@@ -205,7 +209,10 @@ void enumerateNodes (ScanResult& result)
     pw_main_loop_destroy (result.loop);
     result.loop = nullptr;
 
-    finalizeScan (result);
+    // Only publish devices from a complete scan; a core error or the timeout
+    // quits the loop early with partial data, which would list wrong counts.
+    if (result.completed)
+        finalizeScan (result);
 }
 } // namespace
 


### PR DESCRIPTION
The native PipeWire backend merged in #79 connected but **never played** on real hardware: no audio, frozen transport (ALSA was fine). CI/Xvfb only exercised `open()`, so it shipped broken. Confirmed and fixed on a UMC1820.

## Root cause
A single duplex `pw_filter` carries no `media.class` (and can't, for both directions), so WirePlumber's auto-link policy never links it to the device. The node sat at `PAUSED`, was never driven, `on_process` never fired.

## Fixes
- **Link to hardware ourselves** (the JACK model, explicit) instead of relying on the session-manager policy: after connect, discover the target sink/source port ids via a registry roundtrip and create link objects on the filter's core (`link-factory`); `node.want-driver` groups us with the hardware driver so the graph schedules the node. `node.autoconnect=false` so the policy doesn't also link us to the default device.
- **Order links by semantic `audio.channel`** (FL/FR/AUX0…), falling back to our DSP port-name index — correct L/R and physical routing, stable across graph recreation.
- **Honest open**: wait for `STREAMING` after linking (confirms links bound + graph running); fail `open()` otherwise rather than leaving a silent dead device.
- **Adopt the graph's real quantum**: PipeWire runs the graph at its own block size, so report what `on_process` actually delivers, and reject an unusable quantum (`0` or `> maxQuantum`) instead of silently keeping the request.
- **Real device channel counts**: `audio.channels` isn't in a node's registry-global props, so enumeration read 0 and every device fell back to stereo — the main-output picker showed only 1-2. Count the node's audio ports instead; the picker now offers every pair a multichannel interface exposes.

## Testing
Validated on real hardware (UMC1820): reaches STREAMING, audio plays, transport moves, main-output picker lists all pairs. 382 Catch2 tests + pure channel-order self-test checks pass. `node.force-quantum` verified to honor the requested buffer size when no global `clock.force-quantum` override is present.

Backend remains Linux-gated (`DUSKSTUDIO_HAS_PIPEWIRE`); not compiled on the jammy CI runners (libpipewire 0.3.48 too old), so this is validated locally + on hardware, not in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PipeWire device detection by counting actual audio port channels during enumeration, leading to more accurate input/output channel counts.
  - Ensured stable, deterministic channel connection ordering, including correct handling of auxiliary ports and numbered DSP ports.
  - Better negotiation of the actual sample block size and improved latency handling based on measured streaming parameters.
  - Reduced shutdown instability by ensuring duplex audio link connections are fully torn down safely.
- **Improvements**
  - Duplex audio connections now initialize and connect more consistently when opening devices.
- **Tests**
  - Added assertions to verify channel ordering for auxiliary and numbered ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->