### PR TITLE
De-JUCE: events seam (dusk::Timer/callAsync) + flip McuController + I…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,6 +313,7 @@ endif()
 target_sources(DuskStudio PRIVATE
     src/Main.cpp
     src/DuskStudioApp.cpp
+    src/foundation/MessageThread.cpp
     # Native CLAP host is Linux-only (dlopen + poll + X11 editor) — added in the
     # UNIX-AND-NOT-APPLE block below, gated by DUSKSTUDIO_HAS_NATIVE_CLAP.
     src/engine/AudioEngine.cpp

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -376,10 +376,10 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
     // McuController definitions.
     mcuReceiver   = std::make_unique<McuReceiver>   (session);
     mcuController = std::make_unique<McuController> (session);
-    mcuController->setSink ([this] (const juce::MidiBuffer& buf)
+    mcuController->setSink ([this] (const dusk::MidiBuffer& buf)
     {
-        // Message thread (30 Hz MCU tick). The bank's juce send overload keeps
-        // McuController juce-typed (events-tower coupling).
+        // Message thread (30 Hz MCU tick). The bank bridges dusk -> juce for the
+        // direct send.
         const int outIdx = session.mcu.resolvedOutputIdx.load (std::memory_order_acquire);
         if (outIdx >= 0) midiOut.send (outIdx, buf);
     });

--- a/src/engine/McuController.cpp
+++ b/src/engine/McuController.cpp
@@ -37,7 +37,32 @@ void writeStripField (std::array<char, mcu::sysex::kLcdRowBytes>& row,
         row[(size_t) (base + written++)] = ' ';
 }
 
-void emitLcdRow (juce::MidiBuffer& buf,
+// MCU feedback is fixed-form channel-voice + sysex; build the raw status/data
+// bytes directly onto the dusk buffer (message thread, so growth is fine).
+// Channels are 1-based on the wire (status nibble = channel - 1).
+void addNoteOn (dusk::MidiBuffer& buf, int channel1, int note, std::uint8_t velocity)
+{
+    const std::uint8_t bytes[3] = { (std::uint8_t) (0x90 | ((channel1 - 1) & 0x0F)),
+                                    (std::uint8_t) (note & 0x7F), velocity };
+    buf.addEvent (bytes, 3, 0);
+}
+
+void addPitchWheel (dusk::MidiBuffer& buf, int channel1, int value14)
+{
+    const std::uint8_t bytes[3] = { (std::uint8_t) (0xE0 | ((channel1 - 1) & 0x0F)),
+                                    (std::uint8_t) (value14 & 0x7F),
+                                    (std::uint8_t) ((value14 >> 7) & 0x7F) };
+    buf.addEvent (bytes, 3, 0);
+}
+
+void addController (dusk::MidiBuffer& buf, int channel1, int cc, std::uint8_t value)
+{
+    const std::uint8_t bytes[3] = { (std::uint8_t) (0xB0 | ((channel1 - 1) & 0x0F)),
+                                    (std::uint8_t) (cc & 0x7F), value };
+    buf.addEvent (bytes, 3, 0);
+}
+
+void emitLcdRow (dusk::MidiBuffer& buf,
                  int rowAddr,
                  const std::array<char, mcu::sysex::kLcdRowBytes>& row)
 {
@@ -54,13 +79,10 @@ void emitLcdRow (juce::MidiBuffer& buf,
     for (size_t i = 0; i < row.size(); ++i)
         bytes[n++] = (std::uint8_t) row[i];
     bytes[n++] = mcu::sysex::kEnd;
-    // createSysExMessage expects the body WITHOUT F0/F7; we feed the
-    // body slice and let it wrap. Saves one allocation vs constructing
-    // a MidiMessage from raw bytes including the framing.
-    buf.addEvent (juce::MidiMessage (bytes.data(), (int) n), 0);
+    buf.addEvent (bytes.data(), (int) n, 0);
 }
 
-void emitTimecode (juce::MidiBuffer& buf,
+void emitTimecode (dusk::MidiBuffer& buf,
                    const std::array<char, mcu::sysex::kTimecodeDigits>& digits)
 {
     // F0 00 00 66 14 10 <10 digits> F7
@@ -72,7 +94,7 @@ void emitTimecode (juce::MidiBuffer& buf,
     for (size_t i = 0; i < digits.size(); ++i)
         bytes[n++] = (std::uint8_t) digits[i];
     bytes[n++] = mcu::sysex::kEnd;
-    buf.addEvent (juce::MidiMessage (bytes.data(), (int) n), 0);
+    buf.addEvent (bytes.data(), (int) n, 0);
 }
 
 std::string formatFaderDbForLcd (float db)
@@ -106,9 +128,9 @@ McuController::~McuController()
     stopTimer();
 }
 
-juce::MidiBuffer McuController::buildEmitBuffer (bool forceAll)
+dusk::MidiBuffer McuController::buildEmitBuffer (bool forceAll)
 {
-    juce::MidiBuffer buf;
+    dusk::MidiBuffer buf;
     const int bank = session.mcu.bank.load (std::memory_order_acquire);
     const int assign = session.mcu.assignMode.load (std::memory_order_acquire);
     const int selected = session.mcu.selectedChannel.load (std::memory_order_acquire);
@@ -125,35 +147,32 @@ juce::MidiBuffer McuController::buildEmitBuffer (bool forceAll)
         const int pb14 = mcu::faderDbToPitchBend14 (liveDb);
         if (forceAll || pb14 != lastFader[(size_t) strip])
         {
-            // MidiMessage::pitchWheel uses 1-based channels.
-            buf.addEvent (juce::MidiMessage::pitchWheel (strip + 1, pb14), 0);
+            // pitch-bend feedback on 1-based channels.
+            addPitchWheel (buf, strip + 1, pb14);
             lastFader[(size_t) strip] = pb14;
         }
 
         const bool muteOn = trk.strip.mute.load (std::memory_order_relaxed);
         if (forceAll || muteOn != lastMute[(size_t) strip])
         {
-            buf.addEvent (juce::MidiMessage::noteOn (1,
-                mcu::btn::MuteBase + strip,
-                (std::uint8_t) (muteOn ? 0x7F : 0x00)), 0);
+            addNoteOn (buf, 1, mcu::btn::MuteBase + strip,
+                       (std::uint8_t) (muteOn ? 0x7F : 0x00));
             lastMute[(size_t) strip] = muteOn;
         }
 
         const bool soloOn = trk.strip.solo.load (std::memory_order_relaxed);
         if (forceAll || soloOn != lastSolo[(size_t) strip])
         {
-            buf.addEvent (juce::MidiMessage::noteOn (1,
-                mcu::btn::SoloBase + strip,
-                (std::uint8_t) (soloOn ? 0x7F : 0x00)), 0);
+            addNoteOn (buf, 1, mcu::btn::SoloBase + strip,
+                       (std::uint8_t) (soloOn ? 0x7F : 0x00));
             lastSolo[(size_t) strip] = soloOn;
         }
 
         const bool armOn = trk.recordArmed.load (std::memory_order_relaxed);
         if (forceAll || armOn != lastArm[(size_t) strip])
         {
-            buf.addEvent (juce::MidiMessage::noteOn (1,
-                mcu::btn::RecArmBase + strip,
-                (std::uint8_t) (armOn ? 0x7F : 0x00)), 0);
+            addNoteOn (buf, 1, mcu::btn::RecArmBase + strip,
+                       (std::uint8_t) (armOn ? 0x7F : 0x00));
             lastArm[(size_t) strip] = armOn;
         }
     }
@@ -163,7 +182,7 @@ juce::MidiBuffer McuController::buildEmitBuffer (bool forceAll)
     const int masterPb = mcu::faderDbToPitchBend14 (masterDb);
     if (forceAll || masterPb != lastMasterFader)
     {
-        buf.addEvent (juce::MidiMessage::pitchWheel (mcu::kMasterFaderIndex + 1, masterPb), 0);
+        addPitchWheel (buf, mcu::kMasterFaderIndex + 1, masterPb);
         lastMasterFader = masterPb;
     }
 
@@ -172,10 +191,10 @@ juce::MidiBuffer McuController::buildEmitBuffer (bool forceAll)
     {
         const bool leftAvailable  = bank > 0;
         const bool rightAvailable = bank < Session::kNumBanks - 1;
-        buf.addEvent (juce::MidiMessage::noteOn (1, mcu::btn::BankLeft,
-            (std::uint8_t) (leftAvailable ? 0x7F : 0x00)), 0);
-        buf.addEvent (juce::MidiMessage::noteOn (1, mcu::btn::BankRight,
-            (std::uint8_t) (rightAvailable ? 0x7F : 0x00)), 0);
+        addNoteOn (buf, 1, mcu::btn::BankLeft,
+                   (std::uint8_t) (leftAvailable ? 0x7F : 0x00));
+        addNoteOn (buf, 1, mcu::btn::BankRight,
+                   (std::uint8_t) (rightAvailable ? 0x7F : 0x00));
         lastBank = bank;
     }
 
@@ -198,8 +217,7 @@ juce::MidiBuffer McuController::buildEmitBuffer (bool forceAll)
                         mcu::btn::AssignPan,   mcu::btn::AssignPlugin,
                         mcu::btn::AssignEq,    mcu::btn::AssignInst })
         {
-            buf.addEvent (juce::MidiMessage::noteOn (1, n,
-                (std::uint8_t) (n == lit ? 0x7F : 0x00)), 0);
+            addNoteOn (buf, 1, n, (std::uint8_t) (n == lit ? 0x7F : 0x00));
         }
         lastAssignMode = assign;
     }
@@ -216,9 +234,8 @@ juce::MidiBuffer McuController::buildEmitBuffer (bool forceAll)
         {
             const int absTrack = bank * kStripsPerBank + strip;
             const bool lit = (absTrack == selected);
-            buf.addEvent (juce::MidiMessage::noteOn (1,
-                mcu::btn::SelectBase + strip,
-                (std::uint8_t) (lit ? 0x7F : 0x00)), 0);
+            addNoteOn (buf, 1, mcu::btn::SelectBase + strip,
+                       (std::uint8_t) (lit ? 0x7F : 0x00));
         }
         lastSelectedChannel = selected;
     }
@@ -237,19 +254,19 @@ juce::MidiBuffer McuController::buildEmitBuffer (bool forceAll)
                 const bool playing   = (state == (int) Transport::State::Playing);
                 const bool stopped   = (state == (int) Transport::State::Stopped);
                 const bool recording = (state == (int) Transport::State::Recording);
-                buf.addEvent (juce::MidiMessage::noteOn (1, mcu::btn::Play,
-                    (std::uint8_t) ((playing || recording) ? 0x7F : 0x00)), 0);
-                buf.addEvent (juce::MidiMessage::noteOn (1, mcu::btn::Stop,
-                    (std::uint8_t) (stopped ? 0x7F : 0x00)), 0);
-                buf.addEvent (juce::MidiMessage::noteOn (1, mcu::btn::Record,
-                    (std::uint8_t) (recording ? 0x7F : 0x00)), 0);
+                addNoteOn (buf, 1, mcu::btn::Play,
+                           (std::uint8_t) ((playing || recording) ? 0x7F : 0x00));
+                addNoteOn (buf, 1, mcu::btn::Stop,
+                           (std::uint8_t) (stopped ? 0x7F : 0x00));
+                addNoteOn (buf, 1, mcu::btn::Record,
+                           (std::uint8_t) (recording ? 0x7F : 0x00));
                 lastTransportState = state;
             }
             const bool loopOn = transport->isLoopEnabled();
             if (forceAll || loopOn != lastLoopOn)
             {
-                buf.addEvent (juce::MidiMessage::noteOn (1, mcu::btn::Loop,
-                    (std::uint8_t) (loopOn ? 0x7F : 0x00)), 0);
+                addNoteOn (buf, 1, mcu::btn::Loop,
+                           (std::uint8_t) (loopOn ? 0x7F : 0x00));
                 lastLoopOn = loopOn;
             }
         }
