### PR TITLE
87 improve scrolling on native windowsdrop downs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,12 @@ playback.
 
 ### Fixed
 
-- **Aux sends on a monitored input during playback.** With **IN** engaged an
-  audio track's live input reached the master dry but its aux sends went
-  silent the moment PLAY was pressed, returning only on Record - so a vocal
-  monitored with reverb lost the reverb while playing along, then got it back
-  on record. Live input now runs the full channel strip during playback, so
+- **Aux sends on a monitored input during playback.** With **IN** engaged,
+  pressing PLAY selected only the disk take for channel-strip processing, so
+  an audio track's live monitored input - and every aux send fed from it -
+  went silent, returning only on Record - so a vocal monitored with reverb
+  lost the reverb while playing along, then got it back on record. Live input
+  now runs the full channel strip during playback, so
   its sends (headphone reverb/delay while tracking) sound in every transport
   state. The audio twin of the 0.12.1 live-play-along fix.
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1485,7 +1485,9 @@ Drop a `.sfz` or `.sf2` file onto a MIDI track's insert slot to load it through 
 - **Master tune**: −100 to +100 cents.
 - **Polyphony cap**: 1 to 256 voices.
 
-The loaded file path is saved with the session.
+When a `.sf2` holds more than one preset (most GM/GS/XG SoundFonts do), a **preset picker** appears. Click it to open a filterable browser: start typing to filter presets by name or number, or read across the columns. Presets are grouped program-first — an instrument and its bank variations list together, drum kits last — each shown as `program [bank] name`.
+
+The loaded file path and the chosen preset are saved with the session.
 
 \newpage
 

--- a/src/engine/AudioPipelineSelfTest.cpp
+++ b/src/engine/AudioPipelineSelfTest.cpp
@@ -1258,9 +1258,35 @@ juce::String AudioPipelineSelfTest::testAudioPlayAlongSends()
     auto& ts0 = t0.strip;
     auto& aux0 = session.auxLane (0).params;
 
-    // Snapshot the atoms the outer runAll restore doesn't cover.
-    const float savedSend   = ts0.auxSendDb[0].load (std::memory_order_relaxed);
+    // Snapshot the atoms the outer runAll restore doesn't cover. Aux 0's return
+    // level / mute / automation mode all steer meterPostL, so normalise them to
+    // a known empty-lane-at-unity state for the probe and restore afterwards.
+    const float savedSend    = ts0.auxSendDb[0].load (std::memory_order_relaxed);
     const bool  savedAuxMute = aux0.mute.load (std::memory_order_relaxed);
+    const float savedAuxRet  = aux0.returnLevelDb.load (std::memory_order_relaxed);
+    const int   savedAuxMode = aux0.automationMode.load (std::memory_order_relaxed);
+    const int   savedTrkMode = t0.automationMode.load (std::memory_order_relaxed);
+
+    // The dry-pass assumption above only holds with aux 0's insert slots empty;
+    // a plugin / hardware insert left by the loaded session would reshape the
+    // send and mask a dropped monitor path. Snapshot each slot's mode, force it
+    // empty for the probe, restore afterward.
+    auto& auxStrip0 = engine.getAuxLaneStrip (0);
+    std::array<int, AuxLaneStrip::kMaxPlugins> savedInsertMode {};
+    for (int s = 0; s < AuxLaneStrip::kMaxPlugins; ++s)
+    {
+        savedInsertMode[(size_t) s] = auxStrip0.insertMode[(size_t) s].load (std::memory_order_acquire);
+        auxStrip0.insertMode[(size_t) s].store (AuxLaneStrip::kInsertEmpty, std::memory_order_release);
+    }
+
+    // Track 0's own channel-strip insert sits upstream of the aux send (it runs
+    // pre-EQ), so a plugin / hardware insert left by the loaded session would
+    // reshape the monitored signal before it reaches the send and mask a dropped
+    // path just as an aux insert would. prepareCleanState resets the strip's
+    // params but not its DSP insert slot - neutralise it here, restore after.
+    auto& chStrip0 = engine.getChannelStrip (0);
+    const int savedTrkInsertMode = chStrip0.insertMode.load (std::memory_order_acquire);
+    chStrip0.insertMode.store (ChannelStrip::kInsertEmpty, std::memory_order_release);
 
     // Track 0: mono, input-monitored, listening to input channel 0, sending to
     // aux lane 0 at unity. Other tracks muted so only track 0 can drive aux 0.
@@ -1268,14 +1294,27 @@ juce::String AudioPipelineSelfTest::testAudioPlayAlongSends()
     t0.inputSource.store  (0, std::memory_order_relaxed);
     t0.inputMonitor.store (true, std::memory_order_relaxed);
     t0.recordArmed.store  (false, std::memory_order_relaxed);
+    // Off so Read/Touch automation on the loaded session's track 0 can't
+    // override the manual fader / mute / send set below.
+    t0.automationMode.store ((int) AutomationMode::Off, std::memory_order_relaxed);
     ts0.mute.store        (false, std::memory_order_relaxed);
     ts0.faderDb.store     (0.0f, std::memory_order_relaxed);
     ts0.auxSendDb[0].store (0.0f, std::memory_order_relaxed);
-    aux0.mute.store       (false, std::memory_order_relaxed);
+    aux0.mute.store           (false, std::memory_order_relaxed);
+    aux0.returnLevelDb.store  (0.0f,  std::memory_order_relaxed);   // unity return
+    aux0.automationMode.store (0,     std::memory_order_relaxed);   // Off: honour the manual return/mute above
+    // Snapshot + neutralise each other track's automation mode. Read/Touch mute
+    // automation on the loaded session would otherwise un-mute the track at the
+    // current playhead during the Playing probe and let it drive aux 0, defeating
+    // the isolation. Restored below (SavedState doesn't round-trip automationMode).
+    std::array<int, Session::kNumTracks> savedOtherTrkMode {};
     for (int t = 1; t < Session::kNumTracks; ++t)
     {
-        session.track (t).inputMonitor.store (false, std::memory_order_relaxed);
-        session.track (t).strip.mute.store (true, std::memory_order_relaxed);
+        auto& tt = session.track (t);
+        savedOtherTrkMode[(size_t) t] = tt.automationMode.load (std::memory_order_relaxed);
+        tt.inputMonitor.store (false, std::memory_order_relaxed);
+        tt.strip.mute.store (true, std::memory_order_relaxed);
+        tt.automationMode.store ((int) AutomationMode::Off, std::memory_order_relaxed);
     }
     session.recomputeRtCounters();
 
@@ -1310,13 +1349,35 @@ juce::String AudioPipelineSelfTest::testAudioPlayAlongSends()
         return aux0.meterPostL.load (std::memory_order_relaxed);
     };
 
+    // Isolate the monitored-input send path: the meter must reflect the live
+    // overlay alone, never a disk take on track 0. Empty track 0's playback
+    // source and rebuild the readers via play()'s prep path so streams[0] is
+    // null (no disk audio) in both transport states - otherwise a stray disk
+    // region would prop the meter up and mask a dropped send while rolling.
+    auto savedRegions      = std::move (t0.regions);
+    t0.regions.clear();
+    const bool savedFrozen = t0.frozen.load (std::memory_order_acquire);
+    t0.frozen.store (false, std::memory_order_release);
+    engine.getPlaybackEngine().preparePlayback();
+
     const float stoppedDb = probe (Transport::State::Stopped);
     const float playingDb  = probe (Transport::State::Playing);
 
     // Restore.
     engine.getTransport().setState (Transport::State::Stopped);
+    engine.getPlaybackEngine().stopPlayback();   // tear down the probe's temp readers
+    t0.frozen.store (savedFrozen, std::memory_order_release);
+    t0.regions = std::move (savedRegions);
     ts0.auxSendDb[0].store (savedSend, std::memory_order_relaxed);
-    aux0.mute.store        (savedAuxMute, std::memory_order_relaxed);
+    aux0.mute.store           (savedAuxMute, std::memory_order_relaxed);
+    aux0.returnLevelDb.store  (savedAuxRet,  std::memory_order_relaxed);
+    aux0.automationMode.store (savedAuxMode, std::memory_order_relaxed);
+    t0.automationMode.store   (savedTrkMode, std::memory_order_relaxed);
+    for (int t = 1; t < Session::kNumTracks; ++t)
+        session.track (t).automationMode.store (savedOtherTrkMode[(size_t) t], std::memory_order_relaxed);
+    for (int s = 0; s < AuxLaneStrip::kMaxPlugins; ++s)
+        auxStrip0.insertMode[(size_t) s].store (savedInsertMode[(size_t) s], std::memory_order_release);
+    chStrip0.insertMode.store (savedTrkInsertMode, std::memory_order_release);
 
     constexpr float kFloorDb = -60.0f;
     const bool stoppedOK = stoppedDb > kFloorDb;
@@ -1388,17 +1449,24 @@ juce::String AudioPipelineSelfTest::runAll()
     // live input straight to the speakers while each device is open. So probe
     // with monitoring forced OFF on every track, then restore the user's real
     // session once the cycle (which opens real devices) is done.
+    std::array<int, Session::kNumTracks> savedTrkAutoMode {};
     for (int t = 0; t < Session::kNumTracks; ++t)
     {
-        session.track (t).inputMonitor.store (false, std::memory_order_relaxed);
-        session.track (t).recordArmed.store  (false, std::memory_order_relaxed);
+        auto& tt = session.track (t);
+        savedTrkAutoMode[(size_t) t] = tt.automationMode.load (std::memory_order_relaxed);
+        tt.inputMonitor.store (false, std::memory_order_relaxed);
+        tt.recordArmed.store  (false, std::memory_order_relaxed);
         // Clearing monitor/arm stops LIVE input, but a self-generating plugin
         // (drone synth, noise box) on an unmuted track would still reach the
         // speakers while real devices are open. Hard-mute + clear solo for
         // unconditional silence (same enforcement prepareCleanState uses for the
         // synthetic tests). restoreState(savedSession) below reverts both.
-        session.track (t).strip.mute.store (true,  std::memory_order_relaxed);
-        session.track (t).strip.solo.store (false, std::memory_order_relaxed);
+        tt.strip.mute.store (true,  std::memory_order_relaxed);
+        tt.strip.solo.store (false, std::memory_order_relaxed);
+        // Off so Read/Touch mute automation can't override the forced mute at the
+        // current playhead. SavedState doesn't round-trip automationMode, so it's
+        // snapshotted here and restored after the cycle.
+        tt.automationMode.store ((int) AutomationMode::Off, std::memory_order_relaxed);
     }
     // Bus solos too: a soloed bus gates the master mix via the SIP solo logic,
     // so leave none set while probing.
@@ -1408,10 +1476,17 @@ juce::String AudioPipelineSelfTest::runAll()
     // on an unmuted aux lane sums into the master while real devices are open.
     // SavedState doesn't capture aux, so snapshot + restore the mute here.
     std::array<bool, Session::kNumAuxLanes> savedAuxMute {};
+    std::array<int,  Session::kNumAuxLanes> savedAuxAutoMode {};
     for (int a = 0; a < Session::kNumAuxLanes; ++a)
     {
-        savedAuxMute[(size_t) a] = session.auxLane (a).params.mute.load (std::memory_order_relaxed);
-        session.auxLane (a).params.mute.store (true, std::memory_order_relaxed);
+        auto& ap = session.auxLane (a).params;
+        savedAuxMute[(size_t) a]     = ap.mute.load (std::memory_order_relaxed);
+        savedAuxAutoMode[(size_t) a] = ap.automationMode.load (std::memory_order_relaxed);
+        ap.mute.store (true, std::memory_order_relaxed);
+        // Same reason as the per-track Off above: aux lanes carry a mute
+        // automation lane, and Read/Touch would drive liveMute back to the
+        // automated value at the playhead, undoing the forced mute.
+        ap.automationMode.store ((int) AutomationMode::Off, std::memory_order_relaxed);
     }
     session.recomputeRtCounters();
     // The synthetic tests force the engine serial (setWorkerCountForTest(0));
@@ -1426,7 +1501,13 @@ juce::String AudioPipelineSelfTest::runAll()
     // Probe done (devices opened/closed) - reinstate the user's real session.
     restoreState (savedSession);
     for (int a = 0; a < Session::kNumAuxLanes; ++a)
-        session.auxLane (a).params.mute.store (savedAuxMute[(size_t) a], std::memory_order_relaxed);
+    {
+        auto& ap = session.auxLane (a).params;
+        ap.mute.store (savedAuxMute[(size_t) a], std::memory_order_relaxed);
+        ap.automationMode.store (savedAuxAutoMode[(size_t) a], std::memory_order_relaxed);
+    }
+    for (int t = 0; t < Session::kNumTracks; ++t)
+        session.track (t).automationMode.store (savedTrkAutoMode[(size_t) t], std::memory_order_relaxed);
 
     report.add ("");
     report.add ("=== End of Self-Test ===");

--- a/src/engine/multisample/DuskMultisampleProcessor.cpp
+++ b/src/engine/multisample/DuskMultisampleProcessor.cpp
@@ -1,5 +1,6 @@
 #include "DuskMultisampleProcessor.h"
 #include "Sf2ToSfz.h"
+#include "Sf2PresetSort.h"
 #include "../../ui/multisample/DuskMultisampleEditor.h"
 
 #include <sfizz.h>
