### PR TITLE
Device tower P4-P5: native ALSA backend + Linux juce_audio_devices unlink

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -524,7 +524,7 @@ if(WIN32)
     endif()
 endif()
 
-# Dusk Studio-owned ALSA backend - a juce::AudioIODevice + AudioIODeviceType pair
+# Dusk Studio-owned ALSA backend - a dusk device::IODevice + IODeviceType pair
 # written from scratch using Ardour's libs/backends/alsa/ as a reference for
 # patterns (xrun recovery, sw_params choices, format priority, channel-mask
 # handling) but with no copied code. Replaces JUCE's stock ALSA backend,
@@ -533,8 +533,8 @@ endif()
 #
 # Linux-only: the implementation depends on <alsa/asoundlib.h>. macOS and
 # Windows builds skip it and fall back to the audio backends JUCE provides
-# (CoreAudio / WASAPI). The AudioEngine constructor's registration is
-# similarly guarded by #if defined(__linux__).
+# (CoreAudio / WASAPI). Registration in DeviceManager is similarly guarded
+# by DUSKSTUDIO_HAS_ALSA.
 if(UNIX AND NOT APPLE)
     target_sources(DuskStudio PRIVATE
         src/engine/alsa/AlsaAudioIODevice.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1047,9 +1047,14 @@ if((CMAKE_SYSTEM_NAME STREQUAL "Linux") AND TARGET juce::pkgconfig_JUCE_WAYLAND_
     target_link_libraries(DuskStudio PRIVATE juce::pkgconfig_JUCE_WAYLAND_LINUX_DEPS)
 endif()
 
+# Linux uses the native device layer. juce_audio_utils still pulls the JUCE
+# device module transitively until that higher-level module unlinks.
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_link_libraries(DuskStudio PRIVATE juce::juce_audio_devices)
+endif()
+
 target_link_libraries(DuskStudio PRIVATE
     juce::juce_audio_basics
-    juce::juce_audio_devices
     juce::juce_audio_formats
     juce::juce_audio_processors
     juce::juce_audio_utils

--- a/docs/dejuce-campaign.md
+++ b/docs/dejuce-campaign.md
@@ -24,8 +24,8 @@ juce_dsp, juce_events, juce_graphics, juce_gui_basics, juce_gui_extra`
 
 A module leaves the link line only when its whole subsystem is reimplemented
 and every call site is flipped. `juce_core` unlinks last. The
-`tools/juce-gate.sh` ratchet (allowlist currently 194 files) is the
-file-level backstop, not the goal.
+`tools/juce-gate.sh` ratchet (allowlist 184 files on the completed device
+tower branch, 191 on main until merge) is the file-level backstop, not the goal.
 
 Metric caveat: JUCE module declarations pull dependencies transitively —
 e.g. `juce_audio_utils` depends on `juce_audio_devices`, so removing the
@@ -89,20 +89,18 @@ reimplemented.
 
 ## Remaining towers, in order
 
-1. **Device Phase-3-audio** — ACTIVE — native PipeWire/ALSA implement the
-   dusk `IODevice`/`IODeviceType` interfaces directly; drop the Juce*Adapter /
-   CallbackBridge scaffolding inside `DeviceManager.cpp`; remove the direct
-   `juce_audio_devices` link on Linux (mac/win keep the JUCE path; see the
-   metric caveat above). RT-critical: the native backend takes over callback
-   dispatch and removes the JUCE audio safety net/A-B reference. Executable
-   spec: [dejuce-device-phase3-audio-plan.md](dejuce-device-phase3-audio-plan.md)
-   (P0–P5, two PRs, Opus prompts included). Unblocked 2026-07-20: code
-   proceeds now. Marc's hardware bench gates each PR's merge against the
-   bench debts named in *that* PR — PR-A (P0–P2): device-busy-at-boot
-   fallback + legacy-blob migration; PR-B (P3–P5): PipeWire/ALSA streaming +
-   the device-failure paths (hot-unplug, xrun, SR/buffer swap). The debts are
-   split across the two PRs (plan §"Owed to Marc's bench"); there is no single
-   whole-tower "gates merge" pass.
+1. **Device Phase-3-audio** — **CODE-COMPLETE / LINUX-UNLINKED** — native
+   PipeWire/ALSA implement the dusk `IODevice`/`IODeviceType` interfaces and
+   Linux has no direct `juce_audio_devices` link or direct source-TU header
+   includes.
+   macOS/Windows retain the wrapped device path, so this is a platform-scoped
+   unlink and the north-star count stays at 12. PR-A (P0–P2) merged as #103;
+   P3 merged separately as #104; P4–P5 are ready for review on
+   `dejuce/device-phase4-alsa`. Merge remains gated by Marc's bench: PipeWire
+   streaming plus SR/quantum renegotiation; ALSA hot-unplug with the new thread
+   teardown; xrun recovery under load; buffer/SR swaps; and the periods knob.
+   The real UMC1820 performance matrix is already green. Executable spec:
+   [dejuce-device-phase3-audio-plan.md](dejuce-device-phase3-audio-plan.md).
 2. **String-floor remnants** — juce::String in Session/SessionSerializer core
    (blocked by UI writes into Session.h members), ALSA backend (juce virtual
    signatures die with tower 2), hosting surfaces (PluginManager/PluginSlot),

--- a/docs/dejuce-device-phase3-audio-plan.md
+++ b/docs/dejuce-device-phase3-audio-plan.md
@@ -1,50 +1,29 @@
 # De-JUCE tower spec — Device Phase-3-audio
 
-**STATUS: P4 DONE (branch `dejuce/device-phase4-alsa` off main 6c7d569, commit
-5365cec, NOT pushed). P0-P2 merged as #103 (091fcb5); P3 merged as its OWN PR
-#104 (6c7d569) - Marc split the planned batched PR-B, so the `-a`/`-b` branches
-are both retired and PR-B is now P4-P5 on the new branch. P4: AlsaAudioIODevice/
-Type + AlsaPerformanceTest re-based onto device::IODevice/IODeviceType/
-IODeviceCallback (String/Array->std::string/std::vector, BigInteger->ChannelSet,
-HeapBlock/AudioBuffer scratch->std::vector + planar pointer arrays,
-CriticalSection->std::mutex, high-res ticks->std::chrono, runSelfTest()->
-std::string; dead rescan() deleted). Thread swap per §D5: std::thread, ioShouldExit
-acquire-polled at the same five exit sites, ioExited (dusk::AutoResetEvent)
-signalled as the thread's last statement; stop() = 2000 ms timed wait then join,
-on timeout detach + abandon; the WHOLE device is leaked via
-AlsaAudioIODevice::destroyOrPark (createDevice wraps devices in AlsaDeviceHandle
-whose dtor routes there; an abandoned device refuses open/start, close releases
-nothing). Thread body self-promotes via rt::applyRealtimeSchedRR - verified live
-SCHED_RR rt-prio=9 -> kernel 89 under RLIMIT 95; "thread started" stderr line
-kept (juce-prio label renamed rt-prio; nothing greps it). RT hunks proven
-type-rename-only by normalized diff: recoverFromXrun + format table
-byte-identical; rearm/configurePcm/converters/loop/prefill differ only in the
-sanctioned type swaps; ioExited.signal() is the sole addition. DeviceManager.cpp
-registers ALSA natively; JuceDeviceAdapter/JuceDeviceTypeAdapter/shim +
-toBig/fromBig/toStrings/toVector + the JUCE include DELETED - the TU is JUCE-free
-and the gate ratchet forced it OFF the allowlist NOW (the spec's "stays until P5"
-was unsatisfiable: the gate fails clean-but-listed files; P5's allowlist step is
-banked early). DeviceManagerJuce.cpp dropped its unreachable HAS_PIPEWIRE/
-HAS_ALSA registration blocks. Tone test falls back to JUCE stock ALSA until P5.
-Selftest backend cycle picks each type's default device explicitly (P2
-no-auto-open drift reworked) and the restore reports its error. Allowlist
-191->184 (6 alsa + DeviceManager.cpp). Build 0 NEW warnings (the
-readInterleavedS24Packed sign-conversion warning is the pre-existing line,
-verbatim from main). ctest 438/438 incl. NEW tests/alsa_thread_teardown.cpp
-(wedged injected thread: stop() holds the 2000 ms window then detaches+abandons,
-destroyOrPark leaks-not-frees, state valid through the thread's late touch;
-clean thread: joins, freed normally). Xvfb selftest: ALSA pure-logic 15/15 +
-PipeWire 8/8; backend-cycle open attempts fail on this box's environment
-(built-in PipeWire sink delivers quantum 0; UMC kernel device held by WirePlumber
-during the ALSA probe) - diagnostic text only, the restore reopens the UMC.
-DUSKSTUDIO_RUN_ALSA_PERF matrix on real hw:UMC1820,0 (WirePlumber suspended):
-44.1k+48k x 32..2048 duplex, all cells SAFE (one xrun at 44.1k/32), open/close
-50 cycles SAFE, start/stop race 20 cycles SAFE, 34 SCHED_RR thread starts.
-Next: P5 (consumer sweep + Linux CMake unlink + docs, §P5) on the SAME branch
-dejuce/device-phase4-alsa; PR-B (P4-P5) prepared at P5 - Marc may merge P4 alone,
-his call.
-Resume: "P4 (ALSA re-type + thread swap) committed on dejuce/device-phase4-alsa
-(5365cec), not pushed; start P5 (§P5) on the same branch".**
+**STATUS: P5 DONE — TOWER CODE-COMPLETE / LINUX-UNLINKED on branch
+`dejuce/device-phase4-alsa` off main 6c7d569, NOT pushed. P0-P2 merged as #103;
+P3 merged separately as #104; P4 is 5365cec plus review fixes 672020a. P4
+re-based ALSA onto the dusk device interfaces, replaced its I/O Thread with the
+§D5 std::thread lifecycle (including whole-device park-on-timeout), removed the
+last Linux adapters/shim, and took the allowlist 191->184. P5 rewrote the Linux
+headless tone harness over device::DeviceManager with a fixed 440 Hz/-6 dB
+IODeviceCallback; the non-Linux harness retains the wrapped implementation. The
+direct juce_audio_devices link is now NOT-Linux only. juce_audio_utils still
+pulls that module transitively on Linux, so object code remains until the GUI/
+hosting towers unlink it; regenerated compile_commands.json resolves zero Linux
+src/ translation units with direct juce_audio_devices header includes. This is
+a platform-scoped unlink: macOS/Windows retain the wrapped path and the
+north-star count stays 12. MANUAL.md audit: no change needed. Gate stays 184;
+build has zero new warnings; ctest 438/438; private-Xvfb selftest matches P4
+(synthetic green, ALSA 15/15, PipeWire helpers 8/8, known device-open diagnostics
+only). The private-Xvfb native tone probe reports a clean no-device error in this
+sandbox. Pre-paid bench debt: real hw:UMC1820,0 ALSA perf matrix 44.1k/48k x
+32..2048 all SAFE, open/close 50 and start/stop 20 SAFE. Outstanding merge gates:
+ALSA hot-unplug mid-play with the new thread teardown, xrun recovery under load,
+buffer/SR swap, periods knob; PipeWire streaming plus SR/quantum renegotiation
+on hardware (built-in sink quantum-0 could not exercise it). PR-B is P4+P5 and
+may still be split after P4 at Marc's discretion.
+Resume: "PR-B ready for Marc's review; bench debts gate merge".**
 Update this line each session (phase done, branch, resume phrase).
 
 Read order for an executing session: `docs/dejuce-campaign.md` → this file →

--- a/docs/dejuce-device-phase3-audio-plan.md
+++ b/docs/dejuce-device-phase3-audio-plan.md
@@ -1,30 +1,50 @@
 # De-JUCE tower spec — Device Phase-3-audio
 
-**STATUS: P3 DONE (branch `dejuce/device-phase3-audio-b`, commit 9cabe13).
-PR-A (P0-P2) MERGED to main as #103 (squash 091fcb5); the `-a` branch is retired.
-P2 was acdef95 (native DeviceManager orchestrator + owning adapters + DeviceStateBlob
-+ device_manager_native mock suite). P3: PipeWireAudioIODevice/Type re-based onto
-device::IODevice/IODeviceType (BigInteger->ChannelSet, String/Array->std::string/
-std::vector, HeapBlock->std::vector, CriticalSection->std::mutex, runSelfTest()->
-std::string; dead rescan() deleted). RT path frozen, type names only (onProcess /
-xrun rising-edge / over-quantum guard / pre-zeroed outputs / lock-then-dispatch
-byte-identical; pw_thread_loop model unchanged; CallbackContext {}). DeviceManager
-registers the native PipeWire type directly, drops its owning adapter; ALSA keeps
-its adapter until P4 (adapter machinery + JUCE include now gated on ALSA alone, so
-the narrow-link test TU stays JUCE-free). DuskStudioApp tone-test PipeWire
-registration dropped (can't join a juce::AudioDeviceManager once dusk-typed) -
-restored in P5. Allowlist 195->191 (4 pipewire entries out). Build 0 new warnings,
-436/436 ctest, gate 191, Xvfb selftest: native PipeWire opened+streamed (UMC1820
-48000/512/32out/16in, 22 links) + PipeWire pure-logic 8/8 + ALSA 15/15. Optional
-tests/pipewire_helpers.cpp SKIPPED (compiling the .cpp into a test drags in
-libpipewire; the helpers are already covered by the selftest's 8 PASS lines).
-Known drift carried from P2 (harmless): backend-cycle ALSA switch shows
-OPEN-FAILED because setCurrentDeviceType no longer auto-opens per §D2 - diagnostic
-text, not a 15/15 gate; reworked in P4. NOT pushed.
-Next: P4 (ALSA re-type + JUCE-Thread->std::thread swap per §D5/§P4) on the SAME
-branch dejuce/device-phase3-audio-b.
-Resume: "P3 (PipeWire re-type) committed on dejuce/device-phase3-audio-b (9cabe13),
-not pushed; start P4 (ALSA re-type + thread swap, §D5/§P4) on the same branch".**
+**STATUS: P4 DONE (branch `dejuce/device-phase4-alsa` off main 6c7d569, commit
+5365cec, NOT pushed). P0-P2 merged as #103 (091fcb5); P3 merged as its OWN PR
+#104 (6c7d569) - Marc split the planned batched PR-B, so the `-a`/`-b` branches
+are both retired and PR-B is now P4-P5 on the new branch. P4: AlsaAudioIODevice/
+Type + AlsaPerformanceTest re-based onto device::IODevice/IODeviceType/
+IODeviceCallback (String/Array->std::string/std::vector, BigInteger->ChannelSet,
+HeapBlock/AudioBuffer scratch->std::vector + planar pointer arrays,
+CriticalSection->std::mutex, high-res ticks->std::chrono, runSelfTest()->
+std::string; dead rescan() deleted). Thread swap per §D5: std::thread, ioShouldExit
+acquire-polled at the same five exit sites, ioExited (dusk::AutoResetEvent)
+signalled as the thread's last statement; stop() = 2000 ms timed wait then join,
+on timeout detach + abandon; the WHOLE device is leaked via
+AlsaAudioIODevice::destroyOrPark (createDevice wraps devices in AlsaDeviceHandle
+whose dtor routes there; an abandoned device refuses open/start, close releases
+nothing). Thread body self-promotes via rt::applyRealtimeSchedRR - verified live
+SCHED_RR rt-prio=9 -> kernel 89 under RLIMIT 95; "thread started" stderr line
+kept (juce-prio label renamed rt-prio; nothing greps it). RT hunks proven
+type-rename-only by normalized diff: recoverFromXrun + format table
+byte-identical; rearm/configurePcm/converters/loop/prefill differ only in the
+sanctioned type swaps; ioExited.signal() is the sole addition. DeviceManager.cpp
+registers ALSA natively; JuceDeviceAdapter/JuceDeviceTypeAdapter/shim +
+toBig/fromBig/toStrings/toVector + the JUCE include DELETED - the TU is JUCE-free
+and the gate ratchet forced it OFF the allowlist NOW (the spec's "stays until P5"
+was unsatisfiable: the gate fails clean-but-listed files; P5's allowlist step is
+banked early). DeviceManagerJuce.cpp dropped its unreachable HAS_PIPEWIRE/
+HAS_ALSA registration blocks. Tone test falls back to JUCE stock ALSA until P5.
+Selftest backend cycle picks each type's default device explicitly (P2
+no-auto-open drift reworked) and the restore reports its error. Allowlist
+191->184 (6 alsa + DeviceManager.cpp). Build 0 NEW warnings (the
+readInterleavedS24Packed sign-conversion warning is the pre-existing line,
+verbatim from main). ctest 438/438 incl. NEW tests/alsa_thread_teardown.cpp
+(wedged injected thread: stop() holds the 2000 ms window then detaches+abandons,
+destroyOrPark leaks-not-frees, state valid through the thread's late touch;
+clean thread: joins, freed normally). Xvfb selftest: ALSA pure-logic 15/15 +
+PipeWire 8/8; backend-cycle open attempts fail on this box's environment
+(built-in PipeWire sink delivers quantum 0; UMC kernel device held by WirePlumber
+during the ALSA probe) - diagnostic text only, the restore reopens the UMC.
+DUSKSTUDIO_RUN_ALSA_PERF matrix on real hw:UMC1820,0 (WirePlumber suspended):
+44.1k+48k x 32..2048 duplex, all cells SAFE (one xrun at 44.1k/32), open/close
+50 cycles SAFE, start/stop race 20 cycles SAFE, 34 SCHED_RR thread starts.
+Next: P5 (consumer sweep + Linux CMake unlink + docs, §P5) on the SAME branch
+dejuce/device-phase4-alsa; PR-B (P4-P5) prepared at P5 - Marc may merge P4 alone,
+his call.
+Resume: "P4 (ALSA re-type + thread swap) committed on dejuce/device-phase4-alsa
+(5365cec), not pushed; start P5 (§P5) on the same branch".**
 Update this line each session (phase done, branch, resume phrase).
 
 Read order for an executing session: `docs/dejuce-campaign.md` → this file →

--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -27,13 +27,19 @@
 #endif
 #if defined(__linux__)
  #include "engine/alsa/AlsaPerformanceTest.h"
+ #include "engine/device/DeviceManager.h"
+ #include "engine/device/IODeviceCallback.h"
  #include "foundation/Text.h"
 #endif
 #include "session/Session.h"
 
 #include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <thread>
 
 #if JUCE_LINUX
  #include <sys/mman.h>
@@ -266,12 +272,9 @@ static bool envFlagSet (const char* name)
         || s.equalsIgnoreCase ("yes");
 }
 
-// Headless tone-test probe: opens a chosen device at a chosen rate/buffer
-// and runs the same juce::AudioDeviceManager::playTestSound() that the GUI
-// "Test" button in AudioDeviceSelectorComponent calls. No AudioEngine is
-// attached - this isolates the JUCE backend + driver path from any engine
-// DSP. Useful for diagnosing distortion that appears when pressing the
-// Test button at low buffer sizes on ALSA + USB interfaces.
+// Headless tone-test probe: opens a chosen device at a chosen rate/buffer and
+// renders a 440 Hz sine without attaching an AudioEngine. Useful for isolating
+// the backend + driver path from engine DSP when diagnosing low-buffer noise.
 //
 // Env vars (all optional, sensible defaults):
 //   DUSKSTUDIO_TONE_BACKEND     "ALSA" | "PipeWire"       (default "ALSA")
@@ -279,6 +282,128 @@ static bool envFlagSet (const char* name)
 //   DUSKSTUDIO_TONE_RATE        sample rate in Hz         (default 48000)
 //   DUSKSTUDIO_TONE_BUFFER      buffer size in samples    (default 128)
 //   DUSKSTUDIO_TONE_DURATION_MS playback duration (ms)    (default 2000)
+#if defined(__linux__)
+class HeadlessSineCallback final : public device::IODeviceCallback
+{
+public:
+    void audioDeviceIOCallback (const float* const*, int,
+                                float* const* outputChannelData, int numOutputChannels,
+                                int numSamples, const device::CallbackContext&) override
+    {
+        for (int sample = 0; sample < numSamples; ++sample)
+        {
+            const float value = 0.5f * (float) std::sin (phase);
+            phase += phaseStep;
+            if (phase >= twoPi) phase -= twoPi;
+
+            for (int channel = 0; channel < numOutputChannels; ++channel)
+                if (outputChannelData[channel] != nullptr)
+                    outputChannelData[channel][sample] = value;
+        }
+        renderedFrames.fetch_add ((std::uint64_t) numSamples, std::memory_order_relaxed);
+    }
+
+    void audioDeviceAboutToStart (device::IODevice* dev) override
+    {
+        phase = 0.0;
+        phaseStep = dev->getCurrentSampleRate() > 0.0
+                  ? twoPi * 440.0 / dev->getCurrentSampleRate() : 0.0;
+        renderedFrames.store (0, std::memory_order_relaxed);
+    }
+
+    void audioDeviceStopped() override {}
+
+    std::uint64_t framesRendered() const noexcept
+    {
+        return renderedFrames.load (std::memory_order_relaxed);
+    }
+
+private:
+    static constexpr double twoPi = 6.28318530717958647692;
+    double phase = 0.0;
+    double phaseStep = 0.0;
+    std::atomic<std::uint64_t> renderedFrames { 0 };
+};
+
+static void runHeadlessToneTest()
+{
+    auto env = [] (const char* name) -> std::string {
+        if (const char* v = std::getenv (name)) return v;
+        return {};
+    };
+    const std::string backendEnv = env ("DUSKSTUDIO_TONE_BACKEND");
+    const std::string rateEnv    = env ("DUSKSTUDIO_TONE_RATE");
+    const std::string bufferEnv  = env ("DUSKSTUDIO_TONE_BUFFER");
+    const std::string durationEnv = env ("DUSKSTUDIO_TONE_DURATION_MS");
+    const std::string backendName = backendEnv.empty() ? "ALSA" : backendEnv;
+    const std::string deviceName  = env ("DUSKSTUDIO_TONE_DEVICE");
+    const double targetRate = rateEnv.empty() ? 48000.0 : dusk::text::getDoubleValue (rateEnv);
+    const int targetBuf = bufferEnv.empty() ? 128 : dusk::text::getIntValue (bufferEnv);
+    const int durationMs = durationEnv.empty() ? 2000 : dusk::text::getIntValue (durationEnv);
+
+    device::DeviceManager dm;
+
+    std::fprintf (stdout, "=== Dusk Studio Headless Tone Test ===\n");
+    std::fprintf (stdout, "Requested: backend=%s device=\"%s\" rate=%.0f buf=%d duration=%dms\n",
+                  backendName.c_str(), deviceName.c_str(), targetRate, targetBuf, durationMs);
+
+    if (const auto err = dm.initialise (0, 2, {}, false); ! err.empty())
+        std::fprintf (stdout, "init: %s\n", err.c_str());
+
+    dm.setCurrentDeviceType (backendName, /*treatAsChosen*/ true);
+    auto* type = dm.getCurrentDeviceType();
+    if (type == nullptr || type->getTypeName() != backendName)
+    {
+        std::fprintf (stdout, "Open failed: backend \"%s\" is unavailable\n", backendName.c_str());
+        std::fprintf (stdout, "=== End of Tone Test ===\n");
+        std::fflush (stdout);
+        return;
+    }
+
+    type->scanForDevices();
+    const auto outputNames = type->getDeviceNames (false);
+    device::DeviceSetup setup;
+    setup.outputDeviceName = deviceName;
+    if (setup.outputDeviceName.empty())
+    {
+        int defaultIndex = type->getDefaultDeviceIndex (false);
+        if (defaultIndex < 0 && ! outputNames.empty()) defaultIndex = 0;
+        if (defaultIndex >= 0 && defaultIndex < (int) outputNames.size())
+            setup.outputDeviceName = outputNames[(std::size_t) defaultIndex];
+    }
+    setup.sampleRate = targetRate;
+    setup.bufferSize = targetBuf;
+
+    if (const auto err = dm.setSetup (setup, /*treatAsChosen*/ true); ! err.empty())
+        std::fprintf (stdout, "setSetup: %s\n", err.c_str());
+
+    if (auto* dev = dm.getCurrentDevice())
+    {
+        std::fprintf (stdout,
+                      "Opened: \"%s\" type=%s rate=%.0f buf=%d activeOut=%d activeIn=%d bitDepth=%d\n",
+                      dev->getName().c_str(), type->getTypeName().c_str(),
+                      dev->getCurrentSampleRate(), dev->getCurrentBufferSizeSamples(),
+                      dev->getActiveOutputChannels().count(), dev->getActiveInputChannels().count(),
+                      dev->getCurrentBitDepth());
+        const int xrunBefore = dev->getXRunCount();
+        HeadlessSineCallback tone;
+        dm.addCallback (&tone);
+        std::this_thread::sleep_for (std::chrono::milliseconds (durationMs));
+        dm.removeCallback (&tone);
+        const int xrunAfter = dev->getXRunCount();
+
+        std::fprintf (stdout, "Sine render: %llu frames\n",
+                      (unsigned long long) tone.framesRendered());
+        std::fprintf (stdout, "Backend xrun count: before=%d after=%d delta=%d\n",
+                      xrunBefore, xrunAfter, xrunAfter - xrunBefore);
+    }
+    else
+        std::fprintf (stdout, "Open failed: getCurrentDevice() returned nullptr\n");
+
+    std::fprintf (stdout, "=== End of Tone Test ===\n");
+    std::fflush (stdout);
+}
+#else
 static void runHeadlessToneTest()
 {
     auto env = [] (const char* name) -> juce::String {
@@ -302,14 +427,6 @@ static void runHeadlessToneTest()
                   backendName.toRawUTF8(), deviceName.toRawUTF8(),
                   targetRate, targetBuf, durationMs);
 
-    // Both native backends implement the dusk device interfaces now, so neither
-    // fits a JUCE AudioDeviceManager; this probe runs against JUCE's stock
-    // backends until P5 moves the whole tone test onto the dusk DeviceManager.
-   #if defined(__linux__)
-    for (auto* type : dm.getAvailableDeviceTypes())
-        if (type != nullptr) type->scanForDevices();
-   #endif
-
     if (const auto err = dm.initialiseWithDefaultDevices (0, 2); err.isNotEmpty())
         std::fprintf (stdout, "init: %s\n", err.toRawUTF8());
 
@@ -330,17 +447,13 @@ static void runHeadlessToneTest()
     {
         std::fprintf (stdout,
                       "Opened: \"%s\" type=%s rate=%.0f buf=%d activeOut=%d activeIn=%d bitDepth=%d\n",
-                      dev->getName().toRawUTF8(),
-                      dm.getCurrentAudioDeviceType().toRawUTF8(),
-                      dev->getCurrentSampleRate(),
-                      dev->getCurrentBufferSizeSamples(),
+                      dev->getName().toRawUTF8(), dm.getCurrentAudioDeviceType().toRawUTF8(),
+                      dev->getCurrentSampleRate(), dev->getCurrentBufferSizeSamples(),
                       dev->getActiveOutputChannels().countNumberOfSetBits(),
                       dev->getActiveInputChannels().countNumberOfSetBits(),
                       dev->getCurrentBitDepth());
         const int xrunBefore = dev->getXRunCount();
 
-        // Same call the GUI Test button makes. Plays a 440 Hz sine at -6 dB
-        // through the open device for ~1 s.
         dm.playTestSound();
         juce::Thread::sleep (durationMs);
 
@@ -349,13 +462,12 @@ static void runHeadlessToneTest()
                       xrunBefore, xrunAfter, xrunAfter - xrunBefore);
     }
     else
-    {
         std::fprintf (stdout, "Open failed: getCurrentAudioDevice() returned nullptr\n");
-    }
 
     std::fprintf (stdout, "=== End of Tone Test ===\n");
     std::fflush (stdout);
 }
+#endif
 
 // Headless instrument-plugin test: load a single VST3 / LV2 / AU
 // instrument, send a synthetic MIDI chord, and report whether the

--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -26,8 +26,8 @@
  #include "engine/ipc/IpcSelfTest.h"
 #endif
 #if defined(__linux__)
- #include "engine/alsa/AlsaAudioIODeviceType.h"
  #include "engine/alsa/AlsaPerformanceTest.h"
+ #include "foundation/Text.h"
 #endif
 #include "session/Session.h"
 
@@ -302,16 +302,9 @@ static void runHeadlessToneTest()
                   backendName.toRawUTF8(), deviceName.toRawUTF8(),
                   targetRate, targetBuf, durationMs);
 
-    // Linux: pre-register Dusk Studio's own native ALSA backend before init so
-    // JUCE's createDeviceTypesIfNeeded doesn't auto-register its stock ALSA path.
-    // The native PipeWire backend implements the dusk device interfaces, not
-    // JUCE's, so it does not fit a JUCE AudioDeviceManager; P5 moves the whole
-    // tone test onto the dusk DeviceManager and registers PipeWire there.
-    // Pre-scanning lets init's pickCurrentDeviceTypeWithDevices read device
-    // counts without tripping hasScanned assertions.
-   #if defined(__linux__)
-    dm.addAudioDeviceType (std::make_unique<duskstudio::AlsaAudioIODeviceType>());
-   #endif
+    // Both native backends implement the dusk device interfaces now, so neither
+    // fits a JUCE AudioDeviceManager; this probe runs against JUCE's stock
+    // backends until P5 moves the whole tone test onto the dusk DeviceManager.
    #if defined(__linux__)
     for (auto* type : dm.getAvailableDeviceTypes())
         if (type != nullptr) type->scanForDevices();
@@ -1912,25 +1905,24 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
         // none set.
         duskstudio::AlsaPerformanceTest::Options opts;
         if (const auto* v = std::getenv ("DUSKSTUDIO_ALSA_PERF_DEVICE"))      opts.deviceId      = v;
-        if (const auto* v = std::getenv ("DUSKSTUDIO_ALSA_PERF_RATE"))        opts.sampleRate    = (unsigned int) juce::String (v).getIntValue();
-        if (const auto* v = std::getenv ("DUSKSTUDIO_ALSA_PERF_DURATION_MS")) opts.durationMs    = juce::String (v).getIntValue();
-        if (const auto* v = std::getenv ("DUSKSTUDIO_ALSA_PERF_LOAD_US"))     opts.fakeDspLoadUs = juce::String (v).getIntValue();
-        if (const auto* v = std::getenv ("DUSKSTUDIO_ALSA_PERF_LOOPBACK"))    opts.runLoopback   = juce::String (v).getIntValue() != 0;
+        if (const auto* v = std::getenv ("DUSKSTUDIO_ALSA_PERF_RATE"))        opts.sampleRate    = (unsigned int) dusk::text::getIntValue (v);
+        if (const auto* v = std::getenv ("DUSKSTUDIO_ALSA_PERF_DURATION_MS")) opts.durationMs    = dusk::text::getIntValue (v);
+        if (const auto* v = std::getenv ("DUSKSTUDIO_ALSA_PERF_LOAD_US"))     opts.fakeDspLoadUs = dusk::text::getIntValue (v);
+        if (const auto* v = std::getenv ("DUSKSTUDIO_ALSA_PERF_LOOPBACK"))    opts.runLoopback   = dusk::text::getIntValue (v) != 0;
 
         // Tier 2: comma-separated list, e.g. "44100,48000,96000". Empty
         // (or unset) keeps the single-rate Tier 1 behaviour.
         if (const auto* v = std::getenv ("DUSKSTUDIO_ALSA_PERF_RATES"))
         {
-            const auto tokens = juce::StringArray::fromTokens (juce::String (v), ",", "");
-            for (const auto& t : tokens)
+            for (const auto& t : dusk::text::split (v, ','))
             {
-                const int rate = t.trim().getIntValue();
-                if (rate > 0) opts.sampleRates.add ((unsigned int) rate);
+                const int rate = dusk::text::getIntValue (dusk::text::trim (t));
+                if (rate > 0) opts.sampleRates.push_back ((unsigned int) rate);
             }
         }
 
         const auto report = duskstudio::AlsaPerformanceTest::runAll (opts);
-        std::fprintf (stdout, "%s\n", report.toRawUTF8());
+        std::fprintf (stdout, "%s\n", report.c_str());
         std::fflush (stdout);
 
         quit();

--- a/src/engine/AudioPipelineSelfTest.cpp
+++ b/src/engine/AudioPipelineSelfTest.cpp
@@ -978,8 +978,21 @@ std::string AudioPipelineSelfTest::testBackendsOpenCleanly()
         for (const auto& d : outDevs) out += "      out: " + d + "\n";
         for (const auto& d : inDevs)  out += "      in:  " + d + "\n";
 
-        // Try opening the type's default device.
+        // Try opening the type's default device. A backend switch selects
+        // nothing on its own (pick-backend -> pick-device contract), so name
+        // the type's default device explicitly.
         deviceManager.setCurrentDeviceType (type->getTypeName(), /*treatAsChosen*/ true);
+        {
+            device::DeviceSetup pick;
+            const int outIdx = type->getDefaultDeviceIndex (false);
+            const int inIdx  = type->getDefaultDeviceIndex (true);
+            if (outIdx >= 0 && outIdx < (int) outDevs.size()) pick.outputDeviceName = outDevs[(size_t) outIdx];
+            if (inIdx  >= 0 && inIdx  < (int) inDevs.size())  pick.inputDeviceName  = inDevs[(size_t) inIdx];
+            pick.useDefaultInputChannels  = true;
+            pick.useDefaultOutputChannels = true;
+            if (const auto err = deviceManager.setSetup (pick, /*treatAsChosen*/ true); ! err.empty())
+                out += "      setSetup: " + err + "\n";
+        }
         if (auto* dev = deviceManager.getCurrentDevice())
         {
             out += dusk::text::format (
@@ -997,8 +1010,10 @@ std::string AudioPipelineSelfTest::testBackendsOpenCleanly()
 
     // Restore.
     deviceManager.setCurrentDeviceType (origType, /*treatAsChosen*/ true);
-    deviceManager.setSetup (origSetup, /*treatAsChosen*/ true);
-    out += "  (restored original setup: " + origType + ")\n";
+    if (const auto err = deviceManager.setSetup (origSetup, /*treatAsChosen*/ true); ! err.empty())
+        out += "  (restore FAILED: " + err + ")\n";
+    else
+        out += "  (restored original setup: " + origType + ")\n";
     return out;
 }
 
@@ -1394,9 +1409,8 @@ std::string AudioPipelineSelfTest::runAll()
     // Pure-logic self-test for the Dusk Studio-owned ALSA backend. Covers the
     // converter math, channel-mask routing, hw:CARD,DEV parsing, and the
     // periods-knob clamping. Real-device opens of the backend are
-    // exercised by the backend cycle below alongside the JUCE-stock
-    // ALSA / JACK paths.
-    report.push_back (AlsaAudioIODevice::runSelfTest().toStdString());
+    // exercised by the backend cycle below.
+    report.push_back (AlsaAudioIODevice::runSelfTest());
     report.push_back ("");
    #endif
 

--- a/src/engine/AudioPipelineSelfTest.cpp
+++ b/src/engine/AudioPipelineSelfTest.cpp
@@ -884,11 +884,10 @@ std::string AudioPipelineSelfTest::testCompPerTrack()
 
 std::string AudioPipelineSelfTest::probeUMC1820AlsaFormat()
 {
-    // Explicitly open the UMC1820 front: device on the ALSA backend so the
-    // device-open stderr line shows what format/access mode plug negotiated
-    // for THAT specific PCM. Verifies the format-pin patch (S24_3LE first
-    // for non-hw: devices) is taking effect on the actual hardware the user
-    // selects in the dialog.
+    // Explicitly open the UMC1820 on the native ALSA backend (raw hw: PCM) so
+    // the device-open stderr line shows the negotiated format/bit depth for
+    // the exact hardware the user selects in the dialog. Fails honestly with
+    // the backend's EBUSY guidance when another audio server holds the device.
     std::string out;
     out += "--- UMC1820 ALSA Direct Open Probe ---\n";
 
@@ -910,11 +909,10 @@ std::string AudioPipelineSelfTest::probeUMC1820AlsaFormat()
 
     deviceManager.setCurrentDeviceType ("ALSA", true);
 
-    // JUCE-ALSA exposes UMC1820 outputs under several surround-mode names -
-    // probe the most common one used in the dialog.
+    // The native backend enumerates one entry per hw:CARD,DEV PCM, named
+    // "<card>, <pcm>" - no surround-mode aliases.
     const std::vector<std::string> candidates {
-        "UMC1820, USB Audio; Front output / input",
-        "UMC1820, USB Audio; 4.0 Surround output to Front and Rear speakers"
+        "UMC1820, USB Audio"
     };
 
     for (const auto& name : candidates)
@@ -928,6 +926,11 @@ std::string AudioPipelineSelfTest::probeUMC1820AlsaFormat()
         if (! err.empty())
         {
             out += "  " + name + ": ERROR " + err + "\n";
+            // A busy hw: device (held by PipeWire/JACK) fails the channel
+            // probe, which surfaces as zero selectable channels rather than
+            // EBUSY - annotate so it doesn't read as a mask bug.
+            if (dusk::text::contains (err, "no input or output channels"))
+                out += "      (device likely held by another audio server - the channel probe saw 0 channels)\n";
             continue;
         }
 
@@ -935,7 +938,7 @@ std::string AudioPipelineSelfTest::probeUMC1820AlsaFormat()
         {
             out += dusk::text::format (
                 "  %s\n      OPENED rate=%.0f buf=%d in=%d out=%d "
-                "(see [Dusk Studio/JUCE-ALSA] line in stderr for format/access)\n",
+                "(see [Dusk Studio/ALSA] opened line in stderr for format/bits)\n",
                 name.c_str(),
                 dev->getCurrentSampleRate(),
                 dev->getCurrentBufferSizeSamples(),
@@ -949,7 +952,8 @@ std::string AudioPipelineSelfTest::probeUMC1820AlsaFormat()
     }
 
     deviceManager.setCurrentDeviceType (origType, true);
-    deviceManager.setSetup (origSetup, true);
+    if (const auto err = deviceManager.setSetup (origSetup, true); ! err.empty())
+        out += "  (restore FAILED: " + err + ")\n";
     return out;
 }
 

--- a/src/engine/alsa/AlsaAudioIODevice.cpp
+++ b/src/engine/alsa/AlsaAudioIODevice.cpp
@@ -1,5 +1,6 @@
 #include "AlsaAudioIODevice.h"
 #include "../RtPriority.h"
+#include "../../foundation/Text.h"
 
 #include <algorithm>
 #include <cerrno>
@@ -59,7 +60,8 @@ const AlsaFormat* selectFormat (snd_pcm_t* handle, snd_pcm_hw_params_t* hwParams
 // (max_int_value) factor to map float [-1, 1] onto the full int range.
 //
 // Inactive channels are written as zero into the interleaved frame; the
-// caller arranges the active-channel-index mapping.
+// caller arranges the active-channel-index mapping. `src`/`dest` are planar
+// per-channel pointer arrays, numActive entries, each numFrames long.
 
 constexpr float kInt16Scale = 32767.0f;
 constexpr float kInt24Scale = 8388607.0f;
@@ -70,7 +72,7 @@ inline float clampUnit (float v) noexcept
     return v > 1.0f ? 1.0f : (v < -1.0f ? -1.0f : v);
 }
 
-void writeInterleavedS32 (const juce::AudioBuffer<float>& src, void* dest,
+void writeInterleavedS32 (const float* const* src, void* dest,
                            int numFrames, int numDeviceChannels,
                            const int* activeIdx, int numActive)
 {
@@ -78,14 +80,14 @@ void writeInterleavedS32 (const juce::AudioBuffer<float>& src, void* dest,
     std::memset (out, 0, sizeof (int32_t) * (size_t) (numFrames * numDeviceChannels));
     for (int a = 0; a < numActive; ++a)
     {
-        const auto* srcCh = src.getReadPointer (a);
+        const auto* srcCh = src[a];
         const int   col   = activeIdx[a];
         for (int f = 0; f < numFrames; ++f)
             out[f * numDeviceChannels + col] = (int32_t) std::lrint (clampUnit (srcCh[f]) * kInt32Scale);
     }
 }
 
-void writeInterleavedS16 (const juce::AudioBuffer<float>& src, void* dest,
+void writeInterleavedS16 (const float* const* src, void* dest,
                            int numFrames, int numDeviceChannels,
                            const int* activeIdx, int numActive)
 {
@@ -93,14 +95,14 @@ void writeInterleavedS16 (const juce::AudioBuffer<float>& src, void* dest,
     std::memset (out, 0, sizeof (int16_t) * (size_t) (numFrames * numDeviceChannels));
     for (int a = 0; a < numActive; ++a)
     {
-        const auto* srcCh = src.getReadPointer (a);
+        const auto* srcCh = src[a];
         const int   col   = activeIdx[a];
         for (int f = 0; f < numFrames; ++f)
             out[f * numDeviceChannels + col] = (int16_t) std::lrint (clampUnit (srcCh[f]) * kInt16Scale);
     }
 }
 
-void writeInterleavedS24in32 (const juce::AudioBuffer<float>& src, void* dest,
+void writeInterleavedS24in32 (const float* const* src, void* dest,
                                int numFrames, int numDeviceChannels,
                                const int* activeIdx, int numActive)
 {
@@ -110,7 +112,7 @@ void writeInterleavedS24in32 (const juce::AudioBuffer<float>& src, void* dest,
     std::memset (out, 0, sizeof (int32_t) * (size_t) (numFrames * numDeviceChannels));
     for (int a = 0; a < numActive; ++a)
     {
-        const auto* srcCh = src.getReadPointer (a);
+        const auto* srcCh = src[a];
         const int   col   = activeIdx[a];
         for (int f = 0; f < numFrames; ++f)
         {
@@ -122,7 +124,7 @@ void writeInterleavedS24in32 (const juce::AudioBuffer<float>& src, void* dest,
     }
 }
 
-void writeInterleavedS24Packed (const juce::AudioBuffer<float>& src, void* dest,
+void writeInterleavedS24Packed (const float* const* src, void* dest,
                                   int numFrames, int numDeviceChannels,
                                   const int* activeIdx, int numActive)
 {
@@ -130,7 +132,7 @@ void writeInterleavedS24Packed (const juce::AudioBuffer<float>& src, void* dest,
     std::memset (out, 0, (size_t) (3 * numFrames * numDeviceChannels));
     for (int a = 0; a < numActive; ++a)
     {
-        const auto* srcCh = src.getReadPointer (a);
+        const auto* srcCh = src[a];
         const int   col   = activeIdx[a];
         for (int f = 0; f < numFrames; ++f)
         {
@@ -143,7 +145,7 @@ void writeInterleavedS24Packed (const juce::AudioBuffer<float>& src, void* dest,
     }
 }
 
-void writeInterleavedFloat (const juce::AudioBuffer<float>& src, void* dest,
+void writeInterleavedFloat (const float* const* src, void* dest,
                               int numFrames, int numDeviceChannels,
                               const int* activeIdx, int numActive)
 {
@@ -151,7 +153,7 @@ void writeInterleavedFloat (const juce::AudioBuffer<float>& src, void* dest,
     std::memset (out, 0, sizeof (float) * (size_t) (numFrames * numDeviceChannels));
     for (int a = 0; a < numActive; ++a)
     {
-        const auto* srcCh = src.getReadPointer (a);
+        const auto* srcCh = src[a];
         const int   col   = activeIdx[a];
         for (int f = 0; f < numFrames; ++f)
             out[f * numDeviceChannels + col] = srcCh[f];
@@ -162,7 +164,7 @@ void writeInterleavedFloat (const juce::AudioBuffer<float>& src, void* dest,
 // Only the active subset of device channels is materialised into floats; the
 // rest of the device's interleaved data is ignored.
 
-void readInterleavedS32 (const void* src, juce::AudioBuffer<float>& dest,
+void readInterleavedS32 (const void* src, float* const* dest,
                           int numFrames, int numDeviceChannels,
                           const int* activeIdx, int numActive)
 {
@@ -170,14 +172,14 @@ void readInterleavedS32 (const void* src, juce::AudioBuffer<float>& dest,
     constexpr float invScale = 1.0f / kInt32Scale;
     for (int a = 0; a < numActive; ++a)
     {
-        auto*     destCh = dest.getWritePointer (a);
+        auto*     destCh = dest[a];
         const int col    = activeIdx[a];
         for (int f = 0; f < numFrames; ++f)
             destCh[f] = (float) in[f * numDeviceChannels + col] * invScale;
     }
 }
 
-void readInterleavedS16 (const void* src, juce::AudioBuffer<float>& dest,
+void readInterleavedS16 (const void* src, float* const* dest,
                           int numFrames, int numDeviceChannels,
                           const int* activeIdx, int numActive)
 {
@@ -185,14 +187,14 @@ void readInterleavedS16 (const void* src, juce::AudioBuffer<float>& dest,
     constexpr float invScale = 1.0f / kInt16Scale;
     for (int a = 0; a < numActive; ++a)
     {
-        auto*     destCh = dest.getWritePointer (a);
+        auto*     destCh = dest[a];
         const int col    = activeIdx[a];
         for (int f = 0; f < numFrames; ++f)
             destCh[f] = (float) in[f * numDeviceChannels + col] * invScale;
     }
 }
 
-void readInterleavedS24in32 (const void* src, juce::AudioBuffer<float>& dest,
+void readInterleavedS24in32 (const void* src, float* const* dest,
                               int numFrames, int numDeviceChannels,
                               const int* activeIdx, int numActive)
 {
@@ -200,7 +202,7 @@ void readInterleavedS24in32 (const void* src, juce::AudioBuffer<float>& dest,
     constexpr float invScale = 1.0f / kInt24Scale;
     for (int a = 0; a < numActive; ++a)
     {
-        auto*     destCh = dest.getWritePointer (a);
+        auto*     destCh = dest[a];
         const int col    = activeIdx[a];
         for (int f = 0; f < numFrames; ++f)
         {
@@ -211,7 +213,7 @@ void readInterleavedS24in32 (const void* src, juce::AudioBuffer<float>& dest,
     }
 }
 
-void readInterleavedS24Packed (const void* src, juce::AudioBuffer<float>& dest,
+void readInterleavedS24Packed (const void* src, float* const* dest,
                                  int numFrames, int numDeviceChannels,
                                  const int* activeIdx, int numActive)
 {
@@ -219,7 +221,7 @@ void readInterleavedS24Packed (const void* src, juce::AudioBuffer<float>& dest,
     constexpr float invScale = 1.0f / kInt24Scale;
     for (int a = 0; a < numActive; ++a)
     {
-        auto*     destCh = dest.getWritePointer (a);
+        auto*     destCh = dest[a];
         const int col    = activeIdx[a];
         for (int f = 0; f < numFrames; ++f)
         {
@@ -234,14 +236,14 @@ void readInterleavedS24Packed (const void* src, juce::AudioBuffer<float>& dest,
     }
 }
 
-void readInterleavedFloat (const void* src, juce::AudioBuffer<float>& dest,
+void readInterleavedFloat (const void* src, float* const* dest,
                              int numFrames, int numDeviceChannels,
                              const int* activeIdx, int numActive)
 {
     const auto* in = static_cast<const float*> (src);
     for (int a = 0; a < numActive; ++a)
     {
-        auto*     destCh = dest.getWritePointer (a);
+        auto*     destCh = dest[a];
         const int col    = activeIdx[a];
         for (int f = 0; f < numFrames; ++f)
             destCh[f] = in[f * numDeviceChannels + col];
@@ -265,7 +267,7 @@ std::atomic<int> gRequestedPeriods { 3 };
 // ----- Sample rate / buffer size candidates ----------------------------------
 //
 // The device's actual support is checked by ALSA at open(); these are just
-// the values we surface to JUCE's UI. Standard pro-audio rates and sizes.
+// the values we surface to the settings UI. Standard pro-audio rates and sizes.
 const double kCandidateRates[] = {
     44100.0, 48000.0, 88200.0, 96000.0, 176400.0, 192000.0
 };
@@ -277,10 +279,18 @@ const int kCandidateBufferSizes[] = {
 // -> "UMC1820"; "hw:PCH,1" -> "PCH"; anything that doesn't start with "hw:"
 // -> empty. Used by open() to gate snd_pcm_link to same-card pairs (so
 // cross-card duplex doesn't silently drift), and exercised by runSelfTest().
-juce::String cardOfHwId (const juce::String& id)
+std::string cardOfHwId (const std::string& id)
 {
-    return id.fromFirstOccurrenceOf ("hw:", false, false)
-             .upToFirstOccurrenceOf (",", false, false);
+    return dusk::text::upToFirstOccurrenceOf (
+               dusk::text::fromFirstOccurrenceOf (id, "hw:", false), ",", false);
+}
+
+// Process-lifetime holder for abandoned devices (see destroyOrPark). Leaked on
+// purpose: the detached I/O threads referencing these objects may never exit.
+std::vector<AlsaAudioIODevice*>& abandonedHolder()
+{
+    static std::vector<AlsaAudioIODevice*> holder;
+    return holder;
 }
 } // namespace
 
@@ -293,13 +303,22 @@ int AlsaAudioIODevice::getRequestedPeriods() noexcept
     return gRequestedPeriods.load (std::memory_order_relaxed);
 }
 
+void AlsaAudioIODevice::destroyOrPark (std::unique_ptr<AlsaAudioIODevice> dev)
+{
+    if (dev != nullptr && dev->ioThreadWasAbandoned())
+        abandonedHolder().push_back (dev.release());
+}
+
+int AlsaAudioIODevice::abandonedCount() noexcept
+{
+    return (int) abandonedHolder().size();
+}
+
 // ============================================================================
-AlsaAudioIODevice::AlsaAudioIODevice (const juce::String& name,
-                                        const juce::String& inId,
-                                        const juce::String& outId)
-    : juce::AudioIODevice (name, "ALSA"),
-      juce::Thread ("Dusk Studio-ALSA-IO"),
-      inputId (inId),
+AlsaAudioIODevice::AlsaAudioIODevice (const std::string& name,
+                                        const std::string& inId,
+                                        const std::string& outId)
+    : inputId (inId),
       outputId (outId),
       displayName (name)
 {
@@ -308,6 +327,13 @@ AlsaAudioIODevice::AlsaAudioIODevice (const juce::String& name,
 AlsaAudioIODevice::~AlsaAudioIODevice()
 {
     close();
+    // Owners must route an abandoned device through destroyOrPark; reaching
+    // this destructor with the detached thread live is a use-after-free in
+    // waiting. Nothing can be done about it here - flag it loudly.
+    if (threadAbandoned.load (std::memory_order_acquire))
+        std::fprintf (stderr,
+                      "[Dusk Studio/ALSA] ERROR: destroying \"%s\" while its abandoned "
+                      "I/O thread is still live\n", displayName.c_str());
 }
 
 // ----- Capability queries ----------------------------------------------------
@@ -316,17 +342,17 @@ void AlsaAudioIODevice::probeIfNeeded()
     if (hasProbed)
         return;
 
-    auto probe = [] (const juce::String& id, bool isCapture,
+    auto probe = [] (const std::string& id, bool isCapture,
                       unsigned int& maxChans,
-                      juce::Array<double>& rates,
-                      juce::Array<int>& bufSizes)
+                      std::vector<double>& rates,
+                      std::vector<int>& bufSizes)
     {
-        if (id.isEmpty())
+        if (id.empty())
             return;
 
         snd_pcm_t* handle = nullptr;
         if (snd_pcm_open (&handle,
-                           id.toRawUTF8(),
+                           id.c_str(),
                            isCapture ? SND_PCM_STREAM_CAPTURE
                                      : SND_PCM_STREAM_PLAYBACK,
                            SND_PCM_NONBLOCK) < 0)
@@ -342,14 +368,16 @@ void AlsaAudioIODevice::probeIfNeeded()
             maxChans = std::max (maxChans, maxCh);
 
             for (double r : kCandidateRates)
-                if (snd_pcm_hw_params_test_rate (handle, hw, (unsigned int) r, 0) == 0)
-                    rates.addIfNotAlreadyThere (r);
+                if (snd_pcm_hw_params_test_rate (handle, hw, (unsigned int) r, 0) == 0
+                    && std::find (rates.begin(), rates.end(), r) == rates.end())
+                    rates.push_back (r);
 
             for (int b : kCandidateBufferSizes)
             {
                 snd_pcm_uframes_t f = (snd_pcm_uframes_t) b;
-                if (snd_pcm_hw_params_test_period_size (handle, hw, f, 0) == 0)
-                    bufSizes.addIfNotAlreadyThere (b);
+                if (snd_pcm_hw_params_test_period_size (handle, hw, f, 0) == 0
+                    && std::find (bufSizes.begin(), bufSizes.end(), b) == bufSizes.end())
+                    bufSizes.push_back (b);
             }
         }
 
@@ -359,10 +387,10 @@ void AlsaAudioIODevice::probeIfNeeded()
     probe (outputId, false, deviceMaxOutChannels, supportedSampleRates, supportedBufferSizes);
     probe (inputId,  true,  deviceMaxInChannels,  supportedSampleRates, supportedBufferSizes);
 
-    if (supportedSampleRates.isEmpty())
-        for (double r : kCandidateRates) supportedSampleRates.add (r);
-    if (supportedBufferSizes.isEmpty())
-        for (int b : kCandidateBufferSizes) supportedBufferSizes.add (b);
+    if (supportedSampleRates.empty())
+        for (double r : kCandidateRates) supportedSampleRates.push_back (r);
+    if (supportedBufferSizes.empty())
+        for (int b : kCandidateBufferSizes) supportedBufferSizes.push_back (b);
 
     std::sort (supportedSampleRates.begin(), supportedSampleRates.end());
     std::sort (supportedBufferSizes.begin(), supportedBufferSizes.end());
@@ -370,31 +398,31 @@ void AlsaAudioIODevice::probeIfNeeded()
     hasProbed = true;
 }
 
-juce::StringArray AlsaAudioIODevice::getOutputChannelNames()
+std::vector<std::string> AlsaAudioIODevice::getOutputChannelNames()
 {
     probeIfNeeded();
-    juce::StringArray names;
+    std::vector<std::string> names;
     for (unsigned int i = 0; i < deviceMaxOutChannels; ++i)
-        names.add ("channel " + juce::String ((int) i + 1));
+        names.push_back ("channel " + std::to_string ((int) i + 1));
     return names;
 }
 
-juce::StringArray AlsaAudioIODevice::getInputChannelNames()
+std::vector<std::string> AlsaAudioIODevice::getInputChannelNames()
 {
     probeIfNeeded();
-    juce::StringArray names;
+    std::vector<std::string> names;
     for (unsigned int i = 0; i < deviceMaxInChannels; ++i)
-        names.add ("channel " + juce::String ((int) i + 1));
+        names.push_back ("channel " + std::to_string ((int) i + 1));
     return names;
 }
 
-juce::Array<double> AlsaAudioIODevice::getAvailableSampleRates()
+std::vector<double> AlsaAudioIODevice::getAvailableSampleRates()
 {
     probeIfNeeded();
     return supportedSampleRates;
 }
 
-juce::Array<int> AlsaAudioIODevice::getAvailableBufferSizes()
+std::vector<int> AlsaAudioIODevice::getAvailableBufferSizes()
 {
     probeIfNeeded();
     return supportedBufferSizes;
@@ -407,11 +435,11 @@ int AlsaAudioIODevice::getDefaultBufferSize()
 }
 
 // ----- Open / close ----------------------------------------------------------
-bool AlsaAudioIODevice::openOneHandle (const juce::String& id, bool isCapture, snd_pcm_t*& handle)
+bool AlsaAudioIODevice::openOneHandle (const std::string& id, bool isCapture, snd_pcm_t*& handle)
 {
     handle = nullptr;
     const int err = snd_pcm_open (&handle,
-                                    id.toRawUTF8(),
+                                    id.c_str(),
                                     isCapture ? SND_PCM_STREAM_CAPTURE
                                               : SND_PCM_STREAM_PLAYBACK,
                                     SND_PCM_NONBLOCK);
@@ -425,14 +453,14 @@ bool AlsaAudioIODevice::openOneHandle (const juce::String& id, bool isCapture, s
         // suspects.
         if (err == -EBUSY)
         {
-            lastError = juce::String ("Device \"") + id + "\" is in use by another "
+            lastError = "Device \"" + id + "\" is in use by another "
                        "application (PipeWire, JACK, browser audio, or another DAW). "
                        "Stop the other app or run `pactl suspend-sink <sink-name> 1` "
                        "to release the kernel handle, then try again.";
         }
         else
         {
-            lastError = juce::String ("snd_pcm_open(") + id + ", "
+            lastError = "snd_pcm_open(" + id + ", "
                       + (isCapture ? "capture" : "playback") + "): "
                       + snd_strerror (err);
         }
@@ -476,7 +504,7 @@ bool AlsaAudioIODevice::configurePcm (snd_pcm_t* handle, bool isCapture,
 
     if (snd_pcm_hw_params_set_rate_near (handle, hw, &sampleRate, nullptr) < 0)
     {
-        lastError = "device rejected sample rate " + juce::String ((int) sampleRate);
+        lastError = "device rejected sample rate " + std::to_string ((int) sampleRate);
         return false;
     }
 
@@ -487,7 +515,7 @@ bool AlsaAudioIODevice::configurePcm (snd_pcm_t* handle, bool isCapture,
         numChannels = std::clamp (numChannels, minCh, maxCh);
         if (snd_pcm_hw_params_set_channels (handle, hw, numChannels) < 0)
         {
-            lastError = "device rejected channel count " + juce::String ((int) numChannels);
+            lastError = "device rejected channel count " + std::to_string ((int) numChannels);
             return false;
         }
     }
@@ -531,10 +559,18 @@ bool AlsaAudioIODevice::configurePcm (snd_pcm_t* handle, bool isCapture,
     return true;
 }
 
-juce::String AlsaAudioIODevice::open (const juce::BigInteger& inputChannels,
-                                        const juce::BigInteger& outputChannels,
-                                        double sampleRate, int bufferSizeSamples)
+std::string AlsaAudioIODevice::open (const device::ChannelSet& inputChannels,
+                                       const device::ChannelSet& outputChannels,
+                                       double sampleRate, int bufferSizeSamples)
 {
+    if (threadAbandoned.load (std::memory_order_acquire))
+    {
+        // The detached thread still owns the handles and scratch; re-opening
+        // would reallocate under it. The owner replaces the device instead.
+        lastError = "device unusable: its I/O thread was abandoned after a wedged stop";
+        return lastError;
+    }
+
     if (isDeviceOpen.load (std::memory_order_acquire))
         close();
 
@@ -543,8 +579,8 @@ juce::String AlsaAudioIODevice::open (const juce::BigInteger& inputChannels,
     currentInputChannels  = inputChannels;
     currentOutputChannels = outputChannels;
 
-    const bool wantOutput = outputChannels.getHighestBit() >= 0 && outputId.isNotEmpty();
-    const bool wantInput  = inputChannels.getHighestBit()  >= 0 && inputId.isNotEmpty();
+    const bool wantOutput = outputChannels.highestSetBit() >= 0 && ! outputId.empty();
+    const bool wantInput  = inputChannels.highestSetBit()  >= 0 && ! inputId.empty();
 
     if (! wantOutput && ! wantInput)
     {
@@ -597,8 +633,8 @@ juce::String AlsaAudioIODevice::open (const juce::BigInteger& inputChannels,
         bytesPerInSample = inBytes;
         if (inRate != rate)
         {
-            lastError = "capture rate " + juce::String ((int) inRate)
-                       + " != playback rate " + juce::String ((int) rate);
+            lastError = "capture rate " + std::to_string ((int) inRate)
+                       + " != playback rate " + std::to_string ((int) rate);
             close();
             return lastError;
         }
@@ -630,8 +666,8 @@ juce::String AlsaAudioIODevice::open (const juce::BigInteger& inputChannels,
                           "different cards (\"%s\" vs \"%s\"); not linking. The two "
                           "clocks will drift over a long session. For tracking + "
                           "monitoring use the same interface for in and out.\n",
-                          inputId.toRawUTF8(), outputId.toRawUTF8(),
-                          inCard.toRawUTF8(), outCard.toRawUTF8());
+                          inputId.c_str(), outputId.c_str(),
+                          inCard.c_str(), outCard.c_str());
         }
     }
 
@@ -643,8 +679,8 @@ juce::String AlsaAudioIODevice::open (const juce::BigInteger& inputChannels,
 
     // Active-channel index tables. Callback channel `a` corresponds to device
     // channel `activeXXXDeviceChannelIndex[a]`. Mask is the user's UI ticks.
-    activeOutDeviceChannelIndex.clearQuick();
-    activeInDeviceChannelIndex.clearQuick();
+    activeOutDeviceChannelIndex.clear();
+    activeInDeviceChannelIndex.clear();
     // Clamp to the channel count the device actually opened. outNumChannels /
     // inNumChannels can be smaller than the requested mask - a 12-output
     // interface asked to open 32 negotiates down to 12. Without this clamp a
@@ -652,19 +688,19 @@ juce::String AlsaAudioIODevice::open (const juce::BigInteger& inputChannels,
     // addresses the interleaved buffer (sized to the opened count) out of
     // bounds: out[frame * numDeviceChannels + col] with col past the last real
     // channel. That heap overflow is what crashes with "free(): invalid pointer".
-    juce::BigInteger clampedOutMask, clampedInMask;
+    device::ChannelSet clampedOutMask, clampedInMask;
     if (wantOutput)
         for (int i = 0; i < (int) outNumChannels; ++i)
             if (outputChannels[i])
             {
-                activeOutDeviceChannelIndex.add (i);
+                activeOutDeviceChannelIndex.push_back (i);
                 clampedOutMask.setBit (i);
             }
     if (wantInput)
         for (int i = 0; i < (int) inNumChannels; ++i)
             if (inputChannels[i])
             {
-                activeInDeviceChannelIndex.add (i);
+                activeInDeviceChannelIndex.push_back (i);
                 clampedInMask.setBit (i);
             }
     // A stale/invalid mask can select only channels the device doesn't have,
@@ -673,10 +709,10 @@ juce::String AlsaAudioIODevice::open (const juce::BigInteger& inputChannels,
     // channel(s) (a default stereo pair) so we always have at least one.
     if (wantOutput && clampedOutMask.isZero() && (int) outNumChannels > 0)
         for (int i = 0; i < std::min (2, (int) outNumChannels); ++i)
-        { activeOutDeviceChannelIndex.add (i); clampedOutMask.setBit (i); }
+        { activeOutDeviceChannelIndex.push_back (i); clampedOutMask.setBit (i); }
     if (wantInput && clampedInMask.isZero() && (int) inNumChannels > 0)
         for (int i = 0; i < std::min (2, (int) inNumChannels); ++i)
-        { activeInDeviceChannelIndex.add (i); clampedInMask.setBit (i); }
+        { activeInDeviceChannelIndex.push_back (i); clampedInMask.setBit (i); }
 
     // Publish the actually-active masks. The requested mask can be wider than the
     // device opened (32 asked, 12 real); without this, getActiveOutput/Input-
@@ -687,23 +723,29 @@ juce::String AlsaAudioIODevice::open (const juce::BigInteger& inputChannels,
 
     // Pre-size scratch. Allocations on the audio thread are forbidden; the
     // sizing here is the size the I/O loop relies on.
-    const int activeOut = activeOutDeviceChannelIndex.size();
-    const int activeIn  = activeInDeviceChannelIndex.size();
+    const int activeOut = (int) activeOutDeviceChannelIndex.size();
+    const int activeIn  = (int) activeInDeviceChannelIndex.size();
 
-    callbackOutFloats.setSize (std::max (1, activeOut), periodSize, false, true, false);
-    callbackInFloats .setSize (std::max (1, activeIn),  periodSize, false, true, false);
-    callbackOutPointers.resize (activeOut);
-    callbackInPointers .resize (activeIn);
-    for (int i = 0; i < activeOut; ++i) callbackOutPointers.set (i, callbackOutFloats.getWritePointer (i));
-    for (int i = 0; i < activeIn;  ++i) callbackInPointers .set (i, callbackInFloats .getReadPointer  (i));
+    callbackOutStore.assign ((size_t) std::max (1, activeOut) * (size_t) periodSize, 0.0f);
+    callbackInStore .assign ((size_t) std::max (1, activeIn)  * (size_t) periodSize, 0.0f);
+    callbackOutPointers.resize ((size_t) activeOut);
+    callbackInWritePointers.resize ((size_t) activeIn);
+    callbackInPointers.resize ((size_t) activeIn);
+    for (int i = 0; i < activeOut; ++i)
+        callbackOutPointers[(size_t) i] = callbackOutStore.data() + (size_t) i * (size_t) periodSize;
+    for (int i = 0; i < activeIn; ++i)
+    {
+        callbackInWritePointers[(size_t) i] = callbackInStore.data() + (size_t) i * (size_t) periodSize;
+        callbackInPointers[(size_t) i]      = callbackInWritePointers[(size_t) i];
+    }
 
     if (wantOutput)
     {
-        interleavedOutBytes.allocate ((size_t) (bytesPerOutSample * (int) outNumChannels * periodSize), true);
-        silencePrefill.allocate ((size_t) (bytesPerOutSample * (int) outNumChannels * periodSize * periodsCount), true);
+        interleavedOutBytes.assign ((size_t) (bytesPerOutSample * (int) outNumChannels * periodSize), 0);
+        silencePrefill.assign ((size_t) (bytesPerOutSample * (int) outNumChannels * periodSize * periodsCount), 0);
     }
     if (wantInput)
-        interleavedInBytes .allocate ((size_t) (bytesPerInSample  * (int) inNumChannels  * periodSize), true);
+        interleavedInBytes.assign ((size_t) (bytesPerInSample * (int) inNumChannels * periodSize), 0);
 
     if (outHandle != nullptr) snd_pcm_prepare (outHandle);
     if (inHandle  != nullptr) snd_pcm_prepare (inHandle);
@@ -714,7 +756,7 @@ juce::String AlsaAudioIODevice::open (const juce::BigInteger& inputChannels,
     std::fprintf (stderr,
                   "[Dusk Studio/ALSA] opened \"%s\" rate=%u period=%d periods=%d bits=%d %s "
                   "out=%uch in=%uch (active out=%d in=%d)\n",
-                  displayName.toRawUTF8(),
+                  displayName.c_str(),
                   (unsigned) rate, (int) period, (int) periods, openedBitDepth,
                   openedIsFloat ? "float" : "int",
                   outNumChannels, inNumChannels, activeOut, activeIn);
@@ -726,31 +768,39 @@ void AlsaAudioIODevice::close()
 {
     stop();
 
+    if (threadAbandoned.load (std::memory_order_acquire))
+    {
+        // The detached thread still reads the handles and scratch; release
+        // nothing. The device is dead to callers from here (destroyOrPark
+        // leaks the whole object).
+        isDeviceOpen.store (false, std::memory_order_release);
+        return;
+    }
+
     if (outHandle != nullptr) { snd_pcm_close (outHandle); outHandle = nullptr; }
     if (inHandle  != nullptr) { snd_pcm_close (inHandle);  inHandle  = nullptr; }
 
-    interleavedOutBytes.free();
-    interleavedInBytes .free();
-    silencePrefill     .free();
-    callbackOutFloats.setSize (1, 1);
-    callbackInFloats .setSize (1, 1);
+    interleavedOutBytes = {};
+    interleavedInBytes  = {};
+    silencePrefill      = {};
+    callbackOutStore    = {};
+    callbackInStore     = {};
 
     isDeviceOpen.store (false, std::memory_order_release);
 }
 
 // ----- Start / stop ----------------------------------------------------------
-void AlsaAudioIODevice::start (juce::AudioIODeviceCallback* newCallback)
+void AlsaAudioIODevice::start (device::IODeviceCallback* newCallback)
 {
     if (! isDeviceOpen.load (std::memory_order_acquire) || newCallback == nullptr)
         return;
     if (isStarted.load (std::memory_order_acquire))
         return;
 
-    if (newCallback != nullptr)
-        newCallback->audioDeviceAboutToStart (this);
+    newCallback->audioDeviceAboutToStart (this);
 
     {
-        const juce::ScopedLock sl (callbackLock);
+        std::lock_guard<std::mutex> sl (callbackLock);
         callback = newCallback;
     }
 
@@ -778,9 +828,9 @@ void AlsaAudioIODevice::start (juce::AudioIODeviceCallback* newCallback)
     {
         const int frameBytes = bytesPerOutSample * (int) outNumChannels;
         const auto preFillFrames = (size_t) (periodSize * periodsCount);
-        juce::HeapBlock<char> silence (preFillFrames * (size_t) frameBytes, true);
+        std::vector<char> silence (preFillFrames * (size_t) frameBytes, 0);
 
-        snd_pcm_sframes_t wrote = snd_pcm_writei (outHandle, silence.getData(),
+        snd_pcm_sframes_t wrote = snd_pcm_writei (outHandle, silence.data(),
                                                     (snd_pcm_uframes_t) preFillFrames);
         if (wrote < 0)
         {
@@ -791,7 +841,7 @@ void AlsaAudioIODevice::start (juce::AudioIODeviceCallback* newCallback)
             // recoverFromXrun's rearmStream would prefill+start a second time.
             xrunCount.fetch_add (1, std::memory_order_relaxed);
             snd_pcm_recover (outHandle, (int) wrote, /*silent*/ 1);
-            const auto retry = snd_pcm_writei (outHandle, silence.getData(),
+            const auto retry = snd_pcm_writei (outHandle, silence.data(),
                                                  (snd_pcm_uframes_t) preFillFrames);
             if (retry < 0)
                 std::fprintf (stderr, "[Dusk Studio/ALSA] WARNING: pre-fill retry failed: %s\n",
@@ -809,50 +859,10 @@ void AlsaAudioIODevice::start (juce::AudioIODeviceCallback* newCallback)
         snd_pcm_start (startHandle);
     }
 
-    // Run the I/O thread at real-time priority. The rlimit->priority mapping is
-    // shared with the DSP worker pool (see RtPriority.h - the pool MUST run at
-    // the same SCHED_RR level as this thread or the per-block join can starve a
-    // worker sharing this core). jucePriority < 0 means the rlimit admits no
-    // JUCE-reachable realtime level; don't bother asking. 0 IS a valid level
-    // (lowest SCHED_RR), so request RT for it too.
-    const auto rtInfo = duskstudio::rt::queryRealtimePriority();
-    const int  juceRtPrio = rtInfo.jucePriority;
-
-    const bool gotRT = juceRtPrio >= 0
-        && startRealtimeThread (juce::Thread::RealtimeOptions{}.withPriority (juceRtPrio));
-    if (! gotRT)
-        startThread (juce::Thread::Priority::high);
-
-    // Resolve and log the actual kernel sched_priority post-attach so
-    // regressions in JUCE's priority mapping are visible without
-    // re-reading source. juce::Thread::getThreadId() returns the
-    // pthread_t cast through a void*; cast it back here.
-    int kernelPrio = -1;
-    juce::String policyStr = "unknown";
-    if (gotRT)
-    {
-        const auto nativeHandle = (pthread_t) (uintptr_t) getThreadId();
-        if (nativeHandle != 0)
-        {
-            int policy = 0;
-            sched_param sp {};
-            if (pthread_getschedparam (nativeHandle, &policy, &sp) == 0)
-            {
-                kernelPrio = sp.sched_priority;
-                policyStr = (policy == SCHED_RR)    ? "SCHED_RR"
-                          : (policy == SCHED_FIFO)  ? "SCHED_FIFO"
-                          : (policy == SCHED_OTHER) ? "SCHED_OTHER"
-                          :                           "SCHED_?";
-            }
-        }
-    }
-    const juce::String rtLimitStr =
-        (! rtInfo.haveRtLimit)   ? juce::String ("unknown")
-        : (rtInfo.rtLimit < 0)   ? juce::String ("infinity")
-        :                          juce::String ((std::int64_t) rtInfo.rtLimit);
-    std::fprintf (stderr, "[Dusk Studio/ALSA] thread started: %s (juce-prio=%d, kernel-prio=%d, RLIMIT_RTPRIO=%s)\n",
-                  gotRT ? policyStr.toRawUTF8() : "Priority::high",
-                  juceRtPrio, kernelPrio, rtLimitStr.toRawUTF8());
+    // The I/O thread self-promotes to SCHED_RR as its first act (see
+    // ioThreadRun); on kernel refusal it runs as a plain SCHED_OTHER thread.
+    ioShouldExit.store (false, std::memory_order_release);
+    ioThread = std::thread ([this] { ioThreadRun(); });
 
     isStarted.store (true, std::memory_order_release);
 }
@@ -863,21 +873,65 @@ void AlsaAudioIODevice::stop()
         return;
 
     isStarted.store (false, std::memory_order_release);
-    signalThreadShouldExit();
-    stopThread (2000);
+    ioShouldExit.store (true, std::memory_order_release);
 
-    juce::AudioIODeviceCallback* cb = nullptr;
+    if (ioThread.joinable())
     {
-        const juce::ScopedLock sl (callbackLock);
-        std::swap (cb, callback);
+        // The thread signals ioExited as its last statement; every blocking
+        // call in the loop is bounded <= 1 s, so a healthy worst-case exit
+        // lands well inside the window.
+        if (ioExited.wait (2000))
+        {
+            ioThread.join();
+        }
+        else
+        {
+            // No kill escape hatch with std::thread, and the wedged thread
+            // still dereferences this whole object (PCM handles, mutex,
+            // scratch, the flags). Detach it and mark the device abandoned:
+            // close() stops releasing resources and destroyOrPark leaks the
+            // object instead of destroying it, so the owner always outlives
+            // the thread.
+            std::fprintf (stderr,
+                          "[Dusk Studio/ALSA] ERROR: I/O thread did not exit within 2000 ms; "
+                          "detaching it and abandoning \"%s\" (device leaked, not destroyed - "
+                          "the thread still references it)\n",
+                          displayName.c_str());
+            ioThread.detach();
+            threadAbandoned.store (true, std::memory_order_release);
+        }
     }
-    if (cb != nullptr)
-        cb->audioDeviceStopped();
 
-    if (outHandle != nullptr) snd_pcm_drop (outHandle);
-    if (inHandle  != nullptr) snd_pcm_drop (inHandle);
-    if (outHandle != nullptr) snd_pcm_prepare (outHandle);
-    if (inHandle  != nullptr) snd_pcm_prepare (inHandle);
+    if (! threadAbandoned.load (std::memory_order_acquire))
+    {
+        device::IODeviceCallback* cb = nullptr;
+        {
+            std::lock_guard<std::mutex> sl (callbackLock);
+            std::swap (cb, callback);
+        }
+        if (cb != nullptr)
+            cb->audioDeviceStopped();
+
+        if (outHandle != nullptr) snd_pcm_drop (outHandle);
+        if (inHandle  != nullptr) snd_pcm_drop (inHandle);
+        if (outHandle != nullptr) snd_pcm_prepare (outHandle);
+        if (inHandle  != nullptr) snd_pcm_prepare (inHandle);
+    }
+    else
+    {
+        // The live thread may be wedged inside a client callback holding
+        // callbackLock, so a blocking lock here could deadlock stop(). Detach
+        // the callback only if the lock is free, and leave the PCM handles
+        // alone - the thread is still using them.
+        device::IODeviceCallback* cb = nullptr;
+        {
+            std::unique_lock<std::mutex> sl (callbackLock, std::try_to_lock);
+            if (sl.owns_lock())
+                std::swap (cb, callback);
+        }
+        if (cb != nullptr)
+            cb->audioDeviceStopped();
+    }
 }
 
 // ----- Recovery --------------------------------------------------------------
@@ -912,11 +966,11 @@ void AlsaAudioIODevice::rearmStream() noexcept
     if (inHandle != nullptr)
         snd_pcm_prepare (inHandle);
 
-    if (silencePrefill != nullptr && periodsCount > 0 && periodSize > 0)
+    if (! silencePrefill.empty() && periodsCount > 0 && periodSize > 0)
     {
         const auto   frames     = (snd_pcm_uframes_t) (periodSize * periodsCount);
         const size_t frameBytes = (size_t) bytesPerOutSample * (size_t) outNumChannels;
-        const auto*  src        = silencePrefill.getData();
+        const auto*  src        = silencePrefill.data();
         // NONBLOCK PCM: writei can return a short count, or -EPIPE if the ring
         // underran during re-arm. Loop until the full prefill lands (recovering
         // on error) so we never snd_pcm_start an underfilled ring -> instant
@@ -950,12 +1004,12 @@ void AlsaAudioIODevice::rearmStream() noexcept
 }
 
 // ----- Interleave / deinterleave dispatch ------------------------------------
-void AlsaAudioIODevice::interleavePlaybackBlock (const juce::AudioBuffer<float>& src,
+void AlsaAudioIODevice::interleavePlaybackBlock (const float* const* src,
                                                    void* dest, int numFrames) const
 {
     const int n      = (int) outNumChannels;
-    const int active = activeOutDeviceChannelIndex.size();
-    const int* idx   = activeOutDeviceChannelIndex.getRawDataPointer();
+    const int active = (int) activeOutDeviceChannelIndex.size();
+    const int* idx   = activeOutDeviceChannelIndex.data();
 
     if (openedIsFloat)
         writeInterleavedFloat (src, dest, numFrames, n, idx, active);
@@ -970,11 +1024,11 @@ void AlsaAudioIODevice::interleavePlaybackBlock (const juce::AudioBuffer<float>&
 }
 
 void AlsaAudioIODevice::deinterleaveCaptureBlock (const void* src,
-                                                    juce::AudioBuffer<float>& dest, int numFrames) const
+                                                    float* const* dest, int numFrames) const
 {
     const int n      = (int) inNumChannels;
-    const int active = activeInDeviceChannelIndex.size();
-    const int* idx   = activeInDeviceChannelIndex.getRawDataPointer();
+    const int active = (int) activeInDeviceChannelIndex.size();
+    const int* idx   = activeInDeviceChannelIndex.data();
 
     if (openedIsFloat)
         readInterleavedFloat (src, dest, numFrames, n, idx, active);
@@ -989,18 +1043,53 @@ void AlsaAudioIODevice::deinterleaveCaptureBlock (const void* src,
 }
 
 // ----- I/O thread ------------------------------------------------------------
-void AlsaAudioIODevice::run()
+void AlsaAudioIODevice::ioThreadRun()
 {
+    // Self-promote to SCHED_RR before the first block. The rlimit->priority
+    // mapping is shared with the DSP worker pool (see RtPriority.h - the pool
+    // MUST run at the same SCHED_RR level as this thread or the per-block join
+    // can starve a worker sharing this core). jucePriority < 0 means the rlimit
+    // admits no realtime level; don't bother asking. 0 IS a valid level (lowest
+    // SCHED_RR), so request RT for it too. On kernel refusal this stays a plain
+    // SCHED_OTHER thread.
+    const auto rtInfo = rt::queryRealtimePriority();
+    if (rtInfo.jucePriority >= 0)
+        rt::applyRealtimeSchedRR (rtInfo.jucePriority);
+
+    // Resolve and log the actual kernel sched_priority post-promotion so
+    // regressions in the priority mapping are visible without re-reading
+    // source.
+    {
+        int policy = 0;
+        sched_param sp {};
+        int kernelPrio = -1;
+        const char* policyStr = "unknown";
+        if (pthread_getschedparam (pthread_self(), &policy, &sp) == 0)
+        {
+            kernelPrio = sp.sched_priority;
+            policyStr = (policy == SCHED_RR)    ? "SCHED_RR"
+                      : (policy == SCHED_FIFO)  ? "SCHED_FIFO"
+                      : (policy == SCHED_OTHER) ? "SCHED_OTHER"
+                      :                           "SCHED_?";
+        }
+        const std::string rtLimitStr =
+            (! rtInfo.haveRtLimit)   ? std::string ("unknown")
+            : (rtInfo.rtLimit < 0)   ? std::string ("infinity")
+            :                          std::to_string (rtInfo.rtLimit);
+        std::fprintf (stderr, "[Dusk Studio/ALSA] thread started: %s (rt-prio=%d, kernel-prio=%d, RLIMIT_RTPRIO=%s)\n",
+                      policyStr, rtInfo.jucePriority, kernelPrio, rtLimitStr.c_str());
+    }
+
     // Fatal-recovery indicator. When snd_pcm_recover refuses to bring
     // the handle back (typically -ENODEV on USB / Bluetooth hot-unplug)
     // we capture the snd_strerror text and surface it to the
-    // AudioIODeviceCallback after the loop exits. Without this the
+    // IODeviceCallback after the loop exits. Without this the
     // audio thread dies silently and AudioEngine's transport keeps
     // "rolling" against a missing device - recordings continue against
     // a stalled writer until the user notices.
     int          fatalErr = 0;
     const char*  fatalCtx = nullptr;
-    while (! threadShouldExit())
+    while (! ioShouldExit.load (std::memory_order_acquire))
     {
         // Capture path: read one period (blocking with a long timeout). If
         // there's no input device, the playback path drives the loop on its
@@ -1018,7 +1107,7 @@ void AlsaAudioIODevice::run()
                 }
                 continue;
             }
-            if (threadShouldExit()) break;
+            if (ioShouldExit.load (std::memory_order_acquire)) break;
 
             // Loop on partial reads. snd_pcm_readi can short-return after
             // recovery or during state transitions - retry on the residual
@@ -1026,11 +1115,11 @@ void AlsaAudioIODevice::run()
             // distinct from xrun: it just means "wait briefly and try
             // again", not a stream error.
             int       framesRemaining = periodSize;
-            char*     cursor          = (char*) interleavedInBytes.getData();
+            char*     cursor          = interleavedInBytes.data();
             const int frameBytes      = bytesPerInSample * (int) inNumChannels;
             bool      readFatal       = false;
 
-            while (framesRemaining > 0 && ! threadShouldExit())
+            while (framesRemaining > 0 && ! ioShouldExit.load (std::memory_order_acquire))
             {
                 snd_pcm_sframes_t got = snd_pcm_readi (inHandle, cursor,
                                                          (snd_pcm_uframes_t) framesRemaining);
@@ -1061,21 +1150,21 @@ void AlsaAudioIODevice::run()
             }
             if (readFatal) break;
 
-            deinterleaveCaptureBlock (interleavedInBytes.getData(),
-                                        callbackInFloats, periodSize);
+            deinterleaveCaptureBlock (interleavedInBytes.data(),
+                                        callbackInWritePointers.data(), periodSize);
         }
 
-        callbackOutFloats.clear();
+        std::fill (callbackOutStore.begin(), callbackOutStore.end(), 0.0f);
 
         {
-            const juce::ScopedLock sl (callbackLock);
+            std::lock_guard<std::mutex> sl (callbackLock);
             if (callback != nullptr)
             {
-                callback->audioDeviceIOCallbackWithContext (
-                    callbackInPointers.getRawDataPointer(),
-                    callbackInPointers.size(),
-                    callbackOutPointers.getRawDataPointer(),
-                    callbackOutPointers.size(),
+                callback->audioDeviceIOCallback (
+                    callbackInPointers.data(),
+                    (int) callbackInPointers.size(),
+                    callbackOutPointers.data(),
+                    (int) callbackOutPointers.size(),
                     periodSize,
                     {});
             }
@@ -1100,17 +1189,17 @@ void AlsaAudioIODevice::run()
                     }
                     continue;
                 }
-                if (threadShouldExit()) break;
+                if (ioShouldExit.load (std::memory_order_acquire)) break;
             }
 
-            interleavePlaybackBlock (callbackOutFloats,
-                                       interleavedOutBytes.getData(), periodSize);
+            interleavePlaybackBlock (callbackOutPointers.data(),
+                                       interleavedOutBytes.data(), periodSize);
 
             int    framesRemaining = periodSize;
-            char*  cursor          = (char*) interleavedOutBytes.getData();
+            char*  cursor          = interleavedOutBytes.data();
             const int frameBytes   = bytesPerOutSample * (int) outNumChannels;
 
-            while (framesRemaining > 0 && ! threadShouldExit())
+            while (framesRemaining > 0 && ! ioShouldExit.load (std::memory_order_acquire))
             {
                 snd_pcm_sframes_t wrote = snd_pcm_writei (outHandle, cursor,
                                                             (snd_pcm_uframes_t) framesRemaining);
@@ -1141,23 +1230,31 @@ void AlsaAudioIODevice::run()
     }
 loopExit: ;
 
-    // Surface the device loss to AudioDeviceManager so it can switch
-    // to a fallback device (or post audioDeviceError to the UI). Without
-    // this, JUCE's AudioDeviceManager has no signal that the audio
-    // thread died - Dusk Studio's transport keeps "running" with no callbacks
-    // firing and a recording-in-progress accumulates against a stalled
-    // writer.
+    // Surface the device loss to the DeviceManager's fan-out so the engine can
+    // switch to a fallback device (or post the error to the UI). Without
+    // this the audio thread dies silently - Dusk Studio's transport keeps
+    // "running" with no callbacks firing and a recording-in-progress
+    // accumulates against a stalled writer.
     if (fatalErr != 0)
     {
-        const auto msg = juce::String ("ALSA device error in ")
-                       + juce::String (fatalCtx != nullptr ? fatalCtx : "I/O loop")
-                       + ": " + juce::String (snd_strerror (fatalErr));
-        std::fprintf (stderr, "[Dusk Studio/ALSA] fatal: %s\n", msg.toRawUTF8());
+        const auto msg = std::string ("ALSA device error in ")
+                       + (fatalCtx != nullptr ? fatalCtx : "I/O loop")
+                       + ": " + snd_strerror (fatalErr);
+        std::fprintf (stderr, "[Dusk Studio/ALSA] fatal: %s\n", msg.c_str());
 
-        const juce::ScopedLock sl (callbackLock);
+        std::lock_guard<std::mutex> sl (callbackLock);
         if (callback != nullptr)
             callback->audioDeviceError (msg);
     }
+
+    ioExited.signal();
+}
+
+void AlsaAudioIODevice::startThreadForTest (std::function<void (std::atomic<bool>&, dusk::AutoResetEvent&)> body)
+{
+    ioShouldExit.store (false, std::memory_order_release);
+    ioThread = std::thread ([this, body = std::move (body)] { body (ioShouldExit, ioExited); });
+    isStarted.store (true, std::memory_order_release);
 }
 
 // ============================================================================
@@ -1177,15 +1274,15 @@ loopExit: ;
 //
 // Real-device opens (snd_pcm_open + start + writei + readi against actual
 // hardware) are exercised by AudioPipelineSelfTest's existing backend cycle.
-juce::String AlsaAudioIODevice::runSelfTest()
+std::string AlsaAudioIODevice::runSelfTest()
 {
-    juce::StringArray report;
+    std::vector<std::string> report;
     int passed = 0, failed = 0;
 
-    auto record = [&] (const juce::String& name, bool pass, const juce::String& detail = {})
+    auto record = [&] (const std::string& name, bool pass, const std::string& detail = {})
     {
-        report.add (juce::String ("  [") + (pass ? "PASS" : "FAIL") + "] " + name
-                     + (detail.isNotEmpty() ? "  " + detail : juce::String()));
+        report.push_back (std::string ("  [") + (pass ? "PASS" : "FAIL") + "] " + name
+                          + (! detail.empty() ? "  " + detail : std::string()));
         (pass ? passed : failed)++;
     };
 
@@ -1193,12 +1290,13 @@ juce::String AlsaAudioIODevice::runSelfTest()
     {
         constexpr int kFrames = 64;
         constexpr int kDevCh  = 1;
+        constexpr float kPi   = 3.14159265358979323846f;
         const int activeIdx[] = { 0 };
 
-        juce::AudioBuffer<float> src (1, kFrames);
+        std::vector<float> src ((size_t) kFrames);
         for (int i = 0; i < kFrames; ++i)
-            src.setSample (0, i, 0.5f * std::sin (2.0f * juce::MathConstants<float>::pi
-                                                     * 1000.0f * (float) i / 48000.0f));
+            src[(size_t) i] = 0.5f * std::sin (2.0f * kPi * 1000.0f * (float) i / 48000.0f);
+        const float* srcChans[] = { src.data() };
 
         // Precision floors: lossy formats have a max-error budget at twice
         // the LSB of the format's quantization step, since round-trip
@@ -1210,8 +1308,8 @@ juce::String AlsaAudioIODevice::runSelfTest()
             int  bitDepth;
             bool isFloat;
             float epsilon;
-            void (*write) (const juce::AudioBuffer<float>&, void*, int, int, const int*, int);
-            void (*read)  (const void*, juce::AudioBuffer<float>&, int, int, const int*, int);
+            void (*write) (const float* const*, void*, int, int, const int*, int);
+            void (*read)  (const void*, float* const*, int, int, const int*, int);
         };
         const Case cases[] = {
             { "FLOAT_LE", 4, 32, true,  0.0f,                         writeInterleavedFloat,    readInterleavedFloat    },
@@ -1223,20 +1321,20 @@ juce::String AlsaAudioIODevice::runSelfTest()
 
         for (const auto& c : cases)
         {
-            juce::HeapBlock<char> scratch ((size_t) (c.bytesPerSample * kDevCh * kFrames), true);
-            juce::AudioBuffer<float> dest (1, kFrames);
-            dest.clear();
+            std::vector<char> scratch ((size_t) (c.bytesPerSample * kDevCh * kFrames), 0);
+            std::vector<float> dest ((size_t) kFrames, 0.0f);
+            float* destChans[] = { dest.data() };
 
-            c.write (src, scratch.getData(), kFrames, kDevCh, activeIdx, 1);
-            c.read  (scratch.getData(), dest, kFrames, kDevCh, activeIdx, 1);
+            c.write (srcChans, scratch.data(), kFrames, kDevCh, activeIdx, 1);
+            c.read  (scratch.data(), destChans, kFrames, kDevCh, activeIdx, 1);
 
             float maxErr = 0.0f;
             for (int i = 0; i < kFrames; ++i)
-                maxErr = std::max (maxErr, std::abs (src.getSample (0, i) - dest.getSample (0, i)));
+                maxErr = std::max (maxErr, std::abs (src[(size_t) i] - dest[(size_t) i]));
 
-            record (juce::String ("Format round-trip ") + c.name,
+            record (std::string ("Format round-trip ") + c.name,
                      maxErr <= c.epsilon,
-                     juce::String::formatted ("max err %.2e (eps %.2e)", maxErr, c.epsilon));
+                     dusk::text::format ("max err %.2e (eps %.2e)", maxErr, c.epsilon));
         }
     }
 
@@ -1247,17 +1345,18 @@ juce::String AlsaAudioIODevice::runSelfTest()
         const int activeIdx[] = { 0, 2 };
         constexpr int kActive = 2;
 
-        juce::AudioBuffer<float> src (kActive, kFrames);
+        std::vector<float> src ((size_t) (kActive * kFrames));
+        const float* srcChans[] = { src.data(), src.data() + kFrames };
         for (int f = 0; f < kFrames; ++f)
         {
-            src.setSample (0, f,  0.5f);   // active 0 -> device slot 0
-            src.setSample (1, f, -0.25f);  // active 1 -> device slot 2
+            src[(size_t) f]           =  0.5f;   // active 0 -> device slot 0
+            src[(size_t) (kFrames + f)] = -0.25f;  // active 1 -> device slot 2
         }
 
-        juce::HeapBlock<char> scratch ((size_t) (sizeof (int32_t) * kDevCh * kFrames), true);
-        writeInterleavedS32 (src, scratch.getData(), kFrames, kDevCh, activeIdx, kActive);
+        std::vector<char> scratch (sizeof (int32_t) * (size_t) (kDevCh * kFrames), 0);
+        writeInterleavedS32 (srcChans, scratch.data(), kFrames, kDevCh, activeIdx, kActive);
 
-        const auto* raw = reinterpret_cast<const int32_t*> (scratch.getData());
+        const auto* raw = reinterpret_cast<const int32_t*> (scratch.data());
         bool slot0HasData = false, slot2HasData = false;
         bool slot1Zero = true,    slot3Zero = true;
         for (int f = 0; f < kFrames; ++f)
@@ -1270,30 +1369,29 @@ juce::String AlsaAudioIODevice::runSelfTest()
 
         record ("Channel routing - active slots populated",
                  slot0HasData && slot2HasData,
-                 juce::String::formatted ("slot0=%s slot2=%s",
-                                            slot0HasData ? "data" : "ZERO",
-                                            slot2HasData ? "data" : "ZERO"));
+                 dusk::text::format ("slot0=%s slot2=%s",
+                                     slot0HasData ? "data" : "ZERO",
+                                     slot2HasData ? "data" : "ZERO"));
         record ("Channel routing - inactive slots zeroed",
                  slot1Zero && slot3Zero,
-                 juce::String::formatted ("slot1=%s slot3=%s",
-                                            slot1Zero ? "zero" : "NONZERO",
-                                            slot3Zero ? "zero" : "NONZERO"));
+                 dusk::text::format ("slot1=%s slot3=%s",
+                                     slot1Zero ? "zero" : "NONZERO",
+                                     slot3Zero ? "zero" : "NONZERO"));
 
         // Round-trip back through deinterleave verifies the active-index
         // map is symmetric (write puts active a -> slot activeIdx[a],
         // read pulls slot activeIdx[a] -> active a).
-        juce::AudioBuffer<float> dest (kActive, kFrames);
-        dest.clear();
-        readInterleavedS32 (scratch.getData(), dest, kFrames, kDevCh, activeIdx, kActive);
+        std::vector<float> dest ((size_t) (kActive * kFrames), 0.0f);
+        float* destChans[] = { dest.data(), dest.data() + kFrames };
+        readInterleavedS32 (scratch.data(), destChans, kFrames, kDevCh, activeIdx, kActive);
 
         float maxErr = 0.0f;
-        for (int a = 0; a < kActive; ++a)
-            for (int f = 0; f < kFrames; ++f)
-                maxErr = std::max (maxErr, std::abs (src.getSample (a, f) - dest.getSample (a, f)));
+        for (int i = 0; i < kActive * kFrames; ++i)
+            maxErr = std::max (maxErr, std::abs (src[(size_t) i] - dest[(size_t) i]));
 
         record ("Channel routing - round-trip preserves active channels",
                  maxErr <= 2.0f / kInt32Scale,
-                 juce::String::formatted ("max err %.2e", maxErr));
+                 dusk::text::format ("max err %.2e", maxErr));
     }
 
     // ----- 3. cardOfHwId parsing -------------------------------------------
@@ -1308,15 +1406,15 @@ juce::String AlsaAudioIODevice::runSelfTest()
             { "",                     ""        },
         };
         bool allOk = true;
-        juce::String detail;
+        std::string detail;
         for (const auto& c : cases)
         {
-            const juce::String got = cardOfHwId (c.in);
-            const bool ok = got == juce::String (c.expected);
+            const std::string got = cardOfHwId (c.in);
+            const bool ok = got == c.expected;
             if (! ok)
             {
                 allOk = false;
-                detail += juce::String ("'") + c.in + "' -> '" + got + "' (want '"
+                detail += std::string ("'") + c.in + "' -> '" + got + "' (want '"
                         + c.expected + "'); ";
             }
         }
@@ -1348,25 +1446,19 @@ juce::String AlsaAudioIODevice::runSelfTest()
         setRequestedPeriods (8);    const int p8   = getRequestedPeriods();
         setRequestedPeriods (2);    const int p2   = getRequestedPeriods();
 
-        record ("Periods clamping - low (1)",     p1   == 2,
-                 juce::String::formatted ("got %d", p1));
-        record ("Periods clamping - lower (0)",   p0   == 2,
-                 juce::String::formatted ("got %d", p0));
-        record ("Periods clamping - negative",    pNeg == 2,
-                 juce::String::formatted ("got %d", pNeg));
-        record ("Periods clamping - high (99)",   p99  == 16,
-                 juce::String::formatted ("got %d", p99));
-        record ("Periods clamping - in-range (8)",p8   == 8,
-                 juce::String::formatted ("got %d", p8));
-        record ("Periods clamping - in-range (2)",p2   == 2,
-                 juce::String::formatted ("got %d", p2));
+        record ("Periods clamping - low (1)",     p1   == 2, dusk::text::format ("got %d", p1));
+        record ("Periods clamping - lower (0)",   p0   == 2, dusk::text::format ("got %d", p0));
+        record ("Periods clamping - negative",    pNeg == 2, dusk::text::format ("got %d", pNeg));
+        record ("Periods clamping - high (99)",   p99  == 16, dusk::text::format ("got %d", p99));
+        record ("Periods clamping - in-range (8)",p8   == 8, dusk::text::format ("got %d", p8));
+        record ("Periods clamping - in-range (2)",p2   == 2, dusk::text::format ("got %d", p2));
     }
 
-    juce::StringArray header;
-    header.add ("--- ALSA Backend Self-Test (no hardware) ---");
-    header.add (juce::String::formatted ("  Total: %d passed, %d failed", passed, failed));
-    header.add ("");
-    return header.joinIntoString ("\n") + "\n" + report.joinIntoString ("\n");
+    std::vector<std::string> header;
+    header.push_back ("--- ALSA Backend Self-Test (no hardware) ---");
+    header.push_back (dusk::text::format ("  Total: %d passed, %d failed", passed, failed));
+    header.push_back ("");
+    return dusk::text::joinIntoString (header, "\n") + "\n" + dusk::text::joinIntoString (report, "\n");
 }
 
 } // namespace duskstudio

--- a/src/engine/alsa/AlsaAudioIODevice.h
+++ b/src/engine/alsa/AlsaAudioIODevice.h
@@ -1,16 +1,26 @@
 #pragma once
 
-#include <juce_audio_devices/juce_audio_devices.h>
-#include <juce_core/juce_core.h>
+#include "../device/ChannelSet.h"
+#include "../device/IODevice.h"
+#include "../device/IODeviceCallback.h"
+#include "../../foundation/AutoResetEvent.h"
+
 #include <alsa/asoundlib.h>
+
 #include <atomic>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
 
 namespace duskstudio
 {
 // Dusk Studio-owned ALSA audio I/O. One instance per open device pair (a playback
-// PCM, a capture PCM, or both linked together). Implements juce::AudioIODevice
-// so the rest of Dusk Studio (AudioDeviceManager, AudioDeviceSelectorComponent,
-// AudioEngine's callback) can use it interchangeably with the JACK backend.
+// PCM, a capture PCM, or both linked together). Implements device::IODevice
+// so the rest of Dusk Studio (DeviceManager, the selector UI, AudioEngine's
+// callback) can use it interchangeably with the PipeWire backend.
 //
 // Design choices, for new readers:
 //   - Raw `hw:CARD,DEV` PCMs only. No `plug:`/`default:`/`front:` aliases -
@@ -27,56 +37,58 @@ namespace duskstudio
 //     = buffer_size, no silence-fill override. Underrun stops the device,
 //     recovery restarts it cleanly. The xrun counter is surfaced to the UI
 //     so the user knows.
-//   - Open at the device's reported max channel count; map JUCE's active-
+//   - Open at the device's reported max channel count; map the active-
 //     channel mask to per-channel float buffers; zero inactive slots in the
 //     interleaved frame.
-//   - SCHED_RR I/O thread, priority sized below RLIMIT_RTPRIO so
-//     pthread_create won't EPERM. mlockall() is done once at app start.
+//   - SCHED_RR I/O thread (std::thread, self-promoted via rt::applyRealtimeSchedRR),
+//     priority sized below RLIMIT_RTPRIO so the kernel won't EPERM. mlockall()
+//     is done once at app start.
 //
 // Patterns referenced from Ardour's libs/backends/alsa/zita-alsa-pcmi.cc
 // (study only, no copied code).
-class AlsaAudioIODevice final : public juce::AudioIODevice,
-                                  private juce::Thread
+class AlsaAudioIODevice final : public device::IODevice
 {
 public:
-    AlsaAudioIODevice (const juce::String& deviceName,
-                       const juce::String& inputId,
-                       const juce::String& outputId);
+    AlsaAudioIODevice (const std::string& deviceName,
+                       const std::string& inputId,
+                       const std::string& outputId);
     ~AlsaAudioIODevice() override;
 
-    // Identifiers used by the AudioIODeviceType to look up this instance.
-    const juce::String inputId, outputId;
+    // Identifiers used by the IODeviceType to look up this instance.
+    const std::string inputId, outputId;
 
-    // juce::AudioIODevice ------------------------------------------------------
-    juce::StringArray  getOutputChannelNames() override;
-    juce::StringArray  getInputChannelNames()  override;
-    juce::Array<double> getAvailableSampleRates() override;
-    juce::Array<int>    getAvailableBufferSizes() override;
+    // device::IODevice ---------------------------------------------------------
+    std::string getName() const override                      { return displayName; }
+
+    std::vector<std::string> getOutputChannelNames() override;
+    std::vector<std::string> getInputChannelNames()  override;
+    std::vector<double> getAvailableSampleRates() override;
+    std::vector<int>    getAvailableBufferSizes() override;
     int                 getDefaultBufferSize()    override;
 
-    juce::String open (const juce::BigInteger& inputChannels,
-                        const juce::BigInteger& outputChannels,
-                        double sampleRate, int bufferSizeSamples) override;
+    std::string open (const device::ChannelSet& inputChannels,
+                      const device::ChannelSet& outputChannels,
+                      double sampleRate, int bufferSizeSamples) override;
     void  close()  override;
     bool  isOpen() override                                   { return isDeviceOpen.load (std::memory_order_acquire); }
 
-    void  start (juce::AudioIODeviceCallback* newCallback) override;
+    void  start (device::IODeviceCallback* newCallback) override;
     void  stop() override;
     bool  isPlaying() override                                { return isStarted.load (std::memory_order_acquire); }
 
-    juce::String getLastError() override                       { return lastError; }
+    std::string getLastError() override                       { return lastError; }
 
-    int    getCurrentBufferSizeSamples() override              { return periodSize; }
-    double getCurrentSampleRate()        override              { return openedSampleRate; }
-    int    getCurrentBitDepth()          override              { return openedBitDepth; }
+    int    getCurrentBufferSizeSamples() override             { return periodSize; }
+    double getCurrentSampleRate()        override             { return openedSampleRate; }
+    int    getCurrentBitDepth()          override             { return openedBitDepth; }
 
-    juce::BigInteger getActiveOutputChannels() const override  { return currentOutputChannels; }
-    juce::BigInteger getActiveInputChannels()  const override  { return currentInputChannels; }
+    device::ChannelSet getActiveOutputChannels() const override { return currentOutputChannels; }
+    device::ChannelSet getActiveInputChannels()  const override { return currentInputChannels; }
 
-    int getOutputLatencyInSamples() override                   { return outputLatency; }
-    int getInputLatencyInSamples()  override                   { return inputLatency; }
+    int getOutputLatencyInSamples() override                  { return outputLatency; }
+    int getInputLatencyInSamples()  override                  { return inputLatency; }
 
-    int getXRunCount() const noexcept override                 { return xrunCount.load (std::memory_order_relaxed); }
+    int getXRunCount() const noexcept override                { return xrunCount.load (std::memory_order_relaxed); }
 
     // Periods-per-buffer override. Reads as the value that will be used on
     // the NEXT open(). Default 2 (Ardour-style; the lowest value that gives
@@ -94,10 +106,29 @@ public:
     // alongside the engine pipeline tests, so DUSKSTUDIO_RUN_SELFTEST=1 picks
     // it up. Real-device opens are covered by the existing backend cycle
     // section of AudioPipelineSelfTest, not here.
-    static juce::String runSelfTest();
+    static std::string runSelfTest();
+
+    // Wedged-thread abandonment. stop() gives the I/O thread 2000 ms to exit;
+    // on timeout it detaches the thread and marks this device abandoned. The
+    // detached thread still dereferences all of this object (PCM handles,
+    // mutex, scratch, the exit flag and event), so an abandoned device must be
+    // leaked, never destroyed - owners route destruction through destroyOrPark,
+    // which parks an abandoned device in a process-lifetime holder instead of
+    // running its destructor. A destructor that runs while the thread is live
+    // is a use-after-free.
+    bool ioThreadWasAbandoned() const noexcept                { return threadAbandoned.load (std::memory_order_acquire); }
+    static void destroyOrPark (std::unique_ptr<AlsaAudioIODevice> dev);
+    static int  abandonedCount() noexcept;
+
+    // Test-only: launch the I/O thread with `body` in place of the real loop
+    // and arm the stop() join machinery, so the timed-join/abandon path is
+    // testable without hardware. The body must signal the event as its last
+    // statement (the real thread's contract).
+    void startThreadForTest (std::function<void (std::atomic<bool>& shouldExit,
+                                                 dusk::AutoResetEvent& exited)> body);
 
 private:
-    void run() override;  // SCHED_RR I/O thread
+    void ioThreadRun();  // SCHED_RR I/O thread body
 
     // hw_params + sw_params negotiation. Caller passes the requested values;
     // these may be modified by the kernel's "near" snapping. Returns true
@@ -109,7 +140,7 @@ private:
                         unsigned int& periods,
                         int& bytesPerSample, bool& sampleIsFloat);
 
-    bool openOneHandle (const juce::String& id, bool isCapture, snd_pcm_t*& handle);
+    bool openOneHandle (const std::string& id, bool isCapture, snd_pcm_t*& handle);
 
     // Recover from an EPIPE / ESTRPIPE / EBADFD; bumps xrunCount. Returns
     // 0 on successful recovery, the original errno on failure. On success it
@@ -125,27 +156,27 @@ private:
     // Convert one period's worth of float samples to the negotiated sample
     // type, interleaved across all device channels. Inactive channels are
     // zero-filled. The reverse for capture.
-    void interleavePlaybackBlock (const juce::AudioBuffer<float>& src,
+    void interleavePlaybackBlock (const float* const* src,
                                    void* destInterleaved, int numFrames) const;
     void deinterleaveCaptureBlock (const void* srcInterleaved,
-                                    juce::AudioBuffer<float>& dest, int numFrames) const;
+                                    float* const* dest, int numFrames) const;
 
     // Capability cache populated lazily on first sample-rate / buffer-size
     // query (or open()). Avoids re-probing the device for every UI redraw.
-    // Message-thread only: callers are JUCE's channel-name / rate / buffer
-    // queries and open(), all driven from AudioDeviceManager. The cached
-    // members below are not synchronised; do not call from the I/O thread.
+    // Message-thread only: callers are the manager's channel-name / rate /
+    // buffer queries and open(). The cached members below are not
+    // synchronised; do not call from the I/O thread.
     void probeIfNeeded();
 
     // State ---------------------------------------------------------------
-    const juce::String displayName;
+    const std::string displayName;
 
     // Capability cache (probed once, cleared on close).
     bool                hasProbed         = false;
     unsigned int        deviceMaxOutChannels = 0;
     unsigned int        deviceMaxInChannels  = 0;
-    juce::Array<double> supportedSampleRates;
-    juce::Array<int>    supportedBufferSizes;
+    std::vector<double> supportedSampleRates;
+    std::vector<int>    supportedBufferSizes;
 
     // Negotiated values from the most recent successful open().
     snd_pcm_t* outHandle = nullptr;
@@ -162,32 +193,41 @@ private:
     int        outputLatency     = 0;
     int        inputLatency      = 0;
 
-    juce::BigInteger currentOutputChannels, currentInputChannels;
-    juce::Array<int> activeOutDeviceChannelIndex; // active-callback-i -> device-ch-j
-    juce::Array<int> activeInDeviceChannelIndex;
+    device::ChannelSet currentOutputChannels, currentInputChannels;
+    std::vector<int> activeOutDeviceChannelIndex; // active-callback-i -> device-ch-j
+    std::vector<int> activeInDeviceChannelIndex;
 
     // Per-period scratch (allocated on open, never reallocated on the audio
     // thread).
-    juce::HeapBlock<char>     interleavedOutBytes;
-    juce::HeapBlock<char>     interleavedInBytes;
+    std::vector<char> interleavedOutBytes;
+    std::vector<char> interleavedInBytes;
     // periodSize * periodsCount frames of zeroed output bytes, pre-allocated at
     // open so rearmStream can refill the playback ring without allocating on
     // the audio thread.
-    juce::HeapBlock<char>     silencePrefill;
-    juce::AudioBuffer<float>  callbackOutFloats;  // sized [numChannelsActive, periodSize]
-    juce::AudioBuffer<float>  callbackInFloats;
-    juce::Array<float*>       callbackOutPointers;
-    juce::Array<const float*> callbackInPointers;
+    std::vector<char> silencePrefill;
+    // Planar float scratch the callback reads/writes, one periodSize run per
+    // active channel; the pointer arrays index into these stores.
+    std::vector<float>        callbackOutStore;
+    std::vector<float>        callbackInStore;
+    std::vector<float*>       callbackOutPointers;
+    std::vector<float*>       callbackInWritePointers;  // deinterleave target
+    std::vector<const float*> callbackInPointers;       // callback view of the same store
 
-    juce::CriticalSection callbackLock;
-    juce::AudioIODeviceCallback* callback = nullptr;
+    std::mutex callbackLock;
+    device::IODeviceCallback* callback = nullptr;
+
+    std::thread          ioThread;
+    std::atomic<bool>    ioShouldExit { false };
+    dusk::AutoResetEvent ioExited;
+    std::atomic<bool>    threadAbandoned { false };
 
     std::atomic<bool> isDeviceOpen { false };
     std::atomic<bool> isStarted    { false };
     std::atomic<int>  xrunCount    { 0 };
 
-    juce::String lastError;
+    std::string lastError;
 
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (AlsaAudioIODevice)
+    AlsaAudioIODevice (const AlsaAudioIODevice&) = delete;
+    AlsaAudioIODevice& operator= (const AlsaAudioIODevice&) = delete;
 };
 } // namespace duskstudio

--- a/src/engine/alsa/AlsaAudioIODevice.h
+++ b/src/engine/alsa/AlsaAudioIODevice.h
@@ -91,9 +91,9 @@ public:
     int getXRunCount() const noexcept override                { return xrunCount.load (std::memory_order_relaxed); }
 
     // Periods-per-buffer override. Reads as the value that will be used on
-    // the NEXT open(). Default 2 (Ardour-style; the lowest value that gives
-    // the kernel any slack and is the lowest-latency setting that's stable
-    // on most modern interfaces). Range clamped to [2, 16].
+    // the NEXT open(). Default 3 (matches PipeWire/JACK's internal headroom so
+    // the out-of-box ALSA experience doesn't xrun; 2 is the lowest-latency
+    // stable setting for users who opt down). Range clamped to [2, 16].
     static void setRequestedPeriods (int p) noexcept;
     static int  getRequestedPeriods() noexcept;
 

--- a/src/engine/alsa/AlsaAudioIODeviceType.cpp
+++ b/src/engine/alsa/AlsaAudioIODeviceType.cpp
@@ -1,14 +1,95 @@
 #include "AlsaAudioIODeviceType.h"
 #include "AlsaAudioIODevice.h"
 
+#include "../../foundation/Text.h"
+
 #include <alsa/asoundlib.h>
+
+#include <cassert>
 
 namespace duskstudio
 {
-AlsaAudioIODeviceType::AlsaAudioIODeviceType()
-    : juce::AudioIODeviceType ("ALSA")
+namespace
 {
+int indexOfString (const std::vector<std::string>& v, const std::string& s)
+{
+    for (int i = 0; i < (int) v.size(); ++i)
+        if (v[(size_t) i] == s) return i;
+    return -1;
 }
+
+// Disambiguate duplicate device labels: exact (case-sensitive) duplicates get
+// " (1)", " (2)", ... suffixes, the first instance numbered too, so the dropdown
+// never shows two identical names.
+void appendNumbersToDuplicates (std::vector<std::string>& names)
+{
+    auto findFrom = [&names] (const std::string& target, int startIndex) -> int
+    {
+        for (int j = startIndex; j < (int) names.size(); ++j)
+            if (names[(size_t) j] == target) return j;
+        return -1;
+    };
+    for (int i = 0; i + 1 < (int) names.size(); ++i)
+    {
+        int nextIndex = findFrom (names[(size_t) i], i + 1);
+        if (nextIndex < 0) continue;
+        const std::string original = names[(size_t) i];
+        int number = 0;
+        names[(size_t) i] = original + " (" + std::to_string (++number) + ")";
+        while (nextIndex >= 0)
+        {
+            names[(size_t) nextIndex] = names[(size_t) nextIndex] + " (" + std::to_string (++number) + ")";
+            nextIndex = findFrom (original, nextIndex + 1);
+        }
+    }
+}
+
+// Owning handle createDevice hands to the manager. Destruction routes through
+// destroyOrPark: a device whose I/O thread was abandoned (wedged past the timed
+// join in stop()) is leaked into a process-lifetime holder instead of destroyed
+// - the detached thread still dereferences the whole device.
+class AlsaDeviceHandle final : public device::IODevice
+{
+public:
+    explicit AlsaDeviceHandle (std::unique_ptr<AlsaAudioIODevice> d) noexcept : dev (std::move (d)) {}
+    ~AlsaDeviceHandle() override
+    {
+        dev->close();
+        AlsaAudioIODevice::destroyOrPark (std::move (dev));
+    }
+
+    AlsaAudioIODevice* inner() const noexcept { return dev.get(); }
+
+    std::string getName() const override                        { return dev->getName(); }
+    std::vector<std::string> getOutputChannelNames() override   { return dev->getOutputChannelNames(); }
+    std::vector<std::string> getInputChannelNames() override    { return dev->getInputChannelNames(); }
+    std::vector<double> getAvailableSampleRates() override      { return dev->getAvailableSampleRates(); }
+    std::vector<int> getAvailableBufferSizes() override         { return dev->getAvailableBufferSizes(); }
+    int getDefaultBufferSize() override                         { return dev->getDefaultBufferSize(); }
+
+    std::string open (const device::ChannelSet& in, const device::ChannelSet& out,
+                      double sr, int bs) override               { return dev->open (in, out, sr, bs); }
+    void close() override                                       { dev->close(); }
+    bool isOpen() override                                      { return dev->isOpen(); }
+
+    void start (device::IODeviceCallback* cb) override          { dev->start (cb); }
+    void stop() override                                        { dev->stop(); }
+    bool isPlaying() override                                   { return dev->isPlaying(); }
+
+    std::string getLastError() override                         { return dev->getLastError(); }
+    int    getCurrentBufferSizeSamples() override               { return dev->getCurrentBufferSizeSamples(); }
+    double getCurrentSampleRate() override                      { return dev->getCurrentSampleRate(); }
+    int    getCurrentBitDepth() override                        { return dev->getCurrentBitDepth(); }
+    device::ChannelSet getActiveOutputChannels() const override { return dev->getActiveOutputChannels(); }
+    device::ChannelSet getActiveInputChannels() const override  { return dev->getActiveInputChannels(); }
+    int getOutputLatencyInSamples() override                    { return dev->getOutputLatencyInSamples(); }
+    int getInputLatencyInSamples() override                     { return dev->getInputLatencyInSamples(); }
+    int getXRunCount() const noexcept override                  { return dev->getXRunCount(); }
+
+private:
+    std::unique_ptr<AlsaAudioIODevice> dev;
+};
+} // namespace
 
 void AlsaAudioIODeviceType::scanForDevices()
 {
@@ -27,10 +108,10 @@ void AlsaAudioIODeviceType::scanForDevices()
         if (snd_card_next (&cardNum) < 0 || cardNum < 0)
             break;
 
-        const auto cardCtlId = juce::String ("hw:") + juce::String (cardNum);
+        const auto cardCtlId = "hw:" + std::to_string (cardNum);
 
         snd_ctl_t* ctl = nullptr;
-        if (snd_ctl_open (&ctl, cardCtlId.toRawUTF8(), SND_CTL_NONBLOCK) < 0)
+        if (snd_ctl_open (&ctl, cardCtlId.c_str(), SND_CTL_NONBLOCK) < 0)
             continue;
 
         if (snd_ctl_card_info (ctl, cardInfo) < 0)
@@ -42,10 +123,10 @@ void AlsaAudioIODeviceType::scanForDevices()
         // Card "id" is the symbolic short name (e.g. "UMC1820") used for the
         // hw: PCM identifier; "name" is the human-readable form (e.g.
         // "UMC1820, USB Audio") shown in the UI dropdown.
-        juce::String cardSym (snd_ctl_card_info_get_id   (cardInfo));
-        juce::String cardName (snd_ctl_card_info_get_name (cardInfo));
-        if (cardSym.isEmpty())  cardSym  = juce::String (cardNum);
-        if (cardName.isEmpty()) cardName = cardSym;
+        std::string cardSym (snd_ctl_card_info_get_id   (cardInfo));
+        std::string cardName (snd_ctl_card_info_get_name (cardInfo));
+        if (cardSym.empty())  cardSym  = std::to_string (cardNum);
+        if (cardName.empty()) cardName = cardSym;
 
         snd_pcm_info_t* pcmInfo = nullptr;
         snd_pcm_info_alloca (&pcmInfo);
@@ -62,55 +143,55 @@ void AlsaAudioIODeviceType::scanForDevices()
             // Capture name from the FIRST successful query - pcmInfo is
             // mutated by snd_ctl_pcm_info and may be left in an undefined
             // state if a subsequent stream-direction query fails.
-            juce::String pcmName;
+            std::string pcmName;
 
             snd_pcm_info_set_stream (pcmInfo, SND_PCM_STREAM_CAPTURE);
             const bool isInput = (snd_ctl_pcm_info (ctl, pcmInfo) >= 0);
             if (isInput)
-                pcmName = juce::String (snd_pcm_info_get_name (pcmInfo));
+                pcmName = snd_pcm_info_get_name (pcmInfo);
 
             snd_pcm_info_set_stream (pcmInfo, SND_PCM_STREAM_PLAYBACK);
             const bool isOutput = (snd_ctl_pcm_info (ctl, pcmInfo) >= 0);
-            if (isOutput && pcmName.isEmpty())
-                pcmName = juce::String (snd_pcm_info_get_name (pcmInfo));
+            if (isOutput && pcmName.empty())
+                pcmName = snd_pcm_info_get_name (pcmInfo);
 
             if (! (isInput || isOutput))
                 continue;
 
-            const juce::String id   = juce::String ("hw:") + cardSym + "," + juce::String (device);
-            const juce::String name = pcmName.isEmpty() ? cardName
-                                                         : (cardName + ", " + pcmName);
+            const std::string id   = "hw:" + cardSym + "," + std::to_string (device);
+            const std::string name = pcmName.empty() ? cardName
+                                                     : (cardName + ", " + pcmName);
 
             if (isInput)
             {
-                inputNames.add (name);
-                inputIds.add   (id);
+                inputNames.push_back (name);
+                inputIds.push_back   (id);
             }
             if (isOutput)
             {
-                outputNames.add (name);
-                outputIds.add   (id);
+                outputNames.push_back (name);
+                outputIds.push_back   (id);
             }
         }
 
         snd_ctl_close (ctl);
     }
 
-    inputNames.appendNumbersToDuplicates  (false, true);
-    outputNames.appendNumbersToDuplicates (false, true);
+    appendNumbersToDuplicates (inputNames);
+    appendNumbersToDuplicates (outputNames);
 
     hasScanned = true;
 }
 
-juce::StringArray AlsaAudioIODeviceType::getDeviceNames (bool wantInputNames) const
+std::vector<std::string> AlsaAudioIODeviceType::getDeviceNames (bool wantInputNames) const
 {
-    jassert (hasScanned);
+    assert (hasScanned);
     return wantInputNames ? inputNames : outputNames;
 }
 
 int AlsaAudioIODeviceType::getDefaultDeviceIndex (bool forInput) const
 {
-    jassert (hasScanned);
+    assert (hasScanned);
 
     // Heuristic: prefer the first device that doesn't look like a built-in
     // motherboard codec, an HDMI output, or a webcam. Most users running
@@ -120,59 +201,48 @@ int AlsaAudioIODeviceType::getDefaultDeviceIndex (bool forInput) const
     // exact "doesn't work out of the box" experience we want to avoid.
     //
     // This only matters on first launch and after a saved device name no
-    // longer resolves; once the user's selection is persisted via JUCE's
-    // AudioDeviceManager state, that takes precedence.
+    // longer resolves; once the user's selection is persisted via the
+    // DeviceManager state blob, that takes precedence.
     const auto& names = forInput ? inputNames : outputNames;
-    for (int i = 0; i < names.size(); ++i)
+    for (int i = 0; i < (int) names.size(); ++i)
     {
-        const auto& n = names[i];
-        if (n.startsWithIgnoreCase ("HDA "))             continue;
-        if (n.containsIgnoreCase ("HDMI"))               continue;
-        if (forInput && n.containsIgnoreCase ("Webcam")) continue;
+        const auto& n = names[(size_t) i];
+        if (dusk::text::startsWith (dusk::text::toUpperCase (n), "HDA "))    continue;
+        if (dusk::text::containsIgnoreCase (n, "HDMI"))                      continue;
+        if (forInput && dusk::text::containsIgnoreCase (n, "Webcam"))        continue;
         return i;
     }
 
     // Only built-in / unwanted devices are present - fall back to the
     // first entry rather than returning -1, so the dialog still opens
     // something rather than refusing to enumerate.
-    return names.isEmpty() ? -1 : 0;
+    return names.empty() ? -1 : 0;
 }
 
-int AlsaAudioIODeviceType::getIndexOfDevice (juce::AudioIODevice* device, bool asInput) const
+int AlsaAudioIODeviceType::getIndexOfDevice (device::IODevice* dev, bool asInput) const
 {
-    jassert (hasScanned);
-    if (auto* alsa = dynamic_cast<AlsaAudioIODevice*> (device))
-        return (asInput ? inputIds : outputIds).indexOf (asInput ? alsa->inputId : alsa->outputId);
+    assert (hasScanned);
+    if (auto* handle = dynamic_cast<AlsaDeviceHandle*> (dev))
+        return indexOfString (asInput ? inputIds : outputIds,
+                              asInput ? handle->inner()->inputId : handle->inner()->outputId);
     return -1;
 }
 
-juce::AudioIODevice* AlsaAudioIODeviceType::createDevice (const juce::String& outputDeviceName,
-                                                            const juce::String& inputDeviceName)
+std::unique_ptr<device::IODevice> AlsaAudioIODeviceType::createDevice (const std::string& outputDeviceName,
+                                                                       const std::string& inputDeviceName)
 {
-    jassert (hasScanned);
-    const int outIdx = outputNames.indexOf (outputDeviceName);
-    const int inIdx  = inputNames .indexOf (inputDeviceName);
+    assert (hasScanned);
+    const int outIdx = indexOfString (outputNames, outputDeviceName);
+    const int inIdx  = indexOfString (inputNames,  inputDeviceName);
 
     if (outIdx < 0 && inIdx < 0)
         return nullptr;
 
-    const juce::String outId = outIdx >= 0 ? outputIds[outIdx] : juce::String();
-    const juce::String inId  = inIdx  >= 0 ? inputIds [inIdx]  : juce::String();
-    const juce::String name  = outIdx >= 0 ? outputDeviceName : inputDeviceName;
+    const std::string outId = outIdx >= 0 ? outputIds[(size_t) outIdx] : std::string();
+    const std::string inId  = inIdx  >= 0 ? inputIds [(size_t) inIdx]  : std::string();
+    const std::string name  = outIdx >= 0 ? outputDeviceName : inputDeviceName;
 
-    return new AlsaAudioIODevice (name, inId, outId);
-}
-
-void AlsaAudioIODeviceType::rescan()
-{
-    // scanForDevices() was tweaked earlier to drop its hasScanned early-
-    // return so a second call does pick up freshly-plugged hw: devices.
-    // After repopulating, fire the inherited listener notification so
-    // JUCE's AudioDeviceSelectorComponent re-queries getDeviceNames()
-    // and rebuilds its Output/Input combos. Without the listener call,
-    // the new device list sits in our arrays but the dropdown stays
-    // stale until the user closes and reopens the dialog.
-    scanForDevices();
-    callDeviceChangeListeners();
+    return std::make_unique<AlsaDeviceHandle> (
+        std::make_unique<AlsaAudioIODevice> (name, inId, outId));
 }
 } // namespace duskstudio

--- a/src/engine/alsa/AlsaAudioIODeviceType.h
+++ b/src/engine/alsa/AlsaAudioIODeviceType.h
@@ -1,6 +1,10 @@
 #pragma once
 
-#include <juce_audio_devices/juce_audio_devices.h>
+#include "../device/IODeviceType.h"
+
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace duskstudio
 {
@@ -10,33 +14,25 @@ namespace duskstudio
 // the result that "raw hardware" is anything but. The hw: PCMs talk directly
 // to the kernel ALSA driver, the same path Ardour uses.
 //
-// The actual I/O loop lives in AlsaAudioIODevice (Phase 2), wrapping
-// zita-alsa-pcmi (vendored from Ardour). This type is just the factory and
-// enumeration glue.
-class AlsaAudioIODeviceType final : public juce::AudioIODeviceType
+// The actual I/O loop lives in AlsaAudioIODevice. This type is just the factory
+// and enumeration glue; createDevice wraps each device in a small owning handle
+// whose destructor routes through AlsaAudioIODevice::destroyOrPark, so a device
+// whose I/O thread wedged is leaked instead of destroyed under a live thread.
+class AlsaAudioIODeviceType final : public device::IODeviceType
 {
 public:
-    AlsaAudioIODeviceType();
+    std::string getTypeName() const override { return "ALSA"; }
 
-    void               scanForDevices() override;
-    juce::StringArray  getDeviceNames (bool wantInputNames) const override;
-    int                getDefaultDeviceIndex (bool forInput) const override;
-    int                getIndexOfDevice (juce::AudioIODevice* device, bool asInput) const override;
-    bool               hasSeparateInputsAndOutputs() const override { return true; }
-    juce::AudioIODevice* createDevice (const juce::String& outputDeviceName,
-                                        const juce::String& inputDeviceName) override;
-
-    // Re-run device enumeration and notify any registered listeners (which
-    // includes JUCE's AudioDeviceSelectorComponent, so the dropdown
-    // repopulates). The UI's Rescan button calls this after a USB
-    // plug/unplug.
-    void rescan();
+    void scanForDevices() override;
+    std::vector<std::string> getDeviceNames (bool wantInputNames) const override;
+    int  getDefaultDeviceIndex (bool forInput) const override;
+    int  getIndexOfDevice (device::IODevice* dev, bool asInput) const override;
+    std::unique_ptr<device::IODevice> createDevice (const std::string& outputDeviceName,
+                                                    const std::string& inputDeviceName) override;
 
 private:
-    juce::StringArray inputNames, outputNames;
-    juce::StringArray inputIds, outputIds;
+    std::vector<std::string> inputNames, outputNames;
+    std::vector<std::string> inputIds, outputIds;
     bool hasScanned = false;
-
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (AlsaAudioIODeviceType)
 };
 } // namespace duskstudio

--- a/src/engine/alsa/AlsaPerformanceTest.cpp
+++ b/src/engine/alsa/AlsaPerformanceTest.cpp
@@ -1,10 +1,18 @@
 #include "AlsaPerformanceTest.h"
 #include "AlsaAudioIODevice.h"
 
-#include <juce_audio_devices/juce_audio_devices.h>
+#include "../device/ChannelSet.h"
+#include "../device/IODeviceCallback.h"
+#include "../../foundation/Text.h"
+
 #include <algorithm>
 #include <atomic>
+#include <chrono>
+#include <cmath>
 #include <cstring>
+#include <ctime>
+#include <memory>
+#include <thread>
 #include <vector>
 
 namespace duskstudio
@@ -34,18 +42,23 @@ constexpr int kSampleBufferSize = 65536;
 constexpr double kP99WarningRatio = 0.70;
 constexpr double kP99FailureRatio = 0.90;
 
-class MeasuringCallback final : public juce::AudioIODeviceCallback
+using Clock = std::chrono::steady_clock;
+
+void sleepMs (int ms)
+{
+    std::this_thread::sleep_for (std::chrono::milliseconds (ms));
+}
+
+class MeasuringCallback final : public device::IODeviceCallback
 {
 public:
     explicit MeasuringCallback (int fakeLoadMicroseconds)
         : fakeLoadUs (fakeLoadMicroseconds)
     {
         samples.resize (kSampleBufferSize, 0.0);
-        const auto tps = juce::Time::getHighResolutionTicksPerSecond();
-        secondsPerTick = (tps > 0) ? 1.0 / (double) tps : 0.0;
     }
 
-    void audioDeviceAboutToStart (juce::AudioIODevice* dev) override
+    void audioDeviceAboutToStart (device::IODevice* dev) override
     {
         const auto sr = dev->getCurrentSampleRate();
         const auto bs = dev->getCurrentBufferSizeSamples();
@@ -55,24 +68,22 @@ public:
 
     void audioDeviceStopped() override {}
 
-    void audioDeviceIOCallbackWithContext (const float* const* /*inputChannelData*/,
-                                            int /*numInputChannels*/,
-                                            float* const* outputChannelData,
-                                            int numOutputChannels,
-                                            int numSamples,
-                                            const juce::AudioIODeviceCallbackContext&) override
+    void audioDeviceIOCallback (const float* const* /*inputChannelData*/,
+                                int /*numInputChannels*/,
+                                float* const* outputChannelData,
+                                int numOutputChannels,
+                                int numSamples,
+                                const device::CallbackContext&) override
     {
-        const auto t0 = juce::Time::getHighResolutionTicks();
+        const auto t0 = Clock::now();
 
         // Synthetic DSP load: busy-wait so the audio thread actually consumes
         // wall-clock time. Sleep would yield to the scheduler and produce
         // misleading "free" headroom.
         if (fakeLoadUs > 0)
         {
-            const auto budgetTicks = (std::int64_t) (((double) fakeLoadUs * 1.0e-6)
-                                                       / std::max (1.0e-12, secondsPerTick));
-            const auto deadline = t0 + budgetTicks;
-            while (juce::Time::getHighResolutionTicks() < deadline) { /* spin */ }
+            const auto deadline = t0 + std::chrono::microseconds (fakeLoadUs);
+            while (Clock::now() < deadline) { /* spin */ }
         }
 
         // Output silence. Tier 1 measures stability, not signal correctness;
@@ -82,8 +93,9 @@ public:
                 std::memset (outputChannelData[ch], 0,
                               sizeof (float) * (size_t) numSamples);
 
-        const auto t1 = juce::Time::getHighResolutionTicks();
-        const double elapsedMs = (double) (t1 - t0) * secondsPerTick * 1000.0;
+        const auto t1 = Clock::now();
+        const double elapsedMs =
+            std::chrono::duration<double, std::milli> (t1 - t0).count();
 
         const int idx = callbackCount.fetch_add (1, std::memory_order_relaxed);
         if (idx >= kWarmupCallbacks && (idx - kWarmupCallbacks) < kSampleBufferSize)
@@ -133,7 +145,6 @@ private:
     std::atomic<int>    callbackCount { 0 };
     int                 fakeLoadUs    = 0;
     double              budgetMs      = 0.0;
-    double              secondsPerTick = 0.0;
 };
 
 // Open + start an AlsaAudioIODevice in duplex mode. Both directions opened
@@ -141,20 +152,22 @@ private:
 // snd_pcm_link, readi, and the deinterleave path - the input data isn't
 // analyzed by the buffer-sweep callback, but going through the code paths
 // is what catches duplex-only bugs (link drift, capture xrun, deinterleave
-// stride). Caller owns the device, must stop+close.
-std::unique_ptr<AlsaAudioIODevice> openDuplex (const juce::String& deviceId,
+// stride). Caller owns the device, must stop+close and dispose through
+// AlsaAudioIODevice::destroyOrPark so a wedged I/O thread leaks the device
+// instead of racing its destructor.
+std::unique_ptr<AlsaAudioIODevice> openDuplex (const std::string& deviceId,
                                                   unsigned int sampleRate,
                                                   int          bufferSize,
-                                                  juce::AudioIODeviceCallback* callback,
-                                                  juce::String& errorOut)
+                                                  device::IODeviceCallback* callback,
+                                                  std::string& errorOut)
 {
     auto dev = std::make_unique<AlsaAudioIODevice> (deviceId, /*inId*/ deviceId, /*outId*/ deviceId);
-    juce::BigInteger outMask, inMask;
+    device::ChannelSet outMask, inMask;
     outMask.setRange (0, 2, true);  // bits 0 + 1 of output
     inMask .setRange (0, 2, true);  // bits 0 + 1 of input
 
     const auto err = dev->open (inMask, outMask, (double) sampleRate, bufferSize);
-    if (err.isNotEmpty())
+    if (! err.empty())
     {
         errorOut = err;
         return nullptr;
@@ -163,7 +176,7 @@ std::unique_ptr<AlsaAudioIODevice> openDuplex (const juce::String& deviceId,
     return dev;
 }
 
-juce::String formatVerdict (int xruns, double p99, double budget)
+std::string formatVerdict (int xruns, double p99, double budget)
 {
     if (xruns > 0)                                  return "UNSAFE (xruns)";
     if (budget <= 0.0 || p99 <= 0.0)                return "?";
@@ -172,64 +185,62 @@ juce::String formatVerdict (int xruns, double p99, double budget)
     return "SAFE";
 }
 
-juce::String formatTableRow (const AlsaPerformanceTest::Result& r)
+std::string formatTableRow (const AlsaPerformanceTest::Result& r)
 {
     auto fmt = [] (double v)
     {
-        if (v <= 0.0) return juce::String ("    -  ");
-        return juce::String::formatted ("%6.3f ms", v);
+        if (v <= 0.0) return std::string ("    -  ");
+        return dusk::text::format ("%6.3f ms", v);
     };
-    auto bufFromCfg = [] (const juce::String& cfg)
+    auto bufFromCfg = [] (const std::string& cfg)
     {
-        return cfg.fromFirstOccurrenceOf ("buf=", false, false)
-                  .upToFirstOccurrenceOf (" ", false, false);
+        return dusk::text::upToFirstOccurrenceOf (
+                   dusk::text::fromFirstOccurrenceOf (cfg, "buf=", false), " ", false);
     };
 
-    return juce::String::formatted (
+    return dusk::text::format (
         " %5s |  %s | %s | %s | %s | %s |    %4d   | %s",
-        bufFromCfg (r.configuration).toRawUTF8(),
-        fmt (r.budgetMs).toRawUTF8(),
-        fmt (r.meanCallbackMs).toRawUTF8(),
-        fmt (r.p95CallbackMs).toRawUTF8(),
-        fmt (r.p99CallbackMs).toRawUTF8(),
-        fmt (r.maxCallbackMs).toRawUTF8(),
+        bufFromCfg (r.configuration).c_str(),
+        fmt (r.budgetMs).c_str(),
+        fmt (r.meanCallbackMs).c_str(),
+        fmt (r.p95CallbackMs).c_str(),
+        fmt (r.p99CallbackMs).c_str(),
+        fmt (r.maxCallbackMs).c_str(),
         r.xruns,
-        r.verdict.toRawUTF8());
+        r.verdict.c_str());
 }
 } // namespace
 
-juce::Array<AlsaPerformanceTest::Result>
+std::vector<AlsaPerformanceTest::Result>
 AlsaPerformanceTest::runBufferSweep (const Options& opts)
 {
-    juce::Array<int> sizes = opts.bufferSizes;
-    if (sizes.isEmpty())
-        for (int b : kDefaultBufferLadder) sizes.add (b);
+    std::vector<int> sizes = opts.bufferSizes;
+    if (sizes.empty())
+        for (int b : kDefaultBufferLadder) sizes.push_back (b);
 
     // Sort + dedupe so the "first SAFE/MARGINAL row in the results = minimum
     // stable buffer" invariant holds for runAll's recommended-min picker.
     // The default ladder above is already tidy; an opts.bufferSizes supplied
     // by a programmatic caller (or a future env-var path) might not be.
-    sizes.sort();
-    for (int i = sizes.size() - 1; i > 0; --i)
-        if (sizes.getUnchecked (i) == sizes.getUnchecked (i - 1))
-            sizes.remove (i);
+    std::sort (sizes.begin(), sizes.end());
+    sizes.erase (std::unique (sizes.begin(), sizes.end()), sizes.end());
 
-    juce::Array<Result> results;
+    std::vector<Result> results;
     for (int bs : sizes)
     {
         Result r;
         r.testName      = "buffer sweep";
-        r.configuration = juce::String::formatted ("buf=%d rate=%u", bs, opts.sampleRate);
+        r.configuration = dusk::text::format ("buf=%d rate=%u", bs, opts.sampleRate);
 
         MeasuringCallback cb (opts.fakeDspLoadUs);
-        juce::String openErr;
+        std::string openErr;
         auto dev = openDuplex (opts.deviceId, opts.sampleRate, bs, &cb, openErr);
         if (dev == nullptr)
         {
             r.passed   = false;
             r.verdict  = "FAIL (open)";
             r.details  = openErr;
-            results.add (r);
+            results.push_back (r);
             continue;
         }
 
@@ -238,15 +249,16 @@ AlsaPerformanceTest::runBufferSweep (const Options& opts)
         // different bit depth (e.g. capture S32_LE / playback S24_3LE on
         // class-compliant USB).
         r.negotiatedBitDepth  = dev->getCurrentBitDepth();
-        r.activeOutChannels   = dev->getActiveOutputChannels().countNumberOfSetBits();
-        r.activeInChannels    = dev->getActiveInputChannels() .countNumberOfSetBits();
+        r.activeOutChannels   = dev->getActiveOutputChannels().count();
+        r.activeInChannels    = dev->getActiveInputChannels() .count();
 
-        juce::Thread::sleep (opts.durationMs);
+        sleepMs (opts.durationMs);
 
         dev->stop();
         const int xruns = dev->getXRunCount();
         const auto stats = cb.computeStats();
         dev->close();
+        AlsaAudioIODevice::destroyOrPark (std::move (dev));
 
         r.xruns           = xruns;
         r.budgetMs        = cb.getBudgetMs();
@@ -257,7 +269,7 @@ AlsaPerformanceTest::runBufferSweep (const Options& opts)
         r.callbackCount   = stats.n;
         r.verdict         = formatVerdict (xruns, stats.p99, r.budgetMs);
         r.passed          = r.verdict == "SAFE" || r.verdict == "MARGINAL";
-        results.add (r);
+        results.push_back (r);
     }
 
     return results;
@@ -268,24 +280,24 @@ AlsaPerformanceTest::runOpenCloseStress (const Options& opts)
 {
     Result r;
     r.testName = "open/close cycle stress";
-    r.configuration = juce::String::formatted ("cycles=%d", opts.openCloseCycles);
+    r.configuration = dusk::text::format ("cycles=%d", opts.openCloseCycles);
 
     int failures = 0;
-    juce::String firstFailure;
+    std::string firstFailure;
 
     for (int i = 0; i < opts.openCloseCycles; ++i)
     {
         AlsaAudioIODevice dev (opts.deviceId, /*inId*/ opts.deviceId, /*outId*/ opts.deviceId);
-        juce::BigInteger outMask, inMask;
+        device::ChannelSet outMask, inMask;
         outMask.setRange (0, 2, true);
         inMask .setRange (0, 2, true);
 
         const auto err = dev.open (inMask, outMask, (double) opts.sampleRate, 1024);
-        if (err.isNotEmpty())
+        if (! err.empty())
         {
             ++failures;
-            if (firstFailure.isEmpty())
-                firstFailure = juce::String::formatted ("cycle %d: ", i) + err;
+            if (firstFailure.empty())
+                firstFailure = dusk::text::format ("cycle %d: ", i) + err;
             continue;
         }
         // No start/stop - just immediate close. Tests the unstart-then-close
@@ -294,8 +306,9 @@ AlsaPerformanceTest::runOpenCloseStress (const Options& opts)
     }
 
     r.passed  = failures == 0;
-    r.verdict = failures == 0 ? "SAFE" : juce::String::formatted ("UNSAFE (%d/%d failed)",
-                                                                     failures, opts.openCloseCycles);
+    r.verdict = failures == 0 ? std::string ("SAFE")
+                              : dusk::text::format ("UNSAFE (%d/%d failed)",
+                                                    failures, opts.openCloseCycles);
     r.details = firstFailure;
     return r;
 }
@@ -305,15 +318,15 @@ AlsaPerformanceTest::runStartStopRace (const Options& opts)
 {
     Result r;
     r.testName = "start/stop race";
-    r.configuration = juce::String::formatted ("cycles=%d", opts.startStopCycles);
+    r.configuration = dusk::text::format ("cycles=%d", opts.startStopCycles);
 
-    AlsaAudioIODevice dev (opts.deviceId, /*inId*/ opts.deviceId, /*outId*/ opts.deviceId);
-    juce::BigInteger outMask, inMask;
+    auto dev = std::make_unique<AlsaAudioIODevice> (opts.deviceId, /*inId*/ opts.deviceId, /*outId*/ opts.deviceId);
+    device::ChannelSet outMask, inMask;
     outMask.setRange (0, 2, true);
     inMask .setRange (0, 2, true);
 
-    const auto err = dev.open (inMask, outMask, (double) opts.sampleRate, 1024);
-    if (err.isNotEmpty())
+    const auto err = dev->open (inMask, outMask, (double) opts.sampleRate, 1024);
+    if (! err.empty())
     {
         r.passed  = false;
         r.verdict = "FAIL (open)";
@@ -327,24 +340,24 @@ AlsaPerformanceTest::runStartStopRace (const Options& opts)
 
     for (int i = 0; i < opts.startStopCycles; ++i)
     {
-        dev.start (&cb);
+        dev->start (&cb);
         // Brief moment so start() actually fires the device before stop kicks
         // in - 50ms = a few periods at 1024/48k. Without this, the test
         // measures only the queueing layer and misses real start_threshold
         // behavior.
-        juce::Thread::sleep (50);
+        sleepMs (50);
 
-        // CodeRabbit fix: dev.isOpen() reflects open()/close() only, not
-        // start()/stop(), so it stays true after dev.stop() and the previous
-        // check rubber-stamped every cycle. Use the callback count instead -
-        // audioDeviceAboutToStart resets it to 0 at each start, and after
-        // a 50ms sleep at 1024/48k a healthy device will have produced at
-        // least two callbacks. Zero callbacks means start() didn't actually
-        // get the audio thread running (pre-fill failed, recovery cascade,
-        // or a deeper open-state inconsistency).
+        // dev->isOpen() reflects open()/close() only, not start()/stop(), so
+        // it stays true after dev->stop() and would rubber-stamp every cycle.
+        // Use the callback count instead - audioDeviceAboutToStart resets it
+        // to 0 at each start, and after a 50ms sleep at 1024/48k a healthy
+        // device will have produced at least two callbacks. Zero callbacks
+        // means start() didn't actually get the audio thread running
+        // (pre-fill failed, recovery cascade, or a deeper open-state
+        // inconsistency).
         const int callbacksDuringRun = cb.totalCallbacks();
 
-        dev.stop();
+        dev->stop();
 
         if (callbacksDuringRun == 0)
         {
@@ -354,15 +367,16 @@ AlsaPerformanceTest::runStartStopRace (const Options& opts)
         }
     }
 
-    dev.close();
+    dev->close();
 
-    r.xruns   = dev.getXRunCount();
+    r.xruns   = dev->getXRunCount();
     r.passed  = failures == 0;
     r.verdict = failures == 0
-                  ? juce::String ("SAFE")
-                  : juce::String::formatted ("UNSAFE (%d/%d cycles produced no callbacks; first at #%d)",
-                                                failures, opts.startStopCycles, firstFailureCycle);
-    r.details = juce::String::formatted ("xruns over all cycles: %d", r.xruns);
+                  ? std::string ("SAFE")
+                  : dusk::text::format ("UNSAFE (%d/%d cycles produced no callbacks; first at #%d)",
+                                        failures, opts.startStopCycles, firstFailureCycle);
+    r.details = dusk::text::format ("xruns over all cycles: %d", r.xruns);
+    AlsaAudioIODevice::destroyOrPark (std::move (dev));
     return r;
 }
 
@@ -378,10 +392,10 @@ AlsaPerformanceTest::runStartStopRace (const Options& opts)
 // short enough (one period) that it doesn't dominate the test runtime.
 namespace
 {
-class LoopbackCallback final : public juce::AudioIODeviceCallback
+class LoopbackCallback final : public device::IODeviceCallback
 {
 public:
-    void audioDeviceAboutToStart (juce::AudioIODevice* dev) override
+    void audioDeviceAboutToStart (device::IODevice* dev) override
     {
         sampleRate = dev->getCurrentSampleRate();
         callbackCount.store (0, std::memory_order_relaxed);
@@ -391,12 +405,12 @@ public:
 
     void audioDeviceStopped() override {}
 
-    void audioDeviceIOCallbackWithContext (const float* const* inputChannelData,
-                                            int numInputChannels,
-                                            float* const* outputChannelData,
-                                            int numOutputChannels,
-                                            int numSamples,
-                                            const juce::AudioIODeviceCallbackContext&) override
+    void audioDeviceIOCallback (const float* const* inputChannelData,
+                                int numInputChannels,
+                                float* const* outputChannelData,
+                                int numOutputChannels,
+                                int numSamples,
+                                const device::CallbackContext&) override
     {
         const int cb = callbackCount.fetch_add (1, std::memory_order_relaxed);
         const int currentSampleStart = cb * numSamples;
@@ -409,10 +423,11 @@ public:
         if (cb == kBurstCallback && numOutputChannels > 0 && outputChannelData[0] != nullptr
             && sampleRate > 0.0)
         {
+            constexpr double kTwoPi = 6.283185307179586;
             for (int i = 0; i < numSamples; ++i)
             {
                 const double t = (double) (currentSampleStart + i) / sampleRate;
-                const float  v = (float) (kBurstAmplitude * std::sin (2.0 * juce::MathConstants<double>::pi * 1000.0 * t));
+                const float  v = (float) (kBurstAmplitude * std::sin (kTwoPi * 1000.0 * t));
                 outputChannelData[0][i] = v;
             }
             burstStartSample.store (currentSampleStart, std::memory_order_release);
@@ -459,7 +474,7 @@ AlsaPerformanceTest::runLoopbackProbe (const Options& opts)
     LoopbackResult r;
 
     LoopbackCallback cb;
-    juce::String openErr;
+    std::string openErr;
     // Use a moderate buffer (1024) so the warmup callback budget gives the
     // device time to start streaming cleanly before we send the burst.
     auto dev = openDuplex (opts.deviceId, opts.sampleRate, 1024, &cb, openErr);
@@ -472,17 +487,18 @@ AlsaPerformanceTest::runLoopbackProbe (const Options& opts)
     // Run long enough that we're well past the burst callback (100) plus
     // round-trip latency plus a safety margin. 4 seconds at 1024/48k =
     // ~187 callbacks; sends burst at #100, leaves ~87 callbacks to detect.
-    juce::Thread::sleep (4000);
+    sleepMs (4000);
 
     dev->stop();
     dev->close();
+    AlsaAudioIODevice::destroyOrPark (std::move (dev));
 
     r.burstStartSample  = cb.getBurstStartSample();
     r.firstSignalSample = cb.getFirstSignalSample();
 
     if (r.burstStartSample < 0)
     {
-        r.details = juce::String::formatted (
+        r.details = dusk::text::format (
             "burst was never sent (got only %d callbacks, needed >= 101)",
             cb.getTotalCallbacks());
         return r;
@@ -503,42 +519,47 @@ AlsaPerformanceTest::runLoopbackProbe (const Options& opts)
     return r;
 }
 
-juce::String AlsaPerformanceTest::runAll (const Options& opts)
+std::string AlsaPerformanceTest::runAll (const Options& opts)
 {
-    juce::StringArray out;
+    std::vector<std::string> out;
 
     const bool willRunMatrix = opts.sampleRates.size() > 1;
-    out.add (willRunMatrix
-                ? juce::String ("=== ALSA Backend Performance Test (Tier 2: rate matrix) ===")
-                : juce::String ("=== ALSA Backend Performance Test (Tier 1) ==="));
-    out.add (juce::String::formatted ("Time:     %s",
-                                         juce::Time::getCurrentTime().toString (true, true).toRawUTF8()));
-    out.add (juce::String::formatted ("Device:   %s", opts.deviceId.toRawUTF8()));
+    out.push_back (willRunMatrix
+                ? std::string ("=== ALSA Backend Performance Test (Tier 2: rate matrix) ===")
+                : std::string ("=== ALSA Backend Performance Test (Tier 1) ==="));
+    {
+        const std::time_t now = std::time (nullptr);
+        char timeBuf[64] = { 0 };
+        std::strftime (timeBuf, sizeof (timeBuf), "%d %b %Y %H:%M:%S", std::localtime (&now));
+        out.push_back (dusk::text::format ("Time:     %s", timeBuf));
+    }
+    out.push_back (dusk::text::format ("Device:   %s", opts.deviceId.c_str()));
     if (willRunMatrix)
     {
-        juce::StringArray rateLabels;
-        for (auto r : opts.sampleRates) rateLabels.add (juce::String (r));
-        out.add (juce::String::formatted ("Rates:    %s Hz", rateLabels.joinIntoString (", ").toRawUTF8()));
+        std::vector<std::string> rateLabels;
+        for (auto r : opts.sampleRates) rateLabels.push_back (std::to_string (r));
+        out.push_back (dusk::text::format ("Rates:    %s Hz",
+                                           dusk::text::joinIntoString (rateLabels, ", ").c_str()));
     }
     else
     {
-        out.add (juce::String::formatted ("Rate:     %u Hz", opts.sampleRate));
+        out.push_back (dusk::text::format ("Rate:     %u Hz", opts.sampleRate));
     }
-    out.add (juce::String::formatted ("Duration: %d ms per buffer", opts.durationMs));
-    out.add (juce::String::formatted ("DSP load: %d us / callback (synthetic)", opts.fakeDspLoadUs));
-    out.add ("");
+    out.push_back (dusk::text::format ("Duration: %d ms per buffer", opts.durationMs));
+    out.push_back (dusk::text::format ("DSP load: %d us / callback (synthetic)", opts.fakeDspLoadUs));
+    out.push_back ("");
 
     // Build the rate list. Empty Options::sampleRates -> single rate from
     // opts.sampleRate (Tier 1 behaviour). Non-empty -> Tier 2 matrix mode,
     // a buffer sweep at each rate with its own table.
-    juce::Array<unsigned int> rates = opts.sampleRates;
-    if (rates.isEmpty())
-        rates.add (opts.sampleRate);
+    std::vector<unsigned int> rates = opts.sampleRates;
+    if (rates.empty())
+        rates.push_back (opts.sampleRate);
 
     const bool matrixMode = rates.size() > 1;
-    out.add (juce::String (matrixMode ? "--- Rate x Buffer matrix (duplex, silent) ---"
-                                        : "--- Buffer-size sweep (duplex, silent) ---"));
-    out.add ("");
+    out.push_back (matrixMode ? "--- Rate x Buffer matrix (duplex, silent) ---"
+                              : "--- Buffer-size sweep (duplex, silent) ---");
+    out.push_back ("");
 
     int globalRecommendedMin = -1;
 
@@ -551,105 +572,105 @@ juce::String AlsaPerformanceTest::runAll (const Options& opts)
         // Per-rate header: pick negotiated format info from the first
         // successful cell. If every cell failed to open at this rate,
         // surface that explicitly.
-        juce::String formatLabel;
+        std::string formatLabel;
         for (const auto& r : sweep)
         {
             if (r.negotiatedBitDepth > 0)
             {
-                formatLabel = juce::String::formatted ("%d-bit int / %d out, %d in",
-                                                          r.negotiatedBitDepth,
-                                                          r.activeOutChannels,
-                                                          r.activeInChannels);
+                formatLabel = dusk::text::format ("%d-bit int / %d out, %d in",
+                                                  r.negotiatedBitDepth,
+                                                  r.activeOutChannels,
+                                                  r.activeInChannels);
                 break;
             }
         }
-        if (formatLabel.isEmpty())
+        if (formatLabel.empty())
             formatLabel = "(no successful open at this rate)";
 
-        out.add (juce::String::formatted ("Rate: %u Hz   Format: %s",
-                                             rate, formatLabel.toRawUTF8()));
-        out.add (" Buffer | Budget    | Mean      | P95       | P99       | Max       | XRuns/run | Verdict");
-        out.add ("--------|-----------|-----------|-----------|-----------|-----------|-----------|---------");
+        out.push_back (dusk::text::format ("Rate: %u Hz   Format: %s",
+                                           rate, formatLabel.c_str()));
+        out.push_back (" Buffer | Budget    | Mean      | P95       | P99       | Max       | XRuns/run | Verdict");
+        out.push_back ("--------|-----------|-----------|-----------|-----------|-----------|-----------|---------");
 
         int rateRecommendedMin = -1;
         for (const auto& r : sweep)
         {
-            out.add (formatTableRow (r));
+            out.push_back (formatTableRow (r));
             if (rateRecommendedMin < 0 && (r.verdict == "SAFE" || r.verdict == "MARGINAL"))
             {
-                const auto bufStr = r.configuration.fromFirstOccurrenceOf ("buf=", false, false)
-                                                    .upToFirstOccurrenceOf (" ", false, false);
-                rateRecommendedMin = bufStr.getIntValue();
+                const auto bufStr = dusk::text::upToFirstOccurrenceOf (
+                    dusk::text::fromFirstOccurrenceOf (r.configuration, "buf=", false), " ", false);
+                rateRecommendedMin = dusk::text::getIntValue (bufStr);
             }
-            if (r.details.isNotEmpty())
-                out.add (juce::String ("        ") + r.details);
+            if (! r.details.empty())
+                out.push_back ("        " + r.details);
         }
 
         if (rateRecommendedMin > 0)
-            out.add (juce::String::formatted (
+            out.push_back (dusk::text::format (
                 "  Recommended min buffer at %u Hz: %d frames (50%% headroom: %d)",
                 rate, rateRecommendedMin, (rateRecommendedMin * 3) / 2));
         else
-            out.add ("  No buffer size stable at this rate.");
+            out.push_back ("  No buffer size stable at this rate.");
 
         // The "global" recommended min is the highest minimum across all
         // rates - the safest default that works everywhere.
         if (rateRecommendedMin > globalRecommendedMin)
             globalRecommendedMin = rateRecommendedMin;
 
-        out.add ("");
+        out.push_back ("");
     }
 
     if (matrixMode)
     {
         if (globalRecommendedMin > 0)
-            out.add (juce::String::formatted (
+            out.push_back (dusk::text::format (
                 "Global recommended min buffer (max across rates): %d frames", globalRecommendedMin));
         else
-            out.add ("No buffer size was stable at any rate. Check open errors above.");
-        out.add ("");
+            out.push_back ("No buffer size was stable at any rate. Check open errors above.");
+        out.push_back ("");
     }
 
-    out.add ("--- Open/close cycle stress ---");
+    out.push_back ("--- Open/close cycle stress ---");
     {
         const auto r = runOpenCloseStress (opts);
-        out.add (juce::String::formatted ("  %d cycles  %s", opts.openCloseCycles, r.verdict.toRawUTF8()));
-        if (r.details.isNotEmpty()) out.add (juce::String ("        ") + r.details);
+        out.push_back (dusk::text::format ("  %d cycles  %s", opts.openCloseCycles, r.verdict.c_str()));
+        if (! r.details.empty()) out.push_back ("        " + r.details);
     }
-    out.add ("");
+    out.push_back ("");
 
-    out.add ("--- Start/stop race ---");
+    out.push_back ("--- Start/stop race ---");
     {
         const auto r = runStartStopRace (opts);
-        out.add (juce::String::formatted ("  %d cycles  %s", opts.startStopCycles, r.verdict.toRawUTF8()));
-        if (r.details.isNotEmpty()) out.add (juce::String ("        ") + r.details);
+        out.push_back (dusk::text::format ("  %d cycles  %s", opts.startStopCycles, r.verdict.c_str()));
+        if (! r.details.empty()) out.push_back ("        " + r.details);
     }
-    out.add ("");
+    out.push_back ("");
 
     if (opts.runLoopback)
     {
-        out.add ("--- Loopback round-trip probe ---");
+        out.push_back ("--- Loopback round-trip probe ---");
         const auto r = runLoopbackProbe (opts);
         if (r.signalDetected)
         {
-            out.add (juce::String::formatted (
+            out.push_back (dusk::text::format (
                 "  Signal detected: latency %d samples (%.2f ms) at %u Hz",
                 r.latencySamples, r.latencyMs, opts.sampleRate));
-            out.add (juce::String::formatted (
+            out.push_back (dusk::text::format (
                 "  Burst sent at sample %d, detected at sample %d",
                 r.burstStartSample, r.firstSignalSample));
         }
         else
         {
-            out.add (juce::String ("  No round-trip signal detected"));
+            out.push_back ("  No round-trip signal detected");
         }
-        if (r.details.isNotEmpty())
-            out.add (juce::String ("  ") + r.details);
-        out.add ("");
+        if (! r.details.empty())
+            out.push_back ("  " + r.details);
+        out.push_back ("");
     }
 
-    out.add ("=== End of Performance Test ===");
-    return out.joinIntoString ("\n");
+    out.push_back ("=== End of Performance Test ===");
+    return dusk::text::joinIntoString (out, "\n");
 }
 
 } // namespace duskstudio

--- a/src/engine/alsa/AlsaPerformanceTest.h
+++ b/src/engine/alsa/AlsaPerformanceTest.h
@@ -4,13 +4,14 @@
  #error "AlsaPerformanceTest.h is ALSA/Linux-only"
 #endif
 
-#include <juce_core/juce_core.h>
+#include <string>
+#include <vector>
 
 namespace duskstudio
 {
 // Performance + stability test harness for the Dusk Studio-owned ALSA backend.
 // Tier 1: drives an AlsaAudioIODevice directly with a measuring callback,
-// no JUCE AudioDeviceManager involvement, no audible content, no special
+// no DeviceManager involvement, no audible content, no special
 // hardware setup beyond a real ALSA hw: device.
 //
 // Reports per-buffer-size:
@@ -28,9 +29,9 @@ class AlsaPerformanceTest
 public:
     struct Result
     {
-        juce::String testName;
-        juce::String configuration;     // "buf=512 rate=48000"
-        bool         passed = false;
+        std::string testName;
+        std::string configuration;      // "buf=512 rate=48000"
+        bool        passed = false;
 
         int    xruns           = 0;
         double budgetMs        = 0.0;   // (period * 1000.0) / sampleRate
@@ -48,21 +49,21 @@ public:
         int          activeOutChannels   = 0;
         int          activeInChannels    = 0;
 
-        juce::String verdict;           // "SAFE" / "MARGINAL" / "UNSAFE" / "FAIL"
-        juce::String details;
+        std::string verdict;            // "SAFE" / "MARGINAL" / "UNSAFE" / "FAIL"
+        std::string details;
     };
 
     struct Options
     {
-        juce::String              deviceId        = "hw:0,0";
+        std::string               deviceId        = "hw:0,0";
         unsigned int              sampleRate      = 48000;
         int                       durationMs      = 5000;     // per buffer-size step
         int                       fakeDspLoadUs   = 0;        // synthetic CPU work in callback
         int                       openCloseCycles = 50;
         int                       startStopCycles = 20;
         bool                      runLoopback     = false;    // require user-supplied loopback path
-        juce::Array<int>          bufferSizes;                // empty -> use default ladder
-        juce::Array<unsigned int> sampleRates;                // empty -> just opts.sampleRate
+        std::vector<int>          bufferSizes;                // empty -> use default ladder
+        std::vector<unsigned int> sampleRates;                // empty -> just opts.sampleRate
     };
 
     // Loopback round-trip measurement. Only meaningful when there is a
@@ -72,21 +73,21 @@ public:
     // stays false.
     struct LoopbackResult
     {
-        bool         signalDetected = false;
-        int          latencySamples = -1;
-        double       latencyMs      = -1.0;   // -1 == not measured (matches latencySamples sentinel)
-        int          burstStartSample = -1;
-        int          firstSignalSample = -1;
-        juce::String details;
+        bool        signalDetected = false;
+        int         latencySamples = -1;
+        double      latencyMs      = -1.0;   // -1 == not measured (matches latencySamples sentinel)
+        int         burstStartSample = -1;
+        int         firstSignalSample = -1;
+        std::string details;
     };
 
     // Run the full Tier 1 suite (buffer sweep + open/close + start/stop)
     // and return a markdown-style report. If opts.runLoopback is true,
     // also runs the loopback probe and includes results.
-    static juce::String runAll (const Options& opts);
+    static std::string runAll (const Options& opts);
 
     // Individual entry points - useful for targeted reruns.
-    static juce::Array<Result> runBufferSweep    (const Options& opts);
+    static std::vector<Result> runBufferSweep    (const Options& opts);
     static Result              runOpenCloseStress (const Options& opts);
     static Result              runStartStopRace   (const Options& opts);
     static LoopbackResult      runLoopbackProbe   (const Options& opts);

--- a/src/engine/device/DeviceManager.cpp
+++ b/src/engine/device/DeviceManager.cpp
@@ -5,18 +5,14 @@
 #include "../../foundation/MessageThread.h"
 #include "../../foundation/ScopedNoDenormals.h"
 
-// The native PipeWire backend implements the dusk device interfaces directly, so
-// it registers without an adapter. ALSA is still a JUCE AudioIODeviceType,
-// wrapped here in an OWNING adapter (P4 re-bases it and deletes the adapter). The
-// adapter machinery and its JUCE include are gated on ALSA alone, so a build
-// without it (the narrow-link test target) compiles this TU with no JUCE at all.
+// Both native backends implement the dusk device interfaces directly and
+// register without adapters. Gated so a build with neither backend (the
+// narrow-link test target) compiles this TU standalone.
 #if defined(DUSKSTUDIO_HAS_PIPEWIRE)
  #include "../pipewire/PipeWireAudioIODeviceType.h"
 #endif
 #if defined(DUSKSTUDIO_HAS_ALSA)
- #include <juce_audio_devices/juce_audio_devices.h>
  #include "../alsa/AlsaAudioIODeviceType.h"
- #define DUSKSTUDIO_DEVICE_HAS_JUCE_BACKENDS 1
 #endif
 
 #include <algorithm>
@@ -160,130 +156,6 @@ private:
     std::vector<float*> scratchPtrs; // one entry per output channel
 };
 
-#if defined(DUSKSTUDIO_DEVICE_HAS_JUCE_BACKENDS)
-juce::BigInteger toBig (const ChannelSet& cs)
-{
-    juce::BigInteger b;
-    for (int i = 0; i < ChannelSet::kMaxChannels; ++i)
-        if (cs[i]) b.setBit (i);
-    return b;
-}
-
-ChannelSet fromBig (const juce::BigInteger& b)
-{
-    ChannelSet cs;
-    for (int i = 0; i < ChannelSet::kMaxChannels; ++i)
-        if (b[i]) cs.setBit (i);
-    return cs;
-}
-
-std::vector<std::string> toStrings (const juce::StringArray& a)
-{
-    std::vector<std::string> v;
-    v.reserve ((std::size_t) a.size());
-    for (const auto& s : a) v.push_back (s.toStdString());
-    return v;
-}
-
-template <typename T>
-std::vector<T> toVector (const juce::Array<T>& a)
-{
-    std::vector<T> v;
-    v.reserve ((std::size_t) a.size());
-    for (const auto& x : a) v.push_back (x);
-    return v;
-}
-
-// Owning dusk IODevice over a JUCE AudioIODevice. start() installs a small
-// juce-callback shim forwarding the device's RT blocks to the dusk callback (the
-// manager's CallbackFanout), presenting this adapter as the dusk device.
-class JuceDeviceAdapter final : public IODevice
-{
-public:
-    explicit JuceDeviceAdapter (std::unique_ptr<juce::AudioIODevice> d) noexcept : dev (std::move (d)) {}
-
-    std::string getName() const override { return dev ? dev->getName().toStdString() : std::string(); }
-
-    std::vector<std::string> getOutputChannelNames() override
-        { return dev ? toStrings (dev->getOutputChannelNames()) : std::vector<std::string>{}; }
-    std::vector<std::string> getInputChannelNames() override
-        { return dev ? toStrings (dev->getInputChannelNames()) : std::vector<std::string>{}; }
-    std::vector<double> getAvailableSampleRates() override
-        { return dev ? toVector (dev->getAvailableSampleRates()) : std::vector<double>{}; }
-    std::vector<int> getAvailableBufferSizes() override
-        { return dev ? toVector (dev->getAvailableBufferSizes()) : std::vector<int>{}; }
-    int getDefaultBufferSize() override { return dev ? dev->getDefaultBufferSize() : 0; }
-
-    std::string open (const ChannelSet& in, const ChannelSet& out, double sr, int bs) override
-        { return dev ? dev->open (toBig (in), toBig (out), sr, bs).toStdString() : std::string ("no device"); }
-    void close() override { if (dev) dev->close(); }
-    bool isOpen() override { return dev && dev->isOpen(); }
-
-    void start (IODeviceCallback* cb) override { shim.bind (cb, this); if (dev) dev->start (&shim); }
-    void stop() override { if (dev) dev->stop(); }
-    bool isPlaying() override { return dev && dev->isPlaying(); }
-
-    std::string getLastError() override { return dev ? dev->getLastError().toStdString() : std::string(); }
-    int    getCurrentBufferSizeSamples() override { return dev ? dev->getCurrentBufferSizeSamples() : 0; }
-    double getCurrentSampleRate()        override { return dev ? dev->getCurrentSampleRate() : 0.0; }
-    int    getCurrentBitDepth()          override { return dev ? dev->getCurrentBitDepth() : 0; }
-    ChannelSet getActiveOutputChannels() const override { return dev ? fromBig (dev->getActiveOutputChannels()) : ChannelSet{}; }
-    ChannelSet getActiveInputChannels()  const override { return dev ? fromBig (dev->getActiveInputChannels()) : ChannelSet{}; }
-    int getOutputLatencyInSamples() override { return dev ? dev->getOutputLatencyInSamples() : 0; }
-    int getInputLatencyInSamples()  override { return dev ? dev->getInputLatencyInSamples() : 0; }
-    int getXRunCount() const noexcept override { return dev ? dev->getXRunCount() : 0; }
-
-private:
-    struct Shim final : juce::AudioIODeviceCallback
-    {
-        void bind (IODeviceCallback* c, IODevice* ownerDev) noexcept { cb = c; owner = ownerDev; }
-
-        void audioDeviceIOCallbackWithContext (const float* const* in, int numIn,
-                                               float* const* out, int numOut, int numSamples,
-                                               const juce::AudioIODeviceCallbackContext& ctx) override
-        {
-            CallbackContext dctx;
-            dctx.hostTimeNs = ctx.hostTimeNs;
-            cb->audioDeviceIOCallback (in, numIn, out, numOut, numSamples, dctx);
-        }
-        void audioDeviceAboutToStart (juce::AudioIODevice*) override { cb->audioDeviceAboutToStart (owner); }
-        void audioDeviceStopped() override { cb->audioDeviceStopped(); }
-        void audioDeviceError (const juce::String& m) override { cb->audioDeviceError (m.toStdString()); }
-
-        IODeviceCallback* cb = nullptr;
-        IODevice* owner = nullptr;
-    };
-
-    std::unique_ptr<juce::AudioIODevice> dev;
-    Shim shim;
-};
-
-// Owning dusk IODeviceType over a JUCE AudioIODeviceType. createDevice now has a
-// real implementation (the native manager drives device construction directly),
-// returning an owning JuceDeviceAdapter.
-class JuceDeviceTypeAdapter final : public IODeviceType
-{
-public:
-    explicit JuceDeviceTypeAdapter (std::unique_ptr<juce::AudioIODeviceType> t) noexcept : type (std::move (t)) {}
-
-    std::string getTypeName() const override { return type->getTypeName().toStdString(); }
-    void scanForDevices() override { type->scanForDevices(); }
-    std::vector<std::string> getDeviceNames (bool wantInputNames) const override
-        { return toStrings (type->getDeviceNames (wantInputNames)); }
-    int getDefaultDeviceIndex (bool forInput) const override { return type->getDefaultDeviceIndex (forInput); }
-    int getIndexOfDevice (IODevice*, bool) const override { return -1; }
-
-    std::unique_ptr<IODevice> createDevice (const std::string& outputName, const std::string& inputName) override
-    {
-        auto* raw = type->createDevice (juce::String (outputName), juce::String (inputName));
-        if (raw == nullptr) return nullptr;
-        return std::make_unique<JuceDeviceAdapter> (std::unique_ptr<juce::AudioIODevice> (raw));
-    }
-
-private:
-    std::unique_ptr<juce::AudioIODeviceType> type;
-};
-#endif // DUSKSTUDIO_DEVICE_HAS_JUCE_BACKENDS
 } // namespace
 
 struct DeviceManager::Impl
@@ -340,7 +212,7 @@ struct DeviceManager::Impl
         types.push_back (std::make_unique<PipeWireAudioIODeviceType>());
        #endif
        #if defined(DUSKSTUDIO_HAS_ALSA)
-        types.push_back (std::make_unique<JuceDeviceTypeAdapter> (std::make_unique<AlsaAudioIODeviceType>()));
+        types.push_back (std::make_unique<AlsaAudioIODeviceType>());
        #endif
         for (auto& t : types) t->scanForDevices();
     }

--- a/src/engine/device/DeviceManager.h
+++ b/src/engine/device/DeviceManager.h
@@ -17,9 +17,8 @@ namespace juce { class AudioDeviceManager; }
 // is the seam - the public API is pure dusk (IODevice / DeviceSetup / ChannelSet).
 // On Linux (DeviceManager.cpp) it is a native orchestrator: it owns the
 // IODeviceType list, drives IODevice open/start/stop/close itself, and fans the
-// callback out directly, with the PipeWire/ALSA backends still juce-typed behind
-// temporary owning adapters (P3/P4 re-base them onto the dusk interfaces). Off
-// Linux (DeviceManagerJuce.cpp) it delegates to a wrapped juce::AudioDeviceManager,
+// callback out directly to the native PipeWire/ALSA backends. Off Linux
+// (DeviceManagerJuce.cpp) it delegates to a wrapped juce::AudioDeviceManager,
 // adapting JUCE's device/callback types behind this same API.
 //
 // Message-thread only, same contract as juce::AudioDeviceManager: construct,

--- a/src/engine/device/DeviceManagerJuce.cpp
+++ b/src/engine/device/DeviceManagerJuce.cpp
@@ -9,13 +9,6 @@
 
 #include <juce_audio_devices/juce_audio_devices.h>
 
-#if defined(DUSKSTUDIO_HAS_PIPEWIRE)
- #include "../pipewire/PipeWireAudioIODeviceType.h"
-#endif
-#if defined(DUSKSTUDIO_HAS_ALSA)
- #include "../alsa/AlsaAudioIODeviceType.h"
-#endif
-
 #include <atomic>
 #include <map>
 
@@ -238,13 +231,6 @@ struct DeviceManager::Impl : private juce::ChangeListener
     {
         if (backendsRegistered) return;
         backendsRegistered = true;
-
-       #if defined(DUSKSTUDIO_HAS_PIPEWIRE)
-        mgr.addAudioDeviceType (std::make_unique<PipeWireAudioIODeviceType>());
-       #endif
-       #if defined(DUSKSTUDIO_HAS_ALSA)
-        mgr.addAudioDeviceType (std::make_unique<AlsaAudioIODeviceType>());
-       #endif
 
        #if JUCE_WINDOWS
         // Preference order: ASIO (only present when the SDK was built in) ->

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -149,7 +149,11 @@ target_sources(dusk-studio-tests PRIVATE
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_sources(dusk-studio-tests PRIVATE
         alsa_seq_midi.cpp
-        ${CMAKE_SOURCE_DIR}/src/engine/midi/AlsaSeqMidi.cpp)
+        ${CMAKE_SOURCE_DIR}/src/engine/midi/AlsaSeqMidi.cpp
+        # ALSA audio backend: the wedged-I/O-thread abandon/park path needs no
+        # hardware (test-injected thread body, PCMs never opened).
+        alsa_thread_teardown.cpp
+        ${CMAKE_SOURCE_DIR}/src/engine/alsa/AlsaAudioIODevice.cpp)
     target_link_libraries(dusk-studio-tests PRIVATE asound)
 else()
     # The seam picks its backend on __linux__, so off Linux the JUCE fallback is

--- a/tests/alsa_thread_teardown.cpp
+++ b/tests/alsa_thread_teardown.cpp
@@ -43,10 +43,10 @@ TEST_CASE ("AlsaAudioIODevice: wedged I/O thread leaks the device, never frees i
     const auto stopMs = std::chrono::duration_cast<std::chrono::milliseconds> (
         std::chrono::steady_clock::now() - t0).count();
 
-    // stop() must hold the full join window, then detach - neither joining
-    // until the thread exits nor returning early.
+    // stop() must hold the full join window, then detach rather than returning
+    // early. The abandonment assertion below distinguishes this from joining
+    // the thread through its later exit.
     REQUIRE (stopMs >= 1900);
-    REQUIRE (stopMs < 3000);
     REQUIRE (raw->ioThreadWasAbandoned());
 
     // An abandoned device refuses to rejoin the streaming lifecycle.

--- a/tests/alsa_thread_teardown.cpp
+++ b/tests/alsa_thread_teardown.cpp
@@ -1,0 +1,90 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/alsa/AlsaAudioIODevice.h"
+#include "foundation/AutoResetEvent.h"
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+
+// The stop() timed-join / abandon path: a wedged I/O thread is detached after
+// the 2000 ms join window and the whole device must be leaked - never freed -
+// because the detached thread keeps dereferencing it until it finally exits.
+
+using duskstudio::AlsaAudioIODevice;
+
+TEST_CASE ("AlsaAudioIODevice: wedged I/O thread leaks the device, never frees it", "[audio][device]")
+{
+    auto dev = std::make_unique<AlsaAudioIODevice> ("teardown-test", "", "");
+    auto* raw = dev.get();
+
+    // Heap-shared so the detached thread can't dangle into this test's stack
+    // if an assertion unwinds before the final wait.
+    auto lateTouchOk = std::make_shared<std::atomic<bool>> (false);
+    auto threadDone  = std::make_shared<std::atomic<bool>> (false);
+
+    // Body ignores the exit flag well past stop()'s 2000 ms join, then touches
+    // the device's state before signalling - if the owner had freed the object,
+    // those dereferences are use-after-free (caught under ASan, and pinned here
+    // by the state assertions below).
+    raw->startThreadForTest ([lateTouchOk, threadDone, raw]
+                             (std::atomic<bool>&, dusk::AutoResetEvent& exited)
+    {
+        std::this_thread::sleep_for (std::chrono::milliseconds (3500));
+        lateTouchOk->store (raw->getName() == "teardown-test"
+                            && raw->getXRunCount() == 0);
+        exited.signal();
+        threadDone->store (true);
+    });
+
+    const auto t0 = std::chrono::steady_clock::now();
+    raw->stop();
+    const auto stopMs = std::chrono::duration_cast<std::chrono::milliseconds> (
+        std::chrono::steady_clock::now() - t0).count();
+
+    // stop() must hold the full join window, then detach - neither joining
+    // until the thread exits nor returning early.
+    REQUIRE (stopMs >= 1900);
+    REQUIRE (stopMs < 3000);
+    REQUIRE (raw->ioThreadWasAbandoned());
+
+    // An abandoned device refuses to rejoin the streaming lifecycle.
+    duskstudio::device::ChannelSet mask;
+    mask.setBit (0);
+    REQUIRE_FALSE (raw->open (mask, mask, 48000.0, 256).empty());
+
+    // Destruction parks (leaks) the whole object instead of destroying it.
+    const int parkedBefore = AlsaAudioIODevice::abandonedCount();
+    AlsaAudioIODevice::destroyOrPark (std::move (dev));
+    REQUIRE (AlsaAudioIODevice::abandonedCount() == parkedBefore + 1);
+
+    // The parked object stays valid until (and past) the thread's final
+    // signal: wait out the body's late touch and verify it saw intact state.
+    for (int i = 0; i < 500 && ! threadDone->load(); ++i)
+        std::this_thread::sleep_for (std::chrono::milliseconds (10));
+    REQUIRE (threadDone->load());
+    REQUIRE (lateTouchOk->load());
+    REQUIRE (raw->getName() == "teardown-test");
+}
+
+TEST_CASE ("AlsaAudioIODevice: exiting thread joins inside the window, no abandonment", "[audio][device]")
+{
+    auto dev = std::make_unique<AlsaAudioIODevice> ("teardown-clean", "", "");
+    auto* raw = dev.get();
+
+    raw->startThreadForTest ([] (std::atomic<bool>& shouldExit, dusk::AutoResetEvent& exited)
+    {
+        while (! shouldExit.load (std::memory_order_acquire))
+            std::this_thread::sleep_for (std::chrono::milliseconds (1));
+        exited.signal();
+    });
+
+    raw->stop();
+    REQUIRE_FALSE (raw->ioThreadWasAbandoned());
+
+    // A device with a cleanly-joined thread is destroyed normally.
+    const int parkedBefore = AlsaAudioIODevice::abandonedCount();
+    AlsaAudioIODevice::destroyOrPark (std::move (dev));
+    REQUIRE (AlsaAudioIODevice::abandonedCount() == parkedBefore);
+}

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -33,13 +33,6 @@ src/engine/PluginSlot.cpp
 src/engine/PluginSlot.h
 src/engine/RecordManager.cpp
 src/engine/RecordManager.h
-src/engine/alsa/AlsaAudioIODevice.cpp
-src/engine/alsa/AlsaAudioIODevice.h
-src/engine/alsa/AlsaAudioIODeviceType.cpp
-src/engine/alsa/AlsaAudioIODeviceType.h
-src/engine/alsa/AlsaPerformanceTest.cpp
-src/engine/alsa/AlsaPerformanceTest.h
-src/engine/device/DeviceManager.cpp
 src/engine/device/DeviceManager.h
 src/engine/device/DeviceManagerJuce.cpp
 src/engine/hosting/NativePluginId.h


### PR DESCRIPTION
## Summary

This PR contains two deliberately separable halves:

- **P4 — native ALSA backend:** re-types the ALSA device/type/performance-test path onto the dusk device interfaces and replaces the backend I/O thread with the specified `std::thread` lifecycle, including bounded teardown and whole-device parking if the thread cannot be joined safely. The review-fix commit also clarifies the periods default and moves the UMC probe onto the native path.
- **P5 — Linux unlink:** moves the Linux headless tone harness onto `device::DeviceManager`, removes the direct `juce_audio_devices` link on Linux, and confirms that no Linux `src/` translation unit directly includes that module's headers.

The halves are intentionally reviewable and shippable separately. Marc may split after P4, merge P4 alone, and defer P5.

## Link and platform scope

This is a **platform-scoped unlink: Linux-unlinked**. macOS and Windows retain the wrapped device path and their direct link, so the campaign north-star count stays at **12 modules**.

There is also a transitive-link caveat: `juce_audio_utils` still depends on and pulls in `juce_audio_devices` on Linux. The direct Linux link and direct Linux source-TU header includes are gone, but the module still compiles transitively and its object code remains until `juce_audio_utils` is unlinked in a later tower.

## Verification

- `tools/juce-gate.sh`: **184**
- `ctest`: **438/438**
- Private-Xvfb selftest: green at the established P4 baseline
- Full diff review: clean; ALSA recovery, rearm, prefill, and negotiation behavior preserved

## Hardware bench debt — gates merge

- [ ] ALSA hot-unplug mid-play with the new `std::thread` teardown
- [ ] ALSA xrun recovery under load
- [ ] PipeWire streaming on real hardware
- [ ] PipeWire sample-rate/quantum renegotiation on real hardware
- [ ] Buffer/sample-rate swap
- [ ] Periods knob

Pre-paid bench debt: the `DUSKSTUDIO_RUN_ALSA_PERF` matrix is green on real `hw:UMC1820,0` hardware at 44.1/48 kHz across 32–2048-frame buffers, including the open/close and start/stop loops.

Do not merge until the unchecked hardware items above pass.
