### PR TITLE
De-JUCE device Phase 2c: flip selector UI + settings + self-test onto dusk::device::DeviceManager

### DIFF
--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -1017,7 +1017,7 @@ struct DuskStudioApp::BounceTest : private juce::Timer
         // render never needs a device; the bounce re-attaches at the end, harmless
         // against a closed device.
         engine->detachAudioCallback();
-        engine->getDeviceManager().closeAudioDevice();
+        engine->getDeviceManager().closeDevice();
         engine->prepareForSelfTest (sr, bs);
 
         synthesiseContent();

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -452,7 +452,7 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
     // conflict - so it never falls through to the graph. Recover explicitly: the
     // native PipeWire backend (reaches the interface through the graph even while
     // the raw hw handle is held) -> the first ALSA device that opens -> give up
-    // and tell the user. This runs BEFORE addCallback / setChangeCallback: the audio
+    // and tell the user. This runs BEFORE addCallback / addChangeListener: the audio
     // thread isn't attached and no change handler is wired yet, so the
     // setup-switch broadcasts reach no one (no re-entrancy, no fallback loop).
     {
@@ -537,7 +537,7 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
     // Detect hot-unplug (current device becomes null while we had one). Fires on
     // the message thread when the device manager's device list / current device
     // changes.
-    deviceManager.setChangeCallback ([this] { onDeviceManagerChanged(); });
+    deviceManager.addChangeListener (this, [this] { onDeviceManagerChanged(); });
 }
 
 void AudioEngine::refreshMidiInputs()
@@ -1087,7 +1087,7 @@ AudioEngine::~AudioEngine()
     diagTimer.stopTimer();
     if (transport.isRecording())
         recordManager.stopRecording (transport.getPlayhead());
-    deviceManager.setChangeCallback ({});
+    deviceManager.removeChangeListener (this);
     deviceManager.removeCallback (this);
     midiIn.detachCallback();
     deviceManager.closeDevice();

--- a/src/engine/AudioEngine.h
+++ b/src/engine/AudioEngine.h
@@ -84,9 +84,10 @@ public:
     // between captures.
     void setWorkerCountForTest (int n);
 
-    // Escape hatch: the selector UI + MIDI input layer still drive the wrapped
-    // juce::AudioDeviceManager directly (flipped to the dusk API in a later phase).
-    juce::AudioDeviceManager& getDeviceManager() noexcept { return deviceManager.juceManager(); }
+    // The audio-device orchestrator. The settings UI + self-test drive it through
+    // the dusk API (IODevice / DeviceSetup / listener callbacks); no JUCE device
+    // type crosses this boundary.
+    device::DeviceManager& getDeviceManager() noexcept { return deviceManager; }
 
     // Detach / reattach the engine from the audio device. Offline render + self-
     // test detach, then drive audioDeviceIOCallback directly. Reattach re-prepares

--- a/src/engine/AudioPipelineSelfTest.cpp
+++ b/src/engine/AudioPipelineSelfTest.cpp
@@ -31,7 +31,7 @@ std::string fmtPassFail (bool pass) { return pass ? "[PASS]" : "[FAIL]"; }
 } // namespace
 
 AudioPipelineSelfTest::AudioPipelineSelfTest (AudioEngine& e,
-                                              juce::AudioDeviceManager& dm,
+                                              device::DeviceManager& dm,
                                               Session& s) noexcept
     : engine (e), deviceManager (dm), session (s)
 {}
@@ -892,51 +892,52 @@ std::string AudioPipelineSelfTest::probeUMC1820AlsaFormat()
     std::string out;
     out += "--- UMC1820 ALSA Direct Open Probe ---\n";
 
-    const auto origType  = deviceManager.getCurrentAudioDeviceType();
-    const auto origSetup = deviceManager.getAudioDeviceSetup();
+    auto* origTypeObj = deviceManager.getCurrentDeviceType();
+    const std::string origType = origTypeObj != nullptr ? origTypeObj->getTypeName() : std::string();
+    const auto origSetup = deviceManager.getSetup();
 
-    deviceManager.setCurrentAudioDeviceType ("ALSA", true);
+    deviceManager.setCurrentDeviceType ("ALSA", true);
 
     // JUCE-ALSA exposes UMC1820 outputs under several surround-mode names -
     // probe the most common one used in the dialog.
-    const juce::StringArray candidates {
+    const std::vector<std::string> candidates {
         "UMC1820, USB Audio; Front output / input",
         "UMC1820, USB Audio; 4.0 Surround output to Front and Rear speakers"
     };
 
     for (const auto& name : candidates)
     {
-        auto setup = deviceManager.getAudioDeviceSetup();
+        auto setup = deviceManager.getSetup();
         setup.outputDeviceName        = name;
         setup.useDefaultInputChannels = true;
         setup.useDefaultOutputChannels = true;
 
-        const auto err = deviceManager.setAudioDeviceSetup (setup, /*treatAsChosen*/ true);
-        if (err.isNotEmpty())
+        const auto err = deviceManager.setSetup (setup, /*treatAsChosen*/ true);
+        if (! err.empty())
         {
-            out += "  " + name.toStdString() + ": ERROR " + err.toStdString() + "\n";
+            out += "  " + name + ": ERROR " + err + "\n";
             continue;
         }
 
-        if (auto* dev = deviceManager.getCurrentAudioDevice())
+        if (auto* dev = deviceManager.getCurrentDevice())
         {
             out += dusk::text::format (
                 "  %s\n      OPENED rate=%.0f buf=%d in=%d out=%d "
                 "(see [Dusk Studio/JUCE-ALSA] line in stderr for format/access)\n",
-                name.toRawUTF8(),
+                name.c_str(),
                 dev->getCurrentSampleRate(),
                 dev->getCurrentBufferSizeSamples(),
-                dev->getActiveInputChannels().countNumberOfSetBits(),
-                dev->getActiveOutputChannels().countNumberOfSetBits());
+                dev->getActiveInputChannels().count(),
+                dev->getActiveOutputChannels().count());
         }
         else
         {
-            out += "  " + name.toStdString() + ": OPEN-FAILED (getCurrentAudioDevice() == nullptr)\n";
+            out += "  " + name + ": OPEN-FAILED (getCurrentDevice() == nullptr)\n";
         }
     }
 
-    deviceManager.setCurrentAudioDeviceType (origType, true);
-    deviceManager.setAudioDeviceSetup (origSetup, true);
+    deviceManager.setCurrentDeviceType (origType, true);
+    deviceManager.setSetup (origSetup, true);
     return out;
 }
 