@@ -169,7 +170,10 @@ void DuskMultisampleProcessor::clearLoadedFile()
     }
     // Drop SF2 preset state too so the editor's program switcher doesn't
     // show stale presets from the just-unloaded SoundFont.
-    sf2PresetNames.clear();
+    {
+        const juce::ScopedLock sl (sf2PresetsLock);
+        sf2Presets.clear();
+    }
     sf2PresetIndex = -1;
     loadedFilePath.clear();
     lastLoadError.clear();
@@ -189,14 +193,31 @@ bool DuskMultisampleProcessor::loadSf2File (const juce::File& sf2,
         return false;
     }
 
-    // Cache the preset name list (cheap metadata parse, no sample
-    // extraction) so the editor can offer a program switcher.
-    sf2PresetNames.clear();
+    // Cache display metadata without disturbing source indices. SF2 does not
+    // require PHDR records to be ordered, while the source index is persisted
+    // in sessions and passed to the converter. Build it in temporary storage
+    // and commit only after the preset-0 load below succeeds, so a failed load
+    // leaves the previously loaded SF2's metadata intact.
+    std::vector<Sf2PresetInfo> candidates;
     if (auto parsed = readSf2 (sf2); parsed.ok)
-        for (const auto& p : parsed.presets)
-            sf2PresetNames.add (p.name);
+    {
+        candidates.reserve (parsed.presets.size());
+        for (size_t i = 0; i < parsed.presets.size(); ++i)
+        {
+            const auto& p = parsed.presets[i];
+            candidates.push_back ({ p.name, (int) i, (int) p.bank, (int) p.preset });
+        }
+        sortSf2PresetsForDisplay (candidates);
+    }
 
-    return applySf2Preset (sf2, 0, errorMessage);
+    if (! applySf2Preset (sf2, 0, errorMessage))
+        return false;
+
+    {
+        const juce::ScopedLock sl (sf2PresetsLock);
+        sf2Presets = std::move (candidates);
+    }
+    return true;
 }
 
 bool DuskMultisampleProcessor::loadSf2Preset (int presetIndex,
@@ -225,11 +246,18 @@ void DuskMultisampleProcessor::loadFileAsync (
         const bool ok = file.getFileExtension().toLowerCase() == ".sf2"
                             ? loadSf2File (file, err)
                             : loadSfzFile (file, err);
-        juce::MessageManager::callAsync ([this, onDone, ok, err]
+        juce::MessageManager::callAsync (
+            [weak = juce::WeakReference<DuskMultisampleProcessor> (this), onDone, ok, err]
         {
+            // Skip entirely if the processor was destroyed after posting this:
+            // removeAllJobs joins the pool job, not this queued callback.
+            auto* self = weak.get();
+            if (self == nullptr) return;
+            // Clear pending FIRST so the UI refresh in onDone observes the
+            // finished load: getSf2Presets / getNumRegions / control-image
+            // queries all return empty while a load is pending.
+            self->loadPending.store (false, std::memory_order_release);
             if (onDone) onDone (ok, err);
-            // Stay authoritative until the UI completion has run.
-            loadPending.store (false, std::memory_order_release);
         });
     });
 }
@@ -246,11 +274,16 @@ void DuskMultisampleProcessor::loadSf2PresetAsync (
     {
         juce::String err;
         const bool ok = loadSf2Preset (presetIndex, err);
-        juce::MessageManager::callAsync ([this, onDone, ok, err]
+        juce::MessageManager::callAsync (
+            [weak = juce::WeakReference<DuskMultisampleProcessor> (this), onDone, ok, err]
         {
+            auto* self = weak.get();
+            if (self == nullptr) return;
+            // Clear pending FIRST, mirroring loadFileAsync - onDone re-runs the
+            // editor's timerCallback, whose pending-guarded getters would
+            // otherwise observe an empty snapshot.
+            self->loadPending.store (false, std::memory_order_release);
             if (onDone) onDone (ok, err);
-            // Stay authoritative until the UI completion has run.
-            loadPending.store (false, std::memory_order_release);
         });
     });
 }
