### PR TITLE
device: do not report a disconnect the user asked for

### DIFF
--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -2390,15 +2390,22 @@ void AudioEngine::onDeviceManagerChanged()
     if (! hadLiveDevice_.load (std::memory_order_acquire)) return;
     if (deviceManager.getCurrentDevice() != nullptr) return;
 
-    // Defer one tick so a settings-driven device swap can complete
-    // before we decide it's a hot-unplug. The audioDeviceAboutToStart
-    // for the new device will republish hadLiveDevice_ = true and
-    // the deferred check below sees getCurrentDevice() != null,
-    // bailing without spurious alert.
-    dusk::callAsync ([this]
+    // Two things distinguish a real loss from a device change the user asked
+    // for. The defer below covers a swap: audioDeviceAboutToStart republishes
+    // hadLiveDevice_ and the deferred check sees a non-null device, so it bails.
+    // That is not enough for a BACKEND switch, which selects nothing until the
+    // user picks from the new backend's list - no replacement ever arrives, so
+    // consult the manager's pending-change state as well. Sampled here rather
+    // than inside the lambda: what matters is whether THIS notification came
+    // from a deliberate change, not whether one happens to be running a tick
+    // later.
+    const bool fromDeliberateChange = deviceManager.isDeviceChangePending();
+
+    dusk::callAsync ([this, fromDeliberateChange]
     {
         if (deviceManager.getCurrentDevice() != nullptr) return;
         if (! hadLiveDevice_.load (std::memory_order_acquire)) return;
+        if (fromDeliberateChange) return;
 
         // Confirmed loss. Clear the flag so a subsequent change
         // broadcast for the same loss doesn't re-fire.

--- a/src/engine/device/DeviceManager.cpp
+++ b/src/engine/device/DeviceManager.cpp
@@ -10,6 +10,7 @@
  #include "../alsa/AlsaAudioIODeviceType.h"
 #endif
 
+#include <atomic>
 #include <map>
 
 namespace duskstudio::device
@@ -124,7 +125,8 @@ private:
 class CallbackBridge final : public juce::AudioIODeviceCallback
 {
 public:
-    explicit CallbackBridge (IODeviceCallback* c) noexcept : cb (c) {}
+    CallbackBridge (IODeviceCallback* c, std::atomic<bool>& pendingFlag) noexcept
+        : cb (c), deviceChangePending (&pendingFlag) {}
 
     void audioDeviceIOCallbackWithContext (const float* const* in, int numIn,
                                            float* const* out, int numOut, int numSamples,
@@ -137,6 +139,11 @@ public:
 
     void audioDeviceAboutToStart (juce::AudioIODevice* device) override
     {
+        // Synchronous counterpart to the change-listener clear: a device that
+        // starts and is pulled again before the (async) change broadcast lands
+        // would otherwise leave the flag set with no live device to clear it.
+        deviceChangePending->store (false, std::memory_order_release);
+
         adapter.repoint (device);
         cb->audioDeviceAboutToStart (&adapter);
     }
@@ -147,8 +154,9 @@ public:
         { cb->audioDeviceError (message.toStdString()); }
 
 private:
-    IODeviceCallback* cb;
-    JuceDeviceAdapter adapter { nullptr };
+    IODeviceCallback*  cb;
+    std::atomic<bool>* deviceChangePending;
+    JuceDeviceAdapter  adapter { nullptr };
 };
 } // namespace
 
@@ -167,7 +175,16 @@ struct DeviceManager::Impl : private juce::ChangeListener
         mgr.removeChangeListener (this);
     }
 
-    void changeListenerCallback (juce::ChangeBroadcaster*) override { fireListeners(); }
+    void changeListenerCallback (juce::ChangeBroadcaster*) override
+    {
+        // A live device means whatever deliberate change closed the previous one
+        // has landed. Cleared here rather than from the device-started callback
+        // so it does not depend on anyone having registered one.
+        if (mgr.getCurrentAudioDevice() != nullptr)
+            deviceChangePending.store (false, std::memory_order_release);
+
+        fireListeners();
+    }
 
     void fireListeners()
     {
@@ -191,6 +208,10 @@ struct DeviceManager::Impl : private juce::ChangeListener
     }
 
     juce::AudioDeviceManager mgr;
+
+    // Set by a deliberate device-type / setup change, cleared once a device
+    // starts. See DeviceManager::isDeviceChangePending.
+    std::atomic<bool> deviceChangePending { false };
     // Keyed by the juce type pointer (stable for the manager's lifetime), so an
     // adapter is created once and never moved or destroyed while handed out - a
     // returned IODeviceType* stays valid across later calls.
@@ -305,7 +326,27 @@ IODeviceType* DeviceManager::getCurrentDeviceType()
 
 void DeviceManager::setCurrentDeviceType (const std::string& typeName, bool treatAsChosen)
 {
-    impl->mgr.setCurrentAudioDeviceType (juce::String (typeName), treatAsChosen);
+    // Only arm for a request that will actually move: the manager ignores an
+    // unknown type name or one that is already current, closing nothing and
+    // broadcasting nothing. Arming for those would strand the flag set while a
+    // device is still live, and swallow the next genuine disconnection.
+    const juce::String wanted (typeName);
+    bool willChange = wanted != impl->mgr.getCurrentAudioDeviceType();
+    if (willChange)
+    {
+        willChange = false;
+        for (auto* t : impl->mgr.getAvailableDeviceTypes())
+            if (t != nullptr && t->getTypeName() == wanted) { willChange = true; break; }
+    }
+    if (willChange)
+        impl->deviceChangePending.store (true, std::memory_order_release);
+
+    impl->mgr.setCurrentAudioDeviceType (wanted, treatAsChosen);
+}
+
+bool DeviceManager::isDeviceChangePending() const noexcept
+{
+    return impl->deviceChangePending.load (std::memory_order_acquire);
 }
 
 DeviceSetup DeviceManager::getSetup() const
@@ -334,6 +375,12 @@ std::string DeviceManager::setSetup (const DeviceSetup& d, bool treatAsChosen)
     s.outputChannels = toBig (d.outputChannels);
     s.useDefaultInputChannels  = d.useDefaultInputChannels;
     s.useDefaultOutputChannels = d.useDefaultOutputChannels;
+
+    // Same reasoning as setCurrentDeviceType: an unchanged setup against a live
+    // device is a no-op the manager returns from without broadcasting.
+    if (s != impl->mgr.getAudioDeviceSetup() || impl->mgr.getCurrentAudioDevice() == nullptr)
+        impl->deviceChangePending.store (true, std::memory_order_release);
+
     return impl->mgr.setAudioDeviceSetup (s, treatAsChosen).toStdString();
 }
 
@@ -345,7 +392,7 @@ void DeviceManager::addCallback (IODeviceCallback* callback)
     // dropped (leaving mgr with a dangling pointer).
     auto [it, inserted] = impl->bridges.emplace (callback, nullptr);
     if (! inserted) return;
-    it->second = std::make_unique<CallbackBridge> (callback);
+    it->second = std::make_unique<CallbackBridge> (callback, impl->deviceChangePending);
     impl->mgr.addAudioCallback (it->second.get());
 }
 
