### PR TITLE
Dejuce/device phase3 audio a

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,7 +330,8 @@ target_sources(DuskStudio PRIVATE
     src/engine/McuReceiver.cpp
     src/engine/McuController.cpp
     src/engine/MidiTimeCodeEmitter.cpp
-    src/engine/device/DeviceManager.cpp
+    # DeviceManager: native orchestrator on Linux (DeviceManager.cpp), JUCE-wrapped
+    # fallback off Linux (DeviceManagerJuce.cpp). Gated below the target_sources().
     src/engine/midi/MidiDevices.cpp
     src/engine/PlaybackEngine.cpp
     src/engine/PluginManager.cpp
@@ -401,6 +402,19 @@ target_sources(DuskStudio PRIVATE
     src/ui/TransportBar.cpp
     src/ui/VirtualKeyboardComponent.cpp
     src/ui/WindowState.cpp)
+
+# DeviceManager backing: Linux uses the native orchestrator (owns the device
+# types, drives open/start/stop/close and the callback fan-out itself); macOS /
+# Windows keep the JUCE-wrapped implementation. Same public dusk API either way.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    # The native manager reads/writes the state blob directly (dusk JSON + legacy
+    # XML migration); off Linux the JUCE-wrapped manager keeps its own XML path.
+    target_sources(DuskStudio PRIVATE
+        src/engine/device/DeviceManager.cpp
+        src/engine/device/DeviceStateBlob.cpp)
+else()
+    target_sources(DuskStudio PRIVATE src/engine/device/DeviceManagerJuce.cpp)
+endif()
 
 # Cross-platform window-management primitives. One implementation per
 # platform; callsites #include only PlatformWindowing.h and stay

--- a/docs/dejuce-campaign.md
+++ b/docs/dejuce-campaign.md
@@ -27,6 +27,25 @@ and every call site is flipped. `juce_core` unlinks last. The
 `tools/juce-gate.sh` ratchet (allowlist currently 194 files) is the
 file-level backstop, not the goal.
 
+Metric caveat: JUCE module declarations pull dependencies transitively —
+e.g. `juce_audio_utils` depends on `juce_audio_devices`, so removing the
+direct `juce_audio_devices` link still leaves the module compiling until
+`juce_audio_utils` itself unlinks. "Unlinked" for a tower means the direct
+link line is gone AND zero `src/` translation units include the module's
+headers on the platform in question; the object code leaves the binary when
+the last transitive dependent goes.
+
+Platform scope: a module is **globally unlinked** — and only then does the
+north-star count above drop — once its direct CMake link is removed on
+**every** shipping platform (Linux, macOS, Windows). A tower that removes a
+link on one platform while the others keep the JUCE path scores a
+**platform-scoped** unlink (e.g. "Linux-unlinked"): report that progress
+explicitly, but the count stays put until macOS and Windows follow.
+Phase-3-audio is exactly this shape — `juce_audio_devices` goes
+Linux-unlinked while mac/win keep the JUCE device path, so the count of 12
+does not move; it drops to 11 only when the mac/win path is also
+reimplemented.
+
 ## Done (condensed — full history in memory `project_dejuce_history.md`)
 
 - **Phase 0**: CI juce-token ratchet gate + allowlist + Catch2 A/B harness.
@@ -70,14 +89,20 @@ file-level backstop, not the goal.
 
 ## Remaining towers, in order
 
-1. **Device Phase-3-audio** — NEXT — native PipeWire/ALSA implement the dusk
-   `IODevice`/`IODeviceType` interfaces directly; drop the Juce*Adapter /
-   CallbackBridge scaffolding inside `DeviceManager.cpp`; unlink
-   `juce_audio_devices` (the MIDI half is done, so this tower is what finally drops the module). RT-critical: the native
-   backend takes over callback dispatch and removes the JUCE audio safety
-   net/A-B reference. **Blocked on Marc's owed hardware bench** (PipeWire
-   streaming, 2b failure paths: hot-unplug mid-play, xrun recovery, SR/buffer
-   swap). Escalate the kickoff plan to Fable (see policy below).
+1. **Device Phase-3-audio** — ACTIVE — native PipeWire/ALSA implement the
+   dusk `IODevice`/`IODeviceType` interfaces directly; drop the Juce*Adapter /
+   CallbackBridge scaffolding inside `DeviceManager.cpp`; remove the direct
+   `juce_audio_devices` link on Linux (mac/win keep the JUCE path; see the
+   metric caveat above). RT-critical: the native backend takes over callback
+   dispatch and removes the JUCE audio safety net/A-B reference. Executable
+   spec: [dejuce-device-phase3-audio-plan.md](dejuce-device-phase3-audio-plan.md)
+   (P0–P5, two PRs, Opus prompts included). Unblocked 2026-07-20: code
+   proceeds now. Marc's hardware bench gates each PR's merge against the
+   bench debts named in *that* PR — PR-A (P0–P2): device-busy-at-boot
+   fallback + legacy-blob migration; PR-B (P3–P5): PipeWire/ALSA streaming +
+   the device-failure paths (hot-unplug, xrun, SR/buffer swap). The debts are
+   split across the two PRs (plan §"Owed to Marc's bench"); there is no single
+   whole-tower "gates merge" pass.
 2. **String-floor remnants** — juce::String in Session/SessionSerializer core
    (blocked by UI writes into Session.h members), ALSA backend (juce virtual
    signatures die with tower 2), hosting surfaces (PluginManager/PluginSlot),