@@ -297,8 +330,12 @@ bool DuskMultisampleProcessor::applySf2Preset (const juce::File& sf2,
         impl->sf2TempDir.deleteRecursively();
     impl->sf2TempDir = newDir;
 
-    sf2PresetIndex = juce::jlimit (0, juce::jmax (0, sf2PresetNames.size() - 1),
-                                    presetIndex);
+    int presetCount;
+    {
+        const juce::ScopedLock sl (sf2PresetsLock);
+        presetCount = (int) sf2Presets.size();
+    }
+    sf2PresetIndex = juce::jlimit (0, juce::jmax (0, presetCount - 1), presetIndex);
     loadedFilePath = sf2.getFullPathName();
     lastLoadError.clear();
     return true;
@@ -354,7 +391,10 @@ bool DuskMultisampleProcessor::loadSfzFile (const juce::File& sfz,
     }
     // Clear SF2 preset state - an SFZ load has no presets, and leaving
     // the previous SF2's list around would show a stale program switcher.
-    sf2PresetNames.clear();
+    {
+        const juce::ScopedLock sl (sf2PresetsLock);
+        sf2Presets.clear();
+    }
     sf2PresetIndex = -1;
     loadedFilePath = sfz.getFullPathName();
     lastLoadError.clear();
@@ -545,14 +585,19 @@ void DuskMultisampleProcessor::setStateInformation (const void* data, int size)
         setPolyphony (juce::jlimit (1, 256, (int) state.getProperty ("polyphony")));
 
     // Restore the SF2 preset selection (no-op for SFZ). Must run after
-    // the file load above so the SF2 name list + sfizz state exist.
+    // the file load above so the SF2 metadata + sfizz state exist.
     // idx == 0 is deliberately skipped: loadSf2File already loaded
     // preset 0, so re-loading it would be redundant work. Only a
     // non-default saved preset needs an explicit switch.
     if (state.hasProperty ("sf2Preset"))
     {
         const int idx = (int) state.getProperty ("sf2Preset");
-        if (idx > 0 && idx < sf2PresetNames.size())
+        int presetCount;
+        {
+            const juce::ScopedLock sl (sf2PresetsLock);
+            presetCount = (int) sf2Presets.size();
+        }
+        if (idx > 0 && idx < presetCount)
         {
             juce::String err;
             loadSf2Preset (idx, err);

--- a/src/engine/multisample/DuskMultisampleProcessor.h
+++ b/src/engine/multisample/DuskMultisampleProcessor.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <juce_audio_processors/juce_audio_processors.h>
+
 #include <memory>
+#include <vector>
 
 namespace duskstudio
 {
@@ -54,17 +56,35 @@ public:
 
     // Load an .sf2 (SoundFont 2) file. Converts the first preset to SFZ
     // + extracted WAVs (Sf2Reader + Sf2ToSfz) and plays it through the
-    // vendored sfizz engine - no fluidsynth dependency. Caches the
-    // preset name list for the editor's program switcher.
+    // vendored sfizz engine - no fluidsynth dependency. Caches preset
+    // display metadata for the editor's program switcher.
     bool loadSf2File (const juce::File& sf2, juce::String& errorMessage);
 
     // Switch the loaded SF2 to another preset (re-converts + reloads).
     // No-op error when the current file isn't an SF2.
     bool loadSf2Preset (int presetIndex, juce::String& errorMessage);
 
-    // Preset names of the loaded SF2 (empty for SFZ / no file). The
-    // editor populates its program dropdown from this.
-    const juce::StringArray& getSf2PresetNames() const noexcept { return sf2PresetNames; }
+    struct Sf2PresetInfo
+    {
+        juce::String name;
+        int sourceIndex { 0 };
+        int bank        { 0 };
+        int program     { 0 };
+    };
+
+    // Sorted for display by bank/program. sourceIndex remains the preset's
+    // original PHDR position, which is the stable ID used for loading and
+    // session persistence. Hands back a snapshot, not a reference: a background
+    // load clears + rebuilds sf2Presets on the loader thread, so a caller
+    // holding a reference could see it realloc mid-iteration. Empty while a load
+    // is pending (matches getNumRegions / getControlCcLabels /
+    // getControlImagePath).
+    std::vector<Sf2PresetInfo> getSf2Presets() const
+    {
+        if (isLoadPending()) return {};
+        const juce::ScopedLock sl (sf2PresetsLock);
+        return sf2Presets;
+    }
     int getSf2PresetIndex() const noexcept { return sf2PresetIndex; }
 
     // True if a soundfont has been loaded. Used by editor UI to show
@@ -160,9 +180,12 @@ private:
     juce::String lastLoadError;      // most recent setState / load failure
     Overrides overrides;
 
-    // SF2 program switcher state: cached preset names + the active one.
-    juce::StringArray sf2PresetNames;
-    int               sf2PresetIndex { 0 };
+    // SF2 program switcher state: display metadata + active source index.
+    // sf2PresetsLock guards every replacement of the vector against the
+    // snapshot getSf2Presets() copies out on the message thread.
+    std::vector<Sf2PresetInfo> sf2Presets;
+    juce::CriticalSection      sf2PresetsLock;
+    int                        sf2PresetIndex { 0 };
 
     // CC control plumbing. ccCache holds the last value the UI set per
     // CC (-1 = unset) for read-back + state save. ccFifo carries
@@ -198,5 +221,12 @@ private:
     // invert that order either.
     std::atomic<bool> loadPending { false };
     juce::ThreadPool  loadPool { 1 };
+
+    // A background load's completion is posted via MessageManager::callAsync,
+    // which outlives the pool job the destructor joins. The queued callback
+    // guards on this token so it no-ops if the processor was destroyed before
+    // it ran (destruction + the callback are both message-thread, so the weak
+    // ref's clear/get never race).
+    JUCE_DECLARE_WEAK_REFERENCEABLE (DuskMultisampleProcessor)
 };
 } // namespace duskstudio

--- a/src/engine/multisample/Sf2PresetSort.h
+++ b/src/engine/multisample/Sf2PresetSort.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <algorithm>
+#include <vector>
+
+namespace duskstudio
+{
+// Display order for an SF2's presets, program-first: an instrument and its
+// bank "variants" stay together (bank is a MIDI variant selector, not a
+// category), so program 34's Picked Bass variants list as a block rather than
+// scattering one-per-bank. Order is:
+//   1. melodic before percussion  (bank 128 is a drum kit, NOT a variant of
+//      the same-numbered melodic program, so it must not interleave)
+//   2. program ascending
+//   3. bank ascending             (the variants within a program)
+//   4. sourceIndex ascending      (deterministic tiebreak)
+// sourceIndex is the stable ID used for loading and session persistence, so it
+// must never be reordered by the sort - only the visual ordering changes.
+// Templated on the preset struct so the ordering can be unit-tested against a
+// plain POD with no engine or sfizz dependencies (see tests/sf2_preset_sort.cpp).
+template <typename Preset>
+inline void sortSf2PresetsForDisplay (std::vector<Preset>& presets)
+{
+    std::sort (presets.begin(), presets.end(),
+        [] (const Preset& a, const Preset& b)
+        {
+            const bool aPerc = a.bank == 128, bPerc = b.bank == 128;
+            if (aPerc != bPerc)         return ! aPerc;      // melodic first
+            if (a.program != b.program) return a.program < b.program;
+            if (a.bank != b.bank)       return a.bank < b.bank;
+            return a.sourceIndex < b.sourceIndex;
+        });
+}
+} // namespace duskstudio

--- a/src/ui/DuskComboBox.cpp
+++ b/src/ui/DuskComboBox.cpp
@@ -1,6 +1,8 @@
 #include "DuskComboBox.h"
 #include "EmbeddedModal.h"
 
+#include <cmath>
+
 namespace duskstudio
 {
 namespace
@@ -14,68 +16,328 @@ EmbeddedModal& sharedComboModal()
     return m;
 }
 
-// Vertical list panel. One row per non-separator menu item; section
-// headers render as bold labels; separators as thin dividers.
-// Selection fires onPick(itemId) and closes the modal.
-class DuskComboPanel final : public juce::Component
+constexpr int kBorder      = 4;
+constexpr int kTitleH      = 24;
+constexpr int kRowH        = 26;
+constexpr int kSepH        = 8;
+constexpr int kScrollbarW  = 8;
+constexpr int kTextXPad    = 24;  // tick column on the left of each row
+constexpr int kTrailPad    = 18;
+constexpr int kColGap       = 12; // gutter (holding the divider) between grid columns
+constexpr int kHScrollH     = 10; // horizontal scrollbar strip at the popup's foot
+constexpr int kGridCapRows  = 22; // keep the grid short: cap a column at this many rows
+constexpr int kSearchH      = 30; // type-to-filter box atop the grid
+constexpr int kCaretBlinkMs = 500; // filter-box caret blink half-period
+
+struct Row
+{
+    juce::String text;
+    int          itemId    = 0;       // 0 = non-clickable header / separator
+    bool         isHeader  = false;
+    bool         isSep     = false;
+    bool         isTicked  = false;
+    bool         isEnabled = true;
+};
+
+// One vertically-scrolling column of rows. Owns its rows, viewport `bounds`
+// (in panel coordinates) and its scroll/hover state; paints and hit-tests
+// entirely within `bounds`. An ordinary combo is one ListView spanning the
+// popup. (The grid browser flows a flat list into columns instead.)
+struct ListView
+{
+    std::vector<Row>     rows;
+    juce::Rectangle<int> bounds;
+    float scrollOffset = 0.0f;
+    int   hovered      = -1;
+    bool  dragging     = false;
+    int   dragStartY   = 0;
+    float dragStartOffset = 0.0f;
+
+    int count() const noexcept { return (int) rows.size(); }
+
+    int rowExtent (int index) const noexcept
+    {
+        return rows[(size_t) index].isSep ? kSepH : kRowH;
+    }
+
+    int contentHeight() const noexcept
+    {
+        int h = 0;
+        for (int i = 0; i < count(); ++i)
+            h += rowExtent (i);
+        return h;
+    }
+
+    float maxScroll() const noexcept
+    {
+        return (float) juce::jmax (0, contentHeight() - bounds.getHeight());
+    }
+
+    int scrollbarW() const noexcept { return maxScroll() > 0.0f ? kScrollbarW : 0; }
+
+    void setScroll (float offset) noexcept
+    {
+        scrollOffset = juce::jlimit (0.0f, maxScroll(), offset);
+    }
+
+    int rowTop (int index) const noexcept
+    {
+        int y = 0;
+        for (int i = 0; i < index && i < count(); ++i)
+            y += rowExtent (i);
+        return y;
+    }
+
+    bool isSelectable (int index) const noexcept
+    {
+        if (index < 0 || index >= count()) return false;
+        const auto& r = rows[(size_t) index];
+        return ! r.isSep && ! r.isHeader && r.isEnabled && r.itemId != 0;
+    }
+
+    void ensureVisible (int index) noexcept
+    {
+        if (index < 0 || index >= count()) return;
+        const int top    = rowTop (index);
+        const int bottom = top + rowExtent (index);
+        const int vh     = bounds.getHeight();
+        if ((float) top < scrollOffset)
+            setScroll ((float) top);
+        else if ((float) bottom > scrollOffset + (float) vh)
+            setScroll ((float) (bottom - vh));
+    }
+
+    int rowAtY (juce::Point<int> p) const noexcept
+    {
+        if (! bounds.contains (p)) return -1;
+        int yy = bounds.getY() - juce::roundToInt (scrollOffset);
+        for (int i = 0; i < count(); ++i)
+        {
+            const int h = rowExtent (i);
+            if (p.y >= yy && p.y < yy + h) return i;
+            yy += h;
+        }
+        return -1;
+    }
+
+    void moveHover (int direction, int steps) noexcept
+    {
+        int next = hovered;
+        if (next < 0 || next >= count())
+            next = direction > 0 ? -1 : count();
+
+        int moved = 0;
+        while (moved < steps)
+        {
+            do { next += direction; }
+            while (next >= 0 && next < count() && ! isSelectable (next));
+            if (next < 0 || next >= count()) break;
+            hovered = next;
+            ++moved;
+        }
+        ensureVisible (hovered);
+    }
+
+    void moveToBoundary (int direction) noexcept
+    {
+        int next = direction > 0 ? 0 : count() - 1;
+        while (next >= 0 && next < count() && ! isSelectable (next))
+            next += direction;
+        if (isSelectable (next))
+        {
+            hovered = next;
+            ensureVisible (hovered);
+        }
+    }
+
+    juce::Rectangle<int> scrollbarTrack() const noexcept
+    {
+        if (scrollbarW() == 0) return {};
+        return { bounds.getRight() - kScrollbarW, bounds.getY(), kScrollbarW, bounds.getHeight() };
+    }
+
+    juce::Rectangle<int> scrollbarThumb() const noexcept
+    {
+        const auto track = scrollbarTrack();
+        if (track.isEmpty()) return {};
+        const float visibleRatio = (float) bounds.getHeight() / (float) contentHeight();
+        const int thumbHeight = juce::jmax (20, juce::roundToInt (
+                                                    (float) track.getHeight() * visibleRatio));
+        const int travel = juce::jmax (0, track.getHeight() - thumbHeight);
+        const float progress = maxScroll() > 0.0f ? scrollOffset / maxScroll() : 0.0f;
+        return { track.getX(), track.getY() + juce::roundToInt ((float) travel * progress),
+                 track.getWidth(), thumbHeight };
+    }
+
+    bool pressScrollbar (juce::Point<int> p) noexcept
+    {
+        const auto track = scrollbarTrack();
+        if (track.isEmpty() || ! track.contains (p)) return false;
+        auto thumb = scrollbarThumb();
+        if (! thumb.contains (p))
+        {
+            const int travel = juce::jmax (1, track.getHeight() - thumb.getHeight());
+            const float progress = juce::jlimit (
+                0.0f, 1.0f,
+                (float) (p.y - track.getY() - thumb.getHeight() / 2) / (float) travel);
+            setScroll (progress * maxScroll());
+        }
+        dragging = true;
+        dragStartY = p.y;
+        dragStartOffset = scrollOffset;
+        return true;
+    }
+
+    void dragScrollbar (juce::Point<int> p) noexcept
+    {
+        if (! dragging) return;
+        const auto track = scrollbarTrack();
+        const auto thumb = scrollbarThumb();
+        const int travel = juce::jmax (1, track.getHeight() - thumb.getHeight());
+        setScroll (dragStartOffset + (float) (p.y - dragStartY)
+                                        * maxScroll() / (float) travel);
+    }
+
+    void paint (juce::Graphics& g) const
+    {
+        g.saveState();
+        g.reduceClipRegion (bounds);
+        const int rowW = bounds.getWidth() - scrollbarW();
+        int y = bounds.getY() - juce::roundToInt (scrollOffset);
+        for (int i = 0; i < count(); ++i)
+        {
+            const auto& r = rows[(size_t) i];
+            if (r.isSep)
+            {
+                g.setColour (juce::Colour (0xff2a2a30));
+                g.drawHorizontalLine (y + kSepH / 2,
+                                        (float) bounds.getX() + 4.0f,
+                                        (float) (bounds.getX() + rowW - 4));
+                y += kSepH;
+                continue;
+            }
+
+            const auto rowR = juce::Rectangle<int> (bounds.getX(), y, rowW, kRowH);
+            paintRow (g, rowR, r.text, r.isHeader, r.isEnabled, r.isTicked, i == hovered);
+            y += kRowH;
+        }
+        g.restoreState();
+
+        const auto track = scrollbarTrack();
+        if (! track.isEmpty())
+        {
+            g.setColour (juce::Colour (0xff202028));
+            g.fillRect (track);
+            g.setColour (juce::Colour (0xff5a5a68));
+            g.fillRect (scrollbarThumb().reduced (1, 0));
+        }
+    }
+
+    // Shared row painter, also used by the grid.
+    static void paintRow (juce::Graphics& g, juce::Rectangle<int> rowR,
+                          const juce::String& text, bool isHeader, bool isEnabled,
+                          bool isTicked, bool isHovered)
+    {
+        if (isHeader)
+        {
+            g.setColour (juce::Colour (0xff8090a0));
+            g.setFont (juce::Font (juce::FontOptions (12.5f, juce::Font::bold)));
+            g.drawText (text.toUpperCase(), rowR.reduced (10, 0),
+                         juce::Justification::centredLeft, false);
+            return;
+        }
+        if (isHovered)
+        {
+            g.setColour (juce::Colour (0xff2a3a50));
+            g.fillRect (rowR.reduced (2, 0));
+        }
+        g.setColour (isEnabled ? juce::Colours::white : juce::Colour (0xff707080));
+        g.setFont (juce::Font (juce::FontOptions (14.0f)));
+        g.drawText (text,
+                     rowR.withX (rowR.getX() + kTextXPad)
+                          .withWidth (rowR.getWidth() - kTextXPad - 8),
+                     juce::Justification::centredLeft, false);
+        if (isTicked)
+        {
+            g.setColour (juce::Colour (0xff60d060));
+            g.fillEllipse ((float) rowR.getX() + 8.0f,
+                            (float) rowR.getCentreY() - 3.5f, 7.0f, 7.0f);
+        }
+    }
+};
+
+// Popup body. Ordinary combos render a single flat scrolling ListView. When the
+// owning combo opts into the grid browser, the item list is flowed into a short,
+// wide set of columns with a type-to-filter box on top: a long preset list
+// (hundreds of SoundFont programs) reads across instead of scrolling forever.
+// The list is presented in its incoming order (the SF2 editor sorts it
+// program-first so an instrument's bank variants group together).
+class DuskComboPanel final : public juce::Component,
+                             private juce::Timer
 {
 public:
-    struct Row
-    {
-        juce::String text;
-        int          itemId    = 0;       // 0 = non-clickable header / separator
-        bool         isHeader  = false;
-        bool         isSep     = false;
-        bool         isTicked  = false;
-        bool         isEnabled = true;
-    };
+    using Row = duskstudio::Row;
 
     DuskComboPanel (juce::String headerTitle,
                      std::vector<Row> rows,
-                     std::function<void (int)> onPick)
+                     std::function<void (int)> onPick,
+                     std::function<void()> onDismiss,
+                     int maximumHeight,
+                     int maximumWidth,
+                     bool gridBrowser)
         : title (std::move (headerTitle)),
-          rowsData (std::move (rows)),
-          onPickFn (std::move (onPick))
+          onPickFn (std::move (onPick)),
+          onDismissFn (std::move (onDismiss))
     {
         setOpaque (true);
         setWantsKeyboardFocus (true);
 
-        // Compute width from the widest item text so short-item combos
-        // (freq pickers showing "30 Hz" / "8 kHz") don't render a
-        // ridiculous 260-px-wide list. Add fixed padding for the tick
-        // dot column (24 px text X-offset) + trailing space (18 px) +
-        // a min/max clamp so very short or pathologically long items
-        // still render readably.
-        constexpr int kRowH      = 26;
-        constexpr int kSepH      = 8;
-        constexpr int kBottomPad = 8;
-        constexpr int kTextXPad  = 24;  // tick column on the left of each row
-        constexpr int kTrailPad  = 18;
-        constexpr int kMinW      = 100;
-        constexpr int kMaxW      = 320;
-
-        const juce::Font rowFont   { juce::FontOptions (14.0f) };
-        const juce::Font headerFont{ juce::FontOptions (14.5f, juce::Font::bold) };
-        int maxTextW = 0;
-        for (const auto& r : rowsData)
+        // Grid needs room for the fixed chrome (title + search + h-scrollbar)
+        // plus at least one preset row; a pathologically short window falls back
+        // to the flat scrolling list.
+        if (gridBrowser)
         {
-            if (r.isSep) continue;
-            const auto& f = r.isHeader ? headerFont : rowFont;
-            maxTextW = juce::jmax (maxTextW,
-                (int) std::ceil (f.getStringWidthFloat (r.text)));
+            const int chrome = kBorder * 2 + titleHeight() + kSearchH + kHScrollH;
+            useGrid = (juce::jmax (1, maximumHeight) - chrome) / kRowH >= 1;
         }
-        if (title.isNotEmpty())
-            maxTextW = juce::jmax (maxTextW,
-                (int) std::ceil (headerFont.getStringWidthFloat (title)));
 
-        const int w = juce::jlimit (kMinW, kMaxW,
-                                       maxTextW + kTextXPad + kTrailPad);
+        if (useGrid) layoutGrid (std::move (rows), maximumHeight, maximumWidth);
+        else         layoutFlat (std::move (rows), maximumHeight);
 
-        const int headerH = title.isEmpty() ? 0 : 28;
-        int total = headerH + kBottomPad;
-        for (const auto& r : rowsData)
-            total += r.isSep ? kSepH : kRowH;
-        setSize (w, juce::jmax (60, total));
+        setTitle (title.isNotEmpty() ? title : juce::String ("Options"));
+        setDescription (useGrid
+                            ? "Preset browser. Type to filter, arrow keys to move, "
+                              "Return to choose, Escape to close."
+                            : "Arrow keys to move, Return to choose, Escape to close.");
+        announceActive();
+
+        if (useGrid) startTimer (kCaretBlinkMs);   // blinking caret in the filter box
+    }
+
+    void timerCallback() override
+    {
+        caretOn = ! caretOn;
+        repaint (searchRect());
+    }
+
+    // The wide grid reads better centred in the window than crammed under the
+    // combo at the screen edge; the flat list stays anchored to its combo.
+    bool prefersCentred() const noexcept { return useGrid; }
+
+    void resized() override
+    {
+        if (useGrid)
+        {
+            setHScroll (hScroll);
+            ensureColumnVisible (hoverCol);
+        }
+        else
+        {
+            auto area = getLocalBounds().reduced (kBorder);
+            area.removeFromTop (titleHeight());
+            flat.bounds = area;
+            flat.setScroll (flat.scrollOffset);
+        }
     }
 
     void paint (juce::Graphics& g) override
@@ -84,10 +346,10 @@ public:
         g.setColour (juce::Colour (0xff3a3a44));
         g.drawRoundedRectangle (getLocalBounds().toFloat().reduced (0.5f), 4.0f, 1.0f);
 
-        auto area = getLocalBounds().reduced (4);
+        auto area = getLocalBounds().reduced (kBorder);
         if (title.isNotEmpty())
         {
-            auto header = area.removeFromTop (24);
+            auto header = area.removeFromTop (kTitleH);
             g.setColour (juce::Colour (0xffe8e8ec));
             g.setFont (juce::Font (juce::FontOptions (14.5f, juce::Font::bold)));
             g.drawText (title, header.reduced (8, 0),
@@ -98,143 +360,718 @@ public:
                                     (float) header.getRight() - 4.0f);
         }
 
-        // Body rows
-        constexpr int kRowH = 26;
-        constexpr int kSepH = 8;
-        int y = area.getY();
-        for (int i = 0; i < (int) rowsData.size(); ++i)
-        {
-            const auto& r = rowsData[(size_t) i];
-            if (r.isSep)
-            {
-                g.setColour (juce::Colour (0xff2a2a30));
-                g.drawHorizontalLine (y + kSepH / 2,
-                                        (float) area.getX() + 4.0f,
-                                        (float) area.getRight() - 4.0f);
-                y += kSepH;
-                continue;
-            }
-
-            const auto rowR = juce::Rectangle<int> (area.getX(), y, area.getWidth(), kRowH);
-            if (r.isHeader)
-            {
-                g.setColour (juce::Colour (0xff8090a0));
-                g.setFont (juce::Font (juce::FontOptions (12.5f, juce::Font::bold)));
-                g.drawText (r.text.toUpperCase(), rowR.reduced (10, 0),
-                             juce::Justification::centredLeft, false);
-            }
-            else
-            {
-                const bool hovered = (i == hoveredRow);
-                if (hovered)
-                {
-                    g.setColour (juce::Colour (0xff2a3a50));
-                    g.fillRect (rowR.reduced (2, 0));
-                }
-                g.setColour (r.isEnabled ? juce::Colours::white
-                                          : juce::Colour (0xff707080));
-                g.setFont (juce::Font (juce::FontOptions (14.0f)));
-                const int textX = 24;
-                g.drawText (r.text,
-                             rowR.withX (rowR.getX() + textX)
-                                  .withWidth (rowR.getWidth() - textX - 8),
-                             juce::Justification::centredLeft, false);
-                if (r.isTicked)
-                {
-                    g.setColour (juce::Colour (0xff60d060));
-                    g.fillEllipse ((float) rowR.getX() + 8.0f,
-                                    (float) rowR.getCentreY() - 3.5f, 7.0f, 7.0f);
-                }
-            }
-            y += kRowH;
-        }
+        if (useGrid) { paintSearch (g); paintGrid (g); }
+        else         flat.paint (g);
     }
 
+    // hoverCol/hoverRow (and flat.hovered) are the ACTIVE cell - what Return
+    // picks and what arrow keys move from - not a pure pointer-hover highlight.
+    // So a pointer that lands on the search box, a scrollbar, a column gutter,
+    // or leaves the panel entirely only stops tracking; it must not wipe the
+    // active cell out from under the keyboard.
     void mouseMove (const juce::MouseEvent& e) override
     {
-        const int newHover = rowAtY (e.y);
-        if (newHover != hoveredRow)
+        const auto p = e.getPosition();
+        if (useGrid)
         {
-            hoveredRow = newHover;
-            repaint();
+            const auto cell = cellAt (p);
+            if (cell.first < 0) return;
+            if (cell.first != hoverCol || cell.second != hoverRow)
+            {
+                // Not setGridHover: that scrolls the column fully into view,
+                // which would yank the grid sideways under a pointer resting on
+                // a partially-visible edge column.
+                hoverCol = cell.first; hoverRow = cell.second;
+                announceActive();
+                repaint();
+            }
+            return;
         }
-    }
-
-    void mouseExit (const juce::MouseEvent&) override
-    {
-        if (hoveredRow != -1) { hoveredRow = -1; repaint(); }
+        if (flat.scrollbarTrack().contains (p)) return;
+        const int nh = flat.rowAtY (p);
+        if (nh >= 0 && nh != flat.hovered) { flat.hovered = nh; announceActive(); repaint(); }
     }
 
     void mouseDown (const juce::MouseEvent& e) override
     {
-        const int row = rowAtY (e.y);
-        if (row < 0 || row >= (int) rowsData.size()) return;
-        const auto& r = rowsData[(size_t) row];
-        if (r.isSep || r.isHeader || ! r.isEnabled || r.itemId == 0) return;
-        if (onPickFn) onPickFn (r.itemId);
+        const auto p = e.getPosition();
+
+        if (useGrid)
+        {
+            if (filterText.isNotEmpty() && clearButtonRect().contains (p)) { setFilter ({}); return; }
+            if (pressHScrollbar (p)) { hbarDragging = true; repaint(); return; }
+            const auto cell = cellAt (p);
+            if (isSelectableCell (cell.first, cell.second))
+                pickItem (cellRef (cell.first, cell.second).itemId);
+            return;
+        }
+
+        if (flat.pressScrollbar (p)) { repaint(); return; }
+        const int row = flat.rowAtY (p);
+        if (flat.isSelectable (row))
+            pickItem (flat.rows[(size_t) row].itemId);
+    }
+
+    void mouseDrag (const juce::MouseEvent& e) override
+    {
+        if (useGrid)
+        {
+            if (hbarDragging) { dragHScrollbar (e.getPosition()); repaint(); }
+            return;
+        }
+        if (flat.dragging) { flat.dragScrollbar (e.getPosition()); repaint(); }
+    }
+
+    void mouseUp (const juce::MouseEvent&) override
+    {
+        flat.dragging = false;
+        hbarDragging = false;
+    }
+
+    void mouseWheelMove (const juce::MouseEvent& e,
+                         const juce::MouseWheelDetails& wheel) override
+    {
+        if (useGrid)
+        {
+            if (maxHScroll <= 0) return;
+            // A vertical wheel scrolls the grid sideways (its only scroll axis);
+            // a horizontal wheel maps straight through.
+            const float delta = std::abs (wheel.deltaX) > std::abs (wheel.deltaY)
+                                    ? wheel.deltaX : wheel.deltaY;
+            setHScroll (hScroll - delta * 90.0f);
+            repaint();
+            return;
+        }
+        if (flat.maxScroll() <= 0.0f) return;
+        flat.setScroll (flat.scrollOffset - wheel.deltaY * 80.0f);
+        // Follow the row that scrolled under the pointer, but keep the active
+        // row when the pointer isn't over one (see mouseMove).
+        if (! flat.scrollbarTrack().contains (e.getPosition()))
+        {
+            const int nh = flat.rowAtY (e.getPosition());
+            if (nh >= 0 && nh != flat.hovered) { flat.hovered = nh; announceActive(); }
+        }
+        repaint();
     }
 
     bool keyPressed (const juce::KeyPress& k) override
     {
         if (k == juce::KeyPress::escapeKey)
         {
-            sharedComboModal().close();
+            // In the grid, Esc first clears an active filter; a second Esc closes.
+            if (useGrid && filterText.isNotEmpty()) { setFilter ({}); return true; }
+            if (onDismissFn) { auto cb = onDismissFn; cb(); }   // survives panel teardown
             return true;
         }
-        // Up/Down hover navigation; Enter selects.
+
+        if (useGrid)
+            return gridKey (k);
+
         if (k == juce::KeyPress::upKey || k == juce::KeyPress::downKey)
         {
-            const int dir = (k == juce::KeyPress::upKey) ? -1 : 1;
-            int next = hoveredRow;
-            for (int step = 0; step < (int) rowsData.size(); ++step)
-            {
-                next = (next < 0)
-                        ? (dir > 0 ? 0 : (int) rowsData.size() - 1)
-                        : juce::jlimit (0, (int) rowsData.size() - 1, next + dir);
-                const auto& r = rowsData[(size_t) next];
-                if (! r.isSep && ! r.isHeader && r.isEnabled && r.itemId != 0)
-                {
-                    hoveredRow = next;
-                    repaint();
-                    return true;
-                }
-            }
+            flat.moveHover (k == juce::KeyPress::upKey ? -1 : 1, 1);
+            announceActive();
+            repaint();
             return true;
         }
-        if (k == juce::KeyPress::returnKey
-            && hoveredRow >= 0 && hoveredRow < (int) rowsData.size())
+        if (k == juce::KeyPress::pageUpKey || k == juce::KeyPress::pageDownKey)
         {
-            const auto& r = rowsData[(size_t) hoveredRow];
-            if (! r.isSep && ! r.isHeader && r.isEnabled && r.itemId != 0
-                && onPickFn)
-            {
-                onPickFn (r.itemId);
-                return true;
-            }
+            flat.moveHover (k == juce::KeyPress::pageUpKey ? -1 : 1,
+                            juce::jmax (1, flat.bounds.getHeight() / kRowH));
+            announceActive();
+            repaint();
+            return true;
+        }
+        if (k == juce::KeyPress::homeKey || k == juce::KeyPress::endKey)
+        {
+            flat.moveToBoundary (k == juce::KeyPress::homeKey ? 1 : -1);
+            announceActive();
+            repaint();
+            return true;
+        }
+        if (k == juce::KeyPress::returnKey && flat.isSelectable (flat.hovered))
+        {
+            activateActive();
+            return true;
         }
         return false;
     }
 
-private:
-    int rowAtY (int y) const
+    // The rows are painted, not child components, so there is nothing for a
+    // screen reader to walk. The panel itself takes keyboard focus, so expose it
+    // as the popup and report the active row through its accessible title,
+    // re-announced on every navigation. `press` activates the active row, the
+    // same as Return.
+    std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override
     {
-        constexpr int kRowH = 26;
-        constexpr int kSepH = 8;
-        const int top = (title.isEmpty() ? 4 : 4 + 24);
-        int yy = top;
-        for (int i = 0; i < (int) rowsData.size(); ++i)
+        return std::make_unique<juce::AccessibilityHandler> (
+            *this,
+            juce::AccessibilityRole::popupMenu,
+            juce::AccessibilityActions().addAction (
+                juce::AccessibilityActionType::press, [this] { activateActive(); }));
+    }
+
+private:
+    struct Cell
+    {
+        juce::String text;
+        int  itemId    = 0;
+        bool isTicked  = false;
+        bool isEnabled = true;
+    };
+
+    int titleHeight() const noexcept { return title.isEmpty() ? 0 : kTitleH; }
+
+    juce::String activeItemText() const
+    {
+        if (useGrid)
+            return isSelectableCell (hoverCol, hoverRow) ? cellRef (hoverCol, hoverRow).text
+                                                          : juce::String();
+        return flat.isSelectable (flat.hovered) ? flat.rows[(size_t) flat.hovered].text
+                                                 : juce::String();
+    }
+
+    juce::String emptyResultsMessage() const
+    {
+        return filterText.isEmpty() ? juce::String ("No presets")
+                                    : "No presets match \"" + filterText + "\"";
+    }
+
+    void announceActive()
+    {
+        auto label = activeItemText();
+        if (label.isEmpty())
         {
-            const int h = rowsData[(size_t) i].isSep ? kSepH : kRowH;
-            if (y >= yy && y < yy + h) return i;
-            yy += h;
+            // A no-match filter has no active cell; announce that state to a
+            // screen reader rather than leaving the stale last-preset title.
+            if (! useGrid || ! columns.empty()) return;
+            label = emptyResultsMessage();
+        }
+        setTitle (label);
+        if (auto* h = getAccessibilityHandler())
+            h->notifyAccessibilityEvent (juce::AccessibilityEvent::titleChanged);
+    }
+
+    // onPickFn closes the shared modal, which defer-destroys this panel. A
+    // nested message pump inside the caller's onChange could run that teardown
+    // mid-call and free the member std::function we're executing - the stack
+    // copy outlives it.
+    void pickItem (int itemId)
+    {
+        if (! onPickFn) return;
+        auto cb = onPickFn;
+        cb (itemId);
+    }
+
+    void activateActive()
+    {
+        if (useGrid)
+        {
+            if (isSelectableCell (hoverCol, hoverRow))
+                pickItem (cellRef (hoverCol, hoverRow).itemId);
+        }
+        else if (flat.isSelectable (flat.hovered))
+        {
+            pickItem (flat.rows[(size_t) flat.hovered].itemId);
+        }
+    }
+
+    // ---- flat combo ----------------------------------------------------
+
+    void layoutFlat (std::vector<Row> rows, int maximumHeight)
+    {
+        flat.rows = std::move (rows);
+
+        const juce::Font rowFont   { juce::FontOptions (14.0f) };
+        const juce::Font headerFont{ juce::FontOptions (14.5f, juce::Font::bold) };
+        int maxTextW = 0;
+        for (const auto& r : flat.rows)
+        {
+            if (r.isSep) continue;
+            const auto& f = r.isHeader ? headerFont : rowFont;
+            maxTextW = juce::jmax (maxTextW, (int) std::ceil (f.getStringWidthFloat (r.text)));
+        }
+        if (title.isNotEmpty())
+            maxTextW = juce::jmax (maxTextW, (int) std::ceil (headerFont.getStringWidthFloat (title)));
+
+        for (int i = 0; i < flat.count(); ++i)
+            if (flat.rows[(size_t) i].isTicked)
+                flat.hovered = i;
+
+        const int w = juce::jlimit (100, 320, maxTextW + kTextXPad + kTrailPad);
+        const int naturalHeight = kBorder * 2 + titleHeight() + flat.contentHeight();
+        setSize (w, juce::jlimit (1, juce::jmax (60, naturalHeight),
+                                  juce::jmax (1, maximumHeight)));
+        flat.ensureVisible (flat.hovered);
+    }
+
+    // ---- grid browser: flat list flowed into short, wide columns -------
+
+    void layoutGrid (std::vector<Row> rows, int maximumHeight, int maximumWidth)
+    {
+        // Keep the full item list for the lifetime of the popup so the
+        // type-to-filter can rebuild the columns without re-parsing. Headers /
+        // separators (if any) are not part of the flat program list.
+        const juce::Font rowFont { juce::FontOptions (14.0f) };
+        int widest = 0;
+        for (auto& r : rows)
+        {
+            if (r.isSep || r.isHeader) continue;
+            Cell c;
+            c.text = r.text; c.itemId = r.itemId;
+            c.isTicked = r.isTicked; c.isEnabled = r.isEnabled;
+            widest = juce::jmax (widest, (int) std::ceil (rowFont.getStringWidthFloat (c.text)));
+            allItems.push_back (std::move (c));
+        }
+        colWidth = juce::jlimit (150, 300, widest + kTextXPad + kTrailPad);
+
+        // Rows per column: derived from the available height and bounded so the
+        // popup stays short. Overflow flows sideways into more columns.
+        const int chrome = kBorder * 2 + titleHeight() + kSearchH + kHScrollH;
+        rowsPerColumn = juce::jlimit (1, kGridCapRows,
+                                       (juce::jmax (1, maximumHeight) - chrome) / kRowH);
+
+        // Size from the unfiltered layout (its widest case); the filter only ever
+        // shrinks the live column set within this fixed frame.
+        buildColumnsFiltered();
+
+        int usedRows = 0;
+        for (const auto& c : columns)
+            usedRows = juce::jmax (usedRows, (int) c.size());
+        usedRows = juce::jmax (1, usedRows);
+
+        const int totalCols   = (int) columns.size();
+        const int availW      = juce::jmax (1, maximumWidth) - kBorder * 2;
+        const int visibleCols = juce::jlimit (1, juce::jmax (1, totalCols),
+                                               (availW + kColGap) / colStride());
+        const int viewportW   = visibleCols * colWidth + (visibleCols - 1) * kColGap;
+
+        const int w = kBorder * 2 + viewportW;
+        const int h = kBorder * 2 + titleHeight() + kSearchH + usedRows * kRowH + kHScrollH;
+        setSize (w, juce::jlimit (1, h, juce::jmax (1, maximumHeight)));
+
+        finishGrid (/*fromFilter*/ false);
+    }
+
+    // Rebuild `columns` by filtering the flat item list on the current text and
+    // flowing the survivors top-to-bottom, wrapping into the next column.
+    void buildColumnsFiltered()
+    {
+        columns.clear();
+        std::vector<Cell> kept;
+        kept.reserve (allItems.size());
+        for (const auto& it : allItems)
+            if (filterText.isEmpty() || it.text.containsIgnoreCase (filterText))
+                kept.push_back (it);
+        if (kept.empty()) return;
+
+        const int rpc = juce::jmax (1, rowsPerColumn);
+        for (size_t i = 0; i < kept.size(); i += (size_t) rpc)
+        {
+            columns.push_back ({});
+            const size_t end = juce::jmin (i + (size_t) rpc, kept.size());
+            for (size_t j = i; j < end; ++j)
+                columns.back().push_back (kept[j]);
+        }
+    }
+
+    // Recompute horizontal-scroll extent and the focused cell.
+    void finishGrid (bool fromFilter)
+    {
+        const int totalCols = (int) columns.size();
+        const int contentW  = totalCols > 0 ? totalCols * colWidth + (totalCols - 1) * kColGap : 0;
+        maxHScroll = juce::jmax (0, contentW - gridViewport().getWidth());
+
+        hoverCol = hoverRow = -1;
+        if (fromFilter)
+        {
+            hScroll = 0.0f;
+            for (int c = 0; c < totalCols && hoverCol < 0; ++c)
+                for (int r = 0; r < (int) columns[(size_t) c].size(); ++r)
+                    if (isSelectableCell (c, r)) { hoverCol = c; hoverRow = r; break; }
+            setHScroll (0.0f);
+        }
+        else
+        {
+            for (int c = 0; c < totalCols && hoverCol < 0; ++c)
+                for (int r = 0; r < (int) columns[(size_t) c].size(); ++r)
+                    if (columns[(size_t) c][(size_t) r].isTicked) { hoverCol = c; hoverRow = r; break; }
+            setHScroll (hScroll);
+            ensureColumnVisible (hoverCol);
+        }
+    }
+
+    void setFilter (juce::String f)
+    {
+        if (f == filterText) return;
+        filterText = std::move (f);
+        buildColumnsFiltered();
+        finishGrid (/*fromFilter*/ true);
+        announceActive();
+        caretOn = true;             // solid right after a keystroke, then resume blinking
+        startTimer (kCaretBlinkMs);
+        repaint();
+    }
+
+    juce::Rectangle<int> searchRect() const noexcept
+    {
+        auto area = getLocalBounds().reduced (kBorder);
+        area.removeFromTop (titleHeight());
+        return area.removeFromTop (kSearchH).reduced (4, 4);
+    }
+
+    juce::Rectangle<int> clearButtonRect() const noexcept
+    {
+        auto r = searchRect();
+        return r.removeFromRight (24);
+    }
+
+    juce::Rectangle<int> gridViewport() const noexcept
+    {
+        auto area = getLocalBounds().reduced (kBorder);
+        area.removeFromTop (titleHeight());
+        area.removeFromTop (kSearchH);
+        area.removeFromBottom (kHScrollH);
+        return area;
+    }
+
+    int colStride() const noexcept { return colWidth + kColGap; }
+
+    const Cell& cellRef (int col, int row) const noexcept
+    {
+        return columns[(size_t) col][(size_t) row];
+    }
+
+    bool isSelectableCell (int col, int row) const noexcept
+    {
+        if (col < 0 || col >= (int) columns.size()) return false;
+        if (row < 0 || row >= (int) columns[(size_t) col].size()) return false;
+        const auto& c = cellRef (col, row);
+        return c.isEnabled && c.itemId != 0;
+    }
+
+    std::pair<int,int> cellAt (juce::Point<int> p) const noexcept
+    {
+        const auto vp = gridViewport();
+        if (! vp.contains (p)) return { -1, -1 };
+        const float lx = (float) (p.x - vp.getX()) + hScroll;
+        const int col = (int) std::floor (lx / (float) colStride());
+        if (col < 0 || col >= (int) columns.size()) return { -1, -1 };
+        if (lx - (float) (col * colStride()) >= (float) colWidth) return { -1, -1 }; // in the gutter
+        const int row = (p.y - vp.getY()) / kRowH;
+        if (row < 0 || row >= (int) columns[(size_t) col].size()) return { -1, -1 };
+        return { col, row };
+    }
+
+    void setHScroll (float x) noexcept
+    {
+        hScroll = juce::jlimit (0.0f, (float) maxHScroll, x);
+    }
+
+    void ensureColumnVisible (int col) noexcept
+    {
+        if (col < 0) return;
+        const int left  = col * colStride();
+        const int right = left + colWidth;
+        const int vw    = gridViewport().getWidth();
+        if ((float) left < hScroll)              setHScroll ((float) left);
+        else if ((float) right > hScroll + (float) vw) setHScroll ((float) (right - vw));
+    }
+
+    void paintSearch (juce::Graphics& g) const
+    {
+        const auto r = searchRect();
+        g.setColour (juce::Colour (0xff101014));
+        g.fillRoundedRectangle (r.toFloat(), 4.0f);
+        g.setColour (juce::Colour (0xff3a3a44));
+        g.drawRoundedRectangle (r.toFloat(), 4.0f, 1.0f);
+
+        // Magnifier glyph.
+        g.setColour (juce::Colour (0xff6b7280));
+        const float gx = (float) r.getX() + 9.0f, gy = (float) r.getCentreY() - 4.0f;
+        g.drawEllipse (gx, gy, 7.0f, 7.0f, 1.3f);
+        g.drawLine (gx + 6.0f, gy + 6.0f, gx + 9.0f, gy + 9.0f, 1.3f);
+
+        const juce::Font searchFont { juce::FontOptions (13.5f) };
+        g.setFont (searchFont);
+        const auto textArea = r.withTrimmedLeft (26)
+                               .withTrimmedRight (filterText.isNotEmpty() ? 26 : 8);
+        const int textW = filterText.isEmpty()
+                            ? 0 : (int) std::ceil (searchFont.getStringWidthFloat (filterText));
+        if (filterText.isEmpty())
+        {
+            g.setColour (juce::Colour (0xff606672));
+            g.drawText ("Type to filter presets...", textArea.withTrimmedLeft (3),
+                         juce::Justification::centredLeft, false);
+        }
+        else
+        {
+            g.setColour (juce::Colour (0xffe8e8ec));
+            g.drawText (filterText, textArea, juce::Justification::centredLeft, false);
+            // Clear (x) glyph, drawn as two strokes so it never depends on font
+            // coverage for a multi-byte character.
+            const auto cb = clearButtonRect().toFloat().reduced (7.0f, 8.0f);
+            g.setColour (juce::Colour (0xff9098a4));
+            g.drawLine (cb.getX(), cb.getY(), cb.getRight(), cb.getBottom(), 1.4f);
+            g.drawLine (cb.getX(), cb.getBottom(), cb.getRight(), cb.getY(), 1.4f);
+        }
+
+        // Blinking caret so it reads as an active text field (just type - no click).
+        if (caretOn)
+        {
+            const int cx = juce::jmin (textArea.getX() + textW + 1, textArea.getRight());
+            g.setColour (juce::Colour (0xffcfd6e2));
+            g.fillRect (cx, r.getCentreY() - 8, 1, 16);
+        }
+    }
+
+    void paintGrid (juce::Graphics& g)
+    {
+        const auto vp = gridViewport();
+        if (columns.empty())
+        {
+            g.setColour (juce::Colour (0xff707888));
+            g.setFont (juce::Font (juce::FontOptions (14.0f)));
+            g.drawText (emptyResultsMessage(), vp, juce::Justification::centred, false);
+            return;
+        }
+        g.saveState();
+        g.reduceClipRegion (vp);
+        for (int c = 0; c < (int) columns.size(); ++c)
+        {
+            const int x = vp.getX() - juce::roundToInt (hScroll) + c * colStride();
+            if (x + colWidth < vp.getX() || x > vp.getRight()) continue;
+
+            int y = vp.getY();
+            for (int r = 0; r < (int) columns[(size_t) c].size(); ++r)
+            {
+                const auto& cell = cellRef (c, r);
+                const auto rowR = juce::Rectangle<int> (x, y, colWidth, kRowH);
+                ListView::paintRow (g, rowR, cell.text, /*isHeader*/ false, cell.isEnabled,
+                                    cell.isTicked, c == hoverCol && r == hoverRow);
+                y += kRowH;
+            }
+            if (c + 1 < (int) columns.size())
+            {
+                g.setColour (juce::Colour (0xff26262e));
+                g.drawVerticalLine (x + colWidth + kColGap / 2,
+                                     (float) vp.getY(), (float) vp.getBottom());
+            }
+        }
+        g.restoreState();
+
+        if (maxHScroll > 0)
+        {
+            const auto track = hScrollbarTrack();
+            g.setColour (juce::Colour (0xff202028));
+            g.fillRect (track);
+            g.setColour (juce::Colour (0xff5a5a68));
+            g.fillRect (hScrollbarThumb().reduced (0, 1));
+        }
+    }
+
+    juce::Rectangle<int> hScrollbarTrack() const noexcept
+    {
+        if (maxHScroll <= 0) return {};
+        const auto vp = gridViewport();
+        return { vp.getX(), vp.getBottom(), vp.getWidth(), kHScrollH };
+    }
+
+    juce::Rectangle<int> hScrollbarThumb() const noexcept
+    {
+        const auto track = hScrollbarTrack();
+        if (track.isEmpty()) return {};
+        const int contentW = maxHScroll + track.getWidth();
+        const float ratio = (float) track.getWidth() / (float) contentW;
+        const int thumbW = juce::jmax (24, juce::roundToInt ((float) track.getWidth() * ratio));
+        const int travel = juce::jmax (0, track.getWidth() - thumbW);
+        const float progress = maxHScroll > 0 ? hScroll / (float) maxHScroll : 0.0f;
+        return { track.getX() + juce::roundToInt ((float) travel * progress), track.getY(),
+                 thumbW, track.getHeight() };
+    }
+
+    bool pressHScrollbar (juce::Point<int> p) noexcept
+    {
+        const auto track = hScrollbarTrack();
+        if (track.isEmpty() || ! track.contains (p)) return false;
+        auto thumb = hScrollbarThumb();
+        if (! thumb.contains (p))
+        {
+            const int travel = juce::jmax (1, track.getWidth() - thumb.getWidth());
+            const float progress = juce::jlimit (
+                0.0f, 1.0f,
+                (float) (p.x - track.getX() - thumb.getWidth() / 2) / (float) travel);
+            setHScroll (progress * (float) maxHScroll);
+        }
+        hbarDragStartX = p.x;
+        hbarDragStartScroll = hScroll;
+        return true;
+    }
+
+    void dragHScrollbar (juce::Point<int> p) noexcept
+    {
+        const auto track = hScrollbarTrack();
+        const auto thumb = hScrollbarThumb();
+        const int travel = juce::jmax (1, track.getWidth() - thumb.getWidth());
+        setHScroll (hbarDragStartScroll
+                      + (float) (p.x - hbarDragStartX) * (float) maxHScroll / (float) travel);
+    }
+
+    int firstSelectableInColumn (int col, int fromRow, int dir) const noexcept
+    {
+        if (col < 0 || col >= (int) columns.size()) return -1;
+        for (int r = fromRow; r >= 0 && r < (int) columns[(size_t) col].size(); r += dir)
+            if (isSelectableCell (col, r)) return r;
+        return -1;
+    }
+
+    int nearestSelectableInColumn (int col, int targetRow) const noexcept
+    {
+        if (col < 0 || col >= (int) columns.size()) return -1;
+        const int rows = (int) columns[(size_t) col].size();
+        if (rows == 0) return -1;
+        // targetRow is a row index carried over from a possibly-taller source
+        // column; clamp it into this column so the neighbour search reaches its
+        // cells instead of scanning entirely past the shorter column.
+        targetRow = juce::jlimit (0, rows - 1, targetRow);
+        for (int d = 0; d < rows; ++d)
+        {
+            if (isSelectableCell (col, targetRow + d)) return targetRow + d;
+            if (isSelectableCell (col, targetRow - d)) return targetRow - d;
         }
         return -1;
     }
 
+    void setGridHover (int col, int row)
+    {
+        hoverCol = col; hoverRow = row;
+        ensureColumnVisible (col);
+        announceActive();
+        repaint();
+    }
+
+    bool gridKey (const juce::KeyPress& k)
+    {
+        // Type-to-filter. Handled before the empty-grid guard so backspace can
+        // recover from a filter that matched nothing.
+        if (k == juce::KeyPress::backspaceKey)
+        {
+            if (filterText.isNotEmpty()) setFilter (filterText.dropLastCharacters (1));
+            return true;
+        }
+        const bool isNav = k == juce::KeyPress::upKey     || k == juce::KeyPress::downKey
+                        || k == juce::KeyPress::leftKey    || k == juce::KeyPress::rightKey
+                        || k == juce::KeyPress::pageUpKey  || k == juce::KeyPress::pageDownKey
+                        || k == juce::KeyPress::homeKey    || k == juce::KeyPress::endKey
+                        || k == juce::KeyPress::returnKey  || k == juce::KeyPress::tabKey;
+        if (! isNav)
+        {
+            // Shortcut chords (Cmd+W, Alt+F, ...) must not type into the filter;
+            // the popup is modal, so swallow them instead.
+            const auto mods = k.getModifiers();
+            if (mods.isCommandDown() || mods.isCtrlDown() || mods.isAltDown())
+                return true;
+            const juce::juce_wchar ch = k.getTextCharacter();
+            if (ch >= 32 && ch != 127)
+            {
+                setFilter (filterText + juce::String::charToString (ch));
+                return true;
+            }
+        }
+
+        const int totalCols = (int) columns.size();
+        // Filter matched nothing: no cells to navigate, but the popup is still
+        // modal - swallow the key so it can't leak to the app behind it.
+        if (totalCols == 0) return true;
+
+        if (k == juce::KeyPress::returnKey)
+        {
+            activateActive();
+            return true;
+        }
+        if (k == juce::KeyPress::homeKey || k == juce::KeyPress::endKey)
+        {
+            const int dir = (k == juce::KeyPress::homeKey) ? 1 : -1;
+            const int startCol = dir > 0 ? 0 : totalCols - 1;
+            for (int c = startCol; c >= 0 && c < totalCols; c += dir)
+            {
+                const int rows = (int) columns[(size_t) c].size();
+                const int r = firstSelectableInColumn (c, dir > 0 ? 0 : rows - 1, dir);
+                if (r >= 0) { setGridHover (c, r); return true; }
+            }
+            return true;
+        }
+
+        if (hoverCol < 0)   // nothing focused yet: land on the first preset
+        {
+            for (int c = 0; c < totalCols; ++c)
+            {
+                const int r = firstSelectableInColumn (c, 0, 1);
+                if (r >= 0) { setGridHover (c, r); return true; }
+            }
+            return true;
+        }
+
+        if (k == juce::KeyPress::downKey)
+        {
+            int r = firstSelectableInColumn (hoverCol, hoverRow + 1, 1);
+            if (r >= 0) { setGridHover (hoverCol, r); return true; }
+            for (int c = hoverCol + 1; c < totalCols; ++c)
+                if ((r = firstSelectableInColumn (c, 0, 1)) >= 0) { setGridHover (c, r); return true; }
+            return true;
+        }
+        if (k == juce::KeyPress::upKey)
+        {
+            int r = firstSelectableInColumn (hoverCol, hoverRow - 1, -1);
+            if (r >= 0) { setGridHover (hoverCol, r); return true; }
+            for (int c = hoverCol - 1; c >= 0; --c)
+                if ((r = firstSelectableInColumn (c, (int) columns[(size_t) c].size() - 1, -1)) >= 0)
+                    { setGridHover (c, r); return true; }
+            return true;
+        }
+        if (k == juce::KeyPress::rightKey || k == juce::KeyPress::pageDownKey)
+        {
+            for (int c = hoverCol + 1; c < totalCols; ++c)
+            {
+                const int r = nearestSelectableInColumn (c, hoverRow);
+                if (r >= 0) { setGridHover (c, r); return true; }
+            }
+            return true;
+        }
+        if (k == juce::KeyPress::leftKey || k == juce::KeyPress::pageUpKey)
+        {
+            for (int c = hoverCol - 1; c >= 0; --c)
+            {
+                const int r = nearestSelectableInColumn (c, hoverRow);
+                if (r >= 0) { setGridHover (c, r); return true; }
+            }
+            return true;
+        }
+        // A dropdown is modal: swallow every remaining key so none leak to the
+        // app's transport / edit shortcuts behind the popup.
+        return true;
+    }
+
     juce::String title;
-    std::vector<Row> rowsData;
     std::function<void (int)> onPickFn;
-    int hoveredRow = -1;
+    std::function<void()> onDismissFn;
+
+    bool useGrid = false;
+    ListView flat;                 // used when !useGrid
+
+    std::vector<Cell> allItems;               // full program-sorted list; source for the filter
+    juce::String filterText;
+    std::vector<std::vector<Cell>> columns;   // filtered + flowed view (useGrid)
+    int   colWidth      = 0;
+    int   rowsPerColumn = 0;
+    int   maxHScroll    = 0;
+    float hScroll       = 0.0f;
+    int   hoverCol      = -1;
+    int   hoverRow      = -1;
+    bool  hbarDragging  = false;
+    int   hbarDragStartX = 0;
+    float hbarDragStartScroll = 0.0f;
+    bool  caretOn       = true;
 };
 } // namespace
 