@@ -357,7 +404,14 @@ void DeviceManager::removeCallback (IODeviceCallback* callback)
     impl->bridges.erase (it);
 }
 
-void DeviceManager::closeDevice() { impl->mgr.closeAudioDevice(); }
+void DeviceManager::closeDevice()
+{
+    // An explicit close is never a disconnection, whoever asked for it. Nothing
+    // to arm when there is no device to close.
+    if (impl->mgr.getCurrentAudioDevice() != nullptr)
+        impl->deviceChangePending.store (true, std::memory_order_release);
+    impl->mgr.closeAudioDevice();
+}
 
 void DeviceManager::addChangeListener (void* owner, std::function<void()> onChange)
 {

--- a/src/engine/device/DeviceManager.h
+++ b/src/engine/device/DeviceManager.h
@@ -61,6 +61,16 @@ public:
     // Apply a setup. Returns an empty string on success, else an error message.
     std::string setSetup (const DeviceSetup& setup, bool treatAsChosen);
 
+    // True between a deliberate device change - a type switch, a setup change,
+    // or an explicit closeDevice - and the next device coming up. All of those
+    // close the current device, so a null device during that window is expected
+    // rather than a disconnection, and switching backend leaves it null
+    // indefinitely, until the user picks an interface from the new backend's
+    // list. Whoever watches for hot-unplug must consult this before deciding a
+    // null device means the hardware went away. Self clearing: dropped as soon
+    // as a device starts, or as soon as a change broadcast reports a live one.
+    bool isDeviceChangePending() const noexcept;
+
     void addCallback (IODeviceCallback* callback);
     void removeCallback (IODeviceCallback* callback);
     void closeDevice();


### PR DESCRIPTION
Switching backend closes the current device and selects nothing - the new backend's device list is there for the user to pick from. The hot-unplug detector deferred one dispatch tick to let a replacement device arrive, but on a backend switch none ever does, so it read the null device as hardware loss and raised "Audio device disconnected" while the user was still choosing an interface.

DeviceManager now records that a deliberate device change is in flight - type switch, setup change, or an explicit close - and the detector consults it before alarming, sampling it when the notification arrives rather than a tick later, so the decision reflects what caused this notification.

The flag is armed only for a request that will actually move the device. The manager ignores an unknown or already-current type, and returns from an unchanged setup against a live device, in both cases without broadcasting - arming for those would strand the flag set while a device is still live and swallow the next genuine disconnection. It clears on a device starting and on any broadcast reporting a live device; two paths, because a device pulled again before the async broadcast lands would leave nothing to clear it.

A genuine loss after a device is up still alerts: a live device always clears the flag, and real hardware removal runs through none of the deliberate paths.

Not unit-tested: the device tests cover value types only, and reaching this needs a live DeviceManager plus the settings click path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented false “audio device disconnected” alerts during intentional device, backend, or setup changes.
  * Improved handling of temporary periods when no audio device is selected during a planned switch.
  * Audio transport now stops only when an actual device loss is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->