@@ -260,10 +277,10 @@ juce::MidiBuffer McuController::buildEmitBuffer (bool forceAll)
         // default (Stop lit, Play / Record / Loop dark). Matches the
         // controller's idle state on first connect before AudioEngine
         // hooks the provider up.
-        buf.addEvent (juce::MidiMessage::noteOn (1, mcu::btn::Stop,   (std::uint8_t) 0x7F), 0);
-        buf.addEvent (juce::MidiMessage::noteOn (1, mcu::btn::Play,   (std::uint8_t) 0x00), 0);
-        buf.addEvent (juce::MidiMessage::noteOn (1, mcu::btn::Record, (std::uint8_t) 0x00), 0);
-        buf.addEvent (juce::MidiMessage::noteOn (1, mcu::btn::Loop,   (std::uint8_t) 0x00), 0);
+        addNoteOn (buf, 1, mcu::btn::Stop,   (std::uint8_t) 0x7F);
+        addNoteOn (buf, 1, mcu::btn::Play,   (std::uint8_t) 0x00);
+        addNoteOn (buf, 1, mcu::btn::Record, (std::uint8_t) 0x00);
+        addNoteOn (buf, 1, mcu::btn::Loop,   (std::uint8_t) 0x00);
     }
 
     // LCD row 0: track names (7 chars per strip)