@@ -250,13 +1087,13 @@ void DuskComboBox::showPopup()
         return;
     }
 
-    std::vector<DuskComboPanel::Row> rows;
+    std::vector<Row> rows;
     rows.reserve ((size_t) getNumItems() + 4);
     juce::PopupMenu::MenuItemIterator it (*root, /*recursive*/ false);
     while (it.next())
     {
         const auto& item = it.getItem();
-        DuskComboPanel::Row r;
+        Row r;
         r.isSep    = item.isSeparator;
         r.isHeader = item.isSectionHeader;
         r.text     = item.text;
@@ -270,6 +1107,21 @@ void DuskComboBox::showPopup()
     if (parent == nullptr) parent = this;
 
     juce::Component::SafePointer<DuskComboBox> safeSelf (this);
+    auto dismiss = [safeSelf]
+    {
+        sharedComboModal().close();
+        if (auto* s = safeSelf.getComponent())
+            s->hidePopup();
+    };
+    // Click-outside dismissal: close WITHOUT restoring focus so the control the
+    // user clicked outside the popup keeps the focus it just took (useOverlay is
+    // false here, so the click lands on a real sibling, not a dim overlay).
+    auto dismissOutside = [safeSelf]
+    {
+        sharedComboModal().close (/*restoreFocus*/ false);
+        if (auto* s = safeSelf.getComponent())
+            s->hidePopup();
+    };
     auto panel = std::make_unique<DuskComboPanel> (
         getName().isNotEmpty() ? getName() : juce::String(),
         std::move (rows),
@@ -287,23 +1139,30 @@ void DuskComboBox::showPopup()
                 // and showPopupIfNotActive short-circuits -> combo
                 // appears frozen after one selection.
                 s->hidePopup();
-                // Apply selection silently, then fire onChange by hand.
-                // sendNotificationSync ends up calling juce::ComboBox's
-                // internal post-action path (accessibility handler focus
-                // grab + dynamic_cast into the JUCE peer) which has been
-                // observed to abort with __dynamic_cast on Linux/XWayland
-                // when called from inside our modal teardown. Manually
-                // firing onChange keeps the user's handler running while
-                // skipping the dangerous post-action path.
-                s->setSelectedId (chosenId, juce::dontSendNotification);
-                if (s->onChange) s->onChange();
+                // Notify asynchronously. sendNotificationSync runs juce::
+                // ComboBox's post-action path (accessibility handler focus
+                // grab + dynamic_cast into the JUCE peer) inline, which has
+                // been observed to abort with __dynamic_cast on Linux/
+                // XWayland when called from inside our modal teardown.
+                // sendNotificationAsync defers the full notification path
+                // (ComboBox::Listeners, onChange, accessibility event) to
+                // the next message-loop tick, after teardown has finished.
+                // ComboBox itself skips the notification when the id is
+                // unchanged.
+                s->setSelectedId (chosenId, juce::sendNotificationAsync);
             }
-        });
+        },
+        dismiss,
+        juce::jmax (1, parent->getHeight() - 16),
+        juce::jmax (1, parent->getWidth() - 16),
+        gridBrowser);
 
     // Anchor the popup BELOW the combo's screen bounds (or above when it
     // would clip the bottom edge), instead of centring in the parent
     // window. Without this the popup floats in the middle of the screen
