### PR TITLE
MIDI hot-plug auto-detect on Linux

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -428,7 +428,7 @@ Open **Settings → Audio…** to choose your audio device. The panel is divided
 - **Periods (Linux/ALSA only)**: how many buffers the ALSA driver keeps in flight. Two is the lowest-latency safe value; three or more is more robust on a busy machine.
 - **Active output channels**: the master mix uses outputs 1-2. If your interface has more outputs, tick the extra pairs here to open them — each pair then becomes selectable as an aux lane's **Output** (a headphone / cue feed). Off by default; the master stays stereo until you enable more.
 - **Main output**: which physical pair the master mix goes to. **1-2 (default)** in most rigs; move it to another pair (e.g. when you want outputs 1-2 free for a control-room or cue feed). Only pairs the device currently has open are listed. If an aux lane is routed to the same pair as the master, the two sum on that pair.
-- **Rescan devices**: re-enumerates every backend, useful if you plugged in a USB interface after launch.
+- **Rescan devices**: re-enumerates every backend and every MIDI port, useful if you plugged in a USB interface after launch. MIDI controllers on Linux do not need it — see [MIDI hot-plug](#midi-hot-plug).
 
 ### Control surface
 
@@ -966,6 +966,14 @@ For an audio track, the **Input** dropdown lists every input channel on your aud
 For a stereo track, you select two inputs (left and right) independently.
 
 For a MIDI track, you select a MIDI input port and a channel filter. The activity LED next to the input blinks each time a MIDI message arrives, so you can confirm your controller is talking to the right track.
+
+### MIDI hot-plug
+
+On Linux, plugging in a MIDI controller while Dusk Studio is running is enough — the new port appears in the input dropdowns by itself, and tracks whose saved port just came back re-attach to it.
+
+The one rule: the port list is only rebuilt while the transport is **stopped**. Plug something in mid-take and nothing happens until you hit stop, at which point it appears. That is deliberate. Rebuilding the port list briefly interrupts audio, so a controller waking up — or a USB hub blinking — can never put a hole in a take you are recording.
+
+On macOS and Windows, use **Rescan devices** in Audio Settings after plugging a controller in.
 
 ## Arming a track
 

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -534,6 +534,18 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
     duskstudio::midi::setJuceMidiDeviceManager (deviceManager.juceManager());
    #endif
 
+    // Hot-plug. Set before the backend starts: the handler runs on its MIDI
+    // thread, so it only hops to the message thread and lets that side decide
+    // when a rebuild is safe.
+    midiIn.setDeviceChangeHandler ([this, alive = midiHotplugAlive]
+    {
+        dusk::callAsync ([this, alive]
+        {
+            if (alive->load (std::memory_order_acquire))
+                noteMidiDeviceChange();
+        });
+    });
+
     // Build both MIDI banks before ANY callback is registered - the audio
     // callback iterates perInputMidi, so it must not be attachable while
     // rebuildMidiBanks sizes the vector.
@@ -546,6 +558,30 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
     // the message thread when the device manager's device list / current device
     // changes.
     deviceManager.addChangeListener (this, [this] { onDeviceManagerChanged(); });
+}
+
+// Long enough to swallow one device's announce burst, short enough that a
+// controller shows up while the user is still reaching for the mouse. It is
+// also the re-check period while a take holds the refresh off.
+static constexpr int kMidiHotplugDelayMs = 400;
+
+void AudioEngine::noteMidiDeviceChange()
+{
+    // A single plug raises a client arrival plus one port arrival per port, and
+    // a hub raises several devices' worth. The armed timer IS the pending flag,
+    // so re-arming while it runs is what collapses the burst into one rebuild.
+    if (! midiHotplugTimer.isTimerRunning())
+        midiHotplugTimer.startTimer (kMidiHotplugDelayMs);
+}
+
+void AudioEngine::serviceMidiHotplug()
+{
+    // Held, not dropped: refreshMidiInputs detaches the audio callback, so a
+    // hub blip mid-take waits here and applies the moment the take ends.
+    if (! transport.isStopped()) return;
+
+    midiHotplugTimer.stopTimer();
+    refreshMidiInputs();
 }
 
 void AudioEngine::refreshMidiInputs()
