### PR TITLE
De-JUCE: native plugin hosting MIDI path onto dusk::MidiBuffer

### DIFF
--- a/src/dsp/ChannelStrip.cpp
+++ b/src/dsp/ChannelStrip.cpp
@@ -79,6 +79,9 @@ void ChannelStrip::prepare (double sampleRate, int blockSize, int oversamplingFa
     // channel-voice messages per block; far above any sane density even
     // for instrument plugins generating dense controller streams.
     pluginMidiScratch.ensureSize (4096);
+    // Same headroom for the native-host bridge; reserveBytes caps it so the
+    // per-block juce->dusk refill drops any overflow instead of allocating.
+    nativeMidiScratch.reserveBytes (4096);
 
     // Plugin slot - prepared at the same SR/BS so the audio thread never
     // sees an unprepared instance. If the slot has no plugin loaded, this
@@ -1019,19 +1022,25 @@ void ChannelStrip::processAndAccumulate (const float* inL,
             // tick the smoother to keep its state in sync in case the
             // track later flips to audio mode. A native host owns the slot
             // when loaded - same precedence as the effect-insert path.
+#if DUSKSTUDIO_HAS_NATIVE_CLAP || DUSKSTUDIO_HAS_NATIVE_LV2 || DUSKSTUDIO_HAS_NATIVE_VST3
+            // Bridge the block's MIDI into dusk once for whichever native host runs.
+            nativeMidiScratch.clear();
+            for (const auto meta : trackMidi)
+                nativeMidiScratch.addEvent (meta.data, meta.numBytes, meta.samplePosition);
+#endif
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
             if (nativeClapSlot.isLoaded())
-                nativeClapSlot.processStereo (L, R, L, R, numSamples, &trackMidi);
+                nativeClapSlot.processStereo (L, R, L, R, numSamples, &nativeMidiScratch);
             else
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_LV2
             if (nativeLv2Slot.isLoaded())
-                nativeLv2Slot.processStereo (L, R, L, R, numSamples, &trackMidi);
+                nativeLv2Slot.processStereo (L, R, L, R, numSamples, &nativeMidiScratch);
             else
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_VST3
             if (nativeVst3Slot.isLoaded())
-                nativeVst3Slot.processStereo (L, R, L, R, numSamples, &trackMidi);
+                nativeVst3Slot.processStereo (L, R, L, R, numSamples, &nativeMidiScratch);
             else
 #endif
             pluginSlot.processStereoBlock (L, R, numSamples, trackMidi);

--- a/src/dsp/ChannelStrip.h
+++ b/src/dsp/ChannelStrip.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <vector>
 #include "../foundation/IntDelayLine.h"
+#include "../foundation/MidiBuffer.h"
 #include "../foundation/SmoothedValue.h"
 #include "../foundation/StereoOversampler.h"
 #include "../session/Session.h"
@@ -346,6 +347,11 @@ private:
     // processBlock requires a MidiBuffer& even when the insert is an
     // effect. Held as member so the audio thread never default-constructs.
     juce::MidiBuffer pluginMidiScratch;
+
+    // Native hosts (CLAP/LV2/VST3) consume dusk::MidiBuffer; the JUCE PluginSlot
+    // path keeps juce::MidiBuffer. This bridges the instrument block's MIDI into
+    // dusk once per block. Pre-sized in prepare() so the refill never allocates.
+    dusk::MidiBuffer nativeMidiScratch;
 
 #if DUSKSTUDIO_HAS_DUSK_DSP
     duskaudio::FourKEQDSP eq;

--- a/src/engine/clap/ClapInstance.cpp
+++ b/src/engine/clap/ClapInstance.cpp
@@ -333,7 +333,7 @@ void ClapInstance::drainParamRing() noexcept
     }, (uint32_t) eventScratch.size());
 }
 