-    // far from the click - confusing and easy to miss.
+    // far from the click - confusing and easy to miss. The wide grid
+    // browser is the exception: it stays centred (see repositionBody below).
+    const bool centred = panel->prefersCentred();
     const int panelW = panel->getWidth();
     const int panelH = panel->getHeight();
     const auto comboScreen = getScreenBounds();
@@ -317,20 +1176,39 @@ void DuskComboBox::showPopup()
         sx = juce::jmax (parentScreen.getX() + 8, parentScreen.getRight() - panelW - 8);
     sx = juce::jmax (parentScreen.getX() + 8, sx);
 
-    sharedComboModal().show (*parent, std::move (panel),
-                                /*onDismiss*/ [safeSelf]
-                                {
-                                    sharedComboModal().close();
-                                    if (auto* s = safeSelf.getComponent())
-                                        s->hidePopup();   // same reason as the pick path
-                                });
+    // A combo is a lightweight popup, not a new modal task: retain the normal
+    // undimmed view of the editor behind it. Combos can live inside a tagged
+    // plugin editor (the SoundFont editor is one example) - hiding plugin
+    // editors there would hide the combo's own editor and expose only its
+    // opaque EmbeddedModal backdrop as a large black rectangle. Combos outside
+    // any tagged editor still need the hide: native editor child windows paint
+    // above JUCE components and would bury the popup.
+    bool insideTaggedEditor = false;
+    for (auto* c = static_cast<juce::Component*> (this); c != nullptr; c = c->getParentComponent())
+        if ((bool) c->getProperties().getWithDefault (kPluginEditorTag, false))
+            { insideTaggedEditor = true; break; }
+
+    // Only the type-to-filter grid captures typing; flat dropdowns keep
+    // forwarding transport shortcuts (Space, R, ...) to the app.
+    sharedComboModal().show (*parent, std::move (panel), dismiss,
+                             /*dismissOnClickOutside*/ true,
+                             /*dismissOnEscape*/ true,
+                             /*dimAlpha*/ 0.0f,
+                             /*hidePluginEditors*/ ! insideTaggedEditor,
+                             /*useOverlay*/ false,
+                             /*forwardShortcuts*/ ! centred,
+                             /*onDismissOutside*/ dismissOutside);
 
     // EmbeddedModal centred the body during show(); now slam it (and
     // its backdrop) to the anchor position. repositionBody moves both
     // together - moving the body alone leaves the centred backdrop