@@ -1061,6 +1097,11 @@ void AudioEngine::setStage (Stage s) noexcept
 
 AudioEngine::~AudioEngine()
 {
+    // Before anything else: a hop posted by the poll thread can already be
+    // sitting in the message queue, and joining that thread below will not
+    // remove it. Clearing the flag makes it land on a no-op.
+    midiHotplugAlive->store (false, std::memory_order_release);
+    midiHotplugTimer.stopTimer();
     diagTimer.stopTimer();
     if (transport.isRecording())
         recordManager.stopRecording (transport.getPlayhead());

--- a/src/engine/AudioEngine.h
+++ b/src/engine/AudioEngine.h
@@ -776,7 +776,11 @@ private:
 
     // Outlives the engine so a hop still queued when it dies is a no-op instead
     // of a use-after-free: the poll thread posts those, and joining it in the
-    // destructor cannot un-queue what it already posted.
+    // destructor cannot un-queue what it already posted. The timer above needs
+    // no such guard even though it also holds the engine by reference - it
+    // never crosses a thread. Its dispatch re-reads the live timer list, which
+    // stopTimer removes it from, and both the tick and ~AudioEngine run on the
+    // message thread, so a callback cannot be in flight while the engine dies.
     std::shared_ptr<std::atomic<bool>> midiHotplugAlive
         { std::make_shared<std::atomic<bool>> (true) };
 

--- a/src/engine/AudioEngine.h
+++ b/src/engine/AudioEngine.h
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <memory>
 #include <mutex>
 #include <vector>
 #include "../dsp/AuxLaneStrip.h"
@@ -14,6 +15,7 @@
 #include "../dsp/MasteringChain.h"
 #include "../dsp/Metronome.h"
 #include "../dsp/PitchDetector.h"
+#include "../foundation/MessageThread.h"
 #include "MidiSyncReceiver.h"
 #include "MidiTimeCodeReceiver.h"
 #include "MidiClockEmitter.h"
@@ -755,6 +757,28 @@ private:
     // new input. Without this, held notes from the previous device
     // keep ringing (Note Off never arrives on the now-unrouted source).
     std::array<int, Session::kNumTracks> lastMidiInputIndex {};
+
+    // MIDI hot-plug. The backend's MIDI thread reports that the OS port set
+    // moved; noteMidiDeviceChange arms a single delayed pass so one plug (a
+    // client arrival plus a port arrival per port) costs one rebuild, and
+    // serviceMidiHotplug holds that pass until the transport is stopped -
+    // refreshMidiInputs detaches the audio callback, so applying it mid-take
+    // would drop audio. Message thread; only the ALSA backend raises it.
+    void noteMidiDeviceChange();
+    void serviceMidiHotplug();
+    struct MidiHotplugTimer : dusk::Timer
+    {
+        explicit MidiHotplugTimer (AudioEngine& o) : owner (o) {}
+        void timerCallback() override { owner.serviceMidiHotplug(); }
+        AudioEngine& owner;
+    };
+    MidiHotplugTimer midiHotplugTimer { *this };
+
+    // Outlives the engine so a hop still queued when it dies is a no-op instead
+    // of a use-after-free: the poll thread posts those, and joining it in the
+    // destructor cannot un-queue what it already posted.
+    std::shared_ptr<std::atomic<bool>> midiHotplugAlive
+        { std::make_shared<std::atomic<bool>> (true) };
 
     // Rebuild both device banks (message thread, input+audio callbacks
     // DETACHED by the caller). Enumerates hardware, sizes perInputMidi,

--- a/src/engine/midi/AlsaSeqMidi.cpp
+++ b/src/engine/midi/AlsaSeqMidi.cpp
@@ -116,6 +116,25 @@ std::uint32_t addrKey (int client, int port) noexcept
     return ((std::uint32_t) client << 16) | (std::uint32_t) (port & 0xffff);
 }
 