@@ -946,10 +947,11 @@ std::string AudioPipelineSelfTest::testBackendsOpenCleanly()
     out += "--- Backend Open Tests ---\n";
 
     // Capture the user's current setup so we can restore.
-    const auto origType  = deviceManager.getCurrentAudioDeviceType();
-    const auto origSetup = deviceManager.getAudioDeviceSetup();
+    auto* origTypeObj = deviceManager.getCurrentDeviceType();
+    const std::string origType = origTypeObj != nullptr ? origTypeObj->getTypeName() : std::string();
+    const auto origSetup = deviceManager.getSetup();
 
-    auto& types = deviceManager.getAvailableDeviceTypes();
+    const auto types = deviceManager.getAvailableDeviceTypes();
     for (auto* type : types)
     {
         if (type == nullptr) continue;
@@ -959,32 +961,32 @@ std::string AudioPipelineSelfTest::testBackendsOpenCleanly()
         const auto inDevs  = type->getDeviceNames (true);
 
         out += dusk::text::format ("  Backend: %s | %d out devs, %d in devs\n",
-                                   type->getTypeName().toRawUTF8(),
-                                   outDevs.size(), inDevs.size());
-        for (const auto& d : outDevs) out += "      out: " + d.toStdString() + "\n";
-        for (const auto& d : inDevs)  out += "      in:  " + d.toStdString() + "\n";
+                                   type->getTypeName().c_str(),
+                                   (int) outDevs.size(), (int) inDevs.size());
+        for (const auto& d : outDevs) out += "      out: " + d + "\n";
+        for (const auto& d : inDevs)  out += "      in:  " + d + "\n";
 
         // Try opening the type's default device.
-        deviceManager.setCurrentAudioDeviceType (type->getTypeName(), /*treatAsChosenDevice*/ true);
-        if (auto* dev = deviceManager.getCurrentAudioDevice())
+        deviceManager.setCurrentDeviceType (type->getTypeName(), /*treatAsChosen*/ true);
+        if (auto* dev = deviceManager.getCurrentDevice())
         {
             out += dusk::text::format (
                 "      OPENED  rate=%.0f buf=%d in=%d out=%d\n",
                 dev->getCurrentSampleRate(),
                 dev->getCurrentBufferSizeSamples(),
-                dev->getActiveInputChannels().countNumberOfSetBits(),
-                dev->getActiveOutputChannels().countNumberOfSetBits());
+                dev->getActiveInputChannels().count(),
+                dev->getActiveOutputChannels().count());
         }
         else
         {
-            out += "      OPEN-FAILED (deviceManager.getCurrentAudioDevice() returned nullptr)\n";
+            out += "      OPEN-FAILED (deviceManager.getCurrentDevice() returned nullptr)\n";
         }
     }
 
     // Restore.
-    deviceManager.setCurrentAudioDeviceType (origType, /*treatAsChosenDevice*/ true);
-    deviceManager.setAudioDeviceSetup (origSetup, /*treatAsChosenDevice*/ true);
-    out += "  (restored original setup: " + origType.toStdString() + ")\n";
+    deviceManager.setCurrentDeviceType (origType, /*treatAsChosen*/ true);
+    deviceManager.setSetup (origSetup, /*treatAsChosen*/ true);
+    out += "  (restored original setup: " + origType + ")\n";
     return out;
 }
 
@@ -1342,12 +1344,14 @@ std::string AudioPipelineSelfTest::runAll()
     report.push_back ("=== Dusk Studio Audio Pipeline Self-Test ===");
     report.push_back ("Time: " + juce::Time::getCurrentTime().toString (true, true).toStdString());
     {
-        const auto& setup = deviceManager.getAudioDeviceSetup();
+        const auto setup = deviceManager.getSetup();
+        auto* typeObj = deviceManager.getCurrentDeviceType();
+        const std::string backend = typeObj != nullptr ? typeObj->getTypeName() : std::string();
         report.push_back (dusk::text::format (
             "Active backend: %s, %s out, %s in, %.0f Hz, %d-sample buffer",
-            deviceManager.getCurrentAudioDeviceType().toRawUTF8(),
-            setup.outputDeviceName.toRawUTF8(),
-            setup.inputDeviceName.toRawUTF8(),
+            backend.c_str(),
+            setup.outputDeviceName.c_str(),
+            setup.inputDeviceName.c_str(),
             setup.sampleRate,
             setup.bufferSize));
     }
@@ -1393,7 +1397,7 @@ std::string AudioPipelineSelfTest::runAll()
    #endif
 
     // Re-attach the engine BEFORE the backend cycle. Without an audio callback
-    // registered, every setCurrentAudioDeviceType / setAudioDeviceSetup below
+    // registered, every setCurrentDeviceType / setSetup below
     // opens the hardware PCM and the device thread streams whatever's in the
     // kernel/driver buffer (uninitialised memory, stale samples, PipeWire-graph
     // residue) - the "test button distortion" speakers hear on each transition.

--- a/src/engine/AudioPipelineSelfTest.cpp
+++ b/src/engine/AudioPipelineSelfTest.cpp
@@ -892,6 +892,18 @@ std::string AudioPipelineSelfTest::probeUMC1820AlsaFormat()
     std::string out;
     out += "--- UMC1820 ALSA Direct Open Probe ---\n";
 
+    // ALSA-specific by construction (forces the ALSA backend, probes a
+    // hardware-name it exposes). Skip entirely when ALSA isn't registered so
+    // the probe never switches the active backend to a type that doesn't exist.
+    bool alsaAvailable = false;
+    for (auto* t : deviceManager.getAvailableDeviceTypes())
+        if (t != nullptr && t->getTypeName() == "ALSA") { alsaAvailable = true; break; }
+    if (! alsaAvailable)
+    {
+        out += "  (ALSA backend not available - probe skipped)\n";
+        return out;
+    }
+
     auto* origTypeObj = deviceManager.getCurrentDeviceType();
     const std::string origType = origTypeObj != nullptr ? origTypeObj->getTypeName() : std::string();
     const auto origSetup = deviceManager.getSetup();

--- a/src/engine/AudioPipelineSelfTest.h
+++ b/src/engine/AudioPipelineSelfTest.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <juce_audio_devices/juce_audio_devices.h>
 #include <array>
 #include <string>
 #include <vector>
 #include "AudioEngine.h"
