### PR TITLE
De-JUCE device layer Phase 2b: flip AudioEngine onto dusk::audio::DeviceManager

### DIFF
--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -486,7 +486,7 @@ static void runHeadlessPipelineTest (const juce::String& pluginPath)
     // re-prepares), so detach FIRST - before prepareForSelfTest mutates DSP
     // state - so the device thread can't process the engine mid-re-prepare
     // (matches runHeadlessSessionPerf).
-    engine->getDeviceManager().removeAudioCallback (engine.get());
+    engine->detachAudioCallback();
     // Don't depend on a real device coming up - prepare directly.
     engine->prepareForSelfTest (sampleRate, blockSize);
 
@@ -655,7 +655,7 @@ static void runHeadlessPipelineTest (const juce::String& pluginPath)
     for (int c = 0; c < numOutChannels; ++c)
         outputPtrs[(size_t) c] = outputs[(size_t) c].data();
 
-    juce::AudioIODeviceCallbackContext ctx {};
+    duskstudio::device::CallbackContext ctx {};
 
     // Two probes:
     //   - Master output peak/RMS - what the device would hear.
@@ -688,7 +688,7 @@ static void runHeadlessPipelineTest (const juce::String& pluginPath)
         }
 
         for (auto& o : outputs) std::fill (o.begin(), o.end(), 0.0f);
-        engine->audioDeviceIOCallbackWithContext (
+        engine->audioDeviceIOCallback (
             inputPtrs.data(), numInChannels,
             outputPtrs.data(), numOutChannels,
             blockSize, ctx);
@@ -783,7 +783,7 @@ static void runHeadlessPipelineTest (const juce::String& pluginPath)
                     engine->stageTestMidiInjection (midiInputIdx, std::move (midi));
                 }
                 for (auto& o : outs) std::fill (o.begin(), o.end(), 0.0f);
-                engine->audioDeviceIOCallbackWithContext (inP.data(), numInChannels,
+                engine->audioDeviceIOCallback (inP.data(), numInChannels,
                                                           outP.data(), numOutChannels, bs, ctx);
             }
             if (midiInputIdx >= 0)
@@ -793,7 +793,7 @@ static void runHeadlessPipelineTest (const juce::String& pluginPath)
                     midi.addEvent (juce::MidiMessage::noteOff (1, n), 0);
                 engine->stageTestMidiInjection (midiInputIdx, std::move (midi));
                 for (auto& o : outs) std::fill (o.begin(), o.end(), 0.0f);
-                engine->audioDeviceIOCallbackWithContext (inP.data(), numInChannels,
+                engine->audioDeviceIOCallback (inP.data(), numInChannels,
                                                           outP.data(), numOutChannels, bs, ctx);
             }
             std::fprintf (stdout, "BS-CYCLE: %d samples OK\n", bs);
@@ -830,7 +830,7 @@ static void runHeadlessSessionPerf (const juce::String& sessionPath)
     // opened a real device). This perf path drives the callback MANUALLY below,
     // so detach FIRST - before prepareForSelfTest mutates DSP state - so the
     // device thread can't process the engine while that state is in flux.
-    engine->getDeviceManager().removeAudioCallback (engine.get());
+    engine->detachAudioCallback();
     engine->prepareForSelfTest (sampleRate, blockSize);
 
     juce::File f (sessionPath);
@@ -882,7 +882,7 @@ static void runHeadlessSessionPerf (const juce::String& sessionPath)
     for (int c = 0; c < numOutChannels; ++c)
         outputPtrs[(size_t) c] = outputs[(size_t) c].data();
 
-    juce::AudioIODeviceCallbackContext ctx {};
+    duskstudio::device::CallbackContext ctx {};
 
     const double blockMs = 1000.0 * blockSize / sampleRate;
     const auto   wall0   = juce::Time::getMillisecondCounterHiRes();