+// System-announce types that mean the set of ports moved and an enumeration is
+// stale. PORT_SUBSCRIBED / PORT_UNSUBSCRIBED are deliberately NOT here: our own
+// connect_from raises them, so counting them would make every refresh announce
+// the next one and the engine would rebuild forever.
+bool isPortSetChange (int type) noexcept
+{
+    switch (type)
+    {
+        case SND_SEQ_EVENT_CLIENT_START:
+        case SND_SEQ_EVENT_CLIENT_EXIT:
+        case SND_SEQ_EVENT_PORT_START:
+        case SND_SEQ_EVENT_PORT_EXIT:
+        case SND_SEQ_EVENT_PORT_CHANGE:
+            return true;
+        default:
+            return false;
+    }
+}
+
 // JUCE's Linux MIDI identifiers are the raw sequencer address, "<client>-<port>".
 // Sessions saved before this backend existed hold those, so map one back to a
 // live port and hand out its name-based identifier instead. Only valid while the
@@ -150,6 +169,10 @@ struct AlsaSeqMidiInput::Impl
     int               inPort = -1;
     snd_midi_event_t* coder  = nullptr;
     Receiver          receiver;
+
+    // Fired on the poll thread, outside seqMutex, when the announce port
+    // reported a moved port set.
+    DeviceChangeHandler onDeviceChange;
 
     // libasound does not support concurrent use of one snd_seq_t. The poll
     // thread reads events off `seq` while the message thread can be querying it
@@ -190,6 +213,12 @@ struct AlsaSeqMidiInput::Impl
         inPort = snd_seq_create_simple_port (seq, "MIDI In",
                      SND_SEQ_PORT_CAP_WRITE | SND_SEQ_PORT_CAP_SUBS_WRITE,
                      SND_SEQ_PORT_TYPE_MIDI_GENERIC | SND_SEQ_PORT_TYPE_APPLICATION);
+        // Hot-plug feed. Subscribing the input port to the System Announce port
+        // routes client/port arrivals and departures into the same poll loop the
+        // MIDI traffic uses. It is not in sourceIds (queryPorts skips client 0),
+        // so disableAll never tears it down and it survives every refresh.
+        if (inPort >= 0)
+            snd_seq_connect_from (seq, inPort, SND_SEQ_CLIENT_SYSTEM, SND_SEQ_PORT_SYSTEM_ANNOUNCE);
         snd_seq_nonblock (seq, 1);   // poll() drives wakeups; event_input returns EAGAIN when empty
         if (snd_midi_event_new (kCoderBufferBytes, &coder) == 0)
             snd_midi_event_no_status (coder, 1);   // emit a status byte on every decoded message
@@ -263,12 +292,25 @@ struct AlsaSeqMidiInput::Impl
         sx.discarding = ! terminated;
     }
 
-    void pumpEvents()
+    // Returns true when this batch carried an announce meaning the port set
+    // moved. The caller fires the handler once the batch is drained and the
+    // sequencer lock is released - it is consumer code, and holding seqMutex
+    // across it would block enumerate() on the message thread.
+    bool pumpEvents()
     {
+        bool portSetChanged = false;
         const std::lock_guard<std::mutex> lock (seqMutex);
         snd_seq_event_t* ev = nullptr;
         while (snd_seq_event_input (seq, &ev) >= 0 && ev != nullptr)
         {
+            // Announce traffic carries no MIDI, so it is taken before the decode
+            // path rather than being sized and decoded as if it did.
+            if (ev->source.client == SND_SEQ_CLIENT_SYSTEM)
+            {
+                portSetChanged = portSetChanged || isPortSetChange (ev->type);
+                continue;
+            }
+
             // Only SYSEX carries MIDI bytes in variable-length form; other
             // variable events (BOUNCE, USR_VAR, ...) are not MIDI, so skip them
             // before they are sized, decoded, or mistaken for a sysex fragment.
@@ -298,6 +340,7 @@ struct AlsaSeqMidiInput::Impl
             // no_status makes each decode self-contained: no cross-event running
             // status, so no reset between events is needed.
         }
+        return portSetChanged;
     }
 
     void run()