-    // rendering as a stray blank panel where the body used to be.
-    const auto localTopLeft = parent->getLocalPoint (nullptr,
-                                                        juce::Point<int> (sx, sy));
-    sharedComboModal().repositionBody (localTopLeft);
+    // rendering as a stray blank panel where the body used to be. The
+    // grid browser opts out and keeps show()'s centring.
+    if (! centred)
+    {
+        const auto localTopLeft = parent->getLocalPoint (nullptr,
+                                                            juce::Point<int> (sx, sy));
+        sharedComboModal().repositionBody (localTopLeft);
+    }
 }
 } // namespace duskstudio

--- a/src/ui/DuskComboBox.h
+++ b/src/ui/DuskComboBox.h
@@ -21,5 +21,16 @@ public:
     explicit DuskComboBox (const juce::String& componentName) : juce::ComboBox (componentName) {}
 
     void showPopup() override;
+
+    // Opt in to the grid browser: the menu's items are flowed into short,
+    // wide columns with a type-to-filter box on top, instead of one long
+    // scrolling list - a long preset list (hundreds of SoundFont programs)
+    // reads across instead of scrolling forever. Section headers / separators
+    // are dropped; items appear in their incoming order. Off by default so
+    // ordinary combos are unchanged.
+    void setGridBrowser (bool shouldBrowse) noexcept { gridBrowser = shouldBrowse; }
+
+private:
+    bool gridBrowser = false;
 };
 } // namespace duskstudio