@@ -331,7 +348,8 @@ juce::MidiBuffer McuController::buildEmitBuffer (bool forceAll)
                 // 0xD0 status (channel pressure, ch 1): hi-nibble of
                 // data byte = strip 0..7, lo-nibble = level 0..15.
                 const std::uint8_t dataByte = (std::uint8_t) ((strip << 4) | (level & 0x0F));
-                buf.addEvent (juce::MidiMessage (mcu::meter::kStatus, dataByte), 0);
+                const std::uint8_t meterBytes[2] = { (std::uint8_t) mcu::meter::kStatus, dataByte };
+                buf.addEvent (meterBytes, 2, 0);
                 lastMeter[(size_t) strip] = level;
             }
         }
@@ -400,9 +418,8 @@ juce::MidiBuffer McuController::buildEmitBuffer (bool forceAll)
         }
         if (forceAll || ringValue != lastVpotRing[(size_t) strip])
         {
-            buf.addEvent (juce::MidiMessage::controllerEvent (1,
-                mcu::cc::VPotRingBase + strip,
-                (std::uint8_t) (ringValue & 0x7F)), 0);
+            addController (buf, 1, mcu::cc::VPotRingBase + strip,
+                          (std::uint8_t) (ringValue & 0x7F));
             lastVpotRing[(size_t) strip] = ringValue;
         }
     }
@@ -487,7 +504,7 @@ void McuController::timerCallback()
     sink (buf);
 }
 
