### PR TITLE
De-JUCE: SF2 reader onto std::ifstream + std::filesystem

### DIFF
--- a/src/engine/multisample/DuskMultisampleProcessor.cpp
+++ b/src/engine/multisample/DuskMultisampleProcessor.cpp
@@ -194,7 +194,7 @@ bool DuskMultisampleProcessor::loadSf2File (const juce::File& sf2,
     // Cache the preset name list (cheap metadata parse, no sample
     // extraction) so the editor can offer a program switcher.
     sf2PresetNames.clear();
-    if (auto parsed = readSf2 (sf2); parsed.ok)
+    if (auto parsed = readSf2 (std::filesystem::u8path (sf2.getFullPathName().toStdString())); parsed.ok)
         for (const auto& p : parsed.presets)
             sf2PresetNames.add (p.name);
 

--- a/src/engine/multisample/Sf2Reader.cpp
+++ b/src/engine/multisample/Sf2Reader.cpp
@@ -3,6 +3,7 @@
 #include "../../foundation/Text.h"
 
 #include <algorithm>
+#include <fstream>
 
 namespace duskstudio
 {
@@ -101,16 +102,59 @@ std::vector<Sf2Zone> buildZones(int bagStart, int bagEnd,
     }
     return zones;
 }
+
+// Streaming byte cursor over the .sf2 file. Mirrors the slice of
+// JUCE's FileInputStream the parser used: read a count of bytes, a
+// little-endian int32, and the absolute file position (which the sample
+// offsets are recorded in). Streams so the large smpl PCM is skipped, not
+// slurped, exactly as before.
+struct FileCursor
+{
+    std::ifstream in;
+    std::int64_t  length = 0;
+
+    bool open(const std::filesystem::path& p)
+    {
+        in.open(p, std::ios::binary);
+        if (! in) return false;
+        in.seekg(0, std::ios::end);
+        length = (std::int64_t) in.tellg();
+        in.seekg(0, std::ios::beg);
+        return true;
+    }
+
+    int read(void* dst, int n)
+    {
+        in.read(reinterpret_cast<char*>(dst), n);
+        const int got = (int) in.gcount();
+        if (! in) in.clear();   // a short read at EOF must not wedge later seeks
+        return got;
+    }
+
+    // Little-endian int32, matching JUCE's InputStream::readInt.
+    std::int32_t readInt()
+    {
+        std::uint8_t b[4] { 0, 0, 0, 0 };
+        read(b, 4);
+        return (std::int32_t) ((std::uint32_t) b[0]        | ((std::uint32_t) b[1] << 8)
+                               | ((std::uint32_t) b[2] << 16) | ((std::uint32_t) b[3] << 24));
+    }
+
+    std::int64_t getPosition()               { return (std::int64_t) in.tellg(); }
+    void         setPosition(std::int64_t p) { in.clear(); in.seekg(p, std::ios::beg); }
+    std::int64_t getTotalLength() const      { return length; }
+    bool         isExhausted()               { return getPosition() >= length; }
+};
 } // namespace
 
-Sf2File readSf2(const juce::File& file)
+Sf2File readSf2(const std::filesystem::path& file)
 {
     Sf2File out;
 
-    juce::FileInputStream in (file);
-    if (! in.openedOk())
+    FileCursor in;
+    if (! in.open (file))
     {
-        out.error = ("Could not open " + file.getFileName()).toStdString();
+        out.error = "Could not open " + file.filename().string();
         return out;
     }
 
@@ -128,7 +172,7 @@ Sf2File readSf2(const juce::File& file)
         return out;
     }
 
-    juce::MemoryBlock pdtaBytes;
+    std::vector<uint8_t> pdtaBytes;
 
     // Walk the three top-level LIST chunks.
     while (! in.isExhausted())
@@ -185,13 +229,13 @@ Sf2File readSf2(const juce::File& file)
                     (std::int64_t) (in.getTotalLength() - in.getPosition()));
                 if (bodyLen > 0)
                 {
-                    pdtaBytes.setSize((size_t) bodyLen);
-                    const int got = in.read(pdtaBytes.getData(), bodyLen);
+                    pdtaBytes.resize((size_t) bodyLen);
+                    const int got = in.read(pdtaBytes.data(), bodyLen);
                     // Truncated file: shrink to what we actually read so the
                     // sub-chunk parser never walks into uninitialised tail
-                    // bytes (setSize preserves the leading data on shrink).
+                    // bytes (resize preserves the leading data on shrink).
                     if (got < bodyLen)
-                        pdtaBytes.setSize((size_t) std::max(0, got));
+                        pdtaBytes.resize((size_t) std::max(0, got));
                 }
             }
         }