@@ -891,7 +891,7 @@ static void runHeadlessSessionPerf (const juce::String& sessionPath)
     for (int b = 0; b < numBlocks; ++b)
     {
         for (auto& o : outputs) std::fill (o.begin(), o.end(), 0.0f);
-        engine->audioDeviceIOCallbackWithContext (
+        engine->audioDeviceIOCallback (
             inputPtrs.data(), numInChannels,
             outputPtrs.data(), numOutChannels,
             blockSize, ctx);
@@ -1016,7 +1016,7 @@ struct DuskStudioApp::BounceTest : private juce::Timer
         // plugin load + offline render on a machine in active use. The offline
         // render never needs a device; the bounce re-attaches at the end, harmless
         // against a closed device.
-        engine->getDeviceManager().removeAudioCallback (engine.get());
+        engine->detachAudioCallback();
         engine->getDeviceManager().closeAudioDevice();
         engine->prepareForSelfTest (sr, bs);
 
@@ -1033,8 +1033,7 @@ struct DuskStudioApp::BounceTest : private juce::Timer
                       loadedFormat.toRawUTF8(), pluginPath.toRawUTF8());
         std::fflush (stdout);
 
-        bounce = std::make_unique<BounceEngine> (*engine, *session,
-                                                 engine->getDeviceManager());
+        bounce = std::make_unique<BounceEngine> (*engine, *session);
         bounce->onFinished = [this] (bool ok, std::string err)
         {
             // Worker thread. Record + let the poll timer pick it up on the message
@@ -1245,8 +1244,8 @@ private:
         std::vector<float*> outP ((size_t) kOut);
         for (int c = 0; c < kOut; ++c) outP[(size_t) c] = out[(size_t) c].data();
 
-        juce::AudioIODeviceCallbackContext ctx {};
-        engine->audioDeviceIOCallbackWithContext (inP.data(), kIn, outP.data(), kOut, bs, ctx);
+        duskstudio::device::CallbackContext ctx {};
+        engine->audioDeviceIOCallback (inP.data(), kIn, outP.data(), kOut, bs, ctx);
 
         for (int c = 0; c < kOut; ++c)
             for (int i = 0; i < bs; ++i)
@@ -1306,8 +1305,7 @@ private:
                 // out of it, so reassigning the target here would free it under the
                 // worker's feet. A fresh instance also isn't rendering, so
                 // startFreeze() starts on the first tick.
-                bounce = std::make_unique<BounceEngine> (*engine, *session,
-                                                         engine->getDeviceManager());
+                bounce = std::make_unique<BounceEngine> (*engine, *session);
                 bounce->onFinished = [this] (bool ok, std::string err)
                 {
                     freezeOk  = ok;
@@ -1373,8 +1371,7 @@ private:
                 for (const auto& tgt : BounceEngine::collectStemTargets (*session, stemsBase))
                     tgt.file.deleteFile();
 
-                bounce = std::make_unique<BounceEngine> (*engine, *session,
-                                                         engine->getDeviceManager());
+                bounce = std::make_unique<BounceEngine> (*engine, *session);
                 bounce->onFinished = [this] (bool ok, std::string err)
                 {
                     stemsOk  = ok;
@@ -1826,7 +1823,7 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
         std::vector<const float*> inputPtrs { inputs[0].data(), inputs[1].data() };
         std::vector<std::vector<float>> outputs (2, std::vector<float> (blockSize, 0.0f));
         std::vector<float*> outputPtrs { outputs[0].data(), outputs[1].data() };
-        juce::AudioIODeviceCallbackContext ctx {};
+        duskstudio::device::CallbackContext ctx {};
 
         // Drive audio callbacks, then loadFromDescription with plugin B
         // mid-stream to swap. The previousInstance keep-alive in
@@ -1837,7 +1834,7 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
         // thread has many chances to dereference a stale pointer.
         for (int b = 0; b < 200; ++b)
         {
-            engine->audioDeviceIOCallbackWithContext (
+            engine->audioDeviceIOCallback (
                 inputPtrs.data(), 2, outputPtrs.data(), 2, blockSize, ctx);
             if (b == 50)
             {

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -8,13 +8,8 @@
 #include "FaderBindingMap.h"
 #include "../session/RegionEditActions.h"
 #include "DeviceFallbackMessage.h"
-#if defined(DUSKSTUDIO_HAS_ALSA)
-  #include "alsa/AlsaAudioIODeviceType.h"
-#endif
+#include "../foundation/MessageThread.h"
 #include <algorithm>
-#if defined(DUSKSTUDIO_HAS_PIPEWIRE)
-  #include "pipewire/PipeWireAudioIODeviceType.h"
-#endif
 #include <array>
 #include <cstdlib>
 #include <cstring>
@@ -430,76 +425,24 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
     master.bind (session.master());
     masteringChain.bind (session.mastering());
 
-    // Linux: pre-register Dusk Studio's own backends BEFORE
-    // initialiseWithDefaultDevices so JUCE's createDeviceTypesIfNeeded branch is
-    // a no-op (it only auto-registers defaults when the type list is empty,
-    // which would re-add the stock ALSA path). Explicit scanForDevices so init's
-    // pickCurrentDeviceTypeWithDevices doesn't trip hasScanned assertions.
-    //
-    // Registration order = default-backend preference (the pick lands on the
-    // first registered type that has devices): native PipeWire first (correct
-    // graph latency, native node naming, no pipewire-jack shim), native ALSA as
-    // the hardware-direct fallback. JUCE's JACK backend is intentionally NOT
-    // registered - talking to libpipewire directly replaces it.
-    // macOS / Windows let JUCE auto-register natives - these gates aren't defined there.
-   #if defined(DUSKSTUDIO_HAS_PIPEWIRE)
-    deviceManager.addAudioDeviceType (std::make_unique<PipeWireAudioIODeviceType>());
-   #endif
-   #if defined(DUSKSTUDIO_HAS_ALSA)
-    deviceManager.addAudioDeviceType (std::make_unique<AlsaAudioIODeviceType>());
-   #endif
-   #if defined(DUSKSTUDIO_HAS_PIPEWIRE) || defined(DUSKSTUDIO_HAS_ALSA)
-    for (auto* t : deviceManager.getAvailableDeviceTypes())
-        if (t != nullptr) t->scanForDevices();
-   #endif
-
-   #if JUCE_WINDOWS
-    // Windows backend preference. initialiseWithDefaultDevices' default pick
-    // (AudioDeviceManager::pickCurrentDeviceTypeWithDevices) lands on the
-    // FIRST registered type that has devices, and createDeviceTypesIfNeeded
-    // only auto-registers JUCE's defaults when the list is empty. So
-    // pre-registering in preference order both chooses the default backend
-    // and prevents double-listing - same mechanism as the Linux block above.
-    //
-    // Order: ASIO (lowest latency; only compiled in when the SDK was present
-    // at build time) -> WASAPI exclusive (low-latency, no SDK needed: our
-    // fallback for machines with no ASIO driver) -> WASAPI shared -> DirectSound.
-    // ASIO with no installed driver enumerates zero devices, so the pick falls
-    // through to WASAPI exclusive automatically.
-   #if JUCE_ASIO
-    if (auto* asio = juce::AudioIODeviceType::createAudioIODeviceType_ASIO())
-        deviceManager.addAudioDeviceType (std::unique_ptr<juce::AudioIODeviceType> (asio));
-   #endif
-    if (auto* wasapiExclusive = juce::AudioIODeviceType::createAudioIODeviceType_WASAPI (
-            juce::WASAPIDeviceMode::exclusive))
-        deviceManager.addAudioDeviceType (std::unique_ptr<juce::AudioIODeviceType> (wasapiExclusive));
-    if (auto* wasapiShared = juce::AudioIODeviceType::createAudioIODeviceType_WASAPI (
-            juce::WASAPIDeviceMode::shared))
-        deviceManager.addAudioDeviceType (std::unique_ptr<juce::AudioIODeviceType> (wasapiShared));
-    if (auto* directSound = juce::AudioIODeviceType::createAudioIODeviceType_DirectSound())
-        deviceManager.addAudioDeviceType (std::unique_ptr<juce::AudioIODeviceType> (directSound));
-
-    for (auto* t : deviceManager.getAvailableDeviceTypes())
-        if (t != nullptr) t->scanForDevices();
-   #endif
-
-    // Restore the persisted device setup so the backend pick above only
-    // decides the FIRST launch. Without this, every start re-runs the
-    // default pick - on Windows that re-selects the first ASIO entry,
-    // re-instantiating app-shim "drivers" (JRiver et al) the user already
-    // switched away from. Null XML (fresh machine, unreadable file) makes
-    // initialise behave exactly like initialiseWithDefaultDevices.
-    std::unique_ptr<juce::XmlElement> savedDeviceState;
+    // The device manager registers the platform backends (native PipeWire/ALSA
+    // on Linux in preference order, WASAPI/ASIO/DirectSound on Windows) and does
+    // the initial pick. Restore the persisted per-machine setup so that pick only
+    // decides the FIRST launch - otherwise every start re-runs the default pick,
+    // which on Windows re-selects the first ASIO entry and re-instantiates app-shim
+    // drivers the user switched away from. An empty blob (fresh machine, unreadable
+    // file) makes initialise behave like a plain default-device open.
+    std::string savedDeviceState;
     if (const auto stateFile = audioDeviceStateFile(); stateFile.existsAsFile())
-        savedDeviceState = juce::parseXML (stateFile);
+        savedDeviceState = stateFile.loadFileAsString().toStdString();
 
-    if (const auto err = deviceManager.initialise (16, 2, savedDeviceState.get(),
-                                                   /*selectDefaultDeviceOnFailure*/ true);
-        err.isNotEmpty())
+    if (const auto err = deviceManager.initialise (16, 2, savedDeviceState,
+                                                   /*selectDefaultOnFailure*/ true);
+        ! err.empty())
     {
         std::fprintf (stderr,
                       "[Dusk Studio/AudioEngine] device-manager init reported: %s\n",
-                      err.toRawUTF8());
+                      err.c_str());
     }
 
    #if defined(DUSKSTUDIO_HAS_ALSA)
@@ -509,48 +452,46 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
     // conflict - so it never falls through to the graph. Recover explicitly: the
     // native PipeWire backend (reaches the interface through the graph even while
     // the raw hw handle is held) -> the first ALSA device that opens -> give up
-    // and tell the user. This runs BEFORE addAudioCallback / addChangeListener: the audio
-    // thread isn't attached and the engine isn't a change listener yet, so the
+    // and tell the user. This runs BEFORE addCallback / setChangeCallback: the audio
+    // thread isn't attached and no change handler is wired yet, so the
     // setup-switch broadcasts reach no one (no re-entrancy, no fallback loop).
     {
         auto working = [this]
         {
-            auto* d = deviceManager.getCurrentAudioDevice();
+            auto* d = deviceManager.getCurrentDevice();
             // A started SR alone isn't enough: a per-device ALSA name can resolve
             // to 0 active outputs (see the silent-failure guard further down), so
             // require real output channels too.
             return d != nullptr && d->getCurrentSampleRate() > 0.0
-                && d->getActiveOutputChannels().countNumberOfSetBits() > 0;
+                && d->getActiveOutputChannels().count() > 0;
         };
 
-        const juce::String savedName = savedDeviceState != nullptr
-            ? savedDeviceState->getStringAttribute ("audioOutputDeviceName",
-                  savedDeviceState->getStringAttribute ("audioInputDeviceName"))
-            : juce::String();
+        // The restored setup's output device name (empty if nothing was restored).
+        const std::string savedName = deviceManager.getSetup().outputDeviceName;
 
         if (! working())
         {
             // Clear the pinned (busy) device name + use default channels, else
-            // setAudioDeviceSetup can short-circuit to a non-started, sr-0 setup.
-            auto openDefaultOnType = [this] (const char* typeName, const juce::String& devName)
+            // setSetup can short-circuit to a non-started, sr-0 setup.
+            auto openDefaultOnType = [this] (const char* typeName, const std::string& devName)
             {
-                deviceManager.setCurrentAudioDeviceType (typeName, /*treatAsChosen*/ true);
-                auto s = deviceManager.getAudioDeviceSetup();
+                deviceManager.setCurrentDeviceType (typeName, /*treatAsChosen*/ true);
+                auto s = deviceManager.getSetup();
                 s.inputDeviceName.clear();
                 s.outputDeviceName         = devName;   // empty = the type's default device
                 s.useDefaultInputChannels  = true;
                 s.useDefaultOutputChannels = true;
-                // Drop the failed device's rate/buffer so JUCE picks each fallback
-                // device's own defaults instead of carrying over unsupported values.
+                // Drop the failed device's rate/buffer so each fallback device
+                // picks its own defaults instead of carrying over unsupported values.
                 s.sampleRate = 0;
                 s.bufferSize = 0;
-                deviceManager.setAudioDeviceSetup (s, /*treatAsChosen*/ true);
+                deviceManager.setSetup (s, /*treatAsChosen*/ true);
             };
 
             // 1) Native PipeWire default (the graph reaches the interface even
             //    while another app holds the raw ALSA hw handle).
            #if defined(DUSKSTUDIO_HAS_PIPEWIRE)
-            openDefaultOnType ("PipeWire", juce::String());
+            openDefaultOnType ("PipeWire", {});
            #endif
 
             // 2) Walk ALSA device names; the busy one fails, the next (Built-in
@@ -570,14 +511,14 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
         }
 
         // Resolve the outcome unconditionally: this also catches the case where
-        // JUCE's own selectDefaultDeviceOnFailure SILENTLY moved us onto a
-        // different working device than the one saved - the user should still be
-        // told their interface wasn't available. startupDeviceMessage() returns
-        // empty when the saved device opened, so the normal path stays silent.
-        auto* dev = deviceManager.getCurrentAudioDevice();
+        // the default-on-failure pick SILENTLY moved us onto a different working
+        // device than the one saved - the user should still be told their
+        // interface wasn't available. startupDeviceMessage() returns empty when
+        // the saved device opened, so the normal path stays silent.
+        auto* dev = deviceManager.getCurrentDevice();
         const bool opened = working();
         startupDeviceMessage_ = duskstudio::startupDeviceMessage (
-            opened, savedName.toStdString(), opened ? dev->getName().toStdString() : std::string());
+            opened, savedName, opened ? dev->getName() : std::string());
     }
    #endif
 
@@ -585,17 +526,16 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
     // callback iterates perInputMidi, so it must not be attachable while
     // rebuildMidiBanks sizes the vector. Empty deviceIdentifier = every
     // enabled input fans out to midiIn, routed there by source identifier.
-    midiIn.setDeviceManager (deviceManager);
+    midiIn.setDeviceManager (deviceManager.juceManager());
     rebuildMidiBanks();
     midiIn.attachCallback();
 
-    deviceManager.addAudioCallback (this);
+    deviceManager.addCallback (this);
 
-    // Subscribe to AudioDeviceManager change broadcasts so we can
-    // detect hot-unplug (current device becomes null while we had
-    // one). Fires on the message thread per JUCE's ChangeBroadcaster
-    // contract.
-    deviceManager.addChangeListener (this);
+    // Detect hot-unplug (current device becomes null while we had one). Fires on
+    // the message thread when the device manager's device list / current device
+    // changes.
+    deviceManager.setChangeCallback ([this] { onDeviceManagerChanged(); });
 }
 
 void AudioEngine::refreshMidiInputs()
@@ -604,7 +544,7 @@ void AudioEngine::refreshMidiInputs()
     // dispatch sides before returning. Cheapest correct sync for a
     // rare hot-plug event; lock-free vector mutation would cost more
     // throughout the audio path than it's worth.
-    deviceManager.removeAudioCallback (this);
+    deviceManager.removeCallback (this);
     midiIn.detachCallback();
 
     // Disable currently-enabled inputs before rebuilding so the device
@@ -660,7 +600,7 @@ void AudioEngine::refreshMidiInputs()
     openConfiguredMidiOutputs();
 
     midiIn.attachCallback();
-    deviceManager.addAudioCallback (this);
+    deviceManager.addCallback (this);
 
     sendChangeMessage();
 }
@@ -711,7 +651,7 @@ void AudioEngine::recomputePdc() noexcept
         auto& strip = strips[(size_t) t];
         int lat = 0;
         // MIDI tracks report 0: the instrument's latency is already absorbed by
-        // the MIDI scheduling pre-shift (audioDeviceIOCallbackWithContext), so
+        // the MIDI scheduling pre-shift (audioDeviceIOCallback), so
         // their output is timeline-aligned as if zero-latency.
         const bool midi = session.track (t).mode.load (std::memory_order_relaxed)
                               == (int) Track::Mode::Midi;
@@ -1088,16 +1028,19 @@ void AudioEngine::openConfiguredMidiOutputsSafely()
     // paths). Detach the callback for the brief open pass - same contract
     // refreshMidiInputs() relies on. The startup caller runs pre-attach and
     // uses openConfiguredMidiOutputs() directly.
-    deviceManager.removeAudioCallback (this);
+    deviceManager.removeCallback (this);
     openConfiguredMidiOutputs();
-    deviceManager.addAudioCallback (this);
+    deviceManager.addCallback (this);
 }
+
+void AudioEngine::detachAudioCallback()   { deviceManager.removeCallback (this); }
+void AudioEngine::reattachAudioCallback() { deviceManager.addCallback (this); }
 
 int AudioEngine::getBackendXRunCount() const noexcept
 {
-    // const_cast: getCurrentAudioDevice is non-const for historical
-    // reasons. Benign - getXRunCount is noexcept and returns a counter.
-    if (auto* dev = const_cast<juce::AudioDeviceManager&> (deviceManager).getCurrentAudioDevice())
+    // const_cast: getCurrentDevice is non-const (it repoints the adapter view).
+    // Benign - getXRunCount is noexcept and returns a counter.
+    if (auto* dev = const_cast<device::DeviceManager&> (deviceManager).getCurrentDevice())
         return std::max (0, dev->getXRunCount()
                                   - backendXrunBaseline.load (std::memory_order_relaxed));
     return 0;
@@ -1107,7 +1050,7 @@ void AudioEngine::resetXRunCounts() noexcept
 {
     xrunCount.store (0, std::memory_order_relaxed);
     int devCount = 0;
-    if (auto* dev = deviceManager.getCurrentAudioDevice())
+    if (auto* dev = deviceManager.getCurrentDevice())
         devCount = dev->getXRunCount();
     backendXrunBaseline.store (devCount, std::memory_order_relaxed);
 }
@@ -1142,10 +1085,10 @@ AudioEngine::~AudioEngine()
     diagTimer.stopTimer();
     if (transport.isRecording())
         recordManager.stopRecording (transport.getPlayhead());
-    deviceManager.removeChangeListener (this);
-    deviceManager.removeAudioCallback (this);
+    deviceManager.setChangeCallback ({});
+    deviceManager.removeCallback (this);
     midiIn.detachCallback();
-    deviceManager.closeAudioDevice();
+    deviceManager.closeDevice();
     // After the callback is gone - nothing pushes to the out-queue, the
     // pump drains or drops what's left, then the output bank can destruct.
     midiOut.stopPump();
@@ -2031,14 +1974,14 @@ void AudioEngine::consumePluginStateAfterLoad()
 #endif
 }
 
-void AudioEngine::audioDeviceAboutToStart (juce::AudioIODevice* device)
+void AudioEngine::audioDeviceAboutToStart (device::IODevice* device)
 {
     // Mark that a live device is present so the next
-    // changeListenerCallback observing a null current device can
+    // onDeviceManagerChanged observing a null current device can
     // distinguish hot-unplug from steady-state "device was never up".
     // Release ordering so the message-thread reader in
-    // changeListenerCallback sees the bump before it inspects
-    // getCurrentAudioDevice().
+    // onDeviceManagerChanged sees the bump before it inspects
+    // getCurrentDevice().
     hadLiveDevice_.store (true, std::memory_order_release);
 
     // Baseline the readout to the device's CURRENT xrun count, not 0: a reused
@@ -2054,18 +1997,19 @@ void AudioEngine::audioDeviceAboutToStart (juce::AudioIODevice* device)
     // engine writes the master mix to a non-existent destination, and the
     // user gets silence with no error). Loud stderr line + a flag the UI
     // surfaces so the failure is visible instead of mysterious.
-    const int activeIn  = device->getActiveInputChannels().countNumberOfSetBits();
-    const int activeOut = device->getActiveOutputChannels().countNumberOfSetBits();
+    const int activeIn  = device->getActiveInputChannels().count();
+    const int activeOut = device->getActiveOutputChannels().count();
     if (activeOut <= 0)
     {
+        auto* dt = deviceManager.getCurrentDeviceType();
+        const std::string devName  = device->getName();
+        const std::string typeName = dt != nullptr ? dt->getTypeName() : std::string();
         std::fprintf (stderr,
                       "[Dusk Studio/AudioEngine] WARNING: device \"%s\" (type %s) opened with "
                       "0 output channels (in=%d). Engine output will be silent. Pick a "
                       "different device - \"Default ALSA Output\" or another backend - or "
                       "stop PipeWire if you want raw ALSA on this interface.\n",
-                      device->getName().toRawUTF8(),
-                      deviceManager.getCurrentAudioDeviceType().toRawUTF8(),
-                      activeIn);
+                      devName.c_str(), typeName.c_str(), activeIn);
         usableOutputs.store (false, std::memory_order_relaxed);
     }
     else
@@ -2347,7 +2291,7 @@ void AudioEngine::setWorkerCountForTest (int n)
     reconcileWorkerPool (n);
 }
 
-void AudioEngine::audioDeviceError (const juce::String& errorMessage)
+void AudioEngine::audioDeviceError (const std::string& message)
 {
     // Fires from the audio thread (ALSA run() at fatal-recover exit;
     // macOS / Windows backends similar). stderr fprintf is RT-safe
@@ -2356,16 +2300,16 @@ void AudioEngine::audioDeviceError (const juce::String& errorMessage)
     // message-thread-only and gets dispatched via callAsync. Without
     // the dispatch we'd join the disk thread + flush a ThreadedWriter
     // on the audio thread - RecordManager's stopRecording contract
-    // forbids it. JUCE doesn't guarantee a follow-up
+    // forbids it. A backend may not deliver a follow-up
     // audioDeviceStopped after this callback, so we force it.
     std::fprintf (stderr, "[Dusk Studio/AudioEngine] audioDeviceError: %s\n",
-                  errorMessage.toRawUTF8());
+                  message.c_str());
 
-    juce::MessageManager::callAsync (
-        [this, errorMessage]
+    dusk::callAsync (
+        [this, message]
         {
-            juce::Logger::writeToLog ("[Dusk Studio/AudioEngine] audioDeviceError: "
-                                          + errorMessage);
+            juce::Logger::writeToLog (juce::String ("[Dusk Studio/AudioEngine] audioDeviceError: ")
+                                          + juce::String (message));
             audioDeviceStopped();
         });
 }
@@ -2419,43 +2363,39 @@ void AudioEngine::audioDeviceStopped()
     usableOutputs.store (true, std::memory_order_relaxed);
 }
 