@@ -324,7 +367,8 @@ struct AlsaSeqMidiInput::Impl
             const int r = poll (pfds.data(), (nfds_t) (nfds + 1), -1);
             if (r < 0) { if (errno == EINTR) continue; break; }
             if (pfds[(std::size_t) nfds].revents & POLLIN) break;   // stop() woke us
-            pumpEvents();
+            if (pumpEvents() && onDeviceChange)
+                onDeviceChange();
         }
     }
 
@@ -365,6 +409,11 @@ std::vector<BackendDeviceInfo> AlsaSeqMidiInput::enumerate()
 }
 
 void AlsaSeqMidiInput::setReceiver (Receiver r) { impl->receiver = std::move (r); }
+
+void AlsaSeqMidiInput::setDeviceChangeHandler (DeviceChangeHandler h)
+{
+    impl->onDeviceChange = std::move (h);
+}
 
 std::string AlsaSeqMidiInput::migrateIdentifier (const std::string& legacy)
 {
@@ -553,6 +602,7 @@ AlsaSeqMidiInput::AlsaSeqMidiInput()  = default;
 AlsaSeqMidiInput::~AlsaSeqMidiInput() = default;
 std::vector<BackendDeviceInfo> AlsaSeqMidiInput::enumerate() { return {}; }
 void AlsaSeqMidiInput::setReceiver (Receiver) {}
+void AlsaSeqMidiInput::setDeviceChangeHandler (DeviceChangeHandler) {}
 std::string AlsaSeqMidiInput::migrateIdentifier (const std::string&) { return {}; }
 bool AlsaSeqMidiInput::enable (const std::string&) { return false; }
 void AlsaSeqMidiInput::disableAll() {}

--- a/src/engine/midi/AlsaSeqMidi.h
+++ b/src/engine/midi/AlsaSeqMidi.h
@@ -20,6 +20,11 @@
 // fixed key, so two same-named devices can trade identifiers across a replug or
 // reboot.
 //
+// Hot-plug: the input's port also subscribes to the sequencer's System Announce
+// port, so the poll thread that already waits on this handle sees clients and
+// ports come and go and reports them through the device-change handler. No
+// extra thread, no polling.
+//
 // Threading contract (matches the seam's detach/rebuild/attach fence):
 // enumerate / enable / disableAll / open /
 // closeAll / send are called on the message or pump thread while the input
@@ -35,6 +40,7 @@ public:
 
     std::vector<BackendDeviceInfo> enumerate() override;
     void setReceiver (Receiver r) override;
+    void setDeviceChangeHandler (DeviceChangeHandler h) override;
     std::string migrateIdentifier (const std::string& legacy) override;
     bool enable (const std::string& identifier) override;
     void disableAll() override;

--- a/src/engine/midi/MidiBackend.h
+++ b/src/engine/midi/MidiBackend.h
@@ -47,6 +47,16 @@ public:
 
     virtual void setReceiver (Receiver r) = 0;          // set once, before start
 
+    // Fires on the backend's MIDI thread when the OS reports that the set of
+    // MIDI ports moved. A bare signal, not a diff: the only useful response is
+    // a full re-enumeration. One plug raises several, so the consumer coalesces.
+    // The handler must not re-enter the backend - the rebuild that follows a
+    // change calls stop(), which joins the thread the handler runs on.
+    // Default no-op: only the ALSA sequencer has an announce port, so the JUCE
+    // fallback leaves mac/win on the manual rescan path.
+    using DeviceChangeHandler = std::function<void()>;
+    virtual void setDeviceChangeHandler (DeviceChangeHandler) {}   // set once, before start
+
     // Best-effort remap of an identifier minted by a PREVIOUS backend, so a
     // session saved before the backend changed keeps its routing. Returns the
     // current identifier for that device, or "" when it cannot be mapped.

--- a/src/engine/midi/MidiDevices.cpp
+++ b/src/engine/midi/MidiDevices.cpp
@@ -113,6 +113,11 @@ void MidiInputClient::rebuild (double sampleRate)
     virtualKeyboardIndex = (int) collectors.size() - 1;
 }
 