@@ -200,7 +244,7 @@ Sf2File readSf2(const juce::File& file)
         in.setPosition(ckBody + (std::int64_t) ckSize + ((ckSize & 1) ? 1 : 0));
     }
 
-    if (pdtaBytes.getSize() == 0)
+    if (pdtaBytes.empty())
     {
         out.error = "SF2 has no pdta chunk";
         return out;
@@ -209,7 +253,7 @@ Sf2File readSf2(const juce::File& file)
     // Split pdta into its named sub-chunks.
     SubChunk phdr, pbag, pgen, inst, ibag, igen, shdr;
     {
-        Cursor c { (const uint8_t*) pdtaBytes.getData(), pdtaBytes.getSize(), 0 };
+        Cursor c { pdtaBytes.data(), pdtaBytes.size(), 0 };
         while (c.canRead(8))
         {
             SubChunk sc;

--- a/src/engine/multisample/Sf2Reader.cpp
+++ b/src/engine/multisample/Sf2Reader.cpp
@@ -24,6 +24,12 @@ constexpr int kGenSize  = 4;
 constexpr int kInstSize = 22;
 constexpr int kShdrSize = 46;
 
+// The pdta chunk is pure metadata (presets / instruments / samples + their
+// generator records); even a 140 MB GM bank's pdta is only a few MB. Cap it
+// well above that so a corrupt or hostile ckSize can't drive a huge
+// allocation from a correspondingly padded file.
+constexpr std::int64_t kMaxPdtaBytes = 64 * 1024 * 1024;
+
 // A cursor over an in-memory byte span. All SF2 multibyte fields are
 // little-endian.
 struct Cursor
@@ -223,10 +229,16 @@ Sf2File readSf2(const std::filesystem::path& file)
                 // for a 140 MB GM bank. Clamp to the bytes actually left in
                 // the file: a crafted ckSize (~2 GB) must not size an
                 // allocation the read can never fill.
-                const int bodyLen = (int) std::clamp (
+                const std::int64_t claimed = std::clamp (
                     (std::int64_t) ckSize - 4,   // minus the listType
                     (std::int64_t) 0,
                     (std::int64_t) (in.getTotalLength() - in.getPosition()));
+                if (claimed > kMaxPdtaBytes)
+                {
+                    out.error = "SF2 pdta chunk too large";
+                    return out;
+                }
+                const int bodyLen = (int) claimed;
                 if (bodyLen > 0)
                 {
                     pdtaBytes.resize((size_t) bodyLen);

--- a/src/engine/multisample/Sf2Reader.h
+++ b/src/engine/multisample/Sf2Reader.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include <juce_core/juce_core.h>
-
 #include <cstdint>
+#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -120,5 +119,5 @@ struct Sf2File
 // Parse an .sf2 file. On failure returns an Sf2File with ok=false and a
 // populated error string. Does NOT read sample PCM - only metadata + the
 // smpl chunk location.
-Sf2File readSf2(const juce::File& file);
+Sf2File readSf2(const std::filesystem::path& file);
 } // namespace duskstudio

--- a/src/engine/multisample/Sf2ToSfz.cpp
+++ b/src/engine/multisample/Sf2ToSfz.cpp
@@ -124,7 +124,7 @@ Sf2Conversion convertSf2Preset(const juce::File& sf2,
 {
     Sf2Conversion conv;
 
-    auto parsed = readSf2(sf2);
+    auto parsed = readSf2(std::filesystem::u8path(sf2.getFullPathName().toStdString()));
     if (! parsed.ok)
     {
         conv.error = parsed.error;

--- a/tests/sf2_reader_parse.cpp
+++ b/tests/sf2_reader_parse.cpp
@@ -123,7 +123,9 @@ TEST_CASE("Sf2Reader: parses a hand-built minimal SF2", "[sf2]")
     REQUIRE(sf.samples.size()     == 1);
 
     // sdta smpl located via the streamed file position, PCM skipped not read.
-    REQUIRE(sf.smplOffset > 0);
+    // Offset is exact and file-absolute: RIFF header (12) + LIST/sdta header
+    // (12) + smpl id/size (8) = 32.
+    REQUIRE(sf.smplOffset == 32);
     REQUIRE(sf.smplSize   == 200);
 
     REQUIRE(sf.presets[0].name == "pre0");

--- a/tests/sf2_reader_parse.cpp
+++ b/tests/sf2_reader_parse.cpp
@@ -4,19 +4,94 @@
 
 #include <juce_core/juce_core.h>
 
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <vector>
+
 namespace
 {
 // FluidR3 GM/GS - the standard free General MIDI bank. Fixture-gated like
 // the ARIA Swirly test: runs only where the file is present, skipped
 // silently elsewhere so the suite stays portable.
 const juce::File kFluidR3 { "/Users/marckorte/Downloads/FluidR3_GM_GS.sf2" };
+
+std::filesystem::path toPath (const juce::File& f)
+{
+    return std::filesystem::u8path (f.getFullPathName().toStdString());
+}
+
+// Assembles little-endian SF2 chunks so the positive path is exercised on
+// every platform, not only where the FluidR3 fixture is installed.
+struct Buf
+{
+    std::vector<std::uint8_t> b;
+    void u8  (std::uint8_t v)  { b.push_back (v); }
+    void u16 (std::uint16_t v) { u8 ((std::uint8_t) (v & 0xFF)); u8 ((std::uint8_t) (v >> 8)); }
+    void u32 (std::uint32_t v) { for (int i = 0; i < 4; ++i) u8 ((std::uint8_t) (v >> (8 * i))); }
+    void id  (const char* s)   { for (int i = 0; i < 4; ++i) u8 ((std::uint8_t) s[i]); }
+    void name (const char* s)  { char n[20] {}; std::strncpy (n, s, 20); for (int i = 0; i < 20; ++i) u8 ((std::uint8_t) n[i]); }
+    void raw (const std::vector<std::uint8_t>& x) { b.insert (b.end(), x.begin(), x.end()); }
+};
+
+// id + u32 length + body, padded to even length like every RIFF chunk.
+void chunk (Buf& out, const char* id, const std::vector<std::uint8_t>& body)
+{
+    out.id (id);
+    out.u32 ((std::uint32_t) body.size());
+    out.raw (body);
+    if (body.size() & 1) out.u8 (0);
+}
+
+std::vector<std::uint8_t> minimalSf2()
+{
+    // One preset -> one instrument zone (keyRange 0..127 + sampleID 0) ->
+    // one 44.1 kHz sample. Terminal EOP/EOI/EOS sentinels as the spec requires.
+    Buf phdr;
+    phdr.name ("pre0"); phdr.u16 (0); phdr.u16 (0); phdr.u16 (0); phdr.u32 (0); phdr.u32 (0); phdr.u32 (0);
+    phdr.name ("EOP");  phdr.u16 (0); phdr.u16 (0); phdr.u16 (1); phdr.u32 (0); phdr.u32 (0); phdr.u32 (0);
+
+    Buf pbag; pbag.u16 (0); pbag.u16 (0); pbag.u16 (1); pbag.u16 (0);
+    Buf pgen; pgen.u16 (41); pgen.u16 (0);   // 41 = instrument
+
+    Buf inst;
+    inst.name ("inst0"); inst.u16 (0);
+    inst.name ("EOI");   inst.u16 (1);
+
+    Buf ibag; ibag.u16 (0); ibag.u16 (0); ibag.u16 (2); ibag.u16 (0);
+    Buf igen;
+    igen.u16 (43); igen.u16 (0x7F00);   // 43 = keyRange, lo=0 hi=127
+    igen.u16 (53); igen.u16 (0);         // 53 = sampleID -> sample 0
+
+    Buf shdr;
+    shdr.name ("samp0"); shdr.u32 (0); shdr.u32 (100); shdr.u32 (0); shdr.u32 (100);
+    shdr.u32 (44100); shdr.u8 (60); shdr.u8 (0); shdr.u16 (0); shdr.u16 (1);
+    shdr.name ("EOS");  shdr.u32 (0); shdr.u32 (0);   shdr.u32 (0); shdr.u32 (0);
+    shdr.u32 (0);     shdr.u8 (0);  shdr.u8 (0); shdr.u16 (0); shdr.u16 (0);
+
+    Buf pdta; pdta.id ("pdta");
+    chunk (pdta, "phdr", phdr.b); chunk (pdta, "pbag", pbag.b); chunk (pdta, "pgen", pgen.b);
+    chunk (pdta, "inst", inst.b); chunk (pdta, "ibag", ibag.b); chunk (pdta, "igen", igen.b);
+    chunk (pdta, "shdr", shdr.b);
+
+    Buf sdta; sdta.id ("sdta");
+    chunk (sdta, "smpl", std::vector<std::uint8_t> (200, 0));   // 100 16-bit samples
+
+    Buf content; content.id ("sfbk");
+    chunk (content, "LIST", sdta.b);
+    chunk (content, "LIST", pdta.b);
+
+    Buf file; file.id ("RIFF"); file.u32 ((std::uint32_t) content.b.size()); file.raw (content.b);
+    return file.b;
+}
 }
 
 TEST_CASE("Sf2Reader: rejects a non-SF2 file", "[sf2]")
 {
     auto tmp = juce::File::createTempFile(".sf2");
     tmp.replaceWithText("this is not a soundfont");
-    auto sf = duskstudio::readSf2(tmp);
+    auto sf = duskstudio::readSf2(toPath(tmp));
     REQUIRE_FALSE(sf.ok);
     REQUIRE_FALSE(sf.error.empty());
     tmp.deleteFile();
@@ -24,9 +99,50 @@ TEST_CASE("Sf2Reader: rejects a non-SF2 file", "[sf2]")
 
 TEST_CASE("Sf2Reader: missing file errors cleanly", "[sf2]")
 {
-    auto sf = duskstudio::readSf2(juce::File("/no/such/file.sf2"));
+    auto sf = duskstudio::readSf2("/no/such/file.sf2");
     REQUIRE_FALSE(sf.ok);
     REQUIRE_FALSE(sf.error.empty());
+}
+
+TEST_CASE("Sf2Reader: parses a hand-built minimal SF2", "[sf2]")
+{
+    const auto bytes = minimalSf2();
+    auto tmp = juce::File::createTempFile(".sf2");
+    {
+        std::ofstream os (toPath(tmp), std::ios::binary);
+        os.write (reinterpret_cast<const char*>(bytes.data()), (std::streamsize) bytes.size());
+    }
+
+    auto sf = duskstudio::readSf2(toPath(tmp));
+    tmp.deleteFile();
+
+    REQUIRE(sf.ok);
+    REQUIRE(sf.error.empty());
+    REQUIRE(sf.presets.size()     == 1);
+    REQUIRE(sf.instruments.size() == 1);
+    REQUIRE(sf.samples.size()     == 1);
+
+    // sdta smpl located via the streamed file position, PCM skipped not read.
+    REQUIRE(sf.smplOffset > 0);
+    REQUIRE(sf.smplSize   == 200);
+
+    REQUIRE(sf.presets[0].name == "pre0");
+    REQUIRE_FALSE(sf.presets[0].zones.empty());
+    REQUIRE(sf.samples[0].name       == "samp0");
+    REQUIRE(sf.samples[0].sampleRate == 44100);
+
+    bool sawSampleId = false, sawKeyRange = false;
+    for (const auto& z : sf.instruments[0].zones)
+    {
+        if (z.find(duskstudio::kGenSampleID) != nullptr) sawSampleId = true;
+        if (const auto* g = z.find(duskstudio::kGenKeyRange))
+        {
+            REQUIRE(g->lo() <= g->hi());
+            sawKeyRange = true;
+        }
+    }
+    REQUIRE(sawSampleId);
+    REQUIRE(sawKeyRange);
 }
 
 TEST_CASE("Sf2Reader: parses FluidR3 GM structure", "[sf2][.fixture]")
@@ -37,7 +153,7 @@ TEST_CASE("Sf2Reader: parses FluidR3 GM structure", "[sf2][.fixture]")
         return;
     }
 
-    auto sf = duskstudio::readSf2(kFluidR3);
+    auto sf = duskstudio::readSf2(toPath(kFluidR3));
     REQUIRE(sf.ok);
     REQUIRE(sf.error.empty());
 

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -65,8 +65,6 @@ src/engine/multisample/DuskMultisamplePluginFormat.cpp
 src/engine/multisample/DuskMultisamplePluginFormat.h
 src/engine/multisample/DuskMultisampleProcessor.cpp
 src/engine/multisample/DuskMultisampleProcessor.h
-src/engine/multisample/Sf2Reader.cpp
-src/engine/multisample/Sf2Reader.h
 src/engine/multisample/Sf2ToSfz.cpp
 src/engine/multisample/Sf2ToSfz.h
 src/engine/pipewire/PipeWireAudioIODevice.cpp


### PR DESCRIPTION
Removes JUCE from the SoundFont 2 reader.

`readSf2` parsed the `.sf2` RIFF structure over `juce::FileInputStream` and buffered the pdta chunk in a `juce::MemoryBlock`. Both are replaced with a small streaming `FileCursor` over `std::ifstream` and a `std::vector`. Behaviour is preserved: the large `smpl` PCM is skipped by file position rather than read, and the recorded sample offsets stay file-absolute. The in-memory record parser is untouched.

`readSf2` now takes a `std::filesystem::path`; the two callers (Sf2ToSfz, DuskMultisampleProcessor) bridge from their `juce::File` and stay coupled. `Sf2Reader.{h,cpp}` go fully JUCE-free (de-JUCE gate 205 -> 203).

The FluidR3 byte-parse fixture only runs where that bank is installed, so a hand-built minimal SF2 now covers the positive parse path (RIFF walk, LE readInt, position-skip, smpl offset) on every platform.

Verified: app builds with zero new warnings, ctest 383/383, gate 203.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SoundFont file loading across supported file paths and platforms.
  * Added safer handling for incomplete or invalid SoundFont data.

* **Tests**
  * Added coverage for parsing minimal SoundFont files and validating preset, sample, and generator metadata.
  * Expanded checks for missing files and existing SoundFont fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->