+#include "device/DeviceManager.h"
 #include "../session/Session.h"
 
 namespace duskstudio
@@ -24,7 +24,7 @@ class AudioPipelineSelfTest
 {
 public:
     AudioPipelineSelfTest (AudioEngine& engine,
-                            juce::AudioDeviceManager& dm,
+                            device::DeviceManager& dm,
                             Session& session) noexcept;
 
     // Runs the full suite, returns a multi-line formatted report suitable for
@@ -133,7 +133,7 @@ private:
                                     int workerCount = -1);
 
     AudioEngine& engine;
-    juce::AudioDeviceManager& deviceManager;
+    device::DeviceManager& deviceManager;
     Session& session;
 };
 } // namespace duskstudio

--- a/src/engine/device/DeviceManager.cpp
+++ b/src/engine/device/DeviceManager.cpp
@@ -167,7 +167,20 @@ struct DeviceManager::Impl : private juce::ChangeListener
         mgr.removeChangeListener (this);
     }
 
-    void changeListenerCallback (juce::ChangeBroadcaster*) override { if (onChange) onChange(); }
+    void changeListenerCallback (juce::ChangeBroadcaster*) override { fireListeners(); }
+
+    void fireListeners()
+    {
+        // Copy the callbacks before firing: a listener may add or remove
+        // subscribers (e.g. the settings UI relays out) and mutating the map
+        // mid-iteration would invalidate the loop.
+        std::vector<std::function<void()>> callbacks;
+        callbacks.reserve (listeners.size());
+        for (auto& entry : listeners)
+            callbacks.push_back (entry.second);
+        for (auto& cb : callbacks)
+            if (cb) cb();
+    }
 
     juce::AudioDeviceManager mgr;
     // Keyed by the juce type pointer (stable for the manager's lifetime), so an
@@ -176,7 +189,7 @@ struct DeviceManager::Impl : private juce::ChangeListener
     std::map<juce::AudioIODeviceType*, std::unique_ptr<JuceDeviceTypeAdapter>> typeAdapters;
     JuceDeviceAdapter currentDevice { nullptr };
     std::map<IODeviceCallback*, std::unique_ptr<CallbackBridge>> bridges;
-    std::function<void()> onChange;
+    std::map<void*, std::function<void()>> listeners;
     bool backendsRegistered = false;
 
     JuceDeviceTypeAdapter* adapterFor (juce::AudioIODeviceType* t)
@@ -338,7 +351,14 @@ void DeviceManager::removeCallback (IODeviceCallback* callback)
 
 void DeviceManager::closeDevice() { impl->mgr.closeAudioDevice(); }
 
-void DeviceManager::setChangeCallback (std::function<void()> onChange) { impl->onChange = std::move (onChange); }
+void DeviceManager::addChangeListener (void* owner, std::function<void()> onChange)
+{
+    if (owner != nullptr) impl->listeners[owner] = std::move (onChange);
+}
+
+void DeviceManager::removeChangeListener (void* owner) { impl->listeners.erase (owner); }
+
+void DeviceManager::notifyChange() { impl->fireListeners(); }
 
 juce::AudioDeviceManager& DeviceManager::juceManager() { return impl->mgr; }
 } // namespace duskstudio::device

--- a/src/engine/device/DeviceManager.cpp
+++ b/src/engine/device/DeviceManager.cpp
@@ -171,15 +171,23 @@ struct DeviceManager::Impl : private juce::ChangeListener
 
     void fireListeners()
     {
-        // Copy the callbacks before firing: a listener may add or remove
-        // subscribers (e.g. the settings UI relays out) and mutating the map
-        // mid-iteration would invalidate the loop.
-        std::vector<std::function<void()>> callbacks;
-        callbacks.reserve (listeners.size());
+        // Snapshot the owner keys, not the closures: a listener may add or
+        // remove subscribers (e.g. the settings UI relays out). Firing a
+        // copied closure whose owner was already removed by an earlier
+        // callback would invoke a dead listener. So re-check each owner
+        // against the live map and pull its current callback before calling;
+        // copy that callback so an owner removing itself mid-call is safe.
+        std::vector<void*> owners;
+        owners.reserve (listeners.size());
         for (auto& entry : listeners)
-            callbacks.push_back (entry.second);
-        for (auto& cb : callbacks)
+            owners.push_back (entry.first);
+        for (auto* owner : owners)
+        {
+            auto it = listeners.find (owner);
+            if (it == listeners.end()) continue;
+            auto cb = it->second;
             if (cb) cb();
+        }
     }
 
     juce::AudioDeviceManager mgr;

--- a/src/engine/device/DeviceManager.h
+++ b/src/engine/device/DeviceManager.h
@@ -77,7 +77,7 @@ public:
     void notifyChange();
 
     // Escape hatch: the MIDI input layer alone still drives MIDI device
-    // enable/disable through the wrapped juce::AudioDeviceManager. This is now
+    // enable/disable through the wrapped JUCE AudioDeviceManager. This is now
     // its only consumer (the audio-device UI drives the dusk API above). Removed
     // once the native MIDI backend lands and juce_audio_devices unlinks.
     juce::AudioDeviceManager& juceManager();

--- a/src/engine/device/DeviceManager.h
+++ b/src/engine/device/DeviceManager.h
@@ -65,12 +65,21 @@ public:
     void removeCallback (IODeviceCallback* callback);
     void closeDevice();
 
-    // Hot-plug / device-change notification, fired on the message thread.
-    void setChangeCallback (std::function<void()> onChange);
+    // Hot-plug / device-change notification, fired on the message thread. Several
+    // independent subscribers observe device changes (the engine's fallback
+    // handler plus the settings UI), so listeners are keyed by an opaque owner
+    // pointer - each subscriber passes `this` and removes by the same identity.
+    void addChangeListener (void* owner, std::function<void()> onChange);
+    void removeChangeListener (void* owner);
+    // Force-fire every listener (the dusk replacement for a manual JUCE
+    // sendChangeMessage()) - used after a rescan where the backend's own diff
+    // check may swallow the notification.
+    void notifyChange();
 
-    // Escape hatch: the MIDI input layer still drives MIDI device enable/disable
-    // through the same juce::AudioDeviceManager. Removed once the native MIDI
-    // backend lands and juce_audio_devices unlinks.
+    // Escape hatch: the MIDI input layer alone still drives MIDI device
+    // enable/disable through the wrapped juce::AudioDeviceManager. This is now
+    // its only consumer (the audio-device UI drives the dusk API above). Removed
+    // once the native MIDI backend lands and juce_audio_devices unlinks.
     juce::AudioDeviceManager& juceManager();
 
 private:

--- a/src/ui/AudioSettingsPanel.cpp
+++ b/src/ui/AudioSettingsPanel.cpp
@@ -677,10 +677,7 @@ void AudioSettingsPanel::applyRescan()
     // We iterate every type rather than only the current one so that
     // switching backend (e.g. ALSA -> PipeWire) after a hot-plug still sees
     // the freshly-enumerated devices on the new backend.
-    const auto types = deviceManager.getAvailableDeviceTypes();
-    for (auto* type : types)
-        if (type != nullptr)
-            type->scanForDevices();
+    deviceManager.scanAllDeviceTypes();
 
     // The selector subscribes to the device manager's change notification. Most
     // backends' scanForDevices() will already fire it (routed through the

--- a/src/ui/AudioSettingsPanel.cpp
+++ b/src/ui/AudioSettingsPanel.cpp
@@ -13,7 +13,7 @@
 
 namespace duskstudio
 {
-AudioSettingsPanel::AudioSettingsPanel (juce::AudioDeviceManager& dm,
+AudioSettingsPanel::AudioSettingsPanel (device::DeviceManager& dm,
                                           AudioEngine& e, Session& s)
     : deviceManager (dm), engine (e), session (s)
 {
@@ -39,7 +39,7 @@ AudioSettingsPanel::AudioSettingsPanel (juce::AudioDeviceManager& dm,
     addAndMakeVisible (mainOutputCombo);
 
     // Refresh the main-output menu when the device's output count changes.
-    deviceManager.addChangeListener (this);
+    deviceManager.addChangeListener (this, [this] { changeListenerCallback (nullptr); });
 
 #if defined(__linux__)
     addAndMakeVisible (periodsLabel);
@@ -677,19 +677,17 @@ void AudioSettingsPanel::applyRescan()
     // We iterate every type rather than only the current one so that
     // switching backend (e.g. ALSA -> PipeWire) after a hot-plug still sees
     // the freshly-enumerated devices on the new backend.
-    const auto& types = deviceManager.getAvailableDeviceTypes();
+    const auto types = deviceManager.getAvailableDeviceTypes();
     for (auto* type : types)
         if (type != nullptr)
             type->scanForDevices();
 
-    // The selector subscribes to AudioDeviceManager change broadcasts. Most
-    // backends' scanForDevices() will already fire callDeviceChangeListeners()
-    // (which routes through audioDeviceListChanged() -> sendChangeMessage()),
-    // but some only broadcast on a real diff. Force a refresh either way.
-    // Re-applying the same setup via setAudioDeviceSetup is a no-op when
-    // newSetup == currentSetup (JUCE early-returns without notifying), so
-    // poke the broadcaster directly.
-    deviceManager.sendChangeMessage();
+    // The selector subscribes to the device manager's change notification. Most
+    // backends' scanForDevices() will already fire it (routed through the
+    // wrapped manager's device-list-changed broadcast), but some only broadcast
+    // on a real diff. Force a refresh either way - re-applying the same setup is
+    // a no-op when nothing changed, so fire the listeners directly.
+    deviceManager.notifyChange();
 
     // Same rescan also re-enumerates MIDI inputs so freshly plugged-in
     // controllers appear in the per-strip MIDI dropdowns. The engine
@@ -711,8 +709,8 @@ void AudioSettingsPanel::applyPeriodsChange()
     // Re-open the device with the same setup so setParameters() runs and
     // picks up the new period count. Without this, the change only takes
     // effect on the next manual device switch.
-    auto setup = deviceManager.getAudioDeviceSetup();
-    deviceManager.setAudioDeviceSetup (setup, /*treatAsChosenDevice*/ true);
+    auto setup = deviceManager.getSetup();
+    deviceManager.setSetup (setup, /*treatAsChosen*/ true);
 }
 #endif
 
@@ -725,7 +723,7 @@ void AudioSettingsPanel::applyOversamplingChange()
 
     // Re-prepare engine DSP so the new factor takes effect. The factor is only
     // read in AudioEngine::prepareForSelfTest (driven by audioDeviceAboutToStart).
-    // setAudioDeviceSetup() with the SAME setup is a JUCE no-op, and a full
+    // setSetup() with the SAME setup is a no-op, and a full
     // device close/restart disturbs the window peer on Linux (mouse-offset
     // regression). Instead, detach + reattach the engine as the audio callback:
     // removeAudioCallback fires audioDeviceStopped, addAudioCallback fires
@@ -794,14 +792,14 @@ void AudioSettingsPanel::populateMainOutputCombo()
     mainOutputCombo.clear (juce::dontSendNotification);
     mainOutputCombo.addItem ("1-2 (default)", 1);
 
-    if (auto* device = deviceManager.getCurrentAudioDevice())
+    if (auto* device = deviceManager.getCurrentDevice())
     {
         // Only offer pairs the engine can actually write to: both channels of
         // the pair must be in the device's active-output set. Listing inactive
         // physical outputs lets the user route the master to a dead pair and
         // makes it appear to vanish.
         const auto active = device->getActiveOutputChannels();
-        const int count = device->getOutputChannelNames().size();
+        const int count = (int) device->getOutputChannelNames().size();
         // Skip the first pair - it's already the "1-2 (default)" item.
         for (int i = 2; i + 1 < count; i += 2)
             if (active[i] && active[i + 1])

--- a/src/ui/AudioSettingsPanel.h
+++ b/src/ui/AudioSettingsPanel.h
@@ -22,7 +22,7 @@ class AudioSettingsPanel final : public juce::Component,
                                   public juce::ChangeListener
 {
 public:
-    AudioSettingsPanel (juce::AudioDeviceManager& dm,
+    AudioSettingsPanel (device::DeviceManager& dm,
                          AudioEngine& engine,
                          Session& session);
     ~AudioSettingsPanel() override;
@@ -31,11 +31,12 @@ public:
     void resized() override;
     // Engine broadcasts on MIDI-bank rebuild (hot-plug, manual rescan).
     // Refreshes the sync-source combo so new inputs appear without
-    // reopening.
+    // reopening. The device manager relays its own change (audio device
+    // switch / active-output change) through this same handler.
     void changeListenerCallback (juce::ChangeBroadcaster*) override;
 
 private:
-    juce::AudioDeviceManager& deviceManager;
+    device::DeviceManager& deviceManager;
     AudioEngine& engine;
     Session& session;
     std::unique_ptr<DuskAudioDeviceSelector> selector;

--- a/src/ui/AuxLaneComponent.cpp
+++ b/src/ui/AuxLaneComponent.cpp
@@ -480,9 +480,9 @@ void AuxLaneComponent::timerCallback()
     // Rebuild the output-pair menu when the device's ACTIVE output set changes
     // (e.g. the user enabled/swapped outputs in Audio settings - the physical
     // name count wouldn't move, only the active mask).
-    if (auto* dev = engine.getDeviceManager().getCurrentAudioDevice())
+    if (auto* dev = engine.getDeviceManager().getCurrentDevice())
         if (dev->getActiveOutputChannels() != lastOutputChannelMask
-            || dev->getOutputChannelNames().size() != lastOutputChannelCount)
+            || (int) dev->getOutputChannelNames().size() != lastOutputChannelCount)
             populateOutputPairCombo();
 }
 
@@ -491,8 +491,8 @@ void AuxLaneComponent::populateOutputPairCombo()
     outputPairCombo.clear (juce::dontSendNotification);
     outputPairCombo.addItem ("Master only", 1);
 
-    juce::BigInteger activeMask;
-    if (auto* device = engine.getDeviceManager().getCurrentAudioDevice())
+    device::ChannelSet activeMask;
+    if (auto* device = engine.getDeviceManager().getCurrentDevice())
     {
         // Only list pairs the engine can write to - both channels must be in the
         // device's active-output set. Offering inactive physical outputs would
@@ -500,7 +500,7 @@ void AuxLaneComponent::populateOutputPairCombo()
         // timer re-populates when the user toggles outputs in Audio settings
         // (getOutputChannelNames().size() wouldn't change there).
         const auto active = device->getActiveOutputChannels();
-        const int total = device->getOutputChannelNames().size();
+        const int total = (int) device->getOutputChannelNames().size();
         for (int i = 0; i + 1 < total; i += 2)
             if (active[i] && active[i + 1])
                 outputPairCombo.addItem ("Out " + juce::String (i + 1) + "-" + juce::String (i + 2),

--- a/src/ui/AuxLaneComponent.h
+++ b/src/ui/AuxLaneComponent.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include "../session/Session.h"
 #include "DuskComboBox.h"
+#include "../engine/device/ChannelSet.h"
 
 namespace duskstudio
 {
@@ -115,7 +116,7 @@ private:
     // rebuilds it when the device's active-output set changes. A bitmask (not
     // just a set-bit count) so swapping which pair is active - same count,
     // different channels - still triggers a repopulate.
-    juce::BigInteger lastOutputChannelMask;
+    device::ChannelSet lastOutputChannelMask;
     // Output channel count the combo was last built for. The mask alone can
     // match across two devices (both stereo -> bits 0,1) while the physical
     // output count - which drives how many pairs the menu lists - differs, so

--- a/src/ui/DuskAudioDeviceSelector.cpp
+++ b/src/ui/DuskAudioDeviceSelector.cpp
@@ -25,7 +25,7 @@ juce::String formatRate (double r)
 }
 } // namespace
 
-DuskAudioDeviceSelector::DuskAudioDeviceSelector (juce::AudioDeviceManager& dm)
+DuskAudioDeviceSelector::DuskAudioDeviceSelector (device::DeviceManager& dm)
     : deviceManager (dm)
 {
     auto styleRow = [this] (juce::Label& l, DuskComboBox& c)
@@ -43,16 +43,14 @@ DuskAudioDeviceSelector::DuskAudioDeviceSelector (juce::AudioDeviceManager& dm)
     typeCombo.onChange = [this]
     {
         if (updating) return;
-        if (auto* types = &deviceManager.getAvailableDeviceTypes())
+        const auto types = deviceManager.getAvailableDeviceTypes();
+        const int idx = typeCombo.getSelectedId() - 1;
+        if (idx >= 0 && idx < (int) types.size())
         {
-            const int idx = typeCombo.getSelectedId() - 1;
-            if (juce::isPositiveAndBelow (idx, types->size()))
-            {
-                deviceManager.setCurrentAudioDeviceType ((*types)[idx]->getTypeName(),
-                                                          /*treatAsChosen*/ true);
-                rebuildFromManager();
-                if (onDeviceChanged) onDeviceChanged();
-            }
+            deviceManager.setCurrentDeviceType (types[(size_t) idx]->getTypeName(),
+                                                /*treatAsChosen*/ true);
+            rebuildFromManager();
+            if (onDeviceChanged) onDeviceChanged();
         }
     };
     outputCombo.onChange = [this] { applySetupChange (/*deviceChanged*/ true); };
@@ -60,7 +58,8 @@ DuskAudioDeviceSelector::DuskAudioDeviceSelector (juce::AudioDeviceManager& dm)
     rateCombo  .onChange = [this] { applySetupChange (/*deviceChanged*/ false); };
     bufferCombo.onChange = [this] { applySetupChange (/*deviceChanged*/ false); };
 
-    deviceManager.addChangeListener (this);
+    // External change (hot-plug, another panel) - re-sync our combos.
+    deviceManager.addChangeListener (this, [this] { if (! updating) rebuildFromManager(); });
     rebuildFromManager();
 }
 
@@ -69,33 +68,26 @@ DuskAudioDeviceSelector::~DuskAudioDeviceSelector()
     deviceManager.removeChangeListener (this);
 }
 
-void DuskAudioDeviceSelector::changeListenerCallback (juce::ChangeBroadcaster*)
-{
-    // External change (hot-plug, another panel) - re-sync our combos.
-    if (! updating)
-        rebuildFromManager();
-}
-
 void DuskAudioDeviceSelector::rebuildFromManager()
 {
     const juce::ScopedValueSetter<bool> guard (updating, true);
 
-    const auto setup = deviceManager.getAudioDeviceSetup();
-    auto* currentType = deviceManager.getCurrentDeviceTypeObject();
-    auto* device = deviceManager.getCurrentAudioDevice();
+    const auto setup = deviceManager.getSetup();
+    auto* currentType = deviceManager.getCurrentDeviceType();
+    auto* device = deviceManager.getCurrentDevice();
 
     // Backend (device type).
     typeCombo.clear (juce::dontSendNotification);
-    auto& types = deviceManager.getAvailableDeviceTypes();
-    for (int i = 0; i < types.size(); ++i)
-        typeCombo.addItem (types[i]->getTypeName(), i + 1);
+    const auto types = deviceManager.getAvailableDeviceTypes();
+    for (int i = 0; i < (int) types.size(); ++i)
+        typeCombo.addItem (juce::String (types[(size_t) i]->getTypeName()), i + 1);
     if (currentType != nullptr)
-        for (int i = 0; i < types.size(); ++i)
-            if (types[i] == currentType)
+        for (int i = 0; i < (int) types.size(); ++i)
+            if (types[(size_t) i] == currentType)
                 typeCombo.setSelectedId (i + 1, juce::dontSendNotification);
 
     // Output + input device lists (current backend).
-    auto fillDevices = [&] (DuskComboBox& combo, bool isInput, const juce::String& chosen)
+    auto fillDevices = [&] (DuskComboBox& combo, bool isInput, const std::string& chosen)
     {
         combo.clear (juce::dontSendNotification);
         combo.addItem ("(None)", kNoneId);
@@ -103,10 +95,10 @@ void DuskAudioDeviceSelector::rebuildFromManager()
         if (currentType != nullptr)
         {
             const auto names = currentType->getDeviceNames (isInput);
-            for (int i = 0; i < names.size(); ++i)
+            for (int i = 0; i < (int) names.size(); ++i)
             {
-                combo.addItem (names[i], i + 2);
-                if (names[i] == chosen) sel = i + 2;
+                combo.addItem (juce::String (names[(size_t) i]), i + 2);
+                if (names[(size_t) i] == chosen) sel = i + 2;
             }
         }
         combo.setSelectedId (sel, juce::dontSendNotification);
@@ -146,12 +138,12 @@ void DuskAudioDeviceSelector::applySetupChange (bool deviceChanged)
 {
     if (updating) return;
 
-    auto setup = deviceManager.getAudioDeviceSetup();
+    auto setup = deviceManager.getSetup();
 
     const int outId = outputCombo.getSelectedId();
     const int inId  = inputCombo.getSelectedId();
-    setup.outputDeviceName = outId == kNoneId ? juce::String() : outputCombo.getText();
-    setup.inputDeviceName  = inId  == kNoneId ? juce::String() : inputCombo.getText();
+    setup.outputDeviceName = outId == kNoneId ? std::string() : outputCombo.getText().toStdString();
+    setup.inputDeviceName  = inId  == kNoneId ? std::string() : inputCombo.getText().toStdString();
 
     if (! deviceChanged)
     {
@@ -172,20 +164,20 @@ void DuskAudioDeviceSelector::applySetupChange (bool deviceChanged)
     // clamps the request to what the device actually exposes.
     setup.useDefaultOutputChannels = false;
     setup.outputChannels.clear();
-    if (setup.outputDeviceName.isNotEmpty())
+    if (! setup.outputDeviceName.empty())
         setup.outputChannels.setRange (0, kMaxDeviceOutputChannels, true);
 
     setup.useDefaultInputChannels = false;
     setup.inputChannels.clear();
-    if (setup.inputDeviceName.isNotEmpty())
+    if (! setup.inputDeviceName.empty())
         setup.inputChannels.setRange (0, kMaxDeviceInputChannels, true);
 
-    const auto error = deviceManager.setAudioDeviceSetup (setup, /*treatAsChosen*/ true);
+    const auto error = deviceManager.setSetup (setup, /*treatAsChosen*/ true);
 
-    if (error.isNotEmpty())
+    if (! error.empty())
     {
         if (auto* top = getTopLevelComponent())
-            showDuskAlert (*top, "Audio device error", error);
+            showDuskAlert (*top, "Audio device error", juce::String (error));
     }
     else if (onDeviceChanged)
     {

--- a/src/ui/DuskAudioDeviceSelector.h
+++ b/src/ui/DuskAudioDeviceSelector.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <juce_audio_devices/juce_audio_devices.h>
 #include <juce_gui_basics/juce_gui_basics.h>
 #include "DuskComboBox.h"
+#include "../engine/device/DeviceManager.h"
 
 namespace duskstudio
 {
@@ -11,21 +11,19 @@ namespace duskstudio
 // stock JUCE selector pops its own native AlertWindow ("Error when trying to
 // open audio device!") on failure, which can't be intercepted from app code
 // and breaks the in-window-modal convention used everywhere else. This drives
-// the same juce::AudioDeviceManager directly and surfaces open errors through
+// the dusk device::DeviceManager directly and surfaces open errors through
 // showDuskAlert against the top-level window instead.
 //
 // Output + input channels are opened wide (all the device exposes, clamped to
 // the engine's limits) so AudioSettingsPanel's main-output pair menu still
 // finds every active pair - channel check-boxes aren't reproduced.
-class DuskAudioDeviceSelector final : public juce::Component,
-                                       public juce::ChangeListener
+class DuskAudioDeviceSelector final : public juce::Component
 {
 public:
-    explicit DuskAudioDeviceSelector (juce::AudioDeviceManager& dm);
+    explicit DuskAudioDeviceSelector (device::DeviceManager& dm);
     ~DuskAudioDeviceSelector() override;
 
     void resized() override;
-    void changeListenerCallback (juce::ChangeBroadcaster*) override;
 
     // Stacked label+combo rows; AudioSettingsPanel sizes the block to this.
     int getPreferredHeight() const noexcept;
@@ -38,7 +36,7 @@ private:
     void rebuildFromManager();          // repopulate every combo from current state
     void applySetupChange (bool deviceChanged);  // build setup, apply, alert on error
 
-    juce::AudioDeviceManager& deviceManager;
+    device::DeviceManager& deviceManager;
     bool updating = false;              // guard so repopulation doesn't re-apply
 
     juce::Label    typeLabel   { {}, "Audio backend" };

--- a/src/ui/HardwareInsertEditor.cpp
+++ b/src/ui/HardwareInsertEditor.cpp
@@ -81,6 +81,12 @@ HardwareInsertEditor::HardwareInsertEditor (HardwareInsertParams& paramsRef,
     inChCombo .onChange = [this] { publishRoutingFromUi(); };
     populateDropdowns();
 
+    // Rebuild the channel lists when the audio device changes under an open
+    // editor (hot-swap, backend switch in Audio settings) so the dropdowns
+    // stop offering channels the new device doesn't have. populateDropdowns
+    // re-selects the stored routing, so a still-valid patch survives the swap.
+    deviceManager.addChangeListener (this, [this] { populateDropdowns(); });
+
     pingButton.setColour (juce::TextButton::buttonColourId, juce::Colour (0xff2a4a6a));
     pingButton.setColour (juce::TextButton::textColourOffId, juce::Colours::white);
     pingButton.setTooltip ("Send a chirp out the SEND, capture the RETURN, "
@@ -181,7 +187,13 @@ HardwareInsertEditor::HardwareInsertEditor (HardwareInsertParams& paramsRef,
     params.enabled.store (true, std::memory_order_relaxed);
 }
 
-HardwareInsertEditor::~HardwareInsertEditor() { stopTimer(); }   // before derived members destruct
+HardwareInsertEditor::~HardwareInsertEditor()
+{
+    // Both before derived members destruct: the change callback touches the
+    // combos, so it must not fire once they are gone.
+    deviceManager.removeChangeListener (this);
+    stopTimer();
+}
 
 void HardwareInsertEditor::timerCallback()
 {

--- a/src/ui/HardwareInsertEditor.cpp
+++ b/src/ui/HardwareInsertEditor.cpp
@@ -14,7 +14,7 @@ using outputpair::decodePairR;
 constexpr int kMonoChannelIdBase = 1000000;
 
 HardwareInsertEditor::HardwareInsertEditor (HardwareInsertParams& paramsRef,
-                                                juce::AudioDeviceManager& dm,
+                                                device::DeviceManager& dm,
                                                 std::function<void()> onDone,
                                                 bool embedded,
                                                 bool allowMono)
@@ -225,7 +225,7 @@ void HardwareInsertEditor::timerCallback()
             // size without doing arithmetic. When no audio device is
             // open / sample rate is unknown, fall back to "? ms" rather
             // than printing a misleading "0.00 ms".
-            auto* device = deviceManager.getCurrentAudioDevice();
+            auto* device = deviceManager.getCurrentDevice();
             const double sr = device != nullptr ? device->getCurrentSampleRate() : 0.0;
             const juce::String msPart = sr > 0.0
                 ? juce::String::formatted ("%.2f ms", (double) lag * 1000.0 / sr)
@@ -244,7 +244,7 @@ void HardwareInsertEditor::populateDropdowns()
     outChCombo.clear (juce::dontSendNotification);
     inChCombo .clear (juce::dontSendNotification);
 
-    auto* device = deviceManager.getCurrentAudioDevice();
+    auto* device = deviceManager.getCurrentDevice();
     if (device == nullptr)
     {
         outChCombo.addItem ("(no audio device)", 1);
@@ -259,24 +259,25 @@ void HardwareInsertEditor::populateDropdowns()
     const auto routing = currentRouting();
 
     const bool monoFormat = formatMonoButton.getToggleState();
-    auto addPairs = [] (juce::ComboBox& cb, const juce::StringArray& names)
+    auto addPairs = [] (juce::ComboBox& cb, const std::vector<std::string>& names)
     {
         // Pair adjacent channels - typical interface convention is
         // odd/even = L/R. Add a leading "(none)" entry so the user can
         // explicitly clear the routing.
         cb.addItem ("(none)", 1);
-        for (int i = 0; i + 1 < names.size(); i += 2)
+        for (int i = 0; i + 1 < (int) names.size(); i += 2)
         {
             const auto label = juce::String (i + 1) + "-" + juce::String (i + 2)
-                              + "  " + names[i] + " / " + names[i + 1];
+                              + "  " + juce::String (names[(size_t) i])
+                              + " / " + juce::String (names[(size_t) i + 1]);
             cb.addItem (label, encodePair (i, i + 1));
         }
     };
-    auto addSingles = [] (juce::ComboBox& cb, const juce::StringArray& names)
+    auto addSingles = [] (juce::ComboBox& cb, const std::vector<std::string>& names)
     {
         cb.addItem ("(none)", 1);
-        for (int i = 0; i < names.size(); ++i)
-            cb.addItem (juce::String (i + 1) + "  " + names[i],
+        for (int i = 0; i < (int) names.size(); ++i)
+            cb.addItem (juce::String (i + 1) + "  " + juce::String (names[(size_t) i]),
                         kMonoChannelIdBase + i);
     };
     if (monoFormat)

--- a/src/ui/HardwareInsertEditor.h
+++ b/src/ui/HardwareInsertEditor.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <juce_audio_devices/juce_audio_devices.h>
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <functional>
 #include "DuskComboBox.h"
 #include "../session/Session.h"
+#include "../engine/device/DeviceManager.h"
 
 namespace duskstudio
 {
@@ -32,7 +32,7 @@ public:
     // format row - offered on mono tracks, where single-channel outboard
     // (a mono compressor, a guitar pedal) is the natural patch.
     HardwareInsertEditor (HardwareInsertParams& params,
-                          juce::AudioDeviceManager& deviceManager,
+                          device::DeviceManager& deviceManager,
                           std::function<void()> onDone,
                           bool embedded = false,
                           bool allowMono = false);
@@ -51,7 +51,7 @@ private:
     void timerCallback() override;
 
     HardwareInsertParams& params;
-    juce::AudioDeviceManager& deviceManager;
+    device::DeviceManager& deviceManager;
     std::function<void()> onDoneCallback;
     bool isEmbedded = false;
     bool monoAllowed = false;

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -1923,11 +1923,11 @@ void MainComponent::openAudioSettings()
     // The Audio block hosts the DuskAudioDeviceSelector in a fixed slot
     // sized to its preferred height - see AudioSettingsPanel::resized.
     constexpr int kPanelW = 820;
-    // Content height with the bumped 360 px audio block + every
-    // section ends just past 1060 px - anything less clips the
-    // Advanced rows (ALSA periods / oversampling / self-test / rescan,
-    // plus the Multicore DSP row) off the bottom even with a scroll
-    // wrapper, because the viewport never sees the missing pixels.
+    // Content height that fits every section (the selector block sizes to its
+    // own preferred height) - anything less clips the Advanced rows (ALSA
+    // periods / oversampling / self-test / rescan, plus the Multicore DSP row)
+    // off the bottom even with a scroll wrapper, because the viewport never
+    // sees the missing pixels.
     constexpr int kPanelH = 1180;
     panel->setSize (kPanelW, kPanelH);
 

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -1920,8 +1920,8 @@ void MainComponent::openAudioSettings()
     // Tall enough that the new grouped layout (Audio + Control Surface +
     // MIDI Bindings + MIDI Sync + General + Advanced, each with a
     // section header + separator) fits without any group being clipped.
-    // The Audio block hosts JUCE's AudioDeviceSelectorComponent in a
-    // fixed 360 px slot - see AudioSettingsPanel::resized.
+    // The Audio block hosts the DuskAudioDeviceSelector in a fixed slot
+    // sized to its preferred height - see AudioSettingsPanel::resized.
     constexpr int kPanelW = 820;
     // Content height with the bumped 360 px audio block + every
     // section ends just past 1060 px - anything less clips the
@@ -3077,11 +3077,11 @@ bool MainComponent::finishLoadingSessionFrom (const juce::File& sourceJson,
         else if (deviceSr > 0.0
                  && std::abs (session.sessionSampleRate - deviceSr) > 0.5)
         {
-            auto setup = engine.getDeviceManager().getAudioDeviceSetup();
+            auto setup = engine.getDeviceManager().getSetup();
             setup.sampleRate = session.sessionSampleRate;
-            const auto err = engine.getDeviceManager().setAudioDeviceSetup (setup, true);
-            const double after = engine.getDeviceManager().getAudioDeviceSetup().sampleRate;
-            if (err.isNotEmpty() || std::abs (after - session.sessionSampleRate) > 0.5)
+            const auto err = engine.getDeviceManager().setSetup (setup, true);
+            const double after = engine.getDeviceManager().getSetup().sampleRate;
+            if (! err.empty() || std::abs (after - session.sessionSampleRate) > 0.5)
             {
                 warnedSampleRateMismatch = true;
                 const auto body =
@@ -3089,7 +3089,7 @@ bool MainComponent::finishLoadingSessionFrom (const juce::File& sourceJson,
                     + juce::String ((int) session.sessionSampleRate) + " Hz, but the "
                     "audio device is running at " + juce::String ((int) after) + " Hz "
                     "and could not be switched"
-                    + (err.isNotEmpty() ? (":\n\n    " + err) : juce::String (".")) +
+                    + (! err.empty() ? juce::String (":\n\n    " + err) : juce::String (".")) +
                     "\n\nEvery recorded track will play at the wrong speed and pitch "
                     "until the device runs at the session's rate. Pick a device or "
                     "rate of " + juce::String ((int) session.sessionSampleRate)

--- a/src/ui/SelfTestPanel.cpp
+++ b/src/ui/SelfTestPanel.cpp
@@ -6,7 +6,7 @@
 namespace duskstudio
 {
 SelfTestPanel::SelfTestPanel (AudioEngine& e,
-                                juce::AudioDeviceManager& dm,
+                                device::DeviceManager& dm,
                                 Session& s)
     : engine (e), deviceManager (dm), session (s)
 {

--- a/src/ui/SelfTestPanel.h
+++ b/src/ui/SelfTestPanel.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <juce_audio_devices/juce_audio_devices.h>
 #include <juce_gui_basics/juce_gui_basics.h>
+#include "../engine/device/DeviceManager.h"
 
 namespace duskstudio
 {
@@ -15,7 +15,7 @@ class SelfTestPanel final : public juce::Component
 {
 public:
     SelfTestPanel (AudioEngine& engine,
-                    juce::AudioDeviceManager& dm,
+                    device::DeviceManager& dm,
                     Session& session);
 
     // Wired by the host to tear down the EmbeddedModal hosting this panel.
@@ -27,7 +27,7 @@ public:
 
 private:
     AudioEngine& engine;
-    juce::AudioDeviceManager& deviceManager;
+    device::DeviceManager& deviceManager;
     Session& session;
 
     juce::TextEditor   logView;

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -10,7 +10,6 @@ src/dsp/MasteringChain.h
 src/engine/AudioEngine.cpp
 src/engine/AudioEngine.h
 src/engine/AudioPipelineSelfTest.cpp
-src/engine/AudioPipelineSelfTest.h
 src/engine/BounceEngine.cpp
 src/engine/BounceEngine.h
 src/engine/DpAligner.cpp


### PR DESCRIPTION
Phase 2c of the device-layer de-JUCE. `AudioEngine::getDeviceManager()` now returns the dusk `device::DeviceManager` instead of the wrapped `juce::AudioDeviceManager`, so no JUCE device type crosses into the settings UI or self-test.

## What changed

**Seam** (`device/DeviceManager`): single `setChangeCallback` becomes a keyed `addChangeListener(void*, fn)` / `removeChangeListener(void*)` / `notifyChange()`, so the engine's hot-unplug handler and the settings UI subscribe independently. Listeners are copied before firing for re-entrancy safety.

**AudioEngine**: `getDeviceManager()` returns `device::DeviceManager&`; the hot-unplug handler moved to the listener API.

**Consumers flipped** to the dusk API (`getSetup`/`setSetup`, `getCurrentDevice`, `get/setCurrentDeviceType`, `getAvailableDeviceTypes`, `ChannelSet::count()`):
- DuskAudioDeviceSelector, AudioSettingsPanel
- AudioPipelineSelfTest + SelfTestPanel (backend cycle + UMC1820 probe round-trip the dusk setup/type)
- HardwareInsertEditor (+ now refreshes its channel dropdowns on device hot-swap via the listener), AuxLaneComponent (active-output mask `juce::BigInteger` -> `device::ChannelSet`)
- MainComponent sample-rate reconcile, DuskStudioApp bounce close

**MIDI hatch retained**: `juceManager()` stays, wired internally by AudioEngine for `MidiInputClient` alone. It is removed when the native MIDI backend lands and `juce_audio_devices` unlinks (a later phase).

`AudioPipelineSelfTest.h` is now JUCE-free and drops off `tools/juce-allowlist.txt`.

## Validation

- App build clean (no new warnings from touched files)
- 389/389 Catch2 tests pass
- `tools/juce-gate.sh` passes (194 coupled files)
- Self-test under Xvfb: 36 PASS / 0 FAIL; device backend-cycle + setup round-trip confirmed at runtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved audio device change handling across settings, routing, hardware inserts, and self-tests.
  * Audio settings now refresh reliably after rescanning devices or changing backends.
  * Device selector updates dependent controls after successful configuration changes.

* **Bug Fixes**
  * Improved device setup restoration and error reporting.
  * Prevented stale device-change callbacks when closing audio-related panels.
  * Improved output-channel and routing list updates when devices change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->