+void MidiInputClient::setDeviceChangeHandler (std::function<void()> h)
+{
+    backend->setDeviceChangeHandler (std::move (h));
+}
+
 void MidiInputClient::detachCallback()  { backend->stop(); }
 void MidiInputClient::disableAllDevices() { backend->disableAll(); }
 void MidiInputClient::attachCallback()  { backend->start(); }

--- a/src/engine/midi/MidiDevices.h
+++ b/src/engine/midi/MidiDevices.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <atomic>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -49,6 +50,12 @@ public:
     // Mutating the bank with the callback active is UB - see the detach/attach
     // fence.
     void rebuild (double sampleRate);
+
+    // Message thread, before the first attachCallback. Forwarded to the backend,
+    // whose MIDI thread fires it when the OS port set moves. Bursty and raised
+    // off the message thread, so the consumer owns the thread hop and the
+    // coalescing; backends without an OS notification never fire it.
+    void setDeviceChangeHandler (std::function<void()> h);
 
     // Detach half of the fence: stop the backend's dispatch (its stop() joins
     // that side before returning) and release the OS handles before a rebuild.

--- a/src/ui/AudioSettingsPanel.cpp
+++ b/src/ui/AudioSettingsPanel.cpp
@@ -73,9 +73,11 @@ AudioSettingsPanel::AudioSettingsPanel (device::DeviceManager& dm,
     addAndMakeVisible (selfTestButton);
 
     rescanButton.onClick = [this] { applyRescan(); };
-    rescanButton.setTooltip ("Re-enumerate audio backends and devices. "
-                              "Use after plugging in or removing a USB / "
-                              "Thunderbolt audio interface.");
+    rescanButton.setTooltip ("Re-enumerate audio backends, devices and MIDI "
+                              "ports. Use after plugging in or removing a USB / "
+                              "Thunderbolt audio interface. On Linux, MIDI "
+                              "controllers are picked up on their own once the "
+                              "transport is stopped.");
     addAndMakeVisible (rescanButton);
 
     // Effect oversampling - global. ComboBox IDs are the literal factor (1,

--- a/tests/alsa_seq_midi.cpp
+++ b/tests/alsa_seq_midi.cpp
@@ -96,6 +96,62 @@ struct Sink
     }
 };
 
