### PR TITLE
Dejuce/audiofile sweep 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -433,7 +433,8 @@ target_sources(DuskStudio PRIVATE
     src/engine/audiofile/BufferedFileReader.cpp
     src/engine/audiofile/FileReader.cpp
     src/engine/audiofile/FileWriter.cpp
-    src/engine/audiofile/ThreadedFileWriter.cpp)
+    src/engine/audiofile/ThreadedFileWriter.cpp
+    src/engine/audiofile/WriterDrainPool.cpp)
 target_link_libraries(DuskStudio PRIVATE dusk_sndfile)
 
 # DeviceManager backing: Linux uses the native orchestrator (owns the device

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,6 +430,7 @@ else()
 endif()
 
 target_sources(DuskStudio PRIVATE
+    src/engine/audiofile/BufferedFileReader.cpp
     src/engine/audiofile/FileReader.cpp
     src/engine/audiofile/FileWriter.cpp
     src/engine/audiofile/ThreadedFileWriter.cpp)

--- a/docs/dejuce-audiofile-plan.md
+++ b/docs/dejuce-audiofile-plan.md
@@ -1,12 +1,11 @@
 # De-JUCE tower spec — Audio-file call-site sweep (juce_audio_formats consumers → dusk libsndfile seam)
 
-**STATUS: PR-1 READY — A0+A1 DONE on branch `dejuce/audiofile-sweep-1`, plus
-libsndfile made a hard requirement on every platform (CI installs it in all
-workflows) and every `DUSKSTUDIO_HAS_AUDIOFILE` guard + JUCE fallback branch
-deleted: consumers call the seam unconditionally, so the flips are NOT
-Linux-scoped. Resume after merge: "A2 BufferedFileReader on
-dejuce/audiofile-sweep-2 after PR-1 merges" — write A2/A3 code WITHOUT any
-platform gate.**
+**STATUS: PR-1 MERGED (#107, main @ 8c7859e). A2 DONE on branch
+`dejuce/audiofile-sweep-2`: `dusk::audio::BufferedFileReader` built per §B1 and
+PlaybackEngine + MasteringPlayer flipped off the JUCE buffering reader, no
+platform gate anywhere. Resume: "A3 write path (IFileWriteSink +
+WriterDrainPool) on dejuce/audiofile-sweep-2". PR-2 = A2+A3+A4 on that one
+branch — do not open it before A4.**
 Update this line each session (phase done, branch, resume phrase).
 
 Read order for an executing session: `docs/dejuce-campaign.md` → this file →
@@ -107,11 +106,15 @@ thread:
   (timeout-0 parity — never blocks, never does I/O). Return value reports
   full/partial residency so callers can count misses if they care (JUCE's
   API returned bool; keep bool = fully-resident).