--- a/docs/dejuce-device-phase3-audio-plan.md
+++ b/docs/dejuce-device-phase3-audio-plan.md
@@ -1,0 +1,440 @@
+# De-JUCE tower spec — Device Phase-3-audio
+
+**STATUS: P0 DONE (commit a7a06a2) on branch `dejuce/device-phase3-audio-a`.
+Next phase: P1 (DeviceStateBlob unit + A/B tests) on the same branch.**
+Update this line each session (phase done, branch, resume phrase).
+
+Read order for an executing session: `docs/dejuce-campaign.md` → this file →
+memory ledger `project_dejuce_roadmap.md` → the files of the ONE phase you are
+about to execute. Execute one phase per session, then stop.
+
+## Goal
+
+Native PipeWire/ALSA backends implement the dusk `duskstudio::device`
+interfaces (`IODevice`, `IODeviceType`, `IODeviceCallback`) directly.
+`DeviceManager` on Linux drops its wrapped `juce::AudioDeviceManager` and the
+adapter layer. `juce::juce_audio_devices` leaves the Linux link line. mac/win
+keep the JUCE-wrapped path (CoreAudio/ASIO/WASAPI + JuceMidiBackend), mirroring
+the native-MIDI-tower precedent.
+
+**Decisions from Marc (2026-07-20):** code proceeds now; his hardware bench
+validates the NEW native path and gates merge (one bench pass). Two PRs:
+PR-A = P0–P2, PR-B = P3–P5; PR-B branch starts only after PR-A merges.
+
+## Verified ground truth (do not re-derive; re-verify only what you touch)
+
+1. **Only one RT callback consumer exists.** `deviceManager.addCallback()` is
+   called exclusively by `AudioEngine` (AudioEngine.cpp:555/641/1048/1052);
+   Bounce/Freeze detach and reattach the same engine. JUCE's multi-callback
+   summing machinery runs with list size 1 here. We still replicate N-callback
+   support (API allows it) but with pre-sized scratch, never resizing in the
+   callback the way JUCE's `tempBuffer.setSize` does.
+2. **Four stray includes are vestigial.** AudioEngine.h:3, BounceEngine.h:3,
+   FreezeDialog.h:3, BounceDialog.h:3 include `<juce_audio_devices/...>` but
+   reference no type from the module. Pure deletion.
+3. **`type->rescan()` is dead code.** The UI path is
+   `DeviceManager::scanAllDeviceTypes()` + `notifyChange()`
+   (AudioSettingsPanel.cpp:682/689). JUCE's audioDeviceListChanged
+   auto-close-on-vanished path never fires in practice; hot-unplug is detected
+   via the ALSA fatal `-ENODEV` → `audioDeviceError` path and the H5 detector.
+   Delete `rescan()` in P3/P4; do not build type-level change-listener
+   plumbing into the native manager.
+4. **Transitive link caveat (goes in both PR bodies).** `juce_audio_utils`
+   stays linked on Linux (AudioThumbnail in MainComponent.h,
+   AudioRegionEditor, MasteringView, AudioSettingsPanel.h) and its JUCE module
+   declaration depends on `juce_audio_devices`, so the module keeps compiling
+   transitively after we remove the direct link. The tower's honest
+   deliverable: **direct link removed on Linux + zero `src/` translation
+   units include the module's headers on Linux.** Object code physically
+   leaves the binary when `juce_audio_utils` unlinks (hosting/GUI towers).
+5. **Allowlist mechanics.** `JuceMidiBackend.{h,cpp}` set the precedent of
+   *adding* a last-resort mac/win fallback file to `tools/juce-allowlist.txt`.
+   `DeviceManagerJuce.cpp` follows (+1). The tower removes ~11 entries
+   (pipewire ×4, alsa ×6, DeviceManager.cpp). **`DeviceManager.h` STAYS on
+   the allowlist** — it keeps a `#if !defined(__linux__)`-gated `juce`
+   forward declaration for the mac/win MIDI hatch. Do not try to clean it;
+   it dies when the mac/win MIDI fallback dies.
+6. **Legacy state format** (from JUCE-wayland juce_AudioDeviceManager.cpp
+   ~L394-520, 997-1012): one `<DEVICESETUP deviceType= audioOutputDeviceName=
+   audioInputDeviceName= audioDeviceRate= audioDeviceBufferSize=
+   audioDeviceInChans= audioDeviceOutChans=/>` element. Channel masks are
+   BigInteger binary strings, **MSB-first**; `useDefault*Channels` ⇔
+   attribute absent. Trivially parseable without JUCE.
+7. **`getStateBlob()` semantics**: empty until the user explicitly chooses,
+   BUT `initialise(blob)` seeds `lastExplicitSettings` from a parsed blob, so
+   a restored blob round-trips without a re-pick. AudioEngine.cpp:2391-2397
+   depends on both halves. Replicate exactly.
+
+## Design decisions (D1–D6)
+
+### D1 — Sequencing: no big-bang flip
+
+The existing `JuceDeviceAdapter`/`JuceDeviceTypeAdapter` already wrap dusk
+interfaces *over* JUCE objects — exactly the direction needed to run
+juce-typed backends under a dusk-native manager. Therefore:
+
+- **P2**: DeviceManager (Linux) becomes a native orchestrator that owns
+  `IODeviceType`s and drives `IODevice::open/start/stop/close` itself. The
+  backends stay juce-typed, wrapped in *owning* adapters
+  (`JuceDeviceTypeAdapter::createDevice` gains a real implementation
+  returning an owning `JuceDeviceAdapter` whose `start(IODeviceCallback*)`
+  installs a small juce-callback shim). The wrapped
+  `juce::AudioDeviceManager` is deleted from Linux in this phase.
+- **P3**: PipeWire backend re-bases onto the dusk interfaces; its adapter dies.
+- **P4**: ALSA ditto; all adapters and the shim die.
+
+Every phase boundary is a working state: each backend is registered through
+exactly one live path, and the manager's public dusk API (hence
+AudioEngine/UI) never changes.
+
+### D2 — Native DeviceManager internals (Linux, DeviceManager.cpp)
+
+- **Ownership**: `std::vector<std::unique_ptr<IODeviceType>> types`
+  (stable pointers for the selector); `std::unique_ptr<IODevice>
+  currentDevice`; `getCurrentDevice()` returns the raw pointer ("don't cache
+  it" contract unchanged).
+- **Callback fan-out** — `CallbackFanout`, an `IODeviceCallback` handed to
+  `IODevice::start`:
+  - `std::mutex callbackListLock` taken in the RT callback AND in add/remove.
+    This is the identical locking discipline to JUCE's audioCallbackLock:
+    uncontended pthread mutex per block; contention only during
+    message-thread add/remove, which is exactly when JUCE also blocked the
+    audio thread. No condition variable, so no notify-under-lock concern. No
+    TSan suppression exists for the JUCE equivalent, so none is carried;
+    watch the first TSan CI run and add `mutex:duskstudio::device::` entries
+    only if a genuinely-benign report class appears (campaign ritual rule 7).
+  - Dispatch parity: callbacks[0] writes device buffers directly;
+    callbacks[1..] render into a pre-sized planar scratch
+    (`std::vector<float>` + pointer array, sized numOutputChannels ×
+    bufferSize in `audioDeviceAboutToStart`) and are summed in. Empty list ⇒
+    zero outputs. Oversized block (defensive; PipeWire's over-quantum guard
+    already drops those cycles): dispatch callbacks[0] only, skip the summed
+    extras. Never allocate.
+  - `audioDeviceAboutToStart`: synchronously clear `deviceChangePending`
+    (release order) exactly as `CallbackBridge` does today
+    (DeviceManager.cpp:145), then fan out.
+  - `addCallback` while running: prime the newcomer with
+    `audioDeviceAboutToStart(currentDevice)` BEFORE inserting into the list
+    under the lock (JUCE's order — prevents a first block hitting an
+    unprepared engine). `removeCallback` while running: remove under lock,
+    then call `audioDeviceStopped()` on it. Keep today's idempotence guards.
+  - `audioDeviceError`: forward to all clients; manager takes no additional
+    action (engine handles teardown at AudioEngine.cpp:2314).
+- **Device lifecycle** (message thread):
+  - `openDeviceFromSetup(setup, treatAsChosen)`: stop (fan-out delivers
+    `audioDeviceStopped`) → close → reset → resolve type by name →
+    `type->createDevice(out, in)` → channel masks (`useDefault*Channels` ⇒
+    first min(needed, deviceCount) channels, needed = the `initialise(16, 2)`
+    arguments — JUCE parity) → `open(inMask, outMask, rate, buf)` → on
+    success `device->start(&fanout)`, update `lastExplicitSettings` if
+    treatAsChosen, broadcast. On failure propagate the error string; caller
+    decides fallback.
+  - Rate/buffer defaulting when setup carries 0: rate = 48000 if listed,
+    else 44100, else largest listed rate ≥ 44100, else max available;
+    buffer = `device->getDefaultBufferSize()`. Re-derived contract (JUCE
+    prefers the 44.1–48k band); pinned by mock tests as re-baselined
+    behaviour, not bit-parity.
+  - `initialise(numIn, numOut, blob, selectDefaultOnFailure)`: register +
+    scan backends (PipeWire first, ALSA second — preserve today's preference
+    order); parse blob via `DeviceStateBlob` (D3); seed
+    `lastExplicitSettings` from a successfully-parsed blob (ground truth 7);
+    resolve saved type else first type that enumerates devices; open; on
+    failure with selectDefaultOnFailure, open the type's default device with
+    default masks WITHOUT clobbering `lastExplicitSettings` (saved intent
+    must survive a busy device — `DeviceFallbackMessage` and
+    `outputDeviceNameFromState` depend on it).
+  - `setCurrentDeviceType`: arm `deviceChangePending` only for a
+    will-actually-move request (same two-step check as today,
+    DeviceManager.cpp:327-345), close the device, switch type, broadcast,
+    leave the device null until the user picks — documented app contract and
+    the H5 detector's assumption (AudioEngine.cpp:2411-2420). Do not
+    auto-open.
+  - `setSetup`: arm pending iff setup differs or device null (parity with
+    today's :379-382). `closeDevice()`: arm iff device live.
+- **Change notification**: internal broadcasts delivered async + coalesced on
+  the message thread via `dusk::callAsync` with a pending flag — replicating
+  JUCE ChangeBroadcaster timing that `onDeviceManagerChanged`'s defer logic
+  was written against. `notifyChange()` stays synchronous (as today). Keep
+  the exact snapshot-owners re-check loop from `fireListeners()`
+  (DeviceManager.cpp:189-208).
+- **Destructor ordering**: stop + close the device first (delivering
+  `audioDeviceStopped`), then clear listeners WITHOUT firing, and never
+  `callAsync` from the dtor (message pump is torn down after MainComponent;
+  see the SIGSEGV history in DuskStudioApp.cpp:2028-2042 and
+  MainComponent.h:254-258). AudioEngine's dtor already removes its callback
+  first; the manager's own teardown must still be safe standalone.
+
+### D3 — State blob: dusk JSON + one-way legacy migration
+
+New clean unit `src/engine/device/DeviceStateBlob.{h,cpp}`:
+
+- **New format** (always written on Linux):
+  ```json
+  { "version": 1, "deviceType": "PipeWire", "outputDevice": "…",
+    "inputDevice": "…", "sampleRate": 48000.0, "bufferSize": 256,
+    "outputChans": [0,1], "inputChans": [0,1] }
+  ```
+  Channel keys are explicit index arrays; key absent ⇔
+  `useDefault*Channels = true` (preserves JUCE's presence semantics without
+  MSB-first binary strings).
+- **Reader**: sniff first non-space char — `{` ⇒ JSON via `dusk::json`; `<` ⇒
+  legacy DEVICESETUP via a bespoke ~50-line attribute scanner (name="value"
+  pairs in the first element; decode the five standard XML entities +
+  numeric refs; parse mask strings MSB-first exactly as BigInteger's base-2
+  parse does). No JUCE XML parsing anywhere in src/ — keeps the new files
+  clean and lets the device/backend files leave the allowlist. Correctness
+  pinned A/B in tests/ where JUCE IS linkable: same XML through the JUCE
+  parser + BigInteger and through DeviceStateBlob ⇒ identical `DeviceSetup`.
+- **Migration**: read-once fallback. Legacy XML parses to the same in-memory
+  setup; the file converts to JSON the next time the engine persists
+  (AudioEngine.cpp:2395-2397 writes on change broadcast when
+  `lastExplicitSettings` is non-empty; `initialise` seeded it from the
+  legacy blob, so conversion happens without a re-pick and selection can
+  never be silently dropped). Unparseable blob ⇒ behave exactly like empty
+  (fresh default), same as JUCE today.
+- `outputDeviceNameFromState` handles both formats.
+- mac/win keep the JUCE XML blob untouched in DeviceManagerJuce.cpp (state
+  file is per-machine; no cross-OS migration exists).
+
+### D4 — Non-Linux structure: two TUs, zero `#if` sprawl
+
+- `DeviceManager.h`: API unchanged. The `juceManager()` hatch + gated `juce`
+  forward-decl stay; header remains allowlisted (ground truth 5).
+- `src/engine/device/DeviceManager.cpp`: native impl, CMake-gated Linux.
+- `src/engine/device/DeviceManagerJuce.cpp` (new, allowlisted with a reason
+  comment): today's wrapped impl moved essentially verbatim — adapters,
+  CallbackBridge, wrapped manager, Windows ASIO/WASAPI/DirectSound factory
+  registration (today's :243-259), XML state, `juceManager()`. Gated
+  NOT-Linux in CMake. Byte-minimal diff = lowest risk for a path we cannot
+  execute locally; macOS CI build + Windows CI tests are the compile proof
+  (native-MIDI-tower precedent, PR #98).
+
+### D5 — ALSA thread swap: JUCE Thread → std::thread (semantics to preserve)
+
+- Members: `std::thread ioThread; std::atomic<bool> ioShouldExit{false};
+  dusk::AutoResetEvent ioExited;` (AutoResetEvent already has TSan
+  suppressions — reuse, add none).
+- Start (today's AlsaAudioIODevice.cpp:812-857): thread body self-promotes
+  as its first act via `rt::applyRealtimeSchedRR(...)` (RtPriority.h:53 —
+  same map as the DSP worker pool, preserving the RR-fairness invariant at
+  :813-817). If refused: plain SCHED_OTHER thread — JUCE's Priority::high is
+  a no-op on Linux pthreads, so not a behaviour change. Keep the
+  `[Dusk Studio/ALSA] thread started:` stderr line via
+  `pthread_getschedparam(pthread_self())`.
+- Exit-flag polling: `ioShouldExit.load(acquire)` substituted at EVERY
+  existing threadShouldExit site — top of the while (:1003), after
+  snd_pcm_wait (:1021, :1103), inside partial-read (:1033) and partial-write
+  (:1113) retry loops. No site added, none removed.
+- stopThread(2000) equivalent: set `ioShouldExit` (release); wait `ioExited`
+  up to 2000 ms (thread signals it as its last statement); on success
+  `join()`. On timeout (every blocking call in the loop is bounded ≤ 1 s, so
+  healthy worst-case exit ≈ 1.2 s): log loudly, `detach()`, and move the
+  **entire** AlsaAudioIODevice into a deliberately-leaked holder. The
+  detached thread body still dereferences all of `this` — PCM handles, the
+  mutex, the pre-sized scratch pointers, `ioShouldExit`, `ioExited` — so the
+  whole owner must outlive the thread; parking only the PCM handles +
+  interleave buffers would free the rest of the object under a live thread
+  (use-after-free). The owner's destructor must therefore NEVER run while the
+  thread is live: a stuck thread leaks the whole device rather than racing
+  its teardown — strictly safer than JUCE's killThread. The engine's
+  `callbacksInFlight` reconcile (AudioEngine.cpp:2346-2352) stays.
+- Untouched by design (prove via diff review): recoverFromXrun / rearmStream
+  (:884-950), prefill/start sequence (:760-810), format negotiation,
+  interleave converters, `-ENODEV` fatal path → audioDeviceError
+  (:1150-1160).
+- Remaining JUCE in the TU is mechanical: String → std::string/dusk::text,
+  StringArray/Array → std::vector, HeapBlock<char> → std::vector<char>,
+  AudioBuffer<float> scratch → planar std::vector<float> + pointer array
+  (pre-sized at open, as now), CriticalSection → std::mutex, BigInteger →
+  ChannelSet.
+
+### D6 — PipeWire re-type
+
+No thread-model change (pw_thread_loop owns the RT thread). Mechanical: base
+class swap to `device::IODevice`, BigInteger → ChannelSet, String/Array/
+HeapBlock/CriticalSection swaps as in D5, `runSelfTest()` returns
+std::string. RT invariants preserved verbatim: xrun rising-edge counter
+(:727-737), over-quantum drop guard (:739-747), pre-zeroed outputs,
+lock-then-dispatch (:765-770). `CallbackContext` continues to pass `{}` (no
+host timestamp).
+
+## Phase plan
+
+One tower branch per PR. PR-A = P0–P2. PR-B = P3–P5, branched only after
+PR-A merges (squash-merge hygiene: retire the PR-A branch).
+
+### P0 — vestigial include sweep (mechanical)
+
+- Files: `src/engine/AudioEngine.h`, `src/engine/BounceEngine.h`,
+  `src/ui/FreezeDialog.h`, `src/ui/BounceDialog.h` — delete the
+  `<juce_audio_devices/...>` include line in each.
+- Gate: no allowlist movement (files keep other JUCE). Verify: app build
+  zero warnings, ctest green.
+
+### P1 — DeviceStateBlob unit + tests (mechanical, new code only)
+
+- Files: NEW `src/engine/device/DeviceStateBlob.h/.cpp` (per D3); NEW
+  `tests/device_state_blob.cpp`; `tests/CMakeLists.txt`.
+- Test gate (narrow-link Catch2): JSON round-trip incl. absent-channel-keys
+  ⇒ useDefault; legacy XML A/B vs the JUCE parser + BigInteger base-2 parse
+  on: full attribute set, missing chans attrs, entity-laden device names
+  (incl. UTF-8), MSB-first mask strings ("110" ≠ "011"), malformed input ⇒
+  empty-equivalent; `outputDeviceNameFromState` on both formats incl.
+  output-empty-falls-to-input.
+- Not wired into the app yet — zero runtime risk.
+
+### P2 — native DeviceManager on Linux (RT-RISKY: dispatch ownership moves)
+
+- Files: `src/engine/device/DeviceManager.cpp` (native rewrite per D2, with
+  temporary owning adapters per D1); NEW
+  `src/engine/device/DeviceManagerJuce.cpp` (moved wrapped impl, allowlist
+  +1); `DeviceManager.h` (comment truth-up only); `CMakeLists.txt` (gate the
+  two TUs); `tests/CMakeLists.txt`; NEW `tests/device_manager_native.cpp`.
+- The tone-test standalone manager in DuskStudioApp.cpp:301 survives until
+  P5 — self-contained, still links.
+- Test gate — the tower's centerpiece. Mock IODeviceType/IODevice recording
+  open/start/stop/close order, driving synthetic blocks from a test thread:
+  - initialise: empty blob ⇒ first-type-with-devices default; saved blob ⇒
+    named device+type; busy saved device + selectDefaultOnFailure ⇒ fallback
+    opens AND getStateBlob() still round-trips saved intent; blob empty
+    until treatAsChosen.
+  - setSetup: changed ⇒ stop→close→create→open→start ordering; unchanged ⇒
+    no-op, no broadcast, pending untouched.
+  - setCurrentDeviceType: unknown/current name ⇒ no arm; real switch ⇒
+    device null + pending set; pending clears on next aboutToStart (sync)
+    and on broadcast-with-live-device.
+  - fan-out: add-while-running primes with aboutToStart before first block;
+    remove-while-running gets stopped; two callbacks ⇒ summed output
+    bit-exact vs computed reference; zero callbacks ⇒ zeroed output;
+    audioDeviceError reaches all clients.
+  - listeners: owner add/remove during fire (port the fireListeners comment
+    scenarios); async-coalesced broadcast on the message thread (use the
+    foundation message-thread pump pattern from existing tests).
+- Verify: app build; ctest; Xvfb selftest 15/15; manual PipeWire and ALSA
+  open/play/settings-change/backend-switch smoke on the dev box.
+- Named bench debt: dispatch ownership under real hot-unplug + device-busy
+  at boot.
+
+### P3 — PipeWire backend onto dusk interfaces (mechanical re-type)
+
+- Files: `src/engine/pipewire/PipeWireAudioIODevice.h/.cpp`,
+  `PipeWireAudioIODeviceType.h/.cpp` (per D6; delete dead rescan());
+  `src/engine/device/DeviceManager.cpp` (register the native type directly,
+  drop its adapter); `src/engine/AudioPipelineSelfTest.cpp` (+.h if the
+  runSelfTest signature is exposed); `tools/juce-allowlist.txt` (−4).
+- Test gate: build + ctest + Xvfb selftest (backend-cycle section exercises
+  a real open on the dev box's PipeWire). Optional
+  `tests/pipewire_helpers.cpp` porting countActiveChannels/formatNodeLatency
+  A/B out of the selftest. Diff-review assertion: onProcess body identical
+  modulo type names.
+- Bench debt: PipeWire streaming on hardware, SR/quantum swap.
+
+### P4 — ALSA backend + thread swap (RT-RISKY: thread lifecycle)
+
+- Files: `src/engine/alsa/AlsaAudioIODevice.h/.cpp` (per D5),
+  `AlsaAudioIODeviceType.h/.cpp`, `AlsaPerformanceTest.h/.cpp` (dusk
+  callback types; high-res ticks → std::chrono::steady_clock);
+  `src/engine/device/DeviceManager.cpp` (delete adapter/shim machinery
+  entirely); `src/DuskStudioApp.cpp` (perf-harness report strings);
+  `src/engine/AudioPipelineSelfTest.cpp`; `tools/juce-allowlist.txt` (−6).
+- AudioSettingsPanel's `setRequestedPeriods` static calls survive unchanged
+  (signature already juce-free).
+- Test gate: build/ctest/Xvfb selftest; ALSA selftest section (format
+  round-trips, mask routing, periods clamp) green; forced-timeout
+  destruction test (inject a thread body that ignores `ioShouldExit` past the
+  2000 ms join, then destroy the device: assert the whole AlsaAudioIODevice
+  is leaked-not-freed and its state stays valid until the thread finally
+  signals `ioExited` — no use-after-free of the thread context) green;
+  dev-box smoke: open duplex hw device; `DUSKSTUDIO_RUN_ALSA_PERF=1` matrix.
+  Diff-review assertion: recovery/rearm/prefill/negotiation hunks unchanged.
+- Bench debt (the big one): hot-unplug mid-play with std::thread teardown,
+  xrun recovery under load, SR/buffer swap, timed-join timeout path.
+
+### P5 — consumers, CMake unlink, docs (mechanical)
+
+- Files: `src/DuskStudioApp.cpp` (Linux tone test over device::DeviceManager
+  + a ~30-line sine IODeviceCallback replacing the JUCE test-sound path;
+  non-Linux keeps the JUCE body gated — file is allowlisted);
+  `CMakeLists.txt` (line ~1038: the juce_audio_devices link moves into a
+  NOT-Linux block with the transitive-dep caveat comment);
+  `tools/juce-allowlist.txt` (DeviceManager.cpp leaves; 194 → ~184);
+  `docs/dejuce-campaign.md` (tower status + metric caveat); MANUAL.md check
+  (expected no-op — nothing user-visible moves).
+- Verify: full build; confirm the module's headers appear in no Linux src/
+  TU (grep compile_commands.json) and state the transitive result honestly
+  in the PR body; ctest; Xvfb selftest; gate script shows the shrink.
+
+## Risk register
+
+| # | Risk | Phase | Mitigation |
+|---|------|-------|------------|
+| 1 | Callback dispatch ownership moves off JUCE (aboutToStart ordering, add/remove-while-running, pending-flag clears) | P2 | Mock suite pins every ordering; prime-before-insert replicated; bench debt named |
+| 2 | JUCE's lazy in-callback tempBuffer resize replaced by pre-sized scratch — divergence (an improvement) | P2 | Documented; oversized-block fallback dispatches callbacks[0] only |
+| 3 | Change-broadcast timing: engine H5 defer logic assumes async | P2 | callAsync + coalesce; notifyChange() stays sync; H5 scenarios in mock tests |
+| 4 | Teardown SIGSEGV class (manager dtor during shutdown) | P2 | Dtor closes device first, never fires listeners or callAsync |
+| 5 | State migration silently losing device selection | P1/P2 | lastExplicitSettings seeded from legacy blob; fallback never clobbers it; A/B parse tests; unparseable ⇒ fresh default |
+| 6 | ALSA std::thread has no killThread escape hatch; a detached thread must not outlive its owner (UAF on thread context) | P4 | Bounded blocking calls + timed join; on timeout detach + leak the **whole** device so the owner outlives the thread (dtor never races it); forced-timeout destruction test; engine reconcile stays |
+| 7 | Xrun recovery / prefill / rearm regressions | P3/P4 | Logic frozen; enforced by diff review; bench debt named |
+| 8 | mac/win path never executed locally | P2 | Byte-minimal move to DeviceManagerJuce.cpp; macOS CI build + Windows CI tests as compile proof |
+| 9 | TSan new report classes (std::mutex in RT callback) | P2/P4 | No suppression carried (none exists for the JUCE primitive); CI-log-first per ritual rule 7 |
+| 10 | Gate mechanics | P2/P5 | +1 DeviceManagerJuce.cpp (precedented), −11; DeviceManager.h stays listed — do not chase |
+| 11 | Metric honesty: transitive juce_audio_utils dependency | P5 | Caveat in campaign doc + PR bodies; deliverable = direct link + zero includes on Linux |
+
+## Owed to Marc's bench (gates merge; name in both PR descriptions)
+
+- PipeWire streaming on real hardware; quantum/SR renegotiation.
+- ALSA: hot-unplug mid-play (fatal device-loss path with the new thread),
+  xrun recovery under load, buffer/SR swap, periods knob.
+- Device-busy-at-boot fallback + alert copy (DeviceFallbackMessage) against
+  the migrated blob.
+- Legacy-XML → JSON conversion on a machine with a real saved DEVICESETUP.
+
+## Opus session prompts
+
+One fresh Opus session (`/model claude-opus-4-8[1m]`) per phase. Paste the
+matching prompt. Each session: execute the ONE phase, verify, commit (never
+push without Marc's go), update the memory ledger + this file's STATUS line,
+end with a resume phrase.
+
+Common preamble (prepend to every prompt):
+
+> De-JUCE tower session, Dusk Studio repo. Read `docs/dejuce-campaign.md`
+> (rules + ritual), then `docs/dejuce-device-phase3-audio-plan.md` (this
+> tower's spec), then the memory ledger `project_dejuce_roadmap.md`. Follow
+> the campaign ritual exactly: branch first, commit never push, no
+> attribution trailers, AI-slop sweep before commit, gate script before
+> commit, verification bar (app build zero warnings, ctest in build-tests,
+> Xvfb-only selftest — NEVER launch the binary on live Wayland). Delegate
+> wide scouting to Explore agents and bounded 1–2-file edits to cavecrew
+> subagents. Escalate to Fable only for: an RT design question the spec
+> doesn't answer, a stuck A/B test, a novel CI TSan report class. Execute
+> ONLY the phase named below, then verify, commit, update the ledger and the
+> spec STATUS line, and stop with a resume phrase.
+
+- **P0 prompt**: "Phase P0 on a new branch `dejuce/device-phase3-audio-a`:
+  delete the four vestigial juce_audio_devices includes (spec §P0). Re-verify
+  each file really uses no type from the module before deleting. Build +
+  ctest. One commit."
+- **P1 prompt**: "Phase P1 on branch `dejuce/device-phase3-audio-a`:
+  implement DeviceStateBlob per spec §D3/§P1 with the full A/B test matrix.
+  Narrow-link test wiring per tests/CMakeLists.txt conventions. One commit."
+- **P2 prompt**: "Phase P2 on branch `dejuce/device-phase3-audio-a`: native
+  DeviceManager per spec §D1/§D2/§D4/§P2. Re-read DeviceManager.cpp,
+  DeviceManager.h, AudioEngine.cpp callback/H5 sites before editing. Mock
+  suite per §P2 is mandatory. Xvfb selftest + dev-box smoke. Commit; then
+  prepare the PR-A description (bench-debt lines from §Owed, transitive-link
+  caveat from ground truth 4) and stop — Marc reviews before push."
+- **P3 prompt**: "Phase P3 on a new branch `dejuce/device-phase3-audio-b`
+  (only after PR-A merged; verify main): PipeWire re-type per spec §D6/§P3.
+  RT logic frozen — end with a diff review proving onProcess unchanged
+  modulo types. One commit."
+- **P4 prompt**: "Phase P4 on branch `dejuce/device-phase3-audio-b`: ALSA
+  re-type + thread swap per spec §D5/§P4. Re-read AlsaAudioIODevice.cpp in
+  full first. Diff review proving recovery/rearm/prefill/negotiation hunks
+  unchanged. One commit."
+- **P5 prompt**: "Phase P5 on branch `dejuce/device-phase3-audio-b`:
+  consumer sweep + Linux unlink + docs per spec §P5. Verify zero
+  juce_audio_devices includes in Linux src/ TUs via compile_commands.json.
+  Prepare the PR-B description (bench debts + caveat). Update
+  docs/dejuce-campaign.md tower status and the campaign metric caveat.
+  Commit and stop."

--- a/docs/dejuce-device-phase3-audio-plan.md
+++ b/docs/dejuce-device-phase3-audio-plan.md
@@ -1,10 +1,22 @@
 # De-JUCE tower spec — Device Phase-3-audio
 
-**STATUS: P1 DONE (HEAD of branch `dejuce/device-phase3-audio-a`).
-DeviceStateBlob unit + full JSON round-trip / legacy-XML A/B matrix landed
-(8 cases, 427/427 ctest). Next phase: P2 (native DeviceManager on Linux) on the
-same branch. Resume: "P2 on dejuce/device-phase3-audio-a - native DeviceManager
-per spec §D1/§D2/§D4/§P2".**
+**STATUS: P2 DONE (HEAD of branch `dejuce/device-phase3-audio-a`, commit acdef95).
+Native DeviceManager orchestrator on Linux: owns the IODeviceType list, drives
+IODevice open/start/stop/close and the CallbackFanout itself; PipeWire/ALSA stay
+juce-typed behind owning adapters. DeviceStateBlob wired (seed + busy fallback,
+saved intent preserved). Wrapped impl moved verbatim to DeviceManagerJuce.cpp
+(gated NOT-Linux; allowlist 194->195). New device_manager_native.cpp mock suite
+(9 cases). 436/436 ctest, app build 0 warnings, Xvfb selftest clean; real
+PipeWire (legacy XML) + ALSA (new JSON) open/play verified on the dev box. P2
+CLOSES PR-A (P0-P2) - PR-A description drafted, awaiting Marc review before push.
+Known transitional diagnostic drift: AudioPipelineSelfTest's testBackendsOpenCleanly
++ UMC1820 probe rely on JUCE's auto-open-on-type-switch, which the native manager
+drops per §D2 (no-auto-open); those helpers get reworked in P3/P4 (they are in
+those file lists). Next: after PR-A merges, P3 PipeWire re-type per §D6/§P3 on a
+NEW branch dejuce/device-phase3-audio-b.
+Resume: "PR-A (device P0-P2) awaiting Marc review on dejuce/device-phase3-audio-a;
+after merge, start P3 (PipeWire re-type, §D6/§P3) on new branch
+dejuce/device-phase3-audio-b".**
 Update this line each session (phase done, branch, resume phrase).
 
 Read order for an executing session: `docs/dejuce-campaign.md` → this file →

--- a/docs/dejuce-device-phase3-audio-plan.md
+++ b/docs/dejuce-device-phase3-audio-plan.md
@@ -1,7 +1,10 @@
 # De-JUCE tower spec — Device Phase-3-audio
 
-**STATUS: P0 DONE (commit a7a06a2) on branch `dejuce/device-phase3-audio-a`.
-Next phase: P1 (DeviceStateBlob unit + A/B tests) on the same branch.**
+**STATUS: P1 DONE (HEAD of branch `dejuce/device-phase3-audio-a`).
+DeviceStateBlob unit + full JSON round-trip / legacy-XML A/B matrix landed
+(8 cases, 427/427 ctest). Next phase: P2 (native DeviceManager on Linux) on the
+same branch. Resume: "P2 on dejuce/device-phase3-audio-a - native DeviceManager
+per spec §D1/§D2/§D4/§P2".**
 Update this line each session (phase done, branch, resume phrase).
 
 Read order for an executing session: `docs/dejuce-campaign.md` → this file →

--- a/src/engine/AudioEngine.h
+++ b/src/engine/AudioEngine.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <juce_audio_devices/juce_audio_devices.h>
 #include <juce_data_structures/juce_data_structures.h>
 #include <algorithm>
 #include <array>

--- a/src/engine/BounceEngine.h
+++ b/src/engine/BounceEngine.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <juce_audio_devices/juce_audio_devices.h>
 #include <juce_audio_formats/juce_audio_formats.h>
 #include "../session/Session.h"
 #include "../foundation/Text.h"

--- a/src/engine/device/DeviceManager.cpp
+++ b/src/engine/device/DeviceManager.cpp
@@ -1,22 +1,164 @@
 #include "DeviceManager.h"
+#include "DeviceStateBlob.h"
 #include "IODeviceCallback.h"
 
-#include <juce_audio_devices/juce_audio_devices.h>
+#include "../../foundation/MessageThread.h"
 
-#if defined(DUSKSTUDIO_HAS_PIPEWIRE)
- #include "../pipewire/PipeWireAudioIODeviceType.h"
-#endif
-#if defined(DUSKSTUDIO_HAS_ALSA)
- #include "../alsa/AlsaAudioIODeviceType.h"
+// The juce-typed backends the native manager drives during this phase: PipeWire
+// and ALSA are still JUCE AudioIODeviceType subclasses, wrapped here in OWNING
+// adapters (P3/P4 re-base them onto the dusk interfaces and delete the adapters).
+// Gated so a build without either backend (the narrow-link test target) compiles
+// this TU with no JUCE at all - only the owning-adapter machinery needs it.
+#if defined(DUSKSTUDIO_HAS_PIPEWIRE) || defined(DUSKSTUDIO_HAS_ALSA)
+ #include <juce_audio_devices/juce_audio_devices.h>
+ #if defined(DUSKSTUDIO_HAS_PIPEWIRE)
+  #include "../pipewire/PipeWireAudioIODeviceType.h"
+ #endif
+ #if defined(DUSKSTUDIO_HAS_ALSA)
+  #include "../alsa/AlsaAudioIODeviceType.h"
+ #endif
+ #define DUSKSTUDIO_DEVICE_HAS_JUCE_BACKENDS 1
 #endif
 
+#include <algorithm>
 #include <atomic>
+#include <cmath>
+#include <cstddef>
+#include <functional>
 #include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
 
 namespace duskstudio::device
 {
 namespace
 {
+// Rate defaulting when a setup carries 0: prefer 48k, then 44.1k, then the
+// largest listed rate at or above 44.1k, then the max available. Re-derived
+// contract (JUCE prefers the 44.1-48k band), pinned by the mock tests.
+double chooseSampleRate (const std::vector<double>& rates)
+{
+    auto listed = [&rates] (double r)
+    {
+        for (double x : rates) if (std::abs (x - r) < 1.0) return true;
+        return false;
+    };
+    if (listed (48000.0)) return 48000.0;
+    if (listed (44100.0)) return 44100.0;
+
+    double best = 0.0;
+    for (double x : rates) if (x >= 44100.0 && x > best) best = x;   // largest listed >= 44.1k
+    if (best > 0.0) return best;
+
+    for (double x : rates) if (x > best) best = x;                   // max available
+    return best > 0.0 ? best : 44100.0;
+}
+
+// Equality for the setSetup short-circuit. Sample rate goes through a tolerance
+// rather than == (the discrete rates never sit within it, so it is exact in
+// practice while sidestepping a float-equality comparison).
+bool sameSetup (const DeviceSetup& a, const DeviceSetup& b) noexcept
+{
+    return a.outputDeviceName == b.outputDeviceName
+        && a.inputDeviceName  == b.inputDeviceName
+        && std::abs (a.sampleRate - b.sampleRate) < 1e-6
+        && a.bufferSize == b.bufferSize
+        && a.inputChannels  == b.inputChannels
+        && a.outputChannels == b.outputChannels
+        && a.useDefaultInputChannels  == b.useDefaultInputChannels
+        && a.useDefaultOutputChannels == b.useDefaultOutputChannels;
+}
+
+// The single IODeviceCallback handed to IODevice::start. Fans the device's RT
+// blocks out to the registered engine callbacks (list size 1 in practice; the
+// N-callback path is retained but uses pre-sized scratch, never resizing in the
+// callback). The lock is JUCE's audioCallbackLock discipline: uncontended per
+// block, contended only during message-thread add/remove.
+class CallbackFanout final : public IODeviceCallback
+{
+public:
+    explicit CallbackFanout (std::atomic<bool>* pending) noexcept : deviceChangePending (pending) {}
+
+    void audioDeviceIOCallback (const float* const* in, int numIn,
+                                float* const* out, int numOut, int numSamples,
+                                const CallbackContext& ctx) override
+    {
+        std::lock_guard<std::mutex> lock (callbackListLock);
+
+        if (callbacks.empty())
+        {
+            for (int ch = 0; ch < numOut; ++ch)
+                if (out[ch] != nullptr) std::fill (out[ch], out[ch] + numSamples, 0.0f);
+            return;
+        }
+
+        // The first client writes the device output buffers directly.
+        callbacks[0]->audioDeviceIOCallback (in, numIn, out, numOut, numSamples, ctx);
+        if (callbacks.size() == 1) return;
+
+        // Defensive: an over-quantum or over-channel block can't be summed into
+        // the pre-sized scratch. callbacks[0] already ran; skip the summed extras
+        // rather than allocate (PipeWire's over-quantum guard already drops those
+        // cycles, so this is belt-and-braces).
+        if ((std::size_t) numOut > scratchPtrs.size()
+            || (std::size_t) numOut * (std::size_t) numSamples > scratch.size())
+            return;
+
+        for (std::size_t c = 1; c < callbacks.size(); ++c)
+        {
+            for (int ch = 0; ch < numOut; ++ch)
+                scratchPtrs[(std::size_t) ch] = scratch.data() + (std::size_t) ch * (std::size_t) numSamples;
+
+            callbacks[c]->audioDeviceIOCallback (in, numIn, scratchPtrs.data(), numOut, numSamples, ctx);
+
+            for (int ch = 0; ch < numOut; ++ch)
+                if (out[ch] != nullptr)
+                    for (int s = 0; s < numSamples; ++s)
+                        out[ch][s] += scratchPtrs[(std::size_t) ch][s];
+        }
+    }
+
+    void audioDeviceAboutToStart (IODevice* device) override
+    {
+        // Synchronous counterpart to the change-broadcast clear: a device that
+        // starts and is pulled again before the (async) broadcast lands would
+        // otherwise leave the flag set with no live device to clear it.
+        deviceChangePending->store (false, std::memory_order_release);
+
+        std::lock_guard<std::mutex> lock (callbackListLock);
+        const int outCh = std::max (0, (int) device->getOutputChannelNames().size());
+        const int bufSz = std::max (0, device->getCurrentBufferSizeSamples());
+        scratch.assign ((std::size_t) outCh * (std::size_t) bufSz, 0.0f);
+        scratchPtrs.assign ((std::size_t) outCh, nullptr);
+
+        for (auto* cb : callbacks) cb->audioDeviceAboutToStart (device);
+    }
+
+    void audioDeviceStopped() override
+    {
+        std::lock_guard<std::mutex> lock (callbackListLock);
+        for (auto* cb : callbacks) cb->audioDeviceStopped();
+    }
+
+    void audioDeviceError (const std::string& message) override
+    {
+        std::lock_guard<std::mutex> lock (callbackListLock);
+        for (auto* cb : callbacks) cb->audioDeviceError (message);
+    }
+
+    std::mutex callbackListLock;
+    std::vector<IODeviceCallback*> callbacks;
+
+private:
+    std::atomic<bool>* deviceChangePending;
+    std::vector<float>  scratch;     // planar, numOutputChannels x bufferSize
+    std::vector<float*> scratchPtrs; // one entry per output channel
+};
+
+#if defined(DUSKSTUDIO_DEVICE_HAS_JUCE_BACKENDS)
 juce::BigInteger toBig (const ChannelSet& cs)
 {
     juce::BigInteger b;
@@ -36,7 +178,7 @@ ChannelSet fromBig (const juce::BigInteger& b)
 std::vector<std::string> toStrings (const juce::StringArray& a)
 {
     std::vector<std::string> v;
-    v.reserve ((size_t) a.size());
+    v.reserve ((std::size_t) a.size());
     for (const auto& s : a) v.push_back (s.toStdString());
     return v;
 }
@@ -45,19 +187,18 @@ template <typename T>
 std::vector<T> toVector (const juce::Array<T>& a)
 {
     std::vector<T> v;
-    v.reserve ((size_t) a.size());
+    v.reserve ((std::size_t) a.size());
     for (const auto& x : a) v.push_back (x);
     return v;
 }
 
-// dusk IODevice over a juce::AudioIODevice (non-owning: the wrapped juce device
-// is owned by the juce::AudioDeviceManager). Repointed as the current device
-// changes so query call sites always read the live device.
+// Owning dusk IODevice over a JUCE AudioIODevice. start() installs a small
+// juce-callback shim forwarding the device's RT blocks to the dusk callback (the
+// manager's CallbackFanout), presenting this adapter as the dusk device.
 class JuceDeviceAdapter final : public IODevice
 {
 public:
-    explicit JuceDeviceAdapter (juce::AudioIODevice* d) noexcept : dev (d) {}
-    void repoint (juce::AudioIODevice* d) noexcept { dev = d; }
+    explicit JuceDeviceAdapter (std::unique_ptr<juce::AudioIODevice> d) noexcept : dev (std::move (d)) {}
 
     std::string getName() const override { return dev ? dev->getName().toStdString() : std::string(); }
 
@@ -76,9 +217,7 @@ public:
     void close() override { if (dev) dev->close(); }
     bool isOpen() override { return dev && dev->isOpen(); }
 
-    // start()/stop() are driven through the manager's callback path in this seam,
-    // not per-device; forward for interface completeness.
-    void start (IODeviceCallback*) override {}
+    void start (IODeviceCallback* cb) override { shim.bind (cb, this); if (dev) dev->start (&shim); }
     void stop() override { if (dev) dev->stop(); }
     bool isPlaying() override { return dev && dev->isPlaying(); }
 
@@ -93,15 +232,37 @@ public:
     int getXRunCount() const noexcept override { return dev ? dev->getXRunCount() : 0; }
 
 private:
-    juce::AudioIODevice* dev = nullptr;
+    struct Shim final : juce::AudioIODeviceCallback
+    {
+        void bind (IODeviceCallback* c, IODevice* ownerDev) noexcept { cb = c; owner = ownerDev; }
+
+        void audioDeviceIOCallbackWithContext (const float* const* in, int numIn,
+                                               float* const* out, int numOut, int numSamples,
+                                               const juce::AudioIODeviceCallbackContext& ctx) override
+        {
+            CallbackContext dctx;
+            dctx.hostTimeNs = ctx.hostTimeNs;
+            cb->audioDeviceIOCallback (in, numIn, out, numOut, numSamples, dctx);
+        }
+        void audioDeviceAboutToStart (juce::AudioIODevice*) override { cb->audioDeviceAboutToStart (owner); }
+        void audioDeviceStopped() override { cb->audioDeviceStopped(); }
+        void audioDeviceError (const juce::String& m) override { cb->audioDeviceError (m.toStdString()); }
+
+        IODeviceCallback* cb = nullptr;
+        IODevice* owner = nullptr;
+    };
+
+    std::unique_ptr<juce::AudioIODevice> dev;
+    Shim shim;
 };
 
-// dusk IODeviceType over a juce::AudioIODeviceType (non-owning: owned by the
-// juce::AudioDeviceManager). Used for the selector's + recovery's enumeration.
+// Owning dusk IODeviceType over a JUCE AudioIODeviceType. createDevice now has a
+// real implementation (the native manager drives device construction directly),
+// returning an owning JuceDeviceAdapter.
 class JuceDeviceTypeAdapter final : public IODeviceType
 {
 public:
-    explicit JuceDeviceTypeAdapter (juce::AudioIODeviceType* t) noexcept : type (t) {}
+    explicit JuceDeviceTypeAdapter (std::unique_ptr<juce::AudioIODeviceType> t) noexcept : type (std::move (t)) {}
 
     std::string getTypeName() const override { return type->getTypeName().toStdString(); }
     void scanForDevices() override { type->scanForDevices(); }
@@ -110,90 +271,205 @@ public:
     int getDefaultDeviceIndex (bool forInput) const override { return type->getDefaultDeviceIndex (forInput); }
     int getIndexOfDevice (IODevice*, bool) const override { return -1; }
 
-    // Not used in the seam - the juce::AudioDeviceManager constructs devices
-    // internally on setSetup(); the native phase implements this.
-    std::unique_ptr<IODevice> createDevice (const std::string&, const std::string&) override { return nullptr; }
-
-private:
-    juce::AudioIODeviceType* type = nullptr;
-};
-
-// juce::AudioIODeviceCallback forwarding to a dusk IODeviceCallback. Registered
-// with the juce::AudioDeviceManager; the RT path is a straight forward with a
-// context translation, no allocation. Holds its own device adapter for the
-// aboutToStart hand-off.
-class CallbackBridge final : public juce::AudioIODeviceCallback
-{
-public:
-    CallbackBridge (IODeviceCallback* c, std::atomic<bool>& pendingFlag) noexcept
-        : cb (c), deviceChangePending (&pendingFlag) {}
-
-    void audioDeviceIOCallbackWithContext (const float* const* in, int numIn,
-                                           float* const* out, int numOut, int numSamples,
-                                           const juce::AudioIODeviceCallbackContext& ctx) override
+    std::unique_ptr<IODevice> createDevice (const std::string& outputName, const std::string& inputName) override
     {
-        CallbackContext dctx;
-        dctx.hostTimeNs = ctx.hostTimeNs;
-        cb->audioDeviceIOCallback (in, numIn, out, numOut, numSamples, dctx);
+        auto* raw = type->createDevice (juce::String (outputName), juce::String (inputName));
+        if (raw == nullptr) return nullptr;
+        return std::make_unique<JuceDeviceAdapter> (std::unique_ptr<juce::AudioIODevice> (raw));
     }
 
-    void audioDeviceAboutToStart (juce::AudioIODevice* device) override
-    {
-        // Synchronous counterpart to the change-listener clear: a device that
-        // starts and is pulled again before the (async) change broadcast lands
-        // would otherwise leave the flag set with no live device to clear it.
-        deviceChangePending->store (false, std::memory_order_release);
-
-        adapter.repoint (device);
-        cb->audioDeviceAboutToStart (&adapter);
-    }
-
-    void audioDeviceStopped() override { cb->audioDeviceStopped(); }
-
-    void audioDeviceError (const juce::String& message) override
-        { cb->audioDeviceError (message.toStdString()); }
-
 private:
-    IODeviceCallback*  cb;
-    std::atomic<bool>* deviceChangePending;
-    JuceDeviceAdapter  adapter { nullptr };
+    std::unique_ptr<juce::AudioIODeviceType> type;
 };
+#endif // DUSKSTUDIO_DEVICE_HAS_JUCE_BACKENDS
 } // namespace
 
-struct DeviceManager::Impl : private juce::ChangeListener
+struct DeviceManager::Impl
 {
-    Impl() { mgr.addChangeListener (this); }
-    ~Impl() override
+    // Channel counts the app asks for (the initialise(16, 2) arguments); default
+    // channel masks take the first min(needed, deviceChannels) channels.
+    int numInputChannelsNeeded  = 0;
+    int numOutputChannelsNeeded = 0;
+
+    std::vector<std::unique_ptr<IODeviceType>> types;   // stable pointers for the selector
+    IODeviceType*              currentType = nullptr;   // points into `types`
+    std::unique_ptr<IODevice>  currentDevice;
+    DeviceSetup                currentSetup;             // effective setup as applied
+
+    // The user's chosen configuration, empty until an explicit pick (or a
+    // restored blob seeds it). getStateBlob() serialises this; the engine only
+    // persists it when a device is live, so a first-launch default never freezes.
+    std::optional<DeviceStateBlob> lastExplicitSettings;
+
+    // Set by a deliberate device-type / setup change / close, cleared once a
+    // device starts. See DeviceManager::isDeviceChangePending.
+    std::atomic<bool> deviceChangePending { false };
+    std::shared_ptr<std::atomic<bool>> alive { std::make_shared<std::atomic<bool>> (true) };
+    CallbackFanout fanout { &deviceChangePending };
+
+    std::map<void*, std::function<void()>> listeners;
+    std::atomic<bool> broadcastPending { false };
+    bool backendsRegistered = false;
+
+    ~Impl()
     {
-        // Detach every bridge from mgr before the bridge objects die. Members
-        // destruct in reverse order (bridges before mgr), so a bridge left
-        // registered would leave mgr holding a dangling callback while the
-        // device is still streaming.
-        for (auto& entry : bridges)
-            mgr.removeAudioCallback (entry.second.get());
-        bridges.clear();
-        mgr.removeChangeListener (this);
+        // Pending async broadcasts must not touch this after teardown (the
+        // message pump can outlive the manager during shutdown). Flip the latch
+        // first, then stop + close the device so any still-registered client
+        // gets its audioDeviceStopped. Never fire listeners or callAsync here.
+        alive->store (false, std::memory_order_release);
+        if (currentDevice != nullptr)
+        {
+            currentDevice->stop();
+            currentDevice->close();
+            currentDevice.reset();
+        }
+        listeners.clear();
     }
 
-    void changeListenerCallback (juce::ChangeBroadcaster*) override
+    void registerBackends()
     {
-        // A live device means whatever deliberate change closed the previous one
-        // has landed. Cleared here rather than from the device-started callback
-        // so it does not depend on anyone having registered one.
-        if (mgr.getCurrentAudioDevice() != nullptr)
-            deviceChangePending.store (false, std::memory_order_release);
+        if (backendsRegistered) return;
+        backendsRegistered = true;
+       #if defined(DUSKSTUDIO_DEVICE_HAS_JUCE_BACKENDS)
+        // Preference order preserved from the wrapped manager: PipeWire first,
+        // ALSA second (the default pick lands on the first type that enumerates
+        // devices).
+        #if defined(DUSKSTUDIO_HAS_PIPEWIRE)
+         types.push_back (std::make_unique<JuceDeviceTypeAdapter> (std::make_unique<PipeWireAudioIODeviceType>()));
+        #endif
+        #if defined(DUSKSTUDIO_HAS_ALSA)
+         types.push_back (std::make_unique<JuceDeviceTypeAdapter> (std::make_unique<AlsaAudioIODeviceType>()));
+        #endif
+        for (auto& t : types) t->scanForDevices();
+       #endif
+    }
 
-        fireListeners();
+    IODeviceType* findType (const std::string& name)
+    {
+        for (auto& t : types)
+            if (t->getTypeName() == name) return t.get();
+        return nullptr;
+    }
+
+    IODeviceType* firstTypeWithDevices()
+    {
+        for (auto& t : types)
+        {
+            t->scanForDevices();
+            if (! t->getDeviceNames (false).empty() || ! t->getDeviceNames (true).empty())
+                return t.get();
+        }
+        return types.empty() ? nullptr : types.front().get();
+    }
+
+    // The type's default output/input device with default channel masks and
+    // backend-default rate/buffer.
+    DeviceSetup defaultSetupFor (IODeviceType* type)
+    {
+        DeviceSetup s;
+        if (type == nullptr) return s;
+        type->scanForDevices();
+        const auto outNames = type->getDeviceNames (false);
+        const auto inNames  = type->getDeviceNames (true);
+        const int outIdx = type->getDefaultDeviceIndex (false);
+        const int inIdx  = type->getDefaultDeviceIndex (true);
+        if (outIdx >= 0 && outIdx < (int) outNames.size())
+            s.outputDeviceName = outNames[(std::size_t) outIdx];
+        if (numInputChannelsNeeded > 0 && inIdx >= 0 && inIdx < (int) inNames.size())
+            s.inputDeviceName = inNames[(std::size_t) inIdx];
+        s.useDefaultInputChannels  = true;
+        s.useDefaultOutputChannels = true;
+        s.sampleRate = 0.0;
+        s.bufferSize = 0;
+        return s;
+    }
+
+    // Stop+close the live device, create the requested one on currentType, open
+    // and start it. Empty string on success, else the backend error. treatAsChosen
+    // records the applied setup as the user's chosen configuration.
+    std::string openDeviceFromSetup (const DeviceSetup& requested, bool treatAsChosen)
+    {
+        if (currentDevice != nullptr)
+        {
+            currentDevice->stop();     // fan-out delivers audioDeviceStopped
+            currentDevice->close();
+            currentDevice.reset();
+        }
+        if (currentType == nullptr) return "No audio device type selected";
+
+        auto dev = currentType->createDevice (requested.outputDeviceName, requested.inputDeviceName);
+        if (! dev) return "Could not create audio device";
+
+        ChannelSet inMask, outMask;
+        if (requested.useDefaultInputChannels)
+            inMask.setRange (0, std::min (numInputChannelsNeeded, (int) dev->getInputChannelNames().size()), true);
+        else
+            inMask = requested.inputChannels;
+        if (requested.useDefaultOutputChannels)
+            outMask.setRange (0, std::min (numOutputChannelsNeeded, (int) dev->getOutputChannelNames().size()), true);
+        else
+            outMask = requested.outputChannels;
+
+        double rate = requested.sampleRate;
+        if (rate <= 0.0) rate = chooseSampleRate (dev->getAvailableSampleRates());
+        int buf = requested.bufferSize;
+        if (buf <= 0) buf = dev->getDefaultBufferSize();
+
+        const std::string err = dev->open (inMask, outMask, rate, buf);
+        if (! err.empty()) { dev->close(); return err; }
+
+        currentDevice = std::move (dev);
+
+        // Effective setup as applied (a backend may round rate/buffer or clamp
+        // channels); keep the requested useDefault flags.
+        currentSetup = requested;
+        currentSetup.inputChannels  = currentDevice->getActiveInputChannels();
+        currentSetup.outputChannels = currentDevice->getActiveOutputChannels();
+        currentSetup.sampleRate = currentDevice->getCurrentSampleRate();
+        currentSetup.bufferSize = currentDevice->getCurrentBufferSizeSamples();
+
+        // start() synchronously drives audioDeviceAboutToStart, clearing
+        // deviceChangePending and sizing the fan-out scratch.
+        currentDevice->start (&fanout);
+
+        if (treatAsChosen)
+        {
+            DeviceStateBlob b;
+            b.deviceType = currentType->getTypeName();
+            b.setup      = currentSetup;
+            lastExplicitSettings = b;
+        }
+
+        broadcast();
+        return {};
+    }
+
+    void broadcast()
+    {
+        // Coalesced + async on the message thread, replicating the JUCE
+        // ChangeBroadcaster timing onDeviceManagerChanged's defer logic expects.
+        if (broadcastPending.exchange (true, std::memory_order_acq_rel)) return;
+        auto keepAlive = alive;
+        const bool queued = dusk::callAsync ([this, keepAlive]
+        {
+            if (! keepAlive->load (std::memory_order_acquire)) return;
+            broadcastPending.store (false, std::memory_order_release);
+            // A live device means the deliberate change that closed the previous
+            // one has landed.
+            if (currentDevice != nullptr)
+                deviceChangePending.store (false, std::memory_order_release);
+            fireListeners();
+        });
+        if (! queued) broadcastPending.store (false, std::memory_order_release);
     }
 
     void fireListeners()
     {
-        // Snapshot the owner keys, not the closures: a listener may add or
-        // remove subscribers (e.g. the settings UI relays out). Firing a
-        // copied closure whose owner was already removed by an earlier
-        // callback would invoke a dead listener. So re-check each owner
-        // against the live map and pull its current callback before calling;
-        // copy that callback so an owner removing itself mid-call is safe.
+        // Snapshot the owner keys, not the closures: a listener may add or remove
+        // subscribers (e.g. the settings UI relays out). Re-check each owner
+        // against the live map and pull its current callback before calling; copy
+        // that callback so an owner removing itself mid-call is safe.
         std::vector<void*> owners;
         owners.reserve (listeners.size());
         for (auto& entry : listeners)
@@ -207,59 +483,35 @@ struct DeviceManager::Impl : private juce::ChangeListener
         }
     }
 
-    juce::AudioDeviceManager mgr;
-
-    // Set by a deliberate device-type / setup change, cleared once a device
-    // starts. See DeviceManager::isDeviceChangePending.
-    std::atomic<bool> deviceChangePending { false };
-    // Keyed by the juce type pointer (stable for the manager's lifetime), so an
-    // adapter is created once and never moved or destroyed while handed out - a
-    // returned IODeviceType* stays valid across later calls.
-    std::map<juce::AudioIODeviceType*, std::unique_ptr<JuceDeviceTypeAdapter>> typeAdapters;
-    JuceDeviceAdapter currentDevice { nullptr };
-    std::map<IODeviceCallback*, std::unique_ptr<CallbackBridge>> bridges;
-    std::map<void*, std::function<void()>> listeners;
-    bool backendsRegistered = false;
-
-    JuceDeviceTypeAdapter* adapterFor (juce::AudioIODeviceType* t)
+    void addCallback (IODeviceCallback* cb)
     {
-        auto& slot = typeAdapters[t];
-        if (! slot) slot = std::make_unique<JuceDeviceTypeAdapter> (t);
-        return slot.get();
+        if (cb == nullptr) return;
+        {
+            std::lock_guard<std::mutex> lock (fanout.callbackListLock);
+            if (std::find (fanout.callbacks.begin(), fanout.callbacks.end(), cb) != fanout.callbacks.end())
+                return;   // idempotent
+        }
+        // Prime the newcomer BEFORE inserting (JUCE's order): a first block must
+        // not hit an engine that hasn't seen aboutToStart.
+        if (currentDevice != nullptr && currentDevice->isPlaying())
+            cb->audioDeviceAboutToStart (currentDevice.get());
+
+        std::lock_guard<std::mutex> lock (fanout.callbackListLock);
+        if (std::find (fanout.callbacks.begin(), fanout.callbacks.end(), cb) == fanout.callbacks.end())
+            fanout.callbacks.push_back (cb);
     }
 
-    void registerBackends()
+    void removeCallback (IODeviceCallback* cb)
     {
-        if (backendsRegistered) return;
-        backendsRegistered = true;
-
-       #if defined(DUSKSTUDIO_HAS_PIPEWIRE)
-        mgr.addAudioDeviceType (std::make_unique<PipeWireAudioIODeviceType>());
-       #endif
-       #if defined(DUSKSTUDIO_HAS_ALSA)
-        mgr.addAudioDeviceType (std::make_unique<AlsaAudioIODeviceType>());
-       #endif
-
-       #if JUCE_WINDOWS
-        // Preference order: ASIO (only present when the SDK was built in) ->
-        // WASAPI exclusive -> WASAPI shared -> DirectSound. The default pick lands
-        // on the first registered type that enumerates devices.
-       #if JUCE_ASIO
-        if (auto* asio = juce::AudioIODeviceType::createAudioIODeviceType_ASIO())
-            mgr.addAudioDeviceType (std::unique_ptr<juce::AudioIODeviceType> (asio));
-       #endif
-        if (auto* wasapiExclusive = juce::AudioIODeviceType::createAudioIODeviceType_WASAPI (
-                juce::WASAPIDeviceMode::exclusive))
-            mgr.addAudioDeviceType (std::unique_ptr<juce::AudioIODeviceType> (wasapiExclusive));
-        if (auto* wasapiShared = juce::AudioIODeviceType::createAudioIODeviceType_WASAPI (
-                juce::WASAPIDeviceMode::shared))
-            mgr.addAudioDeviceType (std::unique_ptr<juce::AudioIODeviceType> (wasapiShared));
-        if (auto* directSound = juce::AudioIODeviceType::createAudioIODeviceType_DirectSound())
-            mgr.addAudioDeviceType (std::unique_ptr<juce::AudioIODeviceType> (directSound));
-       #endif
-
-        for (auto* t : mgr.getAvailableDeviceTypes())
-            if (t != nullptr) t->scanForDevices();
+        if (cb == nullptr) return;
+        bool needsStop = currentDevice != nullptr;
+        {
+            std::lock_guard<std::mutex> lock (fanout.callbackListLock);
+            auto it = std::find (fanout.callbacks.begin(), fanout.callbacks.end(), cb);
+            needsStop = needsStop && (it != fanout.callbacks.end());
+            if (it != fanout.callbacks.end()) fanout.callbacks.erase (it);
+        }
+        if (needsStop) cb->audioDeviceStopped();
     }
 };
 
@@ -268,80 +520,101 @@ DeviceManager::~DeviceManager() = default;
 
 std::vector<IODeviceType*> DeviceManager::getAvailableDeviceTypes()
 {
+    impl->registerBackends();
     std::vector<IODeviceType*> out;
-    for (auto* t : impl->mgr.getAvailableDeviceTypes())
-        if (t != nullptr)
-            out.push_back (impl->adapterFor (t));
+    out.reserve (impl->types.size());
+    for (auto& t : impl->types)
+        out.push_back (t.get());
     return out;
 }
 
 void DeviceManager::scanAllDeviceTypes()
 {
-    for (auto* t : impl->mgr.getAvailableDeviceTypes())
-        if (t != nullptr) t->scanForDevices();
+    impl->registerBackends();
+    for (auto& t : impl->types)
+        t->scanForDevices();
 }
 
 std::string DeviceManager::initialise (int numInputChannels, int numOutputChannels,
                                        const std::string& savedState, bool selectDefaultOnFailure)
 {
     impl->registerBackends();
+    impl->numInputChannelsNeeded  = numInputChannels;
+    impl->numOutputChannelsNeeded = numOutputChannels;
 
-    std::unique_ptr<juce::XmlElement> state;
-    if (! savedState.empty())
-        state = juce::parseXML (juce::String (savedState));
+    // Seed lastExplicitSettings from a parsed blob so a restored selection
+    // round-trips without a re-pick (an unparseable/empty blob behaves as a
+    // fresh machine, leaving it empty).
+    std::optional<DeviceStateBlob> saved = DeviceStateBlob::parse (savedState);
+    if (saved) impl->lastExplicitSettings = saved;
 
-    return impl->mgr.initialise (numInputChannels, numOutputChannels,
-                                 state.get(), selectDefaultOnFailure).toStdString();
+    IODeviceType* type = nullptr;
+    if (saved && ! saved->deviceType.empty())
+        type = impl->findType (saved->deviceType);
+    if (type == nullptr)
+        type = impl->firstTypeWithDevices();
+    if (type == nullptr)
+        return "No audio device types available";
+    impl->currentType = type;
+
+    const bool usedSaved = saved.has_value();
+    const DeviceSetup setup = usedSaved ? saved->setup : impl->defaultSetupFor (type);
+
+    // Open the saved (or default) setup. treatAsChosen=false: lastExplicitSettings
+    // is already seeded (or intentionally empty for a fresh machine).
+    std::string err = impl->openDeviceFromSetup (setup, /*treatAsChosen*/ false);
+    if (err.empty()) return {};
+    if (! selectDefaultOnFailure) return err;
+    if (! usedSaved) return err;   // the first attempt was already the default
+
+    // Fallback: open the type's default device WITHOUT clobbering
+    // lastExplicitSettings, so the saved intent survives a busy device (the
+    // engine's DeviceFallbackMessage + outputDeviceNameFromState depend on it).
+    return impl->openDeviceFromSetup (impl->defaultSetupFor (type), /*treatAsChosen*/ false);
 }
 
 std::string DeviceManager::getStateBlob() const
 {
-    if (auto xml = impl->mgr.createStateXml())
-        return xml->toString().toStdString();
-    return {};
+    if (! impl->lastExplicitSettings) return {};
+    return impl->lastExplicitSettings->toJson();
 }
 
 std::string DeviceManager::outputDeviceNameFromState (const std::string& savedState) const
 {
-    if (savedState.empty()) return {};
-    if (auto xml = juce::parseXML (juce::String (savedState)))
-        return xml->getStringAttribute ("audioOutputDeviceName",
-                   xml->getStringAttribute ("audioInputDeviceName")).toStdString();
-    return {};
+    return DeviceStateBlob::outputDeviceName (savedState);
 }
 
-IODevice* DeviceManager::getCurrentDevice()
-{
-    auto* d = impl->mgr.getCurrentAudioDevice();
-    if (d == nullptr) return nullptr;
-    impl->currentDevice.repoint (d);
-    return &impl->currentDevice;
-}
+IODevice* DeviceManager::getCurrentDevice() { return impl->currentDevice.get(); }
 
-IODeviceType* DeviceManager::getCurrentDeviceType()
-{
-    auto* t = impl->mgr.getCurrentDeviceTypeObject();
-    return t != nullptr ? impl->adapterFor (t) : nullptr;
-}
+IODeviceType* DeviceManager::getCurrentDeviceType() { return impl->currentType; }
 
-void DeviceManager::setCurrentDeviceType (const std::string& typeName, bool treatAsChosen)
+void DeviceManager::setCurrentDeviceType (const std::string& typeName, bool /*treatAsChosen*/)
 {
-    // Only arm for a request that will actually move: the manager ignores an
-    // unknown type name or one that is already current, closing nothing and
-    // broadcasting nothing. Arming for those would strand the flag set while a
-    // device is still live, and swallow the next genuine disconnection.
-    const juce::String wanted (typeName);
-    bool willChange = wanted != impl->mgr.getCurrentAudioDeviceType();
-    if (willChange)
+    // Only arm for a request that will actually move: an unknown name or the
+    // already-current type closes nothing and broadcasts nothing, and arming
+    // those would strand the flag while a device is still live.
+    const bool differsFromCurrent = impl->currentType == nullptr
+                                  || impl->currentType->getTypeName() != typeName;
+    IODeviceType* target = differsFromCurrent ? impl->findType (typeName) : nullptr;
+    if (target == nullptr) return;
+
+    impl->deviceChangePending.store (true, std::memory_order_release);
+
+    // Close the current device (fan-out delivers audioDeviceStopped); leave the
+    // device null until the user picks an interface from the new type's list -
+    // documented app contract, and the H5 detector's assumption. Do not auto-open.
+    if (impl->currentDevice != nullptr)
     {
-        willChange = false;
-        for (auto* t : impl->mgr.getAvailableDeviceTypes())
-            if (t != nullptr && t->getTypeName() == wanted) { willChange = true; break; }
+        impl->currentDevice->stop();
+        impl->currentDevice->close();
+        impl->currentDevice.reset();
     }
-    if (willChange)
-        impl->deviceChangePending.store (true, std::memory_order_release);
-
-    impl->mgr.setCurrentAudioDeviceType (wanted, treatAsChosen);
+    impl->currentType = target;
+    // Nothing is selected on the new type yet, so drop the old type's device
+    // names / rate / masks: getSetup() reads empty until the user picks, and a
+    // stale cross-backend device name never reaches createDevice.
+    impl->currentSetup = DeviceSetup{};
+    impl->broadcast();
 }
 
 bool DeviceManager::isDeviceChangePending() const noexcept
@@ -349,68 +622,35 @@ bool DeviceManager::isDeviceChangePending() const noexcept
     return impl->deviceChangePending.load (std::memory_order_acquire);
 }
 
-DeviceSetup DeviceManager::getSetup() const
-{
-    const auto s = impl->mgr.getAudioDeviceSetup();
-    DeviceSetup d;
-    d.outputDeviceName = s.outputDeviceName.toStdString();
-    d.inputDeviceName  = s.inputDeviceName.toStdString();
-    d.sampleRate = s.sampleRate;
-    d.bufferSize = s.bufferSize;
-    d.inputChannels  = fromBig (s.inputChannels);
-    d.outputChannels = fromBig (s.outputChannels);
-    d.useDefaultInputChannels  = s.useDefaultInputChannels;
-    d.useDefaultOutputChannels = s.useDefaultOutputChannels;
-    return d;
-}
+DeviceSetup DeviceManager::getSetup() const { return impl->currentSetup; }
 
 std::string DeviceManager::setSetup (const DeviceSetup& d, bool treatAsChosen)
 {
-    auto s = impl->mgr.getAudioDeviceSetup();
-    s.outputDeviceName = juce::String (d.outputDeviceName);
-    s.inputDeviceName  = juce::String (d.inputDeviceName);
-    s.sampleRate = d.sampleRate;
-    s.bufferSize = d.bufferSize;
-    s.inputChannels  = toBig (d.inputChannels);
-    s.outputChannels = toBig (d.outputChannels);
-    s.useDefaultInputChannels  = d.useDefaultInputChannels;
-    s.useDefaultOutputChannels = d.useDefaultOutputChannels;
+    // An unchanged setup against a live device is a no-op: no broadcast, pending
+    // untouched (parity with the wrapped manager's short-circuit).
+    if (sameSetup (d, impl->currentSetup) && impl->currentDevice != nullptr && impl->currentDevice->isOpen())
+        return {};
 
-    // Same reasoning as setCurrentDeviceType: an unchanged setup against a live
-    // device is a no-op the manager returns from without broadcasting.
-    if (s != impl->mgr.getAudioDeviceSetup() || impl->mgr.getCurrentAudioDevice() == nullptr)
-        impl->deviceChangePending.store (true, std::memory_order_release);
-
-    return impl->mgr.setAudioDeviceSetup (s, treatAsChosen).toStdString();
+    impl->deviceChangePending.store (true, std::memory_order_release);
+    return impl->openDeviceFromSetup (d, treatAsChosen);
 }
 
-void DeviceManager::addCallback (IODeviceCallback* callback)
-{
-    if (callback == nullptr) return;
-    // Claim the map slot before creating + registering the bridge, so a repeat
-    // call for the same callback can't register a second bridge that is then
-    // dropped (leaving mgr with a dangling pointer).
-    auto [it, inserted] = impl->bridges.emplace (callback, nullptr);
-    if (! inserted) return;
-    it->second = std::make_unique<CallbackBridge> (callback, impl->deviceChangePending);
-    impl->mgr.addAudioCallback (it->second.get());
-}
+void DeviceManager::addCallback (IODeviceCallback* callback) { impl->addCallback (callback); }
 
-void DeviceManager::removeCallback (IODeviceCallback* callback)
-{
-    auto it = impl->bridges.find (callback);
-    if (it == impl->bridges.end()) return;
-    impl->mgr.removeAudioCallback (it->second.get());
-    impl->bridges.erase (it);
-}
+void DeviceManager::removeCallback (IODeviceCallback* callback) { impl->removeCallback (callback); }
 
 void DeviceManager::closeDevice()
 {
-    // An explicit close is never a disconnection, whoever asked for it. Nothing
-    // to arm when there is no device to close.
-    if (impl->mgr.getCurrentAudioDevice() != nullptr)
+    // An explicit close is never a disconnection. Nothing to arm when there is
+    // no device to close.
+    if (impl->currentDevice != nullptr)
+    {
         impl->deviceChangePending.store (true, std::memory_order_release);
-    impl->mgr.closeAudioDevice();
+        impl->currentDevice->stop();
+        impl->currentDevice->close();
+        impl->currentDevice.reset();
+        impl->broadcast();
+    }
 }
 
 void DeviceManager::addChangeListener (void* owner, std::function<void()> onChange)
@@ -422,7 +662,9 @@ void DeviceManager::removeChangeListener (void* owner) { impl->listeners.erase (
 
 void DeviceManager::notifyChange() { impl->fireListeners(); }
 
-#if ! defined(__linux__)
-juce::AudioDeviceManager& DeviceManager::juceManager() { return impl->mgr; }
-#endif
+void DeviceManager::setDeviceTypesForTest (std::vector<std::unique_ptr<IODeviceType>> types)
+{
+    impl->types = std::move (types);
+    impl->backendsRegistered = true;
+}
 } // namespace duskstudio::device

--- a/src/engine/device/DeviceManager.cpp
+++ b/src/engine/device/DeviceManager.cpp
@@ -504,7 +504,10 @@ struct DeviceManager::Impl
     void removeCallback (IODeviceCallback* cb)
     {
         if (cb == nullptr) return;
-        bool needsStop = currentDevice != nullptr;
+        // Symmetric with addCallback's prime gate: only a callback that saw
+        // aboutToStart (device live AND playing) gets a matching stopped, so a
+        // self-stopped device is never stopped a second time on removal.
+        bool needsStop = currentDevice != nullptr && currentDevice->isPlaying();
         {
             std::lock_guard<std::mutex> lock (fanout.callbackListLock);
             auto it = std::find (fanout.callbacks.begin(), fanout.callbacks.end(), cb);

--- a/src/engine/device/DeviceManager.cpp
+++ b/src/engine/device/DeviceManager.cpp
@@ -3,6 +3,7 @@
 #include "IODeviceCallback.h"
 
 #include "../../foundation/MessageThread.h"
+#include "../../foundation/ScopedNoDenormals.h"
 
 // The juce-typed backends the native manager drives during this phase: PipeWire
 // and ALSA are still JUCE AudioIODeviceType subclasses, wrapped here in OWNING
@@ -86,6 +87,9 @@ public:
                                 float* const* out, int numOut, int numSamples,
                                 const CallbackContext& ctx) override
     {
+        const dusk::audio::ScopedNoDenormals noDenormals;
+        if (numSamples == 0) return;
+
         std::lock_guard<std::mutex> lock (callbackListLock);
 
         if (callbacks.empty())

--- a/src/engine/device/DeviceManager.h
+++ b/src/engine/device/DeviceManager.h
@@ -14,10 +14,13 @@ namespace juce { class AudioDeviceManager; }
 // The engine's audio-device orchestrator, mirroring the slice of JUCE's
 // AudioDeviceManager the app drives: register backends, restore/persist the
 // chosen setup, open a device, and fan the RT callback out to the engine. This
-// is the seam - the public API is pure dusk (IODevice / DeviceSetup / ChannelSet),
-// while the implementation currently delegates to a wrapped juce::AudioDeviceManager
-// and adapts JUCE's device/callback types behind it. A later phase swaps the
-// backing to the native PipeWire/ALSA types with this API unchanged.
+// is the seam - the public API is pure dusk (IODevice / DeviceSetup / ChannelSet).
+// On Linux (DeviceManager.cpp) it is a native orchestrator: it owns the
+// IODeviceType list, drives IODevice open/start/stop/close itself, and fans the
+// callback out directly, with the PipeWire/ALSA backends still juce-typed behind
+// temporary owning adapters (P3/P4 re-base them onto the dusk interfaces). Off
+// Linux (DeviceManagerJuce.cpp) it delegates to a wrapped juce::AudioDeviceManager,
+// adapting JUCE's device/callback types behind this same API.
 //
 // Message-thread only, same contract as juce::AudioDeviceManager: construct,
 // initialise, add/remove callbacks and query the device off the message thread.
@@ -93,6 +96,13 @@ public:
     // entirely when the wrapper does.
     juce::AudioDeviceManager& juceManager();
    #endif
+
+    // Test seam (native Linux orchestrator): install a caller-supplied backend
+    // set in place of the platform PipeWire/ALSA registration, so the mock suite
+    // can drive open/start/stop/close ordering and fan-out with no real device.
+    // Call before initialise(). Off Linux it is an unused no-op (the wrapper owns
+    // its own juce backends and the native mock suite is Linux-only).
+    void setDeviceTypesForTest (std::vector<std::unique_ptr<IODeviceType>> types);
 
 private:
     struct Impl;

--- a/src/engine/device/DeviceManagerJuce.cpp
+++ b/src/engine/device/DeviceManagerJuce.cpp
@@ -1,0 +1,437 @@
+// macOS / Windows DeviceManager: the JUCE-wrapped implementation, compiled only
+// off Linux (CMake gates this TU vs the native DeviceManager.cpp). It wraps a
+// JUCE AudioDeviceManager and adapts JUCE's device / callback types behind the
+// dusk device API, and keeps the juceManager() hatch the JUCE MIDI fallback
+// drives. Moved here essentially verbatim from the pre-native DeviceManager.cpp
+// (native-MIDI-tower JuceMidiBackend precedent); allowlisted for that reason.
+#include "DeviceManager.h"
+#include "IODeviceCallback.h"
+
+#include <juce_audio_devices/juce_audio_devices.h>
+
+#if defined(DUSKSTUDIO_HAS_PIPEWIRE)
+ #include "../pipewire/PipeWireAudioIODeviceType.h"
+#endif
+#if defined(DUSKSTUDIO_HAS_ALSA)
+ #include "../alsa/AlsaAudioIODeviceType.h"
+#endif
+
+#include <atomic>
+#include <map>
+
+namespace duskstudio::device
+{
+namespace
+{
+juce::BigInteger toBig (const ChannelSet& cs)
+{
+    juce::BigInteger b;
+    for (int i = 0; i < ChannelSet::kMaxChannels; ++i)
+        if (cs[i]) b.setBit (i);
+    return b;
+}
+
+ChannelSet fromBig (const juce::BigInteger& b)
+{
+    ChannelSet cs;
+    for (int i = 0; i < ChannelSet::kMaxChannels; ++i)
+        if (b[i]) cs.setBit (i);
+    return cs;
+}
+
+std::vector<std::string> toStrings (const juce::StringArray& a)
+{
+    std::vector<std::string> v;
+    v.reserve ((size_t) a.size());
+    for (const auto& s : a) v.push_back (s.toStdString());
+    return v;
+}
+
+template <typename T>
+std::vector<T> toVector (const juce::Array<T>& a)
+{
+    std::vector<T> v;
+    v.reserve ((size_t) a.size());
+    for (const auto& x : a) v.push_back (x);
+    return v;
+}
+
+// dusk IODevice over a juce::AudioIODevice (non-owning: the wrapped juce device
+// is owned by the juce::AudioDeviceManager). Repointed as the current device
+// changes so query call sites always read the live device.
+class JuceDeviceAdapter final : public IODevice
+{
+public:
+    explicit JuceDeviceAdapter (juce::AudioIODevice* d) noexcept : dev (d) {}
+    void repoint (juce::AudioIODevice* d) noexcept { dev = d; }
+
+    std::string getName() const override { return dev ? dev->getName().toStdString() : std::string(); }
+
+    std::vector<std::string> getOutputChannelNames() override
+        { return dev ? toStrings (dev->getOutputChannelNames()) : std::vector<std::string>{}; }
+    std::vector<std::string> getInputChannelNames() override
+        { return dev ? toStrings (dev->getInputChannelNames()) : std::vector<std::string>{}; }
+    std::vector<double> getAvailableSampleRates() override
+        { return dev ? toVector (dev->getAvailableSampleRates()) : std::vector<double>{}; }
+    std::vector<int> getAvailableBufferSizes() override
+        { return dev ? toVector (dev->getAvailableBufferSizes()) : std::vector<int>{}; }
+    int getDefaultBufferSize() override { return dev ? dev->getDefaultBufferSize() : 0; }
+
+    std::string open (const ChannelSet& in, const ChannelSet& out, double sr, int bs) override
+        { return dev ? dev->open (toBig (in), toBig (out), sr, bs).toStdString() : std::string ("no device"); }
+    void close() override { if (dev) dev->close(); }
+    bool isOpen() override { return dev && dev->isOpen(); }
+
+    // start()/stop() are driven through the manager's callback path in this seam,
+    // not per-device; forward for interface completeness.
+    void start (IODeviceCallback*) override {}
+    void stop() override { if (dev) dev->stop(); }
+    bool isPlaying() override { return dev && dev->isPlaying(); }
+
+    std::string getLastError() override { return dev ? dev->getLastError().toStdString() : std::string(); }
+    int    getCurrentBufferSizeSamples() override { return dev ? dev->getCurrentBufferSizeSamples() : 0; }
+    double getCurrentSampleRate()        override { return dev ? dev->getCurrentSampleRate() : 0.0; }
+    int    getCurrentBitDepth()          override { return dev ? dev->getCurrentBitDepth() : 0; }
+    ChannelSet getActiveOutputChannels() const override { return dev ? fromBig (dev->getActiveOutputChannels()) : ChannelSet{}; }
+    ChannelSet getActiveInputChannels()  const override { return dev ? fromBig (dev->getActiveInputChannels()) : ChannelSet{}; }
+    int getOutputLatencyInSamples() override { return dev ? dev->getOutputLatencyInSamples() : 0; }
+    int getInputLatencyInSamples()  override { return dev ? dev->getInputLatencyInSamples() : 0; }
+    int getXRunCount() const noexcept override { return dev ? dev->getXRunCount() : 0; }
+
+private:
+    juce::AudioIODevice* dev = nullptr;
+};
+
+// dusk IODeviceType over a juce::AudioIODeviceType (non-owning: owned by the
+// juce::AudioDeviceManager). Used for the selector's + recovery's enumeration.
+class JuceDeviceTypeAdapter final : public IODeviceType
+{
+public:
+    explicit JuceDeviceTypeAdapter (juce::AudioIODeviceType* t) noexcept : type (t) {}
+
+    std::string getTypeName() const override { return type->getTypeName().toStdString(); }
+    void scanForDevices() override { type->scanForDevices(); }
+    std::vector<std::string> getDeviceNames (bool wantInputNames) const override
+        { return toStrings (type->getDeviceNames (wantInputNames)); }
+    int getDefaultDeviceIndex (bool forInput) const override { return type->getDefaultDeviceIndex (forInput); }
+    int getIndexOfDevice (IODevice*, bool) const override { return -1; }
+
+    // Not used in the seam - the juce::AudioDeviceManager constructs devices
+    // internally on setSetup(); the native phase implements this.
+    std::unique_ptr<IODevice> createDevice (const std::string&, const std::string&) override { return nullptr; }
+
+private:
+    juce::AudioIODeviceType* type = nullptr;
+};
+
+// juce::AudioIODeviceCallback forwarding to a dusk IODeviceCallback. Registered
+// with the juce::AudioDeviceManager; the RT path is a straight forward with a
+// context translation, no allocation. Holds its own device adapter for the
+// aboutToStart hand-off.
+class CallbackBridge final : public juce::AudioIODeviceCallback
+{
+public:
+    CallbackBridge (IODeviceCallback* c, std::atomic<bool>& pendingFlag) noexcept
+        : cb (c), deviceChangePending (&pendingFlag) {}
+
+    void audioDeviceIOCallbackWithContext (const float* const* in, int numIn,
+                                           float* const* out, int numOut, int numSamples,
+                                           const juce::AudioIODeviceCallbackContext& ctx) override
+    {
+        CallbackContext dctx;
+        dctx.hostTimeNs = ctx.hostTimeNs;
+        cb->audioDeviceIOCallback (in, numIn, out, numOut, numSamples, dctx);
+    }
+
+    void audioDeviceAboutToStart (juce::AudioIODevice* device) override
+    {
+        // Synchronous counterpart to the change-listener clear: a device that
+        // starts and is pulled again before the (async) change broadcast lands
+        // would otherwise leave the flag set with no live device to clear it.
+        deviceChangePending->store (false, std::memory_order_release);
+
+        adapter.repoint (device);
+        cb->audioDeviceAboutToStart (&adapter);
+    }
+
+    void audioDeviceStopped() override { cb->audioDeviceStopped(); }
+
+    void audioDeviceError (const juce::String& message) override
+        { cb->audioDeviceError (message.toStdString()); }
+
+private:
+    IODeviceCallback*  cb;
+    std::atomic<bool>* deviceChangePending;
+    JuceDeviceAdapter  adapter { nullptr };
+};
+} // namespace
+
+struct DeviceManager::Impl : private juce::ChangeListener
+{
+    Impl() { mgr.addChangeListener (this); }
+    ~Impl() override
+    {
+        // Detach every bridge from mgr before the bridge objects die. Members
+        // destruct in reverse order (bridges before mgr), so a bridge left
+        // registered would leave mgr holding a dangling callback while the
+        // device is still streaming.
+        for (auto& entry : bridges)
+            mgr.removeAudioCallback (entry.second.get());
+        bridges.clear();
+        mgr.removeChangeListener (this);
+    }
+
+    void changeListenerCallback (juce::ChangeBroadcaster*) override
+    {
+        // A live device means whatever deliberate change closed the previous one
+        // has landed. Cleared here rather than from the device-started callback
+        // so it does not depend on anyone having registered one.
+        if (mgr.getCurrentAudioDevice() != nullptr)
+            deviceChangePending.store (false, std::memory_order_release);
+
+        fireListeners();
+    }
+
+    void fireListeners()
+    {
+        // Snapshot the owner keys, not the closures: a listener may add or
+        // remove subscribers (e.g. the settings UI relays out). Firing a
+        // copied closure whose owner was already removed by an earlier
+        // callback would invoke a dead listener. So re-check each owner
+        // against the live map and pull its current callback before calling;
+        // copy that callback so an owner removing itself mid-call is safe.
+        std::vector<void*> owners;
+        owners.reserve (listeners.size());
+        for (auto& entry : listeners)
+            owners.push_back (entry.first);
+        for (auto* owner : owners)
+        {
+            auto it = listeners.find (owner);
+            if (it == listeners.end()) continue;
+            auto cb = it->second;
+            if (cb) cb();
+        }
+    }
+
+    juce::AudioDeviceManager mgr;
+
+    // Set by a deliberate device-type / setup change, cleared once a device
+    // starts. See DeviceManager::isDeviceChangePending.
+    std::atomic<bool> deviceChangePending { false };
+    // Keyed by the juce type pointer (stable for the manager's lifetime), so an
+    // adapter is created once and never moved or destroyed while handed out - a
+    // returned IODeviceType* stays valid across later calls.
+    std::map<juce::AudioIODeviceType*, std::unique_ptr<JuceDeviceTypeAdapter>> typeAdapters;
+    JuceDeviceAdapter currentDevice { nullptr };
+    std::map<IODeviceCallback*, std::unique_ptr<CallbackBridge>> bridges;
+    std::map<void*, std::function<void()>> listeners;
+    bool backendsRegistered = false;
+
+    JuceDeviceTypeAdapter* adapterFor (juce::AudioIODeviceType* t)
+    {
+        auto& slot = typeAdapters[t];
+        if (! slot) slot = std::make_unique<JuceDeviceTypeAdapter> (t);
+        return slot.get();
+    }
+
+    void registerBackends()
+    {
+        if (backendsRegistered) return;
+        backendsRegistered = true;
+
+       #if defined(DUSKSTUDIO_HAS_PIPEWIRE)
+        mgr.addAudioDeviceType (std::make_unique<PipeWireAudioIODeviceType>());
+       #endif
+       #if defined(DUSKSTUDIO_HAS_ALSA)
+        mgr.addAudioDeviceType (std::make_unique<AlsaAudioIODeviceType>());
+       #endif
+
+       #if JUCE_WINDOWS
+        // Preference order: ASIO (only present when the SDK was built in) ->
+        // WASAPI exclusive -> WASAPI shared -> DirectSound. The default pick lands
+        // on the first registered type that enumerates devices.
+       #if JUCE_ASIO
+        if (auto* asio = juce::AudioIODeviceType::createAudioIODeviceType_ASIO())
+            mgr.addAudioDeviceType (std::unique_ptr<juce::AudioIODeviceType> (asio));
+       #endif
+        if (auto* wasapiExclusive = juce::AudioIODeviceType::createAudioIODeviceType_WASAPI (
+                juce::WASAPIDeviceMode::exclusive))
+            mgr.addAudioDeviceType (std::unique_ptr<juce::AudioIODeviceType> (wasapiExclusive));
+        if (auto* wasapiShared = juce::AudioIODeviceType::createAudioIODeviceType_WASAPI (
+                juce::WASAPIDeviceMode::shared))
+            mgr.addAudioDeviceType (std::unique_ptr<juce::AudioIODeviceType> (wasapiShared));
+        if (auto* directSound = juce::AudioIODeviceType::createAudioIODeviceType_DirectSound())
+            mgr.addAudioDeviceType (std::unique_ptr<juce::AudioIODeviceType> (directSound));
+       #endif
+
+        for (auto* t : mgr.getAvailableDeviceTypes())
+            if (t != nullptr) t->scanForDevices();
+    }
+};
+
+DeviceManager::DeviceManager() : impl (std::make_unique<Impl>()) {}
+DeviceManager::~DeviceManager() = default;
+
+std::vector<IODeviceType*> DeviceManager::getAvailableDeviceTypes()
+{
+    std::vector<IODeviceType*> out;
+    for (auto* t : impl->mgr.getAvailableDeviceTypes())
+        if (t != nullptr)
+            out.push_back (impl->adapterFor (t));
+    return out;
+}
+
+void DeviceManager::scanAllDeviceTypes()
+{
+    for (auto* t : impl->mgr.getAvailableDeviceTypes())
+        if (t != nullptr) t->scanForDevices();
+}
+
+std::string DeviceManager::initialise (int numInputChannels, int numOutputChannels,
+                                       const std::string& savedState, bool selectDefaultOnFailure)
+{
+    impl->registerBackends();
+
+    std::unique_ptr<juce::XmlElement> state;
+    if (! savedState.empty())
+        state = juce::parseXML (juce::String (savedState));
+
+    return impl->mgr.initialise (numInputChannels, numOutputChannels,
+                                 state.get(), selectDefaultOnFailure).toStdString();
+}
+
+std::string DeviceManager::getStateBlob() const
+{
+    if (auto xml = impl->mgr.createStateXml())
+        return xml->toString().toStdString();
+    return {};
+}
+
+std::string DeviceManager::outputDeviceNameFromState (const std::string& savedState) const
+{
+    if (savedState.empty()) return {};
+    if (auto xml = juce::parseXML (juce::String (savedState)))
+        return xml->getStringAttribute ("audioOutputDeviceName",
+                   xml->getStringAttribute ("audioInputDeviceName")).toStdString();
+    return {};
+}
+
+IODevice* DeviceManager::getCurrentDevice()
+{
+    auto* d = impl->mgr.getCurrentAudioDevice();
+    if (d == nullptr) return nullptr;
+    impl->currentDevice.repoint (d);
+    return &impl->currentDevice;
+}
+
+IODeviceType* DeviceManager::getCurrentDeviceType()
+{
+    auto* t = impl->mgr.getCurrentDeviceTypeObject();
+    return t != nullptr ? impl->adapterFor (t) : nullptr;
+}
+
+void DeviceManager::setCurrentDeviceType (const std::string& typeName, bool treatAsChosen)
+{
+    // Only arm for a request that will actually move: the manager ignores an
+    // unknown type name or one that is already current, closing nothing and
+    // broadcasting nothing. Arming for those would strand the flag set while a
+    // device is still live, and swallow the next genuine disconnection.
+    const juce::String wanted (typeName);
+    bool willChange = wanted != impl->mgr.getCurrentAudioDeviceType();
+    if (willChange)
+    {
+        willChange = false;
+        for (auto* t : impl->mgr.getAvailableDeviceTypes())
+            if (t != nullptr && t->getTypeName() == wanted) { willChange = true; break; }
+    }
+    if (willChange)
+        impl->deviceChangePending.store (true, std::memory_order_release);
+
+    impl->mgr.setCurrentAudioDeviceType (wanted, treatAsChosen);
+}
+
+bool DeviceManager::isDeviceChangePending() const noexcept
+{
+    return impl->deviceChangePending.load (std::memory_order_acquire);
+}
+
+DeviceSetup DeviceManager::getSetup() const
+{
+    const auto s = impl->mgr.getAudioDeviceSetup();
+    DeviceSetup d;
+    d.outputDeviceName = s.outputDeviceName.toStdString();
+    d.inputDeviceName  = s.inputDeviceName.toStdString();
+    d.sampleRate = s.sampleRate;
+    d.bufferSize = s.bufferSize;
+    d.inputChannels  = fromBig (s.inputChannels);
+    d.outputChannels = fromBig (s.outputChannels);
+    d.useDefaultInputChannels  = s.useDefaultInputChannels;
+    d.useDefaultOutputChannels = s.useDefaultOutputChannels;
+    return d;
+}
+
+std::string DeviceManager::setSetup (const DeviceSetup& d, bool treatAsChosen)
+{
+    auto s = impl->mgr.getAudioDeviceSetup();
+    s.outputDeviceName = juce::String (d.outputDeviceName);
+    s.inputDeviceName  = juce::String (d.inputDeviceName);
+    s.sampleRate = d.sampleRate;
+    s.bufferSize = d.bufferSize;
+    s.inputChannels  = toBig (d.inputChannels);
+    s.outputChannels = toBig (d.outputChannels);
+    s.useDefaultInputChannels  = d.useDefaultInputChannels;
+    s.useDefaultOutputChannels = d.useDefaultOutputChannels;
+
+    // Same reasoning as setCurrentDeviceType: an unchanged setup against a live
+    // device is a no-op the manager returns from without broadcasting.
+    if (s != impl->mgr.getAudioDeviceSetup() || impl->mgr.getCurrentAudioDevice() == nullptr)
+        impl->deviceChangePending.store (true, std::memory_order_release);
+
+    return impl->mgr.setAudioDeviceSetup (s, treatAsChosen).toStdString();
+}
+
+void DeviceManager::addCallback (IODeviceCallback* callback)
+{
+    if (callback == nullptr) return;
+    // Claim the map slot before creating + registering the bridge, so a repeat
+    // call for the same callback can't register a second bridge that is then
+    // dropped (leaving mgr with a dangling pointer).
+    auto [it, inserted] = impl->bridges.emplace (callback, nullptr);
+    if (! inserted) return;
+    it->second = std::make_unique<CallbackBridge> (callback, impl->deviceChangePending);
+    impl->mgr.addAudioCallback (it->second.get());
+}
+
+void DeviceManager::removeCallback (IODeviceCallback* callback)
+{
+    auto it = impl->bridges.find (callback);
+    if (it == impl->bridges.end()) return;
+    impl->mgr.removeAudioCallback (it->second.get());
+    impl->bridges.erase (it);
+}
+
+void DeviceManager::closeDevice()
+{
+    // An explicit close is never a disconnection, whoever asked for it. Nothing
+    // to arm when there is no device to close.
+    if (impl->mgr.getCurrentAudioDevice() != nullptr)
+        impl->deviceChangePending.store (true, std::memory_order_release);
+    impl->mgr.closeAudioDevice();
+}
+
+void DeviceManager::addChangeListener (void* owner, std::function<void()> onChange)
+{
+    if (owner != nullptr) impl->listeners[owner] = std::move (onChange);
+}
+
+void DeviceManager::removeChangeListener (void* owner) { impl->listeners.erase (owner); }
+
+void DeviceManager::notifyChange() { impl->fireListeners(); }
+
+// The native mock suite is Linux-only; off Linux this seam is never referenced.
+void DeviceManager::setDeviceTypesForTest (std::vector<std::unique_ptr<IODeviceType>>) {}
+
+#if ! defined(__linux__)
+juce::AudioDeviceManager& DeviceManager::juceManager() { return impl->mgr; }
+#endif
+} // namespace duskstudio::device

--- a/src/engine/device/DeviceStateBlob.cpp
+++ b/src/engine/device/DeviceStateBlob.cpp
@@ -1,0 +1,261 @@
+#include "DeviceStateBlob.h"
+
+#include "../../foundation/Json.h"
+
+#include <nlohmann/json.hpp>
+
+#include <cctype>
+#include <cstdint>
+#include <cstdlib>
+#include <map>
+#include <vector>
+
+namespace duskstudio::device
+{
+namespace
+{
+std::vector<int> channelIndices (const ChannelSet& cs)
+{
+    std::vector<int> out;
+    for (int i = 0; i < ChannelSet::kMaxChannels; ++i)
+        if (cs[i]) out.push_back (i);
+    return out;
+}
+
+ChannelSet maskFromJsonArray (const nlohmann::json& arr)
+{
+    ChannelSet cs;
+    for (const auto& e : arr)
+        if (e.is_number_integer() || e.is_number_unsigned())
+        {
+            const auto v = e.get<std::int64_t>();
+            if (v >= 0 && v < ChannelSet::kMaxChannels) cs.setBit ((int) v);
+        }
+    return cs;
+}
+
+// MSB-first base-2 mask parse, matching JUCE's BigInteger::parseString(str, 2):
+// leading whitespace and a leading '-' are skipped, each '0'/'1' shifts the
+// accumulator left (high bit first), and any other character is ignored while
+// scanning continues to the end. Channel masks never exceed 64 bits (ChannelSet's
+// documented ceiling), so a uint64 accumulator is sufficient.
+ChannelSet parseMaskBase2 (const std::string& t)
+{
+    std::uint64_t v = 0;
+    size_t i = 0;
+    while (i < t.size() && std::isspace ((unsigned char) t[i])) ++i;
+    if (i < t.size() && t[i] == '-') ++i;   // negative flag has no meaning for a mask
+    for (; i < t.size(); ++i)
+    {
+        if      (t[i] == '0') v <<= 1;
+        else if (t[i] == '1') v = (v << 1) | 1u;
+        // any other character is skipped, matching BigInteger's digit >= base path
+    }
+    return ChannelSet::fromRaw (v);
+}
+
+void appendUtf8 (std::string& out, long cp)
+{
+    if (cp < 0) return;
+    if (cp <= 0x7F)        out += (char) cp;
+    else if (cp <= 0x7FF)  { out += (char) (0xC0 | (cp >> 6));  out += (char) (0x80 | (cp & 0x3F)); }
+    else if (cp <= 0xFFFF) { out += (char) (0xE0 | (cp >> 12)); out += (char) (0x80 | ((cp >> 6) & 0x3F)); out += (char) (0x80 | (cp & 0x3F)); }
+    else if (cp <= 0x10FFFF)
+    {
+        out += (char) (0xF0 | (cp >> 18));
+        out += (char) (0x80 | ((cp >> 12) & 0x3F));
+        out += (char) (0x80 | ((cp >> 6) & 0x3F));
+        out += (char) (0x80 | (cp & 0x3F));
+    }
+}
+
+bool iequals (const std::string& a, const char* b)
+{
+    size_t i = 0;
+    for (; i < a.size() && b[i] != 0; ++i)
+        if (std::tolower ((unsigned char) a[i]) != std::tolower ((unsigned char) b[i])) return false;
+    return i == a.size() && b[i] == 0;
+}
+
+// Decode the five standard XML entities + decimal/hex numeric references, exactly
+// as JUCE's XmlDocument::readEntity does. Unknown entities and a stray '&' are left
+// verbatim (an unterminated '&' can't be an entity).
+std::string decodeXmlEntities (const std::string& in)
+{
+    std::string out;
+    out.reserve (in.size());
+    for (size_t i = 0; i < in.size(); )
+    {
+        if (in[i] != '&') { out += in[i]; ++i; continue; }
+
+        const size_t semi = in.find (';', i + 1);
+        if (semi == std::string::npos) { out += in[i]; ++i; continue; }
+
+        const std::string ent = in.substr (i + 1, semi - (i + 1));
+        if      (iequals (ent, "amp"))  out += '&';
+        else if (iequals (ent, "quot")) out += '"';
+        else if (iequals (ent, "apos")) out += '\'';
+        else if (iequals (ent, "lt"))   out += '<';
+        else if (iequals (ent, "gt"))   out += '>';
+        else if (! ent.empty() && ent[0] == '#')
+        {
+            const long cp = (ent.size() >= 2 && (ent[1] == 'x' || ent[1] == 'X'))
+                          ? std::strtol (ent.c_str() + 2, nullptr, 16)
+                          : std::strtol (ent.c_str() + 1, nullptr, 10);
+            appendUtf8 (out, cp);
+        }
+        else { out += '&'; out += ent; out += ';'; }   // unknown entity: leave literal
+
+        i = semi + 1;
+    }
+    return out;
+}
+
+std::optional<DeviceStateBlob> parseJson (const std::string& s)
+{
+    const auto j = nlohmann::json::parse (s, nullptr, false);
+    if (j.is_discarded() || ! j.is_object()) return std::nullopt;
+
+    DeviceStateBlob b;
+    b.deviceType             = dusk::json::getString (j, "deviceType");
+    b.setup.outputDeviceName = dusk::json::getString (j, "outputDevice");
+    b.setup.inputDeviceName  = dusk::json::getString (j, "inputDevice");
+    b.setup.sampleRate       = dusk::json::getDouble (j, "sampleRate", 0.0);
+    b.setup.bufferSize       = dusk::json::getInt (j, "bufferSize", 0);
+
+    // Presence of the channel array is the useDefault toggle: key absent leaves
+    // useDefault*Channels at its true default and the mask cleared.
+    if (dusk::json::has (j, "outputChans"))
+    {
+        b.setup.useDefaultOutputChannels = false;
+        b.setup.outputChannels = maskFromJsonArray (dusk::json::array (j, "outputChans"));
+    }
+    if (dusk::json::has (j, "inputChans"))
+    {
+        b.setup.useDefaultInputChannels = false;
+        b.setup.inputChannels = maskFromJsonArray (dusk::json::array (j, "inputChans"));
+    }
+    return b;
+}
+
+// Bespoke legacy <DEVICESETUP> reader: skip any <?...?> / <!...> prolog, require
+// the DEVICESETUP element, collect its name="value" attributes (entities decoded)
+// and map them the way JUCE's AudioDeviceManager::initialiseFromXML does. A tag
+// mismatch or a structurally malformed element reads as unparseable (nullopt).
+std::optional<DeviceStateBlob> parseLegacyXml (const std::string& s)
+{
+    const size_t n = s.size();
+    size_t i = 0;
+    std::string tag;
+
+    while (i < n)
+    {
+        while (i < n && s[i] != '<') ++i;
+        if (i >= n) return std::nullopt;
+        ++i;   // past '<'
+
+        if (i < n && s[i] == '?')            // processing instruction (e.g. <?xml?>)
+        {
+            const size_t e = s.find ("?>", i);
+            if (e == std::string::npos) return std::nullopt;
+            i = e + 2; continue;
+        }
+        if (i < n && s[i] == '!')            // comment / doctype
+        {
+            const size_t e = s.find ('>', i);
+            if (e == std::string::npos) return std::nullopt;
+            i = e + 1; continue;
+        }
+
+        const size_t ts = i;
+        while (i < n && ! std::isspace ((unsigned char) s[i]) && s[i] != '>' && s[i] != '/') ++i;
+        tag = s.substr (ts, i - ts);
+        break;
+    }
+    if (tag != "DEVICESETUP") return std::nullopt;
+
+    std::map<std::string, std::string> attrs;
+    while (i < n)
+    {
+        while (i < n && std::isspace ((unsigned char) s[i])) ++i;
+        if (i >= n) return std::nullopt;                 // element never closed
+        if (s[i] == '>' || s[i] == '/') break;           // end of open tag / self-close
+
+        const size_t ns = i;
+        while (i < n && s[i] != '=' && ! std::isspace ((unsigned char) s[i]) && s[i] != '>' && s[i] != '/') ++i;
+        const std::string name = s.substr (ns, i - ns);
+
+        while (i < n && std::isspace ((unsigned char) s[i])) ++i;
+        if (i >= n || s[i] != '=') return std::nullopt;
+        ++i;
+        while (i < n && std::isspace ((unsigned char) s[i])) ++i;
+        if (i >= n || (s[i] != '"' && s[i] != '\'')) return std::nullopt;
+
+        const char quote = s[i++];
+        const size_t vs = i;
+        while (i < n && s[i] != quote) ++i;
+        if (i >= n) return std::nullopt;                 // unterminated attribute value
+        const std::string raw = s.substr (vs, i - vs);
+        ++i;   // past closing quote
+
+        if (! name.empty()) attrs[name] = decodeXmlEntities (raw);
+    }
+
+    const auto find = [&attrs] (const char* k) -> const std::string*
+    {
+        const auto it = attrs.find (k);
+        return it == attrs.end() ? nullptr : &it->second;
+    };
+
+    DeviceStateBlob b;
+    if (auto* v = find ("deviceType"))            b.deviceType             = *v;
+    if (auto* v = find ("audioOutputDeviceName")) b.setup.outputDeviceName = *v;
+    if (auto* v = find ("audioInputDeviceName"))  b.setup.inputDeviceName  = *v;
+    if (auto* v = find ("audioDeviceRate"))       b.setup.sampleRate = std::strtod (v->c_str(), nullptr);
+    if (auto* v = find ("audioDeviceBufferSize")) b.setup.bufferSize = (int) std::strtol (v->c_str(), nullptr, 10);
+
+    const std::string* inCh  = find ("audioDeviceInChans");
+    const std::string* outCh = find ("audioDeviceOutChans");
+    b.setup.useDefaultInputChannels  = (inCh  == nullptr);
+    b.setup.useDefaultOutputChannels = (outCh == nullptr);
+    // Absent attribute still parses the "11" default the way JUCE does, so the
+    // stored mask matches even though useDefault makes the engine ignore it.
+    b.setup.inputChannels  = parseMaskBase2 (inCh  != nullptr ? *inCh  : std::string ("11"));
+    b.setup.outputChannels = parseMaskBase2 (outCh != nullptr ? *outCh : std::string ("11"));
+    return b;
+}
+} // namespace
+
+std::string DeviceStateBlob::toJson() const
+{
+    nlohmann::ordered_json j;
+    j["version"]      = 1;
+    j["deviceType"]   = deviceType;
+    j["outputDevice"] = setup.outputDeviceName;
+    j["inputDevice"]  = setup.inputDeviceName;
+    j["sampleRate"]   = setup.sampleRate;
+    j["bufferSize"]   = setup.bufferSize;
+    if (! setup.useDefaultOutputChannels) j["outputChans"] = channelIndices (setup.outputChannels);
+    if (! setup.useDefaultInputChannels)  j["inputChans"]  = channelIndices (setup.inputChannels);
+    return j.dump (2);
+}
+
+std::optional<DeviceStateBlob> DeviceStateBlob::parse (const std::string& blob)
+{
+    size_t i = 0;
+    while (i < blob.size() && std::isspace ((unsigned char) blob[i])) ++i;
+    if (i >= blob.size()) return std::nullopt;
+
+    if (blob[i] == '{') return parseJson (blob);
+    if (blob[i] == '<') return parseLegacyXml (blob);
+    return std::nullopt;
+}
+
+std::string DeviceStateBlob::outputDeviceName (const std::string& blob)
+{
+    const auto b = parse (blob);
+    if (! b) return {};
+    return ! b->setup.outputDeviceName.empty() ? b->setup.outputDeviceName
+                                               : b->setup.inputDeviceName;
+}
+} // namespace duskstudio::device

--- a/src/engine/device/DeviceStateBlob.h
+++ b/src/engine/device/DeviceStateBlob.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "DeviceSetup.h"
+
+#include <optional>
+#include <string>
+
+// The per-machine audio-device state blob: which backend, output/input device,
+// rate, block size and channel masks the user last chose. The app persists it to
+// disk and hands it back to DeviceManager::initialise on the next launch.
+//
+// Dusk writes the version-1 JSON form. It also reads the legacy JUCE <DEVICESETUP>
+// XML form a machine may still carry from before the de-JUCE migration, converting
+// to JSON the next time the engine persists. No JUCE dependency: the reader sniffs
+// the first non-space character ('{' JSON, '<' legacy XML) and decodes each with a
+// small bespoke scanner rather than JUCE's XmlDocument / BigInteger. Parse
+// fidelity against those is pinned A/B in the tests, where JUCE is linkable.
+namespace duskstudio::device
+{
+struct DeviceStateBlob
+{
+    std::string deviceType;   // backend name, e.g. "PipeWire" / "ALSA"
+    DeviceSetup setup;
+
+    // Serialise to the version-1 JSON form (the only form Dusk writes).
+    std::string toJson() const;
+
+    // Parse either supported form. nullopt on an empty or unparseable blob - the
+    // caller then behaves as a fresh machine, matching JUCE's parse-fail contract.
+    static std::optional<DeviceStateBlob> parse (const std::string& blob);
+
+    // The output device name a blob records, falling back to the input device
+    // name, or empty. Reads the user's intended device from either form without
+    // opening anything.
+    static std::string outputDeviceName (const std::string& blob);
+};
+} // namespace duskstudio::device

--- a/src/ui/BounceDialog.h
+++ b/src/ui/BounceDialog.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <juce_audio_devices/juce_audio_devices.h>
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <memory>
 #include "../engine/BounceEngine.h"

--- a/src/ui/FreezeDialog.h
+++ b/src/ui/FreezeDialog.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <juce_audio_devices/juce_audio_devices.h>
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <memory>
 #include "../engine/BounceEngine.h"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,12 @@ add_executable(dusk-studio-tests
     device_interfaces.cpp
     device_state_blob.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/device/DeviceStateBlob.cpp
+    # Native DeviceManager orchestrator (mock-backend suite). Compiled with
+    # neither DUSKSTUDIO_HAS_PIPEWIRE nor DUSKSTUDIO_HAS_ALSA, so the owning
+    # juce adapters compile out and the TU links JUCE-free; the mock suite
+    # injects its own device types via setDeviceTypesForTest.
+    device_manager_native.cpp
+    ${CMAKE_SOURCE_DIR}/src/engine/device/DeviceManager.cpp
     update_checker_version.cpp
     session_schema_migration.cpp
     dsp_components_test.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,6 +44,8 @@ add_executable(dusk-studio-tests
     session_track_shrink.cpp
     device_fallback_message.cpp
     device_interfaces.cpp
+    device_state_blob.cpp
+    ${CMAKE_SOURCE_DIR}/src/engine/device/DeviceStateBlob.cpp
     update_checker_version.cpp
     session_schema_migration.cpp
     dsp_components_test.cpp

--- a/tests/device_manager_native.cpp
+++ b/tests/device_manager_native.cpp
@@ -1,0 +1,585 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "engine/device/DeviceManager.h"
+#include "engine/device/DeviceStateBlob.h"
+#include "engine/device/IODevice.h"
+#include "engine/device/IODeviceCallback.h"
+#include "engine/device/IODeviceType.h"
+#include "foundation/MessageThread.h"
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include <algorithm>
+#include <atomic>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+// The native DeviceManager orchestrator (Linux DeviceManager.cpp) driven against
+// mock IODeviceType / IODevice backends: open/start/stop/close ordering, the
+// callback fan-out (prime-before-insert, remove-stops, pre-sized summing, zero-
+// and error-dispatch), the state-blob seeding / fallback semantics, the
+// device-change pending-flag rules, and the async-coalesced change broadcast.
+// No real audio device, so it links JUCE-free save for the message-loop pump the
+// broadcast test needs.
+
+using duskstudio::device::CallbackContext;
+using duskstudio::device::ChannelSet;
+using duskstudio::device::DeviceManager;
+using duskstudio::device::DeviceSetup;
+using duskstudio::device::DeviceStateBlob;
+using duskstudio::device::IODevice;
+using duskstudio::device::IODeviceCallback;
+using duskstudio::device::IODeviceType;
+
+namespace
+{
+// Ordered record of every lifecycle event across all mocks, so a test can assert
+// relative order (stop before close before create before open before start).
+struct Log
+{
+    std::vector<std::string> events;
+    void add (const std::string& e) { events.push_back (e); }
+    int idx (const std::string& needle) const
+    {
+        for (int i = 0; i < (int) events.size(); ++i)
+            if (events[(size_t) i].find (needle) != std::string::npos) return i;
+        return -1;
+    }
+    bool has (const std::string& needle) const { return idx (needle) >= 0; }
+};
+
+std::vector<std::string> channelNames (int n, const char* prefix)
+{
+    std::vector<std::string> v;
+    for (int i = 0; i < n; ++i) v.push_back (std::string (prefix) + std::to_string (i));
+    return v;
+}
+
+class MockDevice final : public IODevice
+{
+public:
+    MockDevice (Log* logIn, std::string nameIn, int inCh, int outCh,
+                std::vector<double> rateList, int defaultBuf, std::string openError)
+        : name (std::move (nameIn)), log (logIn), inChans (inCh), outChans (outCh),
+          rates (std::move (rateList)), defBuf (defaultBuf), openErr (std::move (openError)) {}
+
+    std::string getName() const override { return name; }
+    std::vector<std::string> getOutputChannelNames() override { return channelNames (outChans, "out"); }
+    std::vector<std::string> getInputChannelNames()  override { return channelNames (inChans, "in"); }
+    std::vector<double> getAvailableSampleRates() override { return rates; }
+    std::vector<int>    getAvailableBufferSizes() override { return { 64, 128, 256, 512 }; }
+    int getDefaultBufferSize() override { return defBuf; }
+
+    std::string open (const ChannelSet& in, const ChannelSet& out, double sr, int bs) override
+    {
+        log->add (name + ".open");
+        if (! openErr.empty()) return openErr;
+        inMask = in; outMask = out; appliedRate = sr; appliedBuf = bs; opened = true;
+        return {};
+    }
+    void close() override { if (opened) log->add (name + ".close"); opened = false; }
+    bool isOpen() override { return opened; }
+
+    void start (IODeviceCallback* c) override
+    {
+        log->add (name + ".start");
+        cb = c; playing = true;
+        cb->audioDeviceAboutToStart (this);   // synchronous, mirroring the JUCE contract
+    }
+    void stop() override
+    {
+        if (playing) { log->add (name + ".stop"); playing = false; if (cb) cb->audioDeviceStopped(); }
+        cb = nullptr;
+    }
+    bool isPlaying() override { return playing; }
+
+    std::string getLastError() override { return {}; }
+    int    getCurrentBufferSizeSamples() override { return appliedBuf; }
+    double getCurrentSampleRate()        override { return appliedRate; }
+    int    getCurrentBitDepth()          override { return 24; }
+    ChannelSet getActiveOutputChannels() const override { return outMask; }
+    ChannelSet getActiveInputChannels()  const override { return inMask; }
+    int getOutputLatencyInSamples() override { return 0; }
+    int getInputLatencyInSamples()  override { return 0; }
+    int getXRunCount() const noexcept override { return 0; }
+
+    // Drive one synthetic block / error through whatever start() installed (the
+    // manager's fan-out).
+    void deliverBlock (const float* const* in, int numIn, float* const* out, int numOut, int numSamples)
+    {
+        CallbackContext ctx;
+        if (cb) cb->audioDeviceIOCallback (in, numIn, out, numOut, numSamples, ctx);
+    }
+    void deliverError (const std::string& m) { if (cb) cb->audioDeviceError (m); }
+
+    std::string name;
+
+private:
+    Log* log;
+    int inChans, outChans;
+    std::vector<double> rates;
+    int defBuf;
+    std::string openErr;
+    ChannelSet inMask, outMask;
+    double appliedRate = 0.0;
+    int appliedBuf = 0;
+    bool opened = false, playing = false;
+    IODeviceCallback* cb = nullptr;
+};
+
+class MockType final : public IODeviceType
+{
+public:
+    MockType (Log* logIn, std::string typeNameIn, std::vector<std::string> outNamesIn,
+              std::vector<std::string> inNamesIn, int inCh, int outCh,
+              std::vector<double> rateList, int defaultBuf)
+        : typeName (std::move (typeNameIn)), log (logIn), outNames (std::move (outNamesIn)),
+          inNames (std::move (inNamesIn)), inChans (inCh), outChans (outCh),
+          rates (std::move (rateList)), defBuf (defaultBuf) {}
+
+    std::string getTypeName() const override { return typeName; }
+    void scanForDevices() override {}
+    std::vector<std::string> getDeviceNames (bool wantInputNames) const override
+        { return wantInputNames ? inNames : outNames; }
+    int getDefaultDeviceIndex (bool forInput) const override { return forInput ? defIn : defOut; }
+    int getIndexOfDevice (IODevice*, bool) const override { return -1; }
+
+    std::unique_ptr<IODevice> createDevice (const std::string& outputName,
+                                            const std::string& inputName) override
+    {
+        const std::string devName = ! outputName.empty() ? outputName : inputName;
+        log->add (typeName + ":create:" + devName);
+        std::string err = busy.count (devName) ? std::string ("device busy") : std::string();
+        auto d = std::make_unique<MockDevice> (log, devName, inChans, outChans, rates, defBuf, err);
+        created.push_back (d.get());
+        return d;
+    }
+
+    std::string typeName;
+    int defOut = 0, defIn = 0;
+    std::set<std::string> busy;          // device names whose open() fails
+    std::vector<MockDevice*> created;    // back-pointers; the manager owns them
+
+private:
+    Log* log;
+    std::vector<std::string> outNames, inNames;
+    int inChans, outChans;
+    std::vector<double> rates;
+    int defBuf;
+};
+
+class MockCallback final : public IODeviceCallback
+{
+public:
+    MockCallback() = default;
+    MockCallback (Log* l, std::string t, float f) : log (l), tag (std::move (t)), fill (f) {}
+
+    void audioDeviceIOCallback (const float* const*, int, float* const* out, int numOut,
+                                int numSamples, const CallbackContext&) override
+    {
+        ++blocks;
+        for (int ch = 0; ch < numOut; ++ch)
+            if (out[ch] != nullptr)
+                for (int s = 0; s < numSamples; ++s) out[ch][s] = fill;
+    }
+    void audioDeviceAboutToStart (IODevice*) override { ++aboutToStart; if (log) log->add (tag + ".aboutToStart"); }
+    void audioDeviceStopped() override { ++stopped; if (log) log->add (tag + ".stopped"); }
+    void audioDeviceError (const std::string& m) override { ++errors; lastError = m; }
+
+    int aboutToStart = 0, stopped = 0, errors = 0, blocks = 0;
+    std::string lastError;
+
+private:
+    Log* log = nullptr;
+    std::string tag;
+    float fill = 0.0f;
+};
+
+// Two-type harness: an ALSA-like type (index 1) and a PipeWire-like type
+// (index 0), plus raw back-pointers the test configures/inspects.
+struct Harness
+{
+    Log log;
+    MockType* pw = nullptr;
+    MockType* alsa = nullptr;
+
+    std::vector<std::unique_ptr<IODeviceType>> build (bool firstTypeEmpty = false)
+    {
+        auto pwType = std::make_unique<MockType> (&log, "PipeWire",
+            firstTypeEmpty ? std::vector<std::string>{} : std::vector<std::string>{ "pw-default", "pw-alt" },
+            firstTypeEmpty ? std::vector<std::string>{} : std::vector<std::string>{ "pw-default", "pw-alt" },
+            2, 2, std::vector<double>{ 44100.0, 48000.0 }, 256);
+        auto alsaType = std::make_unique<MockType> (&log, "ALSA",
+            std::vector<std::string>{ "busyDev", "hw0" },
+            std::vector<std::string>{ "hw0" },
+            2, 2, std::vector<double>{ 44100.0, 48000.0 }, 128);
+        alsaType->defOut = 1;   // default output = "hw0" (not the busy one)
+
+        pw = pwType.get();
+        alsa = alsaType.get();
+
+        std::vector<std::unique_ptr<IODeviceType>> v;
+        v.push_back (std::move (pwType));
+        v.push_back (std::move (alsaType));
+        return v;
+    }
+};
+
+#if ! defined (__APPLE__)
+struct LoopStopper final : dusk::Timer
+{
+    void timerCallback() override
+    {
+        stopTimer();
+        juce::MessageManager::getInstance()->stopDispatchLoop();
+    }
+};
+
+void pumpFor (int ms)
+{
+    LoopStopper stopper;
+    stopper.startTimer (ms);
+    juce::MessageManager::getInstance()->runDispatchLoop();
+}
+#endif
+} // namespace
+
+TEST_CASE ("DeviceManager initialise: empty blob opens first type with devices", "[audio][device]")
+{
+    juce::ScopedJuceInitialiser_GUI juceInit;
+    Harness h;
+    DeviceManager dm;
+    dm.setDeviceTypesForTest (h.build (/*firstTypeEmpty*/ true));   // PipeWire has no devices
+
+    const auto err = dm.initialise (16, 2, "", /*selectDefaultOnFailure*/ true);
+    REQUIRE (err.empty());
+
+    // The empty first type is skipped; ALSA (has devices) is chosen and opened.
+    auto* type = dm.getCurrentDeviceType();
+    REQUIRE (type != nullptr);
+    REQUIRE (type->getTypeName() == "ALSA");
+    REQUIRE (dm.getCurrentDevice() != nullptr);
+
+    // A first-launch default pick is never a chosen setup: the blob stays empty
+    // until the user explicitly picks (treatAsChosen).
+    REQUIRE (dm.getStateBlob().empty());
+}
+
+TEST_CASE ("DeviceManager initialise: saved blob opens the named device and type", "[audio][device]")
+{
+    juce::ScopedJuceInitialiser_GUI juceInit;
+    Harness h;
+    DeviceManager dm;
+    dm.setDeviceTypesForTest (h.build());
+
+    DeviceStateBlob saved;
+    saved.deviceType             = "ALSA";
+    saved.setup.outputDeviceName = "hw0";
+    saved.setup.inputDeviceName  = "hw0";
+    saved.setup.sampleRate       = 48000.0;
+    saved.setup.bufferSize       = 256;
+
+    const auto err = dm.initialise (16, 2, saved.toJson(), /*selectDefaultOnFailure*/ true);
+    REQUIRE (err.empty());
+
+    REQUIRE (dm.getCurrentDeviceType() != nullptr);
+    REQUIRE (dm.getCurrentDeviceType()->getTypeName() == "ALSA");
+    REQUIRE (dm.getCurrentDevice() != nullptr);
+    REQUIRE (dm.getCurrentDevice()->getName() == "hw0");
+
+    // getStateBlob round-trips the saved intent (seeded from the blob).
+    const auto out = DeviceStateBlob::parse (dm.getStateBlob());
+    REQUIRE (out.has_value());
+    REQUIRE (out->deviceType == "ALSA");
+    REQUIRE (out->setup.outputDeviceName == "hw0");
+}
+
+TEST_CASE ("DeviceManager initialise: busy saved device falls back but keeps saved intent", "[audio][device]")
+{
+    juce::ScopedJuceInitialiser_GUI juceInit;
+    Harness h;
+    DeviceManager dm;
+    auto types = h.build();
+    // Mark the saved device busy so its open() fails; the type's default (hw0) is free.
+    h.alsa->busy.insert ("busyDev");
+    dm.setDeviceTypesForTest (std::move (types));
+
+    DeviceStateBlob saved;
+    saved.deviceType             = "ALSA";
+    saved.setup.outputDeviceName = "busyDev";
+    saved.setup.inputDeviceName  = "busyDev";
+    saved.setup.sampleRate       = 48000.0;
+    saved.setup.bufferSize       = 256;
+
+    const auto err = dm.initialise (16, 2, saved.toJson(), /*selectDefaultOnFailure*/ true);
+    REQUIRE (err.empty());
+
+    // Fallback opened the type's default device.
+    REQUIRE (dm.getCurrentDevice() != nullptr);
+    REQUIRE (dm.getCurrentDevice()->getName() == "hw0");
+
+    // The saved intent survives the fallback: getStateBlob still names busyDev,
+    // and outputDeviceNameFromState reports the user's INTENDED device.
+    const auto out = DeviceStateBlob::parse (dm.getStateBlob());
+    REQUIRE (out.has_value());
+    REQUIRE (out->setup.outputDeviceName == "busyDev");
+    REQUIRE (dm.outputDeviceNameFromState (saved.toJson()) == "busyDev");
+}
+
+TEST_CASE ("DeviceManager setSetup: changed reopens stop->close->create->open->start", "[audio][device]")
+{
+    juce::ScopedJuceInitialiser_GUI juceInit;
+    Harness h;
+    DeviceManager dm;
+    dm.setDeviceTypesForTest (h.build());
+    REQUIRE (dm.initialise (16, 2, "", true).empty());
+
+    // Baseline is open on PipeWire's default (pw-default). Switch to pw-alt.
+    h.log.events.clear();
+    auto setup = dm.getSetup();
+    setup.outputDeviceName = "pw-alt";
+    setup.inputDeviceName  = "pw-alt";
+    const auto err = dm.setSetup (setup, /*treatAsChosen*/ true);
+    REQUIRE (err.empty());
+
+    // Ordering: the old device stops + closes, then the new one is created,
+    // opened and started.
+    const int stop   = h.log.idx ("pw-default.stop");
+    const int close  = h.log.idx ("pw-default.close");
+    const int create = h.log.idx ("create:pw-alt");
+    const int open   = h.log.idx ("pw-alt.open");
+    const int start  = h.log.idx ("pw-alt.start");
+    REQUIRE (stop  >= 0);
+    REQUIRE (close  > stop);
+    REQUIRE (create > close);
+    REQUIRE (open   > create);
+    REQUIRE (start  > open);
+
+    // A chosen setup updates getStateBlob to the applied configuration.
+    const auto blob = DeviceStateBlob::parse (dm.getStateBlob());
+    REQUIRE (blob.has_value());
+    REQUIRE (blob->setup.outputDeviceName == "pw-alt");
+}
+
+TEST_CASE ("DeviceManager setSetup: unchanged is a no-op", "[audio][device]")
+{
+    juce::ScopedJuceInitialiser_GUI juceInit;
+    Harness h;
+    DeviceManager dm;
+    dm.setDeviceTypesForTest (h.build());
+    REQUIRE (dm.initialise (16, 2, "", true).empty());
+
+    const bool pendingBefore = dm.isDeviceChangePending();
+    h.log.events.clear();
+
+    const auto same = dm.getSetup();
+    const auto err = dm.setSetup (same, /*treatAsChosen*/ true);
+    REQUIRE (err.empty());
+
+    // No device churn - so openDeviceFromSetup (hence broadcast) was never
+    // entered - and the pending flag is untouched.
+    REQUIRE (h.log.events.empty());
+    REQUIRE (dm.isDeviceChangePending() == pendingBefore);
+}
+
+TEST_CASE ("DeviceManager setCurrentDeviceType: arm rules and pending clears", "[audio][device]")
+{
+    juce::ScopedJuceInitialiser_GUI juceInit;
+    Harness h;
+    DeviceManager dm;
+    dm.setDeviceTypesForTest (h.build());
+    REQUIRE (dm.initialise (16, 2, "", true).empty());   // opens on PipeWire (first with devices)
+
+    REQUIRE (dm.getCurrentDeviceType()->getTypeName() == "PipeWire");
+    REQUIRE_FALSE (dm.isDeviceChangePending());
+
+    SECTION ("unknown type name does not arm and does not move")
+    {
+        dm.setCurrentDeviceType ("Nonexistent", true);
+        REQUIRE_FALSE (dm.isDeviceChangePending());
+        REQUIRE (dm.getCurrentDeviceType()->getTypeName() == "PipeWire");
+        REQUIRE (dm.getCurrentDevice() != nullptr);
+    }
+
+    SECTION ("current type name does not arm")
+    {
+        dm.setCurrentDeviceType ("PipeWire", true);
+        REQUIRE_FALSE (dm.isDeviceChangePending());
+        REQUIRE (dm.getCurrentDevice() != nullptr);
+    }
+
+    SECTION ("real switch leaves device null with pending set, cleared on next open")
+    {
+        dm.setCurrentDeviceType ("ALSA", true);
+        REQUIRE (dm.getCurrentDeviceType()->getTypeName() == "ALSA");
+        REQUIRE (dm.getCurrentDevice() == nullptr);   // does not auto-open
+        REQUIRE (dm.isDeviceChangePending());
+
+        // The async broadcast fires with a null device, so it must NOT clear the
+        // pending flag (a backend switch selects nothing until the user picks).
+#if ! defined (__APPLE__)
+        pumpFor (30);
+        REQUIRE (dm.isDeviceChangePending());
+#endif
+
+        // The user picks a device on the new type: aboutToStart clears pending
+        // synchronously at start().
+        auto setup = dm.getSetup();
+        setup.outputDeviceName = "hw0";
+        setup.inputDeviceName  = "hw0";
+        REQUIRE (dm.setSetup (setup, true).empty());
+        REQUIRE (dm.getCurrentDevice() != nullptr);
+        REQUIRE_FALSE (dm.isDeviceChangePending());
+    }
+}
+
+TEST_CASE ("DeviceManager fan-out: prime, remove-stop, summing, zero, error", "[audio][device]")
+{
+    juce::ScopedJuceInitialiser_GUI juceInit;
+    Harness h;
+    DeviceManager dm;
+    dm.setDeviceTypesForTest (h.build());
+    REQUIRE (dm.initialise (16, 2, "", true).empty());   // device running, no callbacks
+
+    constexpr int numOut = 2, numSamples = 8;
+    std::vector<float> ch0 (numSamples), ch1 (numSamples);
+    float* outPtrs[2] = { ch0.data(), ch1.data() };
+    auto* dev = h.pw->created.back();   // the live device (init opened PipeWire)
+
+    SECTION ("add-while-running primes with aboutToStart before the first block")
+    {
+        MockCallback cb (&h.log, "cbA", 0.5f);
+        dm.addCallback (&cb);
+        REQUIRE (cb.aboutToStart == 1);
+        REQUIRE (cb.blocks == 0);
+
+        dev->deliverBlock (nullptr, 0, outPtrs, numOut, numSamples);
+        REQUIRE (cb.blocks == 1);
+        REQUIRE_THAT (ch0[0], Catch::Matchers::WithinAbs (0.5f, 1e-9));
+
+        dm.removeCallback (&cb);
+    }
+
+    SECTION ("remove-while-running delivers audioDeviceStopped")
+    {
+        MockCallback cb (&h.log, "cbA", 0.5f);
+        dm.addCallback (&cb);
+        REQUIRE (cb.stopped == 0);
+        dm.removeCallback (&cb);
+        REQUIRE (cb.stopped == 1);
+    }
+
+    SECTION ("two callbacks sum bit-exact")
+    {
+        MockCallback cb0 (&h.log, "cb0", 0.5f);    // callbacks[0], writes directly
+        MockCallback cb1 (&h.log, "cb1", 0.25f);   // callbacks[1], summed via scratch
+        dm.addCallback (&cb0);
+        dm.addCallback (&cb1);
+
+        dev->deliverBlock (nullptr, 0, outPtrs, numOut, numSamples);
+        for (int s = 0; s < numSamples; ++s)
+        {
+            REQUIRE_THAT (ch0[(size_t) s], Catch::Matchers::WithinAbs (0.75f, 1e-9));
+            REQUIRE_THAT (ch1[(size_t) s], Catch::Matchers::WithinAbs (0.75f, 1e-9));
+        }
+        dm.removeCallback (&cb0);
+        dm.removeCallback (&cb1);
+    }
+
+    SECTION ("zero callbacks produce zeroed output")
+    {
+        std::fill (ch0.begin(), ch0.end(), 1.0f);
+        std::fill (ch1.begin(), ch1.end(), 1.0f);
+        dev->deliverBlock (nullptr, 0, outPtrs, numOut, numSamples);
+        for (int s = 0; s < numSamples; ++s)
+        {
+            REQUIRE_THAT (ch0[(size_t) s], Catch::Matchers::WithinAbs (0.0f, 1e-9));
+            REQUIRE_THAT (ch1[(size_t) s], Catch::Matchers::WithinAbs (0.0f, 1e-9));
+        }
+    }
+
+    SECTION ("audioDeviceError reaches every client")
+    {
+        MockCallback cb0 (&h.log, "cb0", 0.0f);
+        MockCallback cb1 (&h.log, "cb1", 0.0f);
+        dm.addCallback (&cb0);
+        dm.addCallback (&cb1);
+        dev->deliverError ("boom");
+        REQUIRE (cb0.errors == 1);
+        REQUIRE (cb1.errors == 1);
+        REQUIRE (cb0.lastError == "boom");
+        REQUIRE (cb1.lastError == "boom");
+        dm.removeCallback (&cb0);
+        dm.removeCallback (&cb1);
+    }
+}
+
+TEST_CASE ("DeviceManager listeners: owner removed mid-fire is skipped", "[audio][device]")
+{
+    juce::ScopedJuceInitialiser_GUI juceInit;
+    Harness h;
+    DeviceManager dm;
+    dm.setDeviceTypesForTest (h.build());
+
+    int aCalls = 0, bCalls = 0, cCalls = 0;
+    int ownerB = 0;   // identity key for listener B
+
+    // A removes B before B's turn; B must not be called. C (self-removing) is
+    // safe because fireListeners copies the callback before invoking.
+    dm.addChangeListener (&aCalls, [&]
+    {
+        ++aCalls;
+        dm.removeChangeListener (&ownerB);
+    });
+    dm.addChangeListener (&ownerB, [&] { ++bCalls; });
+    dm.addChangeListener (&cCalls, [&]
+    {
+        ++cCalls;
+        dm.removeChangeListener (&cCalls);   // remove self mid-call
+    });
+
+    dm.notifyChange();   // synchronous fan-out
+    REQUIRE (aCalls == 1);
+    REQUIRE (bCalls == 0);   // removed by A before its turn
+    REQUIRE (cCalls == 1);
+
+    dm.notifyChange();
+    REQUIRE (aCalls == 2);
+    REQUIRE (cCalls == 1);   // self-removed last round, not called again
+
+    dm.removeChangeListener (&aCalls);
+}
+
+#if ! defined (__APPLE__)
+TEST_CASE ("DeviceManager broadcast: async and coalesced on the message thread", "[audio][device]")
+{
+    // A single message-loop pump per case: JUCE's stopDispatchLoop latches the
+    // quit flag, so a second runDispatchLoop would be a no-op.
+    juce::ScopedJuceInitialiser_GUI juceInit;
+    Harness h;
+    DeviceManager dm;
+    dm.setDeviceTypesForTest (h.build());
+
+    int fired = 0;
+    dm.addChangeListener (&fired, [&fired] { ++fired; });
+
+    // Three operations that each request a broadcast: the initial open plus two
+    // buffer-size changes (PipeWire's default is 256, so 128 and 512 are genuine).
+    // With no pump between them they coalesce into a single async fire.
+    REQUIRE (dm.initialise (16, 2, "", true).empty());
+    auto s1 = dm.getSetup(); s1.bufferSize = 128;
+    REQUIRE (dm.setSetup (s1, true).empty());
+    auto s2 = dm.getSetup(); s2.bufferSize = 512;
+    REQUIRE (dm.setSetup (s2, true).empty());
+
+    REQUIRE (fired == 0);   // async: deferred, nothing runs inline
+
+    pumpFor (30);
+    REQUIRE (fired == 1);   // coalesced: three requests, one fire
+
+    dm.removeChangeListener (&fired);
+}
+#endif

--- a/tests/device_manager_native.cpp
+++ b/tests/device_manager_native.cpp
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <functional>
 #include <memory>
 #include <set>
 #include <string>
@@ -229,19 +230,35 @@ struct Harness
 };
 
 #if ! defined (__APPLE__)
-struct LoopStopper final : dusk::Timer
+// Pump the JUCE message loop until `ready()` holds or `timeoutMs` elapses, then
+// exit. A repeating timer polls the condition from inside a single dispatch loop
+// (JUCE_MODAL_LOOPS_PERMITTED is off, so runDispatchLoopUntil is unavailable and
+// stopDispatchLoop latches the quit flag - the loop must be entered and quit
+// exactly once). A met condition returns promptly; a miss still stops at the
+// timeout, so a failing test terminates deterministically instead of hanging.
+struct PumpUntil final : dusk::Timer
 {
+    std::function<bool()> ready;
+    int elapsedMs = 0, timeoutMs = 0, tickMs = 0;
     void timerCallback() override
     {
-        stopTimer();
-        juce::MessageManager::getInstance()->stopDispatchLoop();
+        elapsedMs += tickMs;
+        if (ready() || elapsedMs >= timeoutMs)
+        {
+            stopTimer();
+            juce::MessageManager::getInstance()->stopDispatchLoop();
+        }
     }
 };
 
-void pumpFor (int ms)
+void pumpUntil (std::function<bool()> ready, int timeoutMs = 1000)
 {
-    LoopStopper stopper;
-    stopper.startTimer (ms);
+    if (ready()) return;
+    PumpUntil p;
+    p.ready     = std::move (ready);
+    p.timeoutMs = timeoutMs;
+    p.tickMs    = 5;
+    p.startTimer (p.tickMs);
     juce::MessageManager::getInstance()->runDispatchLoop();
 }
 #endif
@@ -419,10 +436,16 @@ TEST_CASE ("DeviceManager setCurrentDeviceType: arm rules and pending clears", "
         REQUIRE (dm.isDeviceChangePending());
 
         // The async broadcast fires with a null device, so it must NOT clear the
-        // pending flag (a backend switch selects nothing until the user picks).
+        // pending flag (a backend switch selects nothing until the user picks). A
+        // listener observes the broadcast actually landing, so the assertion runs
+        // against a fired broadcast rather than an elapsed timer.
 #if ! defined (__APPLE__)
-        pumpFor (30);
+        int broadcasts = 0;
+        dm.addChangeListener (&broadcasts, [&broadcasts] { ++broadcasts; });
+        pumpUntil ([&] { return broadcasts >= 1; });
+        REQUIRE (broadcasts == 1);
         REQUIRE (dm.isDeviceChangePending());
+        dm.removeChangeListener (&broadcasts);
 #endif
 
         // The user picks a device on the new type: aboutToStart clears pending
@@ -524,33 +547,42 @@ TEST_CASE ("DeviceManager listeners: owner removed mid-fire is skipped", "[audio
     DeviceManager dm;
     dm.setDeviceTypesForTest (h.build());
 
-    int aCalls = 0, bCalls = 0, cCalls = 0;
-    int ownerB = 0;   // identity key for listener B
+    // fireListeners walks the listener map in ascending pointer order
+    // (std::map<void*, ...>), which is independent of registration order. Sort
+    // three distinct owner keys the same way and assign roles by fire position,
+    // so the test holds however the stack lays the locals out.
+    int k0 = 0, k1 = 0, k2 = 0;
+    std::vector<void*> keys { &k0, &k1, &k2 };
+    std::sort (keys.begin(), keys.end(), std::less<void*>{});
+    void* firstOwner  = keys[0];   // fires first  - removes the second before its turn
+    void* secondOwner = keys[1];   // fires second - must be skipped
+    void* thirdOwner  = keys[2];   // fires last   - removes itself mid-call
 
-    // A removes B before B's turn; B must not be called. C (self-removing) is
-    // safe because fireListeners copies the callback before invoking.
-    dm.addChangeListener (&aCalls, [&]
+    int firstCalls = 0, secondCalls = 0, thirdCalls = 0;
+
+    dm.addChangeListener (firstOwner, [&]
     {
-        ++aCalls;
-        dm.removeChangeListener (&ownerB);
+        ++firstCalls;
+        dm.removeChangeListener (secondOwner);
     });
-    dm.addChangeListener (&ownerB, [&] { ++bCalls; });
-    dm.addChangeListener (&cCalls, [&]
+    dm.addChangeListener (secondOwner, [&] { ++secondCalls; });
+    dm.addChangeListener (thirdOwner, [&]
     {
-        ++cCalls;
-        dm.removeChangeListener (&cCalls);   // remove self mid-call
+        ++thirdCalls;
+        dm.removeChangeListener (thirdOwner);   // remove self mid-call; safe because
+                                                // fireListeners copies the callback
     });
 
     dm.notifyChange();   // synchronous fan-out
-    REQUIRE (aCalls == 1);
-    REQUIRE (bCalls == 0);   // removed by A before its turn
-    REQUIRE (cCalls == 1);
+    REQUIRE (firstCalls == 1);
+    REQUIRE (secondCalls == 0);   // removed before its turn by the earlier-firing listener
+    REQUIRE (thirdCalls == 1);
 
     dm.notifyChange();
-    REQUIRE (aCalls == 2);
-    REQUIRE (cCalls == 1);   // self-removed last round, not called again
+    REQUIRE (firstCalls == 2);
+    REQUIRE (thirdCalls == 1);   // self-removed last round, not called again
 
-    dm.removeChangeListener (&aCalls);
+    dm.removeChangeListener (firstOwner);
 }
 
 #if ! defined (__APPLE__)
@@ -577,7 +609,7 @@ TEST_CASE ("DeviceManager broadcast: async and coalesced on the message thread",
 
     REQUIRE (fired == 0);   // async: deferred, nothing runs inline
 
-    pumpFor (30);
+    pumpUntil ([&] { return fired >= 1; });
     REQUIRE (fired == 1);   // coalesced: three requests, one fire
 
     dm.removeChangeListener (&fired);

--- a/tests/device_state_blob.cpp
+++ b/tests/device_state_blob.cpp
@@ -1,0 +1,269 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "engine/device/DeviceStateBlob.h"
+
+#include <juce_core/juce_core.h>
+
+#include <cstdint>
+#include <string>
+
+// DeviceStateBlob reads/writes the per-machine audio-device state. The version-1
+// JSON form is Dusk's own; the legacy <DEVICESETUP> form is what JUCE wrote before
+// the de-JUCE migration. These tests pin two things: the JSON form round-trips,
+// and the bespoke legacy reader is bit-identical to the real juce::XmlDocument +
+// juce::BigInteger path it replaces (A/B - JUCE is linkable in the test binary).
+
+using duskstudio::device::ChannelSet;
+using duskstudio::device::DeviceSetup;
+using duskstudio::device::DeviceStateBlob;
+
+namespace
+{
+std::uint64_t bigToRaw (const juce::BigInteger& b)
+{
+    std::uint64_t v = 0;
+    for (int i = 0; i < 64; ++i)
+        if (b[i]) v |= (std::uint64_t) 1 << i;
+    return v;
+}
+
+// Build the legacy blob string exactly as juce::AudioDeviceManager::createStateXml
+// does (attribute set + XmlElement::toString prolog). A null chans pointer means
+// the attribute is absent (the useDefault*Channels case).
+std::string makeLegacyXml (const std::string& type,
+                           const std::string& outName, const std::string& inName,
+                           double rate, int buf,
+                           const std::string* inChansBase2,
+                           const std::string* outChansBase2)
+{
+    juce::XmlElement xml ("DEVICESETUP");
+    xml.setAttribute ("deviceType", juce::String (type));
+    xml.setAttribute ("audioOutputDeviceName", juce::String (outName));
+    xml.setAttribute ("audioInputDeviceName", juce::String (inName));
+    xml.setAttribute ("audioDeviceRate", rate);
+    xml.setAttribute ("audioDeviceBufferSize", buf);
+    if (inChansBase2  != nullptr) xml.setAttribute ("audioDeviceInChans",  juce::String (*inChansBase2));
+    if (outChansBase2 != nullptr) xml.setAttribute ("audioDeviceOutChans", juce::String (*outChansBase2));
+    return xml.toString().toStdString();
+}
+
+// The reference decode: the JUCE parser + BigInteger, mirroring
+// juce::AudioDeviceManager::initialiseFromXML line for line.
+struct Reference
+{
+    std::string deviceType;
+    DeviceSetup setup;
+};
+
+Reference juceReference (const std::string& blob)
+{
+    Reference r;
+    const auto xml = juce::parseXML (juce::String (blob));
+    REQUIRE (xml != nullptr);
+
+    r.deviceType             = xml->getStringAttribute ("deviceType").toStdString();
+    r.setup.outputDeviceName = xml->getStringAttribute ("audioOutputDeviceName").toStdString();
+    r.setup.inputDeviceName  = xml->getStringAttribute ("audioInputDeviceName").toStdString();
+    r.setup.sampleRate       = xml->getDoubleAttribute ("audioDeviceRate", 0.0);
+    r.setup.bufferSize       = xml->getIntAttribute ("audioDeviceBufferSize", 0);
+
+    juce::BigInteger inB, outB;
+    inB .parseString (xml->getStringAttribute ("audioDeviceInChans",  "11"), 2);
+    outB.parseString (xml->getStringAttribute ("audioDeviceOutChans", "11"), 2);
+    r.setup.inputChannels  = ChannelSet::fromRaw (bigToRaw (inB));
+    r.setup.outputChannels = ChannelSet::fromRaw (bigToRaw (outB));
+
+    r.setup.useDefaultInputChannels  = ! xml->hasAttribute ("audioDeviceInChans");
+    r.setup.useDefaultOutputChannels = ! xml->hasAttribute ("audioDeviceOutChans");
+    return r;
+}
+
+void requireSameSetup (const DeviceStateBlob& got, const Reference& ref)
+{
+    REQUIRE (got.deviceType == ref.deviceType);
+    REQUIRE (got.setup.outputDeviceName == ref.setup.outputDeviceName);
+    REQUIRE (got.setup.inputDeviceName  == ref.setup.inputDeviceName);
+    REQUIRE_THAT (got.setup.sampleRate, Catch::Matchers::WithinAbs (ref.setup.sampleRate, 1e-9));
+    REQUIRE (got.setup.bufferSize == ref.setup.bufferSize);
+    REQUIRE (got.setup.useDefaultInputChannels  == ref.setup.useDefaultInputChannels);
+    REQUIRE (got.setup.useDefaultOutputChannels == ref.setup.useDefaultOutputChannels);
+    REQUIRE (got.setup.inputChannels  == ref.setup.inputChannels);
+    REQUIRE (got.setup.outputChannels == ref.setup.outputChannels);
+}
+
+ChannelSet chans (std::initializer_list<int> idx)
+{
+    ChannelSet cs;
+    for (int i : idx) cs.setBit (i);
+    return cs;
+}
+} // namespace
+
+TEST_CASE ("DeviceStateBlob JSON round-trips explicit channels", "[audio][device]")
+{
+    DeviceStateBlob in;
+    in.deviceType             = "PipeWire";
+    in.setup.outputDeviceName = "UMC1820";
+    in.setup.inputDeviceName  = "UMC1820";
+    in.setup.sampleRate       = 48000.0;
+    in.setup.bufferSize       = 256;
+    in.setup.useDefaultOutputChannels = false;
+    in.setup.useDefaultInputChannels  = false;
+    in.setup.outputChannels = chans ({ 0, 1 });
+    in.setup.inputChannels  = chans ({ 2, 3 });
+
+    const auto blob = in.toJson();
+    const auto out = DeviceStateBlob::parse (blob);
+    REQUIRE (out.has_value());
+
+    REQUIRE (out->deviceType == in.deviceType);
+    REQUIRE (out->setup.outputDeviceName == in.setup.outputDeviceName);
+    REQUIRE (out->setup.inputDeviceName  == in.setup.inputDeviceName);
+    REQUIRE_THAT (out->setup.sampleRate, Catch::Matchers::WithinAbs (in.setup.sampleRate, 1e-9));
+    REQUIRE (out->setup.bufferSize == in.setup.bufferSize);
+    REQUIRE_FALSE (out->setup.useDefaultOutputChannels);
+    REQUIRE_FALSE (out->setup.useDefaultInputChannels);
+    REQUIRE (out->setup.outputChannels == in.setup.outputChannels);
+    REQUIRE (out->setup.inputChannels  == in.setup.inputChannels);
+}
+
+TEST_CASE ("DeviceStateBlob JSON omits channel keys when useDefault", "[audio][device]")
+{
+    DeviceStateBlob in;
+    in.deviceType             = "PipeWire";
+    in.setup.outputDeviceName = "Built-in Audio";
+    in.setup.sampleRate       = 44100.0;
+    in.setup.bufferSize       = 512;
+    // useDefault*Channels stay at their true default.
+
+    const auto blob = in.toJson();
+    REQUIRE (blob.find ("outputChans") == std::string::npos);
+    REQUIRE (blob.find ("inputChans")  == std::string::npos);
+
+    const auto out = DeviceStateBlob::parse (blob);
+    REQUIRE (out.has_value());
+    REQUIRE (out->setup.useDefaultOutputChannels);
+    REQUIRE (out->setup.useDefaultInputChannels);
+    // Absent key => cleared mask.
+    REQUIRE (out->setup.outputChannels.isZero());
+    REQUIRE (out->setup.inputChannels.isZero());
+}
+
+TEST_CASE ("DeviceStateBlob legacy XML A/B: full attribute set", "[audio][device]")
+{
+    const std::string in  = "1111";   // channels 0-3
+    const std::string out = "11";     // channels 0-1
+    const auto blob = makeLegacyXml ("ALSA", "UMC1820", "UMC1820", 48000.0, 256, &in, &out);
+
+    const auto got = DeviceStateBlob::parse (blob);
+    REQUIRE (got.has_value());
+    requireSameSetup (*got, juceReference (blob));
+}
+
+TEST_CASE ("DeviceStateBlob legacy XML A/B: missing chans attrs => useDefault", "[audio][device]")
+{
+    const auto blob = makeLegacyXml ("PipeWire", "Scarlett", "Scarlett", 44100.0, 128, nullptr, nullptr);
+
+    const auto got = DeviceStateBlob::parse (blob);
+    REQUIRE (got.has_value());
+    REQUIRE (got->setup.useDefaultInputChannels);
+    REQUIRE (got->setup.useDefaultOutputChannels);
+    requireSameSetup (*got, juceReference (blob));
+}
+
+TEST_CASE ("DeviceStateBlob legacy XML A/B: entity-laden and UTF-8 device names", "[audio][device]")
+{
+    SECTION ("the five standard XML entities")
+    {
+        const std::string name = "M&M <Audio> \"Pro\" 'X'";
+        const auto blob = makeLegacyXml ("ALSA", name, name, 48000.0, 256, nullptr, nullptr);
+
+        const auto ref = juceReference (blob);
+        REQUIRE (ref.setup.outputDeviceName == name);   // JUCE escaped + decoded losslessly
+
+        const auto got = DeviceStateBlob::parse (blob);
+        REQUIRE (got.has_value());
+        requireSameSetup (*got, ref);
+    }
+
+    SECTION ("UTF-8 device name")
+    {
+        const std::string name = "R\xC3\xB8""de NT\xE2\x84\xA2 \xE2\x99\xAA";   // Røde NT™ ♪
+        const auto blob = makeLegacyXml ("PipeWire", name, "", 48000.0, 256, nullptr, nullptr);
+
+        const auto got = DeviceStateBlob::parse (blob);
+        REQUIRE (got.has_value());
+        requireSameSetup (*got, juceReference (blob));
+    }
+}
+
+TEST_CASE ("DeviceStateBlob legacy XML A/B: MSB-first mask strings", "[audio][device]")
+{
+    // "110" and "011" are different numbers, so different channel sets. This is
+    // the property that a byte-reversed reader would silently break.
+    const std::string a = "110";   // value 6 => channels 1,2
+    const std::string b = "011";   // value 3 => channels 0,1
+
+    const auto blobA = makeLegacyXml ("ALSA", "dev", "dev", 48000.0, 256, &a, &a);
+    const auto blobB = makeLegacyXml ("ALSA", "dev", "dev", 48000.0, 256, &b, &b);
+
+    const auto gotA = DeviceStateBlob::parse (blobA);
+    const auto gotB = DeviceStateBlob::parse (blobB);
+    REQUIRE (gotA.has_value());
+    REQUIRE (gotB.has_value());
+
+    requireSameSetup (*gotA, juceReference (blobA));
+    requireSameSetup (*gotB, juceReference (blobB));
+
+    REQUIRE (gotA->setup.inputChannels != gotB->setup.inputChannels);
+    REQUIRE (gotA->setup.inputChannels == chans ({ 1, 2 }));
+    REQUIRE (gotB->setup.inputChannels == chans ({ 0, 1 }));
+}
+
+TEST_CASE ("DeviceStateBlob malformed input => empty-equivalent", "[audio][device]")
+{
+    REQUIRE_FALSE (DeviceStateBlob::parse ("").has_value());
+    REQUIRE_FALSE (DeviceStateBlob::parse ("    \n\t ").has_value());
+    REQUIRE_FALSE (DeviceStateBlob::parse ("not markup at all").has_value());
+    REQUIRE_FALSE (DeviceStateBlob::parse ("{ broken json ").has_value());
+    REQUIRE_FALSE (DeviceStateBlob::parse ("<OTHERROOT deviceType=\"x\"/>").has_value());
+    REQUIRE_FALSE (DeviceStateBlob::parse ("<DEVICESETUP deviceType=\"x").has_value());   // unterminated value
+    // A non-object JSON value is not a valid blob.
+    REQUIRE_FALSE (DeviceStateBlob::parse ("[1,2,3]").has_value());
+}
+
+TEST_CASE ("DeviceStateBlob outputDeviceName on both formats", "[audio][device]")
+{
+    SECTION ("JSON: output name wins")
+    {
+        DeviceStateBlob in;
+        in.setup.outputDeviceName = "MainOut";
+        in.setup.inputDeviceName  = "MainIn";
+        REQUIRE (DeviceStateBlob::outputDeviceName (in.toJson()) == "MainOut");
+    }
+
+    SECTION ("JSON: empty output falls back to input")
+    {
+        DeviceStateBlob in;
+        in.setup.inputDeviceName = "OnlyIn";
+        REQUIRE (DeviceStateBlob::outputDeviceName (in.toJson()) == "OnlyIn");
+    }
+
+    SECTION ("legacy XML: output name wins")
+    {
+        const auto blob = makeLegacyXml ("ALSA", "MainOut", "MainIn", 48000.0, 256, nullptr, nullptr);
+        REQUIRE (DeviceStateBlob::outputDeviceName (blob) == "MainOut");
+    }
+
+    SECTION ("legacy XML: empty output falls back to input")
+    {
+        const auto blob = makeLegacyXml ("ALSA", "", "OnlyIn", 48000.0, 256, nullptr, nullptr);
+        REQUIRE (DeviceStateBlob::outputDeviceName (blob) == "OnlyIn");
+    }
+
+    SECTION ("unparseable => empty")
+    {
+        REQUIRE (DeviceStateBlob::outputDeviceName ("garbage").empty());
+    }
+}

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -41,6 +41,7 @@ src/engine/alsa/AlsaPerformanceTest.cpp
 src/engine/alsa/AlsaPerformanceTest.h
 src/engine/device/DeviceManager.cpp
 src/engine/device/DeviceManager.h
+src/engine/device/DeviceManagerJuce.cpp
 src/engine/hosting/NativePluginId.h
 src/engine/ipc/IpcSelfTest.cpp
 src/engine/ipc/PluginHostMain.cpp


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native Linux audio-device management with callback fan-out, device switching, lifecycle handling, and change notifications.
  * Added cross-platform device management support for macOS and Windows.
  * Added JSON device-state persistence with compatibility for legacy XML settings.
  * Added device-name extraction and fallback handling from saved settings.

* **Bug Fixes**
  * Improved audio callback behavior, device reconfiguration, and teardown safety.
  * Reduced unnecessary dependencies on JUCE audio-device headers.

* **Documentation**
  * Expanded the Device Phase-3 audio implementation plan and campaign tracking details.

* **Tests**
  * Added coverage for device management, callback behavior, state persistence, migration, and malformed settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->