-void AudioEngine::changeListenerCallback (juce::ChangeBroadcaster* source)
+void AudioEngine::onDeviceManagerChanged()
 {
-    // H5 hot-unplug detector. AudioDeviceManager broadcasts change
-    // messages whenever its device list / current-device state
-    // changes; we ignore broadcasts from any OTHER source (the
-    // engine itself broadcasts via its ChangeBroadcaster base; we
-    // don't want to react to our own messages).
-    if (source != &deviceManager) return;
+    // H5 hot-unplug detector. The device manager fires this whenever its device
+    // list / current-device state changes.
 
-    // Persist the chosen setup. createStateXml returns null until the
-    // user has explicitly picked something (treatAsChosenDevice), so the
-    // first-launch default pick is never frozen into the file - only
-    // deliberate choices survive a restart.
-    if (deviceManager.getCurrentAudioDevice() != nullptr)
-        if (const auto xml = deviceManager.createStateXml())
-            audioDeviceStateFile().replaceWithText (xml->toString());
+    // Persist the chosen setup. getStateBlob returns empty until the user has
+    // explicitly picked something (treatAsChosen), so the first-launch default
+    // pick is never frozen into the file - only deliberate choices survive a
+    // restart.
+    if (deviceManager.getCurrentDevice() != nullptr)
+        if (const auto blob = deviceManager.getStateBlob(); ! blob.empty())
+            audioDeviceStateFile().replaceWithText (juce::String (blob));
 
     // The hot-unplug signal is "we had a live device, now the
     // current device is null." User-driven settings changes also
-    // close the device, but they're followed by addAudioCallback /
+    // close the device, but they're followed by addCallback /
     // audioDeviceAboutToStart for the new selection within the same
     // dispatch loop tick - hadLiveDevice_ would still be true and
     // we'd false-alarm. To avoid that, we re-check after a one-shot
     // callAsync defer: if a new device came up in the meantime,
-    // hadLiveDevice_ is true AND getCurrentAudioDevice() is non-null,
+    // hadLiveDevice_ is true AND getCurrentDevice() is non-null,
     // so we bail. If still null, real loss; fire the alert.
     if (! hadLiveDevice_.load (std::memory_order_acquire)) return;
-    if (deviceManager.getCurrentAudioDevice() != nullptr) return;
+    if (deviceManager.getCurrentDevice() != nullptr) return;
 
     // Defer one tick so a settings-driven device swap can complete
     // before we decide it's a hot-unplug. The audioDeviceAboutToStart
     // for the new device will republish hadLiveDevice_ = true and
-    // the deferred check below sees getCurrentAudioDevice() != null,
+    // the deferred check below sees getCurrentDevice() != null,
     // bailing without spurious alert.
-    juce::MessageManager::callAsync ([this]
+    dusk::callAsync ([this]
     {
-        if (deviceManager.getCurrentAudioDevice() != nullptr) return;
+        if (deviceManager.getCurrentDevice() != nullptr) return;
         if (! hadLiveDevice_.load (std::memory_order_acquire)) return;
 
         // Confirmed loss. Clear the flag so a subsequent change
@@ -2570,12 +2510,12 @@ void AudioEngine::reduceLaneAccum (int numSamples) noexcept
     }
 }
 
-void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputChannelData,
-                                                    int numInputChannels,
-                                                    float* const* outputChannelData,
-                                                    int numOutputChannels,
-                                                    int numSamples,
-                                                    const juce::AudioIODeviceCallbackContext&)
+void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
+                                         int numInputChannels,
+                                         float* const* outputChannelData,
+                                         int numOutputChannels,
+                                         int numSamples,
+                                         const device::CallbackContext&)
 {
     juce::ScopedNoDenormals noDenormals;
 

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -466,8 +466,10 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
                 && d->getActiveOutputChannels().count() > 0;
         };
 
