### PR TITLE
Dejuce/native midi m3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,8 +535,12 @@ if(UNIX AND NOT APPLE)
 endif()
 
 # No native MIDI backend off Linux: the seam falls back to JUCE's MIDI device
-# API, confined to this one TU. Gated on the same condition MidiDevices.cpp
-# selects the backend with (__linux__), so exactly one of the two is present.
+# API, confined to this one TU. This condition is the exact inverse of the
+# __linux__ branch MidiDevices.cpp picks its backend with, so the backend it
+# asks for is always compiled in. (The ALSA block above uses the wider
+# UNIX-AND-NOT-APPLE, so a non-Linux Unix would build AlsaSeqMidi.cpp too - as
+# its own non-Linux stub, unreferenced. Only Linux, macOS and Windows are
+# actually targeted.)
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_sources(DuskStudio PRIVATE src/engine/midi/JuceMidiBackend.cpp)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -527,12 +527,18 @@ if(UNIX AND NOT APPLE)
         src/engine/alsa/AlsaAudioIODeviceType.cpp
         src/engine/alsa/AlsaPerformanceTest.cpp
         # Native ALSA-seq MIDI backend (snd_seq_*, same libasound as the audio
-        # backend). Compiled here so the app build proves it clean; the seam is
-        # not wired to it yet (M3).
+        # backend) - what the MIDI device seam runs on here.
         src/engine/midi/AlsaSeqMidi.cpp
         src/ui/KeyboardStateLinux.cpp)
     target_link_libraries(DuskStudio PRIVATE asound X11 ${CMAKE_DL_LIBS})  # X11/dl: clap host + windowing
     target_compile_definitions(DuskStudio PRIVATE DUSKSTUDIO_HAS_ALSA=1)
+endif()
+
+# No native MIDI backend off Linux: the seam falls back to JUCE's MIDI device
+# API, confined to this one TU. Gated on the same condition MidiDevices.cpp
+# selects the backend with (__linux__), so exactly one of the two is present.
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_sources(DuskStudio PRIVATE src/engine/midi/JuceMidiBackend.cpp)
 endif()
 
 # Dusk Studio-owned native PipeWire backend - a juce::AudioIODevice +

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -9,6 +9,9 @@
 #include "../session/RegionEditActions.h"
 #include "DeviceFallbackMessage.h"
 #include "../foundation/MessageThread.h"
+#if ! defined(__linux__)
+ #include "midi/JuceMidiBackend.h"
+#endif
 #include <algorithm>
 #include <array>
 #include <cstdlib>
@@ -524,11 +527,16 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
     }
    #endif
 
+   #if ! defined(__linux__)
+    // The JUCE MIDI fallback drives its input enable/callback lifecycle through
+    // the device manager. Linux runs the native ALSA-sequencer backend, which
+    // owns its own connections, and compiles this out entirely.
+    duskstudio::midi::setJuceMidiDeviceManager (deviceManager.juceManager());
+   #endif
+
     // Build both MIDI banks before ANY callback is registered - the audio
     // callback iterates perInputMidi, so it must not be attachable while
-    // rebuildMidiBanks sizes the vector. Empty deviceIdentifier = every
-    // enabled input fans out to midiIn, routed there by source identifier.
-    midiIn.setDeviceManager (deviceManager.juceManager());
+    // rebuildMidiBanks sizes the vector.
     rebuildMidiBanks();
     midiIn.attachCallback();
 
@@ -560,21 +568,13 @@ void AudioEngine::refreshMidiInputs()
     // devices. Re-resolve each track's saved identifier so a refresh
     // doesn't silently break existing routing. Tracks with no saved
     // identifier (very old sessions) keep their raw index, clamped.