--- a/src/ui/EmbeddedModal.h
+++ b/src/ui/EmbeddedModal.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <juce_gui_basics/juce_gui_basics.h>
+#include "DimOverlay.h"
 #include <functional>
 #include <memory>
-#include "DimOverlay.h"
+#include <vector>
+#include <algorithm>
 
 namespace duskstudio
 {
@@ -57,7 +59,8 @@ inline constexpr const char* kPluginEditorTag = "dusk_pluginEditor";
 // Paints its own opaque rounded backdrop behind the body so panels
 // without solid background don't bleed channel strips through.
 class EmbeddedModal final : private juce::KeyListener,
-                            private juce::ComponentListener
+                            private juce::ComponentListener,
+                            private juce::MouseListener
 {
 public:
     // Singleton focus-restore target. MainComponent registers itself here
@@ -71,6 +74,38 @@ public:
         return target;
     }
 
+    // App-wide monotonic modal-lifecycle token, bumped by every show() /
+    // showBorrowed() across ALL modal instances. Its sole job is to invalidate
+    // a stale deferred focus grab: close() snapshots the token and its async
+    // re-grab bails if a newer show() has bumped it since, so the grab can't
+    // yank focus off a modal that opened during the async window. WHICH
+    // component regains focus is decided by activeModalStack(), not this token
+    // (see close()).
+    static unsigned long long& modalGeneration()
+    {
+        static unsigned long long gen = 0;
+        return gen;
+    }
+
+    // App-wide stack of currently-open modals, in open order (back() = newest).
+    // Modals stack (a combo opens over an alert / plugin editor); close() pops
+    // itself and hands focus to the newest that remains, falling back to
+    // MainComponent only when the stack empties. Every teardown path
+    // (close / closeAndDeleteBodyNow / ~EmbeddedModal) removes its entry, so a
+    // pointer here is always a live, open modal.
+    static std::vector<EmbeddedModal*>& activeModalStack()
+    {
+        // Heap-allocated and deliberately never freed. The function-local-static
+        // shared modals (DuskAlerts / DuskComboBox / ...) run their destructor ->
+        // close() -> removeFromModalStack() during static teardown. A plain
+        // function-local static vector constructs on the first show() - AFTER
+        // those modals - so it would destruct BEFORE them and turn that teardown
+        // access into a use-after-free. Leaking it keeps the registry valid for
+        // every teardown path.
+        static auto* stack = new std::vector<EmbeddedModal*>();
+        return *stack;
+    }
+
     EmbeddedModal()  = default;
     ~EmbeddedModal() override { close(); }
 
@@ -80,32 +115,71 @@ public:
     //   need explicit button).
     // dismissOnEscape=false : Esc swallowed (focus-locked decision
     //   modals like save-before-quit).
+    // hidePluginEditors=false : keep tagged plugin editors visible. This is
+    //   intended for lightweight controls (such as combo popups) opened from
+    //   inside an editor; hiding the editor would also hide the control that
+    //   owns the popup and leave only its empty backdrop visible.
+    // useOverlay=false : don't place a full-parent JUCE component over the
+    //   host. Some embedded/native editor surfaces render black whenever any
+    //   sibling covers them, even when that sibling paints fully transparent.
+    //   Outside clicks are captured with a global mouse listener instead.
+    // forwardShortcuts=false : do NOT forward transport hotkeys (Space, R, L,
+    //   P, brackets) to MainComponent while this modal is up. Required for a
+    //   body that captures typing itself (e.g. the combo popup's type-to-filter);
+    //   otherwise a typed letter fires the app shortcut behind the modal.
+    // onDismissOutside : invoked instead of onDismiss on a click-outside
+    //   dismissal (falls back to onDismiss when empty). Lets a caller close
+    //   WITHOUT restoring focus so a control clicked outside keeps it (see
+    //   close(bool)); Esc keeps using onDismiss.
     // Defaults preserve "Esc + click-outside both dismiss".
     void show (juce::Component& parent,
                std::unique_ptr<juce::Component> body,
                std::function<void()> onDismiss = {},
                bool dismissOnClickOutside = true,
                bool dismissOnEscape = true,
-               float dimAlpha = 0.55f)   // processing editors pass kEditorDimAlpha
+               float dimAlpha = 0.55f,   // processing editors pass kEditorDimAlpha
+               bool hidePluginEditors = true,
+               bool useOverlay = true,
+               bool forwardShortcuts = true,
+               std::function<void()> onDismissOutside = {})
     {
         close();
+        ++modalGeneration();
         host = &parent;
         body_ = std::move (body);
-        dim_ = std::make_unique<DimOverlay> (dimAlpha);
-        dim_->setBounds (parent.getLocalBounds());
         userOnDismiss = std::move (onDismiss);
+        userOnDismissOutside = std::move (onDismissOutside);
         escapeDismisses = dismissOnEscape;
-        if (dismissOnClickOutside)
-            dim_->onClick = [this]
-            {
-                // Local copy BEFORE invoking - the user's callback may
-                // close() this modal, which resets userOnDismiss = {}
-                // and destroys the closure (with captures) mid-call.
-                // SIGABRT on Linux/XWayland without this.
-                if (auto cb = userOnDismiss) cb();
-                else                          close();
-            };
-        parent.addAndMakeVisible (dim_.get());
+        forwardShortcuts_ = forwardShortcuts;
+        if (useOverlay)
+        {
+            dim_ = std::make_unique<DimOverlay> (dimAlpha);
+            dim_->setBounds (parent.getLocalBounds());
+            if (dismissOnClickOutside)
+                dim_->onClick = [this]
+                {
+                    // An overlay-less popup (DuskComboBox) may be stacked above
+                    // this modal; its global listener dismisses it from the same
+                    // click. Only the topmost modal may act on a dim click, or
+                    // one click tears down both layers.
+                    if (activeModalStack().empty() || activeModalStack().back() != this)
+                        return;
+                    // Local copy BEFORE invoking - the user's callback may
+                    // close() this modal, which resets the dismiss callbacks
+                    // and destroys the closure (with captures) mid-call.
+                    // SIGABRT on Linux/XWayland without this. Prefer the
+                    // outside-click callback so a clicked control keeps focus.
+                    auto cb = userOnDismissOutside ? userOnDismissOutside : userOnDismiss;
+                    if (cb) cb();
+                    else    close();
+                };
+            parent.addAndMakeVisible (dim_.get());
+        }
+        else if (dismissOnClickOutside)
+        {
+            juce::Desktop::getInstance().addGlobalMouseListener (this);
+            listeningForOutsideClicks = true;
+        }
 
         const auto bounds = parent.getLocalBounds();
         const int w = juce::jmax (1, body_->getWidth());
@@ -125,14 +199,18 @@ public:
         // Force topmost - a stage swap that re-adds a fullscreen view
         // (AuxView, MasteringView) after the modal opens can demote it.
         // addAndMakeVisible alone is only topmost-at-add-time.
-        dim_     ->toFront (false);
+        if (dim_ != nullptr)
+            dim_->toFront (false);
         backdrop_->toFront (false);
         body_    ->toFront (true);
         body_->setWantsKeyboardFocus (true);
         body_->grabKeyboardFocus();
         body_->addKeyListener (this);
 
-        hidePluginEditorsUnder (parent);
+        if (hidePluginEditors)
+            hidePluginEditorsUnder (parent);
+
+        activeModalStack().push_back (this);
     }
 
     // Body NOT owned - caller keeps alive across show/close cycles.
@@ -145,8 +223,14 @@ public:
                        std::function<void()> onDismiss = {})
     {
         close();
+        ++modalGeneration();
         host = &parent;
         borrowedBody_ = &body;
+        // Borrowed modals are plugin editors: always forward transport shortcuts
+        // so the engineer can play / loop / audition while the editor is open.
+        // Reset explicitly - a prior show(..., forwardShortcuts=false) on this
+        // instance leaves it disabled (close() doesn't reset it).
+        forwardShortcuts_ = true;
         // showBorrowed is plugin-editors-only - use the lighter editor dim so
         // the strip meters behind stay readable while auditioning.
         dim_ = std::make_unique<DimOverlay> (kEditorDimAlpha);
@@ -154,7 +238,10 @@ public:
         userOnDismiss = std::move (onDismiss);
         dim_->onClick = [this]
         {
-            // See owning show()'s onClick - local copy survives close().
+            // See owning show()'s onClick - topmost-only guard + local copy
+            // survives close().
+            if (activeModalStack().empty() || activeModalStack().back() != this)
+                return;
             if (auto cb = userOnDismiss) cb();
             else                          close();
         };
@@ -191,6 +278,8 @@ public:
         parent.addComponentListener (this);
 
         hidePluginEditorsUnder (parent);
+
+        activeModalStack().push_back (this);
     }
 
     // Idempotent. For owning show, destructs body; for showBorrowed,
@@ -202,6 +291,12 @@ public:
     // trusting close() won't double-fire. Audit every caller before
     // changing this contract.
     //
+    // restoreFocus=false : skip the immediate MainComponent focus grab. For a
+    // click-outside dismissal the clicked control has already taken focus;
+    // grabbing it back to MainComponent would steal it (see show()'s
+    // onDismissOutside). A deferred grab still fires if nothing took focus.
+    // Esc / pick / button closes keep the default.
+    //
     // Safe from inside a body's callback (button onClick): synchronous
     // path detaches body/backdrop/dim from parent so the modal
     // disappears immediately, then defers destruction to the next
@@ -209,9 +304,12 @@ public:
     // would run ~Button -> ~std::function while the button's onClick
     // lambda is still on the stack - observed to corrupt JUCE's
     // message-thread state and crash compositors on next X11 round.
-    void close()
+    void close (bool restoreFocus = true)
     {
         if (host == nullptr) return;
+
+        removeFromModalStack();
+        stopListeningForOutsideClicks();
 
         // Restore any plugin editors we hid in show() before tearing
         // down the modal body. Done first so their setVisible(true)
@@ -259,29 +357,51 @@ public:
             juce::MessageManager::callAsync (
                 [trash]() mutable { (void) trash; });
         }
-        // Restore keyboard focus. MainComponent registered itself with
-        // focusRestoreTarget() in its ctor; we grab focus on it both
-        // synchronously (so the very next key event already lands
-        // there) AND deferred (so any focus stolen by JUCE's own modal
-        // teardown / focus-traverser logic gets overridden once the
-        // trash lambdas have run and the modal's children are gone).
+        // Restore keyboard focus to whatever should own it now this modal is
+        // gone. With modals stacked (a combo opened over an alert / plugin
+        // editor), focus must return to the newest modal STILL open, not all
+        // the way back to MainComponent - the latter would yank focus off a
+        // modal the user can still see. Fall back to MainComponent (registered
+        // in its ctor via focusRestoreTarget()) only when the stack empties.
         //
-        // Without this, every popup pick leaves focus orphaned on the
-        // DocumentWindow itself - JUCE's default focus traverser does
-        // NOT reliably drill into the content component on this hybrid
-        // X11/Wayland setup, so spacebar / R silently die until the
-        // user clicks the canvas.
-        if (auto* mc = focusRestoreTarget().getComponent())
-            mc->grabKeyboardFocus();
-
-        auto safeTarget = focusRestoreTarget();
-        juce::MessageManager::callAsync ([safeTarget]() mutable
+        // Grab both synchronously (so the very next key event already lands
+        // there) AND deferred (JUCE's own modal-teardown / focus-traverser can
+        // steal focus once the trash lambdas run and this modal's children are
+        // gone; the default traverser does NOT reliably drill into the content
+        // component on this hybrid X11/Wayland setup, so spacebar / R silently
+        // die without the re-grab). The epoch snapshot invalidates the deferred
+        // grab if a show()/showBorrowed() during the async window opened a newer
+        // modal that now owns focus - don't steal it back.
         {
-            if (auto* c = safeTarget.getComponent())
-                c->grabKeyboardFocus();
-        });
+            juce::Component::SafePointer<juce::Component> target;
+            const auto& stack = activeModalStack();
+            if (! stack.empty())
+                target = stack.back()->getBody();
+            if (target == nullptr)
+                target = focusRestoreTarget();
+
+            if (restoreFocus)
+                if (auto* c = target.getComponent())
+                    c->grabKeyboardFocus();
+
+            // restoreFocus=false still needs the deferred pass: the dismissing
+            // click may have landed on a component that takes no keyboard focus
+            // (setMouseClickGrabsKeyboardFocus(false)), leaving focus orphaned
+            // once the body is destroyed. Grab only when nothing else took it.
+            const auto genAtClose = modalGeneration();
+            juce::MessageManager::callAsync ([target, genAtClose, restoreFocus]() mutable
+            {
+                if (genAtClose != modalGeneration()) return;
+                if (! restoreFocus
+                    && juce::Component::getCurrentlyFocusedComponent() != nullptr)
+                    return;   // the clicked control owns focus - keep it there
+                if (auto* c = target.getComponent())
+                    c->grabKeyboardFocus();
+            });
+        }
         host = nullptr;
         userOnDismiss = {};
+        userOnDismissOutside = {};
     }
 
     // Shutdown-only teardown. close() defers body destruction to the
@@ -294,6 +414,8 @@ public:
     // ~MainComponent / beginSafeShutdown.
     void closeAndDeleteBodyNow()
     {
+        removeFromModalStack();
+        stopListeningForOutsideClicks();
         restoreHiddenPluginEditors();
 
         if (host != nullptr)
@@ -316,6 +438,7 @@ public:
         borrowedBody_ = nullptr;
         host = nullptr;
         userOnDismiss = {};
+        userOnDismissOutside = {};
     }
 
     bool isOpen() const noexcept { return body_ != nullptr || borrowedBody_ != nullptr; }