-- Prefetch thread follows the highest `startFrame` seen (forward-only, JUCE
-  parity); an explicit `prefetch(startFrame)` hint lets `preparePlayback`
-  and loop-wrap logic pre-warm — PlaybackEngine's manual loopCacheL/R stays
-  as-is (do NOT fold it into the reader; it exists precisely because
-  forward-only prefetch can't cover loop wraps, and it works).
+- Prefetch thread follows the LAST `startFrame` seen, not the highest: it
+  buffers forward from that position only (JUCE parity, and why the loop
+  pre-cache is needed), but a position outside the window restarts the window
+  there rather than being ignored. Tracking the maximum instead would leave a
+  loop longer than the pre-cache silent for the rest of its cycle, forever.
+  An explicit `prefetch(startFrame)` hint lets `preparePlayback` and
+  loop-wrap logic pre-warm — PlaybackEngine's manual loopCacheL/R stays as-is
+  (do NOT fold it into the reader; it exists precisely because forward
+  prefetch can't cover loop wraps, and it works).
 - One background std::thread per BufferedFileReader, normal priority,
   condition-variable wakeup on hint/position change, joined in dtor.
   AutoResetEvent reuse fine. No allocation after construction (window sized

--- a/docs/dejuce-audiofile-plan.md
+++ b/docs/dejuce-audiofile-plan.md
@@ -1,11 +1,13 @@
 # De-JUCE tower spec — Audio-file call-site sweep (juce_audio_formats consumers → dusk libsndfile seam)
 
-**STATUS: PR-1 MERGED (#107, main @ 8c7859e). A2 DONE on branch
-`dejuce/audiofile-sweep-2`: `dusk::audio::BufferedFileReader` built per §B1 and
-PlaybackEngine + MasteringPlayer flipped off the JUCE buffering reader, no
-platform gate anywhere. Resume: "A3 write path (IFileWriteSink +
-WriterDrainPool) on dejuce/audiofile-sweep-2". PR-2 = A2+A3+A4 on that one
-branch — do not open it before A4.**
+**STATUS: PR-1 MERGED (#107, main @ 8c7859e). A2 + A3 DONE on branch
+`dejuce/audiofile-sweep-2`: A2 built `dusk::audio::BufferedFileReader` (§B1) and
+flipped PlaybackEngine + MasteringPlayer; A3 wired the write path — LameMp3Writer
+re-based onto IFileWriteSink (now JUCE-free, plain FILE*), RecordManager +
+BounceEngine + RtBounceSink drain through WriterDrainPools, no platform gate
+anywhere. Net allowlist −2 (LameMp3Writer.{h,cpp} cleaned → gate 182). Resume:
+"A4 residue sweep + docs on dejuce/audiofile-sweep-2". PR-2 = A2+A3+A4 on that
+one branch — do not open it before A4.**
 Update this line each session (phase done, branch, resume phrase).
 
 Read order for an executing session: `docs/dejuce-campaign.md` → this file →

--- a/docs/dejuce-audiofile-plan.md
+++ b/docs/dejuce-audiofile-plan.md
@@ -1,14 +1,18 @@
 # De-JUCE tower spec — Audio-file call-site sweep (juce_audio_formats consumers → dusk libsndfile seam)
 
-**STATUS: PR-1 MERGED (#107, main @ 8c7859e). A2 + A3 DONE on branch
-`dejuce/audiofile-sweep-2`: A2 built `dusk::audio::BufferedFileReader` (§B1) and
-flipped PlaybackEngine + MasteringPlayer; A3 wired the write path — LameMp3Writer
-re-based onto IFileWriteSink (now JUCE-free, plain FILE*), RecordManager +
-BounceEngine + RtBounceSink drain through WriterDrainPools, no platform gate
-anywhere. Net allowlist −2 (LameMp3Writer.{h,cpp} cleaned → gate 182). Resume:
-"A4 residue sweep + docs on dejuce/audiofile-sweep-2". PR-2 = A2+A3+A4 on that
-one branch — do not open it before A4.**
-Update this line each session (phase done, branch, resume phrase).
+**STATUS: TOWER COMPLETE. PR-1 MERGED (#107, main @ 8c7859e); PR-2 =
+A2+A3+A4 on `dejuce/audiofile-sweep-2`. A2 built
+`dusk::audio::BufferedFileReader` (§B1) and flipped PlaybackEngine +
+MasteringPlayer; A3 wired the write path — LameMp3Writer re-based onto
+IFileWriteSink (now JUCE-free, plain FILE*), RecordManager + BounceEngine +
+RtBounceSink drain through WriterDrainPools, no platform gate anywhere; A4
+swept the residue (orphaned umbrella includes in FileImporter/DpImporter/
+DpAligner headers) and closed the docs. Net allowlist −2
+(LameMp3Writer.{h,cpp} cleaned → gate 182) — the honest-yield "zero
+movement" prediction missed this. Zero production call sites remain on the
+JUCE audio-format APIs; the module unlink waits on juce_audio_utils (GUI
+tower). Bench debts at §Owed.**
+This spec is archival once PR-2 merges.
 
 Read order for an executing session: `docs/dejuce-campaign.md` → this file →
 memory ledger `project_dejuce_roadmap.md` → the files of the ONE phase you are

--- a/docs/dejuce-campaign.md
+++ b/docs/dejuce-campaign.md
@@ -101,9 +101,10 @@ reimplemented.
   [dejuce-device-phase3-audio-plan.md](dejuce-device-phase3-audio-plan.md).
 - **Audio-file call-site sweep (A0–A4, PR #107 + the sweep-2 PR)**: every
   production consumer of the JUCE audio-format APIs
-  (record/playback/bounce/importers/mastering/mp3) runs on the dusk
-  libsndfile seam, unconditionally on all platforms (libsndfile is a hard
-  configure requirement; no fallback branch). New RT primitives:
+  (record/playback/bounce/importers/mastering) runs on the dusk audio-file
+  seams, unconditionally on all platforms: libsndfile-backed PCM I/O
+  (WAV/FLAC/AIFF; hard configure requirement, no fallback branch) plus the
+  JUCE-free LAME sink for MP3. New RT primitives:
   `BufferedFileReader` (last-position prefetch window, timeout-0 parity),
   `IFileWriteSink` + externally-drained `ThreadedFileWriter` +
   `WriterDrainPool` (one disk thread per subsystem, as before). LameMp3Writer
@@ -119,8 +120,9 @@ reimplemented.
    only hosts; delete `juce::AudioPluginInstance`/`AudioProcessor` hosting
    path (PluginSlot/PluginManager/PluginHostMain). Depends on donor DPF ports
    finishing (APVTS gone) and Marc's call on dropping JUCE-plugin-format
-   support. Unlinks `juce_audio_processors`/`juce_audio_utils`/
-   `juce_audio_formats` territory.
+   support. Unlinks `juce_audio_processors`; `juce_audio_utils` and
+   `juce_audio_formats` stay for AudioThumbnail regardless — the GUI tower
+   replacing the thumbnail views is the sole unlink criterion for those two.
 2. **FFT** — DpAligner + MasteringEqEditor onto pffft/kissfft (lib decision
    open). No ratchet movement, low priority; batch with whichever tower
    touches those files.

--- a/docs/dejuce-campaign.md
+++ b/docs/dejuce-campaign.md
@@ -53,7 +53,7 @@ reimplemented.
   `dusk::json`; integer-typedef sweep; jmax/jmin/jlimit fully gone from src/
   (math sweep, ~1080 sites).
 - **Audio file I/O**: libsndfile FileReader/Writer/ThreadedFileWriter
-  (`src/engine/audiofile/`); reader call-site swaps parked (coupled files).
+  (`src/engine/audiofile/`), A/B bit-exact vs JUCE's WavAudioFormat.
 - **Audio math**: `dusk::audio` Decibels / SmoothedValue / ScopedNoDenormals,
   A/B bit-exact vs JUCE.
 - **DSP tower**: `duskaudio::Biquad` + donor halfband FIR oversampler adopted
@@ -99,26 +99,32 @@ reimplemented.
   under load, buffer/SR swap, periods knob, PipeWire streaming + SR/quantum
   renegotiation (UMC1820 perf matrix green pre-merge). Spec:
   [dejuce-device-phase3-audio-plan.md](dejuce-device-phase3-audio-plan.md).
+- **Audio-file call-site sweep (A0–A4, PR #107 + the sweep-2 PR)**: every
+  production consumer of the JUCE audio-format APIs
+  (record/playback/bounce/importers/mastering/mp3) runs on the dusk
+  libsndfile seam, unconditionally on all platforms (libsndfile is a hard
+  configure requirement; no fallback branch). New RT primitives:
+  `BufferedFileReader` (last-position prefetch window, timeout-0 parity),
+  `IFileWriteSink` + externally-drained `ThreadedFileWriter` +
+  `WriterDrainPool` (one disk thread per subsystem, as before). LameMp3Writer
+  is JUCE-free (allowlist −2, gate 182 — the "zero movement" honest-yield
+  prediction missed this). `juce_audio_formats` stays linked only for
+  `juce_audio_utils`/AudioThumbnail; it unlinks globally with the GUI tower.
+  Bench debts at spec §Owed. Spec:
+  [dejuce-audiofile-plan.md](dejuce-audiofile-plan.md).
 
 ## Remaining towers, in order
 
-1. **Audio-file call-site sweep** — NEXT — flip all juce_audio_formats
-   consumers (record/playback/bounce/importers/mastering/mp3) onto the dusk
-   libsndfile seam (`src/engine/audiofile/`, already JUCE-free and A/B-proven
-   but test-only today). Honest yield: zero allowlist movement and no unlink
-   yet — the deliverable is zero production call sites, so the module drops
-   the moment `juce_audio_utils` goes with the GUI tower. Executable spec:
-   [dejuce-audiofile-plan.md](dejuce-audiofile-plan.md) (A0–A4, two PRs).
-2. **Plugin-hosting JUCE fallback drop** — native CLAP/LV2/VST3 become the
+1. **Plugin-hosting JUCE fallback drop** — native CLAP/LV2/VST3 become the
    only hosts; delete `juce::AudioPluginInstance`/`AudioProcessor` hosting
    path (PluginSlot/PluginManager/PluginHostMain). Depends on donor DPF ports
    finishing (APVTS gone) and Marc's call on dropping JUCE-plugin-format
    support. Unlinks `juce_audio_processors`/`juce_audio_utils`/
    `juce_audio_formats` territory.
-3. **FFT** — DpAligner + MasteringEqEditor onto pffft/kissfft (lib decision
+2. **FFT** — DpAligner + MasteringEqEditor onto pffft/kissfft (lib decision
    open). No ratchet movement, low priority; batch with whichever tower
    touches those files.
-4. **Events remainder + GUI tower (finale)** — ~40 UI juce::Timer subclasses,
+3. **Events remainder + GUI tower (finale)** — ~40 UI juce::Timer subclasses,
    ~79 callAsync sites, then the bespoke Wayland toolkit (xdg-shell +
    XWayland/XEmbed for plugin UIs, 2D renderer TBD Blend2D/Skia,
    HarfBuzz/FreeType, own widget layer; swap behind the existing

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -4839,8 +4839,8 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
     // file with silence. The scratch WIPES are not gated: the taps
     // accumulate during stopped callbacks too (input monitoring runs the
     // strips), and an unwiped pre-roll prints as a summed burst at sample 0.
-    // ThreadedWriter::write is a lock-free FIFO push (its TimeSliceThread
-    // drains to disk), so this stays RT-safe.
+    // ThreadedFileWriter::push is a lock-free SPSC ring push (a shared drain
+    // pool writes it to disk), so this stays RT-safe.
     if (const int nSinks = rtBounceSinkCount.load (std::memory_order_acquire);
         nSinks > 0)
     {
@@ -4865,7 +4865,7 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
                 if (n > 0)
                 {
                     const float* chans[2] = { srcL + offset, srcR + offset };
-                    if (sink.writer->write (chans, n))
+                    if (sink.writer->push (chans, 2, n))
                         sink.written.store (already + n, std::memory_order_release);
                     else
                         sink.writeFailed.store (true, std::memory_order_release);

--- a/src/engine/AudioEngine.h
+++ b/src/engine/AudioEngine.h
@@ -32,6 +32,8 @@
 #include "Transport.h"
 #include "DuskStudioPlayHead.h"
 
+namespace dusk::audio { class ThreadedFileWriter; }
+
 namespace duskstudio
 {
 // input -> channel strip (live or playback source) -> aux/master.
@@ -313,7 +315,7 @@ public:
     }
 
     // Realtime bounce: the live callback pushes each armed sink's source
-    // block into its ThreadedWriter after the mix is complete (post-master,
+    // block into its ThreadedFileWriter after the mix is complete (post-master,
     // pre-metronome, so the monitoring click never prints). srcL == nullptr
     // means "the master mix bus". leadRemaining samples are dropped from the
     // head on the audio thread (per-kind PDC trim); writing stops at cap so
@@ -322,7 +324,7 @@ public:
     // the transport has stopped (the callback may be mid-block at disarm).
     struct RtBounceSink
     {
-        juce::AudioFormatWriter::ThreadedWriter* writer = nullptr;
+        dusk::audio::ThreadedFileWriter* writer = nullptr;
         const float* srcL = nullptr;
         const float* srcR = nullptr;
         // Stem taps ACCUMULATE into their scratch, so after consuming a block

--- a/src/engine/BounceEngine.cpp
+++ b/src/engine/BounceEngine.cpp
@@ -1,10 +1,15 @@
 #include "BounceEngine.h"
+#include <juce_audio_basics/juce_audio_basics.h>
 #include <algorithm>
 #include <cmath>
+#include <vector>
 #include "AudioEngine.h"
 #include "LameMp3Writer.h"
 #include "MasteringPlayer.h"
 #include "../session/Session.h"
+#include "audiofile/FileWriter.h"
+#include "audiofile/ThreadedFileWriter.h"
+#include "audiofile/WriterDrainPool.h"
 
 namespace duskstudio
 {
@@ -79,20 +84,16 @@ bool BounceEngine::runOnMessageThread (std::function<void()> fn)
     return true;
 }
 
-std::unique_ptr<juce::AudioFormatWriter>
-BounceEngine::makeWriter (std::unique_ptr<juce::FileOutputStream> outStream,
-                            std::string& errOut) const
+std::unique_ptr<dusk::audio::IFileWriteSink>
+BounceEngine::makeWriter (const juce::File& outFile, std::string& errOut) const
 {
-    constexpr unsigned kNumChannels = 2;   // bounce is always stereo
+    constexpr int kNumChannels = 2;   // bounce is always stereo
+    const auto path = outFile.getFullPathName().toStdString();
 
     if (renderFormat == Format::Mp3)
     {
-        // LameMp3Writer's base ctor takes ownership of the stream immediately,
-        // so hand it the raw pointer up front; on failure the writer's destructor
-        // frees it (no double-free with the unique_ptr).
-        auto writer = std::make_unique<LameMp3Writer> (outStream.release(),
-                                                        renderSampleRate, kNumChannels,
-                                                        renderBitrateKbps);
+        auto writer = std::make_unique<LameMp3Writer> (path, renderSampleRate,
+                                                        kNumChannels, renderBitrateKbps);
         if (! writer->isOk())
         {
             errOut = "MP3 export is not available - this build has no libmp3lame.";
@@ -101,18 +102,17 @@ BounceEngine::makeWriter (std::unique_ptr<juce::FileOutputStream> outStream,
         return writer;
     }
 
-    // WAV: createWriterFor takes ownership of the stream only on success.
-    juce::WavAudioFormat wavFormat;
-    juce::StringPairArray metadata;
-    std::unique_ptr<juce::AudioFormatWriter> writer (
-        wavFormat.createWriterFor (outStream.get(), renderSampleRate,
-                                     kNumChannels, renderWavBitDepth, metadata, 0));
+    dusk::audio::WriteSpec spec;
+    spec.sampleRate    = renderSampleRate;
+    spec.numChannels   = kNumChannels;
+    spec.bitsPerSample = renderWavBitDepth;
+    spec.format        = dusk::audio::WriteSpec::Format::Wav;
+    auto writer = dusk::audio::FileWriter::create (path, spec);
     if (writer == nullptr)
     {
         errOut = "Could not create WAV writer";
-        return nullptr;   // outStream still owns + frees the stream
+        return nullptr;
     }
-    outStream.release();
     return writer;
 }
 
@@ -180,14 +180,14 @@ bool BounceEngine::start (const juce::File& outFile, double sr, int bs, double t
     renderMode      = mode;
     // Stems must stay WAV: MP3 encoder delay + frame padding shift each stem by
     // a different amount and change its length, breaking the sample-accurate
-    // alignment stems need for re-import. Realtime is WAV too: the disk path
-    // is ThreadedWriter, which owns its writer outright, so the MP3 encoder's
-    // explicit finalize flush has no place to run. Force WAV at the engine
-    // boundary regardless of what the caller requested.
+    // alignment stems need for re-import. Realtime is WAV too: its disk path
+    // streams through the drain pool, whose sinks flush on drain-to-empty, so
+    // the MP3 encoder's explicit finalize flush has no place to run. Force WAV
+    // at the engine boundary regardless of what the caller requested.
     renderFormat    = (mode == Mode::Stems || renderRealtime) ? Format::Wav : format;
     renderBitrateKbps = mp3BitrateKbps;
     // Stems keep 24-bit regardless: they exist for re-import, not delivery.
-    // Realtime does too: its disk path streams through ThreadedWriter with no
+    // Realtime does too: its disk path streams straight to the sink with no
     // dither stage, so a 16-bit realtime file would truncate undithered (the
     // offline loop is where the TPDF dither lives).
     renderWavBitDepth = (mode != Mode::Stems && ! renderRealtime && wavBitDepth == 16)
@@ -288,28 +288,13 @@ void BounceEngine::run()
 
     // Open the writer first - failure here means we don't bother touching the
     // engine state.
-    std::unique_ptr<juce::FileOutputStream> outStream (outputFile.createOutputStream());
-    if (outStream == nullptr)
-    {
-        const std::string err = ("Could not open output file " + outputFile.getFullPathName()).toStdString();
-        {
-            const juce::ScopedLock lock (lastErrorLock);
-            lastError = err;
-        }
-        rendering.store (false, std::memory_order_relaxed);
-        if (onFinished) onFinished (false, err);
-        return;
-    }
-    outStream->setPosition (0);
-    outStream->truncate();
-
     constexpr int kNumChannels = 2;   // bounce is always stereo
     std::string writerErr;
-    std::unique_ptr<juce::AudioFormatWriter> writer = makeWriter (std::move (outStream), writerErr);
+    auto writer = makeWriter (outputFile, writerErr);
     if (writer == nullptr)
     {
-        // Writer failed AFTER we truncated the file above - drop the now-zeroed
-        // file so we don't leave a 0-byte output behind (mirrors renderOneStem).
+        // makeWriter may have created + truncated the file before failing - drop
+        // it so we don't leave a 0-byte output behind (mirrors renderOneStem).
         outputFile.deleteFile();
         {
             const juce::ScopedLock lock (lastErrorLock);
@@ -410,6 +395,7 @@ void BounceEngine::run()
     bool succeeded = true;
     const bool dither16 = renderFormat == Format::Wav && renderWavBitDepth == 16;
     juce::Random ditherRng;
+    std::vector<float> interleaved ((size_t) renderBlockSize * kNumChannels, 0.0f);
     while (done < toRender && ! cancelRequested.load (std::memory_order_relaxed))
     {
         const int remaining = (int) std::min ((std::int64_t) renderBlockSize,
@@ -448,7 +434,10 @@ void BounceEngine::run()
                         p[i] += (ditherRng.nextFloat() - ditherRng.nextFloat()) * lsb;
                 }
             }
-            if (! writer->writeFromFloatArrays (offPtrs.data(), kNumChannels, writeCount))
+            for (int i = 0; i < writeCount; ++i)
+                for (int c = 0; c < kNumChannels; ++c)
+                    interleaved[(size_t) i * kNumChannels + (size_t) c] = offPtrs[(size_t) c][i];
+            if (! writer->writeInterleaved (interleaved.data(), writeCount))
             {
                 const juce::ScopedLock lock (lastErrorLock);
                 lastError = "Writer failed mid-render at " + std::to_string (written) + " samples";
@@ -472,17 +461,16 @@ void BounceEngine::run()
         lastError = kCancelledError;
     }
 
-    // MP3: the final frames only hit the stream at flush. Flush explicitly so
-    // a disk-full there fails the bounce instead of reporting success.
-    if (auto* mp3 = dynamic_cast<LameMp3Writer*> (writer.get());
-        mp3 != nullptr && ! mp3->finalize() && succeeded)
+    // Flush before close so a disk-full at flush (notably the MP3 encoder's
+    // final frames + Xing rewrite) fails the bounce instead of reporting success.
+    if (! writer->flush() && succeeded)
     {
         succeeded = false;
         const juce::ScopedLock lock (lastErrorLock);
-        lastError = "MP3 encoder flush failed (disk full?)";
+        lastError = "Writer flush failed (disk full?)";
     }
 
-    writer.reset();  // flush + close
+    writer.reset();  // close (flush already done above)
     // A cancelled or failed render must not leave a truncated file where the
     // user's previous good bounce was - stems and freeze already do this.
     if (! succeeded)
@@ -520,18 +508,10 @@ void BounceEngine::run()
     if (onFinished) onFinished (succeeded, errSnapshot);
 }
 
-std::unique_ptr<juce::AudioFormatWriter>
+std::unique_ptr<dusk::audio::IFileWriteSink>
 BounceEngine::openWriterFor (const juce::File& outFile, std::string& errOut) const
 {
-    std::unique_ptr<juce::FileOutputStream> outStream (outFile.createOutputStream());
-    if (outStream == nullptr)
-    {
-        errOut = ("Could not open output file " + outFile.getFullPathName()).toStdString();
-        return nullptr;
-    }
-    outStream->setPosition (0);
-    outStream->truncate();
-    auto writer = makeWriter (std::move (outStream), errOut);
+    auto writer = makeWriter (outFile, errOut);
     if (writer == nullptr)
         errOut += (" (" + outFile.getFileName() + ")").toStdString();
     return writer;
@@ -613,7 +593,7 @@ bool BounceEngine::runStemsMode()
     // Open every writer up front so a full disk / bad path fails before any
     // rendering.
     bool succeeded = true;
-    std::vector<std::unique_ptr<juce::AudioFormatWriter>> writers;
+    std::vector<std::unique_ptr<dusk::audio::IFileWriteSink>> writers;
     writers.reserve ((size_t) numStems);
     for (const auto& tgt : targets)
     {
@@ -648,6 +628,8 @@ bool BounceEngine::runStemsMode()
                                                    std::vector<float> ((size_t) renderBlockSize, 0.0f));
         std::vector<float*> outputPtrs (kNumChannels);
         for (int c = 0; c < kNumChannels; ++c) outputPtrs[(size_t) c] = outputs[(size_t) c].data();
+
+        std::vector<float> interleaved ((size_t) renderBlockSize * kNumChannels, 0.0f);
 
         duskstudio::device::CallbackContext ctx {};
 
@@ -702,9 +684,14 @@ bool BounceEngine::runStemsMode()
                                                            totalSamples - writtenFor[(size_t) i]);
                 if (writeCount > 0)
                 {
-                    const float* ptrs[kNumChannels] = { capL[(size_t) i].data() + writeStart,
-                                                        capR[(size_t) i].data() + writeStart };
-                    if (! writers[(size_t) i]->writeFromFloatArrays (ptrs, kNumChannels, writeCount))
+                    const float* srcL = capL[(size_t) i].data() + writeStart;
+                    const float* srcR = capR[(size_t) i].data() + writeStart;
+                    for (int f = 0; f < writeCount; ++f)
+                    {
+                        interleaved[(size_t) f * 2]       = srcL[f];
+                        interleaved[(size_t) f * 2 + 1]   = srcR[f];
+                    }
+                    if (! writers[(size_t) i]->writeInterleaved (interleaved.data(), writeCount))
                     {
                         const juce::ScopedLock lock (lastErrorLock);
                         lastError = "Writer failed mid-stem at "
@@ -772,7 +759,7 @@ bool BounceEngine::runRealtimeMode()
 {
     // Realtime capture: the engine stays attached and the session PLAYS.
     // The audio callback pushes the capture taps (or the master mix) into
-    // ThreadedWriters (see AudioEngine::RtBounceSink); this worker only
+    // ThreadedFileWriters (see AudioEngine::RtBounceSink); this worker only
     // orchestrates transport state and polls progress. Hardware inserts run
     // their external loop for real - the whole point of this mode.
     std::vector<StemTarget> files;
@@ -793,9 +780,6 @@ bool BounceEngine::runRealtimeMode()
     }
     const int numFiles = (int) files.size();
 
-    juce::TimeSliceThread diskThread ("Dusk Studio bounce disk");
-    diskThread.startThread();
-
     // Capture scratches sized to the live block; the callback never hands the
     // strips more than the prepared block size (oversized host blocks are
     // guarded upstream).
@@ -808,8 +792,14 @@ bool BounceEngine::runRealtimeMode()
     }
 
     bool succeeded = true;
-    std::vector<std::unique_ptr<juce::AudioFormatWriter::ThreadedWriter>> writers;
+    std::vector<std::unique_ptr<dusk::audio::ThreadedFileWriter>> writers;
     writers.reserve ((size_t) numFiles);
+
+    // One disk thread drains every writer's ring round-robin. Declared after the
+    // writers so it destructs first: its thread joins before any ThreadedFileWriter
+    // is torn down (the teardown also unregisters + drains each writer explicitly).
+    dusk::audio::WriterDrainPool drainPool (numFiles);
+
     for (const auto& f : files)
     {
         std::string writerErr;
@@ -823,8 +813,10 @@ bool BounceEngine::runRealtimeMode()
             succeeded = false;
             break;
         }
-        writers.push_back (std::make_unique<juce::AudioFormatWriter::ThreadedWriter> (
-            writer.release(), diskThread, 1 << 17));
+        auto threaded = std::make_unique<dusk::audio::ThreadedFileWriter> (
+            std::move (writer), 1 << 17, dusk::audio::ThreadedFileWriter::Drain::External);
+        drainPool.add (threaded.get());
+        writers.push_back (std::move (threaded));
     }
 
     auto& transport = engine.getTransport();
@@ -961,10 +953,13 @@ bool BounceEngine::runRealtimeMode()
         });
     }
 
-    // ThreadedWriter destructors flush their queues to disk.
+    // Producers are stopped (engine.stop + the process fence above): drain each
+    // writer's ring to disk and unregister it before the pool thread goes away,
+    // then destroy the writers. drainPool joins its disk thread at scope exit.
     const size_t writersOpened = writers.size();
+    for (auto& w : writers)
+        drainPool.remove (w.get());
     writers.clear();
-    diskThread.stopThread (2000);
 
     runOnMessageThread ([&transport, savedPlayhead, savedLoop]
     {
@@ -1046,22 +1041,12 @@ bool BounceEngine::renderFreezeTrack (int trackIndex, const juce::File& outFile,
     renderFormat     = Format::Wav;   // freeze is always WAV (sample-accurate re-import)
 
     // Open the writer first - a failure here means we never touch engine state.
-    std::unique_ptr<juce::FileOutputStream> outStream (outFile.createOutputStream());
-    if (outStream == nullptr)
-    {
-        const juce::ScopedLock lock (lastErrorLock);
-        lastError = ("Could not open freeze file " + outFile.getFullPathName()).toStdString();
-        return false;
-    }
-    outStream->setPosition (0);
-    outStream->truncate();
-
     constexpr int kNumChannels = 2;
     std::string writerErr;
-    std::unique_ptr<juce::AudioFormatWriter> writer = makeWriter (std::move (outStream), writerErr);
+    auto writer = makeWriter (outFile, writerErr);
     if (writer == nullptr)
     {
-        outFile.deleteFile();   // drop the 0-byte file we just truncated
+        outFile.deleteFile();   // drop any partial file makeWriter truncated
         const juce::ScopedLock lock (lastErrorLock);
         lastError = writerErr;
         return false;
@@ -1099,6 +1084,7 @@ bool BounceEngine::renderFreezeTrack (int trackIndex, const juce::File& outFile,
     // per-block so a strip early-return writes silence, never a stale block.
     std::vector<float> capL ((size_t) renderBlockSize, 0.0f);
     std::vector<float> capR ((size_t) renderBlockSize, 0.0f);
+    std::vector<float> interleaved ((size_t) renderBlockSize * kNumChannels, 0.0f);
 
     duskstudio::device::CallbackContext ctx {};
 
@@ -1161,8 +1147,14 @@ bool BounceEngine::renderFreezeTrack (int trackIndex, const juce::File& outFile,
         const int writeCount = remaining - writeStart;
         if (writeCount > 0)
         {
-            float* capPtrs[kNumChannels] = { capL.data() + writeStart, capR.data() + writeStart };
-            if (! writer->writeFromFloatArrays (capPtrs, kNumChannels, writeCount))
+            const float* srcL = capL.data() + writeStart;
+            const float* srcR = capR.data() + writeStart;
+            for (int i = 0; i < writeCount; ++i)
+            {
+                interleaved[(size_t) i * 2]     = srcL[i];
+                interleaved[(size_t) i * 2 + 1] = srcR[i];
+            }
+            if (! writer->writeInterleaved (interleaved.data(), writeCount))
             {
                 const juce::ScopedLock lock (lastErrorLock);
                 lastError = "Writer failed mid-freeze at " + std::to_string (written) + " samples";

--- a/src/engine/BounceEngine.cpp
+++ b/src/engine/BounceEngine.cpp
@@ -96,7 +96,9 @@ BounceEngine::makeWriter (const juce::File& outFile, std::string& errOut) const
                                                         kNumChannels, renderBitrateKbps);
         if (! writer->isOk())
         {
-            errOut = "MP3 export is not available - this build has no libmp3lame.";
+            errOut = writer->fileOpened()
+                         ? "MP3 export is not available - this build has no libmp3lame."
+                         : "Could not create the MP3 output file.";
             return nullptr;
         }
         return writer;

--- a/src/engine/BounceEngine.h
+++ b/src/engine/BounceEngine.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include <juce_audio_formats/juce_audio_formats.h>
+#include <juce_core/juce_core.h>
 #include "../session/Session.h"
 #include "../foundation/Text.h"
+#include "audiofile/IFileWriteSink.h"
 #include <array>
 #include <atomic>
 #include <functional>
@@ -293,16 +294,16 @@ private:
 
     std::int64_t computeBounceLength (double sampleRate, double tail) const;
 
-    // Create the WAV or MP3 writer for the chosen format over an already-opened
-    // (truncated) output stream. Returns null + sets errOut on failure. Takes
-    // ownership of outStream on success; on failure outStream is freed.
-    std::unique_ptr<juce::AudioFormatWriter>
-        makeWriter (std::unique_ptr<juce::FileOutputStream> outStream, std::string& errOut) const;
+    // Create the WAV (libsndfile) or MP3 (libmp3lame) write sink for the chosen
+    // format, opening + truncating outFile itself. Null + errOut on failure; the
+    // file may already be truncated by then, so failure paths that must preserve
+    // prior content delete it.
+    std::unique_ptr<dusk::audio::IFileWriteSink>
+        makeWriter (const juce::File& outFile, std::string& errOut) const;
 
-    // Open + truncate outFile, then wrap it in the configured format writer.
-    // Null + errOut on failure - the file may already be truncated by then,
-    // so failure paths that must preserve prior content delete it.
-    std::unique_ptr<juce::AudioFormatWriter>
+    // makeWriter with the file name appended to the error, for the stem / realtime
+    // paths that render many files at once.
+    std::unique_ptr<dusk::audio::IFileWriteSink>
         openWriterFor (const juce::File& outFile, std::string& errOut) const;
 
     // Stem-tap registry plumbing shared by the offline and realtime stem

--- a/src/engine/DpAligner.h
+++ b/src/engine/DpAligner.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <juce_audio_formats/juce_audio_formats.h>
 #include <juce_core/juce_core.h>
 #include <vector>
 

--- a/src/engine/DpImporter.h
+++ b/src/engine/DpImporter.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <juce_audio_formats/juce_audio_formats.h>
 #include <juce_core/juce_core.h>
 #include <string>
 #include <vector>

--- a/src/engine/FileImporter.h
+++ b/src/engine/FileImporter.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <juce_audio_formats/juce_audio_formats.h>
 #include <juce_core/juce_core.h>
 #include "../session/Session.h"
 #include <string>

--- a/src/engine/LameMp3Writer.cpp
+++ b/src/engine/LameMp3Writer.cpp
@@ -10,128 +10,142 @@ namespace duskstudio
 {
 namespace
 {
-constexpr float kInt32ToFloat = 1.0f / 2147483648.0f;   // 32-bit int -> [-1, 1)
-
-int mp3BufferCapacity (int numSamples) noexcept
+// LAME's documented worst case for a block: 1.25 * frames + 7200 bytes.
+int mp3BufferCapacity (int numFrames) noexcept
 {
-    // LAME's documented worst case for a block: 1.25 * samples + 7200 bytes.
-    return (int) (1.25 * (double) numSamples) + 7200;
+    return (int) (1.25 * (double) numFrames) + 7200;
 }
+
+// Deinterleave + encode this many frames per LAME call, so writeInterleaved
+// stays allocation-free for any ring-chunk size the drain hands it.
+constexpr int kEncodeChunkFrames = 1 << 14;
 } // namespace
 
-LameMp3Writer::LameMp3Writer (juce::OutputStream* destStream, double sampleRate,
-                               unsigned int numChannels, int bitrateKbps)
-    : juce::AudioFormatWriter (destStream, "MP3 file", sampleRate,
-                                std::max (1u, numChannels), 16),
+LameMp3Writer::LameMp3Writer (const std::filesystem::path& path, double sampleRate,
+                               int numChannels, int bitrateKbps)
+    : channels (std::clamp (numChannels, 1, 2)),
       bitrate (bitrateKbps)
 {
+    file = std::fopen (path.string().c_str(), "wb");
+    if (file == nullptr)
+        return;
 #if DUSKSTUDIO_HAS_LAME
     auto* g = lame_init();
     if (g == nullptr) return;
     lame_set_in_samplerate  (g, (int) sampleRate);
     lame_set_out_samplerate (g, (int) sampleRate);
-    lame_set_num_channels   (g, (int) std::clamp (numChannels, 1u, 2u));
-    lame_set_mode           (g, numChannels >= 2 ? JOINT_STEREO : MONO);
+    lame_set_num_channels   (g, channels);
+    lame_set_mode           (g, channels >= 2 ? JOINT_STEREO : MONO);
     lame_set_brate          (g, bitrate);
     lame_set_quality        (g, 2);   // 0 = best/slowest .. 9 = worst; 2 is high
-    // Emit the Info (CBR Xing) placeholder frame; finalize() rewrites it with
-    // the real frame/byte counts so players report duration and seek
-    // correctly. Headerless CBR made some players guess the length.
+    // Emit the Info (CBR Xing) placeholder frame; flush() rewrites it with the
+    // real frame/byte counts so players report duration and seek correctly.
     lame_set_bWriteVbrTag   (g, 1);
     if (lame_init_params (g) < 0) { lame_close (g); return; }
     encoder = g;
-    mp3buf.resize ((size_t) mp3BufferCapacity (1 << 16));
+    mp3buf.resize ((size_t) mp3BufferCapacity (kEncodeChunkFrames));
+    scratchL.resize ((size_t) kEncodeChunkFrames);
+    scratchR.resize ((size_t) kEncodeChunkFrames);
 #else
-    juce::ignoreUnused (sampleRate, numChannels);
+    (void) sampleRate;
 #endif
 }
 
 LameMp3Writer::~LameMp3Writer()
 {
+    flush();   // best-effort; failure is unreportable from a destructor
 #if DUSKSTUDIO_HAS_LAME
     if (encoder != nullptr)
-    {
-        finalize();   // best-effort; failure is unreportable from a destructor
         lame_close (static_cast<lame_global_flags*> (encoder));
-        encoder = nullptr;
-    }
 #endif
-    // base ~AudioFormatWriter deletes `output` (the FileOutputStream flushes
-    // its remaining bytes and closes the file).
+    encoder = nullptr;
+    if (file != nullptr)
+    {
+        std::fclose (file);
+        file = nullptr;
+    }
 }
 
-bool LameMp3Writer::finalize()
+bool LameMp3Writer::flush()
 {
 #if DUSKSTUDIO_HAS_LAME
-    if (encoder == nullptr) return false;
+    if (encoder == nullptr || file == nullptr) return false;
     if (flushed) return true;
     flushed = true;
     auto* g = static_cast<lame_global_flags*> (encoder);
     if (mp3buf.size() < 7200) mp3buf.resize (7200);
     const int bytes = lame_encode_flush (g, mp3buf.data(), (int) mp3buf.size());
     if (bytes < 0)  return false;
-    if (bytes > 0 && (output == nullptr || ! output->write (mp3buf.data(), (size_t) bytes)))
+    if (bytes > 0 && std::fwrite (mp3buf.data(), 1, (size_t) bytes, file) != (size_t) bytes)
         return false;
 
-    // Rewrite the Info placeholder (first frame) with the real frame/byte
-    // counts. Best-effort: a stream that can't seek keeps the placeholder,
-    // which decodes as silence and merely costs the duration metadata.
-    if (output != nullptr)
+    // Rewrite the Info placeholder (first frame) with the real frame/byte counts.
+    // Best-effort: a stream that can't seek keeps the placeholder, which decodes
+    // as silence and merely costs the duration metadata.
+    unsigned char tag[2880];
+    const size_t tagSize = lame_get_lametag_frame (g, tag, sizeof (tag));
+    if (tagSize > 0 && tagSize <= sizeof (tag))
     {
-        unsigned char tag[2880];
-        const size_t tagSize = lame_get_lametag_frame (g, tag, sizeof (tag));
-        if (tagSize > 0 && tagSize <= sizeof (tag))
+        const long endPos = std::ftell (file);
+        if (endPos >= 0 && std::fseek (file, 0, SEEK_SET) == 0)
         {
-            const std::int64_t endPos = output->getPosition();
-            if (output->setPosition (0))
-            {
-                output->write (tag, tagSize);
-                output->setPosition (endPos);
-            }
+            std::fwrite (tag, 1, tagSize, file);
+            std::fseek (file, endPos, SEEK_SET);
         }
     }
+    std::fflush (file);
     return true;
 #else
     return false;
 #endif
 }
 
-bool LameMp3Writer::encode (const float* left, const float* right, int numSamples)
+bool LameMp3Writer::writeInterleaved (const float* interleaved, std::int64_t numFrames) noexcept
 {
 #if DUSKSTUDIO_HAS_LAME
-    if (encoder == nullptr) return false;
-    if (numSamples <= 0)    return true;
-    const int cap = mp3BufferCapacity (numSamples);
-    if ((int) mp3buf.size() < cap) mp3buf.resize ((size_t) cap);
-    auto* g = static_cast<lame_global_flags*> (encoder);
-    const int bytes = lame_encode_buffer_ieee_float (g, left, right, numSamples,
-                                                       mp3buf.data(), (int) mp3buf.size());
-    if (bytes < 0) return false;
-    return bytes == 0 || (output != nullptr && output->write (mp3buf.data(), (size_t) bytes));
+    if (encoder == nullptr || file == nullptr) return false;
+    if (numFrames <= 0) return true;
+
+    for (std::int64_t done = 0; done < numFrames; )
+    {
+        const int n = (int) std::min ((std::int64_t) kEncodeChunkFrames, numFrames - done);
+        const float* src = interleaved + done * channels;
+        if (channels >= 2)
+        {
+            for (int i = 0; i < n; ++i)
+            {
+                scratchL[(size_t) i] = src[(size_t) i * 2];
+                scratchR[(size_t) i] = src[(size_t) i * 2 + 1];
+            }
+        }
+        else
+        {
+            for (int i = 0; i < n; ++i)
+                scratchL[(size_t) i] = scratchR[(size_t) i] = src[(size_t) i];
+        }
+        if (! encode (scratchL.data(), scratchR.data(), n))
+            return false;
+        done += n;
+    }
+    return true;
 #else
-    juce::ignoreUnused (left, right, numSamples);
+    (void) interleaved; (void) numFrames;
     return false;
 #endif
 }
 
-bool LameMp3Writer::write (const int** samplesToWrite, int numSamples)
+bool LameMp3Writer::encode (const float* left, const float* right, int numFrames) noexcept
 {
-    if (numSamples <= 0)
-        return true;    // nothing to write - a legitimate no-op, not a failure
-    if (encoder == nullptr || samplesToWrite == nullptr)
-        return false;   // can't encode (consistent with the null-data check below)
-
-    // JUCE hands writers 32-bit-left-justified ints; convert to float for LAME.
-    scratchL.resize ((size_t) numSamples);
-    scratchR.resize ((size_t) numSamples);
-    const int* l = samplesToWrite[0];
-    const int* r = (numChannels > 1 && samplesToWrite[1] != nullptr) ? samplesToWrite[1] : l;
-    if (l == nullptr) return false;
-    for (int i = 0; i < numSamples; ++i)
-    {
-        scratchL[(size_t) i] = (float) l[i] * kInt32ToFloat;
-        scratchR[(size_t) i] = (float) r[i] * kInt32ToFloat;
-    }
-    return encode (scratchL.data(), scratchR.data(), numSamples);
+#if DUSKSTUDIO_HAS_LAME
+    if (numFrames <= 0) return true;
+    auto* g = static_cast<lame_global_flags*> (encoder);
+    const int bytes = lame_encode_buffer_ieee_float (g, left, right, numFrames,
+                                                       mp3buf.data(), (int) mp3buf.size());
+    if (bytes < 0) return false;
+    return bytes == 0 || std::fwrite (mp3buf.data(), 1, (size_t) bytes, file) == (size_t) bytes;
+#else
+    (void) left; (void) right; (void) numFrames;
+    return false;
+#endif
 }
 } // namespace duskstudio

--- a/src/engine/LameMp3Writer.cpp
+++ b/src/engine/LameMp3Writer.cpp
@@ -70,7 +70,7 @@ bool LameMp3Writer::flush()
 {
 #if DUSKSTUDIO_HAS_LAME
     if (encoder == nullptr || file == nullptr) return false;
-    if (flushed) return true;
+    if (flushed) return flushOk;
     flushed = true;
     auto* g = static_cast<lame_global_flags*> (encoder);
     if (mp3buf.size() < 7200) mp3buf.resize (7200);
@@ -94,6 +94,7 @@ bool LameMp3Writer::flush()
         }
     }
     std::fflush (file);
+    flushOk = true;
     return true;
 #else
     return false;

--- a/src/engine/LameMp3Writer.h
+++ b/src/engine/LameMp3Writer.h
@@ -1,46 +1,54 @@
 #pragma once
 
-#include <juce_audio_formats/juce_audio_formats.h>
+#include "audiofile/IFileWriteSink.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
 #include <vector>
 
 namespace duskstudio
 {
-// A juce::AudioFormatWriter backed by libmp3lame (constant bitrate). Owns the
-// OutputStream like every JUCE writer (the base destructor deletes it). When the
-// build has no LAME (DUSKSTUDIO_HAS_LAME unset), construction yields
-// isOk() == false and the caller errors out / falls back to WAV - the class
-// always compiles so call sites don't need their own #if guards.
-class LameMp3Writer final : public juce::AudioFormatWriter
+// A dusk::audio::IFileWriteSink backed by libmp3lame (constant bitrate), writing
+// to a stdio FILE it opens and owns. When the build has no LAME
+// (DUSKSTUDIO_HAS_LAME unset), construction yields isOk() == false and the caller
+// errors out / falls back to WAV - the class always compiles so call sites don't
+// need their own #if guards.
+class LameMp3Writer final : public dusk::audio::IFileWriteSink
 {
 public:
-    // Takes ownership of destStream. bitrateKbps is the CBR target (e.g. 320).
-    LameMp3Writer (juce::OutputStream* destStream, double sampleRate,
-                   unsigned int numChannels, int bitrateKbps);
+    // Opens path for writing (truncating). bitrateKbps is the CBR target (e.g. 320).
+    LameMp3Writer (const std::filesystem::path& path, double sampleRate,
+                   int numChannels, int bitrateKbps);
     ~LameMp3Writer() override;
 
-    bool isOk() const noexcept { return encoder != nullptr; }
+    LameMp3Writer (const LameMp3Writer&)            = delete;
+    LameMp3Writer& operator= (const LameMp3Writer&) = delete;
 
-    // Flush the encoder's buffered frames to the stream and report whether the
-    // write succeeded. The destructor also flushes, but it can't report a
-    // failure - call this first when the caller needs to distinguish a
-    // truncated file (disk full at flush) from a good one. Idempotent.
-    bool finalize();
+    bool isOk() const noexcept { return encoder != nullptr && file != nullptr; }
 
-    // Only write(int**) is virtual in juce::AudioFormatWriter; the float-array
-    // path (writeFromFloatArrays) is non-virtual and routes here after JUCE's
-    // float->32-bit-int conversion, which we convert back to float for LAME.
-    bool write (const int** samplesToWrite, int numSamples) override;
+    int numChannels() const noexcept override { return channels; }
+
+    // Interleaved float, matching the drain ring's storage. Deinterleaves in
+    // fixed chunks and encodes to LAME; allocation-free (scratch pre-sized in the
+    // ctor). The disk/pool thread is the only caller, never the audio thread.
+    bool writeInterleaved (const float* interleaved, std::int64_t numFrames) noexcept override;
+
+    // Flush the encoder's buffered frames and rewrite the Info (Xing) frame with
+    // the real frame/byte counts so players report duration + seek. Idempotent.
+    // The destructor also flushes, but it can't report a failure - call this
+    // first when a truncated-file (disk full at flush) distinction matters.
+    bool flush() override;
 
 private:
-    bool encode (const float* left, const float* right, int numSamples);
+    bool encode (const float* left, const float* right, int numFrames) noexcept;
 
-    void* encoder = nullptr;            // lame_global_flags* (opaque here so
-                                        // lame.h stays confined to the .cpp)
-    int   bitrate = 320;
+    void*      encoder = nullptr;   // lame_global_flags* (opaque so lame.h stays in the .cpp)
+    std::FILE* file    = nullptr;
+    int        channels = 2;
+    int        bitrate  = 320;
     std::vector<unsigned char> mp3buf;
     std::vector<float>         scratchL, scratchR;
     bool  flushed = false;
-
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (LameMp3Writer)
 };
 } // namespace duskstudio

--- a/src/engine/LameMp3Writer.h
+++ b/src/engine/LameMp3Writer.h
@@ -27,6 +27,10 @@ public:
 
     bool isOk() const noexcept { return encoder != nullptr && file != nullptr; }
 
+    // Splits the isOk()==false causes: false means the output file could not be
+    // opened; true means the file opened but the encoder is unavailable.
+    bool fileOpened() const noexcept { return file != nullptr; }
+
     int numChannels() const noexcept override { return channels; }
 
     // Interleaved float, matching the drain ring's storage. Deinterleaves in
@@ -35,9 +39,10 @@ public:
     bool writeInterleaved (const float* interleaved, std::int64_t numFrames) noexcept override;
 
     // Flush the encoder's buffered frames and rewrite the Info (Xing) frame with
-    // the real frame/byte counts so players report duration + seek. Idempotent.
-    // The destructor also flushes, but it can't report a failure - call this
-    // first when a truncated-file (disk full at flush) distinction matters.
+    // the real frame/byte counts so players report duration + seek. Idempotent;
+    // repeat calls report the first attempt's result, so a failed flush stays a
+    // failure. The destructor also flushes, but it can't report a failure - call
+    // this first when a truncated-file (disk full at flush) distinction matters.
     bool flush() override;
 
 private:
@@ -50,5 +55,6 @@ private:
     std::vector<unsigned char> mp3buf;
     std::vector<float>         scratchL, scratchR;
     bool  flushed = false;
+    bool  flushOk = false;
 };
 } // namespace duskstudio

--- a/src/engine/MasteringPlayer.cpp
+++ b/src/engine/MasteringPlayer.cpp
@@ -11,7 +11,9 @@ namespace duskstudio
 {
 MasteringPlayer::~MasteringPlayer()
 {
-    currentReader.store (nullptr, std::memory_order_release);
+    // Parks currentReader on null and drains any in-flight process() so the
+    // readers can't be destroyed under a callback that latched the pointer.
+    parkAndWaitForAudio();
     previousReader.reset();
     ownedReader.reset();
 }

--- a/src/engine/MasteringPlayer.cpp
+++ b/src/engine/MasteringPlayer.cpp
@@ -4,24 +4,16 @@
 #include <cmath>
 #include <cstdio>
 #include <cstring>
+#include <filesystem>
 #include <thread>
 
 namespace duskstudio
 {
-MasteringPlayer::MasteringPlayer()
-{
-    formatManager.registerBasicFormats();
-    bufferingThread.startThread();
-}
-
 MasteringPlayer::~MasteringPlayer()
 {
-    // Readers detach from bufferingThread on destruction; drop them
-    // before joining the thread.
     currentReader.store (nullptr, std::memory_order_release);
     previousReader.reset();
     ownedReader.reset();
-    bufferingThread.stopThread (2000);
 }
 
 bool MasteringPlayer::parkAndWaitForAudio()
@@ -68,7 +60,7 @@ void MasteringPlayer::prepare (int maxBlockSize, double deviceSampleRate)
 
 void MasteringPlayer::updateResampleState()
 {
-    const double srcRate = ownedReader != nullptr ? ownedReader->sampleRate : 0.0;
+    const double srcRate = ownedReader != nullptr ? ownedReader->info().sampleRate : 0.0;
     const double ratio   = (srcRate > 0.0 && preparedDeviceRate > 0.0)
                                ? srcRate / preparedDeviceRate : 1.0;
     // Worst-case source samples one output block can consume, plus the
@@ -86,18 +78,14 @@ bool MasteringPlayer::loadFile (const juce::File& file)
     unloadFile();
     if (! file.existsAsFile()) return false;
 
-    std::unique_ptr<juce::AudioFormatReader> raw (formatManager.createReaderFor (file));
+    auto raw = dusk::audio::FileReader::open (
+        std::filesystem::u8path (file.getFullPathName().toStdString()));
     if (raw == nullptr) return false;
 
-    // Wrap in a BufferingAudioReader so process() reads from prefetched
-    // memory. 96000 samples ≈ 1-2 s of lead; timeout 0 keeps the audio
-    // thread non-blocking - a prefetch miss (right after a seek) returns
-    // silence until the prefetch catches up. Same pattern as
-    // PlaybackEngine.
-    constexpr int kSamplesToBuffer = 96000;
-    auto r = std::make_unique<juce::BufferingAudioReader> (
-        raw.release(), bufferingThread, kSamplesToBuffer);
-    r->setReadTimeout (0);
+    // Buffered so process() reads from prefetched memory: the default window
+    // is 1-2 s of lead, and a miss (right after a seek) returns silence until
+    // the prefetch catches up. Same pattern as PlaybackEngine.
+    auto r = std::make_unique<dusk::audio::BufferedFileReader> (std::move (raw));
 
     // Stop playback before swapping the reader. The audio thread reads
     // `playing` first and bails before touching the reader pointer; this
@@ -140,12 +128,12 @@ void MasteringPlayer::unloadFile()
 
 std::int64_t MasteringPlayer::getLengthSamples() const noexcept
 {
-    return ownedReader ? ownedReader->lengthInSamples : 0;
+    return ownedReader ? ownedReader->info().numFrames : 0;
 }
 
 double MasteringPlayer::getSourceSampleRate() const noexcept
 {
-    return ownedReader ? ownedReader->sampleRate : 0.0;
+    return ownedReader ? ownedReader->info().sampleRate : 0.0;
 }
 
 void MasteringPlayer::process (float* L, float* R, int numSamples) noexcept
@@ -166,9 +154,11 @@ void MasteringPlayer::process (float* L, float* R, int numSamples) noexcept
     auto* r = currentReader.load (std::memory_order_acquire);
     if (r == nullptr) return;
 
-    const std::int64_t start = playhead.load (std::memory_order_relaxed);
+    const std::int64_t start  = playhead.load (std::memory_order_relaxed);
+    const std::int64_t length = r->info().numFrames;
+    const bool         mono   = r->info().numChannels < 2;
     if (start < 0) return;
-    if (start >= r->lengthInSamples)
+    if (start >= length)
     {
         // Past EOF - auto-stop so the UI can flip the Play button back.
         playing.store (false, std::memory_order_relaxed);
@@ -179,15 +169,15 @@ void MasteringPlayer::process (float* L, float* R, int numSamples) noexcept
     if (std::abs (ratio - 1.0) < 1.0e-9)
     {
         const int  available = (int) std::min ((std::int64_t) numSamples,
-                                                  (std::int64_t) (r->lengthInSamples - start));
+                                                  (std::int64_t) (length - start));
         if (available > readScratch.getNumSamples()) return;  // shouldn't happen
 
-        // Read into our 2-ch scratch. AudioFormatReader::read with two non-null
-        // destination pointers fills both; for mono sources it duplicates the
-        // single channel into both, which is exactly what we want.
-        r->read (&readScratch, 0, available, start,
-                  /*useLeftChan*/  true,
-                  /*useRightChan*/ true);
+        // The reader zero-fills destination channels the file doesn't have, so
+        // a mono source is duplicated here to keep the stage stereo.
+        float* dest[2] = { readScratch.getWritePointer (0), readScratch.getWritePointer (1) };
+        r->readRt (dest, 2, start, available);
+        if (mono)
+            std::memcpy (dest[1], dest[0], sizeof (float) * (size_t) available);
 
         std::memcpy (L, readScratch.getReadPointer (0), sizeof (float) * (size_t) available);
         std::memcpy (R, readScratch.getReadPointer (1), sizeof (float) * (size_t) available);
@@ -195,7 +185,7 @@ void MasteringPlayer::process (float* L, float* R, int numSamples) noexcept
         playhead.fetch_add (available, std::memory_order_relaxed);
 
         // If we just hit EOF mid-block, auto-stop.
-        if (start + available >= r->lengthInSamples)
+        if (start + available >= length)
             playing.store (false, std::memory_order_relaxed);
         return;
     }
@@ -216,21 +206,26 @@ void MasteringPlayer::process (float* L, float* R, int numSamples) noexcept
 
     // Read past-EOF input as silence so the interpolator can flush the tail.
     const int inAvailable = (int) std::min ((std::int64_t) inNeeded,
-                                               (std::int64_t) (r->lengthInSamples - start));
+                                               (std::int64_t) (length - start));
     inScratch.clear();
     if (inAvailable > 0)
-        r->read (&inScratch, 0, inAvailable, start, true, true);
+    {
+        float* dest[2] = { inScratch.getWritePointer (0), inScratch.getWritePointer (1) };
+        r->readRt (dest, 2, start, inAvailable);
+        if (mono)
+            std::memcpy (dest[1], dest[0], sizeof (float) * (size_t) inAvailable);
+    }
 
     const int usedL = interpL.process (ratio, inScratch.getReadPointer (0), L, numSamples);
     const int usedR = interpR.process (ratio, inScratch.getReadPointer (1), R, numSamples);
     juce::ignoreUnused (usedR);   // both consume identically for equal ratios
 
     const std::int64_t consumed = std::min ((std::int64_t) usedL,
-                                              (std::int64_t) (r->lengthInSamples - start));
+                                              (std::int64_t) (length - start));
     playhead.fetch_add (consumed, std::memory_order_relaxed);
     resampleReadPos = start + consumed;
 
-    if (start + consumed >= r->lengthInSamples)
+    if (start + consumed >= length)
         playing.store (false, std::memory_order_relaxed);
 }
 } // namespace duskstudio

--- a/src/engine/MasteringPlayer.h
+++ b/src/engine/MasteringPlayer.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <juce_audio_basics/juce_audio_basics.h>
-#include <juce_audio_formats/juce_audio_formats.h>
 #include <juce_core/juce_core.h>
 #include <atomic>
 #include <memory>
+#include "audiofile/BufferedFileReader.h"
 
 namespace duskstudio
 {
@@ -21,7 +21,6 @@ namespace duskstudio
 class MasteringPlayer
 {
 public:
-    MasteringPlayer();
     ~MasteringPlayer();
 
     // Message thread. deviceSampleRate drives the resampler: a source whose
@@ -51,26 +50,18 @@ public:
     void process (float* L, float* R, int numSamples) noexcept;
 
 private:
-    juce::AudioFormatManager formatManager;
-
-    // Declared before the readers so it outlives them (destruction is
-    // reverse declaration order). Prefetches for the BufferingAudioReader
-    // wrapper so process() never does synchronous disk I/O - a cold file
-    // or a seek after setPlayhead would otherwise stall the callback.
-    juce::TimeSliceThread bufferingThread { "Dusk Studio mastering prefetch" };
-
     // Owning pointer - mutated only on the message thread (loadFile /
     // unloadFile). The audio thread reads via the `currentReader` atomic
     // below (PluginSlot pattern). `previousReader` keeps the prior owned
     // reader alive across one publish so the audio thread can safely finish
     // its current block with the old pointer; the next publish drops it.
-    std::unique_ptr<juce::AudioFormatReader> ownedReader;
-    std::unique_ptr<juce::AudioFormatReader> previousReader;
+    std::unique_ptr<dusk::audio::BufferedFileReader> ownedReader;
+    std::unique_ptr<dusk::audio::BufferedFileReader> previousReader;
 
     // Audio-thread-safe view of `ownedReader.get()`. The audio thread
     // acquire-loads this once per block and uses the resulting pointer for
     // the rest of the block. Message-thread writes are release-stores.
-    std::atomic<juce::AudioFormatReader*> currentReader { nullptr };
+    std::atomic<dusk::audio::BufferedFileReader*> currentReader { nullptr };
 
     juce::File loadedFile;
 

--- a/src/engine/PlaybackEngine.cpp
+++ b/src/engine/PlaybackEngine.cpp
@@ -5,12 +5,18 @@
 #include <cmath>
 #include <cstdio>
 #include <cstring>
+#include <filesystem>
 #include <thread>
 
 namespace duskstudio
 {
 namespace
 {
+std::filesystem::path audioPath (const juce::File& file)
+{
+    return std::filesystem::u8path (file.getFullPathName().toStdString());
+}
+
 // Samples pre-cached at the loop start per region (~0.68 s at 48 kHz) -
 // comfortably longer than the prefetch thread needs to re-warm a reader
 // after the backward seek at a loop wrap.
@@ -24,24 +30,11 @@ constexpr int kLoopSeamFade = 64;
 // would degenerate into per-sample spans.
 constexpr std::int64_t kMinLoopLenForSplit = 2 * (std::int64_t) kLoopSeamFade;
 } // namespace
-PlaybackEngine::PlaybackEngine (Session& s) : session (s)
-{
-    formatManager.registerBasicFormats();
-
-    // Start the prefetch thread once at construction. BufferingAudioReader
-    // instances created later in preparePlayback() attach themselves via
-    // addTimeSliceClient (handled by the BufferingAudioReader ctor) and
-    // detach on destruction in stopPlayback().
-    bufferingThread.startThread();
-}
+PlaybackEngine::PlaybackEngine (Session& s) : session (s) {}
 
 PlaybackEngine::~PlaybackEngine()
 {
-    // Tear down readers (which detach from bufferingThread) before letting
-    // the thread member go out of scope. stopPlayback handles the readers;
-    // ~TimeSliceThread joins.
     stopPlayback();
-    bufferingThread.stopThread (2000);
 }
 
 void PlaybackEngine::prepare (int maxBlockSize)
@@ -115,20 +108,27 @@ void PlaybackEngine::preparePlayback()
         {
             if (! region.file.existsAsFile()) continue;
 
-            std::unique_ptr<juce::AudioFormatReader> rawReader (
-                formatManager.createReaderFor (region.file));
+            auto rawReader = dusk::audio::FileReader::open (audioPath (region.file));
             if (rawReader == nullptr) continue;
 
-            // Wrap in a BufferingAudioReader. Sample rate of the source isn't
-            // known at this scope without inspecting `rawReader`, so size by
-            // a fixed sample count: 96000 samples is ~1 s at 96 kHz / ~2 s at
-            // 44.1 kHz - generous given block sizes are 256-2048. Read
-            // timeout 0 keeps the audio thread non-blocking; missed reads
-            // return silence until prefetch catches up.
-            constexpr int kSamplesToBuffer = 96000;
-            auto buffered = std::make_unique<juce::BufferingAudioReader> (
-                rawReader.release(), bufferingThread, kSamplesToBuffer);
-            buffered->setReadTimeout (0);
+            // 96000 frames is ~1 s at 96 kHz / ~2 s at 44.1 kHz - generous
+            // given block sizes are 256-2048 - but a region shorter than that
+            // never reads past its own end, and a take-heavy session opens one
+            // reader per region, so cap the window at the region length.
+            const std::int64_t windowFrames =
+                std::clamp (region.lengthInSamples, (std::int64_t) 8192,
+                             dusk::audio::BufferedFileReader::kDefaultWindowFrames);
+            auto buffered = std::make_unique<dusk::audio::BufferedFileReader> (
+                std::move (rawReader), windowFrames);
+            // Warm where playback will begin, not at the region head - every
+            // caller sets the playhead before rebuilding, so Play from mid-song
+            // starts warm instead of dropping blocks while the window re-seeks.
+            const std::int64_t startInRegion =
+                transport != nullptr
+                    ? std::clamp (transport->getPlayhead() - region.timelineStart,
+                                   (std::int64_t) 0, std::max ((std::int64_t) 0, region.lengthInSamples))
+                    : 0;
+            buffered->prefetch (region.sourceOffset + startInRegion);
 
             RegionStream rs;
             rs.reader          = std::move (buffered);
@@ -228,21 +228,23 @@ void PlaybackEngine::primeLoopCaches (std::int64_t loopStart, std::int64_t loopE
                                                         regionEnd);
             if (cacheEnd <= cacheStart) continue;
 
-            // A fresh plain reader for the fill: the region's own
-            // BufferingAudioReader would return silence on a cold window
-            // (timeout 0), and bumping its window here would fight the
-            // audio thread's forward prefetch.
-            std::unique_ptr<juce::AudioFormatReader> fillReader (
-                formatManager.createReaderFor (rs.sourceFile));
+            // A fresh plain reader for the fill: the region's own buffered
+            // reader would return silence on a cold window, and bumping its
+            // window here would fight the audio thread's forward prefetch.
+            auto fillReader = dusk::audio::FileReader::open (audioPath (rs.sourceFile));
             if (fillReader == nullptr) continue;
 
             const int len = (int) (cacheEnd - cacheStart);
-            const bool stereo = (rs.numChannels == 2);
+            // A region can claim two channels over a mono file (hand-edited
+            // session, file replaced on disk). Reading one channel and letting
+            // the audio path duplicate it keeps that case center-panned instead
+            // of silencing the right side.
+            const bool stereo = (rs.numChannels == 2) && fillReader->info().numChannels >= 2;
             juce::AudioBuffer<float> tmp (2, len);
             tmp.clear();
-            fillReader->read (&tmp, 0, len,
-                               rs.sourceOffset + (cacheStart - rs.timelineStart),
-                               true, stereo);
+            float* fillDest[2] = { tmp.getWritePointer (0), tmp.getWritePointer (1) };
+            fillReader->read (fillDest, stereo ? 2 : 1,
+                               rs.sourceOffset + (cacheStart - rs.timelineStart), len);
 
             rs.loopCacheL.assign (tmp.getReadPointer (0), tmp.getReadPointer (0) + len);
             if (stereo)
@@ -404,14 +406,13 @@ void PlaybackEngine::readSpanForTrack (PerTrackStream& slotRef,
         if (withinSamples > readScratch.getNumSamples()) continue;
 
         const std::int64_t readStart = r.sourceOffset + (firstWithin - r.timelineStart);
-        // For mono regions, read L only. For stereo, read both. The
-        // BufferingAudioReader's read(useLeft, useRight) flags do the
-        // right thing on either side; we always have a 2-channel
-        // readScratch so the call is safe regardless.
-        const bool readStereo = (r.numChannels == 2);
-        r.reader->read (&readScratch, 0, withinSamples, readStart,
-                         /*useLeftChan*/ true,
-                         /*useRightChan*/ readStereo);
+        // For mono regions, read L only. For stereo, read both. readScratch is
+        // always 2-channel, so the call is safe either way. A stereo region
+        // over a mono file reads one channel and duplicates below, rather than
+        // taking the reader's zero-filled second channel as silence.
+        const bool readStereo = (r.numChannels == 2) && r.reader->info().numChannels >= 2;
+        float* dest[2] = { readScratch.getWritePointer (0), readScratch.getWritePointer (1) };
+        r.reader->readRt (dest, readStereo ? 2 : 1, readStart, withinSamples);
 
         // Serve the loop-start window from the pre-cache: the forward-only
         // reader misses (returns silence) right after a wrap's backward

--- a/src/engine/PlaybackEngine.h
+++ b/src/engine/PlaybackEngine.h
@@ -1,21 +1,21 @@
 #pragma once
 
 #include <juce_audio_basics/juce_audio_basics.h>
-#include <juce_audio_formats/juce_audio_formats.h>
 #include <juce_core/juce_core.h>
 #include <array>
 #include <atomic>
 #include <memory>
+#include "audiofile/BufferedFileReader.h"
 #include "../session/Session.h"
 
 namespace duskstudio
 {
 class Transport;
 
-// Multi-region playback. One BufferingAudioReader per region, all sharing
-// a TimeSliceThread for prefetch. Audio thread reads from pre-filled
-// buffers; on prefetch miss (right after Play or seek) readers return
-// silence rather than block.
+// Multi-region playback. One buffered reader per region, each keeping a
+// prefetch window resident. Audio thread reads from those windows; on a
+// prefetch miss (right after Play or seek) a reader returns silence rather
+// than block.
 class PlaybackEngine
 {
 public:
@@ -59,15 +59,10 @@ public:
 private:
     Session& session;
     const Transport* transport = nullptr;
-    juce::AudioFormatManager formatManager;
-
-    // Declared before streams so it outlives the readers attached to
-    // it (destruction is reverse declaration order).
-    juce::TimeSliceThread bufferingThread { "Dusk Studio playback prefetch" };
 
     struct RegionStream
     {
-        std::unique_ptr<juce::BufferingAudioReader> reader;
+        std::unique_ptr<dusk::audio::BufferedFileReader> reader;
         juce::File  sourceFile;
         std::int64_t timelineStart   = 0;
         std::int64_t lengthInSamples = 0;
@@ -92,10 +87,10 @@ private:
         float       gainLinear      = 1.0f;
         bool        muted           = false;
 
-        // Loop-start pre-cache. BufferingAudioReader prefetches forward
-        // only, so the backward seek at every loop wrap misses and (with
-        // timeout 0) returns silence until the prefetch thread catches
-        // up - an audible dropout at the top of every cycle. These hold
+        // Loop-start pre-cache. The reader's window follows playback
+        // forward, so the backward seek at every loop wrap misses and
+        // returns silence until the prefetch thread catches up - an
+        // audible dropout at the top of every cycle. These hold
         // the region's raw source samples for the timeline window
         // [loopCacheTimelineStart, +loopCacheLen), filled on the message
         // thread in preparePlayback while the audio thread is guaranteed

--- a/src/engine/RecordManager.cpp
+++ b/src/engine/RecordManager.cpp
@@ -1,6 +1,7 @@
 #include "RecordManager.h"
 #include "audiofile/FileWriter.h"
 #include <algorithm>
+#include <new>
 #include <thread>
 #include <unordered_map>
 
@@ -163,18 +164,38 @@ bool RecordManager::startRecording (double sampleRate, std::int64_t startSample)
         // exotic low-rate setups.
         const int kRingFrames = std::max (65536, (int) (sampleRate * 4.0));
 
-        // The ThreadedFileWriter ctor allocates its interleaved ring and can
-        // throw std::bad_alloc on a memory-starved system; we let it propagate
-        // out of startRecording cleanly. Any per-track writers already built
-        // unwind via the array's unique_ptr dtors (each drains + closes its
-        // WAV), active was never set true so the audio thread stays a no-op,
-        // and the caller surfaces "recording cannot start" to the user.
-        auto perTrack = std::make_unique<PerTrackWriter>();
-        perTrack->file = outFile;
-        perTrack->numChannels = trackChannels;
-        perTrack->writer = std::make_unique<dusk::audio::ThreadedFileWriter> (
-            std::move (fileWriter), kRingFrames,
-            dusk::audio::ThreadedFileWriter::Drain::External);
+        // The ThreadedFileWriter ctor allocates a multi-MB ring per track, the
+        // realistic bad_alloc site in this loop on a memory-starved system.
+        // Unwind the whole take and return false so record() surfaces the
+        // failure; active is still false, so nothing here is visible to the
+        // audio thread and the writers built so far can be unregistered and
+        // destroyed safely.
+        std::unique_ptr<PerTrackWriter> perTrack;
+        try
+        {
+            perTrack = std::make_unique<PerTrackWriter>();
+            perTrack->file = outFile;
+            perTrack->numChannels = trackChannels;
+            perTrack->writer = std::make_unique<dusk::audio::ThreadedFileWriter> (
+                std::move (fileWriter), kRingFrames,
+                dusk::audio::ThreadedFileWriter::Drain::External);
+        }
+        catch (const std::bad_alloc&)
+        {
+            std::fprintf (stderr,
+                          "[Dusk Studio/RecordManager] startRecording: track %d "
+                          "writer ring allocation failed; aborting the take.\n", t + 1);
+            lastSetupFailures.push_back (t);
+            for (auto& w : writers)
+                if (w != nullptr)
+                {
+                    drainPool.remove (w->writer.get());
+                    w.reset();
+                }
+            for (auto& cap : midiCaptures)
+                cap.reset();
+            return false;
+        }
 
         // Registry sized to kNumTracks (never full here); a false return would
         // leave a writer whose ring nothing drains, so drop the take instead.

--- a/src/engine/RecordManager.cpp
+++ b/src/engine/RecordManager.cpp
@@ -1,4 +1,5 @@
 #include "RecordManager.h"
+#include "audiofile/FileWriter.h"
 #include <algorithm>
 #include <thread>
 #include <unordered_map>
@@ -23,16 +24,12 @@ void trimTakeHistory (Region& region) noexcept
 }
 } // namespace
 
-RecordManager::RecordManager (Session& s) : session (s)
-{
-    diskThread.startThread();
-}
+RecordManager::RecordManager (Session& s) : session (s) {}
 
 RecordManager::~RecordManager()
 {
     if (active.load (std::memory_order_relaxed))
         stopRecording (0);
-    diskThread.stopThread (2000);
 }
 
 bool RecordManager::startRecording (double sampleRate, std::int64_t startSample)
@@ -131,18 +128,6 @@ bool RecordManager::startRecording (double sampleRate, std::int64_t startSample)
             outFile = audioDir.getNonexistentChildFile (
                 trackName.upToLastOccurrenceOf (".wav", false, true), ".wav");
 
-        auto* fileStream = outFile.createOutputStream().release();
-        if (fileStream == nullptr)
-        {
-            std::fprintf (stderr,
-                          "[Dusk Studio/RecordManager] startRecording: track %d "
-                          "createOutputStream failed for \"%s\" - take will be silently "
-                          "dropped without this surface.\n",
-                          t + 1, outFile.getFullPathName().toRawUTF8());
-            lastSetupFailures.push_back (t);
-            continue;
-        }
-
         // 24-bit WAV per the spec. Channel count follows the track's mode:
         // 1 for Mono / Midi (MIDI tracks don't audio-record yet), 2 for
         // Stereo. The writer's channel count is captured here so writeInput-
@@ -151,19 +136,21 @@ bool RecordManager::startRecording (double sampleRate, std::int64_t startSample)
             session.track (t).mode.load (std::memory_order_relaxed)
                 == (int) Track::Mode::Stereo ? 2 : 1;
 
-        std::unique_ptr<juce::AudioFormatWriter> writer (
-            wav.createWriterFor (fileStream, sampleRate, (unsigned int) trackChannels,
-                                  24, {}, 0));
-        if (writer == nullptr)
+        dusk::audio::WriteSpec spec;
+        spec.sampleRate    = sampleRate;
+        spec.numChannels   = trackChannels;
+        spec.bitsPerSample = 24;
+        spec.format        = dusk::audio::WriteSpec::Format::Wav;
+        auto fileWriter = dusk::audio::FileWriter::create (
+            outFile.getFullPathName().toStdString(), spec);
+        if (fileWriter == nullptr)
         {
             std::fprintf (stderr,
                           "[Dusk Studio/RecordManager] startRecording: track %d "
-                          "createWriterFor failed (format-level error).\n",
-                          t + 1);
+                          "FileWriter::create failed for \"%s\" - take will be silently "
+                          "dropped without this surface.\n",
+                          t + 1, outFile.getFullPathName().toRawUTF8());
             lastSetupFailures.push_back (t);
-            // juce::AudioFormat::createWriterFor contract: takes ownership
-            // of the stream on success AND deletes it on failure, so we must
-            // not delete it ourselves here.
             continue;
         }
 
@@ -174,41 +161,28 @@ bool RecordManager::startRecording (double sampleRate, std::int64_t startSample)
         // case constant: ≈ 1.5 MB / track @ 48k stereo vs ≈ 3 MB @ 96k.
         // Floor at 65536 samples to guarantee a safety margin even on
         // exotic low-rate setups.
-        const int kThreadedWriterSamples = std::max (65536, (int) (sampleRate * 4.0));
+        const int kRingFrames = std::max (65536, (int) (sampleRate * 4.0));
 
-        // ThreadedWriter ctor allocates its FIFO + worker queue and can
-        // throw std::bad_alloc on a memory-starved system. We do NOT catch
-        // here: ownership of the raw AudioFormatWriter passes into JUCE
-        // mid-ctor and the exact transfer point is implementation-detail,
-        // so a catch-and-cleanup is ambiguous (potential double-free if
-        // JUCE already destroyed the writer in unwind). On bad_alloc the
-        // exception propagates out of startRecording cleanly:
-        //   - any per-track writers we already built unwind via the array's
-        //     unique_ptr dtors (each drains its FIFO + closes its WAV);
-        //   - active was never set to true, so the audio thread sees
-        //     active=false and is a no-op;
-        //   - caller (AudioEngine::record) sees a false return and surfaces
-        //     "recording cannot start" to the user.
-        // bad_alloc here means the system is in genuine memory exhaustion;
-        // failing the record arm is the correct response.
+        // The ThreadedFileWriter ctor allocates its interleaved ring and can
+        // throw std::bad_alloc on a memory-starved system; we let it propagate
+        // out of startRecording cleanly. Any per-track writers already built
+        // unwind via the array's unique_ptr dtors (each drains + closes its
+        // WAV), active was never set true so the audio thread stays a no-op,
+        // and the caller surfaces "recording cannot start" to the user.
         auto perTrack = std::make_unique<PerTrackWriter>();
         perTrack->file = outFile;
         perTrack->numChannels = trackChannels;
-        perTrack->writer = std::make_unique<juce::AudioFormatWriter::ThreadedWriter> (
-            writer.release(), diskThread, kThreadedWriterSamples);
-        if (perTrack->writer == nullptr)
+        perTrack->writer = std::make_unique<dusk::audio::ThreadedFileWriter> (
+            std::move (fileWriter), kRingFrames,
+            dusk::audio::ThreadedFileWriter::Drain::External);
+
+        // Registry sized to kNumTracks (never full here); a false return would
+        // leave a writer whose ring nothing drains, so drop the take instead.
+        if (! drainPool.add (perTrack->writer.get()))
         {
-            // Defensive: make_unique returning null is not standard-conformant
-            // (it throws on failure, never returns null), but a future custom
-            // allocator or instrumented build could. We can't reclaim the raw
-            // AudioFormatWriter since its ownership state is undefined here;
-            // treat the slot as "armed but inactive" and continue. The
-            // existing slot->writer null-check on the audio thread
-            // (writeInputBlock) makes the missing entry safe.
             std::fprintf (stderr,
                           "[Dusk Studio/RecordManager] startRecording: track %d "
-                          "ThreadedWriter is null after construction; take dropped.\n",
-                          t + 1);
+                          "drain pool full; take dropped.\n", t + 1);
             lastSetupFailures.push_back (t);
             continue;
         }
@@ -489,7 +463,11 @@ void RecordManager::stopRecording (std::int64_t endSample)
         if (slot == nullptr) continue;
 
         const auto frames = slot->framesWritten;
-        slot->writer.reset();  // closes the file
+        // Producer stopped (active false + audioInFlight drained above): the
+        // pool drains this writer's ring to empty and flushes it on this thread,
+        // then unregisters it, so the file is complete before reset() closes it.
+        drainPool.remove (slot->writer.get());
+        slot->writer.reset();  // flush + close
 
         if (frames > 0)
         {
@@ -786,8 +764,8 @@ void RecordManager::writeInputBlock (int trackIndex,
     if (slot == nullptr || slot->writer == nullptr || L == nullptr) return;
 
     // Build the channel-pointer array to match the writer's channel count.
-    // ThreadedWriter::write reads exactly numChannels pointers from the
-    // array, so each slot it touches must be non-null.
+    // push() reads numChannels pointers from the array, so each slot it
+    // touches must be non-null.
     //   - Mono writer (numChannels == 1): only L is read; R is ignored even
     //     if the caller supplied it (mono-armed track + stereo input is a
     //     caller bug, asserted below).
@@ -797,7 +775,7 @@ void RecordManager::writeInputBlock (int trackIndex,
     const float* channels[2] = { L, (R != nullptr) ? R : L };
     jassert (channels[0] != nullptr
              && (slot->numChannels < 2 || channels[1] != nullptr));
-    if (slot->writer->write (channels, numSamples))
+    if (slot->writer->push (channels, slot->numChannels, numSamples))
         slot->framesWritten += numSamples;
     else
         slot->writeFailures.fetch_add (1, std::memory_order_relaxed);

--- a/src/engine/RecordManager.h
+++ b/src/engine/RecordManager.h
@@ -1,19 +1,20 @@
 #pragma once
 
 #include <juce_audio_basics/juce_audio_basics.h>
-#include <juce_audio_formats/juce_audio_formats.h>
 #include <juce_core/juce_core.h>
 #include <array>
 #include <atomic>
 #include <memory>
 #include "../session/Session.h"
+#include "audiofile/ThreadedFileWriter.h"
+#include "audiofile/WriterDrainPool.h"
 
 namespace duskstudio
 {
 // Per-track threaded WAV writer. Created on the message thread at
-// startRecording, written from the audio thread (lock-free queue),
-// drained by a TimeSliceThread, finalized on the message thread at
-// stopRecording.
+// startRecording, written from the audio thread (lock-free ring),
+// drained by a shared WriterDrainPool disk thread, finalized on the
+// message thread at stopRecording.
 class RecordManager
 {
 public:
@@ -84,17 +85,19 @@ private:
 
     struct PerTrackWriter
     {
-        std::unique_ptr<juce::AudioFormatWriter::ThreadedWriter> writer;
+        std::unique_ptr<dusk::audio::ThreadedFileWriter> writer;
         juce::File file;
         std::int64_t framesWritten = 0;
         int numChannels = 1;
         std::atomic<std::uint64_t> writeFailures { 0 };
     };
 
-    juce::TimeSliceThread diskThread { "Dusk Studio recorder" };
-    juce::WavAudioFormat wav;
-
     std::array<std::unique_ptr<PerTrackWriter>, Session::kNumTracks> writers;
+
+    // Declared after the writers so it destructs FIRST: the pool's disk thread
+    // joins before any ThreadedFileWriter is torn down, so nothing races the
+    // per-writer drainOnce() the pool would otherwise be running.
+    dusk::audio::WriterDrainPool drainPool { Session::kNumTracks };
 
     // ~30 min of busy controller stream (16 events/s × 1800 s = 28k).
     // RawEvent is POD so the FIFO pre-sizes without audio-thread heap.

--- a/src/engine/audiofile/BufferedFileReader.cpp
+++ b/src/engine/audiofile/BufferedFileReader.cpp
@@ -1,0 +1,186 @@
+#include "BufferedFileReader.h"
+
+#include <algorithm>
+#include <cstring>
+
+namespace dusk::audio
+{
+namespace
+{
+// Frames pulled from disk per pass. Large enough that a full window is a
+// handful of reads, small enough that the destructor's stop flag is seen
+// between them.
+constexpr std::int64_t kFillChunkFrames = 8192;
+
+// How long the worker sleeps once the window is full. Short while the read
+// position is moving, because an offline render drains the window far faster
+// than real time; long once it has stopped, because a session holds a reader
+// per region and most of them are never read.
+constexpr int kActiveWaitMs = 5;
+constexpr int kIdleWaitMs   = 100;
+} // namespace
+
+BufferedFileReader::BufferedFileReader (std::unique_ptr<FileReader> src,
+                                        std::int64_t windowFrames,
+                                        Fill fill)
+    : source (std::move (src)),
+      fileInfo (source != nullptr ? source->info() : FileInfo {}),
+      channels (fileInfo.numChannels),
+      capacity (std::max<std::int64_t> (2, windowFrames))
+{
+    if (channels <= 0) return;   // unreadable file: every read stays a miss
+
+    ring.resize ((size_t) capacity * (size_t) channels, 0.0f);
+    fillDest.resize ((size_t) channels, nullptr);
+
+    if (fill == Fill::Background)
+        worker = std::thread ([this] { run(); });
+}
+
+BufferedFileReader::~BufferedFileReader()
+{
+    stop.store (true, std::memory_order_release);
+    wake.signal();
+    if (worker.joinable())
+        worker.join();
+}
+
+void BufferedFileReader::prefetch (std::int64_t startFrame) noexcept
+{
+    hintFrame.store (std::max<std::int64_t> (0, startFrame), std::memory_order_release);
+    wake.signal();
+}
+
+void BufferedFileReader::fillNow()
+{
+    while (fillStep()) {}
+}
+
+void BufferedFileReader::run()
+{
+    std::int64_t lastHint = -1;
+    while (! stop.load (std::memory_order_acquire))
+    {
+        if (fillStep()) continue;
+
+        const std::int64_t h = hintFrame.load (std::memory_order_acquire);
+        const bool moving = (h != lastHint);
+        lastHint = h;
+        wake.wait (moving ? kActiveWaitMs : kIdleWaitMs);
+    }
+}
+
+bool BufferedFileReader::fillStep()
+{
+    if (channels <= 0) return false;
+
+    const std::int64_t h = std::clamp (hintFrame.load (std::memory_order_acquire),
+                                       (std::int64_t) 0, fileInfo.numFrames);
+    std::int64_t s = residentStart.load (std::memory_order_relaxed);
+    std::int64_t e = residentEnd.load (std::memory_order_relaxed);
+
+    if (h < s || h > e)
+    {
+        // Seek out of the window: the frames it holds are worthless and their
+        // slots are about to be refilled. The odd generation covers the gap
+        // where a reader has already latched the old bounds.
+        generation.fetch_add (1, std::memory_order_acq_rel);
+        residentStart.store (h, std::memory_order_release);
+        residentEnd.store (h, std::memory_order_release);
+        generation.fetch_add (1, std::memory_order_acq_rel);
+        s = e = h;
+    }
+    else if (h > s)
+    {
+        // Retire played frames before the append below reuses their slots:
+        // the append only writes slots holding frames below residentStart, so
+        // publishing it first is what keeps the write head off anything a
+        // concurrent readRt is copying.
+        residentStart.store (h, std::memory_order_release);
+        s = h;
+    }
+
+    const std::int64_t room = std::min (capacity - 1 - (e - s), fileInfo.numFrames - e);
+    if (room <= 0) return false;
+
+    const std::int64_t slot  = e % capacity;
+    const std::int64_t chunk = std::min ({ kFillChunkFrames, room, capacity - slot });
+
+    for (int c = 0; c < channels; ++c)
+        fillDest[(size_t) c] = ring.data() + (size_t) c * (size_t) capacity + (size_t) slot;
+
+    const std::int64_t got = source->read (fillDest.data(), channels, e, chunk);
+    if (got <= 0) return false;   // read error: keep the window as it stands
+
+    residentEnd.store (e + got, std::memory_order_release);
+    return true;
+}
+
+bool BufferedFileReader::readRt (float* const* dest, int numDestCh,
+                                 std::int64_t startFrame, std::int64_t numFrames) noexcept
+{
+    if (dest == nullptr || numDestCh <= 0 || numFrames <= 0) return true;
+
+    hintFrame.store (std::max<std::int64_t> (0, startFrame), std::memory_order_release);
+
+    const auto clearAll = [&]
+    {
+        for (int c = 0; c < numDestCh; ++c)
+            std::fill (dest[c], dest[c] + numFrames, 0.0f);
+    };
+
+    const std::uint64_t gen = generation.load (std::memory_order_acquire);
+    const std::int64_t  s   = residentStart.load (std::memory_order_acquire);
+    const std::int64_t  e   = residentEnd.load (std::memory_order_acquire);
+
+    const std::int64_t wantEnd = std::min (startFrame + numFrames, fileInfo.numFrames);
+    const std::int64_t from    = std::max (startFrame, s);
+    const std::int64_t to      = std::min (wantEnd, e);
+
+    if ((gen & 1) != 0 || to <= from)
+    {
+        clearAll();
+        return (gen & 1) == 0 && startFrame >= wantEnd;
+    }
+
+    const std::int64_t have   = to - from;
+    const std::int64_t dstOff = from - startFrame;
+    const int          copyCh = std::min (numDestCh, channels);
+
+    for (int c = 0; c < numDestCh; ++c)
+    {
+        if (c >= copyCh)
+        {
+            std::fill (dest[c], dest[c] + numFrames, 0.0f);
+            continue;
+        }
+        std::fill (dest[c], dest[c] + dstOff, 0.0f);
+        std::fill (dest[c] + dstOff + have, dest[c] + numFrames, 0.0f);
+    }
+
+    for (std::int64_t done = 0; done < have; )
+    {
+        const std::int64_t slot = (from + done) % capacity;
+        const std::int64_t run  = std::min (have - done, capacity - slot);
+        for (int c = 0; c < copyCh; ++c)
+            std::memcpy (dest[c] + dstOff + done,
+                         ring.data() + (size_t) c * (size_t) capacity + (size_t) slot,
+                         sizeof (float) * (size_t) run);
+        done += run;
+    }
+
+    // The copy raced the fill thread if the window was thrown away or the span
+    // was retired under it. The retire case needs an earlier read in the same
+    // block to have published a higher position (the loop-wrap block reads
+    // pre-wrap, then wrapped); dest then holds the wrong material, not a gap.
+    std::atomic_thread_fence (std::memory_order_acquire);
+    if (generation.load (std::memory_order_relaxed) != gen
+        || residentStart.load (std::memory_order_relaxed) > from)
+    {
+        clearAll();
+        return false;
+    }
+
+    return from == startFrame && to == wantEnd;
+}
+} // namespace dusk::audio

--- a/src/engine/audiofile/BufferedFileReader.h
+++ b/src/engine/audiofile/BufferedFileReader.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "FileReader.h"
+#include "../../foundation/AutoResetEvent.h"
+
+namespace dusk::audio
+{
+// Audio-thread front end for FileReader. A background thread keeps a rolling
+// window of the file resident in memory; readRt() serves the audio thread from
+// that window and never blocks, allocates or touches the disk. Anything not
+// resident - right after a seek, or when the disk falls behind - is zero-filled
+// and reported as a miss, which is the contract the playback path is built on.
+//
+// One file, one window (sized at construction, never reallocated), one worker.
+//
+// Concurrency: only the fill thread mutates the window, only readRt reads it,
+// and the two are kept apart by publishing every discard before it happens.
+// The fill thread retires frames up to the last position readRt published
+// BEFORE it reuses their ring slots, and it brackets a seek that throws the
+// whole window away in an odd `generation`. readRt re-reads both after copying
+// and reports a miss if either moved, which covers the case where an earlier
+// read in the same block published a higher position than the one being served
+// (the loop-wrap block reads pre-wrap, then wrapped).
+class BufferedFileReader
+{
+public:
+    enum class Fill
+    {
+        Background,   // owned thread keeps the window resident
+        Manual        // no thread; the owner drives fillNow()
+    };
+
+    static constexpr std::int64_t kDefaultWindowFrames = 96000;
+
+    explicit BufferedFileReader (std::unique_ptr<FileReader> source,
+                                 std::int64_t windowFrames = kDefaultWindowFrames,
+                                 Fill fill = Fill::Background);
+    ~BufferedFileReader();
+
+    BufferedFileReader (const BufferedFileReader&)            = delete;
+    BufferedFileReader& operator= (const BufferedFileReader&) = delete;
+
+    const FileInfo& info() const noexcept { return fileInfo; }
+
+    // Audio thread. Copies the resident part of [startFrame, startFrame +
+    // numFrames) into dest, zero-filling the rest; destination channels past
+    // the file's channel count are zero-filled too. Returns false when a
+    // wanted frame was missing - frames past the end of the file are silence
+    // by definition and don't count as a miss. Publishes startFrame as the
+    // prefetch position, so the window follows playback.
+    bool readRt (float* const* dest, int numDestCh,
+                 std::int64_t startFrame, std::int64_t numFrames) noexcept;
+
+    // Message thread. Points the window at startFrame and wakes the worker -
+    // warms a position before the audio thread reaches it, where readRt's own
+    // hint only moves the window after a miss.
+    void prefetch (std::int64_t startFrame) noexcept;
+
+    // Fills the window from the current position until it is full or at EOF,
+    // on the calling thread. For Fill::Manual owners: it does the disk I/O the
+    // worker would otherwise do, which is what makes residency testable.
+    void fillNow();
+
+private:
+    bool fillStep();
+    void run();
+
+    std::unique_ptr<FileReader> source;     // fill thread only, once constructed
+    FileInfo                    fileInfo;
+    const int                   channels;
+    const std::int64_t          capacity;   // frames per channel; one is left
+                                            // free so the write head can never
+                                            // land on a resident frame
+    std::vector<float>          ring;       // channel-major: ch * capacity + frame % capacity
+    std::vector<float*>         fillDest;   // FileReader::read target, fill thread only
+
+    // Resident file frames [residentStart, residentEnd); written by the fill
+    // thread only, monotonic within a generation.
+    std::atomic<std::int64_t>  residentStart { 0 };
+    std::atomic<std::int64_t>  residentEnd   { 0 };
+    std::atomic<std::int64_t>  hintFrame     { 0 };
+    std::atomic<std::uint64_t> generation    { 0 };   // odd while the window is in flux
+
+    std::atomic<bool> stop { false };
+    AutoResetEvent    wake;
+    std::thread       worker;
+};
+} // namespace dusk::audio

--- a/src/engine/audiofile/BufferedFileReader.h
+++ b/src/engine/audiofile/BufferedFileReader.h
@@ -1,13 +1,13 @@
 #pragma once
 
+#include "FileReader.h"
+#include "../../foundation/AutoResetEvent.h"
+
 #include <atomic>
 #include <cstdint>
 #include <memory>
 #include <thread>
 #include <vector>
-
-#include "FileReader.h"
-#include "../../foundation/AutoResetEvent.h"
 
 namespace dusk::audio
 {

--- a/src/engine/audiofile/FileWriter.h
+++ b/src/engine/audiofile/FileWriter.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include "IFileWriteSink.h"
+
 #include <cstdint>
 #include <filesystem>
 #include <memory>
 #include <vector>
-
-#include "IFileWriteSink.h"
 
 namespace dusk::audio
 {

--- a/src/engine/audiofile/FileWriter.h
+++ b/src/engine/audiofile/FileWriter.h
@@ -5,6 +5,8 @@
 #include <memory>
 #include <vector>
 
+#include "IFileWriteSink.h"
+
 namespace dusk::audio
 {
 struct WriteSpec
@@ -20,25 +22,25 @@ struct WriteSpec
 // Sound-file writer backed by libsndfile. Container + sample format come from
 // WriteSpec. MP3 is deliberately absent: libsndfile MP3 support is build
 // dependent, so MP3 stays on the dedicated libmp3lame path.
-class FileWriter
+class FileWriter final : public IFileWriteSink
 {
 public:
     static std::unique_ptr<FileWriter> create (const std::filesystem::path& path, const WriteSpec& spec);
-    ~FileWriter();
+    ~FileWriter() override;
 
     FileWriter (const FileWriter&)            = delete;
     FileWriter& operator= (const FileWriter&) = delete;
 
-    int numChannels() const noexcept { return channels; }
+    int numChannels() const noexcept override { return channels; }
 
     // Deinterleaved. src carries numCh channel pointers of >= numFrames.
     bool write (const float* const* src, int numCh, int64_t numFrames);
 
     // Interleaved, allocation-free: the real-time drain path uses this so the
     // disk thread never touches the heap mid-record.
-    bool writeInterleaved (const float* interleaved, int64_t numFrames) noexcept;
+    bool writeInterleaved (const float* interleaved, int64_t numFrames) noexcept override;
 
-    bool flush();
+    bool flush() override;
 
 private:
     FileWriter (void* handle, int channels);

--- a/src/engine/audiofile/IFileWriteSink.h
+++ b/src/engine/audiofile/IFileWriteSink.h
@@ -20,6 +20,9 @@ public:
     // allocate.
     virtual bool writeInterleaved (const float* interleaved, std::int64_t numFrames) noexcept = 0;
 
+    // May be called more than once: WriterDrainPool::remove() flushes and the
+    // externally-drained ThreadedFileWriter destructor flushes again, so
+    // implementations must make repeat calls no-ops.
     virtual bool flush() = 0;
 };
 } // namespace dusk::audio

--- a/src/engine/audiofile/IFileWriteSink.h
+++ b/src/engine/audiofile/IFileWriteSink.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+
+namespace dusk::audio
+{
+// Drain target for ThreadedFileWriter and WriterDrainPool, so the threaded ring
+// and the pool stay format-agnostic: the libsndfile FileWriter implements it for
+// WAV/FLAC/AIFF, and the libmp3lame writer for MP3. Interleaved float, matching
+// the ring's storage; the disk/worker thread is the only caller.
+class IFileWriteSink
+{
+public:
+    virtual ~IFileWriteSink() = default;
+
+    virtual int numChannels() const noexcept = 0;
+
+    // interleaved holds numFrames * numChannels samples. Returns false on a
+    // short or failed write, which latches the drain's failure flag. Must not
+    // allocate.
+    virtual bool writeInterleaved (const float* interleaved, std::int64_t numFrames) noexcept = 0;
+
+    virtual bool flush() = 0;
+};
+} // namespace dusk::audio

--- a/src/engine/audiofile/ThreadedFileWriter.cpp
+++ b/src/engine/audiofile/ThreadedFileWriter.cpp
@@ -85,8 +85,10 @@ int64_t ThreadedFileWriter::drainOnce() noexcept
 
 void ThreadedFileWriter::finalizeExternal()
 {
-    if (writer != nullptr && ! writeFailed.load (std::memory_order_acquire))
-        writer->flush();
+    if (writer == nullptr || writeFailed.load (std::memory_order_acquire))
+        return;
+    if (! writer->flush())
+        writeFailed.store (true, std::memory_order_release);
 }
 
 void ThreadedFileWriter::run()

--- a/src/engine/audiofile/ThreadedFileWriter.cpp
+++ b/src/engine/audiofile/ThreadedFileWriter.cpp
@@ -5,13 +5,14 @@
 
 namespace dusk::audio
 {
-ThreadedFileWriter::ThreadedFileWriter (std::unique_ptr<FileWriter> w, int fifoFrames)
+ThreadedFileWriter::ThreadedFileWriter (std::unique_ptr<IFileWriteSink> w, int fifoFrames,
+                                        Drain drain)
     : writer (std::move (w)),
       channels (writer != nullptr ? writer->numChannels() : 0),
       capacityFrames ((int64_t) std::max (2, fifoFrames) + 1)
 {
     ring.resize ((size_t) capacityFrames * (size_t) channels, 0.0f);
-    if (writer != nullptr)
+    if (writer != nullptr && drain == Drain::Internal)
         worker = std::thread ([this] { run(); });
 }
 
@@ -19,9 +20,19 @@ ThreadedFileWriter::~ThreadedFileWriter()
 {
     stop.store (true, std::memory_order_release);
     if (worker.joinable())
+    {
         worker.join();
-    // run() flushes once on normal drain-to-empty (and skips flush on failure);
-    // join() guarantees it has finished, so no flush is needed here.
+        // run() flushes once on normal drain-to-empty (and skips flush on
+        // failure); join() guarantees it has finished, so no flush here.
+        return;
+    }
+    // Drain::External with no thread: the owning pool normally drains and
+    // flushes via remove() first, leaving this a no-op. If it did not, drain
+    // the remainder single-threaded here so a dropped remove() never loses a
+    // clean take. Precondition either way: no producer or pool is still
+    // touching this writer.
+    while (drainOnce() > 0) {}
+    finalizeExternal();
 }
 
 bool ThreadedFileWriter::push (const float* const* src, int numCh, int64_t numFrames) noexcept
@@ -48,33 +59,56 @@ bool ThreadedFileWriter::push (const float* const* src, int numCh, int64_t numFr
     return true;
 }
 
+int64_t ThreadedFileWriter::drainOnce() noexcept
+{
+    if (writer == nullptr || writeFailed.load (std::memory_order_acquire))
+        return 0;
+
+    const int64_t r = readPos.load (std::memory_order_relaxed);
+    const int64_t w = writePos.load (std::memory_order_acquire);
+    const int64_t avail = used (w, r);
+    if (avail == 0)
+        return 0;
+
+    // Write the contiguous run up to the ring wrap; the next pass takes the rest.
+    const int64_t chunk = std::min (avail, capacityFrames - r);
+    if (! writer->writeInterleaved (&ring[(size_t) r * (size_t) channels], chunk))
+    {
+        // Disk write failed/short: leave readPos so nothing is treated as
+        // persisted and flag the failure so push() starts rejecting.
+        writeFailed.store (true, std::memory_order_release);
+        return 0;
+    }
+    readPos.store ((r + chunk) % capacityFrames, std::memory_order_release);
+    return chunk;
+}
+
+void ThreadedFileWriter::finalizeExternal()
+{
+    if (writer != nullptr && ! writeFailed.load (std::memory_order_acquire))
+        writer->flush();
+}
+
 void ThreadedFileWriter::run()
 {
     using namespace std::chrono_literals;
     for (;;)
     {
-        const int64_t r = readPos.load (std::memory_order_relaxed);
-        const int64_t w = writePos.load (std::memory_order_acquire);
-        const int64_t avail = used (w, r);
-
-        if (avail == 0)
+        if (drainOnce() > 0)
+            continue;   // more may be ready; keep draining before sleeping
+        if (writeFailed.load (std::memory_order_acquire))
+            break;
+        if (stop.load (std::memory_order_acquire))
         {
-            if (stop.load (std::memory_order_acquire))
+            // Stop wins only once the ring is empty, so a block pushed just
+            // before stop is still written.
+            const int64_t r = readPos.load (std::memory_order_relaxed);
+            const int64_t w = writePos.load (std::memory_order_acquire);
+            if (used (w, r) == 0)
                 break;
-            std::this_thread::sleep_for (2ms);
             continue;
         }
-
-        // Write the contiguous run up to the ring wrap; the next pass takes the rest.
-        const int64_t chunk = std::min (avail, capacityFrames - r);
-        if (! writer->writeInterleaved (&ring[(size_t) r * (size_t) channels], chunk))
-        {
-            // Disk write failed/short: leave readPos so nothing is treated as
-            // persisted, flag the failure so push() starts rejecting, and stop.
-            writeFailed.store (true, std::memory_order_release);
-            break;
-        }
-        readPos.store ((r + chunk) % capacityFrames, std::memory_order_release);
+        std::this_thread::sleep_for (2ms);
     }
     if (! writeFailed.load (std::memory_order_acquire))
         writer->flush();

--- a/src/engine/audiofile/ThreadedFileWriter.h
+++ b/src/engine/audiofile/ThreadedFileWriter.h
@@ -1,12 +1,12 @@
 #pragma once
 
+#include "IFileWriteSink.h"
+
 #include <atomic>
 #include <cstdint>
 #include <memory>
 #include <thread>
 #include <vector>
-
-#include "IFileWriteSink.h"
 
 namespace dusk::audio
 {

--- a/src/engine/audiofile/ThreadedFileWriter.h
+++ b/src/engine/audiofile/ThreadedFileWriter.h
@@ -6,25 +6,34 @@
 #include <thread>
 #include <vector>
 
-#include "FileWriter.h"
+#include "IFileWriteSink.h"
 
 namespace dusk::audio
 {
-// Real-time-safe front end for FileWriter. The audio thread push()es blocks
-// into a lock-free interleaved ring; an owned worker thread drains the ring to
-// disk. push() never allocates or blocks; on overflow it drops the block and
-// returns false, matching the disk-can't-keep-up contract of the recorder.
+// Real-time-safe front end for a file write sink. The audio thread push()es
+// blocks into a lock-free interleaved ring; the ring drains to disk either from
+// an owned worker thread (Drain::Internal) or from an external WriterDrainPool
+// that calls drainOnce() (Drain::External). push() never allocates or blocks;
+// on overflow it drops the block and returns false, matching the
+// disk-can't-keep-up contract of the recorder.
 class ThreadedFileWriter
 {
 public:
-    ThreadedFileWriter (std::unique_ptr<FileWriter> writer, int fifoFrames);
+    enum class Drain
+    {
+        Internal,   // owned worker thread drains the ring
+        External    // no thread; a WriterDrainPool calls drainOnce()
+    };
+
+    ThreadedFileWriter (std::unique_ptr<IFileWriteSink> writer, int fifoFrames,
+                        Drain drain = Drain::Internal);
     ~ThreadedFileWriter();
 
     ThreadedFileWriter (const ThreadedFileWriter&)            = delete;
     ThreadedFileWriter& operator= (const ThreadedFileWriter&) = delete;
 
-    // False once construction got a null FileWriter (a failed create) or the
-    // disk write has failed - callers must check this before trusting push().
+    // False once construction got a null sink (a failed create) or the disk
+    // write has failed - callers must check this before trusting push().
     bool isValid() const noexcept { return writer != nullptr && ! writeFailed.load (std::memory_order_acquire); }
 
     // Audio thread. Deinterleaved src, numCh pointers of >= numFrames. Returns
@@ -32,14 +41,24 @@ public:
     // or a prior disk write failed. A false must not be read as "persisted".
     bool push (const float* const* src, int numCh, int64_t numFrames) noexcept;
 
+    // Disk/pool thread only. Writes the one contiguous ring run currently ready
+    // and returns the frames written; 0 means the ring was empty or the sink
+    // has failed. Both the internal worker and the pool drive the file through
+    // this. NOT called by the audio thread.
+    int64_t drainOnce() noexcept;
+
+    // Pool thread only, after draining to empty: flush the sink if it hasn't
+    // failed. Drain::Internal flushes from its own worker instead.
+    void finalizeExternal();
+
 private:
     void run();
     int64_t used (int64_t w, int64_t r) const noexcept { return (w - r + capacityFrames) % capacityFrames; }
 
-    std::unique_ptr<FileWriter> writer;
-    const int                   channels;
-    const int64_t               capacityFrames;   // one frame kept free to tell full from empty
-    std::vector<float>          ring;              // interleaved, capacityFrames * channels
+    std::unique_ptr<IFileWriteSink> writer;
+    const int                       channels;
+    const int64_t                   capacityFrames;   // one frame kept free to tell full from empty
+    std::vector<float>              ring;              // interleaved, capacityFrames * channels
 
     std::atomic<int64_t> writePos    { 0 };
     std::atomic<int64_t> readPos     { 0 };

--- a/src/engine/audiofile/WriterDrainPool.cpp
+++ b/src/engine/audiofile/WriterDrainPool.cpp
@@ -27,6 +27,10 @@ bool WriterDrainPool::add (ThreadedFileWriter* w)
         return false;
 
     std::lock_guard<std::mutex> lk (m);
+    // A duplicate would survive remove() as a stale entry and dangle once the
+    // caller destroys the writer.
+    if (std::find (writers.begin(), writers.end(), w) != writers.end())
+        return false;
     if (writers.size() >= maxWriters)
         return false;
     writers.push_back (w);

--- a/src/engine/audiofile/WriterDrainPool.cpp
+++ b/src/engine/audiofile/WriterDrainPool.cpp
@@ -1,0 +1,66 @@
+#include "WriterDrainPool.h"
+
+#include "ThreadedFileWriter.h"
+
+#include <algorithm>
+
+namespace dusk::audio
+{
+WriterDrainPool::WriterDrainPool (int maxWritersIn)
+    : maxWriters ((std::size_t) std::max (1, maxWritersIn))
+{
+    writers.reserve (maxWriters);
+    worker = std::thread ([this] { run(); });
+}
+
+WriterDrainPool::~WriterDrainPool()
+{
+    stop.store (true, std::memory_order_release);
+    wake.signal();
+    if (worker.joinable())
+        worker.join();
+}
+
+bool WriterDrainPool::add (ThreadedFileWriter* w)
+{
+    if (w == nullptr)
+        return false;
+
+    std::lock_guard<std::mutex> lk (m);
+    if (writers.size() >= maxWriters)
+        return false;
+    writers.push_back (w);
+    wake.signal();
+    return true;
+}
+
+void WriterDrainPool::remove (ThreadedFileWriter* w)
+{
+    std::lock_guard<std::mutex> lk (m);
+    const auto it = std::find (writers.begin(), writers.end(), w);
+    if (it == writers.end())
+        return;
+
+    // Producer is stopped (precondition): drain to empty on this thread, then
+    // flush, so nothing is left unwritten before the caller destroys the writer.
+    while (w->drainOnce() > 0) {}
+    w->finalizeExternal();
+    writers.erase (it);
+}
+
+void WriterDrainPool::run()
+{
+    while (! stop.load (std::memory_order_acquire))
+    {
+        bool anyWork = false;
+        {
+            std::lock_guard<std::mutex> lk (m);
+            for (auto* w : writers)
+                if (w != nullptr && w->drainOnce() > 0)
+                    anyWork = true;
+        }
+        if (! anyWork)
+            wake.wait (2);
+    }
+}
+} // namespace dusk::audio

--- a/src/engine/audiofile/WriterDrainPool.h
+++ b/src/engine/audiofile/WriterDrainPool.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "../../foundation/AutoResetEvent.h"
+
+namespace dusk::audio
+{
+class ThreadedFileWriter;
+
+// One disk thread draining many externally-drained ThreadedFileWriter rings, so
+// a 24-track record or an N-stem bounce costs one thread instead of N. The audio
+// thread never touches the pool - it only pushes to each writer's SPSC ring. The
+// pool thread and the message-thread add()/remove() calls share `m`; the audio
+// thread does not, so holding `m` across a drain pass never blocks the RT path.
+class WriterDrainPool
+{
+public:
+    explicit WriterDrainPool (int maxWritersIn);
+    ~WriterDrainPool();
+
+    WriterDrainPool (const WriterDrainPool&)            = delete;
+    WriterDrainPool& operator= (const WriterDrainPool&) = delete;
+
+    // Message thread. Registers a writer built in ThreadedFileWriter::Drain::
+    // External mode. False if the fixed registry is full. The pool does not own
+    // the writer.
+    bool add (ThreadedFileWriter* w);
+
+    // Message thread. Drains the writer to empty, flushes it, then drops it from
+    // the pool. PRECONDITION: the audio thread has stopped pushing to this
+    // writer, else the drain never reaches empty. The writer may be destroyed
+    // once this returns.
+    void remove (ThreadedFileWriter* w);
+
+private:
+    void run();
+
+    const std::size_t             maxWriters;
+    std::mutex                    m;
+    std::vector<ThreadedFileWriter*> writers;   // guarded by m
+    std::atomic<bool>             stop { false };
+    AutoResetEvent                wake;
+    std::thread                   worker;
+};
+} // namespace dusk::audio

--- a/src/engine/audiofile/WriterDrainPool.h
+++ b/src/engine/audiofile/WriterDrainPool.h
@@ -1,12 +1,12 @@
 #pragma once
 
+#include "../../foundation/AutoResetEvent.h"
+
 #include <atomic>
 #include <cstddef>
 #include <mutex>
 #include <thread>
 #include <vector>
-
-#include "../../foundation/AutoResetEvent.h"
 
 namespace dusk::audio
 {
@@ -27,8 +27,8 @@ public:
     WriterDrainPool& operator= (const WriterDrainPool&) = delete;
 
     // Message thread. Registers a writer built in ThreadedFileWriter::Drain::
-    // External mode. False if the fixed registry is full. The pool does not own
-    // the writer.
+    // External mode. False if the fixed registry is full or the writer is
+    // already registered. The pool does not own the writer.
     bool add (ThreadedFileWriter* w);
 
     // Message thread. Drains the writer to empty, flushes it, then drops it from

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -171,6 +171,8 @@ endif()
 target_sources(dusk-studio-tests PRIVATE
     audiofile_roundtrip.cpp
     audiofile_ab_null.cpp
+    audiofile_buffered_reader.cpp
+    ${CMAKE_SOURCE_DIR}/src/engine/audiofile/BufferedFileReader.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/audiofile/FileReader.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/audiofile/FileWriter.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/audiofile/ThreadedFileWriter.cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -172,10 +172,12 @@ target_sources(dusk-studio-tests PRIVATE
     audiofile_roundtrip.cpp
     audiofile_ab_null.cpp
     audiofile_buffered_reader.cpp
+    audiofile_drain_pool.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/audiofile/BufferedFileReader.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/audiofile/FileReader.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/audiofile/FileWriter.cpp
-    ${CMAKE_SOURCE_DIR}/src/engine/audiofile/ThreadedFileWriter.cpp)
+    ${CMAKE_SOURCE_DIR}/src/engine/audiofile/ThreadedFileWriter.cpp
+    ${CMAKE_SOURCE_DIR}/src/engine/audiofile/WriterDrainPool.cpp)
 target_link_libraries(dusk-studio-tests PRIVATE dusk_sndfile)
 
 # Console-saturation calibration test + the donor DSP headers it needs

--- a/tests/audiofile_buffered_reader.cpp
+++ b/tests/audiofile_buffered_reader.cpp
@@ -1,0 +1,289 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/audiofile/BufferedFileReader.h"
+#include "engine/audiofile/FileWriter.h"
+
+#include <cmath>
+#include <filesystem>
+#include <memory>
+#include <system_error>
+#include <vector>
+
+using namespace dusk::audio;
+
+namespace
+{
+constexpr int      kChannels = 2;
+constexpr std::int64_t kFrames = 16384;
+constexpr std::int64_t kWindow = 4096;   // small enough that the window has to roll
+constexpr std::int64_t kBlock  = 512;
+
+float sample (int ch, std::int64_t f)
+{
+    return 0.9f * std::sin ((float) f * 0.002f + (float) ch * 1.7f);
+}
+
+std::filesystem::path tmp (const char* name)
+{
+    return std::filesystem::temp_directory_path() / name;
+}
+
+// Non-throwing, and only ever called once the readers are released: Windows
+// refuses to unlink an open file, and the throwing overload would fail a run
+// whose assertions all passed.
+void discard (const std::filesystem::path& p)
+{
+    std::error_code ec;
+    std::filesystem::remove (p, ec);
+}
+
+// 32-bit float WAV so residency comparisons are exact, not tolerance-based.
+bool writeRamp (const std::filesystem::path& path)
+{
+    std::vector<std::vector<float>> ch ((size_t) kChannels, std::vector<float> ((size_t) kFrames));
+    for (int c = 0; c < kChannels; ++c)
+        for (std::int64_t f = 0; f < kFrames; ++f)
+            ch[(size_t) c][(size_t) f] = sample (c, f);
+
+    std::vector<const float*> src;
+    for (auto& v : ch) src.push_back (v.data());
+
+    WriteSpec spec;
+    spec.sampleRate    = 48000.0;
+    spec.numChannels   = kChannels;
+    spec.bitsPerSample = 32;
+
+    auto w = FileWriter::create (path, spec);
+    return w != nullptr && w->write (src.data(), kChannels, kFrames);
+}
+
+struct Block
+{
+    std::vector<std::vector<float>> data;
+    std::vector<float*>             ptrs;
+
+    explicit Block (std::int64_t frames, float fill = -1.0f)
+        : data ((size_t) kChannels, std::vector<float> ((size_t) frames, fill))
+    {
+        for (auto& v : data) ptrs.push_back (v.data());
+    }
+
+    bool isSilent() const
+    {
+        for (const auto& v : data)
+            for (float f : v)
+                if (f != 0.0f) return false;
+        return true;
+    }
+};
+
+bool matchesSource (const Block& b, std::int64_t startFrame, std::int64_t numFrames)
+{
+    for (int c = 0; c < kChannels; ++c)
+        for (std::int64_t f = 0; f < numFrames; ++f)
+            if (b.data[(size_t) c][(size_t) f] != sample (c, startFrame + f))
+                return false;
+    return true;
+}
+
+std::unique_ptr<BufferedFileReader> manualReader (const std::filesystem::path& path)
+{
+    auto raw = FileReader::open (path);
+    if (raw == nullptr) return nullptr;
+    return std::make_unique<BufferedFileReader> (std::move (raw), kWindow,
+                                                  BufferedFileReader::Fill::Manual);
+}
+} // namespace
+
+TEST_CASE ("BufferedFileReader reports silence for a span that is not resident",
+           "[audiofile][buffered]")
+{
+    const auto path = tmp ("dusk_bfr_miss.wav");
+    REQUIRE (writeRamp (path));
+
+    auto r = manualReader (path);
+    REQUIRE (r != nullptr);
+
+    // Nothing has been filled, so every frame is a miss - and a miss must be
+    // silence, not stale scratch.
+    Block b (kBlock);
+    REQUIRE_FALSE (r->readRt (b.ptrs.data(), kChannels, 0, kBlock));
+    REQUIRE (b.isSilent());
+
+    r.reset();
+    discard (path);
+}
+
+TEST_CASE ("BufferedFileReader serves a resident span bit-exactly",
+           "[audiofile][buffered]")
+{
+    const auto path = tmp ("dusk_bfr_resident.wav");
+    REQUIRE (writeRamp (path));
+
+    auto r = manualReader (path);
+    REQUIRE (r != nullptr);
+    REQUIRE (r->info().numFrames == kFrames);
+    r->fillNow();
+
+    Block b (kBlock);
+    REQUIRE (r->readRt (b.ptrs.data(), kChannels, 0, kBlock));
+    REQUIRE (matchesSource (b, 0, kBlock));
+
+    // Same bytes an unbuffered read of the same span produces.
+    auto raw = FileReader::open (path);
+    REQUIRE (raw != nullptr);
+    Block direct (kBlock);
+    REQUIRE (raw->read (direct.ptrs.data(), kChannels, 0, kBlock) == kBlock);
+    for (int c = 0; c < kChannels; ++c)
+        for (std::int64_t f = 0; f < kBlock; ++f)
+            REQUIRE (b.data[(size_t) c][(size_t) f] == direct.data[(size_t) c][(size_t) f]);
+
+    raw.reset();
+    r.reset();
+    discard (path);
+}
+
+TEST_CASE ("BufferedFileReader window rolls forward past its own capacity",
+           "[audiofile][buffered]")
+{
+    const auto path = tmp ("dusk_bfr_roll.wav");
+    REQUIRE (writeRamp (path));
+
+    auto r = manualReader (path);
+    REQUIRE (r != nullptr);
+
+    // Play the whole file in blocks, topping the window up between them the way
+    // the worker would. Every block must be fully resident even though the file
+    // is four windows long.
+    for (std::int64_t pos = 0; pos + kBlock <= kFrames; pos += kBlock)
+    {
+        r->prefetch (pos);
+        r->fillNow();
+
+        Block b (kBlock);
+        REQUIRE (r->readRt (b.ptrs.data(), kChannels, pos, kBlock));
+        REQUIRE (matchesSource (b, pos, kBlock));
+    }
+
+    // Having played to the end, a jump back to the top is a miss again until
+    // the window is refilled - forward prefetch cannot cover a backward seek,
+    // which is why the loop pre-cache in PlaybackEngine exists.
+    Block back (kBlock);
+    REQUIRE_FALSE (r->readRt (back.ptrs.data(), kChannels, 0, kBlock));
+    REQUIRE (back.isSilent());
+
+    r.reset();
+    discard (path);
+}
+
+TEST_CASE ("BufferedFileReader prefetch warms a span the audio thread has not asked for",
+           "[audiofile][buffered]")
+{
+    const auto path = tmp ("dusk_bfr_prefetch.wav");
+    REQUIRE (writeRamp (path));
+
+    auto r = manualReader (path);
+    REQUIRE (r != nullptr);
+
+    const std::int64_t far = kFrames - kWindow;
+    r->prefetch (far);
+    r->fillNow();
+
+    Block warm (kBlock);
+    REQUIRE (r->readRt (warm.ptrs.data(), kChannels, far, kBlock));
+    REQUIRE (matchesSource (warm, far, kBlock));
+
+    // Backwards, over a span the window has already left behind.
+    r->prefetch (0);
+    r->fillNow();
+
+    Block rewound (kBlock);
+    REQUIRE (r->readRt (rewound.ptrs.data(), kChannels, 0, kBlock));
+    REQUIRE (matchesSource (rewound, 0, kBlock));
+
+    r.reset();
+    discard (path);
+}
+
+TEST_CASE ("BufferedFileReader treats frames past the end of the file as silence",
+           "[audiofile][buffered]")
+{
+    const auto path = tmp ("dusk_bfr_eof.wav");
+    REQUIRE (writeRamp (path));
+
+    auto r = manualReader (path);
+    REQUIRE (r != nullptr);
+
+    const std::int64_t tail = kFrames - 100;
+    r->prefetch (tail);
+    r->fillNow();
+
+    // Straddling EOF: the file's last 100 frames, then silence, and not a miss.
+    Block b (kBlock);
+    REQUIRE (r->readRt (b.ptrs.data(), kChannels, tail, kBlock));
+    REQUIRE (matchesSource (b, tail, 100));
+    for (int c = 0; c < kChannels; ++c)
+        for (std::int64_t f = 100; f < kBlock; ++f)
+            REQUIRE (b.data[(size_t) c][(size_t) f] == 0.0f);
+
+    Block past (kBlock);
+    REQUIRE (r->readRt (past.ptrs.data(), kChannels, kFrames + 1000, kBlock));
+    REQUIRE (past.isSilent());
+
+    r.reset();
+    discard (path);
+}
+
+TEST_CASE ("BufferedFileReader zero-fills destination channels beyond the file",
+           "[audiofile][buffered]")
+{
+    const auto path = tmp ("dusk_bfr_mono.wav");
+    std::vector<float> mono ((size_t) kFrames);
+    for (std::int64_t f = 0; f < kFrames; ++f) mono[(size_t) f] = sample (0, f);
+    const float* src = mono.data();
+
+    WriteSpec spec;
+    spec.sampleRate    = 48000.0;
+    spec.numChannels   = 1;
+    spec.bitsPerSample = 32;
+    {
+        auto w = FileWriter::create (path, spec);
+        REQUIRE (w != nullptr);
+        REQUIRE (w->write (&src, 1, kFrames));
+    }
+
+    auto r = manualReader (path);
+    REQUIRE (r != nullptr);
+    r->fillNow();
+
+    Block b (kBlock);
+    REQUIRE (r->readRt (b.ptrs.data(), kChannels, 0, kBlock));
+    for (std::int64_t f = 0; f < kBlock; ++f)
+    {
+        REQUIRE (b.data[0][(size_t) f] == sample (0, f));
+        REQUIRE (b.data[1][(size_t) f] == 0.0f);
+    }
+
+    r.reset();
+    discard (path);
+}
+
+TEST_CASE ("BufferedFileReader background worker fills and joins",
+           "[audiofile][buffered]")
+{
+    const auto path = tmp ("dusk_bfr_worker.wav");
+    REQUIRE (writeRamp (path));
+
+    auto raw = FileReader::open (path);
+    REQUIRE (raw != nullptr);
+
+    // Residency is a race here by construction, so assert only what holds
+    // either way: the read is silent-or-correct and the worker joins cleanly.
+    auto r = std::make_unique<BufferedFileReader> (std::move (raw), kWindow);
+    Block b (kBlock);
+    if (r->readRt (b.ptrs.data(), kChannels, 0, kBlock))
+        REQUIRE (matchesSource (b, 0, kBlock));
+
+    r.reset();
+    discard (path);
+}

--- a/tests/audiofile_drain_pool.cpp
+++ b/tests/audiofile_drain_pool.cpp
@@ -1,0 +1,247 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "engine/audiofile/FileReader.h"
+#include "engine/audiofile/FileWriter.h"
+#include "engine/audiofile/IFileWriteSink.h"
+#include "engine/audiofile/ThreadedFileWriter.h"
+#include "engine/audiofile/WriterDrainPool.h"
+
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <filesystem>
+#include <memory>
+#include <system_error>
+#include <thread>
+#include <vector>
+
+using namespace dusk::audio;
+using Catch::Matchers::WithinAbs;
+
+namespace
+{
+constexpr int      kChannels = 2;
+constexpr int      kFifo     = 16384;
+
+float sample (int ch, std::int64_t f)
+{
+    return 0.8f * std::sin ((float) f * 0.003f + (float) ch * 1.1f);
+}
+
+std::filesystem::path tmp (const char* name)
+{
+    return std::filesystem::temp_directory_path() / name;
+}
+
+void discard (const std::filesystem::path& p)
+{
+    std::error_code ec;
+    std::filesystem::remove (p, ec);
+}
+
+std::unique_ptr<ThreadedFileWriter> makeWavWriter (const std::filesystem::path& path)
+{
+    WriteSpec spec;
+    spec.sampleRate    = 48000.0;
+    spec.numChannels   = kChannels;
+    spec.bitsPerSample = 32;   // float: bit-exact round-trip
+    auto fw = FileWriter::create (path, spec);
+    if (fw == nullptr) return nullptr;
+    return std::make_unique<ThreadedFileWriter> (std::move (fw), kFifo,
+                                                 ThreadedFileWriter::Drain::External);
+}
+
+// Pushes a ramp of `frames` to a writer, waiting for ring space (the pool
+// drains concurrently) up to a deadline. Returns false if it could not place
+// every frame - a genuine overflow the pool never relieved, i.e. a bug.
+bool pushRamp (ThreadedFileWriter& tw, std::int64_t frames, std::int64_t block)
+{
+    std::vector<float> l ((size_t) block), r ((size_t) block);
+    for (std::int64_t off = 0; off < frames; off += block)
+    {
+        const std::int64_t n = std::min (block, frames - off);
+        for (std::int64_t f = 0; f < n; ++f)
+        {
+            l[(size_t) f] = sample (0, off + f);
+            r[(size_t) f] = sample (1, off + f);
+        }
+        const float* p[kChannels] = { l.data(), r.data() };
+
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds (5);
+        while (! tw.push (p, kChannels, n))
+        {
+            if (! tw.isValid() || std::chrono::steady_clock::now() > deadline)
+                return false;
+            std::this_thread::yield();
+        }
+    }
+    return true;
+}
+
+bool fileMatchesRamp (const std::filesystem::path& path, std::int64_t frames)
+{
+    auto r = FileReader::open (path);
+    if (r == nullptr || r->info().numFrames != frames) return false;
+
+    std::vector<std::vector<float>> out ((size_t) kChannels,
+                                         std::vector<float> ((size_t) frames, 0.0f));
+    std::vector<float*> outP;
+    for (auto& v : out) outP.push_back (v.data());
+    if (r->read (outP.data(), kChannels, 0, frames) != frames) return false;
+
+    for (int c = 0; c < kChannels; ++c)
+        for (std::int64_t f = 0; f < frames; ++f)
+            if (std::abs (out[(size_t) c][(size_t) f] - sample (c, f)) > 1.0e-6f)
+                return false;
+    return true;
+}
+} // namespace
+
+TEST_CASE ("WriterDrainPool drains several writers to disk bit-exactly",
+           "[audiofile][pool]")
+{
+    constexpr int kWriters = 3;
+    constexpr std::int64_t kFrames = 40000;   // several ring-fulls per writer
+
+    WriterDrainPool pool (kWriters);
+    std::vector<std::filesystem::path> paths;
+    std::vector<std::unique_ptr<ThreadedFileWriter>> tws;
+
+    for (int i = 0; i < kWriters; ++i)
+    {
+        const auto path = tmp (("dusk_pool_" + std::to_string (i) + ".wav").c_str());
+        paths.push_back (path);
+        auto tw = makeWavWriter (path);
+        REQUIRE (tw != nullptr);
+        REQUIRE (pool.add (tw.get()));
+        tws.push_back (std::move (tw));
+    }
+
+    // Producers run concurrently; the pool's single thread keeps every ring
+    // from overflowing.
+    std::vector<std::thread> producers;
+    std::atomic<int> ok { 0 };
+    for (auto& tw : tws)
+        producers.emplace_back ([&] { if (pushRamp (*tw, kFrames, 512)) ok.fetch_add (1); });
+    for (auto& t : producers) t.join();
+    REQUIRE (ok.load() == kWriters);
+
+    for (auto& tw : tws) pool.remove (tw.get());   // drains to empty + flushes
+    tws.clear();
+
+    for (const auto& path : paths)
+    {
+        REQUIRE (fileMatchesRamp (path, kFrames));
+        discard (path);
+    }
+}
+
+TEST_CASE ("WriterDrainPool rejects registration past its fixed capacity",
+           "[audiofile][pool]")
+{
+    WriterDrainPool pool (2);
+    const auto p0 = tmp ("dusk_pool_cap0.wav");
+    const auto p1 = tmp ("dusk_pool_cap1.wav");
+    const auto p2 = tmp ("dusk_pool_cap2.wav");
+
+    auto a = makeWavWriter (p0);
+    auto b = makeWavWriter (p1);
+    auto c = makeWavWriter (p2);
+    REQUIRE (a); REQUIRE (b); REQUIRE (c);
+
+    REQUIRE (pool.add (a.get()));
+    REQUIRE (pool.add (b.get()));
+    REQUIRE_FALSE (pool.add (c.get()));   // full
+
+    pool.remove (a.get());
+    REQUIRE (pool.add (c.get()));          // a slot freed
+
+    pool.remove (b.get());
+    pool.remove (c.get());
+    a.reset(); b.reset(); c.reset();
+    discard (p0); discard (p1); discard (p2);
+}
+
+namespace
+{
+// Fails once cumulative frames pass a limit; models a disk going full mid-drain.
+struct FailingSink final : IFileWriteSink
+{
+    explicit FailingSink (std::int64_t limitFrames) : limit (limitFrames) {}
+    int numChannels() const noexcept override { return kChannels; }
+    bool writeInterleaved (const float*, std::int64_t n) noexcept override
+    {
+        return total.fetch_add (n) + n <= limit;
+    }
+    bool flush() override { return true; }
+
+    const std::int64_t     limit;
+    std::atomic<std::int64_t> total { 0 };
+};
+} // namespace
+
+TEST_CASE ("WriterDrainPool isolates a failed writer from a healthy one",
+           "[audiofile][pool]")
+{
+    constexpr std::int64_t kFrames = 20000;
+
+    WriterDrainPool pool (2);
+
+    const auto goodPath = tmp ("dusk_pool_good.wav");
+    auto good = makeWavWriter (goodPath);
+    REQUIRE (good != nullptr);
+
+    // Bad writer fails partway; its ring is large enough to accept every push,
+    // so failure comes from the sink, not overflow.
+    auto badSink = std::make_unique<FailingSink> (kFrames / 4);
+    auto bad = std::make_unique<ThreadedFileWriter> (std::move (badSink), (int) kFrames + 1,
+                                                     ThreadedFileWriter::Drain::External);
+
+    REQUIRE (pool.add (good.get()));
+    REQUIRE (pool.add (bad.get()));
+
+    std::thread pg ([&] { pushRamp (*good, kFrames, 512); });
+    // The bad writer stops accepting pushes once the drain latches failure;
+    // push what fits and move on rather than waiting on a writer that will
+    // never free space.
+    std::thread pb ([&]
+    {
+        std::vector<float> l (512, 0.25f), r (512, -0.25f);
+        const float* p[kChannels] = { l.data(), r.data() };
+        for (std::int64_t off = 0; off < kFrames && bad->push (p, kChannels, 512); off += 512) {}
+    });
+    pg.join();
+    pb.join();
+
+    pool.remove (good.get());
+    pool.remove (bad.get());
+
+    REQUIRE_FALSE (bad->isValid());        // failure latched
+    REQUIRE (fileMatchesRamp (goodPath, kFrames));   // sibling unharmed
+
+    good.reset();
+    bad.reset();
+    discard (goodPath);
+}
+
+TEST_CASE ("ThreadedFileWriter external dtor flushes a take a missed remove() left",
+           "[audiofile][pool]")
+{
+    const auto path = tmp ("dusk_pool_dtor.wav");
+    constexpr std::int64_t kFrames = 4096;   // fits the ring with no draining
+
+    {
+        auto tw = makeWavWriter (path);
+        REQUIRE (tw != nullptr);
+        // No pool: push into the ring and let the destructor drain it, the
+        // insurance path for an owner that forgot to remove().
+        std::vector<float> l ((size_t) kFrames), r ((size_t) kFrames);
+        for (std::int64_t f = 0; f < kFrames; ++f) { l[(size_t) f] = sample (0, f); r[(size_t) f] = sample (1, f); }
+        const float* p[kChannels] = { l.data(), r.data() };
+        REQUIRE (tw->push (p, kChannels, kFrames));
+    } // dtor drains + flushes
+
+    REQUIRE (fileMatchesRamp (path, kFrames));
+    discard (path);
+}

--- a/tests/audiofile_drain_pool.cpp
+++ b/tests/audiofile_drain_pool.cpp
@@ -118,14 +118,10 @@ TEST_CASE ("WriterDrainPool drains several writers to disk bit-exactly",
         tws.push_back (std::move (tw));
     }
 
-    // Producers run concurrently; the pool's single thread keeps every ring
-    // from overflowing.
-    std::vector<std::thread> producers;
-    std::atomic<int> ok { 0 };
+    // The pool's single thread drains concurrently, so pushRamp's ring-space
+    // waits resolve without producer threads.
     for (auto& tw : tws)
-        producers.emplace_back ([&] { if (pushRamp (*tw, kFrames, 512)) ok.fetch_add (1); });
-    for (auto& t : producers) t.join();
-    REQUIRE (ok.load() == kWriters);
+        REQUIRE (pushRamp (*tw, kFrames, 512));
 
     for (auto& tw : tws) pool.remove (tw.get());   // drains to empty + flushes
     tws.clear();
@@ -201,18 +197,15 @@ TEST_CASE ("WriterDrainPool isolates a failed writer from a healthy one",
     REQUIRE (pool.add (good.get()));
     REQUIRE (pool.add (bad.get()));
 
-    std::thread pg ([&] { pushRamp (*good, kFrames, 512); });
+    REQUIRE (pushRamp (*good, kFrames, 512));
     // The bad writer stops accepting pushes once the drain latches failure;
     // push what fits and move on rather than waiting on a writer that will
     // never free space.
-    std::thread pb ([&]
     {
         std::vector<float> l (512, 0.25f), r (512, -0.25f);
         const float* p[kChannels] = { l.data(), r.data() };
         for (std::int64_t off = 0; off < kFrames && bad->push (p, kChannels, 512); off += 512) {}
-    });
-    pg.join();
-    pb.join();
+    }
 
     pool.remove (good.get());
     pool.remove (bad.get());

--- a/tests/lame_mp3_writer.cpp
+++ b/tests/lame_mp3_writer.cpp
@@ -4,6 +4,7 @@
 
 #include <juce_audio_formats/juce_audio_formats.h>
 #include <cmath>
+#include <vector>
 
 using namespace duskstudio;
 
@@ -13,10 +14,16 @@ namespace
 juce::File encodeToMp3 (const juce::AudioBuffer<float>& src, double sr, int bitrate)
 {
     const auto mp3 = juce::File::createTempFile (".mp3");
-    auto* stream = mp3.createOutputStream().release();
-    LameMp3Writer writer (stream, sr, 2, bitrate);
+    LameMp3Writer writer (mp3.getFullPathName().toStdString(), sr, 2, bitrate);
     REQUIRE (writer.isOk());
-    REQUIRE (writer.writeFromAudioSampleBuffer (src, 0, src.getNumSamples()));
+    const int n = src.getNumSamples();
+    std::vector<float> interleaved ((size_t) n * 2, 0.0f);
+    for (int i = 0; i < n; ++i)
+    {
+        interleaved[(size_t) i * 2]     = src.getSample (0, i);
+        interleaved[(size_t) i * 2 + 1] = src.getSample (1, i);
+    }
+    REQUIRE (writer.writeInterleaved (interleaved.data(), n));
     return mp3;   // writer destructor (end of scope) flushes + closes
 }
 }

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -20,8 +20,6 @@ src/engine/DuskStudioPlayHead.h
 src/engine/FileImporter.cpp
 src/engine/FileImporter.h
 src/engine/JuceCompat.h
-src/engine/LameMp3Writer.cpp
-src/engine/LameMp3Writer.h
 src/engine/MasteringPlayer.cpp
 src/engine/MasteringPlayer.h
 src/engine/NativeScanRows.h


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved audio file playback with buffered reading and smoother prefetching during playback and looping.
  * Updated recording, bouncing, stem export, and freeze rendering for more reliable WAV and MP3 output.
  * Added improved handling for mono files, seeks, end-of-file playback, and background audio writing.

* **Bug Fixes**
  * Ensured pending audio data is fully written and files are finalized correctly, including after recording or rendering errors.

* **Documentation**
  * Updated audio file I/O status and implementation notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->