-    auto resolveByIdentifier = [] (const std::vector<duskstudio::midi::MidiDeviceInfo>& devices,
-                                    const juce::String& wantedId)
-    {
-        for (int i = 0; i < (int) devices.size(); ++i)
-            if (devices[(size_t) i].identifier == wantedId)
-                return i;
-        return -1;
-    };
     for (int t = 0; t < Session::kNumTracks; ++t)
     {
         auto& track = session.track (t);
         if (track.midiInputIdentifier.isNotEmpty())
         {
             track.midiInputIndex.store (
-                resolveByIdentifier (midiIn.getDevices(), track.midiInputIdentifier),
+                midiIn.resolveIndex (track.midiInputIdentifier.toStdString()),
                 std::memory_order_relaxed);
         }
         else
@@ -586,7 +586,7 @@ void AudioEngine::refreshMidiInputs()
         if (track.midiOutputIdentifier.isNotEmpty())
         {
             track.midiOutputIndex.store (
-                resolveByIdentifier (midiOut.getDevices(), track.midiOutputIdentifier),
+                midiOut.resolveIndex (track.midiOutputIdentifier.toStdString()),
                 std::memory_order_relaxed);
         }
         else
@@ -908,27 +908,19 @@ void AudioEngine::reresolveTrackMidiFromSession()
     // no audio glitch. Cheap enough to run on every session load. (The full
     // refreshMidiInputs hot-plug path would detach/reattach the audio callback
     // and disable/re-enable every MIDI device - seconds of frozen UI on load.)
-    auto resolveByIdentifier = [] (const std::vector<duskstudio::midi::MidiDeviceInfo>& devices,
-                                    const juce::String& wantedId)
-    {
-        for (int i = 0; i < (int) devices.size(); ++i)
-            if (devices[(size_t) i].identifier == wantedId)
-                return i;
-        return -1;
-    };
     for (int t = 0; t < Session::kNumTracks; ++t)
     {
         auto& track = session.track (t);
         if (track.midiInputIdentifier.isNotEmpty())
             track.midiInputIndex.store (
-                resolveByIdentifier (midiIn.getDevices(), track.midiInputIdentifier),
+                midiIn.resolveIndex (track.midiInputIdentifier.toStdString()),
                 std::memory_order_relaxed);
         else if (track.midiInputIndex.load (std::memory_order_relaxed) >= (int) midiIn.getDevices().size())
             track.midiInputIndex.store (-1, std::memory_order_relaxed);
 
         if (track.midiOutputIdentifier.isNotEmpty())
             track.midiOutputIndex.store (
-                resolveByIdentifier (midiOut.getDevices(), track.midiOutputIdentifier),
+                midiOut.resolveIndex (track.midiOutputIdentifier.toStdString()),
                 std::memory_order_relaxed);
         else if (track.midiOutputIndex.load (std::memory_order_relaxed) >= (int) midiOut.getDevices().size())
             track.midiOutputIndex.store (-1, std::memory_order_relaxed);
@@ -939,17 +931,10 @@ void AudioEngine::reresolveTrackMidiFromSession()
     // so a session load must remap them to current bank indices too - else the
     // engine's sync + MCU consumers read stale indices until the user reopens
     // Audio Settings. release-ordered to match their setters in AudioSettingsPanel.
-    auto resolveSessionIdx = [&] (std::atomic<int>& idx,
-                                   const std::vector<duskstudio::midi::MidiDeviceInfo>& devices,
-                                   const juce::String& wantedId)
-    {
-        idx.store (wantedId.isNotEmpty() ? resolveByIdentifier (devices, wantedId) : -1,
-                   std::memory_order_release);
-    };
-    resolveSessionIdx (session.syncSourceInputIdx,    midiIn.getDevices(),  session.syncSourceInputIdentifier);
-    resolveSessionIdx (session.syncOutputIdx,         midiOut.getDevices(), session.syncOutputIdentifier);
-    resolveSessionIdx (session.mcu.resolvedInputIdx,  midiIn.getDevices(),  session.mcu.inputIdentifier);
-    resolveSessionIdx (session.mcu.resolvedOutputIdx, midiOut.getDevices(), session.mcu.outputIdentifier);
+    session.syncSourceInputIdx   .store (midiIn .resolveIndex (session.syncSourceInputIdentifier.toStdString()), std::memory_order_release);
+    session.syncOutputIdx        .store (midiOut.resolveIndex (session.syncOutputIdentifier     .toStdString()), std::memory_order_release);
+    session.mcu.resolvedInputIdx .store (midiIn .resolveIndex (session.mcu.inputIdentifier      .toStdString()), std::memory_order_release);
+    session.mcu.resolvedOutputIdx.store (midiOut.resolveIndex (session.mcu.outputIdentifier     .toStdString()), std::memory_order_release);
 
     // A session load may have replaced the tempo map - republish the audio
     // thread's snapshot so the MIDI scheduler + metronome see the loaded points.
@@ -979,18 +964,10 @@ void AudioEngine::rebuildMidiBanks()
     // hot-plug doesn't strand an index at a stale slot (STAYS in the engine -
     // the banks don't know session identifiers). Empty / no match = -1. release
     // pairs with the audio-thread acquires and the AudioSettingsPanel setters.
-    auto resolve = [] (const std::vector<duskstudio::midi::MidiDeviceInfo>& devices,
-                        const juce::String& wantedId)
-    {
-        if (wantedId.isEmpty()) return -1;
-        for (int i = 0; i < (int) devices.size(); ++i)
-            if (devices[(size_t) i].identifier == wantedId) return i;
-        return -1;
-    };
-    session.syncSourceInputIdx   .store (resolve (midiIn.getDevices(),  session.syncSourceInputIdentifier), std::memory_order_release);
-    session.mcu.resolvedInputIdx .store (resolve (midiIn.getDevices(),  session.mcu.inputIdentifier),       std::memory_order_release);
-    session.syncOutputIdx        .store (resolve (midiOut.getDevices(), session.syncOutputIdentifier),      std::memory_order_release);
-    session.mcu.resolvedOutputIdx.store (resolve (midiOut.getDevices(), session.mcu.outputIdentifier),      std::memory_order_release);
+    session.syncSourceInputIdx   .store (midiIn .resolveIndex (session.syncSourceInputIdentifier.toStdString()), std::memory_order_release);
+    session.mcu.resolvedInputIdx .store (midiIn .resolveIndex (session.mcu.inputIdentifier      .toStdString()), std::memory_order_release);
+    session.syncOutputIdx        .store (midiOut.resolveIndex (session.syncOutputIdentifier     .toStdString()), std::memory_order_release);
+    session.mcu.resolvedOutputIdx.store (midiOut.resolveIndex (session.mcu.outputIdentifier     .toStdString()), std::memory_order_release);
 
     // Eager-open the sync + MCU output ports so the first clock byte / MCU tick
     // doesn't wait on a synchronous ALSA snd_seq_connect. Per-track outputs open

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -376,8 +376,8 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
     mcuController = std::make_unique<McuController> (session);
     mcuController->setSink ([this] (const dusk::MidiBuffer& buf)
     {
-        // Message thread (30 Hz MCU tick). The bank bridges dusk -> juce for the
-        // direct send.
+        // Message thread (30 Hz MCU tick); the bank's direct send blocks here,
+        // not on the audio thread.
         const int outIdx = session.mcu.resolvedOutputIdx.load (std::memory_order_acquire);
         if (outIdx >= 0) midiOut.send (outIdx, buf);
     });

--- a/src/engine/AudioEngine.h
+++ b/src/engine/AudioEngine.h
@@ -161,11 +161,11 @@ public:
         return midiOut.getDevices();
     }
 
-    // Synthetic "Virtual Keyboard (Dusk Studio)" collector appended to the
-    // input bank. nullptr until the input bank has been built.
-    juce::MidiMessageCollector* getVirtualKeyboardCollector() noexcept
+    // Feed the synthetic "Virtual Keyboard (Dusk Studio)" input slot with a
+    // complete MIDI message. No-op until the input bank has been built.
+    void postVirtualKeyboardMidi (const std::uint8_t* bytes, int numBytes) noexcept
     {
-        return midiIn.getVirtualKeyboardCollector();
+        midiIn.postVirtualKeyboardMidi (bytes, numBytes);
     }
 
     // Index of the virtual keyboard inside the input bank, or -1 if the bank
@@ -722,9 +722,9 @@ private:
     void processStripLane (int lane) noexcept;            // one worker lane
     void reduceLaneAccum (int numSamples) noexcept;       // sum lanes -> mix
 
-    // The single JUCE-device seam. midiIn owns the per-input collector bank and
-    // is itself the input callback; midiOut owns the output-port bank + RT
-    // out-queue + pump thread. The audio thread only calls midiIn.drainBlock /
+    // The MIDI device seam. midiIn owns the per-input collector bank and
+    // receives the backend's input callback; midiOut owns the output-port bank +
+    // RT out-queue + pump thread. The audio thread only calls midiIn.drainBlock /
     // midiOut.queueRt (both take dusk::MidiBuffer). The detach-rebuild-reattach
     // fence around a hot-plug is orchestrated by rebuildMidiBanks below.
     duskstudio::midi::MidiInputClient  midiIn;

--- a/src/engine/device/DeviceManager.cpp
+++ b/src/engine/device/DeviceManager.cpp
@@ -422,5 +422,7 @@ void DeviceManager::removeChangeListener (void* owner) { impl->listeners.erase (
 
 void DeviceManager::notifyChange() { impl->fireListeners(); }
 
+#if ! defined(__linux__)
 juce::AudioDeviceManager& DeviceManager::juceManager() { return impl->mgr; }
+#endif
 } // namespace duskstudio::device

--- a/src/engine/device/DeviceManager.h
+++ b/src/engine/device/DeviceManager.h
@@ -86,11 +86,13 @@ public:
     // check may swallow the notification.
     void notifyChange();
 
-    // Escape hatch: the MIDI input layer alone still drives MIDI device
-    // enable/disable through the wrapped JUCE AudioDeviceManager. This is now
-    // its only consumer (the audio-device UI drives the dusk API above). Removed
-    // once the native MIDI backend lands and juce_audio_devices unlinks.
+   #if ! defined(__linux__)
+    // Off Linux the MIDI seam falls back to JUCE's MIDI device API, whose input
+    // enable/callback lifecycle runs against this same manager. Linux drives the
+    // native ALSA-sequencer backend and compiles this hatch out; it disappears
+    // entirely when the wrapper does.
     juce::AudioDeviceManager& juceManager();
+   #endif
 
 private:
     struct Impl;

--- a/src/engine/midi/AlsaSeqMidi.cpp
+++ b/src/engine/midi/AlsaSeqMidi.cpp
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <map>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <utility>
@@ -150,6 +151,14 @@ struct AlsaSeqMidiInput::Impl
     snd_midi_event_t* coder  = nullptr;
     Receiver          receiver;
 
+    // libasound does not support concurrent use of one snd_seq_t. The poll
+    // thread reads events off `seq` while the message thread can be querying it
+    // (migrateIdentifier runs during a session load, which deliberately does NOT
+    // stop the poll thread). Every use of the handle takes this - except poll()
+    // itself, which must stay outside or the message thread would block until
+    // MIDI happens to arrive.
+    std::mutex seqMutex;
+
     // Live source address -> identifier, for demuxing incoming events. Built at
     // enable() (poll thread stopped); read only from the poll thread.
     std::map<std::uint32_t, std::string> sourceIds;
@@ -256,6 +265,7 @@ struct AlsaSeqMidiInput::Impl
 
     void pumpEvents()
     {
+        const std::lock_guard<std::mutex> lock (seqMutex);
         snd_seq_event_t* ev = nullptr;
         while (snd_seq_event_input (seq, &ev) >= 0 && ev != nullptr)
         {
@@ -292,11 +302,18 @@ struct AlsaSeqMidiInput::Impl
 
     void run()
     {
-        const int nfds = snd_seq_poll_descriptors_count (seq, POLLIN);
+        int nfds = 0;
+        {
+            const std::lock_guard<std::mutex> lock (seqMutex);
+            nfds = snd_seq_poll_descriptors_count (seq, POLLIN);
+        }
         std::vector<pollfd> pfds ((std::size_t) nfds + 1);
         while (running.load (std::memory_order_acquire))
         {
-            snd_seq_poll_descriptors (seq, pfds.data(), (unsigned) nfds, POLLIN);
+            {
+                const std::lock_guard<std::mutex> lock (seqMutex);
+                snd_seq_poll_descriptors (seq, pfds.data(), (unsigned) nfds, POLLIN);
+            }
             pfds[(std::size_t) nfds] = { wakePipe[0], POLLIN, 0 };
             const int r = poll (pfds.data(), (nfds_t) (nfds + 1), -1);
             if (r < 0) { if (errno == EINTR) continue; break; }
@@ -335,6 +352,7 @@ std::vector<BackendDeviceInfo> AlsaSeqMidiInput::enumerate()
 {
     std::vector<BackendDeviceInfo> out;
     if (! impl->ready()) return out;
+    const std::lock_guard<std::mutex> lock (impl->seqMutex);
     for (auto& p : queryPorts (impl->seq, /*wantRead*/ true))
         out.push_back ({ p.name, p.identifier });
     return out;
@@ -345,12 +363,14 @@ void AlsaSeqMidiInput::setReceiver (Receiver r) { impl->receiver = std::move (r)
 std::string AlsaSeqMidiInput::migrateIdentifier (const std::string& legacy)
 {
     if (! impl->ready()) return {};
+    const std::lock_guard<std::mutex> lock (impl->seqMutex);
     return migrateLegacyAddress (impl->seq, /*wantRead*/ true, legacy);
 }
 
 bool AlsaSeqMidiInput::enable (const std::string& identifier)
 {
     if (! impl->ready()) return false;
+    const std::lock_guard<std::mutex> lock (impl->seqMutex);
     for (auto& p : queryPorts (impl->seq, true))
     {
         if (p.identifier != identifier) continue;
@@ -364,6 +384,7 @@ bool AlsaSeqMidiInput::enable (const std::string& identifier)
 
 void AlsaSeqMidiInput::disableAll()
 {
+    const std::lock_guard<std::mutex> lock (impl->seqMutex);
     if (impl->seq != nullptr)
         for (auto& kv : impl->sourceIds)
             snd_seq_disconnect_from (impl->seq, impl->inPort,
@@ -384,6 +405,12 @@ struct AlsaSeqMidiOutput::Impl
     int               outPort = -1;
     snd_midi_event_t* coder   = nullptr;
     std::map<std::string, std::pair<int, int>> openDests;   // identifier -> (client,port)
+
+    // As on the input side: the pump thread sends through `seq` while the
+    // message thread can be opening or querying it. Taken by the public entry
+    // points only - Impl::closeAll is also reached from the destructor, which
+    // must not re-enter it.
+    std::mutex seqMutex;
 
     // Fully initialised = usable. A null coder (no encode) or missing port means
     // the backend cannot send, so it must not advertise or open devices.
@@ -426,6 +453,7 @@ std::vector<BackendDeviceInfo> AlsaSeqMidiOutput::enumerate()
 {
     std::vector<BackendDeviceInfo> out;
     if (! impl->ready()) return out;
+    const std::lock_guard<std::mutex> lock (impl->seqMutex);
     for (auto& p : queryPorts (impl->seq, /*wantRead*/ false))
         out.push_back ({ p.name, p.identifier });
     return out;
@@ -434,12 +462,14 @@ std::vector<BackendDeviceInfo> AlsaSeqMidiOutput::enumerate()
 std::string AlsaSeqMidiOutput::migrateIdentifier (const std::string& legacy)
 {
     if (! impl->ready()) return {};
+    const std::lock_guard<std::mutex> lock (impl->seqMutex);
     return migrateLegacyAddress (impl->seq, /*wantRead*/ false, legacy);
 }
 
 bool AlsaSeqMidiOutput::open (const std::string& identifier)
 {
     if (! impl->ready()) return false;
+    const std::lock_guard<std::mutex> lock (impl->seqMutex);
     if (impl->openDests.count (identifier)) return true;   // lazy open is idempotent
     for (auto& p : queryPorts (impl->seq, false))
     {
@@ -452,10 +482,15 @@ bool AlsaSeqMidiOutput::open (const std::string& identifier)
     return false;
 }
 
-void AlsaSeqMidiOutput::closeAll() { impl->closeAll(); }
+void AlsaSeqMidiOutput::closeAll()
+{
+    const std::lock_guard<std::mutex> lock (impl->seqMutex);
+    impl->closeAll();
+}
 
 bool AlsaSeqMidiOutput::isOpen (const std::string& identifier) const
 {
+    const std::lock_guard<std::mutex> lock (impl->seqMutex);
     return impl->openDests.count (identifier) > 0;
 }
 
@@ -469,6 +504,7 @@ bool AlsaSeqMidiOutput::send (const std::string& identifier, const dusk::MidiBuf
     (void) baseTimeMs;
     (void) sampleRate;
 
+    const std::lock_guard<std::mutex> lock (impl->seqMutex);
     if (impl->seq == nullptr || impl->coder == nullptr) return false;
     auto it = impl->openDests.find (identifier);
     if (it == impl->openDests.end()) return false;

--- a/src/engine/midi/AlsaSeqMidi.cpp
+++ b/src/engine/midi/AlsaSeqMidi.cpp
@@ -10,8 +10,8 @@
 
 #include <atomic>
 #include <cerrno>
-#include <chrono>
 #include <cstdint>
+#include <cstdlib>
 #include <map>
 #include <string>
 #include <thread>
@@ -32,14 +32,6 @@ constexpr std::size_t kMaxSysexBytes    = 1u << 20;
 // scratch a little headroom for those before it has to grow.
 constexpr std::size_t kShortEventBytes  = 16;
 constexpr char        kIdPrefix[]       = "alsa-seq:";
-
-// Hi-res millisecond clock in the same domain the seam's MidiCollector drains
-// against (M3 passes the equivalent clock to removeNextBlock).
-double nowMs() noexcept
-{
-    using namespace std::chrono;
-    return duration<double, std::milli> (steady_clock::now().time_since_epoch()).count();
-}
 
 // Escape '\' and ':' so the ':'-delimited identifier stays unambiguous even when
 // a client or port name itself contains a colon.
@@ -122,6 +114,30 @@ std::uint32_t addrKey (int client, int port) noexcept
 {
     return ((std::uint32_t) client << 16) | (std::uint32_t) (port & 0xffff);
 }
+
+// JUCE's Linux MIDI identifiers are the raw sequencer address, "<client>-<port>".
+// Sessions saved before this backend existed hold those, so map one back to a
+// live port and hand out its name-based identifier instead. Only valid while the
+// numbers still point at the same hardware - the very instability that motivated
+// the name-based scheme - so a miss is normal and returns "".
+std::string migrateLegacyAddress (snd_seq_t* seq, bool wantRead, const std::string& legacy)
+{
+    const auto dash = legacy.find ('-');
+    if (dash == std::string::npos || dash == 0 || dash + 1 >= legacy.size()) return {};
+
+    const char* s = legacy.c_str();
+    char* endClient = nullptr;
+    char* endPort   = nullptr;
+    const long client = std::strtol (s, &endClient, 10);
+    if (endClient != s + dash) return {};
+    const long port = std::strtol (s + dash + 1, &endPort, 10);
+    if (endPort != s + legacy.size()) return {};
+
+    for (const auto& p : queryPorts (seq, wantRead))
+        if (p.client == client && p.port == port)
+            return p.identifier;
+    return {};
+}
 } // namespace
 
 // ---------------------------------------------------------------------------
@@ -190,7 +206,7 @@ struct AlsaSeqMidiInput::Impl
         if (! receiver || n <= 0) return;
         auto it = sourceIds.find (addrKey (client, port));
         if (it != sourceIds.end())
-            receiver (it->second, bytes, n, nowMs());
+            receiver (it->second, bytes, n, backendClockMs());
     }
 
     // Reassemble sysex spanning multiple events; pass everything else straight
@@ -326,6 +342,12 @@ std::vector<BackendDeviceInfo> AlsaSeqMidiInput::enumerate()
 
 void AlsaSeqMidiInput::setReceiver (Receiver r) { impl->receiver = std::move (r); }
 
+std::string AlsaSeqMidiInput::migrateIdentifier (const std::string& legacy)
+{
+    if (! impl->ready()) return {};
+    return migrateLegacyAddress (impl->seq, /*wantRead*/ true, legacy);
+}
+
 bool AlsaSeqMidiInput::enable (const std::string& identifier)
 {
     if (! impl->ready()) return false;
@@ -409,6 +431,12 @@ std::vector<BackendDeviceInfo> AlsaSeqMidiOutput::enumerate()
     return out;
 }
 
+std::string AlsaSeqMidiOutput::migrateIdentifier (const std::string& legacy)
+{
+    if (! impl->ready()) return {};
+    return migrateLegacyAddress (impl->seq, /*wantRead*/ false, legacy);
+}
+
 bool AlsaSeqMidiOutput::open (const std::string& identifier)
 {
     if (! impl->ready()) return false;
@@ -437,7 +465,7 @@ bool AlsaSeqMidiOutput::send (const std::string& identifier, const dusk::MidiBuf
     // The pump runs at ~1 ms cadence, so events fire immediately (output_direct)
     // rather than being scheduled per sample-offset within the block; the sub-ms
     // ordering within a block is preserved by send order. Per-offset queue
-    // scheduling, if it proves audible, lands with the M3 seam timing.
+    // scheduling stays unimplemented until it proves audible.
     (void) baseTimeMs;
     (void) sampleRate;
 
@@ -483,6 +511,7 @@ AlsaSeqMidiInput::AlsaSeqMidiInput()  = default;
 AlsaSeqMidiInput::~AlsaSeqMidiInput() = default;
 std::vector<BackendDeviceInfo> AlsaSeqMidiInput::enumerate() { return {}; }
 void AlsaSeqMidiInput::setReceiver (Receiver) {}
+std::string AlsaSeqMidiInput::migrateIdentifier (const std::string&) { return {}; }
 bool AlsaSeqMidiInput::enable (const std::string&) { return false; }
 void AlsaSeqMidiInput::disableAll() {}
 void AlsaSeqMidiInput::start() {}
@@ -491,6 +520,7 @@ void AlsaSeqMidiInput::stop()  {}
 AlsaSeqMidiOutput::AlsaSeqMidiOutput()  = default;
 AlsaSeqMidiOutput::~AlsaSeqMidiOutput() = default;
 std::vector<BackendDeviceInfo> AlsaSeqMidiOutput::enumerate() { return {}; }
+std::string AlsaSeqMidiOutput::migrateIdentifier (const std::string&) { return {}; }
 bool AlsaSeqMidiOutput::open (const std::string&) { return false; }
 void AlsaSeqMidiOutput::closeAll() {}
 bool AlsaSeqMidiOutput::isOpen (const std::string&) const { return false; }

--- a/src/engine/midi/AlsaSeqMidi.cpp
+++ b/src/engine/midi/AlsaSeqMidi.cpp
@@ -307,6 +307,12 @@ struct AlsaSeqMidiInput::Impl
             const std::lock_guard<std::mutex> lock (seqMutex);
             nfds = snd_seq_poll_descriptors_count (seq, POLLIN);
         }
+        // A negative count is an alsa error code, and it must not reach the
+        // sizing below: cast to size_t it either wraps to a huge allocation or
+        // to zero, and the wake-pipe slot is then written out of bounds. Nothing
+        // is pollable in that case, so the thread has no work to do.
+        if (nfds <= 0) return;
+
         std::vector<pollfd> pfds ((std::size_t) nfds + 1);
         while (running.load (std::memory_order_acquire))
         {

--- a/src/engine/midi/AlsaSeqMidi.h
+++ b/src/engine/midi/AlsaSeqMidi.h
@@ -20,8 +20,8 @@
 // fixed key, so two same-named devices can trade identifiers across a replug or
 // reboot.
 //
-// Threading contract (matches the seam's detach/rebuild/attach fence, same as
-// the JUCE backing it replaces): enumerate / enable / disableAll / open /
+// Threading contract (matches the seam's detach/rebuild/attach fence):
+// enumerate / enable / disableAll / open /
 // closeAll / send are called on the message or pump thread while the input
 // poll thread is stopped. start() launches the poll thread; stop() joins it, so
 // no Receiver callback is in flight once stop() returns.
@@ -35,6 +35,7 @@ public:
 
     std::vector<BackendDeviceInfo> enumerate() override;
     void setReceiver (Receiver r) override;
+    std::string migrateIdentifier (const std::string& legacy) override;
     bool enable (const std::string& identifier) override;
     void disableAll() override;
     void start() override;
@@ -52,6 +53,7 @@ public:
     ~AlsaSeqMidiOutput() override;
 
     std::vector<BackendDeviceInfo> enumerate() override;
+    std::string migrateIdentifier (const std::string& legacy) override;
     bool open (const std::string& identifier) override;
     void closeAll() override;
     bool isOpen (const std::string& identifier) const override;

--- a/src/engine/midi/JuceMidiBackend.cpp
+++ b/src/engine/midi/JuceMidiBackend.cpp
@@ -1,6 +1,7 @@
 #include "JuceMidiBackend.h"
 
 #include <map>
+#include <mutex>
 #include <utility>
 #include <vector>
 
@@ -95,6 +96,7 @@ public:
 
     bool open (const std::string& identifier) override
     {
+        const std::lock_guard<std::mutex> lock (m);
         if (outputs.count (identifier)) return true;   // lazy open is idempotent
         auto out = juce::MidiOutput::openDevice (juce::String (identifier));
         if (out == nullptr) return false;
@@ -105,16 +107,25 @@ public:
         return true;
     }
 
-    void closeAll() override { outputs.clear(); }
+    void closeAll() override
+    {
+        const std::lock_guard<std::mutex> lock (m);
+        outputs.clear();
+    }
 
     bool isOpen (const std::string& identifier) const override
     {
+        const std::lock_guard<std::mutex> lock (m);
         return outputs.count (identifier) > 0;
     }
 
     bool send (const std::string& identifier, const dusk::MidiBuffer& events,
                double baseTimeMs, double sampleRate) override
     {
+        // Held across the send, not just the lookup: releasing early would let a
+        // concurrent closeAll destroy the output this iterator points at.
+        const std::lock_guard<std::mutex> lock (m);
+
         const auto it = outputs.find (identifier);
         if (it == outputs.end() || it->second == nullptr) return false;
 
@@ -136,8 +147,13 @@ public:
     }
 
 private:
+    // The seam serialises every call into this backend under its own mutex, but
+    // that is the caller's discipline, not a property of this class. Guarding
+    // here keeps it safe for any caller, on the platforms where this fallback is
+    // the MIDI path and the ALSA backend's equivalent guard does not apply.
+    mutable std::mutex m;
     std::map<std::string, std::unique_ptr<juce::MidiOutput>> outputs;
-    juce::MidiBuffer scratch;   // pump thread only
+    juce::MidiBuffer scratch;   // guarded by m
 };
 } // namespace
 

--- a/src/engine/midi/JuceMidiBackend.cpp
+++ b/src/engine/midi/JuceMidiBackend.cpp
@@ -1,0 +1,146 @@
+#include "JuceMidiBackend.h"
+
+#include <map>
+#include <utility>
+#include <vector>
+
+namespace duskstudio::midi
+{
+namespace
+{
+juce::AudioDeviceManager* deviceManager = nullptr;
+
+class JuceMidiInput final : public IMidiInputBackend,
+                            private juce::MidiInputCallback
+{
+public:
+    ~JuceMidiInput() override { stop(); }
+
+    std::vector<BackendDeviceInfo> enumerate() override
+    {
+        std::vector<BackendDeviceInfo> out;
+        for (const auto& d : juce::MidiInput::getAvailableDevices())
+            out.push_back ({ d.name.toStdString(), d.identifier.toStdString() });
+        return out;
+    }
+
+    void setReceiver (Receiver r) override { receiver = std::move (r); }
+
+    // JUCE's identifiers are what earlier sessions already hold on the platforms
+    // this backend serves, so there is nothing to migrate.
+    std::string migrateIdentifier (const std::string&) override { return {}; }
+
+    bool enable (const std::string& identifier) override
+    {
+        if (deviceManager == nullptr) return false;
+        const juce::String id (identifier);
+        // setMidiInputDeviceEnabled returns void - re-query to verify.
+        deviceManager->setMidiInputDeviceEnabled (id, true);
+        if (! deviceManager->isMidiInputDeviceEnabled (id)) return false;
+        enabled.push_back (identifier);
+        return true;
+    }
+
+    void disableAll() override
+    {
+        if (deviceManager != nullptr)
+            for (const auto& id : enabled)
+                deviceManager->setMidiInputDeviceEnabled (juce::String (id), false);
+        enabled.clear();
+    }
+
+    void start() override
+    {
+        // Empty identifier = every enabled input fans in here, demuxed by source.
+        if (deviceManager != nullptr)
+            deviceManager->addMidiInputDeviceCallback ({}, this);
+    }
+
+    void stop() override
+    {
+        // JUCE's remove joins the MIDI dispatch side before returning, which is
+        // the detach fence the seam relies on.
+        if (deviceManager != nullptr)
+            deviceManager->removeMidiInputDeviceCallback ({}, this);
+    }
+
+private:
+    void handleIncomingMidiMessage (juce::MidiInput* source,
+                                    const juce::MidiMessage& message) override
+    {
+        if (source == nullptr || ! receiver) return;
+        // Stamped with the seam's clock, not the message's own timestamp: the
+        // collector this feeds drains against backendClockMs(), and JUCE's
+        // timestamp epoch is a different one.
+        receiver (source->getIdentifier().toStdString(),
+                  message.getRawData(), message.getRawDataSize(), backendClockMs());
+    }
+
+    Receiver                 receiver;
+    std::vector<std::string> enabled;
+};
+
+class JuceMidiOutput final : public IMidiOutputBackend
+{
+public:
+    std::vector<BackendDeviceInfo> enumerate() override
+    {
+        std::vector<BackendDeviceInfo> out;
+        for (const auto& d : juce::MidiOutput::getAvailableDevices())
+            out.push_back ({ d.name.toStdString(), d.identifier.toStdString() });
+        return out;
+    }
+
+    std::string migrateIdentifier (const std::string&) override { return {}; }
+
+    bool open (const std::string& identifier) override
+    {
+        if (outputs.count (identifier)) return true;   // lazy open is idempotent
+        auto out = juce::MidiOutput::openDevice (juce::String (identifier));
+        if (out == nullptr) return false;
+        // Background thread so sendBlockOfMessages enqueues without blocking the
+        // pump on the OS port.
+        out->startBackgroundThread();
+        outputs[identifier] = std::move (out);
+        return true;
+    }
+
+    void closeAll() override { outputs.clear(); }
+
+    bool isOpen (const std::string& identifier) const override
+    {
+        return outputs.count (identifier) > 0;
+    }
+
+    bool send (const std::string& identifier, const dusk::MidiBuffer& events,
+               double baseTimeMs, double sampleRate) override
+    {
+        const auto it = outputs.find (identifier);
+        if (it == outputs.end() || it->second == nullptr) return false;
+
+        scratch.clear();
+        for (const auto meta : events)
+            scratch.addEvent (meta.data, meta.numBytes, meta.samplePosition);
+
+        // baseTimeMs comes from the seam's clock; sendBlockOfMessages schedules
+        // against JUCE's, a different epoch. The pump's ~1 ms cadence makes
+        // "now" the right base anyway - the same immediate-send policy the
+        // native backend uses.
+        (void) baseTimeMs;
+        it->second->sendBlockOfMessages (scratch,
+                                         juce::Time::getMillisecondCounterHiRes(),
+                                         sampleRate > 0.0 ? sampleRate : 48000.0);
+        return true;
+    }
+
+private:
+    std::map<std::string, std::unique_ptr<juce::MidiOutput>> outputs;
+    juce::MidiBuffer scratch;   // pump thread only
+};
+} // namespace
+
+void setJuceMidiDeviceManager (juce::AudioDeviceManager& dm) { deviceManager = &dm; }
+
+std::unique_ptr<IMidiInputBackend>  makeJuceMidiInputBackend()  { return std::make_unique<JuceMidiInput>(); }
+std::unique_ptr<IMidiOutputBackend> makeJuceMidiOutputBackend() { return std::make_unique<JuceMidiOutput>(); }
+} // namespace duskstudio::midi

--- a/src/engine/midi/JuceMidiBackend.cpp
+++ b/src/engine/midi/JuceMidiBackend.cpp
@@ -122,13 +122,15 @@ public:
         for (const auto meta : events)
             scratch.addEvent (meta.data, meta.numBytes, meta.samplePosition);
 
-        // baseTimeMs comes from the seam's clock; sendBlockOfMessages schedules
-        // against JUCE's, a different epoch. The pump's ~1 ms cadence makes
-        // "now" the right base anyway - the same immediate-send policy the
-        // native backend uses.
-        (void) baseTimeMs;
+        // baseTimeMs is stamped in the seam's clock; sendBlockOfMessages
+        // schedules against JUCE's counter, which runs off a different epoch.
+        // Shift by the current offset between the two rather than substituting
+        // "now", so a block queued before the pump woke keeps the timing it was
+        // stamped with. Both clocks are monotonic, so the offset is read fresh
+        // per send rather than cached.
+        const double toJuceClock = juce::Time::getMillisecondCounterHiRes() - backendClockMs();
         it->second->sendBlockOfMessages (scratch,
-                                         juce::Time::getMillisecondCounterHiRes(),
+                                         baseTimeMs + toJuceClock,
                                          sampleRate > 0.0 ? sampleRate : 48000.0);
         return true;
     }

--- a/src/engine/midi/JuceMidiBackend.h
+++ b/src/engine/midi/JuceMidiBackend.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "MidiBackend.h"
+
+#include <juce_audio_devices/juce_audio_devices.h>
+#include <memory>
+
+// JUCE-backed MIDI backend for platforms without a native one (macOS, Windows).
+// Linux uses AlsaSeqMidi and never compiles this TU, so the JUCE MIDI device
+// API - including the juce::AudioDeviceManager the input side needs for its
+// enable/callback lifecycle - is confined here rather than leaking into the
+// seam or the engine.
+namespace duskstudio::midi
+{
+// Must be called before the input backend is built. The manager outlives the
+// backend (the engine owns both).
+void setJuceMidiDeviceManager (juce::AudioDeviceManager& dm);
+
+std::unique_ptr<IMidiInputBackend>  makeJuceMidiInputBackend();
+std::unique_ptr<IMidiOutputBackend> makeJuceMidiOutputBackend();
+} // namespace duskstudio::midi

--- a/src/engine/midi/MidiBackend.h
+++ b/src/engine/midi/MidiBackend.h
@@ -2,6 +2,7 @@
 
 #include "../../foundation/MidiBuffer.h"
 
+#include <chrono>
 #include <cstdint>
 #include <functional>
 #include <string>
@@ -20,6 +21,16 @@ struct BackendDeviceInfo
     std::string identifier;
 };
 
+// The one clock the MIDI path is timed against: backends stamp incoming events
+// with it, and the seam drains its collectors against it. Both sides MUST read
+// the same source - a backend stamping a different epoch than the drain
+// compares to would retime every event by the offset between them.
+inline double backendClockMs() noexcept
+{
+    using namespace std::chrono;
+    return duration<double, std::milli> (steady_clock::now().time_since_epoch()).count();
+}
+
 class IMidiInputBackend
 {
 public:
@@ -35,6 +46,13 @@ public:
                                          double timeMs)>;
 
     virtual void setReceiver (Receiver r) = 0;          // set once, before start
+
+    // Best-effort remap of an identifier minted by a PREVIOUS backend, so a
+    // session saved before the backend changed keeps its routing. Returns the
+    // current identifier for that device, or "" when it cannot be mapped.
+    // Message thread.
+    [[nodiscard]] virtual std::string migrateIdentifier (const std::string& legacy) = 0;
+
     [[nodiscard]] virtual bool enable (const std::string& identifier) = 0;
     virtual void disableAll() = 0;
     virtual void start() = 0;                            // attach fence
@@ -50,6 +68,9 @@ public:
     virtual ~IMidiOutputBackend() = default;
 
     [[nodiscard]] virtual std::vector<BackendDeviceInfo> enumerate() = 0;
+
+    // As IMidiInputBackend::migrateIdentifier, for output ports.
+    [[nodiscard]] virtual std::string migrateIdentifier (const std::string& legacy) = 0;
 
     [[nodiscard]] virtual bool open (const std::string& identifier) = 0;   // lazy, message thread
     virtual void closeAll() = 0;

--- a/src/engine/midi/MidiDevices.cpp
+++ b/src/engine/midi/MidiDevices.cpp
@@ -18,6 +18,9 @@ namespace
 // thread has genuinely stopped draining.
 constexpr std::size_t kInputRingBytes = 16384;
 
+// Stand-in rate for a collector built before the audio device reports one.
+constexpr double kFallbackSampleRate = 48000.0;
+
 int indexOfIdentifier (const std::vector<MidiDeviceInfo>& devices, const std::string& identifier)
 {
     for (int i = 0; i < (int) devices.size(); ++i)
@@ -72,11 +75,18 @@ void MidiInputClient::rebuild (double sampleRate)
     devices.reserve (avail.size() + 1);
     collectors.reserve (avail.size() + 1);
 
+    // A collector must never be left unseeded: its retime is relative to
+    // lastCallbackTime, so a drain against an unset one would measure the whole
+    // steady-clock epoch and overflow the sample number. The engine rebuilds
+    // with sampleRate 0 before a device is open (and after one stops), so fall
+    // back to a placeholder rate here; audioDeviceAboutToStart resets to the
+    // real one before the first drain.
     const double now = backendClockMs();
+    const double rate = sampleRate > 0.0 ? sampleRate : kFallbackSampleRate;
     for (const auto& d : avail)
     {
         auto col = std::make_unique<dusk::MidiCollector> (kInputRingBytes);
-        if (sampleRate > 0.0) col->reset (sampleRate, now);
+        col->reset (rate, now);
 
         // Failure usually = OS denied access (another app exclusively owns the
         // port). Keep the slot: it stays addressable, it just never fires.
@@ -97,7 +107,7 @@ void MidiInputClient::rebuild (double sampleRate)
     devices.push_back ({ "Virtual Keyboard (Dusk Studio)", kVirtualKeyboardIdentifier });
     {
         auto vkb = std::make_unique<dusk::MidiCollector> (kInputRingBytes);
-        if (sampleRate > 0.0) vkb->reset (sampleRate, now);
+        vkb->reset (rate, now);
         collectors.push_back (std::move (vkb));
     }
     virtualKeyboardIndex = (int) collectors.size() - 1;
@@ -109,9 +119,10 @@ void MidiInputClient::attachCallback()  { backend->start(); }
 
 void MidiInputClient::resetCollectors (double sampleRate)
 {
-    const double now = backendClockMs();
+    const double now  = backendClockMs();
+    const double rate = sampleRate > 0.0 ? sampleRate : kFallbackSampleRate;
     for (auto& c : collectors)
-        if (c != nullptr) c->reset (sampleRate, now);
+        if (c != nullptr) c->reset (rate, now);
 }
 
 int MidiInputClient::resolveIndex (const std::string& savedIdentifier)
@@ -178,15 +189,27 @@ void MidiOutputBank::rebuild()
     // written; the mutex excludes the pump's drain.
     readCount.store (writeCount.load (std::memory_order_acquire), std::memory_order_release);
 
+    // Retract the open flags before the ports move: anything still reading them
+    // sees "closed" rather than a bound that no longer matches the bank.
+    numOpenFlags.store (0, std::memory_order_release);
+
     backend->closeAll();
     devices.clear();
     for (const auto& d : backend->enumerate())
+    {
+        if ((int) devices.size() >= kMaxPorts)
+        {
+            std::fprintf (stderr,
+                          "[Dusk Studio/MidiDevices] WARNING: more than %d MIDI outputs; "
+                          "the rest are not addressable.\n", kMaxPorts);
+            break;
+        }
         devices.push_back ({ d.name, d.identifier });
+    }
 
-    openFlags = std::make_unique<std::atomic<bool>[]> (devices.size());
-    numOpenFlags = devices.size();
-    for (std::size_t i = 0; i < numOpenFlags; ++i)
-        openFlags[i].store (false, std::memory_order_relaxed);
+    for (int i = 0; i < (int) devices.size(); ++i)
+        openFlags[(size_t) i].store (false, std::memory_order_relaxed);
+    numOpenFlags.store ((int) devices.size(), std::memory_order_release);
 }
 
 int MidiOutputBank::resolveIndex (const std::string& savedIdentifier)
@@ -229,13 +252,13 @@ void MidiOutputBank::closeAll()
 {
     const std::lock_guard<std::mutex> lock (bankMutex);
     backend->closeAll();
-    for (std::size_t i = 0; i < numOpenFlags; ++i)
-        openFlags[i].store (false, std::memory_order_release);
+    for (int i = 0; i < numOpenFlags.load (std::memory_order_acquire); ++i)
+        openFlags[(size_t) i].store (false, std::memory_order_release);
 }
 
 bool MidiOutputBank::isOpen (int index) const noexcept
 {
-    return index >= 0 && (std::size_t) index < numOpenFlags
+    return index >= 0 && index < numOpenFlags.load (std::memory_order_acquire)
              && openFlags[(size_t) index].load (std::memory_order_acquire);
 }
 

--- a/src/engine/midi/MidiDevices.cpp
+++ b/src/engine/midi/MidiDevices.cpp
@@ -1,127 +1,163 @@
 #include "MidiDevices.h"
+
+#if defined(__linux__)
+ #include "AlsaSeqMidi.h"
+#else
+ #include "JuceMidiBackend.h"
+#endif
+
 #include <cstdio>
+#include <utility>
 
 namespace duskstudio::midi
 {
+namespace
+{
+// Per-input ring capacity. Sized well past a dense controller burst plus a
+// 1 kB-class sysex so the drop-whole-record policy only fires when the audio
+// thread has genuinely stopped draining.
+constexpr std::size_t kInputRingBytes = 16384;
+
+int indexOfIdentifier (const std::vector<MidiDeviceInfo>& devices, const std::string& identifier)
+{
+    for (int i = 0; i < (int) devices.size(); ++i)
+        if (devices[(size_t) i].identifier == identifier)
+            return i;
+    return -1;
+}
+
+std::unique_ptr<IMidiInputBackend> makeInputBackend()
+{
+   #if defined(__linux__)
+    return std::make_unique<AlsaSeqMidiInput>();
+   #else
+    return makeJuceMidiInputBackend();
+   #endif
+}
+
+std::unique_ptr<IMidiOutputBackend> makeOutputBackend()
+{
+   #if defined(__linux__)
+    return std::make_unique<AlsaSeqMidiOutput>();
+   #else
+    return makeJuceMidiOutputBackend();
+   #endif
+}
+} // namespace
+
 // MidiInputClient
+
+MidiInputClient::MidiInputClient()
+    : backend (makeInputBackend())
+{
+    backend->setReceiver ([this] (const std::string& identifier,
+                                  const std::uint8_t* bytes, int numBytes, double timeMs)
+    {
+        handleIncoming (identifier, bytes, numBytes, timeMs);
+    });
+}
+
+MidiInputClient::~MidiInputClient()
+{
+    backend->stop();
+}
 
 void MidiInputClient::rebuild (double sampleRate)
 {
-    jassert (deviceManager != nullptr);
-
-    const auto avail = juce::MidiInput::getAvailableDevices();
     devices.clear();
-    devices.reserve ((size_t) avail.size() + 1);
     collectors.clear();
-    collectors.reserve ((size_t) avail.size() + 1);
+    indexByIdentifier.clear();
 
+    const auto avail = backend->enumerate();
+    devices.reserve (avail.size() + 1);
+    collectors.reserve (avail.size() + 1);
+
+    const double now = backendClockMs();
     for (const auto& d : avail)
     {
-        devices.push_back ({ d.name, d.identifier });
+        auto col = std::make_unique<dusk::MidiCollector> (kInputRingBytes);
+        if (sampleRate > 0.0) col->reset (sampleRate, now);
 
-        auto col = std::make_unique<juce::MidiMessageCollector>();
-        if (sampleRate > 0.0) col->reset (sampleRate);
-
-        // setMidiInputDeviceEnabled returns void - re-query to verify. Failure
-        // usually = OS denied access (another app exclusively owns the port).
-        deviceManager->setMidiInputDeviceEnabled (d.identifier, true);
-        if (! deviceManager->isMidiInputDeviceEnabled (d.identifier))
+        // Failure usually = OS denied access (another app exclusively owns the
+        // port). Keep the slot: it stays addressable, it just never fires.
+        if (! backend->enable (d.identifier))
             std::fprintf (stderr,
                           "[Dusk Studio/MidiDevices] WARNING: failed to enable MIDI input \"%s\" "
                           "(id %s). Another application may be holding it open.\n",
-                          d.name.toRawUTF8(), d.identifier.toRawUTF8());
+                          d.name.c_str(), d.identifier.c_str());
 
+        indexByIdentifier[d.identifier] = (int) collectors.size();
+        devices.push_back ({ d.name, d.identifier });
         collectors.push_back (std::move (col));
     }
 
     // Appended after real hardware so the VKB's index is stable across hot-plug.
-    // Not bound to any OS device - the on-screen keyboard addMessageToQueues into
-    // its collector directly; the audio thread drains it like any other input.
-    devices.push_back ({ juce::String ("Virtual Keyboard (Dusk Studio)"),
-                         juce::String (kVirtualKeyboardIdentifier) });
+    // Not bound to any OS device - the on-screen keyboard posts into its
+    // collector directly; the audio thread drains it like any other input.
+    devices.push_back ({ "Virtual Keyboard (Dusk Studio)", kVirtualKeyboardIdentifier });
     {
-        auto vkb = std::make_unique<juce::MidiMessageCollector>();
-        if (sampleRate > 0.0) vkb->reset (sampleRate);
+        auto vkb = std::make_unique<dusk::MidiCollector> (kInputRingBytes);
+        if (sampleRate > 0.0) vkb->reset (sampleRate, now);
         collectors.push_back (std::move (vkb));
     }
     virtualKeyboardIndex = (int) collectors.size() - 1;
-
-    // Pre-size the RT drain scratch well past the 4096-byte dusk copy cap so a
-    // dense burst drops downstream (bounded) instead of reallocating here on
-    // the audio thread.
-    drainScratch.ensureSize (16384);
 }
 
-void MidiInputClient::detachCallback()
-{
-    if (deviceManager != nullptr)
-        deviceManager->removeMidiInputDeviceCallback ({}, this);
-}
-
-void MidiInputClient::disableAllDevices()
-{
-    if (deviceManager == nullptr) return;
-    for (const auto& d : devices)
-        deviceManager->setMidiInputDeviceEnabled (d.identifier, false);
-}
-
-void MidiInputClient::attachCallback()
-{
-    if (deviceManager != nullptr)
-        deviceManager->addMidiInputDeviceCallback ({}, this);
-}
+void MidiInputClient::detachCallback()  { backend->stop(); }
+void MidiInputClient::disableAllDevices() { backend->disableAll(); }
+void MidiInputClient::attachCallback()  { backend->start(); }
 
 void MidiInputClient::resetCollectors (double sampleRate)
 {
+    const double now = backendClockMs();
     for (auto& c : collectors)
-        if (c != nullptr) c->reset (sampleRate);
+        if (c != nullptr) c->reset (sampleRate, now);
 }
 
-juce::MidiMessageCollector* MidiInputClient::getVirtualKeyboardCollector() noexcept
+int MidiInputClient::resolveIndex (const std::string& savedIdentifier)
 {
-    if (virtualKeyboardIndex < 0 || virtualKeyboardIndex >= (int) collectors.size())
-        return nullptr;
-    return collectors[(size_t) virtualKeyboardIndex].get();
+    if (savedIdentifier.empty()) return -1;
+    const int exact = indexOfIdentifier (devices, savedIdentifier);
+    if (exact >= 0) return exact;
+    const auto migrated = backend->migrateIdentifier (savedIdentifier);
+    return migrated.empty() ? -1 : indexOfIdentifier (devices, migrated);
+}
+
+void MidiInputClient::postVirtualKeyboardMidi (const std::uint8_t* bytes, int numBytes) noexcept
+{
+    if (virtualKeyboardIndex < 0 || virtualKeyboardIndex >= (int) collectors.size()) return;
+    if (auto* col = collectors[(size_t) virtualKeyboardIndex].get())
+        col->addMessage (bytes, numBytes, backendClockMs());
 }
 
 void MidiInputClient::drainBlock (int inputIndex, dusk::MidiBuffer& out, int numSamples) noexcept
 {
     out.clear();
     if (inputIndex < 0 || inputIndex >= (int) collectors.size()) return;
-    auto* col = collectors[(size_t) inputIndex].get();
-    if (col == nullptr) return;
-
-    drainScratch.clear();
-    col->removeNextBlockOfMessages (drainScratch, numSamples);
-    for (const auto meta : drainScratch)
-        out.addEvent (meta.data, meta.numBytes, meta.samplePosition);
+    if (auto* col = collectors[(size_t) inputIndex].get())
+        col->removeNextBlock (out, numSamples, backendClockMs());
 }
 
-void MidiInputClient::handleIncomingMidiMessage (juce::MidiInput* source,
-                                                 const juce::MidiMessage& message)
+void MidiInputClient::handleIncoming (const std::string& identifier,
+                                      const std::uint8_t* bytes, int numBytes, double timeMs) noexcept
 {
-    if (source == nullptr) return;
-    // JUCE guarantees identifier stability per device per session.
-    const auto sourceId = source->getIdentifier();
-    for (int i = 0; i < (int) devices.size(); ++i)
-    {
-        if (devices[(size_t) i].identifier == sourceId)
-        {
-            if (i < (int) collectors.size() && collectors[(size_t) i] != nullptr)
-                collectors[(size_t) i]->addMessageToQueue (message);
-            return;
-        }
-    }
+    const auto it = indexByIdentifier.find (identifier);
+    if (it == indexByIdentifier.end()) return;
+    if (it->second < (int) collectors.size())
+        if (auto* col = collectors[(size_t) it->second].get())
+            col->addMessage (bytes, numBytes, timeMs);
 }
 
 // MidiOutputBank
 
 MidiOutputBank::MidiOutputBank()
+    : backend (makeOutputBackend())
 {
     // Pre-size every slot buffer so the audio-thread copy in queueRt never
-    // allocates (kSlotBytes matches the drop-on-oversize cap there).
+    // allocates - reserveBytes also caps it, so an over-cap block is dropped by
+    // addEvent rather than reallocated.
     for (auto& slot : queue)
-        slot.events.ensureSize (kSlotBytes);
+        slot.events.reserveBytes (kSlotBytes);
 }
 
 MidiOutputBank::~MidiOutputBank()
@@ -129,189 +165,157 @@ MidiOutputBank::~MidiOutputBank()
     stopPump();
 }
 
-std::vector<MidiDeviceInfo> MidiOutputBank::enumerate()
-{
-    std::vector<MidiDeviceInfo> result;
-    const auto avail = juce::MidiOutput::getAvailableDevices();
-    result.reserve ((size_t) avail.size());
-    for (const auto& d : avail)
-        result.push_back ({ d.name, d.identifier });
-    return result;
-}
-
 void MidiOutputBank::rebuild()
 {
-    // Mutating outputs is safe only with the audio callback detached (the audio
-    // thread writes port indices into the FIFO while running) and under
-    // bankMutex (the pump dereferences the ports).
+    // Mutating the bank is safe only with the audio callback detached (the audio
+    // thread writes port indices into the queue while running) and under
+    // bankMutex (the pump is sending through the backend).
     const std::lock_guard<std::mutex> lock (bankMutex);
 
     // Discard queued-but-unsent blocks first: their port indices were minted
     // against the OLD device order and could land on a different physical port
     // after re-enumeration. The callback is detached, so nothing new is being
     // written; the mutex excludes the pump's drain.
-    const int stale = fifo.getNumReady();
-    if (stale > 0)
-    {
-        int s1 = 0, n1 = 0, s2 = 0, n2 = 0;
-        fifo.prepareToRead (stale, s1, n1, s2, n2);
-        fifo.finishedRead (n1 + n2);
-    }
+    readCount.store (writeCount.load (std::memory_order_acquire), std::memory_order_release);
 
-    outputs.clear();
-    devices = enumerate();
-    outputs.resize (devices.size());
+    backend->closeAll();
+    devices.clear();
+    for (const auto& d : backend->enumerate())
+        devices.push_back ({ d.name, d.identifier });
+
+    openFlags = std::make_unique<std::atomic<bool>[]> (devices.size());
+    numOpenFlags = devices.size();
+    for (std::size_t i = 0; i < numOpenFlags; ++i)
+        openFlags[i].store (false, std::memory_order_relaxed);
+}
+
+int MidiOutputBank::resolveIndex (const std::string& savedIdentifier)
+{
+    if (savedIdentifier.empty()) return -1;
+    const int exact = indexOfIdentifier (devices, savedIdentifier);
+    if (exact >= 0) return exact;
+    const std::lock_guard<std::mutex> lock (bankMutex);
+    const auto migrated = backend->migrateIdentifier (savedIdentifier);
+    return migrated.empty() ? -1 : indexOfIdentifier (devices, migrated);
 }
 
 bool MidiOutputBank::ensureOpen (int index)
 {
-    if (index < 0 || index >= (int) outputs.size())
+    if (index < 0 || index >= (int) devices.size())
         return false;
-    if (outputs[(size_t) index] != nullptr)
-        return true;  // already open
+    if (isOpen (index))
+        return true;
 
-    auto out = juce::MidiOutput::openDevice (devices[(size_t) index].identifier);
-    if (out == nullptr)
+    bool opened = false;
+    {
+        // The pump may be sending through the backend.
+        const std::lock_guard<std::mutex> lock (bankMutex);
+        opened = backend->open (devices[(size_t) index].identifier);
+    }
+    if (! opened)
     {
         std::fprintf (stderr,
                       "[Dusk Studio/MidiDevices] WARNING: failed to open MIDI output \"%s\" "
                       "(id %s). Another application may be holding it open.\n",
-                      devices[(size_t) index].name.toRawUTF8(),
-                      devices[(size_t) index].identifier.toRawUTF8());
+                      devices[(size_t) index].name.c_str(),
+                      devices[(size_t) index].identifier.c_str());
         return false;
     }
-    // Background thread so the pump's sendBlockOfMessages enqueues without
-    // blocking on the OS port.
-    out->startBackgroundThread();
-    {
-        // The pump may be dereferencing this slot's pointer.
-        const std::lock_guard<std::mutex> lock (bankMutex);
-        outputs[(size_t) index] = std::move (out);
-    }
+    openFlags[(size_t) index].store (true, std::memory_order_release);
     return true;
 }
 
 void MidiOutputBank::closeAll()
 {
     const std::lock_guard<std::mutex> lock (bankMutex);
-    outputs.clear();
+    backend->closeAll();
+    for (std::size_t i = 0; i < numOpenFlags; ++i)
+        openFlags[i].store (false, std::memory_order_release);
 }
 
 bool MidiOutputBank::isOpen (int index) const noexcept
 {
-    return index >= 0 && index < (int) outputs.size() && outputs[(size_t) index] != nullptr;
-}
-
-void MidiOutputBank::toJuceBuffer (const dusk::MidiBuffer& in, juce::MidiBuffer& out)
-{
-    out.clear();
-    for (const auto meta : in)
-    {
-        const auto& m = meta.getMessage();
-        out.addEvent (m.getRawData(), m.getRawDataSize(), meta.samplePosition);
-    }
-}
-
-bool MidiOutputBank::sendJuce (int index, const juce::MidiBuffer& events, double sampleRate) noexcept
-{
-    if (index < 0 || index >= (int) outputs.size())
-        return false;
-    auto* out = outputs[(size_t) index].get();
-    if (out == nullptr) return false;
-    // Absolute ms-since-epoch base; getMillisecondCounterHiRes = "ASAP".
-    out->sendBlockOfMessages (events,
-                              juce::Time::getMillisecondCounterHiRes(),
-                              sampleRate > 0.0 ? sampleRate : 48000.0);
-    return true;
+    return index >= 0 && (std::size_t) index < numOpenFlags
+             && openFlags[(size_t) index].load (std::memory_order_acquire);
 }
 
 bool MidiOutputBank::send (int index, const dusk::MidiBuffer& events) noexcept
 {
-    // Bridge the dusk boundary buffer to juce here (the seam owns the
-    // conversion). sampleRate is for time stamps only - the direct send carries
-    // no offsets.
-    juce::MidiBuffer juceEvents;
-    toJuceBuffer (events, juceEvents);
-    return sendJuce (index, juceEvents, 48000.0);
+    if (index < 0 || index >= (int) devices.size()) return false;
+    const std::lock_guard<std::mutex> lock (bankMutex);
+    // sampleRate is for the offset->ms conversion only; a direct send carries no
+    // offsets, and backendClockMs() = "ASAP".
+    return backend->send (devices[(size_t) index].identifier, events, backendClockMs(), 48000.0);
 }
 
 void MidiOutputBank::queueRt (int port, const dusk::MidiBuffer& events, double sampleRate) noexcept
 {
-    int start1 = 0, size1 = 0, start2 = 0, size2 = 0;
-    fifo.prepareToWrite (1, start1, size1, start2, size2);
-    if (size1 + size2 < 1) return;   // pump stalled - drop the block
+    const auto w = writeCount.load (std::memory_order_relaxed);
+    if (w - readCount.load (std::memory_order_acquire) >= (std::uint32_t) kQueueSlots)
+        return;   // pump stalled - drop the block
 
-    // The lone writable slot lands in the SECOND segment when the write wraps
-    // (size1 == 0, size2 == 1); use start2 then, not the stale start1.
-    auto& slot = queue[(size_t) (size1 > 0 ? start1 : start2)];
+    auto& slot = queue[(size_t) (w % (std::uint32_t) kQueueSlots)];
     slot.events.clear();   // keeps the pre-sized capacity
 
-    // Convert dusk -> juce directly into the slot, stopping before the pre-sized
-    // cap so the copy never reallocates on the audio thread. A block past the cap
-    // is dropped whole (same policy as queue-full) rather than realloc'd; the
-    // reserved slot is simply left uncommitted (no finishedWrite).
+    // A block past the pre-sized cap is dropped whole (same policy as
+    // queue-full) rather than split: addEvent refuses to grow, so a partial copy
+    // would tear paired events apart. The reserved slot is simply left
+    // uncommitted.
     for (const auto meta : events)
     {
-        const auto& m = meta.getMessage();
-        const int nb = m.getRawDataSize();
-        if ((int) slot.events.data.size() + kJuceEventHeaderBytes + nb > kSlotBytes)
+        if (! slot.events.addEvent (meta.data, meta.numBytes, meta.samplePosition))
         {
             slot.events.clear();
             return;
         }
-        slot.events.addEvent (m.getRawData(), nb, meta.samplePosition);
     }
 
     slot.port       = port;
-    slot.timeMs     = juce::Time::getMillisecondCounterHiRes();
+    slot.timeMs     = backendClockMs();
     slot.sampleRate = sampleRate > 0.0 ? sampleRate : 48000.0;
-    fifo.finishedWrite (1);
+    writeCount.store (w + 1, std::memory_order_release);
 }
 
 void MidiOutputBank::drainQueue()
 {
-    // The whole read cycle holds bankMutex - not just the port dereference - so
-    // rebuild can discard stale slots under the same mutex without racing a
-    // half-finished drain (the FIFO's reader side is single-consumer). The audio
-    // thread only touches the writer side and never takes this mutex.
+    // The whole read cycle holds bankMutex - not just the send - so rebuild can
+    // discard stale slots under the same mutex without racing a half-finished
+    // drain (the queue's reader side is single-consumer). The audio thread only
+    // touches the writer side and never takes this mutex.
     const std::lock_guard<std::mutex> lock (bankMutex);
 
-    const int ready = fifo.getNumReady();
-    if (ready <= 0) return;
-
-    int start1 = 0, size1 = 0, start2 = 0, size2 = 0;
-    fifo.prepareToRead (ready, start1, size1, start2, size2);
-    auto sendSlots = [this] (int start, int n)
+    auto r = readCount.load (std::memory_order_relaxed);
+    const auto w = writeCount.load (std::memory_order_acquire);
+    while (r != w)
     {
-        for (int i = 0; i < n; ++i)
-        {
-            auto& slot = queue[(size_t) (start + i)];
-            if (slot.port >= 0 && slot.port < (int) outputs.size())
-                if (auto* out = outputs[(size_t) slot.port].get())
-                    out->sendBlockOfMessages (slot.events, slot.timeMs, slot.sampleRate);
-        }
-    };
-    sendSlots (start1, size1);
-    sendSlots (start2, size2);
-    fifo.finishedRead (size1 + size2);
+        const auto& slot = queue[(size_t) (r % (std::uint32_t) kQueueSlots)];
+        if (slot.port >= 0 && slot.port < (int) devices.size())
+            (void) backend->send (devices[(size_t) slot.port].identifier, slot.events,
+                                  slot.timeMs, slot.sampleRate);
+        ++r;
+    }
+    readCount.store (r, std::memory_order_release);
 }
 
-void MidiOutputBank::Pump::run()
+void MidiOutputBank::pumpLoop()
 {
-    while (! threadShouldExit())
+    while (pumpRunning.load (std::memory_order_acquire))
     {
-        bank.drainQueue();
-        wait (1);
+        drainQueue();
+        pumpWake.wait (1);
     }
 }
 
 void MidiOutputBank::startPump()
 {
-    pump.startThread (juce::Thread::Priority::high);
+    if (pumpRunning.exchange (true)) return;
+    pump = std::thread ([this] { pumpLoop(); });
 }
 
 void MidiOutputBank::stopPump()
 {
-    pump.stopThread (2000);
+    if (! pumpRunning.exchange (false)) return;
+    pumpWake.signal();
+    if (pump.joinable()) pump.join();
 }
 } // namespace duskstudio::midi

--- a/src/engine/midi/MidiDevices.cpp
+++ b/src/engine/midi/MidiDevices.cpp
@@ -190,7 +190,10 @@ void MidiOutputBank::rebuild()
 
     // Then drop queued-but-unsent blocks: their port indices were minted against
     // the OLD device order and could land on a different physical port after
-    // re-enumeration. The mutex excludes the pump's drain.
+    // re-enumeration. The mutex excludes the pump's drain. The generation bump
+    // covers the block a producer is midway through publishing, which the cursor
+    // reset cannot see.
+    queueGeneration.fetch_add (1, std::memory_order_release);
     readCount.store (writeCount.load (std::memory_order_acquire), std::memory_order_release);
 
     backend->closeAll();
@@ -260,6 +263,7 @@ void MidiOutputBank::closeAll()
     // a stale note-on landing after a deliberate close hangs a note on the
     // device. Re-checking the open flag at drain time would NOT catch this -
     // by then the port is open again.
+    queueGeneration.fetch_add (1, std::memory_order_release);
     readCount.store (writeCount.load (std::memory_order_acquire), std::memory_order_release);
 
     backend->closeAll();
@@ -282,6 +286,11 @@ bool MidiOutputBank::send (int index, const dusk::MidiBuffer& events) noexcept
 
 void MidiOutputBank::queueRt (int port, const dusk::MidiBuffer& events, double sampleRate) noexcept
 {
+    // Sampled before the port is tested, not after: a close landing between the
+    // two must leave this block carrying the pre-close generation so the pump
+    // rejects it.
+    const auto generation = queueGeneration.load (std::memory_order_acquire);
+
     // A port that is not open cannot be delivered to, so drop before spending a
     // slot and a copy on it: the pump would only discard the block once it saw
     // the same state under bankMutex.
@@ -310,6 +319,7 @@ void MidiOutputBank::queueRt (int port, const dusk::MidiBuffer& events, double s
     slot.port       = port;
     slot.timeMs     = backendClockMs();
     slot.sampleRate = sampleRate > 0.0 ? sampleRate : 48000.0;
+    slot.generation = generation;
     writeCount.store (w + 1, std::memory_order_release);
 }
 
@@ -323,10 +333,12 @@ void MidiOutputBank::drainQueue()
 
     auto r = readCount.load (std::memory_order_relaxed);
     const auto w = writeCount.load (std::memory_order_acquire);
+    const auto generation = queueGeneration.load (std::memory_order_acquire);
     while (r != w)
     {
         const auto& slot = queue[(size_t) (r % (std::uint32_t) kQueueDepth)];
-        if (slot.port >= 0 && slot.port < (int) devices.size())
+        if (slot.generation == generation
+              && slot.port >= 0 && slot.port < (int) devices.size())
             (void) backend->send (devices[(size_t) slot.port].identifier, slot.events,
                                   slot.timeMs, slot.sampleRate);
         ++r;

--- a/src/engine/midi/MidiDevices.cpp
+++ b/src/engine/midi/MidiDevices.cpp
@@ -183,15 +183,15 @@ void MidiOutputBank::rebuild()
     // bankMutex (the pump is sending through the backend).
     const std::lock_guard<std::mutex> lock (bankMutex);
 
-    // Discard queued-but-unsent blocks first: their port indices were minted
-    // against the OLD device order and could land on a different physical port
-    // after re-enumeration. The callback is detached, so nothing new is being
-    // written; the mutex excludes the pump's drain.
-    readCount.store (writeCount.load (std::memory_order_acquire), std::memory_order_release);
-
-    // Retract the open flags before the ports move: anything still reading them
-    // sees "closed" rather than a bound that no longer matches the bank.
+    // Retract the open flags before anything else: queueRt gates on them, so
+    // this is what stops new blocks arriving. Discarding first would leave a
+    // window for one to commit against the outgoing device order.
     numOpenFlags.store (0, std::memory_order_release);
+
+    // Then drop queued-but-unsent blocks: their port indices were minted against
+    // the OLD device order and could land on a different physical port after
+    // re-enumeration. The mutex excludes the pump's drain.
+    readCount.store (writeCount.load (std::memory_order_acquire), std::memory_order_release);
 
     backend->closeAll();
     devices.clear();
@@ -251,9 +251,18 @@ bool MidiOutputBank::ensureOpen (int index)
 void MidiOutputBank::closeAll()
 {
     const std::lock_guard<std::mutex> lock (bankMutex);
-    backend->closeAll();
+
     for (int i = 0; i < numOpenFlags.load (std::memory_order_acquire); ++i)
         openFlags[(size_t) i].store (false, std::memory_order_release);
+
+    // Blocks already queued predate the close, so they must not survive it: a
+    // port reopened before the pump next runs would otherwise receive them, and
+    // a stale note-on landing after a deliberate close hangs a note on the
+    // device. Re-checking the open flag at drain time would NOT catch this -
+    // by then the port is open again.
+    readCount.store (writeCount.load (std::memory_order_acquire), std::memory_order_release);
+
+    backend->closeAll();
 }
 
 bool MidiOutputBank::isOpen (int index) const noexcept

--- a/src/engine/midi/MidiDevices.cpp
+++ b/src/engine/midi/MidiDevices.cpp
@@ -273,11 +273,16 @@ bool MidiOutputBank::send (int index, const dusk::MidiBuffer& events) noexcept
 
 void MidiOutputBank::queueRt (int port, const dusk::MidiBuffer& events, double sampleRate) noexcept
 {
+    // A port that is not open cannot be delivered to, so drop before spending a
+    // slot and a copy on it: the pump would only discard the block once it saw
+    // the same state under bankMutex.
+    if (! isOpen (port)) return;
+
     const auto w = writeCount.load (std::memory_order_relaxed);
-    if (w - readCount.load (std::memory_order_acquire) >= (std::uint32_t) kQueueSlots)
+    if (w - readCount.load (std::memory_order_acquire) >= (std::uint32_t) kQueueDepth)
         return;   // pump stalled - drop the block
 
-    auto& slot = queue[(size_t) (w % (std::uint32_t) kQueueSlots)];
+    auto& slot = queue[(size_t) (w % (std::uint32_t) kQueueDepth)];
     slot.events.clear();   // keeps the pre-sized capacity
 
     // A block past the pre-sized cap is dropped whole (same policy as
@@ -311,7 +316,7 @@ void MidiOutputBank::drainQueue()
     const auto w = writeCount.load (std::memory_order_acquire);
     while (r != w)
     {
-        const auto& slot = queue[(size_t) (r % (std::uint32_t) kQueueSlots)];
+        const auto& slot = queue[(size_t) (r % (std::uint32_t) kQueueDepth)];
         if (slot.port >= 0 && slot.port < (int) devices.size())
             (void) backend->send (devices[(size_t) slot.port].identifier, slot.events,
                                   slot.timeMs, slot.sampleRate);

--- a/src/engine/midi/MidiDevices.h
+++ b/src/engine/midi/MidiDevices.h
@@ -139,12 +139,16 @@ public:
     // backends own one encoder and one connection per direction.
     bool send (int index, const dusk::MidiBuffer& events) noexcept;
 
+    // Blocks the audio thread can have in flight at once. A push past this is
+    // dropped, so it also bounds how much the pump can deliver per wake.
+    static constexpr int kQueueDepth = 64;
+
     // Audio thread. Backend sends are not audio-thread safe (they block on the
     // OS port), so the audio thread pushes whole per-port blocks into the
     // lock-free queue and the pump drains them. Slot buffers are pre-sized so
-    // the copy never allocates; a block past the slot cap OR a full queue drops
-    // the block (dropping clock bytes beats an xrun). sampleRate carries the
-    // sample-offset->ms math.
+    // the copy never allocates; a closed port, a block past the slot cap, or a
+    // full queue drops the block (dropping clock bytes beats an xrun).
+    // sampleRate carries the sample-offset->ms math.
     void queueRt (int port, const dusk::MidiBuffer& events, double sampleRate) noexcept;
 
     // Pump lifecycle (message thread).
@@ -175,7 +179,6 @@ private:
     // it only touches the queue's writer side.
     std::mutex bankMutex;
 
-    static constexpr int kQueueSlots = 64;
     static constexpr int kSlotBytes  = 4096;
     struct QueuedMidiOut
     {
@@ -184,10 +187,10 @@ private:
         double           sampleRate = 48000.0;
         dusk::MidiBuffer events;
     };
-    std::array<QueuedMidiOut, kQueueSlots> queue;
+    std::array<QueuedMidiOut, kQueueDepth> queue;
 
     // SPSC cursors over `queue`: monotonic counters, slot index = counter %
-    // kQueueSlots. The audio thread owns writeCount, the pump owns readCount;
+    // kQueueDepth. The audio thread owns writeCount, the pump owns readCount;
     // each publishes with release and observes the other with acquire.
     std::atomic<std::uint32_t> writeCount { 0 };
     std::atomic<std::uint32_t> readCount  { 0 };

--- a/src/engine/midi/MidiDevices.h
+++ b/src/engine/midi/MidiDevices.h
@@ -185,6 +185,7 @@ private:
         int              port       = -1;
         double           timeMs     = 0.0;
         double           sampleRate = 48000.0;
+        std::uint32_t    generation = 0;
         dusk::MidiBuffer events;
     };
     std::array<QueuedMidiOut, kQueueDepth> queue;
@@ -194,6 +195,13 @@ private:
     // each publishes with release and observes the other with acquire.
     std::atomic<std::uint32_t> writeCount { 0 };
     std::atomic<std::uint32_t> readCount  { 0 };
+
+    // Bumped by every close or re-enumeration. queueRt samples it before it
+    // tests the port, so a producer preempted between that test and its publish
+    // carries the OLD value and the pump discards its block. Resetting the
+    // cursors alone cannot cover that: the block is not committed yet when the
+    // discard runs, so it survives as if it had been queued afterwards.
+    std::atomic<std::uint32_t> queueGeneration { 0 };
 
     std::thread       pump;
     std::atomic<bool> pumpRunning { false };

--- a/src/engine/midi/MidiDevices.h
+++ b/src/engine/midi/MidiDevices.h
@@ -158,10 +158,17 @@ private:
     std::unique_ptr<IMidiOutputBackend> backend;
     std::vector<MidiDeviceInfo> devices;
 
-    // Parallel to `devices`, allocated on rebuild. Heap array rather than a
-    // vector because std::atomic is neither movable nor copyable.
-    std::unique_ptr<std::atomic<bool>[]> openFlags;
-    std::size_t numOpenFlags = 0;
+    // Ports the audio thread may see beyond this are not addressable; no
+    // sequencer exposes anywhere near it.
+    static constexpr int kMaxPorts = 256;
+
+    // Parallel to `devices`, but fixed storage with a published count: the audio
+    // thread reads these in isOpen while the message thread re-enumerates, so
+    // neither the array nor its bound may be swapped under it. rebuild()
+    // publishes 0 before it touches anything and the new count after, so a
+    // racing reader sees "closed", never a stale bound.
+    std::array<std::atomic<bool>, kMaxPorts> openFlags {};
+    std::atomic<int> numOpenFlags { 0 };
 
     // Serialises the pump thread's backend access against message-thread bank
     // mutation (rebuild / ensureOpen / send). The audio thread never takes it -

--- a/src/engine/midi/MidiDevices.h
+++ b/src/engine/midi/MidiDevices.h
@@ -1,57 +1,62 @@
 #pragma once
 
-#include <juce_audio_devices/juce_audio_devices.h>
+#include "MidiBackend.h"
+#include "../../foundation/AutoResetEvent.h"
 #include "../../foundation/MidiBuffer.h"
+#include "../../foundation/MidiCollector.h"
 #include <array>
+#include <atomic>
+#include <cstdint>
 #include <memory>
 #include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
 #include <vector>
 
-// The single seam between Dusk Studio's engine and JUCE's MIDI device backend.
-// Its BOUNDARY type is dusk::MidiBuffer - the RT drain hands the audio thread
-// dusk events, and the RT out-queue takes them - so a future native ALSA-
-// sequencer backend can replace this file pair without touching the engine.
-// Internal storage stays juce-typed (collectors, outputs, the SPSC slots); only
-// the API is dusk. This is the only JUCE-device-touching code, hence the
-// deliberate juce-allowlist entry.
+// The single seam between Dusk Studio's engine and the platform MIDI backend.
+// Everything above it - the engine, the UI, the session - speaks dusk types;
+// below it an IMidiInputBackend / IMidiOutputBackend pair does the OS work
+// (native ALSA sequencer on Linux, a JUCE-backed fallback elsewhere). The seam
+// owns what the backends deliberately do not: the index<->identifier mapping the
+// session persists, the per-input retiming collectors, and the RT out-queue.
 namespace duskstudio::midi
 {
 struct MidiDeviceInfo
 {
-    juce::String name;
-    juce::String identifier;
+    std::string name;
+    std::string identifier;
 };
 
-// Owns the per-input MidiMessageCollector bank and is itself the juce callback
-// bound to every enabled input; routes by source identifier. The detach-rebuild-
-// reattach fence around a hot-plug is orchestrated by the engine (which also
-// detaches its own audio callback) - this class only exposes the pieces.
-class MidiInputClient final : public juce::MidiInputCallback
+// Owns the per-input collector bank and receives every enabled input's bytes on
+// the backend's MIDI thread, routing them by source identifier. The
+// detach-rebuild-reattach fence around a hot-plug is orchestrated by the engine
+// (which also detaches its own audio callback) - this class only exposes the
+// pieces.
+class MidiInputClient final
 {
 public:
     // Fixed identifier for the synthetic Virtual-Keyboard slot so saved sessions
     // resolve back to it across hot-plug (its index is otherwise re-derived).
     static constexpr const char* kVirtualKeyboardIdentifier = "Dusk Studio:virtual-keyboard";
 
-    // Message thread. Stash the device manager the enable/disable lifecycle and
-    // callback (un)registration run against. Call once before rebuild().
-    void setDeviceManager (juce::AudioDeviceManager& dm) noexcept { deviceManager = &dm; }
+    MidiInputClient();
+    ~MidiInputClient();
 
     // Message thread, input callback DETACHED. Enumerate the hardware inputs,
-    // enable each on the device manager, build a per-input MidiMessageCollector,
-    // then append the synthetic Virtual-Keyboard slot last (fixed identifier, no
-    // OS device). Mutating the bank with the callback active is UB - see the
-    // detach/attach fence.
+    // enable each on the backend, build a per-input collector, then append the
+    // synthetic Virtual-Keyboard slot last (fixed identifier, no OS device).
+    // Mutating the bank with the callback active is UB - see the detach/attach
+    // fence.
     void rebuild (double sampleRate);
 
-    // Detach half of the fence: unregister the input callback (JUCE's remove
-    // joins the MIDI dispatch side before returning) and disable every device so
-    // the OS handles are released before a rebuild.
+    // Detach half of the fence: stop the backend's dispatch (its stop() joins
+    // that side before returning) and release the OS handles before a rebuild.
     void detachCallback();
     void disableAllDevices();
 
-    // Reattach: empty identifier = every enabled input fans out to
-    // handleIncomingMidiMessage, routed there by source identifier.
+    // Reattach: start the backend's dispatch again. Every enabled input fans in
+    // to one receiver, routed to a collector by source identifier.
     void attachCallback();
 
     // Re-arm every collector to a new sample rate so the MIDI thread's ms
@@ -62,37 +67,44 @@ public:
     int getNumInputs() const noexcept { return (int) collectors.size(); }
 
     int getVirtualKeyboardIndex() const noexcept { return virtualKeyboardIndex; }
-    juce::MidiMessageCollector* getVirtualKeyboardCollector() noexcept;
 
-    // Audio thread. Pull this input's block out of its collector and copy the
-    // events into the dusk boundary buffer. RT-safe provided (a) `out` was
-    // reserveBytes()'d off the RT path by the caller and (b) the incoming burst
-    // fits the collector's pre-sized scratch - a rare overflow grows it, exactly
-    // as the pre-flip perInputMidi drain did. Call once per input index per
-    // block: the collector drain is destructive.
+    // Message thread. Saved-identifier -> current index, with the backend's
+    // migration fallback for identifiers minted by an earlier backend. -1 when
+    // the device is gone (or the identifier is empty).
+    int resolveIndex (const std::string& savedIdentifier);
+
+    // Message thread. Push a complete MIDI message into the synthetic
+    // Virtual-Keyboard slot, stamped with the same clock the backends use so it
+    // retimes like hardware input. No-op before the bank is built.
+    void postVirtualKeyboardMidi (const std::uint8_t* bytes, int numBytes) noexcept;
+
+    // Audio thread. Retime this input's pending events into the dusk boundary
+    // buffer. RT-safe: the collector's ring is pre-sized and never grows (an
+    // over-capacity burst drops whole records), and `out` was reserveBytes()'d
+    // off the RT path by the caller. Call once per input index per block - the
+    // drain is destructive.
     void drainBlock (int inputIndex, dusk::MidiBuffer& out, int numSamples) noexcept;
 
-    // juce::MidiInputCallback. Fires on JUCE's MIDI input thread (NOT the audio
-    // thread); routes by source identifier to the matching collector, which the
-    // audio thread later drains lock-free (JUCE contract).
-    void handleIncomingMidiMessage (juce::MidiInput* source,
-                                    const juce::MidiMessage& message) override;
-
 private:
-    juce::AudioDeviceManager* deviceManager = nullptr;
-    std::vector<MidiDeviceInfo> devices;
-    std::vector<std::unique_ptr<juce::MidiMessageCollector>> collectors;
-    int virtualKeyboardIndex = -1;
+    // Backend MIDI thread. Routes by source identifier to the matching
+    // collector, which the audio thread later drains lock-free.
+    void handleIncoming (const std::string& identifier,
+                         const std::uint8_t* bytes, int numBytes, double timeMs) noexcept;
 
-    // Single reused juce scratch the RT drain removes into before copying to the
-    // dusk boundary buffer. drainBlock runs sequentially per input on the audio
-    // thread, so one instance suffices.
-    juce::MidiBuffer drainScratch;
+    std::unique_ptr<IMidiInputBackend> backend;
+    std::vector<MidiDeviceInfo> devices;
+    std::vector<std::unique_ptr<dusk::MidiCollector>> collectors;
+
+    // Identifier -> collector index for the receiver's demux. Rebuilt only with
+    // the backend stopped, so the MIDI thread reads it without synchronisation.
+    std::unordered_map<std::string, int> indexByIdentifier;
+
+    int virtualKeyboardIndex = -1;
 };
 
 // Owns the output-port bank plus the whole RT out-queue apparatus: the SPSC
-// FIFO the audio thread pushes per-port blocks into and the 1 ms pump thread
-// that drains it into sendBlockOfMessages where blocking is harmless.
+// queue the audio thread pushes per-port blocks into and the 1 ms pump thread
+// that drains it into the backend, where blocking is harmless.
 class MidiOutputBank
 {
 public:
@@ -102,77 +114,79 @@ public:
     // Message thread, audio callback DETACHED. Discard queued blocks (their port
     // indices were minted against the old device order), close open outputs, and
     // re-enumerate. Does NOT eager-open: opening every port at startup blocks the
-    // message thread on each snd_seq_connect_to and spawns a thread per port,
-    // stalling MainWindow::setVisible for seconds on USB-MIDI systems. Open on
-    // demand via ensureOpen. Session sync/MCU eager-opens stay with the engine.
+    // message thread on each subscription, stalling MainWindow::setVisible for
+    // seconds on USB-MIDI systems. Open on demand via ensureOpen. Session
+    // sync/MCU eager-opens stay with the engine.
     void rebuild();
 
-    // Lazy open + start the port's background delivery thread so the pump's
-    // sendBlockOfMessages enqueues without blocking on the OS port. Message
-    // thread.
+    // Lazy open. Message thread.
     bool ensureOpen (int index);
 
     void closeAll();
 
     const std::vector<MidiDeviceInfo>& getDevices() const noexcept { return devices; }
-    int  getNumOutputs() const noexcept { return (int) outputs.size(); }
+    int  getNumOutputs() const noexcept { return (int) devices.size(); }
+
+    // As MidiInputClient::resolveIndex.
+    int resolveIndex (const std::string& savedIdentifier);
+
+    // Audio thread reads this to skip queueing at a closed port, so it is an
+    // atomic flag rather than a backend query (which walks a string-keyed map
+    // the message thread mutates).
     bool isOpen (int index) const noexcept;
 
-    // Message thread. Direct send with an ms-since-epoch base
-    // (getMillisecondCounterHiRes = "ASAP", lower latency than buffering for the
-    // next block). Takes the dusk boundary buffer and bridges to juce internally.
+    // Message thread. Direct send, serialised against the pump's drain - the
+    // backends own one encoder and one connection per direction.
     bool send (int index, const dusk::MidiBuffer& events) noexcept;
 
-    // Audio thread. sendBlockOfMessages is NOT audio-thread safe (it takes the
-    // delivery thread's mutex and heap-allocates under it). The audio thread
-    // instead pushes whole per-port blocks into the lock-free FIFO; the pump
-    // drains them. Slot buffers are pre-sized so the copy never allocates; a
-    // block past the slot cap OR a full queue drops the block (dropping clock
-    // bytes beats an xrun). timeMs/sampleRate carry the sample-offset->ms math.
+    // Audio thread. Backend sends are not audio-thread safe (they block on the
+    // OS port), so the audio thread pushes whole per-port blocks into the
+    // lock-free queue and the pump drains them. Slot buffers are pre-sized so
+    // the copy never allocates; a block past the slot cap OR a full queue drops
+    // the block (dropping clock bytes beats an xrun). sampleRate carries the
+    // sample-offset->ms math.
     void queueRt (int port, const dusk::MidiBuffer& events, double sampleRate) noexcept;
 
-    // Pump lifecycle (message thread). High priority so a loaded message thread
-    // can't starve clock / note delivery; still below the audio thread.
+    // Pump lifecycle (message thread).
     void startPump();
     void stopPump();
 
-    // Convert a dusk event buffer into a juce one. Factored out so the send +
-    // queue conversions are unit-testable without a real output device.
-    static void toJuceBuffer (const dusk::MidiBuffer& in, juce::MidiBuffer& out);
-
 private:
     void drainQueue();     // pump thread
-    bool sendJuce (int index, const juce::MidiBuffer& events, double sampleRate) noexcept;
-    static std::vector<MidiDeviceInfo> enumerate();
+    void pumpLoop();
 
+    std::unique_ptr<IMidiOutputBackend> backend;
     std::vector<MidiDeviceInfo> devices;
-    std::vector<std::unique_ptr<juce::MidiOutput>> outputs;
 
-    // Serialises the pump thread's port access against message-thread bank
-    // mutation (rebuild / ensureOpen). The audio thread never takes it - it only
-    // touches the FIFO writer side.
+    // Parallel to `devices`, allocated on rebuild. Heap array rather than a
+    // vector because std::atomic is neither movable nor copyable.
+    std::unique_ptr<std::atomic<bool>[]> openFlags;
+    std::size_t numOpenFlags = 0;
+
+    // Serialises the pump thread's backend access against message-thread bank
+    // mutation (rebuild / ensureOpen / send). The audio thread never takes it -
+    // it only touches the queue's writer side.
     std::mutex bankMutex;
 
     static constexpr int kQueueSlots = 64;
     static constexpr int kSlotBytes  = 4096;
-    // juce::MidiBuffer per-event overhead: int32 samplePosition + uint16 length.
-    static constexpr int kJuceEventHeaderBytes = 6;
     struct QueuedMidiOut
     {
-        int    port       = -1;
-        double timeMs     = 0.0;
-        double sampleRate = 48000.0;
-        juce::MidiBuffer events;
+        int              port       = -1;
+        double           timeMs     = 0.0;
+        double           sampleRate = 48000.0;
+        dusk::MidiBuffer events;
     };
-    juce::AbstractFifo fifo { kQueueSlots };
     std::array<QueuedMidiOut, kQueueSlots> queue;
 
-    struct Pump final : juce::Thread
-    {
-        explicit Pump (MidiOutputBank& b) : juce::Thread ("Dusk Studio MIDI out"), bank (b) {}
-        void run() override;
-        MidiOutputBank& bank;
-    };
-    Pump pump { *this };
+    // SPSC cursors over `queue`: monotonic counters, slot index = counter %
+    // kQueueSlots. The audio thread owns writeCount, the pump owns readCount;
+    // each publishes with release and observes the other with acquire.
+    std::atomic<std::uint32_t> writeCount { 0 };
+    std::atomic<std::uint32_t> readCount  { 0 };
+
+    std::thread       pump;
+    std::atomic<bool> pumpRunning { false };
+    dusk::AutoResetEvent pumpWake;
 };
 } // namespace duskstudio::midi

--- a/src/session/SessionSerializer.cpp
+++ b/src/session/SessionSerializer.cpp
@@ -1,6 +1,5 @@
 #include "SessionSerializer.h"
 #include "../foundation/Json.h"
-#include <juce_audio_devices/juce_audio_devices.h>
 #include <nlohmann/json.hpp>
 #include <cmath>
 #include <limits>
@@ -213,31 +212,6 @@ void fsyncFile (const juce::File& path)
    #else
     (void) path;
    #endif
-}
-
-// Resolve a MIDI device identifier (saved with a prior session) to its
-// current index in juce::MidiInput::getAvailableDevices(). Returns -1 if
-// the identifier doesn't match any currently-available device. The lookup
-// is O(N) in the device list but called at most once per track on load,
-// which is negligible compared to the JSON parse.
-int resolveMidiInputIndexByIdentifier (const juce::String& identifier)
-{
-    if (identifier.isEmpty()) return -1;
-    const auto devices = juce::MidiInput::getAvailableDevices();
-    for (int i = 0; i < devices.size(); ++i)
-        if (devices[i].identifier == identifier)
-            return i;
-    return -1;
-}
-
-int resolveMidiOutputIndexByIdentifier (const juce::String& identifier)
-{
-    if (identifier.isEmpty()) return -1;
-    const auto devices = juce::MidiOutput::getAvailableDevices();
-    for (int i = 0; i < devices.size(); ++i)
-        if (devices[i].identifier == identifier)
-            return i;
-    return -1;
 }
 
 juce::String colourToHex (juce::Colour c)
@@ -803,20 +777,17 @@ void restoreTrack (Track& t, const nlohmann::json& v, double defaultRecordBpm,
     setBool  (t.printEffects,       "print_effects");
     setInt   (t.inputSource,        "input_source");
     setInt   (t.inputSourceR,       "input_source_r");
-    // MIDI input: prefer the stable identifier when present (resolved to
-    // the current device list's index). Fall back to the legacy raw int
-    // for sessions saved before identifiers existed, OR when the saved
-    // identifier doesn't match any currently-available device (USB MIDI
-    // gear unplugged, different machine, etc.) so the user can re-pick
-    // without the index pointing at a wrong device.
+    // MIDI input: the stable identifier is the source of truth when present;
+    // AudioEngine::reresolveTrackMidiFromSession maps it to a live bank index
+    // after the load (the MIDI device seam owns that mapping, and its bank
+    // order is the one the audio thread indexes). Until then the index stays
+    // unrouted rather than pointing at whatever now sits at the old slot. The
+    // legacy raw int is still honoured for sessions saved before identifiers
+    // existed.
     if (json::has (v, "midi_input_id"))
     {
         t.midiInputIdentifier = json::getString (v, "midi_input_id");
-        const int resolved = resolveMidiInputIndexByIdentifier (t.midiInputIdentifier);
-        if (resolved >= 0)
-            t.midiInputIndex.store (resolved, std::memory_order_relaxed);
-        else
-            t.midiInputIndex.store (-1, std::memory_order_relaxed);
+        t.midiInputIndex.store (-1, std::memory_order_relaxed);
     }
     else
     {
@@ -827,9 +798,7 @@ void restoreTrack (Track& t, const nlohmann::json& v, double defaultRecordBpm,
     if (json::has (v, "midi_output_id"))
     {
         t.midiOutputIdentifier = json::getString (v, "midi_output_id");
-        const int resolved = resolveMidiOutputIndexByIdentifier (t.midiOutputIdentifier);
-        t.midiOutputIndex.store (resolved >= 0 ? resolved : -1,
-                                  std::memory_order_relaxed);
+        t.midiOutputIndex.store (-1, std::memory_order_relaxed);
     }
     else
     {

--- a/src/ui/AudioSettingsPanel.cpp
+++ b/src/ui/AudioSettingsPanel.cpp
@@ -838,8 +838,8 @@ void AudioSettingsPanel::populateSyncSourceCombo()
     int matchId = 1;
     for (int i = 0; i < (int) devices.size(); ++i)
     {
-        syncSourceCombo.addItem (devices[i].name, i + 2);
-        if (devices[i].identifier == session.syncSourceInputIdentifier)
+        syncSourceCombo.addItem (juce::String (devices[i].name), i + 2);
+        if (session.syncSourceInputIdentifier == juce::String (devices[i].identifier))
             matchId = i + 2;
     }
     syncSourceCombo.setSelectedId (matchId, juce::dontSendNotification);
@@ -857,7 +857,7 @@ void AudioSettingsPanel::applySyncSourceChange()
     const auto& devices = engine.getMidiInputDevices();
     const int idx = id - 2;
     if (idx < 0 || idx >= (int) devices.size()) return;
-    session.syncSourceInputIdentifier = devices[idx].identifier;
+    session.syncSourceInputIdentifier = juce::String (devices[idx].identifier);
     session.syncSourceInputIdx.store (idx, std::memory_order_release);
 }
 
@@ -871,8 +871,8 @@ void AudioSettingsPanel::populateSyncOutputCombo()
     int matchId = 1;
     for (int i = 0; i < (int) devices.size(); ++i)
     {
-        syncOutputCombo.addItem (devices[i].name, i + 2);
-        if (devices[i].identifier == session.syncOutputIdentifier)
+        syncOutputCombo.addItem (juce::String (devices[i].name), i + 2);
+        if (session.syncOutputIdentifier == juce::String (devices[i].identifier))
             matchId = i + 2;
     }
     syncOutputCombo.setSelectedId (matchId, juce::dontSendNotification);
@@ -890,7 +890,7 @@ void AudioSettingsPanel::applySyncOutputChange()
     const auto& devices = engine.getMidiOutputDevices();
     const int idx = id - 2;
     if (idx < 0 || idx >= (int) devices.size()) return;
-    session.syncOutputIdentifier = devices[idx].identifier;
+    session.syncOutputIdentifier = juce::String (devices[idx].identifier);
     session.syncOutputIdx.store (idx, std::memory_order_release);
     // Eagerly open the port so the first audio-thread emission doesn't
     // race with a synchronous ALSA snd_seq_connect.
@@ -905,8 +905,8 @@ void AudioSettingsPanel::populateMcuInputCombo()
     int matchId = 1;
     for (int i = 0; i < (int) devices.size(); ++i)
     {
-        mcuInputCombo.addItem (devices[i].name, i + 2);
-        if (devices[i].identifier == session.mcu.inputIdentifier)
+        mcuInputCombo.addItem (juce::String (devices[i].name), i + 2);
+        if (session.mcu.inputIdentifier == juce::String (devices[i].identifier))
             matchId = i + 2;
     }
     mcuInputCombo.setSelectedId (matchId, juce::dontSendNotification);
@@ -920,8 +920,8 @@ void AudioSettingsPanel::populateMcuOutputCombo()
     int matchId = 1;
     for (int i = 0; i < (int) devices.size(); ++i)
     {
-        mcuOutputCombo.addItem (devices[i].name, i + 2);
-        if (devices[i].identifier == session.mcu.outputIdentifier)
+        mcuOutputCombo.addItem (juce::String (devices[i].name), i + 2);
+        if (session.mcu.outputIdentifier == juce::String (devices[i].identifier))
             matchId = i + 2;
     }
     mcuOutputCombo.setSelectedId (matchId, juce::dontSendNotification);
@@ -939,7 +939,7 @@ void AudioSettingsPanel::applyMcuInputChange()
     const auto& devices = engine.getMidiInputDevices();
     const int idx = id - 2;
     if (idx < 0 || idx >= (int) devices.size()) return;
-    session.mcu.inputIdentifier = devices[idx].identifier;
+    session.mcu.inputIdentifier = juce::String (devices[idx].identifier);
     session.mcu.resolvedInputIdx.store (idx, std::memory_order_release);
 }
 
@@ -955,7 +955,7 @@ void AudioSettingsPanel::applyMcuOutputChange()
     const auto& devices = engine.getMidiOutputDevices();
     const int idx = id - 2;
     if (idx < 0 || idx >= (int) devices.size()) return;
-    session.mcu.outputIdentifier = devices[idx].identifier;
+    session.mcu.outputIdentifier = juce::String (devices[idx].identifier);
     session.mcu.resolvedOutputIdx.store (idx, std::memory_order_release);
     // Eagerly open so the first 30 Hz emit doesn't race with ALSA's
     // synchronous snd_seq_connect.

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -1098,7 +1098,7 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
         {
             const auto& inputs = engine.getMidiInputDevices();
             track.midiInputIdentifier = (idx < (int) inputs.size())
-                                          ? inputs[idx].identifier
+                                          ? juce::String (inputs[idx].identifier)
                                           : juce::String();
         }
         else
@@ -1141,7 +1141,7 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
         {
             const auto& outs = engine.getMidiOutputDevices();
             track.midiOutputIdentifier = (idx < (int) outs.size())
-                                           ? outs[idx].identifier
+                                           ? juce::String (outs[idx].identifier)
                                            : juce::String();
             // Eagerly open the port so the first audio-thread emission
             // doesn't race a synchronous ALSA snd_seq_connect.
@@ -1467,7 +1467,7 @@ void ChannelStripComponent::rebuildMidiInputDropdown()
     midiInputSelector.addItem ("None", 1);
     const auto& inputs = engine.getMidiInputDevices();
     for (int i = 0; i < (int) inputs.size(); ++i)
-        midiInputSelector.addItem (inputs[i].name, 2 + i);
+        midiInputSelector.addItem (juce::String (inputs[i].name), 2 + i);
 
     // Prefer identifier-based selection when we have one - it survives
     // device-list reordering. Fall back to the raw index for older
@@ -1477,7 +1477,7 @@ void ChannelStripComponent::rebuildMidiInputDropdown()
     {
         for (int i = 0; i < (int) inputs.size(); ++i)
         {
-            if (inputs[i].identifier == track.midiInputIdentifier)
+            if (track.midiInputIdentifier == juce::String (inputs[i].identifier))
             {
                 idx = i; break;
             }
@@ -1501,14 +1501,14 @@ void ChannelStripComponent::rebuildMidiOutputDropdown()
     midiOutputSelector.addItem ("None", 1);
     const auto& outs = engine.getMidiOutputDevices();
     for (int i = 0; i < (int) outs.size(); ++i)
-        midiOutputSelector.addItem (outs[i].name, 2 + i);
+        midiOutputSelector.addItem (juce::String (outs[i].name), 2 + i);
 
     int idx = -1;
     if (track.midiOutputIdentifier.isNotEmpty())
     {
         for (int i = 0; i < (int) outs.size(); ++i)
         {
-            if (outs[i].identifier == track.midiOutputIdentifier)
+            if (track.midiOutputIdentifier == juce::String (outs[i].identifier))
             {
                 idx = i; break;
             }

--- a/src/ui/VirtualKeyboardComponent.cpp
+++ b/src/ui/VirtualKeyboardComponent.cpp
@@ -220,15 +220,19 @@ void VirtualKeyboardComponent::timerCallback()
 
 void VirtualKeyboardComponent::sendNoteOn (int note, int vel, int chan)
 {
-    if (auto* col = engine.getVirtualKeyboardCollector())
-        col->addMessageToQueue (juce::MidiMessage::noteOn (chan, note, (std::uint8_t) vel));
+    const std::uint8_t bytes[3] { (std::uint8_t) (0x90 | ((chan - 1) & 0x0f)),
+                                  (std::uint8_t) (note & 0x7f),
+                                  (std::uint8_t) (vel & 0x7f) };
+    engine.postVirtualKeyboardMidi (bytes, 3);
     if (onNoteOn) onNoteOn (note, vel, chan);
 }
 
 void VirtualKeyboardComponent::sendNoteOff (int note, int chan)
 {
-    if (auto* col = engine.getVirtualKeyboardCollector())
-        col->addMessageToQueue (juce::MidiMessage::noteOff (chan, note));
+    const std::uint8_t bytes[3] { (std::uint8_t) (0x80 | ((chan - 1) & 0x0f)),
+                                  (std::uint8_t) (note & 0x7f),
+                                  0 };
+    engine.postVirtualKeyboardMidi (bytes, 3);
     if (onNoteOff) onNoteOff (note, chan);
 }
 

--- a/src/ui/VirtualKeyboardComponent.cpp
+++ b/src/ui/VirtualKeyboardComponent.cpp
@@ -220,7 +220,9 @@ void VirtualKeyboardComponent::timerCallback()
 
 void VirtualKeyboardComponent::sendNoteOn (int note, int vel, int chan)
 {
-    const std::uint8_t bytes[3] { (std::uint8_t) (0x90 | ((chan - 1) & 0x0f)),
+    // Clamp rather than mask the channel: masking would wrap an out-of-range
+    // one onto a different channel instead of the nearest valid one.
+    const std::uint8_t bytes[3] { (std::uint8_t) (0x90 | (std::clamp (chan, 1, 16) - 1)),
                                   (std::uint8_t) (note & 0x7f),
                                   (std::uint8_t) (vel & 0x7f) };
     engine.postVirtualKeyboardMidi (bytes, 3);
@@ -229,7 +231,7 @@ void VirtualKeyboardComponent::sendNoteOn (int note, int vel, int chan)
 
 void VirtualKeyboardComponent::sendNoteOff (int note, int chan)
 {
-    const std::uint8_t bytes[3] { (std::uint8_t) (0x80 | ((chan - 1) & 0x0f)),
+    const std::uint8_t bytes[3] { (std::uint8_t) (0x80 | (std::clamp (chan, 1, 16) - 1)),
                                   (std::uint8_t) (note & 0x7f),
                                   0 };
     engine.postVirtualKeyboardMidi (bytes, 3);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -145,9 +145,12 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_link_libraries(dusk-studio-tests PRIVATE asound)
 else()
     # The seam picks its backend on __linux__, so off Linux the JUCE fallback is
-    # what MidiDevices.cpp links against.
+    # what MidiDevices.cpp links against. It is the only remaining user of the
+    # JUCE MIDI device API in the test binary, so the module is linked here
+    # rather than for every platform.
     target_sources(dusk-studio-tests PRIVATE
         ${CMAKE_SOURCE_DIR}/src/engine/midi/JuceMidiBackend.cpp)
+    target_link_libraries(dusk-studio-tests PRIVATE juce::juce_audio_devices)
 endif()
 
 # Phase 1a de-JUCE: JUCE-free audio file I/O (libsndfile backend), test-only for

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -143,6 +143,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         alsa_seq_midi.cpp
         ${CMAKE_SOURCE_DIR}/src/engine/midi/AlsaSeqMidi.cpp)
     target_link_libraries(dusk-studio-tests PRIVATE asound)
+else()
+    # The seam picks its backend on __linux__, so off Linux the JUCE fallback is
+    # what MidiDevices.cpp links against.
+    target_sources(dusk-studio-tests PRIVATE
+        ${CMAKE_SOURCE_DIR}/src/engine/midi/JuceMidiBackend.cpp)
 endif()
 
 # Phase 1a de-JUCE: JUCE-free audio file I/O (libsndfile backend), test-only for
@@ -237,12 +242,6 @@ target_link_libraries(dusk-studio-tests PRIVATE
     Catch2::Catch2WithMain
     ${CMAKE_DL_LIBS}   # dl: ClapBundle dlopen
     juce::juce_audio_basics
-    # juce_audio_devices required by SessionSerializer.cpp for
-    # juce::MidiInput::getAvailableDevices() — resolves Track::
-    # midiInputIdentifier back to an index on session load. Removing
-    # this triggers an ld undefined-reference on the MidiInput /
-    # MidiOutput statics.
-    juce::juce_audio_devices
     juce::juce_audio_formats
     # juce_audio_processors brings in juce::AudioPluginInstance for
     # multisample tests (DuskMultisampleProcessor subclasses it).

--- a/tests/alsa_seq_midi.cpp
+++ b/tests/alsa_seq_midi.cpp
@@ -251,15 +251,41 @@ TEST_CASE ("MidiOutputBank RT queue delivers through the pump, bounded by its de
     REQUIRE_FALSE (sink.waitFor ((std::size_t) MidiOutputBank::kQueueDepth + 1, 250));
 
     bank.stopPump();
-    in.stop();
 
-    std::lock_guard<std::mutex> lk (sink.m);
-    REQUIRE (sink.messages.size() == (std::size_t) MidiOutputBank::kQueueDepth);
-    for (int i = 0; i < (int) sink.messages.size(); ++i)
     {
-        REQUIRE (sink.messages[(size_t) i].size() == 3);
-        REQUIRE (sink.messages[(size_t) i][1] == (std::uint8_t) i);   // FIFO order, first kQueueDepth pushed
+        std::lock_guard<std::mutex> lk (sink.m);
+        REQUIRE (sink.messages.size() == (std::size_t) MidiOutputBank::kQueueDepth);
+        for (int i = 0; i < (int) sink.messages.size(); ++i)
+        {
+            REQUIRE (sink.messages[(size_t) i].size() == 3);
+            REQUIRE (sink.messages[(size_t) i][1] == (std::uint8_t) i);   // FIFO order, first kQueueDepth pushed
+        }
+        sink.messages.clear();
     }
+
+    SECTION ("a close discards what was queued before it, even if the port reopens")
+    {
+        bank.queueRt (dst, oneNote (0x11), 48000.0);
+        bank.closeAll();
+        REQUIRE_FALSE (bank.isOpen (dst));
+
+        // Reopened before the pump ever ran: the block from before the close
+        // must be gone, not delivered late to the reopened port.
+        REQUIRE (bank.ensureOpen (dst));
+        bank.startPump();
+        REQUIRE_FALSE (sink.waitFor (1, 250));
+
+        // Delivery still works for anything queued after the reopen.
+        bank.queueRt (dst, oneNote (0x22), 48000.0);
+        REQUIRE (sink.waitFor (1));
+        bank.stopPump();
+
+        std::lock_guard<std::mutex> lk (sink.m);
+        REQUIRE (sink.messages.size() == 1);
+        REQUIRE (sink.messages[0][1] == 0x22);
+    }
+
+    in.stop();
 }
 
 TEST_CASE ("ALSA seq MIDI loopback round-trips bytes exactly", "[midi][alsa]")

--- a/tests/alsa_seq_midi.cpp
+++ b/tests/alsa_seq_midi.cpp
@@ -28,6 +28,40 @@ std::string findId (const std::vector<BackendDeviceInfo>& devs, const std::strin
     return {};
 }
 
+// Raw "<client>-<port>" sequencer address of the named port, which is exactly
+// the identifier format JUCE minted on Linux and therefore what pre-existing
+// sessions carry.
+std::string legacyAddressOf (const std::string& clientName, const std::string& portName)
+{
+    snd_seq_t* seq = nullptr;
+    if (snd_seq_open (&seq, "default", SND_SEQ_OPEN_INPUT, 0) < 0)
+        return {};
+
+    std::string found;
+    snd_seq_client_info_t* cinfo;
+    snd_seq_port_info_t*   pinfo;
+    snd_seq_client_info_alloca (&cinfo);
+    snd_seq_port_info_alloca (&pinfo);
+
+    snd_seq_client_info_set_client (cinfo, -1);
+    while (found.empty() && snd_seq_query_next_client (seq, cinfo) >= 0)
+    {
+        const int client = snd_seq_client_info_get_client (cinfo);
+        if (clientName != snd_seq_client_info_get_name (cinfo)) continue;
+
+        snd_seq_port_info_set_client (pinfo, client);
+        snd_seq_port_info_set_port (pinfo, -1);
+        while (snd_seq_query_next_port (seq, pinfo) >= 0)
+        {
+            if (portName != snd_seq_port_info_get_name (pinfo)) continue;
+            found = std::to_string (client) + "-" + std::to_string (snd_seq_port_info_get_port (pinfo));
+            break;
+        }
+    }
+    snd_seq_close (seq);
+    return found;
+}
+
 // Receiver-side collector: the poll thread pushes decoded messages; the test
 // waits on the condition variable instead of sleeping/polling.
 struct Sink
@@ -110,6 +144,37 @@ TEST_CASE ("ALSA seq backend enumerates its loopback partner and stable ids", "[
         REQUIRE (a == b);
         REQUIRE (a.rfind ("alsa-seq:", 0) == 0);
     }
+}
+
+TEST_CASE ("ALSA seq backend migrates a legacy address identifier", "[midi][alsa]")
+{
+    if (! loopbackAvailable())
+        SKIP ("ALSA sequencer loopback unavailable - headless CI");
+
+    AlsaSeqMidiInput  in;
+    AlsaSeqMidiOutput out;
+
+    const std::string current = findId (out.enumerate(), "Dusk Studio: MIDI In");
+    const std::string legacy  = legacyAddressOf ("Dusk Studio", "MIDI In");
+    REQUIRE_FALSE (current.empty());
+    REQUIRE_FALSE (legacy.empty());
+
+    // A session saved under the old scheme resolves back to the same port.
+    REQUIRE (out.migrateIdentifier (legacy) == current);
+
+    // Addresses that no longer point anywhere, and anything not in the legacy
+    // shape at all, report a miss rather than guessing.
+    REQUIRE (out.migrateIdentifier ("9999-0").empty());
+    REQUIRE (out.migrateIdentifier ("").empty());
+    REQUIRE (out.migrateIdentifier ("-").empty());
+    REQUIRE (out.migrateIdentifier ("12").empty());
+    REQUIRE (out.migrateIdentifier ("12-").empty());
+    REQUIRE (out.migrateIdentifier ("x-0").empty());
+    REQUIRE (out.migrateIdentifier ("12-0junk").empty());
+    REQUIRE (out.migrateIdentifier (current).empty());   // already migrated
+
+    REQUIRE (in.migrateIdentifier (legacyAddressOf ("Dusk Studio", "MIDI Out"))
+             == findId (in.enumerate(), "Dusk Studio: MIDI Out"));
 }
 
 TEST_CASE ("ALSA seq MIDI loopback round-trips bytes exactly", "[midi][alsa]")

--- a/tests/alsa_seq_midi.cpp
+++ b/tests/alsa_seq_midi.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "engine/midi/AlsaSeqMidi.h"
+#include "engine/midi/MidiDevices.h"
 #include "foundation/MidiBuffer.h"
 
 #include <alsa/asoundlib.h>
@@ -60,6 +61,14 @@ std::string legacyAddressOf (const std::string& clientName, const std::string& p
     }
     snd_seq_close (seq);
     return found;
+}
+
+int indexOfName (const std::vector<MidiDeviceInfo>& devs, const std::string& portSubstr)
+{
+    for (int i = 0; i < (int) devs.size(); ++i)
+        if (devs[(size_t) i].name.find (portSubstr) != std::string::npos)
+            return i;
+    return -1;
 }
 
 // Receiver-side collector: the poll thread pushes decoded messages; the test
@@ -175,6 +184,82 @@ TEST_CASE ("ALSA seq backend migrates a legacy address identifier", "[midi][alsa
 
     REQUIRE (in.migrateIdentifier (legacyAddressOf ("Dusk Studio", "MIDI Out"))
              == findId (in.enumerate(), "Dusk Studio: MIDI Out"));
+}
+
+TEST_CASE ("MidiOutputBank RT queue delivers through the pump, bounded by its depth",
+           "[midi][alsa]")
+{
+    if (! loopbackAvailable())
+        SKIP ("ALSA sequencer loopback unavailable - headless CI");
+
+    Sink sink;
+    AlsaSeqMidiInput in;
+    in.setReceiver ([&] (const std::string& id, const std::uint8_t* b, int n, double)
+                    { sink.onMidi (id, b, n); });
+
+    // Built after the input backend so its port is in the enumeration. The bank
+    // owns its own output backend, which the input sees as a source.
+    MidiOutputBank bank;
+    bank.rebuild();
+
+    const int dst = indexOfName (bank.getDevices(), "Dusk Studio: MIDI In");
+    REQUIRE (dst >= 0);
+
+    const std::string src = findId (in.enumerate(), "Dusk Studio: MIDI Out");
+    REQUIRE_FALSE (src.empty());
+    REQUIRE (in.enable (src));
+    in.start();
+
+    auto oneNote = [] (int note)
+    {
+        dusk::MidiBuffer b;
+        b.reserveBytes (64);
+        const std::uint8_t bytes[3] { 0x90, (std::uint8_t) (note & 0x7f), 100 };
+        b.addEvent (bytes, 3, 0);
+        return b;
+    };
+
+    // A closed port takes no slot: this must not consume queue depth, so all
+    // kQueueDepth of the notes below still commit.
+    REQUIRE_FALSE (bank.isOpen (dst));
+    for (int i = 0; i < MidiOutputBank::kQueueDepth; ++i)
+        bank.queueRt (dst, oneNote (0x7f), 48000.0);
+
+    REQUIRE (bank.ensureOpen (dst));
+    REQUIRE (bank.isOpen (dst));
+
+    // Past the slot cap: dropped whole rather than truncated, and likewise takes
+    // no slot.
+    dusk::MidiBuffer big;
+    big.reserveBytes (1 << 16);
+    const std::uint8_t filler[3] { 0x90, 0x7f, 100 };
+    for (int i = 0; i < 4096; ++i)
+        REQUIRE (big.addEvent (filler, 3, i));
+    bank.queueRt (dst, big, 48000.0);
+
+    // The pump is not running, so only kQueueDepth blocks can commit; the rest
+    // drop. Each carries its own note number, so the delivered set identifies
+    // exactly which ones survived.
+    constexpr int kPushed = MidiOutputBank::kQueueDepth * 3;
+    for (int i = 0; i < kPushed; ++i)
+        bank.queueRt (dst, oneNote (i), 48000.0);
+
+    bank.startPump();
+    REQUIRE (sink.waitFor ((std::size_t) MidiOutputBank::kQueueDepth));
+    // Nothing beyond the queue's depth is ever delivered - neither the dropped
+    // blocks nor the over-cap one.
+    REQUIRE_FALSE (sink.waitFor ((std::size_t) MidiOutputBank::kQueueDepth + 1, 250));
+
+    bank.stopPump();
+    in.stop();
+
+    std::lock_guard<std::mutex> lk (sink.m);
+    REQUIRE (sink.messages.size() == (std::size_t) MidiOutputBank::kQueueDepth);
+    for (int i = 0; i < (int) sink.messages.size(); ++i)
+    {
+        REQUIRE (sink.messages[(size_t) i].size() == 3);
+        REQUIRE (sink.messages[(size_t) i][1] == (std::uint8_t) i);   // FIFO order, first kQueueDepth pushed
+    }
 }
 
 TEST_CASE ("ALSA seq MIDI loopback round-trips bytes exactly", "[midi][alsa]")

--- a/tests/alsa_seq_midi.cpp
+++ b/tests/alsa_seq_midi.cpp
@@ -285,6 +285,28 @@ TEST_CASE ("MidiOutputBank RT queue delivers through the pump, bounded by its de
         REQUIRE (sink.messages[0][1] == 0x22);
     }
 
+    SECTION ("a re-enumeration discards what was queued against the old order")
+    {
+        bank.queueRt (dst, oneNote (0x33), 48000.0);
+        bank.rebuild();
+
+        // Indices are minted afresh, so the pre-rebuild block must not be sent
+        // even though the same physical port is still there and reopens.
+        const int again = indexOfName (bank.getDevices(), "Dusk Studio: MIDI In");
+        REQUIRE (again >= 0);
+        REQUIRE (bank.ensureOpen (again));
+        bank.startPump();
+        REQUIRE_FALSE (sink.waitFor (1, 250));
+
+        bank.queueRt (again, oneNote (0x44), 48000.0);
+        REQUIRE (sink.waitFor (1));
+        bank.stopPump();
+
+        std::lock_guard<std::mutex> lk (sink.m);
+        REQUIRE (sink.messages.size() == 1);
+        REQUIRE (sink.messages[0][1] == 0x44);
+    }
+
     in.stop();
 }
 
@@ -314,7 +336,10 @@ TEST_CASE ("ALSA seq identifier migration is safe while the poll thread runs",
                     { sink.onMidi (id, b, n); });
     in.start();
 
-    const std::string legacy = legacyAddressOf ("Dusk Studio", "MIDI In");
+    // The migration has to run on the INPUT backend: that is the one whose poll
+    // thread is reading the handle being queried. Migrating on the output side
+    // would query a handle nothing else touches and prove nothing.
+    const std::string legacy = legacyAddressOf ("Dusk Studio", "MIDI Out");
     REQUIRE_FALSE (legacy.empty());
 
     dusk::MidiBuffer note;
@@ -324,8 +349,10 @@ TEST_CASE ("ALSA seq identifier migration is safe while the poll thread runs",
     constexpr int kRounds = 64;
     for (int i = 0; i < kRounds; ++i)
     {
+        // The send keeps the poll thread busy on the same handle the migration
+        // walks.
         REQUIRE (out.send (inAsDest, note, 0.0, 48000.0));
-        REQUIRE (out.migrateIdentifier (legacy) == inAsDest);
+        REQUIRE (in.migrateIdentifier (legacy) == outAsSource);
     }
 
     REQUIRE (sink.waitFor (kRounds));

--- a/tests/alsa_seq_midi.cpp
+++ b/tests/alsa_seq_midi.cpp
@@ -288,6 +288,51 @@ TEST_CASE ("MidiOutputBank RT queue delivers through the pump, bounded by its de
     in.stop();
 }
 
+TEST_CASE ("ALSA seq identifier migration is safe while the poll thread runs",
+           "[midi][alsa]")
+{
+    if (! loopbackAvailable())
+        SKIP ("ALSA sequencer loopback unavailable - headless CI");
+
+    // A session load resolves saved identifiers WITHOUT stopping MIDI input
+    // (AudioEngine::reresolveTrackMidiFromSession is deliberately detach-free),
+    // so migrateIdentifier queries the same sequencer handle the poll thread is
+    // reading. Drive both at once: the assertions below hold either way, but
+    // this is the shape a sanitiser build needs in order to see the conflict.
+    Sink sink;
+    AlsaSeqMidiInput  in;
+    AlsaSeqMidiOutput out;
+
+    const std::string outAsSource = findId (in.enumerate(),  "Dusk Studio: MIDI Out");
+    const std::string inAsDest    = findId (out.enumerate(), "Dusk Studio: MIDI In");
+    REQUIRE_FALSE (outAsSource.empty());
+    REQUIRE_FALSE (inAsDest.empty());
+    REQUIRE (in.enable (outAsSource));
+    REQUIRE (out.open (inAsDest));
+
+    in.setReceiver ([&] (const std::string& id, const std::uint8_t* b, int n, double)
+                    { sink.onMidi (id, b, n); });
+    in.start();
+
+    const std::string legacy = legacyAddressOf ("Dusk Studio", "MIDI In");
+    REQUIRE_FALSE (legacy.empty());
+
+    dusk::MidiBuffer note;
+    const std::uint8_t bytes[3] { 0x90, 60, 100 };
+    note.addEvent (bytes, 3, 0);
+
+    constexpr int kRounds = 64;
+    for (int i = 0; i < kRounds; ++i)
+    {
+        REQUIRE (out.send (inAsDest, note, 0.0, 48000.0));
+        REQUIRE (out.migrateIdentifier (legacy) == inAsDest);
+    }
+
+    REQUIRE (sink.waitFor (kRounds));
+    in.stop();
+    out.closeAll();
+}
+
 TEST_CASE ("ALSA seq MIDI loopback round-trips bytes exactly", "[midi][alsa]")
 {
     if (! loopbackAvailable())

--- a/tests/foundation_midi_buffer.cpp
+++ b/tests/foundation_midi_buffer.cpp
@@ -74,3 +74,36 @@ TEST_CASE ("dusk::MidiBuffer clear keeps capacity and empties", "[foundation][mi
     for (auto it = d.begin(); it != d.end(); ++it) ++n;
     REQUIRE (n == 0);
 }
+
+TEST_CASE ("dusk::MidiBuffer drops past its reserved cap instead of growing",
+           "[foundation][midi]")
+{
+    // The RT out-queue relies on this: a reserved buffer must refuse an event
+    // that would exceed the cap rather than reallocate on the audio thread.
+    constexpr std::size_t kCap = 64;
+    dusk::MidiBuffer d;
+    d.reserveBytes (kCap);
+
+    const std::uint8_t note[3] { 0x90, 60, 100 };
+    int accepted = 0;
+    while (d.addEvent (note, 3, accepted)) ++accepted;
+
+    // 8-byte header + 3 payload bytes per event.
+    REQUIRE (accepted == (int) (kCap / 11));
+
+    // Rejection leaves the existing contents intact and is repeatable.
+    int counted = 0;
+    for (const auto meta : d)
+    {
+        REQUIRE (meta.numBytes == 3);
+        REQUIRE (meta.samplePosition == counted);
+        ++counted;
+    }
+    REQUIRE (counted == accepted);
+    REQUIRE (! d.addEvent (note, 3, 0));
+
+    // Unreserved buffers keep growing freely (message-thread use).
+    dusk::MidiBuffer unbounded;
+    for (int i = 0; i < 1000; ++i)
+        REQUIRE (unbounded.addEvent (note, 3, i));
+}

--- a/tests/foundation_midi_buffer.cpp
+++ b/tests/foundation_midi_buffer.cpp
@@ -73,6 +73,17 @@ TEST_CASE ("dusk::MidiBuffer clear keeps capacity and empties", "[foundation][mi
     int n = 0;
     for (auto it = d.begin(); it != d.end(); ++it) ++n;
     REQUIRE (n == 0);
+
+    // The reserved cap has to survive the clear, or the RT path would start
+    // reallocating on the audio thread after the first block. It is only
+    // observable through the drop it causes, and the fill is bounded so a lost
+    // cap fails here rather than growing until the runner is killed.
+    constexpr int kMoreThanFits = 256;
+    int accepted = 0;
+    while (accepted < kMoreThanFits && d.addEvent (&clk, 1, accepted)) ++accepted;
+    REQUIRE (accepted > 0);
+    REQUIRE (accepted < kMoreThanFits);
+    REQUIRE (! d.addEvent (&clk, 1, 0));
 }
 
 TEST_CASE ("dusk::MidiBuffer drops past its reserved cap instead of growing",
@@ -85,11 +96,14 @@ TEST_CASE ("dusk::MidiBuffer drops past its reserved cap instead of growing",
     d.reserveBytes (kCap);
 
     const std::uint8_t note[3] { 0x90, 60, 100 };
+    // 8-byte header + 3 payload bytes per event. Bounded well past that so a
+    // buffer that wrongly grows fails the count instead of running away.
+    constexpr int kPerEvent = 11;
+    constexpr int kMoreThanFits = (int) (kCap / kPerEvent) + 8;
     int accepted = 0;
-    while (d.addEvent (note, 3, accepted)) ++accepted;
+    while (accepted < kMoreThanFits && d.addEvent (note, 3, accepted)) ++accepted;
 
-    // 8-byte header + 3 payload bytes per event.
-    REQUIRE (accepted == (int) (kCap / 11));
+    REQUIRE (accepted == (int) (kCap / kPerEvent));
 
     // Rejection leaves the existing contents intact and is repeatable.
     int counted = 0;

--- a/tests/midi_device_layer.cpp
+++ b/tests/midi_device_layer.cpp
@@ -114,29 +114,6 @@ TEST_CASE ("Seam resolves saved identifiers back to bank indices", "[midi][devic
     REQUIRE (! bank.isOpen (bank.getNumOutputs()));
 }
 
-TEST_CASE ("MidiOutputBank queueRt survives over-cap and over-depth blocks",
-           "[midi][devices]")
-{
-    MidiOutputBank bank;
-    bank.rebuild();
-
-    // The drop policies themselves are asserted where they are observable (the
-    // MidiBuffer cap test in foundation_midi_buffer). What this pins down is
-    // that queueRt honours them without wedging or overrunning the fixed queue:
-    // no device is open and the pump is not started, so every push must be
-    // absorbed and discarded.
-    dusk::MidiBuffer big;
-    big.reserveBytes (1 << 16);
-    const std::uint8_t note[3] { 0x90, 64, 100 };
-    for (int i = 0; i < 4096; ++i)
-        REQUIRE (big.addEvent (note, 3, i));
-
-    for (int i = 0; i < 128; ++i)   // twice the queue depth: nothing may commit
-        bank.queueRt (0, big, 48000.0);
-
-    dusk::MidiBuffer small;
-    small.reserveBytes (256);
-    REQUIRE (small.addEvent (note, 3, 0));
-    for (int i = 0; i < 128; ++i)   // past the queue depth: drops, never grows
-        bank.queueRt (0, small, 48000.0);
-}
+// What queueRt actually delivers is asserted end to end in alsa_seq_midi.cpp,
+// where a real port receives the bytes; there is no way to observe it here
+// without a device.

--- a/tests/midi_device_layer.cpp
+++ b/tests/midi_device_layer.cpp
@@ -114,15 +114,17 @@ TEST_CASE ("Seam resolves saved identifiers back to bank indices", "[midi][devic
     REQUIRE (! bank.isOpen (bank.getNumOutputs()));
 }
 
-TEST_CASE ("MidiOutputBank queueRt drops a block past the slot cap", "[midi][devices]")
+TEST_CASE ("MidiOutputBank queueRt survives over-cap and over-depth blocks",
+           "[midi][devices]")
 {
     MidiOutputBank bank;
     bank.rebuild();
 
-    // No device needed: queueRt only fills a slot, and the pump (not started
-    // here) is what would consume it. A block far past the 4 kB slot cap must be
-    // dropped whole rather than reallocated on the audio thread, and the queue
-    // must stay usable afterwards.
+    // The drop policies themselves are asserted where they are observable (the
+    // MidiBuffer cap test in foundation_midi_buffer). What this pins down is
+    // that queueRt honours them without wedging or overrunning the fixed queue:
+    // no device is open and the pump is not started, so every push must be
+    // absorbed and discarded.
     dusk::MidiBuffer big;
     big.reserveBytes (1 << 16);
     const std::uint8_t note[3] { 0x90, 64, 100 };

--- a/tests/midi_device_layer.cpp
+++ b/tests/midi_device_layer.cpp
@@ -1,51 +1,43 @@
 #include <catch2/catch_test_macros.hpp>
 
-#include <juce_audio_devices/juce_audio_devices.h>
 #include "engine/midi/MidiDevices.h"
 #include "foundation/MidiBuffer.h"
-#include <array>
 #include <cstdint>
-#include <vector>
+#include <string>
 
 using duskstudio::midi::MidiInputClient;
 using duskstudio::midi::MidiOutputBank;
 
+// These run against whatever the platform backend enumerates - no assertion
+// depends on a device being present, so a headless machine exercises the same
+// paths as one with hardware attached.
+
 TEST_CASE ("MidiInputClient appends a stable Virtual-Keyboard slot", "[midi][devices]")
 {
-    juce::AudioDeviceManager dm;
     MidiInputClient client;
-    client.setDeviceManager (dm);
     client.rebuild (48000.0);
 
     const int vkb = client.getVirtualKeyboardIndex();
     REQUIRE (vkb >= 0);
-    REQUIRE (client.getVirtualKeyboardCollector() != nullptr);
 
     // VKB is always the last slot, carrying the fixed identifier.
     const auto& devs = client.getDevices();
     REQUIRE (vkb == (int) devs.size() - 1);
     REQUIRE (client.getNumInputs() == (int) devs.size());
-    REQUIRE (devs[(size_t) vkb].identifier
-             == juce::String (MidiInputClient::kVirtualKeyboardIdentifier));
+    REQUIRE (devs[(size_t) vkb].identifier == std::string (MidiInputClient::kVirtualKeyboardIdentifier));
 }
 
 TEST_CASE ("MidiInputClient VKB feed round-trips through the dusk boundary", "[midi][devices]")
 {
-    juce::AudioDeviceManager dm;
     MidiInputClient client;
-    client.setDeviceManager (dm);
     client.rebuild (48000.0);
 
     const int vkb = client.getVirtualKeyboardIndex();
-    auto* col = client.getVirtualKeyboardCollector();
-    REQUIRE (col != nullptr);
+    REQUIRE (vkb >= 0);
 
-    // Feed a note-on the way the on-screen keyboard does: an ms-since-epoch
-    // timestamp (the collector asserts on a zero stamp and derives the sample
-    // offset from it).
-    auto noteOn = juce::MidiMessage::noteOn (1, 60, (juce::uint8) 100);
-    noteOn.setTimeStamp (juce::Time::getMillisecondCounterHiRes() * 0.001);
-    col->addMessageToQueue (noteOn);
+    // Feed a note-on the way the on-screen keyboard does: raw status + data.
+    const std::uint8_t noteOn[3] { 0x90, 60, 100 };
+    client.postVirtualKeyboardMidi (noteOn, 3);
 
     constexpr int numSamples = 512;
     dusk::MidiBuffer out;
@@ -56,34 +48,37 @@ TEST_CASE ("MidiInputClient VKB feed round-trips through the dusk boundary", "[m
     for (const auto meta : out)
     {
         ++count;
-        const auto& m = meta.getMessage();
-        REQUIRE (m.getRawDataSize() == 3);
-        const auto* b = m.getRawData();
-        REQUIRE ((b[0] & 0xf0) == 0x90);   // note-on
-        REQUIRE ((b[0] & 0x0f) == 0x00);   // channel 1
-        REQUIRE (b[1] == 60);
-        REQUIRE (b[2] == 100);
+        REQUIRE (meta.numBytes == 3);
+        REQUIRE (meta.data[0] == 0x90);
+        REQUIRE (meta.data[1] == 60);
+        REQUIRE (meta.data[2] == 100);
         // The collector clamps the offset into the requested block.
         REQUIRE (meta.samplePosition >= 0);
         REQUIRE (meta.samplePosition < numSamples);
     }
     REQUIRE (count == 1);
+
+    // The drain is destructive - a second one on the same slot yields nothing.
+    client.drainBlock (vkb, out, numSamples);
+    REQUIRE (out.isEmpty());
 }
 
 TEST_CASE ("MidiInputClient drainBlock clears and bounds-checks", "[midi][devices]")
 {
-    juce::AudioDeviceManager dm;
     MidiInputClient client;
-    client.setDeviceManager (dm);
     client.rebuild (48000.0);
 
     dusk::MidiBuffer out;
     out.reserveBytes (256);
 
     // Out-of-range index just clears the destination.
-    const std::uint8_t junk[3] = { 0x90, 1, 1 };
-    out.addEvent (junk, 3, 0);
+    const std::uint8_t junk[3] { 0x90, 1, 1 };
+    REQUIRE (out.addEvent (junk, 3, 0));
     client.drainBlock (9999, out, 256);
+    REQUIRE (out.isEmpty());
+
+    REQUIRE (out.addEvent (junk, 3, 0));
+    client.drainBlock (-1, out, 256);
     REQUIRE (out.isEmpty());
 
     // Empty collector -> empty out.
@@ -91,33 +86,55 @@ TEST_CASE ("MidiInputClient drainBlock clears and bounds-checks", "[midi][device
     REQUIRE (out.isEmpty());
 }
 
-TEST_CASE ("MidiOutputBank dusk->juce conversion preserves bytes + offsets", "[midi][devices]")
+TEST_CASE ("Seam resolves saved identifiers back to bank indices", "[midi][devices]")
 {
-    dusk::MidiBuffer in;
-    in.reserveBytes (256);
-    const std::uint8_t noteOn[3]  = { 0x90, 60, 100 };
-    const std::uint8_t cc[3]      = { 0xB0, 7, 127 };
-    const std::uint8_t noteOff[3] = { 0x80, 60, 0 };
-    in.addEvent (noteOn,  3, 0);
-    in.addEvent (cc,      3, 128);
-    in.addEvent (noteOff, 3, 400);
+    MidiInputClient client;
+    client.rebuild (48000.0);
 
-    juce::MidiBuffer juceOut;
-    MidiOutputBank::toJuceBuffer (in, juceOut);
+    REQUIRE (client.resolveIndex (MidiInputClient::kVirtualKeyboardIdentifier)
+             == client.getVirtualKeyboardIndex());
+    REQUIRE (client.resolveIndex ("") == -1);
+    REQUIRE (client.resolveIndex ("no-such-backend:No Such Client:No Such Port") == -1);
 
-    struct Ev { int pos; std::array<std::uint8_t, 3> b; };
-    std::vector<Ev> got;
-    for (const auto meta : juceOut)
+    const auto& inputs = client.getDevices();
+    for (int i = 0; i < (int) inputs.size(); ++i)
+        REQUIRE (client.resolveIndex (inputs[(size_t) i].identifier) == i);
+
+    MidiOutputBank bank;
+    bank.rebuild();
+    REQUIRE (bank.resolveIndex ("") == -1);
+    REQUIRE (bank.resolveIndex ("no-such-backend:No Such Client:No Such Port") == -1);
+    REQUIRE (bank.getNumOutputs() == (int) bank.getDevices().size());
+    for (int i = 0; i < bank.getNumOutputs(); ++i)
     {
-        REQUIRE (meta.numBytes == 3);
-        got.push_back ({ meta.samplePosition,
-                         { meta.data[0], meta.data[1], meta.data[2] } });
+        REQUIRE (bank.resolveIndex (bank.getDevices()[(size_t) i].identifier) == i);
+        REQUIRE (! bank.isOpen (i));   // rebuild never eager-opens
     }
+    REQUIRE (! bank.isOpen (-1));
+    REQUIRE (! bank.isOpen (bank.getNumOutputs()));
+}
 
-    REQUIRE (got.size() == 3);
-    // juce::MidiBuffer keeps events sorted by sample position; the inputs were
-    // already ascending, so the order carries over 1:1.
-    REQUIRE (got[0].pos == 0);   REQUIRE (got[0].b[0] == 0x90);
-    REQUIRE (got[1].pos == 128); REQUIRE (got[1].b[0] == 0xB0);
-    REQUIRE (got[2].pos == 400); REQUIRE (got[2].b[0] == 0x80);
+TEST_CASE ("MidiOutputBank queueRt drops a block past the slot cap", "[midi][devices]")
+{
+    MidiOutputBank bank;
+    bank.rebuild();
+
+    // No device needed: queueRt only fills a slot, and the pump (not started
+    // here) is what would consume it. A block far past the 4 kB slot cap must be
+    // dropped whole rather than reallocated on the audio thread, and the queue
+    // must stay usable afterwards.
+    dusk::MidiBuffer big;
+    big.reserveBytes (1 << 16);
+    const std::uint8_t note[3] { 0x90, 64, 100 };
+    for (int i = 0; i < 4096; ++i)
+        REQUIRE (big.addEvent (note, 3, i));
+
+    for (int i = 0; i < 128; ++i)   // twice the queue depth: nothing may commit
+        bank.queueRt (0, big, 48000.0);
+
+    dusk::MidiBuffer small;
+    small.reserveBytes (256);
+    REQUIRE (small.addEvent (note, 3, 0));
+    for (int i = 0; i < 128; ++i)   // past the queue depth: drops, never grows
+        bank.queueRt (0, small, 48000.0);
 }

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -45,8 +45,8 @@ src/engine/hosting/NativePluginId.h
 src/engine/ipc/IpcSelfTest.cpp
 src/engine/ipc/PluginHostMain.cpp
 src/engine/ipc/PluginScanProtocol.h
-src/engine/midi/MidiDevices.cpp
-src/engine/midi/MidiDevices.h
+src/engine/midi/JuceMidiBackend.cpp
+src/engine/midi/JuceMidiBackend.h
 src/engine/multisample/AriaBank.cpp
 src/engine/multisample/AriaBank.h
 src/engine/multisample/AriaGui.cpp


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a JUCE-backed MIDI device path for non-Linux platforms.
  * Added best-effort migration support for legacy saved MIDI identifiers.
  * Virtual keyboard now injects MIDI directly into the engine’s input path.

* **Bug Fixes**
  * Improved MIDI timing, input refresh/hot-plug re-resolution, and resilience during rebuild/closure.
  * Prevented stale queued MIDI delivery and reduced session MIDI port mismatch behavior.

* **Tests**
  * Expanded MIDI backend/migration, RT queue behavior, concurrency, virtual keyboard, and MIDI buffer capacity coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->