+// A MIDI client that comes and goes on demand - what a hot-plug looks like to
+// the sequencer. Creating it raises CLIENT_START + PORT_START on the announce
+// port; closing it raises PORT_EXIT + CLIENT_EXIT.
+struct ProbeClient
+{
+    static constexpr const char* kClientName = "Dusk Hotplug Probe";
+    static constexpr const char* kPortName   = "Probe Out";
+    static constexpr const char* kDisplayName = "Dusk Hotplug Probe: Probe Out";
+
+    snd_seq_t* seq = nullptr;
+
+    bool appear()
+    {
+        if (snd_seq_open (&seq, "default", SND_SEQ_OPEN_DUPLEX, 0) < 0) { seq = nullptr; return false; }
+        snd_seq_set_client_name (seq, kClientName);
+        return snd_seq_create_simple_port (seq, kPortName,
+                   SND_SEQ_PORT_CAP_READ | SND_SEQ_PORT_CAP_SUBS_READ,
+                   SND_SEQ_PORT_TYPE_MIDI_GENERIC) >= 0;
+    }
+
+    void vanish()
+    {
+        if (seq != nullptr) snd_seq_close (seq);
+        seq = nullptr;
+    }
+
+    ~ProbeClient() { vanish(); }
+};
+
+// Device-change reports, counted off the poll thread.
+struct ChangeCounter
+{
+    std::mutex              m;
+    std::condition_variable cv;
+    int                     count = 0;
+
+    void bump()
+    {
+        std::lock_guard<std::mutex> lk (m);
+        ++count;
+        cv.notify_all();
+    }
+
+    int total()
+    {
+        std::lock_guard<std::mutex> lk (m);
+        return count;
+    }
+
+    bool waitFor (int want, int ms = 2000)
+    {
+        std::unique_lock<std::mutex> lk (m);
+        return cv.wait_for (lk, std::chrono::milliseconds (ms), [&] { return count >= want; });
+    }
+};
+
 // A successful snd_seq_open is not enough: a constrained CI sequencer accepts
 // the handle yet cannot create or route ports, so the loopback would fail
 // rather than skip. Probe an actual send -> receive round-trip and only run the
@@ -437,4 +493,67 @@ TEST_CASE ("ALSA seq MIDI loopback round-trips bytes exactly", "[midi][alsa]")
 
     in.stop();
     out.closeAll();
+}
+
+TEST_CASE ("ALSA seq backend reports a port appearing and disappearing", "[midi][alsa]")
+{
+    if (! loopbackAvailable())
+        SKIP ("ALSA sequencer loopback unavailable - headless CI");
+
+    ChangeCounter changes;
+    AlsaSeqMidiInput in;
+    in.setDeviceChangeHandler ([&] { changes.bump(); });
+    in.start();
+
+    ProbeClient probe;
+    REQUIRE (probe.appear());
+    REQUIRE (changes.waitFor (1));
+
+    // The report is only worth anything if re-enumerating on the back of it
+    // actually finds the new port - that is all the engine does when it fires.
+    REQUIRE_FALSE (findId (in.enumerate(), ProbeClient::kDisplayName).empty());
+
+    const int afterAppear = changes.total();
+    probe.vanish();
+    REQUIRE (changes.waitFor (afterAppear + 1));
+    REQUIRE (findId (in.enumerate(), ProbeClient::kDisplayName).empty());
+
+    in.stop();
+}
+
+TEST_CASE ("ALSA seq backend does not report its own subscriptions as a change",
+           "[midi][alsa]")
+{
+    if (! loopbackAvailable())
+        SKIP ("ALSA sequencer loopback unavailable - headless CI");
+
+    // enable() subscribes, and the sequencer announces every subscription. Were
+    // those counted, each refresh would announce the next one and the engine
+    // would rebuild for ever.
+    //
+    // The output backend is constructed FIRST so its port already exists when
+    // the input subscribes to the announce port - otherwise its arrival is
+    // itself a genuine port-set change, queued and delivered mid-test.
+    AlsaSeqMidiOutput out;
+    AlsaSeqMidiInput  in;
+
+    const std::string src = findId (in.enumerate(), "Dusk Studio: MIDI Out");
+    REQUIRE_FALSE (src.empty());
+
+    ChangeCounter changes;
+    in.setDeviceChangeHandler ([&] { changes.bump(); });
+    in.start();
+
+    for (int i = 0; i < 8; ++i)
+    {
+        REQUIRE (in.enable (src));
+        in.disableAll();
+    }
+
+    // Nothing came or went, so nothing may be reported. A failure here means
+    // either subscribe traffic is being counted or some other MIDI client on the
+    // machine appeared during the window.
+    REQUIRE_FALSE (changes.waitFor (1, 250));
+
+    in.stop();
 }