@@ -360,6 +483,44 @@ public:
     }
 
 private:
+    void removeFromModalStack()
+    {
+        auto& stack = activeModalStack();
+        stack.erase (std::remove (stack.begin(), stack.end(), this), stack.end());
+    }
+
+    void mouseDown (const juce::MouseEvent& e) override
+    {
+        if (! listeningForOutsideClicks) return;
+
+        // Only the topmost open modal may act on an outside click - with a
+        // modal stacked above this one, that layer owns the click, and
+        // dismissing from underneath would tear down both layers at once.
+        if (activeModalStack().empty() || activeModalStack().back() != this)
+            return;
+
+        // Test against the backdrop frame, not just the body - the visible
+        // popup includes the kBackdropMargin ring, and a click on it must not
+        // count as "outside".
+        juce::Component* hit = backdrop_ != nullptr ? backdrop_.get() : getBody();
+        if (hit != nullptr && hit->getScreenBounds().contains (e.getScreenPosition()))
+            return;
+
+        // Keep the callback alive across close(), which clears the dismiss
+        // callbacks. Prefer the outside-click callback so the clicked control
+        // keeps focus.
+        auto cb = userOnDismissOutside ? userOnDismissOutside : userOnDismiss;
+        if (cb) cb();
+        else    close();
+    }
+
+    void stopListeningForOutsideClicks()
+    {
+        if (! listeningForOutsideClicks) return;
+        juce::Desktop::getInstance().removeGlobalMouseListener (this);
+        listeningForOutsideClicks = false;
+    }
+
     bool keyPressed (const juce::KeyPress& k, juce::Component*) override
     {
         if (k == juce::KeyPress::escapeKey)
@@ -379,7 +540,7 @@ private:
         // handles its title-bar shortcuts. Edit/destructive keys are excluded
         // (see isModalForwardableShortcut). TextEditor children consume their
         // keys before this fires, so typing isn't affected.
-        if (isModalForwardableShortcut (k))
+        if (forwardShortcuts_ && isModalForwardableShortcut (k))
         {
             if (auto* mc = focusRestoreTarget().getComponent())
                 return mc->keyPressed (k);
@@ -432,7 +593,10 @@ private:
     std::unique_ptr<juce::Component> body_;
     juce::Component* borrowedBody_ = nullptr;
     std::function<void()> userOnDismiss;
+    std::function<void()> userOnDismissOutside;
     bool escapeDismisses = true;
+    bool forwardShortcuts_ = true;
+    bool listeningForOutsideClicks = false;
 
     // Components hidden by hidePluginEditorsUnder() in show(); restored
     // by restoreHiddenPluginEditors() in close(). Plugin editors (in

--- a/src/ui/multisample/DuskMultisampleEditor.cpp
+++ b/src/ui/multisample/DuskMultisampleEditor.cpp
@@ -94,10 +94,13 @@ DuskMultisampleEditor::DuskMultisampleEditor (DuskMultisampleProcessor& proc)
     sf2PresetLabel.setFont (juce::Font (juce::FontOptions (12.0f)));
     addChildComponent (sf2PresetLabel);
     sf2PresetSelector.setTooltip ("Switch between the SoundFont's presets.");
+    // Multi-bank SoundFonts (GS/XG) carry hundreds of presets; flow them into
+    // a filterable grid of columns instead of one long scrolling list.
+    sf2PresetSelector.setGridBrowser (true);
     sf2PresetSelector.onChange = [this]
     {
         const int idx = sf2PresetSelector.getSelectedId() - 1;   // IDs are 1-based
-        if (idx < 0 || idx >= processor.getSf2PresetNames().size()) return;
+        if (idx < 0 || idx >= (int) processor.getSf2Presets().size()) return;
         startAsyncLoad ({}, idx);
     };
     addChildComponent (sf2PresetSelector);
@@ -134,6 +137,18 @@ DuskMultisampleEditor::~DuskMultisampleEditor()
 
 void DuskMultisampleEditor::timerCallback()
 {
+    // A background load is in flight. startAsyncLoad already set the
+    // "(loading ...)" label and disabled the controls; bail before the
+    // refresh below so the timer can't overwrite that message, re-enable the
+    // controls mid-load, or rebuild the skin off a half-populated processor
+    // (getSf2Presets() hands back an empty vector until the load clears, so a
+    // rebuild here would hide the preset selector AND consume the path-change
+    // signal, leaving it hidden after the load lands). loadFileAsync clears
+    // pending before its onDone re-runs timerCallback, so the full refresh +
+    // skin rebuild fires then.
+    if (processor.isLoadPending())
+        return;
+
     const auto err  = processor.getLastLoadError();
     const auto path = processor.getLoadedFilePath();
     juce::String display;
@@ -239,13 +254,21 @@ void DuskMultisampleEditor::rebuildSkin()
     // SF2 program switcher: populate + show when the loaded SF2 has
     // more than one preset. (SF2 never has an ARIA skin, so it always
     // rides in the default layout.)
-    const auto& presets = processor.getSf2PresetNames();
+    const auto presets = processor.getSf2Presets();
     const bool showSf2Presets = showDefaults && presets.size() > 1;
     if (showSf2Presets)
     {
         sf2PresetSelector.clear (juce::dontSendNotification);
-        for (int i = 0; i < presets.size(); ++i)
-            sf2PresetSelector.addItem (presets[i], i + 1);   // IDs 1-based
+        for (const auto& preset : presets)
+        {
+            // Program-first display: "PPP [bank] Name" so an instrument's bank
+            // variants read as a group. Bank is the MIDI variant selector
+            // (128 = percussion kit, sorted to the end).
+            const auto number = juce::String (preset.program + 1).paddedLeft ('0', 3);
+            const auto name = preset.name.isNotEmpty() ? preset.name : juce::String ("(unnamed)");
+            sf2PresetSelector.addItem (number + " [" + juce::String (preset.bank) + "] " + name,
+                                        preset.sourceIndex + 1);
+        }
         sf2PresetSelector.setSelectedId (juce::jmax (1, processor.getSf2PresetIndex() + 1),
                                           juce::dontSendNotification);
     }
@@ -338,13 +361,25 @@ void DuskMultisampleEditor::startAsyncLoad (const juce::File& file, int presetIn
     if (processor.isLoadPending()) return;
 
     setLoadControlsEnabled (false);
-    filePathLabel.setText ("(loading " + (presetIndex >= 0
-                               ? "preset " + juce::String (presetIndex + 1)
-                               : file.getFileName()) + " ...)",
+    auto loadingTarget = file.getFileName();
+    if (presetIndex >= 0)
+    {
+        loadingTarget = "preset " + juce::String (presetIndex + 1);
+        for (const auto& preset : processor.getSf2Presets())
+            if (preset.sourceIndex == presetIndex)
+            {
+                const auto name = preset.name.isNotEmpty() ? preset.name
+                                                           : juce::String ("(unnamed)");
+                loadingTarget = "program " + juce::String (preset.program + 1)
+                              + " - " + name;
+                break;
+            }
+    }
+    filePathLabel.setText ("(loading " + loadingTarget + " ...)",
                             juce::dontSendNotification);
 
     juce::Component::SafePointer<DuskMultisampleEditor> safe (this);
-    auto onDone = [safe] (bool ok, juce::String err)
+    auto onDone = [safe, presetIndex] (bool ok, juce::String err)
     {
         // The processor outlives a closed editor (worker joins in ITS
         // destructor) - only the UI refresh needs the guard.
@@ -352,7 +387,16 @@ void DuskMultisampleEditor::startAsyncLoad (const juce::File& file, int presetIn
         {
             self->setLoadControlsEnabled (true);
             if (! ok)
+            {
                 self->filePathLabel.setText ("(" + err + ")", juce::dontSendNotification);
+                // A failed preset switch leaves the selector on the choice that
+                // didn't load; snap it back to the preset still playing so the
+                // UI doesn't misreport the active program.
+                if (presetIndex >= 0)
+                    self->sf2PresetSelector.setSelectedId (
+                        juce::jmax (1, self->processor.getSf2PresetIndex() + 1),
+                        juce::dontSendNotification);
+            }
             else
                 self->timerCallback();
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,6 +80,7 @@ add_executable(dusk-studio-tests
     aria_gui_parse.cpp
     sf2_reader_parse.cpp
     sf2_to_sfz_convert.cpp
+    sf2_preset_sort.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/multisample/DuskMultisampleProcessor.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/multisample/AriaBank.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/multisample/AriaGui.cpp

--- a/tests/sf2_preset_sort.cpp
+++ b/tests/sf2_preset_sort.cpp
@@ -1,0 +1,96 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/multisample/Sf2PresetSort.h"
+
+#include <vector>
+
+// Mirrors the shape of DuskMultisampleProcessor::Sf2PresetInfo without
+// pulling in the processor's JUCE deps - sortSf2PresetsForDisplay is a
+// template, so this POD instantiates the exact ordering the SF2 program
+// switcher uses.
+namespace
+{
+struct Preset
+{
+    int sourceIndex;
+    int bank;
+    int program;
+};
+
+std::vector<int> sourceOrder (const std::vector<Preset>& v)
+{
+    std::vector<int> out;
+    out.reserve (v.size());
+    for (const auto& p : v)
+        out.push_back (p.sourceIndex);
+    return out;
+}
+} // namespace
+
+using duskstudio::sortSf2PresetsForDisplay;
+
+TEST_CASE ("SF2 presets sort by program, then bank (variants grouped)", "[sf2][preset]")
+{
+    // PHDR (source) order is deliberately unsorted. Program 5 has two bank
+    // variants that must end up adjacent, not split across the list.
+    std::vector<Preset> presets {
+        { /*src*/ 0, /*bank*/ 1, /*prog*/ 5 },   // Picked Bass 2
+        { /*src*/ 1, /*bank*/ 0, /*prog*/ 8 },   // some prog-8 sound
+        { /*src*/ 2, /*bank*/ 0, /*prog*/ 5 },   // Picked Bass 1
+        { /*src*/ 3, /*bank*/ 0, /*prog*/ 2 },   // a prog-2 sound
+    };
+
+    sortSf2PresetsForDisplay (presets);
+
+    // Expected: prog2, then prog5[bank0], prog5[bank1], then prog8.
+    REQUIRE (sourceOrder (presets) == std::vector<int> { 3, 2, 0, 1 });
+}
+
+TEST_CASE ("SF2 sort keeps percussion (bank 128) after melodic", "[sf2][preset]")
+{
+    // Program 0 exists in both bank 0 (Grand Piano) and bank 128 (a drum kit).
+    // The kit must NOT interleave as a "variant" of the piano - percussion
+    // sorts to the end regardless of its program number.
+    std::vector<Preset> presets {
+        { /*src*/ 0, /*bank*/ 128, /*prog*/ 0 },  // Standard Kit
+        { /*src*/ 1, /*bank*/ 0,   /*prog*/ 40 }, // a high melodic program
+        { /*src*/ 2, /*bank*/ 0,   /*prog*/ 0 },  // Grand Piano
+    };
+
+    sortSf2PresetsForDisplay (presets);
+
+    // Melodic first (prog0 piano, prog40), percussion kit last.
+    REQUIRE (sourceOrder (presets) == std::vector<int> { 2, 1, 0 });
+}
+
+TEST_CASE ("SF2 preset sort breaks ties by sourceIndex", "[sf2][preset]")
+{
+    // Duplicate program+bank: the stable persisted ID (sourceIndex) decides,
+    // ascending, so the display order is deterministic across loads.
+    std::vector<Preset> presets {
+        { /*src*/ 7, /*bank*/ 0, /*prog*/ 3 },
+        { /*src*/ 2, /*bank*/ 0, /*prog*/ 3 },
+        { /*src*/ 5, /*bank*/ 0, /*prog*/ 3 },
+    };
+
+    sortSf2PresetsForDisplay (presets);
+
+    REQUIRE (sourceOrder (presets) == std::vector<int> { 2, 5, 7 });
+}
+
+TEST_CASE ("SF2 preset sort preserves source indices (IDs, not positions)",
+           "[sf2][preset]")
+{
+    // The sort must reorder rows for display but never renumber sourceIndex:
+    // that value is the stable ID used for loading + session persistence.
+    std::vector<Preset> presets {
+        { 3, 2, 1 }, { 0, 0, 0 }, { 1, 1, 4 },
+    };
+
+    sortSf2PresetsForDisplay (presets);
+
+    // Every original sourceIndex still present exactly once.
+    auto ids = sourceOrder (presets);
+    std::sort (ids.begin(), ids.end());
+    REQUIRE (ids == std::vector<int> { 0, 1, 3 });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a grid-based SoundFont preset browser with filtering, keyboard navigation, and clearer program/bank information.
  * Multi-preset `.sf2` files now show a preset picker after loading.
  * Selected SoundFont presets are saved and restored with sessions.
  * Improved modal and dropdown behavior, including focus handling and outside-click dismissal.

* **Bug Fixes**
  * Improved loading feedback and prevented stale preset selections during failed or in-progress loads.
  * Corrected monitored-input and auxiliary-send behavior during playback and recording.

* **Documentation**
  * Updated the multi-sample instrument documentation with the new SoundFont preset workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->