-        // The restored setup's output device name (empty if nothing was restored).
-        const std::string savedName = deviceManager.getSetup().outputDeviceName;
+        // The user's INTENDED output device (from the saved blob), not whatever
+        // initialise() landed on - so a saved device that failed to open is still
+        // named in the startup message even after a silent fallback.
+        const std::string savedName = deviceManager.outputDeviceNameFromState (savedDeviceState);
 
         if (! working())
         {

--- a/src/engine/AudioEngine.h
+++ b/src/engine/AudioEngine.h
@@ -19,6 +19,9 @@
 #include "MidiClockEmitter.h"
 #include "MidiTimeCodeEmitter.h"
 #include "midi/MidiDevices.h"
+#include "device/DeviceManager.h"
+#include "device/IODevice.h"
+#include "device/IODeviceCallback.h"
 #include "../session/Session.h"
 #include "AudioWorkerPool.h"
 #include "MasteringPlayer.h"
@@ -32,9 +35,8 @@ namespace duskstudio
 {
 // input -> channel strip (live or playback source) -> aux/master.
 // Owns Transport, recording, playback, plugin host.
-class AudioEngine final : public juce::AudioIODeviceCallback,
-                            public juce::ChangeBroadcaster,
-                            public juce::ChangeListener
+class AudioEngine final : public device::IODeviceCallback,
+                            public juce::ChangeBroadcaster
 {
 public:
     // Recording / Mixing / Aux share the live track-to-master path; only
@@ -82,7 +84,15 @@ public:
     // between captures.
     void setWorkerCountForTest (int n);
 
-    juce::AudioDeviceManager& getDeviceManager() noexcept { return deviceManager; }
+    // Escape hatch: the selector UI + MIDI input layer still drive the wrapped
+    // juce::AudioDeviceManager directly (flipped to the dusk API in a later phase).
+    juce::AudioDeviceManager& getDeviceManager() noexcept { return deviceManager.juceManager(); }
+
+    // Detach / reattach the engine from the audio device. Offline render + self-
+    // test detach, then drive audioDeviceIOCallback directly. Reattach re-prepares
+    // the engine (the device manager fires audioDeviceAboutToStart). Message thread.
+    void detachAudioCallback();
+    void reattachAudioCallback();
 
     // Track FREEZE (message thread). The render is ASYNC (BounceEngine::
     // startFreeze on a worker thread) so a long render never wedges the UI, so
@@ -244,19 +254,19 @@ public:
     void jumpToZero();
     void jumpToLastRecordPoint();
 
-    void audioDeviceIOCallbackWithContext (const float* const* inputChannelData,
-                                           int numInputChannels,
-                                           float* const* outputChannelData,
-                                           int numOutputChannels,
-                                           int numSamples,
-                                           const juce::AudioIODeviceCallbackContext& context) override;
+    void audioDeviceIOCallback (const float* const* inputChannelData,
+                                int numInputChannels,
+                                float* const* outputChannelData,
+                                int numOutputChannels,
+                                int numSamples,
+                                const device::CallbackContext& context) override;
 
-    void audioDeviceAboutToStart (juce::AudioIODevice* device) override;
+    void audioDeviceAboutToStart (device::IODevice* device) override;
     void audioDeviceStopped() override;
-    // Fires when the backend can no longer service I/O. JUCE doesn't
+    // Fires when the backend can no longer service I/O. A backend may not
     // guarantee a follow-up audioDeviceStopped, so we do the same
     // flush-record-and-stop dance to keep recordings recoverable.
-    void audioDeviceError (const juce::String& errorMessage) override;
+    void audioDeviceError (const std::string& message) override;
 
     // Prepare without a real AudioIODevice. The self-test detaches the
     // engine and drives audioDeviceIOCallbackWithContext directly with
@@ -488,15 +498,14 @@ public:
         onRecordBlocked_ = std::move (sink);
     }
 
-    // juce::ChangeListener - fires on the message thread when
-    // AudioDeviceManager's device list / current device changes.
-    // We use it to detect hot-unplug (current device became nullptr
-    // while we had one). Message-thread-only.
-    void changeListenerCallback (juce::ChangeBroadcaster* source) override;
+    // Fires on the message thread when the device manager's device list /
+    // current device changes. We use it to detect hot-unplug (current device
+    // became nullptr while we had one). Message-thread-only.
+    void onDeviceManagerChanged();
 
 private:
     Session& session;
-    juce::AudioDeviceManager deviceManager;
+    device::DeviceManager deviceManager;
 
     // Last freezeTrack failure reason, surfaced via getLastFreezeError().
     // Message-thread-only.

--- a/src/engine/AudioPipelineSelfTest.cpp
+++ b/src/engine/AudioPipelineSelfTest.cpp
@@ -196,7 +196,7 @@ AudioPipelineSelfTest::runSynthetic (double sampleRate, int blockSize,
     for (int c = 0; c < numOutChannels; ++c)
         outputPtrs[(size_t) c] = outputs[(size_t) c].data();
 
-    juce::AudioIODeviceCallbackContext ctx {};
+    duskstudio::device::CallbackContext ctx {};
 
     const double phaseInc = 2.0 * juce::MathConstants<double>::pi * (double) toneHz / sampleRate;
     double phase = 0.0;
@@ -220,7 +220,7 @@ AudioPipelineSelfTest::runSynthetic (double sampleRate, int blockSize,
         for (auto& o : outputs)
             std::fill (o.begin(), o.end(), 0.0f);
 
-        engine.audioDeviceIOCallbackWithContext (
+        engine.audioDeviceIOCallback (
             inputPtrs.data(), numInChannels,
             outputPtrs.data(), numOutChannels,
             blockSize, ctx);
@@ -410,7 +410,7 @@ std::string AudioPipelineSelfTest::testChannelRoutingFourOut()
     std::vector<float*> outputPtrs (4, nullptr);
     for (int c = 0; c < 4; ++c) outputPtrs[(size_t) c] = outputs[(size_t) c].data();
 
-    juce::AudioIODeviceCallbackContext ctx {};
+    duskstudio::device::CallbackContext ctx {};
     const double phaseInc = 2.0 * juce::MathConstants<double>::pi * (double) kToneHz / 48000.0;
     double phase = 0.0;
 
@@ -428,7 +428,7 @@ std::string AudioPipelineSelfTest::testChannelRoutingFourOut()
         }
         for (auto& o : outputs) std::fill (o.begin(), o.end(), 0.0f);
 
-        engine.audioDeviceIOCallbackWithContext (inputPtrs.data(), 16,
+        engine.audioDeviceIOCallback (inputPtrs.data(), 16,
                                                   outputPtrs.data(), 4, bs, ctx);
 
         if (b >= warmup)
@@ -591,7 +591,7 @@ void captureToneOutput (AudioEngine& engine, double sr, int blockSize,
     for (int c = 0; c < numOutChannels; ++c)
         outputPtrs[(size_t) c] = outputs[(size_t) c].data();
 
-    juce::AudioIODeviceCallbackContext ctx {};
+    duskstudio::device::CallbackContext ctx {};
     const double phaseInc = 2.0 * juce::MathConstants<double>::pi * (double) toneHz / sr;
     double phase = 0.0;
 
@@ -610,7 +610,7 @@ void captureToneOutput (AudioEngine& engine, double sr, int blockSize,
                 phase -= 2.0 * juce::MathConstants<double>::pi;
         }
         for (auto& o : outputs) std::fill (o.begin(), o.end(), 0.0f);
-        engine.audioDeviceIOCallbackWithContext (
+        engine.audioDeviceIOCallback (
             inputPtrs.data(), numInChannels,
             outputPtrs.data(), numOutChannels,
             blockSize, ctx);
@@ -1052,7 +1052,7 @@ std::string AudioPipelineSelfTest::testParallelMatchesSerial()
         std::vector<float*> outP ((size_t) numOut);
         for (int c = 0; c < numOut; ++c) outP[(size_t) c] = outs[(size_t) c].data();
 
-        juce::AudioIODeviceCallbackContext ctx {};
+        duskstudio::device::CallbackContext ctx {};
         const double inc = 2.0 * juce::MathConstants<double>::pi * (double) kToneHz / sr;
         std::vector<double> phase ((size_t) numIn, 0.0);
         outL.clear(); outR.clear();
@@ -1070,7 +1070,7 @@ std::string AudioPipelineSelfTest::testParallelMatchesSerial()
                 phase[(size_t) c] += inc * (double) bs;
             }
             for (auto& o : outs) std::fill (o.begin(), o.end(), 0.0f);
-            engine.audioDeviceIOCallbackWithContext (inP.data(), numIn, outP.data(), numOut, bs, ctx);
+            engine.audioDeviceIOCallback (inP.data(), numIn, outP.data(), numOut, bs, ctx);
             if (b >= warmup)
                 for (int s = 0; s < bs; ++s)
                 {
@@ -1178,12 +1178,12 @@ std::string AudioPipelineSelfTest::testMidiPlayAlongMonitor()
     std::vector<std::vector<float>> outb ((size_t) numOut, std::vector<float> ((size_t) bs, 0.0f));
     std::vector<float*> outp ((size_t) numOut, nullptr);
     for (int c = 0; c < numOut; ++c) outp[(size_t) c] = outb[(size_t) c].data();
-    juce::AudioIODeviceCallbackContext ctx {};
+    duskstudio::device::CallbackContext ctx {};
 
     auto runBlock = [&] ()
     {
         for (auto& o : outb) std::fill (o.begin(), o.end(), 0.0f);
-        engine.audioDeviceIOCallbackWithContext (inp.data(), numIn, outp.data(),
+        engine.audioDeviceIOCallback (inp.data(), numIn, outp.data(),
                                                   numOut, bs, ctx);
     };
 
@@ -1291,7 +1291,7 @@ std::string AudioPipelineSelfTest::testAudioPlayAlongSends()
     std::vector<std::vector<float>> outb ((size_t) numOut, std::vector<float> ((size_t) bs, 0.0f));
     std::vector<float*> outp ((size_t) numOut, nullptr);
     for (int c = 0; c < numOut; ++c) outp[(size_t) c] = outb[(size_t) c].data();
-    juce::AudioIODeviceCallbackContext ctx {};
+    duskstudio::device::CallbackContext ctx {};
 
     const double inc = 2.0 * juce::MathConstants<double>::pi * 1000.0 / sr;
     double phase = 0.0;
@@ -1310,7 +1310,7 @@ std::string AudioPipelineSelfTest::testAudioPlayAlongSends()
                 phase += inc;
             }
             for (auto& o : outb) std::fill (o.begin(), o.end(), 0.0f);
-            engine.audioDeviceIOCallbackWithContext (inp.data(), numIn, outp.data(),
+            engine.audioDeviceIOCallback (inp.data(), numIn, outp.data(),
                                                       numOut, bs, ctx);
         }
         return aux0.meterPostL.load (std::memory_order_relaxed);
@@ -1355,7 +1355,7 @@ std::string AudioPipelineSelfTest::runAll()
 
     // Save state, detach engine.
     const auto savedSession = saveState();
-    deviceManager.removeAudioCallback (&engine);
+    engine.detachAudioCallback();
 
     report.push_back ("--- Synthetic Engine Pipeline Tests (no hardware) ---");
     report.push_back (testPassThroughUnity());
@@ -1431,7 +1431,7 @@ std::string AudioPipelineSelfTest::runAll()
     // The synthetic tests force the engine serial (setWorkerCountForTest(0));
     // restore the live configured worker pool before re-attaching.
     engine.applyDesiredWorkers();
-    deviceManager.addAudioCallback (&engine);
+    engine.reattachAudioCallback();
 
     report.push_back (testBackendsOpenCleanly());
     report.push_back ("");
@@ -1509,7 +1509,7 @@ std::string AudioPipelineSelfTest::runPerfBenchmark (const std::string& label,
     for (int c = 0; c < kOutChannels; ++c)
         outputPtrs[(size_t) c] = outputs[(size_t) c].data();
 
-    juce::AudioIODeviceCallbackContext ctx {};
+    duskstudio::device::CallbackContext ctx {};
 
     std::vector<double> phase ((size_t) kInChannels, 0.0);
     std::vector<double> phaseInc ((size_t) kInChannels, 0.0);
@@ -1536,7 +1536,7 @@ std::string AudioPipelineSelfTest::runPerfBenchmark (const std::string& label,
         }
 
         const auto t0 = juce::Time::getHighResolutionTicks();
-        engine.audioDeviceIOCallbackWithContext (
+        engine.audioDeviceIOCallback (
             inputPtrs.data(), kInChannels,
             outputPtrs.data(), kOutChannels,
             blockSize, ctx);
@@ -1580,12 +1580,12 @@ std::string AudioPipelineSelfTest::runPerfSuite()
     report.push_back ("=== Dusk Studio Engine Perf Benchmark ===");
     report.push_back ("Time: " + juce::Time::getCurrentTime().toString (true, true).toStdString());
     report.push_back ("Measures pure-engine callback wall time across configs.");
-    report.push_back ("All callbacks driven directly via audioDeviceIOCallbackWithContext;");
+    report.push_back ("All callbacks driven directly via audioDeviceIOCallback;");
     report.push_back ("no audio device, no PipeWire, no ALSA - engine DSP only.");
     report.push_back ("");
 
     const auto saved = saveState();
-    deviceManager.removeAudioCallback (&engine);
+    engine.detachAudioCallback();
 
     constexpr int warm = 32;
     constexpr int meas = 512;
@@ -1666,7 +1666,7 @@ std::string AudioPipelineSelfTest::runPerfSuite()
     restoreState (saved);
     // The perf sweep forces the engine serial; restore the configured pool.
     engine.applyDesiredWorkers();
-    deviceManager.addAudioCallback (&engine);
+    engine.reattachAudioCallback();
 
     report.push_back ("=== End of Engine Perf Benchmark ===");
     return dusk::text::joinIntoString (report, "\n");

--- a/src/engine/AudioPipelineSelfTest.h
+++ b/src/engine/AudioPipelineSelfTest.h
@@ -10,7 +10,7 @@
 namespace duskstudio
 {
 // Headless self-test for the audio pipeline. The synthetic tests detach the
-// AudioEngine from deviceManager and call audioDeviceIOCallbackWithContext
+// AudioEngine from deviceManager and call audioDeviceIOCallback
 // directly with known input buffers, then measure the output. This catches
 // internal bugs (mute, fader, master DSP, channel routing) without requiring
 // audio hardware. The backend tests cycle through available device types and

--- a/src/engine/BounceEngine.cpp
+++ b/src/engine/BounceEngine.cpp
@@ -27,9 +27,8 @@ struct ScopedOfflineRender
 };
 } // namespace
 
-BounceEngine::BounceEngine (AudioEngine& e, Session& s,
-                              juce::AudioDeviceManager& dm) noexcept
-    : juce::Thread ("Dusk Studio bounce"), engine (e), session (s), deviceManager (dm)
+BounceEngine::BounceEngine (AudioEngine& e, Session& s) noexcept
+    : juce::Thread ("Dusk Studio bounce"), engine (e), session (s)
 {}
 
 BounceEngine::~BounceEngine()
@@ -331,7 +330,7 @@ void BounceEngine::run()
     // cleared before the live re-prepare below.
     if (! runOnMessageThread ([this]
         {
-            deviceManager.removeAudioCallback (&engine);
+            engine.detachAudioCallback();
             engine.setRenderOversamplingOverride (kRenderOversamplingFactor);
             engine.prepareForSelfTest (renderSampleRate, renderBlockSize);
         }))
@@ -360,7 +359,7 @@ void BounceEngine::run()
     std::vector<float*> outputPtrs (kNumChannels);
     for (int c = 0; c < kNumChannels; ++c) outputPtrs[(size_t) c] = outputs[(size_t) c].data();
 
-    juce::AudioIODeviceCallbackContext ctx {};
+    duskstudio::device::CallbackContext ctx {};
 
     // Drive the transport / mastering player from sample 0. We don't go
     // through engine.play() because that's RT-safe-message-thread; we
@@ -419,7 +418,7 @@ void BounceEngine::run()
         // Reset outputs each block.
         for (auto& o : outputs) std::fill (o.begin(), o.end(), 0.0f);
 
-        engine.audioDeviceIOCallbackWithContext (inputPtrs.data(), kNumIn,
+        engine.audioDeviceIOCallback (inputPtrs.data(), kNumIn,
                                                    outputPtrs.data(), kNumChannels,
                                                    remaining, ctx);
 
@@ -509,7 +508,7 @@ void BounceEngine::run()
     runOnMessageThread ([this]
     {
         engine.setRenderOversamplingOverride (0);
-        deviceManager.addAudioCallback (&engine);
+        engine.reattachAudioCallback();
     });
 
     rendering.store (false, std::memory_order_relaxed);
@@ -585,7 +584,7 @@ bool BounceEngine::runStemsMode()
     // the live re-prepare below.
     if (! runOnMessageThread ([this]
         {
-            deviceManager.removeAudioCallback (&engine);
+            engine.detachAudioCallback();
             engine.setRenderOversamplingOverride (kRenderOversamplingFactor);
             engine.prepareForSelfTest (renderSampleRate, renderBlockSize);
         }))
@@ -650,7 +649,7 @@ bool BounceEngine::runStemsMode()
         std::vector<float*> outputPtrs (kNumChannels);
         for (int c = 0; c < kNumChannels; ++c) outputPtrs[(size_t) c] = outputs[(size_t) c].data();
 
-        juce::AudioIODeviceCallbackContext ctx {};
+        duskstudio::device::CallbackContext ctx {};
 
         transport.setPlayhead (0);
         transport.setState (Transport::State::Playing);
@@ -683,7 +682,7 @@ bool BounceEngine::runStemsMode()
                 juce::FloatVectorOperations::clear (capR[(size_t) i].data(), remaining);
             }
 
-            engine.audioDeviceIOCallbackWithContext (inputPtrs.data(), kNumIn,
+            engine.audioDeviceIOCallback (inputPtrs.data(), kNumIn,
                                                        outputPtrs.data(), kNumChannels,
                                                        remaining, ctx);
 
@@ -757,7 +756,7 @@ bool BounceEngine::runStemsMode()
     runOnMessageThread ([this]
     {
         engine.setRenderOversamplingOverride (0);
-        deviceManager.addAudioCallback (&engine);
+        engine.reattachAudioCallback();
     });
 
     if (cancelRequested.load (std::memory_order_relaxed))
@@ -1073,7 +1072,7 @@ bool BounceEngine::renderFreezeTrack (int trackIndex, const juce::File& outFile,
     ScopedOfflineRender offlineGuard (engine);
     if (! runOnMessageThread ([this]
         {
-            deviceManager.removeAudioCallback (&engine);
+            engine.detachAudioCallback();
             engine.setRenderOversamplingOverride (kRenderOversamplingFactor);
             engine.prepareForSelfTest (renderSampleRate, renderBlockSize);
         }))
@@ -1101,7 +1100,7 @@ bool BounceEngine::renderFreezeTrack (int trackIndex, const juce::File& outFile,
     std::vector<float> capL ((size_t) renderBlockSize, 0.0f);
     std::vector<float> capR ((size_t) renderBlockSize, 0.0f);
 
-    juce::AudioIODeviceCallbackContext ctx {};
+    duskstudio::device::CallbackContext ctx {};
 
     auto& transport = engine.getTransport();
     const auto savedTransportState = transport.getState();
@@ -1149,7 +1148,7 @@ bool BounceEngine::renderFreezeTrack (int trackIndex, const juce::File& outFile,
         std::fill (capL.begin(), capL.end(), 0.0f);
         std::fill (capR.begin(), capR.end(), 0.0f);
 
-        engine.audioDeviceIOCallbackWithContext (inputPtrs.data(), kNumIn,
+        engine.audioDeviceIOCallback (inputPtrs.data(), kNumIn,
                                                    outputPtrs.data(), kNumChannels,
                                                    remaining, ctx);
 
@@ -1196,7 +1195,7 @@ bool BounceEngine::renderFreezeTrack (int trackIndex, const juce::File& outFile,
     runOnMessageThread ([this]
     {
         engine.setRenderOversamplingOverride (0);
-        deviceManager.addAudioCallback (&engine);
+        engine.reattachAudioCallback();
     });
 
     if (! ok || cancelRequested.load (std::memory_order_relaxed))

--- a/src/engine/BounceEngine.h
+++ b/src/engine/BounceEngine.h
@@ -184,8 +184,7 @@ public:
         return false;
     }
 
-    BounceEngine (AudioEngine& engine, Session& session,
-                   juce::AudioDeviceManager& deviceManager) noexcept;
+    BounceEngine (AudioEngine& engine, Session& session) noexcept;
     ~BounceEngine() override;
 
     // False if a render is already in flight. sampleRate <= 0 uses
@@ -271,7 +270,6 @@ private:
 
     AudioEngine& engine;
     Session&     session;
-    juce::AudioDeviceManager& deviceManager;
 
     juce::File   outputFile;
     double       renderSampleRate = 0.0;

--- a/src/engine/device/DeviceManager.cpp
+++ b/src/engine/device/DeviceManager.cpp
@@ -259,6 +259,15 @@ std::string DeviceManager::getStateBlob() const
     return {};
 }
 
+std::string DeviceManager::outputDeviceNameFromState (const std::string& savedState) const
+{
+    if (savedState.empty()) return {};
+    if (auto xml = juce::parseXML (juce::String (savedState)))
+        return xml->getStringAttribute ("audioOutputDeviceName",
+                   xml->getStringAttribute ("audioInputDeviceName")).toStdString();
+    return {};
+}
+
 IODevice* DeviceManager::getCurrentDevice()
 {
     auto* d = impl->mgr.getCurrentAudioDevice();

--- a/src/engine/device/DeviceManager.cpp
+++ b/src/engine/device/DeviceManager.cpp
@@ -143,6 +143,9 @@ public:
 
     void audioDeviceStopped() override { cb->audioDeviceStopped(); }
 
+    void audioDeviceError (const juce::String& message) override
+        { cb->audioDeviceError (message.toStdString()); }
+
 private:
     IODeviceCallback* cb;
     JuceDeviceAdapter adapter { nullptr };

--- a/src/engine/device/DeviceManager.h
+++ b/src/engine/device/DeviceManager.h
@@ -46,6 +46,11 @@ public:
     // caller writes it to disk and hands it back to initialise()).
     std::string getStateBlob() const;
 
+    // The output device name recorded in a saved state blob (falling back to the
+    // input device name), or empty. Reads the user's INTENDED device, which may
+    // differ from the one initialise() actually opened on failure.
+    std::string outputDeviceNameFromState (const std::string& savedState) const;
+
     // A view of the live device, repointed on each call - use it, don't cache it
     // (a later call reflects a different device through the same object).
     IODevice*     getCurrentDevice();

--- a/src/engine/device/IODeviceCallback.h
+++ b/src/engine/device/IODeviceCallback.h
@@ -40,5 +40,10 @@ public:
     // The stream has stopped; no further audioDeviceIOCallback will arrive until
     // the next aboutToStart.
     virtual void audioDeviceStopped() = 0;
+
+    // The backend can no longer service I/O (fatal error). A backend may not
+    // deliver a following audioDeviceStopped, so callers treat this as terminal.
+    // Default empty - most callbacks don't need it.
+    virtual void audioDeviceError (const std::string& message) { (void) message; }
 };
 } // namespace duskstudio::device

--- a/src/ui/AudioSettingsPanel.cpp
+++ b/src/ui/AudioSettingsPanel.cpp
@@ -732,8 +732,8 @@ void AudioSettingsPanel::applyOversamplingChange()
     // audioDeviceAboutToStart -> prepareForSelfTest, rebuilding every
     // strip/bus/master oversampler at the new factor - all WITHOUT touching the
     // device or the window. Brief silence gap only.
-    deviceManager.removeAudioCallback (&engine);
-    deviceManager.addAudioCallback (&engine);
+    engine.detachAudioCallback();
+    engine.reattachAudioCallback();
 }
 
 void AudioSettingsPanel::applyMulticoreChange()
@@ -759,9 +759,9 @@ void AudioSettingsPanel::applyMulticoreChange()
     // stop+start safely; addAudioCallback re-prepares DSP and resumes. The pool
     // is changed ONLY here - prepare no longer touches it - so a routine
     // buffer-size change can never race the pool. Brief silence gap only.
-    deviceManager.removeAudioCallback (&engine);
+    engine.detachAudioCallback();
     engine.applyDesiredWorkers();
-    deviceManager.addAudioCallback (&engine);
+    engine.reattachAudioCallback();
 }
 
 AudioSettingsPanel::~AudioSettingsPanel()

--- a/src/ui/BounceDialog.cpp
+++ b/src/ui/BounceDialog.cpp
@@ -6,7 +6,6 @@ namespace duskstudio
 {
 BounceDialog::BounceDialog (AudioEngine& e,
                               Session& s,
-                              juce::AudioDeviceManager& dm,
                               const juce::File& f,
                               BounceEngine::Mode mode,
                               BounceEngine::Format format,
@@ -14,7 +13,7 @@ BounceDialog::BounceDialog (AudioEngine& e,
                               double sampleRate,
                               int bitDepth,
                               bool realtime)
-    : engine (e), session (s), deviceManager (dm), outputFile (f),
+    : engine (e), session (s), outputFile (f),
       renderMode (mode), renderFormat (format), mp3Bitrate (mp3BitrateKbps),
       renderSampleRate (sampleRate), wavBitDepth (bitDepth),
       renderRealtime (realtime),
@@ -78,7 +77,7 @@ BounceDialog::BounceDialog (AudioEngine& e,
     addAndMakeVisible (cancelButton);
     addAndMakeVisible (closeButton);
 
-    bounceEngine = std::make_unique<BounceEngine> (engine, session, deviceManager);
+    bounceEngine = std::make_unique<BounceEngine> (engine, session);
 
     // BounceEngine fires its callbacks on the worker thread. We don't touch
     // UI state from there - instead each frame the timer reads the engine's

--- a/src/ui/BounceDialog.h
+++ b/src/ui/BounceDialog.h
@@ -31,7 +31,6 @@ public:
     // print); MasterMix / Stems only.
     BounceDialog (AudioEngine& engine,
                    Session& session,
-                   juce::AudioDeviceManager& deviceManager,
                    const juce::File& outputFile,
                    BounceEngine::Mode mode = BounceEngine::Mode::MasterMix,
                    BounceEngine::Format format = BounceEngine::Format::Wav,
@@ -63,7 +62,6 @@ private:
 
     AudioEngine& engine;
     Session& session;
-    juce::AudioDeviceManager& deviceManager;
     juce::File outputFile;
     BounceEngine::Mode renderMode;
     BounceEngine::Format renderFormat;

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -3038,8 +3038,7 @@ void ChannelStripComponent::handleFreezeClick()
     // Freeze renders offline; run it async behind a progress + cancel modal so a
     // long render never wedges the UI. The dialog commits the freeze on success;
     // we just refresh the button (snowflake) when it closes.
-    auto dialog = std::make_unique<FreezeDialog> (engine, session,
-                                                   engine.getDeviceManager(), trackIndex);
+    auto dialog = std::make_unique<FreezeDialog> (engine, session, trackIndex);
     dialog->setSize (440, 150);
 
     juce::Component::SafePointer<ChannelStripComponent> safe (this);

--- a/src/ui/FreezeDialog.cpp
+++ b/src/ui/FreezeDialog.cpp
@@ -4,9 +4,8 @@
 
 namespace duskstudio
 {
-FreezeDialog::FreezeDialog (AudioEngine& e, Session& s,
-                              juce::AudioDeviceManager& dm, int t)
-    : engine (e), session (s), deviceManager (dm), trackIndex (t),
+FreezeDialog::FreezeDialog (AudioEngine& e, Session& s, int t)
+    : engine (e), session (s), trackIndex (t),
       progressBar (progressValue)
 {
     titleLabel.setJustificationType (juce::Justification::centredLeft);
@@ -66,7 +65,7 @@ FreezeDialog::FreezeDialog (AudioEngine& e, Session& s,
 
     // Async render on the worker thread; the timer polls progress. No worker->UI
     // callbacks, so there's no lifetime race against a closing dialog.
-    bounceEngine = std::make_unique<BounceEngine> (engine, session, deviceManager);
+    bounceEngine = std::make_unique<BounceEngine> (engine, session);
     if (! bounceEngine->startFreeze (trackIndex, outFile, lenSamples,
                                       engine.getCurrentSampleRate()))
     {

--- a/src/ui/FreezeDialog.h
+++ b/src/ui/FreezeDialog.h
@@ -20,8 +20,7 @@ class FreezeDialog final : public juce::Component,
                             private juce::Timer
 {
 public:
-    FreezeDialog (AudioEngine& engine, Session& session,
-                  juce::AudioDeviceManager& deviceManager, int trackIndex);
+    FreezeDialog (AudioEngine& engine, Session& session, int trackIndex);
     ~FreezeDialog() override;
 
     void resized() override;
@@ -38,7 +37,6 @@ private:
 
     AudioEngine& engine;
     Session& session;
-    juce::AudioDeviceManager& deviceManager;
     int trackIndex;
     juce::File outFile;
     std::int64_t lenSamples = 0;

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -2093,7 +2093,7 @@ void MainComponent::doMixdown()
     askBounceRealtime ([this, target] (bool realtime)
     {
         auto panel = std::make_unique<BounceDialog> (engine, session,
-                                                       engine.getDeviceManager(), target,
+                                                       target,
                                                        BounceEngine::Mode::MasterMix,
                                                        BounceEngine::Format::Wav, 320, 0.0, 24,
                                                        realtime);
@@ -2391,7 +2391,7 @@ bool MainComponent::saveSessionTo (const juce::File& dir)
     const bool reattachAudioAfter = ! engineDetached;
     if (! engineDetached)
     {
-        engine.getDeviceManager().removeAudioCallback (&engine);
+        engine.detachAudioCallback();
         engineDetached = true;   // tell publishPluginStateForSave to skip park sleeps
     }
 
@@ -2410,7 +2410,7 @@ bool MainComponent::saveSessionTo (const juce::File& dir)
         // already called prepareToPlay on each plugin during state
         // capture (resume side of the suspend bracket), so each plugin
         // is ready for the next callback.
-        engine.getDeviceManager().addAudioCallback (&engine);
+        engine.reattachAudioCallback();
         engineDetached = false;
     }
 
@@ -2734,7 +2734,7 @@ void MainComponent::requestQuit()
             // I/O. stopTimer prevents the autosave timer from re-
             // entering a save mid-shutdown.
             self->stopTimer();
-            self->engine.getDeviceManager().removeAudioCallback (&self->engine);
+            self->engine.detachAudioCallback();
             self->engineDetached = true;
 
             self->saveSessionAndThen ([safeThis] (bool ok)
@@ -2790,7 +2790,7 @@ void MainComponent::beginSafeShutdown()
     if (! engineDetached)
     {
         markPhase ("phase 3: detach audio callback");
-        engine.getDeviceManager().removeAudioCallback (&engine);
+        engine.detachAudioCallback();
         engineDetached = true;
     }
     else
@@ -3388,7 +3388,7 @@ void MainComponent::openBounceDialog()
             auto launchBounce = [this, target, format, realtime]
             {
                 auto panel = std::make_unique<BounceDialog> (engine, session,
-                                                               engine.getDeviceManager(), target,
+                                                               target,
                                                                BounceEngine::Mode::MasterMix, format,
                                                                320, 0.0, 24, realtime);
                 panel->setSize (520, 200);
@@ -3461,7 +3461,7 @@ void MainComponent::openBounceStemsDialog()
         auto launch = [this, outFile] (bool realtime)
         {
             auto panel = std::make_unique<BounceDialog> (engine, session,
-                                                           engine.getDeviceManager(), outFile,
+                                                           outFile,
                                                            BounceEngine::Mode::Stems,
                                                            BounceEngine::Format::Wav,
                                                            320, 0.0, 24, realtime);

--- a/src/ui/MasteringView.cpp
+++ b/src/ui/MasteringView.cpp
@@ -811,7 +811,7 @@ void MasteringView::openExportBrowser (int preset)
         const auto fmt = mp3Preset ? BounceEngine::Format::Mp3 : BounceEngine::Format::Wav;
 
         auto panel = std::make_unique<BounceDialog> (engine, session,
-                                                       engine.getDeviceManager(), target,
+                                                       target,
                                                        BounceEngine::Mode::MasteringChain, fmt,
                                                        320, rate, depth);
         panel->setSize (520, 200);

--- a/src/ui/ScreenshotCapture.cpp
+++ b/src/ui/ScreenshotCapture.cpp
@@ -418,7 +418,7 @@ void MainComponent::captureScreenshots (const juce::File& outDir)
         // on destruction. Done last so the offline-render device detach can't
         // disturb earlier snapshots.
         auto target = outDir.getChildFile ("_demo").getChildFile ("bounce.wav");
-        BounceDialog bd (engine, session, engine.getDeviceManager(), target,
+        BounceDialog bd (engine, session, target,
                          BounceEngine::Mode::MasterMix);
         modalShot (bd, 520, 200, "qg-07-bounce-dialog.png", 200);
     }


### PR DESCRIPTION
Phase 2b of replacing `juce::AudioDeviceManager`. AudioEngine now talks to the `dusk::audio::DeviceManager` seam (merged in #89) instead of juce directly. **Behavior-preserving** — the seam wraps juce, so the whole app opens + streams a real device exactly as before.

## What changed
- AudioEngine implements `dusk::audio::IODeviceCallback` (was `juce::AudioIODeviceCallback`) and owns a `dusk::audio::DeviceManager` (was `juce::AudioDeviceManager`).
- Callbacks: `audioDeviceIOCallbackWithContext` → `audioDeviceIOCallback` (dusk `CallbackContext`); `aboutToStart`/`stopped` take dusk `IODevice`; `audioDeviceError` takes `std::string` (added to the dusk interface + bridged).
- Backend registration moved out of AudioEngine into the seam's `initialise()`; saved device state read/restored as an opaque blob.
- ALSA busy-device recovery + hot-unplug detector re-expressed against the dusk API (`getSetup`/`setSetup`/`getCurrentDevice`/`getStateBlob`, `setChangeCallback` replacing the juce `ChangeListener`); `callAsync` → `dusk::callAsync`.
- Offline render + self-test detach/reattach via new `AudioEngine::detach/reattachAudioCallback()` instead of poking the manager with `&engine`. This removed the now-dead `juce::AudioDeviceManager&` members threaded through BounceEngine and the Bounce/Freeze dialogs (net −56 lines).

`getDeviceManager()` returns the seam's `juceManager()` escape hatch, so the selector UI + MIDI input layer (not yet flipped) compile unchanged — Phase 2c moves those, Phase 3 swaps the backing to native and unlinks `juce_audio_devices` on Linux.

## Review
One reviewer-confirmed regression fixed (061f9ba): the startup "device unavailable" message read the device name from `getSetup()` after `initialise()`, which returns the fallback device on failure, so the alert never fired — now reads the intended device from the saved blob.

## Verification
- gate stays 195 (behavior-preserving; module-drop is Phase 3)
- app build 0 new warnings, ctest 389/389
- Xvfb selftest 15/15 with a real UMC1820 opening + streaming, Parallel-Matches-Serial bit-identical

**Owed before merge:** hardware bench on the failure paths (hot-unplug mid-play, xrun recovery, device/SR/buffer swap in settings, ASIO re-pick) — headless can't exercise those.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio-device recovery when the selected device is unavailable, including more reliable fallback behavior.
  * Improved handling of device changes and hot-unplug events to reduce false warnings during normal reconfiguration.
  * Improved audio callback management during saving, exporting, freezing, and DSP setting changes.
* **Improvements**
  * Audio device settings are now restored more reliably between launches.
  * Bounce and freeze workflows now manage audio devices more consistently during rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->