### PR TITLE
De-JUCE: hosting transport seam (dusk::TransportPosition)

### DIFF
--- a/src/engine/hosting/InsertAdapter.cpp
+++ b/src/engine/hosting/InsertAdapter.cpp
@@ -40,7 +40,7 @@ void InsertAdapter::process (INativeInstance& inst,
                              const float* sidechainL,
                              const float* sidechainR,
                              const dusk::MidiBuffer* midiIn,
-                             const juce::AudioPlayHead::PositionInfo* transport) noexcept
+                             const dusk::TransportPosition* transport) noexcept
 {
     if (! inst.isActive() || numFrames <= 0 || numFrames > maxFrames)
         return;   // dry passthrough - leave L/R untouched
@@ -60,7 +60,7 @@ void InsertAdapter::process (INativeInstance& inst,
         std::memcpy (inPtrs[0], L, n * sizeof (float));
         std::memcpy (inPtrs[1], R, n * sizeof (float));
         for (int c = 2; c < inChans; ++c)   // extra main-in channels (rare) get silence
-            juce::FloatVectorOperations::clear (inPtrs[(size_t) c], numFrames);
+            std::fill (inPtrs[(size_t) c], inPtrs[(size_t) c] + n, 0.0f);
     }
     // inChans == 0 -> instrument: no audio input to build.
 
@@ -68,23 +68,23 @@ void InsertAdapter::process (INativeInstance& inst,
     if (scChans >= 1)
     {
         if (sidechainL != nullptr) std::memcpy (scPtrs[0], sidechainL, n * sizeof (float));
-        else                       juce::FloatVectorOperations::clear (scPtrs[0], numFrames);
+        else                       std::fill (scPtrs[0], scPtrs[0] + n, 0.0f);
 
         if (scChans >= 2)
         {
             const float* r = sidechainR != nullptr ? sidechainR : sidechainL;   // mono source -> dup
             if (r != nullptr) std::memcpy (scPtrs[1], r, n * sizeof (float));
-            else              juce::FloatVectorOperations::clear (scPtrs[1], numFrames);
+            else              std::fill (scPtrs[1], scPtrs[1] + n, 0.0f);
 
             for (int c = 2; c < scChans; ++c)
-                juce::FloatVectorOperations::clear (scPtrs[(size_t) c], numFrames);
+                std::fill (scPtrs[(size_t) c], scPtrs[(size_t) c] + n, 0.0f);
         }
     }
 
     // Clear the output scratch so any main-out channel the plugin leaves
     // unwritten reads as silence, not last block's data.
     for (int c = 0; c < outChans; ++c)
-        juce::FloatVectorOperations::clear (outPtrs[(size_t) c], numFrames);
+        std::fill (outPtrs[(size_t) c], outPtrs[(size_t) c] + n, 0.0f);
 
     PortBuffers io;
     io.mainIn              = inChans  > 0 ? inPtrs.data() : nullptr;

--- a/src/engine/hosting/InsertAdapter.h
+++ b/src/engine/hosting/InsertAdapter.h
@@ -40,7 +40,7 @@ public:
                   const float* sidechainL = nullptr,
                   const float* sidechainR = nullptr,
                   const dusk::MidiBuffer* midiIn = nullptr,
-                  const juce::AudioPlayHead::PositionInfo* transport = nullptr) noexcept;
+                  const dusk::TransportPosition* transport = nullptr) noexcept;
 
     int inputChannels()     const noexcept { return inChans; }
     int outputChannels()    const noexcept { return outChans; }

--- a/src/engine/hosting/PortBuffers.h
+++ b/src/engine/hosting/PortBuffers.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include <juce_audio_basics/juce_audio_basics.h>   // AudioPlayHead::PositionInfo
-
 #include "../../foundation/MidiBuffer.h"
+#include "../../foundation/TransportPosition.h"
 
 namespace duskstudio::hosting
 {
@@ -12,9 +11,9 @@ namespace duskstudio::hosting
 // or locked on the audio thread. Channel arrays are `float* const*` (an array of
 // per-channel pointers), so mono / stereo / multi-out all use one shape.
 //
-// dusk::MidiBuffer and juce AudioPlayHead::PositionInfo are the engine's existing
-// currency for MIDI and transport; each host translates them into its own format
-// (VST3 Event, LV2 atom-midi, CLAP note events) internally.
+// dusk::MidiBuffer and dusk::TransportPosition are the engine's currency for MIDI
+// and transport; each host translates them into its own format (VST3 Event, LV2
+// atom-midi, CLAP note events) internally.
 struct PortBuffers
 {
     // Main audio I/O. The audio arrays are mutable (float* const*) because
@@ -41,6 +40,6 @@ struct PortBuffers
     dusk::MidiBuffer*       midiOut = nullptr;
 
     // Optional transport for tempo-synced plugins (null = not supplied).
-    const juce::AudioPlayHead::PositionInfo* transport = nullptr;
+    const dusk::TransportPosition* transport = nullptr;
 };
 } // namespace duskstudio::hosting

