### PR TITLE
ci: run the build and test workflows on release/** branches

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -2,9 +2,9 @@ name: Linux build
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release/**']
   pull_request:
-    branches: [main]
+    branches: [main, 'release/**']
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/linux-sanitizer.yml
+++ b/.github/workflows/linux-sanitizer.yml
@@ -8,9 +8,9 @@ name: Linux sanitizer (TSan)
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release/**']
   pull_request:
-    branches: [main]
+    branches: [main, 'release/**']
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -8,9 +8,9 @@ name: macOS build
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release/**']
   pull_request:
-    branches: [main]
+    branches: [main, 'release/**']
   workflow_dispatch:
 
 # A new push to the same ref cancels an in-flight run — the macOS runner

--- a/.github/workflows/raspberry-pi-build.yml
+++ b/.github/workflows/raspberry-pi-build.yml
@@ -8,9 +8,9 @@ name: Raspberry Pi build (arm64)
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release/**']
   pull_request:
-    branches: [main]
+    branches: [main, 'release/**']
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -10,9 +10,9 @@ name: Windows tests
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, 'release/**']
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, 'release/**']
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
0.12.x patches ship from release/0.12 by cherry-pick, but the build and test workflows triggered on main only, so a pick got no CI until its tag fired the release build - the first signal was a failed release, not a failed check. Picks cross the de-JUCE divergence (a std::string fix landing on juce::String code), which is exactly where an untested pick breaks, so add release/** to the push and pull_request filters on linux-build, linux-sanitizer, macos-build, raspberry-pi-build and windows-tests. The tag-triggered release workflows are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build and test checks now run for release branches across Linux, macOS, Windows, and Raspberry Pi environments.
  * Release branch updates and proposed changes receive more consistent automated validation before delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->