### PR TITLE
De-JUCE device layer Phases 1+2a: dusk::audio device interfaces + DeviceManager seam

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,6 +330,7 @@ target_sources(DuskStudio PRIVATE
     src/engine/McuReceiver.cpp
     src/engine/McuController.cpp
     src/engine/MidiTimeCodeEmitter.cpp
+    src/engine/device/DeviceManager.cpp
     src/engine/midi/MidiDevices.cpp
     src/engine/PlaybackEngine.cpp
     src/engine/PluginManager.cpp

--- a/src/engine/device/ChannelSet.h
+++ b/src/engine/device/ChannelSet.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <cstdint>
+
+// A fixed-width channel activation mask: the dusk replacement for the JUCE
+// BigInteger the audio device layer carries to mark which channels of a device
+// are active. Audio devices
+// top out at a few dozen channels (the app ceiling is 32 out / 16 in), so a
+// 64-bit backing is ample and keeps the type trivially copyable and allocation-
+// free - safe to pass by value across the device/callback boundary. Bit index i
+// is channel i; setRange / count / highestSetBit mirror the JUCE BigInteger
+// operations the device code and selector UI relied on.
+namespace duskstudio::device
+{
+class ChannelSet
+{
+public:
+    static constexpr int kMaxChannels = 64;
+
+    ChannelSet() = default;
+
+    void clear() noexcept { bits = 0; }
+    bool isZero() const noexcept { return bits == 0; }
+
+    void setBit (int index, bool shouldBeSet = true) noexcept
+    {
+        if (index < 0 || index >= kMaxChannels) return;
+        const std::uint64_t mask = std::uint64_t (1) << index;
+        if (shouldBeSet) bits |=  mask;
+        else             bits &= ~mask;
+    }
+
+    // Set (or clear) `num` consecutive bits starting at `start`. Matches
+    // BigInteger::setRange; out-of-range bits are ignored (channels never
+    // exceed kMaxChannels).
+    void setRange (int start, int num, bool shouldBeSet) noexcept
+    {
+        for (int i = start; i < start + num; ++i)
+            setBit (i, shouldBeSet);
+    }
+
+    bool operator[] (int index) const noexcept
+    {
+        if (index < 0 || index >= kMaxChannels) return false;
+        return (bits & (std::uint64_t (1) << index)) != 0;
+    }
+
+    // Number of active channels (BigInteger::countNumberOfSetBits).
+    int count() const noexcept
+    {
+        int n = 0;
+        for (std::uint64_t b = bits; b != 0; b &= (b - 1))
+            ++n;
+        return n;
+    }
+
+    // Highest set bit index, or -1 if none (BigInteger::getHighestBit).
+    int highestSetBit() const noexcept
+    {
+        for (int i = kMaxChannels - 1; i >= 0; --i)
+            if ((bits & (std::uint64_t (1) << i)) != 0)
+                return i;
+        return -1;
+    }
+
+    bool operator== (const ChannelSet& o) const noexcept { return bits == o.bits; }
+    bool operator!= (const ChannelSet& o) const noexcept { return bits != o.bits; }
+
+    // Raw access for bridging to/from a JUCE BigInteger at the seam boundary.
+    std::uint64_t raw() const noexcept { return bits; }
+    static ChannelSet fromRaw (std::uint64_t r) noexcept { ChannelSet c; c.bits = r; return c; }
+
+private:
+    std::uint64_t bits = 0;
+};
+} // namespace duskstudio::device

--- a/src/engine/device/DeviceManager.cpp
+++ b/src/engine/device/DeviceManager.cpp
@@ -1,0 +1,313 @@
+#include "DeviceManager.h"
+#include "IODeviceCallback.h"
+
+#include <juce_audio_devices/juce_audio_devices.h>
+
+#if defined(DUSKSTUDIO_HAS_PIPEWIRE)
+ #include "../pipewire/PipeWireAudioIODeviceType.h"
+#endif
+#if defined(DUSKSTUDIO_HAS_ALSA)
+ #include "../alsa/AlsaAudioIODeviceType.h"
+#endif
+
+#include <map>
+
+namespace duskstudio::device
+{
+namespace
+{
+juce::BigInteger toBig (const ChannelSet& cs)
+{
+    juce::BigInteger b;
+    for (int i = 0; i < ChannelSet::kMaxChannels; ++i)
+        if (cs[i]) b.setBit (i);
+    return b;
+}
+
+ChannelSet fromBig (const juce::BigInteger& b)
+{
+    ChannelSet cs;
+    for (int i = 0; i < ChannelSet::kMaxChannels; ++i)
+        if (b[i]) cs.setBit (i);
+    return cs;
+}
+
+std::vector<std::string> toStrings (const juce::StringArray& a)
+{
+    std::vector<std::string> v;
+    v.reserve ((size_t) a.size());
+    for (const auto& s : a) v.push_back (s.toStdString());
+    return v;
+}
+
+template <typename T>
+std::vector<T> toVector (const juce::Array<T>& a)
+{
+    std::vector<T> v;
+    v.reserve ((size_t) a.size());
+    for (const auto& x : a) v.push_back (x);
+    return v;
+}
+
+// dusk IODevice over a juce::AudioIODevice (non-owning: the wrapped juce device
+// is owned by the juce::AudioDeviceManager). Repointed as the current device
+// changes so query call sites always read the live device.
+class JuceDeviceAdapter final : public IODevice
+{
+public:
+    explicit JuceDeviceAdapter (juce::AudioIODevice* d) noexcept : dev (d) {}
+    void repoint (juce::AudioIODevice* d) noexcept { dev = d; }
+
+    std::string getName() const override { return dev ? dev->getName().toStdString() : std::string(); }
+
+    std::vector<std::string> getOutputChannelNames() override
+        { return dev ? toStrings (dev->getOutputChannelNames()) : std::vector<std::string>{}; }
+    std::vector<std::string> getInputChannelNames() override
+        { return dev ? toStrings (dev->getInputChannelNames()) : std::vector<std::string>{}; }
+    std::vector<double> getAvailableSampleRates() override
+        { return dev ? toVector (dev->getAvailableSampleRates()) : std::vector<double>{}; }
+    std::vector<int> getAvailableBufferSizes() override
+        { return dev ? toVector (dev->getAvailableBufferSizes()) : std::vector<int>{}; }
+    int getDefaultBufferSize() override { return dev ? dev->getDefaultBufferSize() : 0; }
+
+    std::string open (const ChannelSet& in, const ChannelSet& out, double sr, int bs) override
+        { return dev ? dev->open (toBig (in), toBig (out), sr, bs).toStdString() : std::string ("no device"); }
+    void close() override { if (dev) dev->close(); }
+    bool isOpen() override { return dev && dev->isOpen(); }
+
+    // start()/stop() are driven through the manager's callback path in this seam,
+    // not per-device; forward for interface completeness.
+    void start (IODeviceCallback*) override {}
+    void stop() override { if (dev) dev->stop(); }
+    bool isPlaying() override { return dev && dev->isPlaying(); }
+
+    std::string getLastError() override { return dev ? dev->getLastError().toStdString() : std::string(); }
+    int    getCurrentBufferSizeSamples() override { return dev ? dev->getCurrentBufferSizeSamples() : 0; }
+    double getCurrentSampleRate()        override { return dev ? dev->getCurrentSampleRate() : 0.0; }
+    int    getCurrentBitDepth()          override { return dev ? dev->getCurrentBitDepth() : 0; }
+    ChannelSet getActiveOutputChannels() const override { return dev ? fromBig (dev->getActiveOutputChannels()) : ChannelSet{}; }
+    ChannelSet getActiveInputChannels()  const override { return dev ? fromBig (dev->getActiveInputChannels()) : ChannelSet{}; }
+    int getOutputLatencyInSamples() override { return dev ? dev->getOutputLatencyInSamples() : 0; }
+    int getInputLatencyInSamples()  override { return dev ? dev->getInputLatencyInSamples() : 0; }
+    int getXRunCount() const noexcept override { return dev ? dev->getXRunCount() : 0; }
+
+private:
+    juce::AudioIODevice* dev = nullptr;
+};
+
+// dusk IODeviceType over a juce::AudioIODeviceType (non-owning: owned by the
+// juce::AudioDeviceManager). Used for the selector's + recovery's enumeration.
+class JuceDeviceTypeAdapter final : public IODeviceType
+{
+public:
+    explicit JuceDeviceTypeAdapter (juce::AudioIODeviceType* t) noexcept : type (t) {}
+    juce::AudioIODeviceType* juceType() const noexcept { return type; }
+
+    std::string getTypeName() const override { return type->getTypeName().toStdString(); }
+    void scanForDevices() override { type->scanForDevices(); }
+    std::vector<std::string> getDeviceNames (bool wantInputNames) const override
+        { return toStrings (type->getDeviceNames (wantInputNames)); }
+    int getDefaultDeviceIndex (bool forInput) const override { return type->getDefaultDeviceIndex (forInput); }
+    int getIndexOfDevice (IODevice*, bool) const override { return -1; }
+
+    // Not used in the seam - the juce::AudioDeviceManager constructs devices
+    // internally on setSetup(); the native phase implements this.
+    std::unique_ptr<IODevice> createDevice (const std::string&, const std::string&) override { return nullptr; }
+
+private:
+    juce::AudioIODeviceType* type = nullptr;
+};
+
+// juce::AudioIODeviceCallback forwarding to a dusk IODeviceCallback. Registered
+// with the juce::AudioDeviceManager; the RT path is a straight forward with a
+// context translation, no allocation. Holds its own device adapter for the
+// aboutToStart hand-off.
+class CallbackBridge final : public juce::AudioIODeviceCallback
+{
+public:
+    explicit CallbackBridge (IODeviceCallback* c) noexcept : cb (c) {}
+
+    void audioDeviceIOCallbackWithContext (const float* const* in, int numIn,
+                                           float* const* out, int numOut, int numSamples,
+                                           const juce::AudioIODeviceCallbackContext& ctx) override
+    {
+        CallbackContext dctx;
+        dctx.hostTimeNs = ctx.hostTimeNs;
+        cb->audioDeviceIOCallback (in, numIn, out, numOut, numSamples, dctx);
+    }
+
+    void audioDeviceAboutToStart (juce::AudioIODevice* device) override
+    {
+        adapter.repoint (device);
+        cb->audioDeviceAboutToStart (&adapter);
+    }
+
+    void audioDeviceStopped() override { cb->audioDeviceStopped(); }
+
+private:
+    IODeviceCallback* cb;
+    JuceDeviceAdapter adapter { nullptr };
+};
+} // namespace
+
+struct DeviceManager::Impl : private juce::ChangeListener
+{
+    Impl() { mgr.addChangeListener (this); }
+    ~Impl() override { mgr.removeChangeListener (this); }
+
+    void changeListenerCallback (juce::ChangeBroadcaster*) override { if (onChange) onChange(); }
+
+    juce::AudioDeviceManager mgr;
+    std::vector<std::unique_ptr<JuceDeviceTypeAdapter>> typeAdapters;
+    JuceDeviceAdapter currentDevice { nullptr };
+    std::map<IODeviceCallback*, std::unique_ptr<CallbackBridge>> bridges;
+    std::function<void()> onChange;
+
+    void registerBackends()
+    {
+       #if defined(DUSKSTUDIO_HAS_PIPEWIRE)
+        mgr.addAudioDeviceType (std::make_unique<PipeWireAudioIODeviceType>());
+       #endif
+       #if defined(DUSKSTUDIO_HAS_ALSA)
+        mgr.addAudioDeviceType (std::make_unique<AlsaAudioIODeviceType>());
+       #endif
+
+       #if JUCE_WINDOWS
+        // Preference order: ASIO (only present when the SDK was built in) ->
+        // WASAPI exclusive -> WASAPI shared -> DirectSound. The default pick lands
+        // on the first registered type that enumerates devices.
+       #if JUCE_ASIO
+        if (auto* asio = juce::AudioIODeviceType::createAudioIODeviceType_ASIO())
+            mgr.addAudioDeviceType (std::unique_ptr<juce::AudioIODeviceType> (asio));
+       #endif
+        if (auto* wasapiExclusive = juce::AudioIODeviceType::createAudioIODeviceType_WASAPI (
+                juce::WASAPIDeviceMode::exclusive))
+            mgr.addAudioDeviceType (std::unique_ptr<juce::AudioIODeviceType> (wasapiExclusive));
+        if (auto* wasapiShared = juce::AudioIODeviceType::createAudioIODeviceType_WASAPI (
+                juce::WASAPIDeviceMode::shared))
+            mgr.addAudioDeviceType (std::unique_ptr<juce::AudioIODeviceType> (wasapiShared));
+        if (auto* directSound = juce::AudioIODeviceType::createAudioIODeviceType_DirectSound())
+            mgr.addAudioDeviceType (std::unique_ptr<juce::AudioIODeviceType> (directSound));
+       #endif
+
+        for (auto* t : mgr.getAvailableDeviceTypes())
+            if (t != nullptr) t->scanForDevices();
+    }
+};
+
+DeviceManager::DeviceManager() : impl (std::make_unique<Impl>()) {}
+DeviceManager::~DeviceManager() = default;
+
+std::vector<IODeviceType*> DeviceManager::getAvailableDeviceTypes()
+{
+    impl->typeAdapters.clear();
+    std::vector<IODeviceType*> out;
+    for (auto* t : impl->mgr.getAvailableDeviceTypes())
+    {
+        if (t == nullptr) continue;
+        impl->typeAdapters.push_back (std::make_unique<JuceDeviceTypeAdapter> (t));
+        out.push_back (impl->typeAdapters.back().get());
+    }
+    return out;
+}
+
+void DeviceManager::scanAllDeviceTypes()
+{
+    for (auto* t : impl->mgr.getAvailableDeviceTypes())
+        if (t != nullptr) t->scanForDevices();
+}
+
+std::string DeviceManager::initialise (int numInputChannels, int numOutputChannels,
+                                       const std::string& savedState, bool selectDefaultOnFailure)
+{
+    impl->registerBackends();
+
+    std::unique_ptr<juce::XmlElement> state;
+    if (! savedState.empty())
+        state = juce::parseXML (juce::String (savedState));
+
+    return impl->mgr.initialise (numInputChannels, numOutputChannels,
+                                 state.get(), selectDefaultOnFailure).toStdString();
+}
+
+std::string DeviceManager::getStateBlob() const
+{
+    if (auto xml = impl->mgr.createStateXml())
+        return xml->toString().toStdString();
+    return {};
+}
+
+IODevice* DeviceManager::getCurrentDevice()
+{
+    auto* d = impl->mgr.getCurrentAudioDevice();
+    if (d == nullptr) return nullptr;
+    impl->currentDevice.repoint (d);
+    return &impl->currentDevice;
+}
+
+IODeviceType* DeviceManager::getCurrentDeviceType()
+{
+    auto* t = impl->mgr.getCurrentDeviceTypeObject();
+    if (t == nullptr) return nullptr;
+    for (auto& a : impl->typeAdapters)
+        if (a->juceType() == t) return a.get();
+    impl->typeAdapters.push_back (std::make_unique<JuceDeviceTypeAdapter> (t));
+    return impl->typeAdapters.back().get();
+}
+
+void DeviceManager::setCurrentDeviceType (const std::string& typeName, bool treatAsChosen)
+{
+    impl->mgr.setCurrentAudioDeviceType (juce::String (typeName), treatAsChosen);
+}
+
+DeviceSetup DeviceManager::getSetup() const
+{
+    const auto s = impl->mgr.getAudioDeviceSetup();
+    DeviceSetup d;
+    d.outputDeviceName = s.outputDeviceName.toStdString();
+    d.inputDeviceName  = s.inputDeviceName.toStdString();
+    d.sampleRate = s.sampleRate;
+    d.bufferSize = s.bufferSize;
+    d.inputChannels  = fromBig (s.inputChannels);
+    d.outputChannels = fromBig (s.outputChannels);
+    d.useDefaultInputChannels  = s.useDefaultInputChannels;
+    d.useDefaultOutputChannels = s.useDefaultOutputChannels;
+    return d;
+}
+
+std::string DeviceManager::setSetup (const DeviceSetup& d, bool treatAsChosen)
+{
+    auto s = impl->mgr.getAudioDeviceSetup();
+    s.outputDeviceName = juce::String (d.outputDeviceName);
+    s.inputDeviceName  = juce::String (d.inputDeviceName);
+    s.sampleRate = d.sampleRate;
+    s.bufferSize = d.bufferSize;
+    s.inputChannels  = toBig (d.inputChannels);
+    s.outputChannels = toBig (d.outputChannels);
+    s.useDefaultInputChannels  = d.useDefaultInputChannels;
+    s.useDefaultOutputChannels = d.useDefaultOutputChannels;
+    return impl->mgr.setAudioDeviceSetup (s, treatAsChosen).toStdString();
+}
+
+void DeviceManager::addCallback (IODeviceCallback* callback)
+{
+    if (callback == nullptr || impl->bridges.count (callback) != 0) return;
+    auto bridge = std::make_unique<CallbackBridge> (callback);
+    impl->mgr.addAudioCallback (bridge.get());
+    impl->bridges.emplace (callback, std::move (bridge));
+}
+
+void DeviceManager::removeCallback (IODeviceCallback* callback)
+{
+    auto it = impl->bridges.find (callback);
+    if (it == impl->bridges.end()) return;
+    impl->mgr.removeAudioCallback (it->second.get());
+    impl->bridges.erase (it);
+}
+
+void DeviceManager::closeDevice() { impl->mgr.closeAudioDevice(); }
+
+void DeviceManager::setChangeCallback (std::function<void()> onChange) { impl->onChange = std::move (onChange); }
+
+juce::AudioDeviceManager& DeviceManager::juceManager() { return impl->mgr; }
+} // namespace duskstudio::device

--- a/src/engine/device/DeviceManager.cpp
+++ b/src/engine/device/DeviceManager.cpp
@@ -101,7 +101,6 @@ class JuceDeviceTypeAdapter final : public IODeviceType
 {
 public:
     explicit JuceDeviceTypeAdapter (juce::AudioIODeviceType* t) noexcept : type (t) {}
-    juce::AudioIODeviceType* juceType() const noexcept { return type; }
 
     std::string getTypeName() const override { return type->getTypeName().toStdString(); }
     void scanForDevices() override { type->scanForDevices(); }
@@ -158,13 +157,27 @@ struct DeviceManager::Impl : private juce::ChangeListener
     void changeListenerCallback (juce::ChangeBroadcaster*) override { if (onChange) onChange(); }
 
     juce::AudioDeviceManager mgr;
-    std::vector<std::unique_ptr<JuceDeviceTypeAdapter>> typeAdapters;
+    // Keyed by the juce type pointer (stable for the manager's lifetime), so an
+    // adapter is created once and never moved or destroyed while handed out - a
+    // returned IODeviceType* stays valid across later calls.
+    std::map<juce::AudioIODeviceType*, std::unique_ptr<JuceDeviceTypeAdapter>> typeAdapters;
     JuceDeviceAdapter currentDevice { nullptr };
     std::map<IODeviceCallback*, std::unique_ptr<CallbackBridge>> bridges;
     std::function<void()> onChange;
+    bool backendsRegistered = false;
+
+    JuceDeviceTypeAdapter* adapterFor (juce::AudioIODeviceType* t)
+    {
+        auto& slot = typeAdapters[t];
+        if (! slot) slot = std::make_unique<JuceDeviceTypeAdapter> (t);
+        return slot.get();
+    }
 
     void registerBackends()
     {
+        if (backendsRegistered) return;
+        backendsRegistered = true;
+
        #if defined(DUSKSTUDIO_HAS_PIPEWIRE)
         mgr.addAudioDeviceType (std::make_unique<PipeWireAudioIODeviceType>());
        #endif
@@ -200,14 +213,10 @@ DeviceManager::~DeviceManager() = default;
 
 std::vector<IODeviceType*> DeviceManager::getAvailableDeviceTypes()
 {
-    impl->typeAdapters.clear();
     std::vector<IODeviceType*> out;
     for (auto* t : impl->mgr.getAvailableDeviceTypes())
-    {
-        if (t == nullptr) continue;
-        impl->typeAdapters.push_back (std::make_unique<JuceDeviceTypeAdapter> (t));
-        out.push_back (impl->typeAdapters.back().get());
-    }
+        if (t != nullptr)
+            out.push_back (impl->adapterFor (t));
     return out;
 }
 
@@ -248,11 +257,7 @@ IODevice* DeviceManager::getCurrentDevice()
 IODeviceType* DeviceManager::getCurrentDeviceType()
 {
     auto* t = impl->mgr.getCurrentDeviceTypeObject();
-    if (t == nullptr) return nullptr;
-    for (auto& a : impl->typeAdapters)
-        if (a->juceType() == t) return a.get();
-    impl->typeAdapters.push_back (std::make_unique<JuceDeviceTypeAdapter> (t));
-    return impl->typeAdapters.back().get();
+    return t != nullptr ? impl->adapterFor (t) : nullptr;
 }
 
 void DeviceManager::setCurrentDeviceType (const std::string& typeName, bool treatAsChosen)

--- a/src/engine/device/DeviceManager.cpp
+++ b/src/engine/device/DeviceManager.cpp
@@ -306,10 +306,14 @@ std::string DeviceManager::setSetup (const DeviceSetup& d, bool treatAsChosen)
 
 void DeviceManager::addCallback (IODeviceCallback* callback)
 {
-    if (callback == nullptr || impl->bridges.count (callback) != 0) return;
-    auto bridge = std::make_unique<CallbackBridge> (callback);
-    impl->mgr.addAudioCallback (bridge.get());
-    impl->bridges.emplace (callback, std::move (bridge));
+    if (callback == nullptr) return;
+    // Claim the map slot before creating + registering the bridge, so a repeat
+    // call for the same callback can't register a second bridge that is then
+    // dropped (leaving mgr with a dangling pointer).
+    auto [it, inserted] = impl->bridges.emplace (callback, nullptr);
+    if (! inserted) return;
+    it->second = std::make_unique<CallbackBridge> (callback);
+    impl->mgr.addAudioCallback (it->second.get());
 }
 
 void DeviceManager::removeCallback (IODeviceCallback* callback)

--- a/src/engine/device/DeviceManager.cpp
+++ b/src/engine/device/DeviceManager.cpp
@@ -152,7 +152,17 @@ private:
 struct DeviceManager::Impl : private juce::ChangeListener
 {
     Impl() { mgr.addChangeListener (this); }
-    ~Impl() override { mgr.removeChangeListener (this); }
+    ~Impl() override
+    {
+        // Detach every bridge from mgr before the bridge objects die. Members
+        // destruct in reverse order (bridges before mgr), so a bridge left
+        // registered would leave mgr holding a dangling callback while the
+        // device is still streaming.
+        for (auto& entry : bridges)
+            mgr.removeAudioCallback (entry.second.get());
+        bridges.clear();
+        mgr.removeChangeListener (this);
+    }
 
     void changeListenerCallback (juce::ChangeBroadcaster*) override { if (onChange) onChange(); }
 

--- a/src/engine/device/DeviceManager.h
+++ b/src/engine/device/DeviceManager.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "DeviceSetup.h"
+#include "IODevice.h"
+#include "IODeviceType.h"
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace juce { class AudioDeviceManager; }
+
+// The engine's audio-device orchestrator, mirroring the slice of JUCE's
+// AudioDeviceManager the app drives: register backends, restore/persist the
+// chosen setup, open a device, and fan the RT callback out to the engine. This
+// is the seam - the public API is pure dusk (IODevice / DeviceSetup / ChannelSet),
+// while the implementation currently delegates to a wrapped juce::AudioDeviceManager
+// and adapts JUCE's device/callback types behind it. A later phase swaps the
+// backing to the native PipeWire/ALSA types with this API unchanged.
+namespace duskstudio::device
+{
+class IODeviceCallback;
+
+class DeviceManager
+{
+public:
+    DeviceManager();
+    ~DeviceManager();
+
+    std::vector<IODeviceType*> getAvailableDeviceTypes();
+    void scanAllDeviceTypes();
+
+    // Open the persisted (or default) device. savedState is the opaque blob from a
+    // previous getStateBlob() ("" = fresh machine -> default device). Returns an
+    // empty string on success, else a human-readable error.
+    std::string initialise (int numInputChannels, int numOutputChannels,
+                            const std::string& savedState, bool selectDefaultOnFailure);
+
+    // Serialised device configuration for per-machine persistence (opaque; the
+    // caller writes it to disk and hands it back to initialise()).
+    std::string getStateBlob() const;
+
+    IODevice*     getCurrentDevice();
+    IODeviceType* getCurrentDeviceType();
+    void          setCurrentDeviceType (const std::string& typeName, bool treatAsChosen);
+
+    DeviceSetup getSetup() const;
+    // Apply a setup. Returns an empty string on success, else an error message.
+    std::string setSetup (const DeviceSetup& setup, bool treatAsChosen);
+
+    void addCallback (IODeviceCallback* callback);
+    void removeCallback (IODeviceCallback* callback);
+    void closeDevice();
+
+    // Hot-plug / device-change notification, fired on the message thread.
+    void setChangeCallback (std::function<void()> onChange);
+
+    // Escape hatch: the MIDI input layer still drives MIDI device enable/disable
+    // through the same juce::AudioDeviceManager. Removed once the native MIDI
+    // backend lands and juce_audio_devices unlinks.
+    juce::AudioDeviceManager& juceManager();
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl;
+
+    DeviceManager (const DeviceManager&) = delete;
+    DeviceManager& operator= (const DeviceManager&) = delete;
+};
+} // namespace duskstudio::device

--- a/src/engine/device/DeviceManager.h
+++ b/src/engine/device/DeviceManager.h
@@ -18,6 +18,11 @@ namespace juce { class AudioDeviceManager; }
 // while the implementation currently delegates to a wrapped juce::AudioDeviceManager
 // and adapts JUCE's device/callback types behind it. A later phase swaps the
 // backing to the native PipeWire/ALSA types with this API unchanged.
+//
+// Message-thread only, same contract as juce::AudioDeviceManager: construct,
+// initialise, add/remove callbacks and query the device off the message thread.
+// The audio thread receives blocks through the registered IODeviceCallback, never
+// by calling into this class.
 namespace duskstudio::device
 {
 class IODeviceCallback;
@@ -41,6 +46,8 @@ public:
     // caller writes it to disk and hands it back to initialise()).
     std::string getStateBlob() const;
 
+    // A view of the live device, repointed on each call - use it, don't cache it
+    // (a later call reflects a different device through the same object).
     IODevice*     getCurrentDevice();
     IODeviceType* getCurrentDeviceType();
     void          setCurrentDeviceType (const std::string& typeName, bool treatAsChosen);

--- a/src/engine/device/DeviceSetup.h
+++ b/src/engine/device/DeviceSetup.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "ChannelSet.h"
+
+#include <string>
+
+// The chosen device configuration, mirroring JUCE's AudioDeviceManager 
+// AudioDeviceSetup: which output/input device, the rate and block size, and the
+// active channel masks. The device manager reads this to open a device and hands
+// it back so the selector UI and session persistence can round-trip it.
+namespace duskstudio::device
+{
+struct DeviceSetup
+{
+    std::string outputDeviceName;
+    std::string inputDeviceName;
+
+    double sampleRate = 0.0;   // 0 = backend default
+    int    bufferSize = 0;     // 0 = backend default
+
+    ChannelSet inputChannels;
+    ChannelSet outputChannels;
+
+    // When true, the manager picks a sensible default channel set for the device
+    // and ignores the mask above (the useDefault*Channels semantics JUCE used).
+    bool useDefaultInputChannels  = true;
+    bool useDefaultOutputChannels = true;
+};
+} // namespace duskstudio::device

--- a/src/engine/device/IODevice.h
+++ b/src/engine/device/IODevice.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "ChannelSet.h"
+
+#include <string>
+#include <vector>
+
+// One open audio device (a sink, a source, or a duplex pair), mirroring the
+// JUCE's AudioIODevice interface the PipeWire and ALSA backends implement. All
+// currency is dusk / STL: names are std::string, capability lists std::vector,
+// channel masks ChannelSet. A bespoke device manager drives this; no JUCE.
+namespace duskstudio::device
+{
+class IODeviceCallback;
+
+class IODevice
+{
+public:
+    virtual ~IODevice() = default;
+
+    virtual std::string getName() const = 0;
+
+    virtual std::vector<std::string> getOutputChannelNames() = 0;
+    virtual std::vector<std::string> getInputChannelNames()  = 0;
+    virtual std::vector<double>      getAvailableSampleRates() = 0;
+    virtual std::vector<int>         getAvailableBufferSizes() = 0;
+    virtual int                      getDefaultBufferSize()    = 0;
+
+    // Open the device with the given active channels, sample rate and block size.
+    // Returns an empty string on success, or a human-readable error otherwise.
+    virtual std::string open (const ChannelSet& inputChannels,
+                              const ChannelSet& outputChannels,
+                              double sampleRate, int bufferSizeSamples) = 0;
+    virtual void close()  = 0;
+    virtual bool isOpen() = 0;
+
+    // Begin streaming, delivering blocks to `callback` on the RT thread. stop()
+    // ends streaming; the callback is not retained after stop() returns.
+    virtual void start (IODeviceCallback* callback) = 0;
+    virtual void stop()      = 0;
+    virtual bool isPlaying() = 0;
+
+    virtual std::string getLastError() = 0;
+
+    // The values actually in force after open() (a backend may round the request
+    // to a graph- or kernel-supported value).
+    virtual int    getCurrentBufferSizeSamples() = 0;
+    virtual double getCurrentSampleRate()        = 0;
+    virtual int    getCurrentBitDepth()          = 0;
+
+    virtual ChannelSet getActiveOutputChannels() const = 0;
+    virtual ChannelSet getActiveInputChannels()  const = 0;
+
+    virtual int getOutputLatencyInSamples() = 0;
+    virtual int getInputLatencyInSamples()  = 0;
+
+    virtual int getXRunCount() const noexcept = 0;
+};
+} // namespace duskstudio::device

--- a/src/engine/device/IODeviceCallback.h
+++ b/src/engine/device/IODeviceCallback.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <cstdint>
+
+// The real-time audio callback the device layer drives, mirroring the slice of
+// JUCE's AudioIODeviceCallback the engine implements. A backend (PipeWire, ALSA)
+// invokes audioDeviceIOCallback on its RT thread once per block; aboutToStart /
+// stopped bracket the stream on start()/stop(). Nothing here touches JUCE.
+namespace duskstudio::device
+{
+class IODevice;
+
+// Extra per-callback data, mirroring JUCE's AudioIODeviceCallbackContext. A null
+// hostTimeNs means the backend supplied no hardware timestamp for this block.
+struct CallbackContext
+{
+    const std::uint64_t* hostTimeNs = nullptr;
+};
+
+class IODeviceCallback
+{
+public:
+    virtual ~IODeviceCallback() = default;
+
+    // RT thread. inputChannelData / outputChannelData are arrays of
+    // numInputChannels / numOutputChannels per-channel pointers, each numSamples
+    // long. Output buffers are the callee's to fill; unwritten channels must be
+    // cleared by the callback (the backend does not pre-zero them).
+    virtual void audioDeviceIOCallback (const float* const* inputChannelData,
+                                        int numInputChannels,
+                                        float* const* outputChannelData,
+                                        int numOutputChannels,
+                                        int numSamples,
+                                        const CallbackContext& context) = 0;
+
+    // Message thread (or the backend's start path). The stream is opened and
+    // about to run at device->getCurrentSampleRate() / bufferSize.
+    virtual void audioDeviceAboutToStart (IODevice* device) = 0;
+
+    // The stream has stopped; no further audioDeviceIOCallback will arrive until
+    // the next aboutToStart.
+    virtual void audioDeviceStopped() = 0;
+};
+} // namespace duskstudio::device

--- a/src/engine/device/IODeviceType.h
+++ b/src/engine/device/IODeviceType.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+// A family of audio devices sharing a backend (PipeWire, ALSA, and on Windows /
+// macOS the wrapped JUCE natives), mirroring JUCE's AudioIODeviceType. Enumerates
+// device names and constructs an IODevice for a chosen output/input pair.
+namespace duskstudio::device
+{
+class IODevice;
+
+class IODeviceType
+{
+public:
+    virtual ~IODeviceType() = default;
+
+    virtual std::string getTypeName() const = 0;
+
+    // (Re)scan the backend for available devices; must run before getDeviceNames.
+    virtual void scanForDevices() = 0;
+
+    virtual std::vector<std::string> getDeviceNames (bool wantInputNames) const = 0;
+    virtual int getDefaultDeviceIndex (bool forInput) const = 0;
+    virtual int getIndexOfDevice (IODevice* device, bool asInput) const = 0;
+
+    // Construct a device for the named output/input pair. Either name may be
+    // empty (output-only / input-only). Returns null if neither resolves.
+    virtual std::unique_ptr<IODevice> createDevice (const std::string& outputDeviceName,
+                                                    const std::string& inputDeviceName) = 0;
+};
+} // namespace duskstudio::device

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(dusk-studio-tests
     session_portable_paths.cpp
     session_track_shrink.cpp
     device_fallback_message.cpp
+    device_interfaces.cpp
     update_checker_version.cpp
     session_schema_migration.cpp
     dsp_components_test.cpp

--- a/tests/device_interfaces.cpp
+++ b/tests/device_interfaces.cpp
@@ -1,0 +1,211 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "engine/device/ChannelSet.h"
+#include "engine/device/DeviceSetup.h"
+#include "engine/device/IODevice.h"
+#include "engine/device/IODeviceCallback.h"
+#include "engine/device/IODeviceType.h"
+
+#include <juce_core/juce_core.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace duskstudio::device;
+
+// ChannelSet replaces the juce::BigInteger channel mask the device layer carried.
+// A/B every operation the device code + selector use against juce::BigInteger so
+// the replacement is provably bit-identical.
+
+namespace
+{
+// Apply the same edit script to both a ChannelSet and a juce::BigInteger, then
+// assert they agree on every channel + the aggregate queries.
+void assertMatches (const ChannelSet& cs, const juce::BigInteger& bi)
+{
+    REQUIRE (cs.count()        == bi.countNumberOfSetBits());
+    REQUIRE (cs.highestSetBit() == bi.getHighestBit());
+    for (int i = 0; i < ChannelSet::kMaxChannels; ++i)
+        REQUIRE (cs[i] == bi[i]);
+}
+} // namespace
+
+TEST_CASE ("ChannelSet matches juce::BigInteger across setRange / setBit", "[device][channelset]")
+{
+    SECTION ("stereo from zero")
+    {
+        ChannelSet cs; juce::BigInteger bi;
+        cs.setRange (0, 2, true);  bi.setRange (0, 2, true);
+        assertMatches (cs, bi);
+        REQUIRE (cs.count() == 2);
+    }
+
+    SECTION ("wide multichannel range")
+    {
+        ChannelSet cs; juce::BigInteger bi;
+        cs.setRange (0, 24, true);  bi.setRange (0, 24, true);
+        assertMatches (cs, bi);
+    }
+
+    SECTION ("sparse individual bits")
+    {
+        ChannelSet cs; juce::BigInteger bi;
+        for (int b : { 0, 3, 7, 15, 31 })
+        {
+            cs.setBit (b, true);
+            bi.setBit (b, true);
+        }
+        assertMatches (cs, bi);
+        REQUIRE (cs.highestSetBit() == 31);
+    }
+
+    SECTION ("clearing a sub-range")
+    {
+        ChannelSet cs; juce::BigInteger bi;
+        cs.setRange (0, 8, true);   bi.setRange (0, 8, true);
+        cs.setRange (2, 3, false);  bi.setRange (2, 3, false);
+        assertMatches (cs, bi);
+    }
+
+    SECTION ("empty set")
+    {
+        ChannelSet cs; juce::BigInteger bi;
+        REQUIRE (cs.isZero());
+        REQUIRE (cs.highestSetBit() == -1);
+        assertMatches (cs, bi);
+    }
+}
+
+TEST_CASE ("ChannelSet ignores out-of-range bits and round-trips raw()", "[device][channelset]")
+{
+    ChannelSet cs;
+    cs.setBit (ChannelSet::kMaxChannels, true);   // out of range: no-op
+    cs.setBit (-1, true);                          // out of range: no-op
+    REQUIRE (cs.isZero());
+
+    cs.setRange (0, 4, true);
+    REQUIRE (ChannelSet::fromRaw (cs.raw()) == cs);
+}
+
+// Minimal implementations proving the three interfaces are complete +
+// implementable, standing in for the PipeWire / ALSA backends and the engine
+// callback that arrive in later phases.
+namespace
+{
+class StubDevice final : public IODevice
+{
+public:
+    std::string getName() const override { return "Stub"; }
+    std::vector<std::string> getOutputChannelNames() override { return { "L", "R" }; }
+    std::vector<std::string> getInputChannelNames()  override { return {}; }
+    std::vector<double> getAvailableSampleRates() override { return { 44100.0, 48000.0 }; }
+    std::vector<int>    getAvailableBufferSizes() override { return { 128, 256, 512 }; }
+    int getDefaultBufferSize() override { return 512; }
+
+    std::string open (const ChannelSet&, const ChannelSet& out, double sr, int bs) override
+    {
+        outChans = out; rate = sr; block = bs; opened = true;
+        return {};
+    }
+    void close() override { opened = false; }
+    bool isOpen() override { return opened; }
+
+    void start (IODeviceCallback* cb) override { callback = cb; playing = true; }
+    void stop() override { playing = false; callback = nullptr; }
+    bool isPlaying() override { return playing; }
+
+    std::string getLastError() override { return {}; }
+    int    getCurrentBufferSizeSamples() override { return block; }
+    double getCurrentSampleRate()        override { return rate; }
+    int    getCurrentBitDepth()          override { return 32; }
+    ChannelSet getActiveOutputChannels() const override { return outChans; }
+    ChannelSet getActiveInputChannels()  const override { return {}; }
+    int getOutputLatencyInSamples() override { return 0; }
+    int getInputLatencyInSamples()  override { return 0; }
+    int getXRunCount() const noexcept override { return 0; }
+
+    IODeviceCallback* callback = nullptr;
+
+private:
+    ChannelSet outChans;
+    double rate = 0.0;
+    int block = 0;
+    bool opened = false, playing = false;
+};
+
+class StubType final : public IODeviceType
+{
+public:
+    std::string getTypeName() const override { return "StubType"; }
+    void scanForDevices() override { scanned = true; }
+    std::vector<std::string> getDeviceNames (bool wantInputNames) const override
+    {
+        return wantInputNames ? std::vector<std::string>{} : std::vector<std::string>{ "Stub" };
+    }
+    int getDefaultDeviceIndex (bool) const override { return 0; }
+    int getIndexOfDevice (IODevice*, bool) const override { return 0; }
+    std::unique_ptr<IODevice> createDevice (const std::string&, const std::string&) override
+    {
+        return std::make_unique<StubDevice>();
+    }
+    bool scanned = false;
+};
+
+class CountingCallback final : public IODeviceCallback
+{
+public:
+    void audioDeviceIOCallback (const float* const*, int,
+                                float* const* out, int numOut,
+                                int numSamples, const CallbackContext&) override
+    {
+        for (int c = 0; c < numOut; ++c)
+            for (int i = 0; i < numSamples; ++i)
+                out[c][i] = 0.0f;
+        ++blocks;
+    }
+    void audioDeviceAboutToStart (IODevice*) override { started = true; }
+    void audioDeviceStopped() override { started = false; }
+
+    int  blocks  = 0;
+    bool started = false;
+};
+} // namespace
+
+TEST_CASE ("device interfaces are implementable and drive a callback", "[device][interface]")
+{
+    StubType type;
+    type.scanForDevices();
+    REQUIRE (type.scanned);
+    REQUIRE (type.getDeviceNames (false).size() == 1);
+
+    auto device = type.createDevice ("Stub", {});
+    REQUIRE (device != nullptr);
+
+    ChannelSet out; out.setRange (0, 2, true);
+    REQUIRE (device->open ({}, out, 48000.0, 256).empty());
+    REQUIRE (device->isOpen());
+    REQUIRE_THAT (device->getCurrentSampleRate(), Catch::Matchers::WithinAbs (48000.0, 1e-9));
+    REQUIRE (device->getActiveOutputChannels().count() == 2);
+
+    CountingCallback cb;
+    cb.audioDeviceAboutToStart (device.get());
+    device->start (&cb);
+    REQUIRE (device->isPlaying());
+
+    // Drive one block through the callback contract by hand.
+    constexpr int n = 64;
+    std::vector<float> l (n, 1.0f), r (n, 1.0f);
+    float* outArr[2] = { l.data(), r.data() };
+    CallbackContext ctx;
+    cb.audioDeviceIOCallback (nullptr, 0, outArr, 2, n, ctx);
+    REQUIRE (cb.blocks == 1);
+    REQUIRE_THAT (l[0], Catch::Matchers::WithinAbs (0.0, 1e-9));
+
+    device->stop();
+    cb.audioDeviceStopped();
+    device->close();
+    REQUIRE_FALSE (device->isOpen());
+    REQUIRE_FALSE (cb.started);
+}

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -40,6 +40,8 @@ src/engine/alsa/AlsaAudioIODeviceType.cpp
 src/engine/alsa/AlsaAudioIODeviceType.h
 src/engine/alsa/AlsaPerformanceTest.cpp
 src/engine/alsa/AlsaPerformanceTest.h
+src/engine/device/DeviceManager.cpp
+src/engine/device/DeviceManager.h
 src/engine/hosting/NativePluginId.h
 src/engine/ipc/IpcSelfTest.cpp
 src/engine/ipc/PluginHostMain.cpp


### PR DESCRIPTION
First two phases of replacing `juce::AudioDeviceManager` with a bespoke device layer. **Additive** — nothing wires to it yet, so no behavior change. Phase 2b flips AudioEngine onto the seam; Phase 3 swaps the backing to native and unlinks `juce_audio_devices` on Linux.

## Phase 1 — JUCE-free interfaces (`src/engine/device/`)
- `ChannelSet` — 64-bit channel activation mask replacing `juce::BigInteger`; `setRange`/`count`/`highestSetBit` mirror the ops the device code + selector use.
- `IODevice` / `IODeviceType` / `IODeviceCallback` (+ `CallbackContext`) — the device, factory, and RT-callback interfaces, all `std::string`/`std::vector`/`ChannelSet` currency.
- `DeviceSetup` — the chosen configuration (mirrors `AudioDeviceSetup`).

Tests (`device_interfaces.cpp`): A/B `ChannelSet` against `juce::BigInteger` (bit-identical across setRange/setBit/count/highestBit), and drive a stub device+type+callback to prove the interfaces are complete + implementable.

## Phase 2a — `dusk::audio::DeviceManager` seam over juce
Pure-dusk API; the impl delegates to a wrapped `juce::AudioDeviceManager` and adapts JUCE's device/type/callback types behind it:
- `JuceDeviceAdapter` / `JuceDeviceTypeAdapter` wrap the juce device + type for query/enumeration.
- `CallbackBridge` forwards the RT audio callback to a dusk `IODeviceCallback` with a context translation, no allocation.
- `ChannelSet <-> juce::BigInteger` and `DeviceSetup <-> AudioDeviceSetup` bridges.
- Backend registration (PipeWire/ALSA on Linux, WASAPI/ASIO/DirectSound on Windows) moved into `initialise()`.
- `juceManager()` is a temporary escape hatch: the MIDI input layer still drives MIDI device enable/disable through the same `juce::AudioDeviceManager`, so it stays until a native MIDI backend lands and `juce_audio_devices` unlinks.

Includes review fixes: stable type-adapter storage keyed by the juce type pointer (a returned `IODeviceType*` no longer dangles across calls), and an idempotent `registerBackends()` guard.

## Verification
- gate 193 → 195 (the two seam files; interface headers are JUCE-free)
- app build 0 new warnings, ctest 389/389, Xvfb selftest 15/15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new audio device management layer with device discovery, setup persistence, selection, opening/closing, and change notifications.
  * Introduced public device interfaces for device types, devices, RT streaming callbacks, and channel configuration (64-channel activation/range masks).
  * Added device setup configuration (sample rate, buffer size, channel masks, and default-channel options).
* **Tests**
  * Added automated tests covering channel mask correctness and end-to-end device/interface behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->