### PR TITLE
De-JUCE: OOP plugin hosting MIDI path onto dusk::MidiBuffer

### DIFF
--- a/src/engine/PluginSlot.cpp
+++ b/src/engine/PluginSlot.cpp
@@ -342,6 +342,10 @@ void PluginSlot::prepareToPlay (double sampleRate, int blockSize)
     // a stereo-only plugin is in the slot.
     stereoScratch.setSize (2, preparedBlockSize, false, false, true);
 
+   #if DUSKSTUDIO_HAS_OOP_PLUGINS
+    oopMidiScratch.reserveBytes (duskstudio::ipc::kMidiBytes);
+   #endif
+
     blocksSinceLoad     = 0;
     consecutiveOverruns = 0;
 
@@ -1256,9 +1260,12 @@ void PluginSlot::processMonoBlock (float* monoData, int numSamples,
             inPtrs[0] = nullptr;
         }
 
+        oopMidiScratch.clear();
+        for (const auto meta : midiMessages)
+            oopMidiScratch.addEvent (meta.data, meta.numBytes, meta.samplePosition);
         if (! r->processBlockSync (inPtrs, std::max (rNumIn, 0),
                                        std::max (rNumOut, 0),
-                                       numSamples, midiMessages,
+                                       numSamples, oopMidiScratch,
                                        kOopProcessTimeoutNs))
         {
             engageAutoBypass();
@@ -1436,9 +1443,12 @@ void PluginSlot::processStereoBlock (float* L, float* R, int numSamples,
             return;
         }
 
+        oopMidiScratch.clear();
+        for (const auto meta : midiMessages)
+            oopMidiScratch.addEvent (meta.data, meta.numBytes, meta.samplePosition);
         if (! r->processBlockSync (inPtrs, std::max (rNumIn, 0),
                                        std::max (rNumOut, 0),
-                                       numSamples, midiMessages,
+                                       numSamples, oopMidiScratch,
                                        kOopProcessTimeoutNs))
         {
             // Either the futex timed out or the connection was already

--- a/src/engine/PluginSlot.h
+++ b/src/engine/PluginSlot.h
@@ -320,6 +320,11 @@ private:
     std::atomic<bool> remoteIsInstrument { false };
     std::atomic<bool> remoteCrashed { false };
 
+    // The OOP round-trip serialises MIDI to raw bytes; processBlockSync takes
+    // a dusk::MidiBuffer. Bridged once per block from the caller's juce buffer
+    // (which the in-process JUCE path still needs). Pre-sized in prepareToPlay.
+    dusk::MidiBuffer oopMidiScratch;
+
     // Cached for getDescriptionXmlForSave (which can't
     // fillInPluginDescription on a remote instance).
     juce::String savedDescriptionXml;

--- a/src/engine/ipc/IpcSelfTest.cpp
+++ b/src/engine/ipc/IpcSelfTest.cpp
@@ -47,7 +47,7 @@ int runIpcSelfTest (const std::string& hostExecutablePath,
 
     int verifyFails = 0;
     constexpr long long kTimeoutNs = 100'000'000LL;  // 100 ms - generous
-    juce::MidiBuffer emptyMidi;
+    dusk::MidiBuffer emptyMidi;
 
     for (int it = 0; it < iterations; ++it)
     {
@@ -207,7 +207,7 @@ int runIpcHostTest (const std::string& hostExecutablePath,
 
     bool anyDifference = false;
     constexpr long long kTimeoutNs = 1'000'000'000LL;  // 1 s - plugins take time to warm up
-    juce::MidiBuffer emptyMidi;
+    dusk::MidiBuffer emptyMidi;
 
     for (int it = 0; it < iterations; ++it)
     {

--- a/src/engine/ipc/IpcSelfTest.cpp
+++ b/src/engine/ipc/IpcSelfTest.cpp
@@ -51,6 +51,10 @@ int runIpcSelfTest (const std::string& hostExecutablePath,
 
     for (int it = 0; it < iterations; ++it)
     {
+        // processBlockSync overwrites the buffer with the child's MIDI
+        // output; clear it so that never feeds back as the next input.
+        emptyMidi.clear();
+
         // Vary content so a buggy stub that returns a stale buffer
         // would fail the verify on subsequent iterations.
         for (int i = 0; i < numSamples; ++i)
@@ -211,6 +215,10 @@ int runIpcHostTest (const std::string& hostExecutablePath,
 
     for (int it = 0; it < iterations; ++it)
     {
+        // processBlockSync overwrites the buffer with the child's MIDI
+        // output; clear it so that never feeds back as the next input.
+        emptyMidi.clear();
+
         for (int i = 0; i < numSamples; ++i)
         {
             // White-ish content (low freq sine + small noise) so an EQ /

--- a/src/engine/ipc/RemotePluginConnection.cpp
+++ b/src/engine/ipc/RemotePluginConnection.cpp
@@ -150,7 +150,7 @@ bool RemotePluginConnection::connect (const std::string& hostExecutablePath,
 
 bool RemotePluginConnection::processBlockSync (const float* const* inChannels,
                                                  int numIn, int numOut, int numSamples,
-                                                 juce::MidiBuffer& midi,
+                                                 dusk::MidiBuffer& midi,
                                                  long long timeoutNs) noexcept
 {
     if (! shm.isMapped() || crashed.load (std::memory_order_acquire))
@@ -174,15 +174,16 @@ bool RemotePluginConnection::processBlockSync (const float* const* inChannels,
         std::uint32_t written = 0;
         for (const auto meta : midi)
         {
-            const auto m = meta.getMessage();
-            const int len = m.getRawDataSize();
+            const int len = meta.numBytes;
             if (len <= 0) continue;
+            // The kMidiBytes bound (16 KB) caps len far below the uint16 wire
+            // limit, so the l16 cast below never truncates.
             if (written + 4 + 2 + (std::uint32_t) len > kMidiBytes) break;
             const int sample = meta.samplePosition;
             std::memcpy (out + written, &sample, 4);             written += 4;
             const std::uint16_t l16 = (std::uint16_t) len;
             std::memcpy (out + written, &l16, 2);                written += 2;
-            std::memcpy (out + written, m.getRawData(),
+            std::memcpy (out + written, meta.data,
                          (std::size_t) len);                      written += (std::uint32_t) len;
         }
         hdr->midiInBytes = written;
@@ -216,7 +217,7 @@ bool RemotePluginConnection::processBlockSync (const float* const* inChannels,
             if (off + (std::uint32_t) eventLen > midiOutBytes)   break;
             std::memcpy (evBuf, base + off, (std::size_t) eventLen);
             off += (std::uint32_t) eventLen;
-            midi.addEvent (juce::MidiMessage (evBuf, eventLen), sample);
+            midi.addEvent (evBuf, eventLen, sample);
         }
     };
 

--- a/src/engine/ipc/RemotePluginConnection.cpp
+++ b/src/engine/ipc/RemotePluginConnection.cpp
@@ -205,7 +205,6 @@ bool RemotePluginConnection::processBlockSync (const float* const* inChannels,
         if (midiOutBytes == 0 || midiOutBytes > kMidiBytes) return;
         const std::uint8_t* base = midiOut (shm.data());
         std::uint32_t off = 0;
-        std::uint8_t evBuf[256];
         while (off + 6 <= midiOutBytes)
         {
             int sample = 0;
@@ -213,11 +212,13 @@ bool RemotePluginConnection::processBlockSync (const float* const* inChannels,
             std::uint16_t l16 = 0;
             std::memcpy (&l16, base + off, 2); off += 2;
             const int eventLen = (int) l16;
-            if (eventLen <= 0 || eventLen > (int) sizeof (evBuf)) break;
-            if (off + (std::uint32_t) eventLen > midiOutBytes)   break;
-            std::memcpy (evBuf, base + off, (std::size_t) eventLen);
+            if (eventLen <= 0) break;
+            if (off + (std::uint32_t) eventLen > midiOutBytes) break;
+            // base + off points into the SHM midiOut region, bounded above by
+            // midiOutBytes; addEvent copies the bytes, so no local buffer and
+            // no size ceiling - larger SysEx events pass through intact.
+            midi.addEvent (base + off, eventLen, sample);
             off += (std::uint32_t) eventLen;
-            midi.addEvent (evBuf, eventLen, sample);
         }
     };
 

--- a/src/engine/ipc/RemotePluginConnection.h
+++ b/src/engine/ipc/RemotePluginConnection.h
@@ -13,7 +13,7 @@
 #include <thread>
 #include <vector>
 
-#include <juce_audio_basics/juce_audio_basics.h>  // juce::MidiBuffer
+#include "../../foundation/MidiBuffer.h"
 
 namespace duskstudio::ipc
 {
@@ -62,8 +62,8 @@ public:
     // `timeoutMs`. Used by the supervisor heartbeat in Phase 4.
     bool ping (int timeoutMs, std::string& errorOut);
 
-    // Load a plugin from its `juce::PluginDescription::createXml()`
-    // string at the given sample rate / block size. Fills `numInOut`
+    // Load a plugin from its PluginDescription XML string at the given
+    // sample rate / block size. Fills `numInOut`
     // with the plugin's reported channel layout and `latencyOut` with
     // its reported latency in samples.
     bool loadPlugin (const std::string& pluginDescriptionXml,
@@ -108,7 +108,7 @@ public:
 
     // --- Parameter mirror (3c-3a, --ipc-host mode only) ------------------
     // Parent -> child one-shot SetParam send. The child applies the new
-    // value to its DSP-side instance via juce::MessageManager::callAsync.
+    // value to its DSP-side instance on the message thread.
     // No reply is expected; this returns false only if the socket write
     // itself fails (peer-closed, EBADF, etc.).
     //
@@ -153,9 +153,9 @@ public:
     //
     // RT-safe: only memcpy + futex syscalls, no allocation. The output
     // MIDI buffer is rebuilt via clear() + addEvent() into the caller's
-    // `midi`; juce::MidiBuffer::clear is RT-safe and addEvent only
-    // allocates when capacity is exceeded - the engine pre-sizes per-
-    // track scratch buffers so this stays allocation-free in practice.
+    // `midi`; dusk::MidiBuffer::clear is RT-safe and addEvent drops
+    // events over the reserved cap instead of allocating - the engine
+    // pre-sizes per-track scratch buffers so this stays allocation-free.
     // numOut is the plugin's output channel count (queried at scan/load
     // and stored in PluginSlot::remoteNumOut). The child copies its
     // plugin's processBlock output into the first `numOut` SHM channels;
@@ -165,7 +165,7 @@ public:
     // reads stale SHM.
     bool processBlockSync (const float* const* inChannels, int numIn, int numOut,
                             int numSamples,
-                            juce::MidiBuffer& midi,
+                            dusk::MidiBuffer& midi,
                             long long timeoutNs) noexcept;
 
     // Read the i'th output channel from SHM. Valid pointer for the life

--- a/tests/ipc_stub_round_trip.cpp
+++ b/tests/ipc_stub_round_trip.cpp
@@ -54,7 +54,7 @@ TEST_CASE ("ipc-stub: connect, round-trip 32 blocks, byte-exact echo",
     std::vector<float> bufL ((std::size_t) kBlockSize);
     std::vector<float> bufR ((std::size_t) kBlockSize);
     const float* in[kNumChans] { bufL.data(), bufR.data() };
-    juce::MidiBuffer midi;  // empty in/out for stub mode
+    dusk::MidiBuffer midi;
 
     for (int it = 0; it < kIterations; ++it)
     {
@@ -66,7 +66,26 @@ TEST_CASE ("ipc-stub: connect, round-trip 32 blocks, byte-exact echo",
             bufR[(std::size_t) i] = 0.5f * std::cos (((float) (i + it)) * 0.1f);
         }
 
+        // The stub echoes midiIn -> midiOut, so a fed note-on must round-trip
+        // back byte-exact through the dusk serialise (in) / deserialise (out).
+        const std::uint8_t noteOn[3] { 0x90, (std::uint8_t) (0x40 + it % 8), 0x7F };
+        const int notePos = it % kBlockSize;
+        midi.clear();
+        midi.addEvent (noteOn, 3, notePos);
+
         REQUIRE (conn.processBlockSync (in, kNumChans, kNumChans, kBlockSize, midi, kTimeoutNs));
+
+        int midiEvents = 0;
+        for (const auto meta : midi)
+        {
+            REQUIRE (meta.numBytes       == 3);
+            REQUIRE (meta.samplePosition == notePos);
+            REQUIRE (meta.data[0]        == noteOn[0]);
+            REQUIRE (meta.data[1]        == noteOn[1]);
+            REQUIRE (meta.data[2]        == noteOn[2]);
+            ++midiEvents;
+        }
+        REQUIRE (midiEvents == 1);
 
         for (int c = 0; c < kNumChans; ++c)
         {
@@ -97,7 +116,7 @@ TEST_CASE ("ipc-stub: rejects oversize block", "[ipc]")
     // return false rather than overrun the SHM audio region.
     std::vector<float> oversize (4096, 0.0f);
     const float* in[1] { oversize.data() };
-    juce::MidiBuffer midi;
+    dusk::MidiBuffer midi;
     REQUIRE_FALSE (conn.processBlockSync (in, 1, 1, 4096, midi, 1'000'000LL));
     REQUIRE_FALSE (conn.isCrashed());  // bad-input rejection isn't a crash
 }

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -50,7 +50,6 @@ src/engine/ipc/IpcSelfTest.cpp
 src/engine/ipc/PluginHostMain.cpp
 src/engine/ipc/PluginScanProtocol.h
 src/engine/ipc/RemotePluginConnection.cpp
-src/engine/ipc/RemotePluginConnection.h
 src/engine/midi/MidiDevices.cpp
 src/engine/midi/MidiDevices.h
 src/engine/multisample/AriaBank.cpp


### PR DESCRIPTION
Completes the hosting-layer MIDI migration: no `juce::MidiBuffer` remains in either the in-process (#84) or out-of-process plugin path.

`RemotePluginConnection::processBlockSync` took a `juce::MidiBuffer` for the out-of-process round-trip. It already serialises MIDI to raw bytes for the SHM transport and rebuilds the reply the same way, so `dusk::MidiBuffer` is a drop-in. The input loop reads `meta.numBytes` / `meta.data` directly; deserialising the child's echoed MIDI `addEvent`s raw bytes instead of constructing a `juce::MidiMessage`.

`PluginSlot` keeps `juce::MidiBuffer` (the in-process JUCE instance path needs it) and bridges the block into a pre-sized `dusk::MidiBuffer` scratch before each OOP call; the child's MIDI output is discarded by the caller as before (PluginSlot reads only `readOutChannel` after the call).

`RemotePluginConnection.h` goes fully JUCE-free (de-JUCE gate 199 -> 198); the `.cpp` stays coupled via `juce_events` (the `ParamChangedFromChild` async dispatch, unrelated to MIDI).

The ipc-stub round-trip test now feeds a note-on and asserts it echoes back byte-exact through the real child process (`--ipc-stub` echoes midiIn -> midiOut), covering the serialise/deserialise flip end-to-end.

Verified: app builds with zero new warnings, ctest 383/383, gate 198, Xvfb selftest 15/15.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MIDI handling during remote plugin processing for more reliable event transfer.
  * Reduced unnecessary per-block memory growth during remote plugin operation.

* **Tests**
  * Expanded IPC round-trip validation to verify MIDI event data and timing positions.
  * Updated MIDI-related self-tests for improved transport coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->