### PR DESCRIPTION
Plug in a MIDI controller while Dusk Studio is running and it does not appear until restart. This makes it appear on its own.

## The bug

`AudioEngine::refreshMidiInputs()` had exactly one caller: the Rescan button in Audio Settings. Nothing ever invoked it automatically, and `onDeviceManagerChanged` watches audio devices only. Enumeration was always live and correct — nothing asked it to run. This predates the native MIDI tower; it is not a regression from it.

## How it works

**Poll thread (ALSA).** `AlsaSeqMidiInput::Impl` subscribes its input port to the sequencer's System Announce port. The poll thread already sits in `poll()` on that handle, so this costs no extra thread and no polling: client and port arrivals arrive alongside MIDI traffic. `pumpEvents` intercepts `source.client == SND_SEQ_CLIENT_SYSTEM` before the decode path and returns whether the port set moved; `run()` fires the handler *after* releasing `seqMutex`, since holding the sequencer lock across consumer code would block `enumerate()` on the message thread.

**Seam.** New `IMidiInputBackend::setDeviceChangeHandler`, forwarded by `MidiInputClient`. The signal is deliberately bare — no diff, no identifier — because the only useful response is a full re-enumeration.

**Engine.** The handler hops to the message thread via `dusk::callAsync` and arms a 400 ms one-shot `dusk::Timer`. The armed timer doubles as the pending flag, so one plug (a client arrival plus a port arrival per port) collapses into a single rebuild.

**The transport gate.** `refreshMidiInputs()` detaches the audio callback — `rebuildMidiBanks()` reassigns `perInputMidi`, which the audio thread iterates. That detach is the entire source of the dropout, so the refresh is held until the transport is stopped. A hub blip mid-take is held, not dropped, and lands the moment the take ends.

Two things worth a reviewer's eye:

- `isPortSetChange` excludes `PORT_SUBSCRIBED` / `PORT_UNSUBSCRIBED`. Our own `connect_from` raises those, so counting them would make each refresh announce the next one, forever. There is a test for exactly this.
- The `midiHotplugAlive` flag guards the cross-thread `callAsync` hop; the timer next to it needs no such guard because it never crosses a thread. The asymmetry is deliberate and commented.

## Scope

**Linux only.** The JUCE fallback backend on mac/win has no announce equivalent, so `setDeviceChangeHandler` is a virtual with a default no-op body and manual **Rescan** stays the path there. The tooltip and MANUAL both say so — this is not parity.

## Verification

- App build, zero new warnings.
- `juce-gate` flat at **194** — this tower adds no JUCE.
- ctest **419/419** (was 417; two new `[alsa]` cases, both driving a real sequencer round-trip and `SKIP()`ing on headless CI).
- `DUSKSTUDIO_RUN_SELFTEST=1` **15/15** under Xvfb on a private DISPLAY.

Six mutations run against the new assertions, five caught: no announce subscription, no client-0 intercept, handler never fired, EXIT types dropped, subscribe traffic counted. The sixth showed that a "receiver saw no MIDI" assertion could not fail — `snd_midi_event_decode` rejects announce events regardless — so that assertion was deleted rather than shipped dead.

## Owed to the bench

Real hardware: plug a controller in **during a take** and confirm it lands on stop with no audible hole. The ALSA layer is mutation-tested; the transport gate has no unit test because it needs a live `AudioEngine`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MIDI controllers now appear automatically on Linux when transport is stopped.
  * Added MIDI hot-plug support to detect newly connected or removed ports.
  * On macOS and Windows, use **Audio → Rescan devices** after connecting a MIDI controller.

* **Documentation**
  * Clarified that **Rescan devices** refreshes audio backends and MIDI ports.
  * Added platform-specific guidance for MIDI hot-plug behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->