-void ClapInstance::appendMidiEvents (const juce::MidiBuffer& midi) noexcept
+void ClapInstance::appendMidiEvents (const dusk::MidiBuffer& midi) noexcept
 {
     if (! noteInPort) return;
     const uint32_t cap = (uint32_t) eventScratch.size();

--- a/src/engine/clap/ClapInstance.h
+++ b/src/engine/clap/ClapInstance.h
@@ -176,7 +176,7 @@ private:
 
     // Audio thread. Convert the block's MidiBuffer into note / raw-MIDI events
     // appended after the drained param changes.
-    void appendMidiEvents (const juce::MidiBuffer& midi) noexcept;
+    void appendMidiEvents (const dusk::MidiBuffer& midi) noexcept;
     uint32_t             eventCount = 0;
     clap_input_events_t  inEvents {};
 

--- a/src/engine/hosting/InsertAdapter.cpp
+++ b/src/engine/hosting/InsertAdapter.cpp
@@ -39,7 +39,7 @@ void InsertAdapter::process (INativeInstance& inst,
                              float* L, float* R, int numFrames,
                              const float* sidechainL,
                              const float* sidechainR,
-                             const juce::MidiBuffer* midiIn,
+                             const dusk::MidiBuffer* midiIn,
                              const juce::AudioPlayHead::PositionInfo* transport) noexcept
 {
     if (! inst.isActive() || numFrames <= 0 || numFrames > maxFrames)

--- a/src/engine/hosting/InsertAdapter.h
+++ b/src/engine/hosting/InsertAdapter.h
@@ -39,7 +39,7 @@ public:
                   float* L, float* R, int numFrames,
                   const float* sidechainL = nullptr,
                   const float* sidechainR = nullptr,
-                  const juce::MidiBuffer* midiIn = nullptr,
+                  const dusk::MidiBuffer* midiIn = nullptr,
                   const juce::AudioPlayHead::PositionInfo* transport = nullptr) noexcept;
 
     int inputChannels()     const noexcept { return inChans; }

--- a/src/engine/hosting/NativeInsertSlot.h
+++ b/src/engine/hosting/NativeInsertSlot.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <juce_audio_basics/juce_audio_basics.h>   // JUCE MidiBuffer (audio path)
+#include "../../foundation/MidiBuffer.h"
 
 #include "InsertAdapter.h"
 #include "SpscRing.h"
@@ -140,7 +140,7 @@ public:
     // and MIDI-driven effects (null ok).
     void processStereo (const float* inL, const float* inR,
                         float* outL, float* outR, int numFrames,
-                        const juce::MidiBuffer* midiIn = nullptr) noexcept
+                        const dusk::MidiBuffer* midiIn = nullptr) noexcept
     {
         auto clearOutputs = [&]
         {

--- a/src/engine/hosting/PortBuffers.h
+++ b/src/engine/hosting/PortBuffers.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#include <juce_audio_basics/juce_audio_basics.h>   // MidiBuffer, AudioPlayHead::PositionInfo
+#include <juce_audio_basics/juce_audio_basics.h>   // AudioPlayHead::PositionInfo
+
+#include "../../foundation/MidiBuffer.h"
 
 namespace duskstudio::hosting
 {
@@ -10,7 +12,7 @@ namespace duskstudio::hosting
 // or locked on the audio thread. Channel arrays are `float* const*` (an array of
 // per-channel pointers), so mono / stereo / multi-out all use one shape.
 //
-// juce::MidiBuffer and AudioPlayHead::PositionInfo are the engine's existing
+// dusk::MidiBuffer and juce AudioPlayHead::PositionInfo are the engine's existing
 // currency for MIDI and transport; each host translates them into its own format
 // (VST3 Event, LV2 atom-midi, CLAP note events) internally.
 struct PortBuffers
@@ -35,8 +37,8 @@ struct PortBuffers
 
     // Optional MIDI. midiIn drives instrument / MIDI-effect inserts; midiOut
     // collects a plugin's emitted MIDI (null until a destination is wired).
-    const juce::MidiBuffer* midiIn  = nullptr;
-    juce::MidiBuffer*       midiOut = nullptr;
+    const dusk::MidiBuffer* midiIn  = nullptr;
+    dusk::MidiBuffer*       midiOut = nullptr;
 
     // Optional transport for tempo-synced plugins (null = not supplied).
     const juce::AudioPlayHead::PositionInfo* transport = nullptr;

--- a/src/engine/ipc/PluginIpc.h
+++ b/src/engine/ipc/PluginIpc.h
@@ -26,7 +26,7 @@ constexpr std::uint32_t kMagic     = 0x46434C30;  // 'FCL0'
 constexpr std::uint32_t kVersion   = 1;
 constexpr int           kMaxBlock  = 1024;        // upper bound on numSamples per block
 constexpr int           kMaxChans  = 2;           // stereo plenty for v1
-constexpr std::size_t   kMidiBytes = 16 * 1024;   // serialised juce::MidiBuffer cap
+constexpr std::size_t   kMidiBytes = 16 * 1024;   // serialised MIDI-block byte cap
 constexpr std::size_t   kStateBytes = 4 * 1024 * 1024; // up to 4 MB plugin state blob
 // Hard cap on a single control-socket payload. Legit payloads are small
 // (LoadPlugin XML is the largest, a few KB); anything bigger goes via the SHM
@@ -76,7 +76,7 @@ enum class OpCode : std::uint32_t
     // instance changes (host automation, MIDI-mapped controller move,
     // preset load). The parent's reader thread demuxes this opcode out
     // of the sync reply path and dispatches the payload onto the parent's
-    // registered ParamChangedSink via juce::MessageManager::callAsync.
+    // registered ParamChangedSink via the message thread (MessageManager).
     // ONE-SHOT - parent sends NO reply.
     ParamChangedFromChild = 11,
 };

--- a/src/foundation/MidiBuffer.h
+++ b/src/foundation/MidiBuffer.h
@@ -29,10 +29,15 @@ private:
 };
 
 // One iterated event: the message view plus its sample offset within the block.
+// data / numBytes mirror JUCE's MidiMessageMetadata raw-byte fields so the same
+// iteration body (meta.data, meta.numBytes, meta.samplePosition) works over a
+// dusk::MidiBuffer - what the native plugin hosts read.
 struct MidiBufferMetadata
 {
-    MidiMessage message;
-    int         samplePosition = 0;
+    MidiMessage         message;
+    int                 samplePosition = 0;
+    const std::uint8_t* data           = nullptr;
+    int                 numBytes       = 0;
 
     const MidiMessage& getMessage() const noexcept { return message; }
 };
@@ -75,10 +80,12 @@ public:
     public:
         explicit Iterator (const std::uint8_t* p) noexcept : ptr (p) {}
         bool operator!= (const Iterator& o) const noexcept { return ptr != o.ptr; }
-        void operator++ ()                        noexcept { ptr += kHeader + readInt (ptr + 4); }
+        void operator++ ()                        noexcept { ptr += kHeader + (std::size_t) readInt (ptr + 4); }
         MidiBufferMetadata operator* () const noexcept
         {
-            return { MidiMessage (ptr + kHeader, readInt (ptr + 4)), readInt (ptr) };
+            const std::uint8_t* d = ptr + kHeader;
+            const int           n = readInt (ptr + 4);
+            return { MidiMessage (d, n), readInt (ptr), d, n };
         }
     private:
         const std::uint8_t* ptr;

--- a/tests/foundation_midi_buffer.cpp
+++ b/tests/foundation_midi_buffer.cpp
@@ -46,6 +46,14 @@ TEST_CASE ("dusk::MidiBuffer iterates like juce::MidiBuffer", "[foundation][midi
         REQUIRE (dm.getRawDataSize()  == jm.getRawDataSize());
         for (int b = 0; b < dm.getRawDataSize(); ++b)
             REQUIRE (dm.getRawData()[b] == jm.getRawData()[b]);
+
+        // The native plugin hosts iterate via meta.data / meta.numBytes (the
+        // juce::MidiMessageMetadata shape); these must match the message view.
+        REQUIRE ((*di).numBytes == dm.getRawDataSize());
+        REQUIRE ((*di).data     == dm.getRawData());
+        REQUIRE ((*di).data     != nullptr);
+        for (int b = 0; b < (*di).numBytes; ++b)
+            REQUIRE ((*di).data[b] == jm.getRawData()[b]);
         ++count;
     }
     REQUIRE (ji == j.end());

--- a/tests/native_instrument_process.cpp
+++ b/tests/native_instrument_process.cpp
@@ -5,6 +5,8 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include "support/DuskMidiTestBridge.h"
+
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
  #include "engine/clap/NativeClapSlot.h"
 #endif
@@ -48,9 +50,10 @@ float driveNote (Slot& slot, int blocks)
             for (const int k : keys)
                 for (const int ch : { 1, 10 })
                     midi.addEvent (juce::MidiMessage::noteOff (ch, k), 0);
+        const dusk::MidiBuffer dmidi = duskstudio::test::toDusk (midi);
         std::fill (L.begin(), L.end(), 0.0f);
         std::fill (R.begin(), R.end(), 0.0f);
-        slot.processStereo (L.data(), R.data(), L.data(), R.data(), kBlock, &midi);
+        slot.processStereo (L.data(), R.data(), L.data(), R.data(), kBlock, &dmidi);
         for (int i = 0; i < kBlock; ++i)
         {
             REQUIRE (std::isfinite (L[(size_t) i]));

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -42,16 +42,12 @@ src/engine/alsa/AlsaAudioIODeviceType.cpp
 src/engine/alsa/AlsaAudioIODeviceType.h
 src/engine/alsa/AlsaPerformanceTest.cpp
 src/engine/alsa/AlsaPerformanceTest.h
-src/engine/clap/ClapInstance.cpp
-src/engine/clap/ClapInstance.h
 src/engine/hosting/InsertAdapter.cpp
 src/engine/hosting/InsertAdapter.h
-src/engine/hosting/NativeInsertSlot.h
 src/engine/hosting/NativePluginId.h
 src/engine/hosting/PortBuffers.h
 src/engine/ipc/IpcSelfTest.cpp
 src/engine/ipc/PluginHostMain.cpp
-src/engine/ipc/PluginIpc.h
 src/engine/ipc/PluginScanProtocol.h
 src/engine/ipc/RemotePluginConnection.cpp
 src/engine/ipc/RemotePluginConnection.h


### PR DESCRIPTION
Removes JUCE from the in-process native plugin hosting MIDI path.

The hosting currency (`PortBuffers::midiIn/midiOut`) carried `juce::MidiBuffer`; the CLAP/VST3/LV2 instances already iterate it purely for raw bytes. `dusk::MidiBufferMetadata` gains `data`/`numBytes` so it is a drop-in for that iterator shape, and the whole hosting path moves onto `dusk::MidiBuffer` with no instance-body edits.

ChannelStrip is the one live feeder: its instrument branch fed `&trackMidi` (a `juce::MidiBuffer`, shared with the JUCE PluginSlot path) into the native slots. It now bridges that block's MIDI into a pre-sized `dusk::MidiBuffer` scratch once per block and passes that to the native hosts; PluginSlot keeps `trackMidi`.

`ClapInstance.{cpp,h}`, `NativeInsertSlot.h`, and `PluginIpc.h` go fully JUCE-free (de-JUCE gate 205 -> 201). PortBuffers/InsertAdapter stay coupled via `AudioPlayHead::PositionInfo`.

Verified: app builds with zero new warnings, ctest 382/382, gate 201, Xvfb selftest 15/15 (Parallel-Matches-Serial bit-identical, MIDI play-along pass).

Independent of #83 (disjoint files + disjoint allowlist lines); merges cleanly in either order.