-juce::MidiBuffer McuController::buildBufferForTest()
+dusk::MidiBuffer McuController::buildBufferForTest()
 {
     // Test entry: build the buffer but don't touch the engine.
     // Always full-resync semantics so a test's first call gets the

--- a/src/engine/McuController.cpp
+++ b/src/engine/McuController.cpp
@@ -68,8 +68,8 @@ void emitLcdRow (dusk::MidiBuffer& buf,
 {
     // Mackie LCD sysex: F0 00 00 66 14 12 <offset> <chars...> F7
     // Build the byte sequence into a small stack buffer (5 prefix + 1
-    // cmd + 1 offset + 56 chars + 1 end = 64 bytes max) and feed it
-    // to MidiMessage::createSysExMessage which copies internally.
+    // cmd + 1 offset + 56 chars + 1 end = 64 bytes max); addEvent copies
+    // the bytes into the buffer.
     std::array<std::uint8_t, 64> bytes;
     size_t n = 0;
     for (size_t i = 0; i < mcu::sysex::kPrefixLen; ++i)

--- a/src/engine/McuController.h
+++ b/src/engine/McuController.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <juce_audio_basics/juce_audio_basics.h>
-#include <juce_events/juce_events.h>
+#include "../foundation/MessageThread.h"
+#include "../foundation/MidiBuffer.h"
 #include <array>
 #include <atomic>
 #include <functional>
@@ -22,7 +22,7 @@ class Session;
 //   Bank arrows    : 0x2E left / 0x2F right (lit when steppable)
 //   Assign modes   : 0x28..0x2D (exactly one lit)
 //   Selected ch    : 0x18 + (selected - bank*8) when inside visible bank
-class McuController : public juce::Timer
+class McuController : public dusk::Timer
 {
 public:
     static constexpr int kStripsPerBank = 8;
@@ -30,7 +30,7 @@ public:
 
     // Called on the message thread with the deltas to push. Empty
     // buffers are skipped before invocation.
-    using SinkFn = std::function<void (const juce::MidiBuffer&)>;
+    using SinkFn = std::function<void (const dusk::MidiBuffer&)>;
 
     explicit McuController (Session& sessionRef) noexcept;
     ~McuController() override;
@@ -61,12 +61,12 @@ public:
 
     // Test: build what the next tick would send without touching the
     // engine's output bank or updating lastSent caches.
-    juce::MidiBuffer buildBufferForTest();
+    dusk::MidiBuffer buildBufferForTest();
 
 private:
     void timerCallback() override;
 
-    juce::MidiBuffer buildEmitBuffer (bool forceAll);
+    dusk::MidiBuffer buildEmitBuffer (bool forceAll);
 
     Session&     session;
     SinkFn       sink;

--- a/src/engine/ipc/RemotePluginConnection.cpp
+++ b/src/engine/ipc/RemotePluginConnection.cpp
@@ -15,7 +15,7 @@
  #include <sys/socket.h>
 #endif
 
-#include <juce_events/juce_events.h>
+#include "../../foundation/MessageThread.h"
 
 namespace duskstudio::ipc
 {
@@ -582,8 +582,8 @@ void RemotePluginConnection::readerLoop()
 
         if (hdr.op == (std::uint32_t) OpCode::ParamChangedFromChild)
         {
-            // Async push from child. Marshal to the JUCE message thread
-            // via callAsync - never invoke the sink directly here (we're
+            // Async push from child. Marshal to the message thread via
+            // dusk::callAsync - never invoke the sink directly here (we're
             // on the reader thread, sink callers may touch UI / JUCE
             // listener state).
             //
@@ -600,7 +600,7 @@ void RemotePluginConnection::readerLoop()
                 ParamChangedPayload p {};
                 std::memcpy (&p, payload.data(), sizeof (p));
                 auto state = sinkState_;
-                juce::MessageManager::callAsync ([state, p]
+                dusk::callAsync ([state, p]
                 {
                     ParamChangedSink localSink;
                     {

--- a/src/engine/midi/MidiDevices.cpp
+++ b/src/engine/midi/MidiDevices.cpp
@@ -225,10 +225,14 @@ bool MidiOutputBank::sendJuce (int index, const juce::MidiBuffer& events, double
     return true;
 }
 
-bool MidiOutputBank::send (int index, const juce::MidiBuffer& events) noexcept
+bool MidiOutputBank::send (int index, const dusk::MidiBuffer& events) noexcept
 {
-    // sampleRate is for time stamps only - the direct send carries no offsets.
-    return sendJuce (index, events, 48000.0);
+    // Bridge the dusk boundary buffer to juce here (the seam owns the
+    // conversion). sampleRate is for time stamps only - the direct send carries
+    // no offsets.
+    juce::MidiBuffer juceEvents;
+    toJuceBuffer (events, juceEvents);
+    return sendJuce (index, juceEvents, 48000.0);
 }
 
 void MidiOutputBank::queueRt (int port, const dusk::MidiBuffer& events, double sampleRate) noexcept

--- a/src/engine/midi/MidiDevices.h
+++ b/src/engine/midi/MidiDevices.h
@@ -120,9 +120,8 @@ public:
 
     // Message thread. Direct send with an ms-since-epoch base
     // (getMillisecondCounterHiRes = "ASAP", lower latency than buffering for the
-    // next block). juce-typed because McuController still builds juce buffers
-    // (events-tower coupling).
-    bool send (int index, const juce::MidiBuffer& events) noexcept;
+    // next block). Takes the dusk boundary buffer and bridges to juce internally.
+    bool send (int index, const dusk::MidiBuffer& events) noexcept;
 
     // Audio thread. sendBlockOfMessages is NOT audio-thread safe (it takes the
     // delivery thread's mutex and heap-allocates under it). The audio thread

--- a/src/foundation/MessageThread.cpp
+++ b/src/foundation/MessageThread.cpp
@@ -1,0 +1,35 @@
+#include "MessageThread.h"
+
+#include <juce_events/juce_events.h>
+
+namespace dusk
+{
+// The backend timer. Nested so it can reach Timer's protected timerCallback()
+// (enclosing-class access) and forward the tick to the derived override.
+struct Timer::Impl final : private juce::Timer
+{
+    explicit Impl (dusk::Timer& o) noexcept : owner (o) {}
+
+    void timerCallback() override { owner.timerCallback(); }
+
+    void start (int intervalMs)  noexcept { startTimer (intervalMs); }
+    void startHz (int hz)        noexcept { startTimerHz (hz); }
+    void stop()                  noexcept { stopTimer(); }
+    bool running() const         noexcept { return isTimerRunning(); }
+
+    dusk::Timer& owner;
+};
+
+Timer::Timer() : impl (std::make_unique<Impl> (*this)) {}
+Timer::~Timer() { impl->stop(); }
+
+void Timer::startTimer   (int intervalMs) noexcept { impl->start (intervalMs); }
+void Timer::startTimerHz (int hz)         noexcept { impl->startHz (hz); }
+void Timer::stopTimer()                   noexcept { impl->stop(); }
+bool Timer::isTimerRunning() const        noexcept { return impl->running(); }
+
+bool callAsync (std::function<void()> fn)
+{
+    return juce::MessageManager::callAsync (std::move (fn));
+}
+} // namespace dusk

--- a/src/foundation/MessageThread.h
+++ b/src/foundation/MessageThread.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+
+// The message-thread event seam: a periodic Timer and a post-to-message-thread
+// callAsync, mirroring the slice of JUCE's Timer / MessageManager the non-GUI
+// engine code consumes. Backed by the platform event loop (JUCE today; a
+// bespoke Wayland loop later) so those engine units can drop their JUCE
+// includes now and the backend swaps behind this pair without touching them.
+// Construct, start and stop a Timer on the message thread only. callAsync may be
+// called from any thread - that is its purpose: schedule work onto the message
+// thread from off it.
+namespace dusk
+{
+// Periodic message-thread callback. Override timerCallback(); start/stop it via
+// the interval helpers. Not copyable (owns a backend timer). Stopping is
+// idempotent and happens automatically at destruction.
+class Timer
+{
+public:
+    Timer();
+    virtual ~Timer();
+
+    void startTimer (int intervalMs) noexcept;
+    void startTimerHz (int hz) noexcept;
+    void stopTimer() noexcept;
+    bool isTimerRunning() const noexcept;
+
+protected:
+    virtual void timerCallback() = 0;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl;
+
+    Timer (const Timer&) = delete;
+    Timer& operator= (const Timer&) = delete;
+};
+
+// Post fn to run once on the message thread. Returns false if the message loop
+// is gone (shutdown) and the call could not be queued.
+bool callAsync (std::function<void()> fn);
+} // namespace dusk

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,8 +69,10 @@ add_executable(dusk-studio-tests
     mcu_receiver_decode.cpp
     mcu_controller_emit.cpp
     mcu_fader_taper.cpp
+    foundation_message_thread.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/McuReceiver.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/McuController.cpp
+    ${CMAKE_SOURCE_DIR}/src/foundation/MessageThread.cpp
     multisample_state_roundtrip.cpp
     bounce_stem_filename.cpp
     bounce_stem_targets.cpp

--- a/tests/foundation_message_thread.cpp
+++ b/tests/foundation_message_thread.cpp
@@ -6,13 +6,13 @@
 
 #include <atomic>
 
-// The event seam is a thin wrapper over the platform message loop. These tests
-// drive a real JUCE message loop and pump it, verifying that dusk::Timer
-// actually fires on the message thread and that dusk::callAsync dispatches - the
-// behaviour the non-GUI engine code relies on after dropping its juce includes.
-// ScopedJuceInitialiser_GUI brings the platform loop up (NSApplication /
-// CFRunLoop on macOS, the message queue elsewhere) and tears it down when the
-// scope unwinds, including on a failed REQUIRE.
+// The event seam is a thin wrapper over the platform message loop.
+// ScopedJuceInitialiser_GUI brings the loop up and tears it down when the scope
+// unwinds (including on a failed REQUIRE). The start/stop state and callAsync's
+// defer-not-run-inline contract are checked everywhere; the actual-fire
+// assertions pump a real loop and so run on Linux and Windows only - a headless
+// macOS CI runner has no Aqua session, so runDispatchLoop returns without ever
+// driving a juce::Timer tick.
 
 namespace
 {
@@ -22,6 +22,7 @@ struct CountingTimer final : dusk::Timer
     void timerCallback() override { ticks.fetch_add (1, std::memory_order_relaxed); }
 };
 
+#if ! defined (__APPLE__)
 // Breaks out of runDispatchLoop after a bounded window (this JUCE build has no
 // runDispatchLoopUntil). Itself a dusk::Timer, so it also exercises the seam.
 struct LoopStopper final : dusk::Timer
@@ -39,9 +40,10 @@ void pumpFor (int ms)
     stopper.startTimer (ms);
     juce::MessageManager::getInstance()->runDispatchLoop();
 }
+#endif
 } // namespace
 
-TEST_CASE ("dusk::Timer fires while running and stops on request", "[foundation][events]")
+TEST_CASE ("dusk::Timer starts, stops, and fires on the message thread", "[foundation][events]")
 {
     juce::ScopedJuceInitialiser_GUI juceInit;
 
@@ -51,19 +53,23 @@ TEST_CASE ("dusk::Timer fires while running and stops on request", "[foundation]
     timer.startTimerHz (60);
     REQUIRE (timer.isTimerRunning());
 
+#if ! defined (__APPLE__)
     pumpFor (150);
     REQUIRE (timer.ticks.load() > 0);
+#endif
 
     timer.stopTimer();
     REQUIRE_FALSE (timer.isTimerRunning());
 
+#if ! defined (__APPLE__)
     // Nothing new should arrive once stopped.
     const int afterStop = timer.ticks.load();
     pumpFor (60);
     REQUIRE (timer.ticks.load() == afterStop);
+#endif
 }
 
-TEST_CASE ("dusk::callAsync runs its callback on the next dispatch", "[foundation][events]")
+TEST_CASE ("dusk::callAsync defers and dispatches on the message thread", "[foundation][events]")
 {
     juce::ScopedJuceInitialiser_GUI juceInit;
 
@@ -72,6 +78,8 @@ TEST_CASE ("dusk::callAsync runs its callback on the next dispatch", "[foundatio
     REQUIRE (queued);
     REQUIRE_FALSE (ran.load());   // deferred, not run inline
 
+#if ! defined (__APPLE__)
     pumpFor (50);
     REQUIRE (ran.load());
+#endif
 }

--- a/tests/foundation_message_thread.cpp
+++ b/tests/foundation_message_thread.cpp
@@ -1,0 +1,78 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "foundation/MessageThread.h"
+
+#include <juce_events/juce_events.h>
+
+#include <atomic>
+
+// The event seam is a thin wrapper over the platform message loop. These tests
+// drive a real JUCE MessageManager and pump it, verifying that dusk::Timer
+// actually fires on the message thread and that dusk::callAsync dispatches - the
+// behaviour the non-GUI engine code relies on after dropping its juce includes.
+
+namespace
+{
+struct CountingTimer final : dusk::Timer
+{
+    std::atomic<int> ticks { 0 };
+    void timerCallback() override { ticks.fetch_add (1, std::memory_order_relaxed); }
+};
+
+// Breaks out of runDispatchLoop after a bounded window (this JUCE build has no
+// runDispatchLoopUntil). Itself a dusk::Timer, so it also exercises the seam.
+struct LoopStopper final : dusk::Timer
+{
+    void timerCallback() override
+    {
+        stopTimer();
+        juce::MessageManager::getInstance()->stopDispatchLoop();
+    }
+};
+
+void pumpFor (int ms)
+{
+    LoopStopper stopper;
+    stopper.startTimer (ms);
+    juce::MessageManager::getInstance()->runDispatchLoop();
+}
+} // namespace
+
+TEST_CASE ("dusk::Timer fires while running and stops on request", "[foundation][events]")
+{
+    juce::MessageManager::getInstance();   // this thread becomes the message thread
+
+    CountingTimer timer;
+    REQUIRE_FALSE (timer.isTimerRunning());
+
+    timer.startTimerHz (60);
+    REQUIRE (timer.isTimerRunning());
+
+    pumpFor (150);
+    REQUIRE (timer.ticks.load() > 0);
+
+    timer.stopTimer();
+    REQUIRE_FALSE (timer.isTimerRunning());
+
+    // Nothing new should arrive once stopped.
+    const int afterStop = timer.ticks.load();
+    pumpFor (60);
+    REQUIRE (timer.ticks.load() == afterStop);
+
+    juce::MessageManager::deleteInstance();
+}
+
+TEST_CASE ("dusk::callAsync runs its callback on the next dispatch", "[foundation][events]")
+{
+    juce::MessageManager::getInstance();
+
+    std::atomic<bool> ran { false };
+    const bool queued = dusk::callAsync ([&ran] { ran.store (true, std::memory_order_relaxed); });
+    REQUIRE (queued);
+    REQUIRE_FALSE (ran.load());   // deferred, not run inline
+
+    pumpFor (50);
+    REQUIRE (ran.load());
+
+    juce::MessageManager::deleteInstance();
+}

--- a/tests/foundation_message_thread.cpp
+++ b/tests/foundation_message_thread.cpp
@@ -2,14 +2,17 @@
 
 #include "foundation/MessageThread.h"
 
-#include <juce_events/juce_events.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
 #include <atomic>
 
 // The event seam is a thin wrapper over the platform message loop. These tests
-// drive a real JUCE MessageManager and pump it, verifying that dusk::Timer
+// drive a real JUCE message loop and pump it, verifying that dusk::Timer
 // actually fires on the message thread and that dusk::callAsync dispatches - the
 // behaviour the non-GUI engine code relies on after dropping its juce includes.
+// ScopedJuceInitialiser_GUI brings the platform loop up (NSApplication /
+// CFRunLoop on macOS, the message queue elsewhere) and tears it down when the
+// scope unwinds, including on a failed REQUIRE.
 
 namespace
 {
@@ -40,7 +43,7 @@ void pumpFor (int ms)
 
 TEST_CASE ("dusk::Timer fires while running and stops on request", "[foundation][events]")
 {
-    juce::MessageManager::getInstance();   // this thread becomes the message thread
+    juce::ScopedJuceInitialiser_GUI juceInit;
 
     CountingTimer timer;
     REQUIRE_FALSE (timer.isTimerRunning());
@@ -58,13 +61,11 @@ TEST_CASE ("dusk::Timer fires while running and stops on request", "[foundation]
     const int afterStop = timer.ticks.load();
     pumpFor (60);
     REQUIRE (timer.ticks.load() == afterStop);
-
-    juce::MessageManager::deleteInstance();
 }
 
 TEST_CASE ("dusk::callAsync runs its callback on the next dispatch", "[foundation][events]")
 {
-    juce::MessageManager::getInstance();
+    juce::ScopedJuceInitialiser_GUI juceInit;
 
     std::atomic<bool> ran { false };
     const bool queued = dusk::callAsync ([&ran] { ran.store (true, std::memory_order_relaxed); });
@@ -73,6 +74,4 @@ TEST_CASE ("dusk::callAsync runs its callback on the next dispatch", "[foundatio
 
     pumpFor (50);
     REQUIRE (ran.load());
-
-    juce::MessageManager::deleteInstance();
 }

--- a/tests/mcu_controller_emit.cpp
+++ b/tests/mcu_controller_emit.cpp
@@ -4,8 +4,6 @@
 #include "engine/McuProtocol.h"
 #include "session/Session.h"
 
-#include <juce_audio_basics/juce_audio_basics.h>
-
 using namespace duskstudio;
 
 namespace
@@ -14,7 +12,7 @@ namespace
 // pitch-bend channel). Returns the velocity / value byte (data2) or
 // -1 if not found. Avoids the test-asserting on event order across the
 // buffer.
-int findValueForNote (const juce::MidiBuffer& buf, int status, int data1)
+int findValueForNote (const dusk::MidiBuffer& buf, int status, int data1)
 {
     for (const auto meta : buf)
     {
@@ -29,7 +27,7 @@ int findValueForNote (const juce::MidiBuffer& buf, int status, int data1)
     return -1;
 }
 
-int findPitchBend14 (const juce::MidiBuffer& buf, int channel0Indexed)
+int findPitchBend14 (const dusk::MidiBuffer& buf, int channel0Indexed)
 {
     for (const auto meta : buf)
     {
@@ -42,6 +40,54 @@ int findPitchBend14 (const juce::MidiBuffer& buf, int channel0Indexed)
             return (raw[1] & 0x7F) | ((raw[2] & 0x7F) << 7);
     }
     return -1;
+}
+
+// CC (0xB0) value for a given controller number, or -1.
+int findControllerValue (const dusk::MidiBuffer& buf, int cc)
+{
+    for (const auto meta : buf)
+    {
+        const auto& m = meta.getMessage();
+        const auto* raw = m.getRawData();
+        const int sz = m.getRawDataSize();
+        if (raw == nullptr || sz < 3) continue;
+        if ((raw[0] & 0xF0) == 0xB0 && (raw[1] & 0x7F) == (cc & 0x7F))
+            return raw[2] & 0x7F;
+    }
+    return -1;
+}
+
+// Channel-pressure (0xD0) low-nibble (meter level) for the strip in the data
+// byte's high nibble, or -1 if no meter event for that strip.
+int findMeterLevel (const dusk::MidiBuffer& buf, int strip)
+{
+    for (const auto meta : buf)
+    {
+        const auto& m = meta.getMessage();
+        const auto* raw = m.getRawData();
+        const int sz = m.getRawDataSize();
+        if (raw == nullptr || sz < 2) continue;
+        if (raw[0] == mcu::meter::kStatus && (raw[1] >> 4) == strip)
+            return raw[1] & 0x0F;
+    }
+    return -1;
+}
+
+// True if a Mackie LCD sysex (F0 00 00 66 14 12 ...) addressed at `rowAddr`
+// is present.
+bool hasLcdSysex (const dusk::MidiBuffer& buf, int rowAddr)
+{
+    for (const auto meta : buf)
+    {
+        const auto& m = meta.getMessage();
+        const auto* raw = m.getRawData();
+        const int sz = m.getRawDataSize();
+        if (raw == nullptr || sz < (int) mcu::sysex::kPrefixLen + 3) continue;
+        if (raw[0] == 0xF0 && raw[mcu::sysex::kPrefixLen] == mcu::sysex::kCmdLcd
+            && raw[mcu::sysex::kPrefixLen + 1] == (rowAddr & 0x7F))
+            return true;
+    }
+    return false;
 }
 } // namespace
 
@@ -128,4 +174,30 @@ TEST_CASE ("McuController: bank flip relights the eight SELECT LEDs", "[mcu][con
     s.mcu.selectedChannel.store (10, std::memory_order_relaxed);
     auto buf2 = controller.buildBufferForTest();
     REQUIRE (findValueForNote (buf2, 0x90, mcu::btn::SelectBase + 2) == 0x7F);
+}
+
+// Exercises the remaining raw-byte builders on the dusk buffer: V-pot ring
+// CC (0xB0), meter channel-pressure (0xD0, 2-byte), and the LCD sysex framing.
+// Guards the nibble / status math the byte helpers now do by hand.
+TEST_CASE ("McuController: v-pot, meter and LCD sysex wire bytes", "[mcu][controller]")
+{
+    Session s;
+    McuController controller (s);
+
+    // Assign mode 0 (PAN) emits a V-pot ring CC per banked strip.
+    auto buf = controller.buildBufferForTest();
+
+    // V-pot ring for strip 0 = CC 0x30. Centre pan -> centre-dot bit set, so
+    // the value is non-zero; just require the CC exists.
+    REQUIRE (findControllerValue (buf, mcu::cc::VPotRingBase + 0) >= 0);
+    REQUIRE (findControllerValue (buf, mcu::cc::VPotRingBase + 7) >= 0);
+
+    // Meter channel-pressure for strip 3: default (silent) input -> level 0,
+    // data byte high nibble == strip.
+    REQUIRE (findMeterLevel (buf, 3) == 0);
+    REQUIRE (findMeterLevel (buf, 7) == 0);
+
+    // Both LCD rows framed as Mackie sysex.
+    REQUIRE (hasLcdSysex (buf, mcu::sysex::kLcdRow0Addr));
+    REQUIRE (hasLcdSysex (buf, mcu::sysex::kLcdRow1Addr));
 }

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -25,8 +25,6 @@ src/engine/LameMp3Writer.cpp
 src/engine/LameMp3Writer.h
 src/engine/MasteringPlayer.cpp
 src/engine/MasteringPlayer.h
-src/engine/McuController.cpp
-src/engine/McuController.h
 src/engine/NativeScanRows.h
 src/engine/PlaybackEngine.cpp
 src/engine/PlaybackEngine.h
@@ -49,7 +47,6 @@ src/engine/hosting/PortBuffers.h
 src/engine/ipc/IpcSelfTest.cpp
 src/engine/ipc/PluginHostMain.cpp
 src/engine/ipc/PluginScanProtocol.h
-src/engine/ipc/RemotePluginConnection.cpp
 src/engine/midi/MidiDevices.cpp
 src/engine/midi/MidiDevices.h
 src/engine/multisample/AriaBank.cpp
@@ -66,6 +63,7 @@ src/engine/pipewire/PipeWireAudioIODevice.cpp
 src/engine/pipewire/PipeWireAudioIODevice.h
 src/engine/pipewire/PipeWireAudioIODeviceType.cpp
 src/engine/pipewire/PipeWireAudioIODeviceType.h
+src/foundation/MessageThread.cpp
 src/session/MarkerEditActions.h
 src/session/MidiBindings.cpp
 src/session/MidiBindings.h


### PR DESCRIPTION
…PC param dispatch

Add src/foundation/MessageThread.h/.cpp: a thin message-thread event seam (dusk::Timer, dusk::callAsync) wrapping JUCE's Timer/MessageManager, so non-GUI engine units can drop their juce_events include and the backend swaps to a bespoke Wayland loop later without touching them. Pimpl keeps the header token-clean; only the .cpp is JUCE-coupled (allowlisted).

Flip the two non-GUI units that go fully clean:
- McuController: base juce::Timer -> dusk::Timer; feedback buffers juce::MidiBuffer -> dusk::MidiBuffer; the MidiMessage note/pitch-bend/CC/ channel-pressure/sysex builders become raw-byte helpers on the dusk buffer. MidiOutputBank::send now takes the dusk boundary buffer and bridges to juce internally (the seam owns the one dusk->juce MIDI-out conversion).
- RemotePluginConnection: the ParamChangedFromChild async dispatch juce::MessageManager::callAsync -> dusk::callAsync.

Tests: foundation_message_thread drives a real MessageManager and verifies dusk::Timer fires + stops and callAsync dispatches; mcu_controller_emit goes dusk-native and gains v-pot CC / meter channel-pressure / LCD sysex byte assertions (the hardware-critical wire-format check for the new raw builders).

gate 198 -> 196; ctest 386/386; Xvfb selftest 15/15.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a non-GUI message-thread timer and one-shot async scheduling support for engine operations.
  * Expanded MIDI controller output processing for feedback elements like meters, LEDs, and LCD SysEx.
* **Bug Fixes**
  * Improved MIDI event delivery between the engine’s internal buffering and connected MIDI outputs.
  * Ensured parameter-change updates are dispatched safely via the message thread.
* **Tests**
  * Added message-thread scheduling tests and broadened MIDI feedback validation to cover additional controller-emitted data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->