--- a/src/foundation/TransportPosition.h
+++ b/src/foundation/TransportPosition.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+
+// The engine's transport currency at the plugin-hosting boundary, mirroring the
+// slice of JUCE's AudioPlayHead::PositionInfo a tempo-synced plugin needs. Each
+// native host (CLAP note events, VST3 ProcessContext, LV2 time atoms) translates
+// this into its own format. A null PortBuffers::transport pointer means "not
+// supplied"; the fields are only read when a caller wires a live transport.
+namespace dusk
+{
+struct TransportPosition
+{
+    double       bpm                     = 120.0;
+    double       ppqPosition             = 0.0;
+    double       timeInSeconds           = 0.0;
+    std::int64_t timeInSamples           = 0;
+    int          timeSignatureNumerator   = 4;
+    int          timeSignatureDenominator = 4;
+    bool         isPlaying               = false;
+    bool         isRecording             = false;
+    bool         isLooping               = false;
+};
+} // namespace dusk

--- a/tests/clap_ab_nulltest.cpp
+++ b/tests/clap_ab_nulltest.cpp
@@ -12,6 +12,7 @@
 #include "engine/clap/ClapInstance.h"
 #include "engine/hosting/InsertAdapter.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdlib>
 #include <string>

--- a/tests/hosting_port_layout.cpp
+++ b/tests/hosting_port_layout.cpp
@@ -5,6 +5,7 @@
 #include "engine/hosting/PortBuffers.h"
 #include "engine/hosting/PortLayout.h"
 
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -127,7 +128,7 @@ public:
     void processBlock (const PortBuffers& io) noexcept override
     {
         if (! active || io.numFrames <= 0 || io.numFrames > maxFrames) return;
-        const int ch = juce::jmin (io.mainInChannels, io.mainOutChannels);
+        const int ch = std::min (io.mainInChannels, io.mainOutChannels);
         for (int c = 0; c < ch; ++c)
             for (int i = 0; i < io.numFrames; ++i)
                 io.mainOut[c][i] = io.mainIn[c][i] * 0.5f;

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -40,10 +40,7 @@ src/engine/alsa/AlsaAudioIODeviceType.cpp
 src/engine/alsa/AlsaAudioIODeviceType.h
 src/engine/alsa/AlsaPerformanceTest.cpp
 src/engine/alsa/AlsaPerformanceTest.h
-src/engine/hosting/InsertAdapter.cpp
-src/engine/hosting/InsertAdapter.h
 src/engine/hosting/NativePluginId.h
-src/engine/hosting/PortBuffers.h
 src/engine/ipc/IpcSelfTest.cpp
 src/engine/ipc/PluginHostMain.cpp
 src/engine/ipc/PluginScanProtocol.h


### PR DESCRIPTION
First of two disjoint de-JUCE PRs off main (the other is the device-interfaces branch).

Replaces `juce::AudioPlayHead::PositionInfo` with a new JUCE-free `dusk::TransportPosition` at the native plugin-hosting boundary, flipping three files fully clean.

## What
- New `src/foundation/TransportPosition.h` — JUCE-free struct mirroring the `AudioPlayHead::PositionInfo` slice a tempo-synced plugin needs (bpm, ppq, timeInSamples, time sig, playing/recording/looping).
- `PortBuffers.h`: `transport` member `juce::AudioPlayHead::PositionInfo*` → `dusk::TransportPosition*`, drops the `juce_audio_basics` include.
- `InsertAdapter.{h,cpp}`: `process()` transport param follows; the 5 `juce::FloatVectorOperations::clear` scratch-clears become `std::fill`.

## Why zero behavior change
Transport is dead in the native path today — `ClapInstance` forces `p.transport = nullptr`, nobody dereferences it, and the lone caller (`NativeInsertSlot`) passes the default nullptr. This is a pure type-boundary swap plus a forward-looking type for when real transport wiring lands in the CLAP/VST3/LV2 hosts.

## Verification
- gate 196 → 193 (InsertAdapter.{h,cpp} + PortBuffers.h off the allowlist)
- app build 0 new warnings, ctest 386/386, Xvfb selftest 15/15
- Two test include fixes exposed by dropping the transitive `juce_audio_basics`: `hosting_port_layout.cpp` (`juce::jmin`→`std::min` + `<algorithm>`), `clap_ab_nulltest.cpp` (`<algorithm>`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a unified transport state representation for tempo, timing, playback, recording, and looping information.

- **Bug Fixes**
  - Improved compatibility for tempo- and transport-synchronized plugins.
  - Ensured unused, missing, or extra audio channels are reliably silenced.
  - Improved handling of sidechain and output buffers to prevent unintended audio.

- **Tests**
  - Updated audio processing tests to improve coverage and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->