### PR TITLE
Dejuce/hosting h4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,7 +334,9 @@ target_sources(DuskStudio PRIVATE
     # DeviceManager: native orchestrator on Linux (DeviceManager.cpp), JUCE-wrapped
     # fallback off Linux (DeviceManagerJuce.cpp). Gated below the target_sources().
     src/engine/midi/MidiDevices.cpp
+    src/engine/NativePluginCache.cpp
     src/engine/PlaybackEngine.cpp
+    src/engine/PluginDescriptor.cpp
     src/engine/PluginManager.cpp
     src/engine/PluginSlot.cpp
     src/engine/RecordManager.cpp
@@ -786,6 +788,7 @@ if(_duskstudio_oop_enabled)
         BUNDLE_ID    "audio.dusk.studio.pluginhost")
     target_sources(dusk-studio-plugin-host PRIVATE
         src/engine/ipc/PluginHostMain.cpp
+        src/engine/PluginDescriptor.cpp
         src/foundation/MessageThread.cpp
         ${_duskstudio_ipc_child_platform_sources})
     target_compile_features (dusk-studio-plugin-host PRIVATE cxx_std_17)
@@ -813,6 +816,7 @@ if(_duskstudio_oop_enabled)
         target_link_libraries(dusk-studio-plugin-host PRIVATE synchronization)
     endif()
     target_include_directories(dusk-studio-plugin-host PRIVATE src)
+    target_include_directories(dusk-studio-plugin-host SYSTEM PRIVATE external/json)
     # Native-format discovery runs sandboxed through this child (--scan-native):
     # it needs each format's bundle loader, nothing else from the native hosts.
     if(DUSKSTUDIO_NATIVE_CLAP)

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1411,7 +1411,7 @@ Plugin scan results are cached in:
 - macOS: `~/Library/Application Support/Dusk Studio/plugin-cache.xml`
 - Windows: `%APPDATA%\Dusk Studio\plugin-cache.xml`
 
-On Linux the native hosts keep their own sidecar caches next to it (`clap-cache.xml`, `lv2-native-cache.xml`, `vst3-native-cache.xml`), rebuilt by the same **Scan plugins** button. The native LV2 scan reads only the bundles' manifests — it never loads the plugin binary, so a broken bundle cannot crash the scan; it is simply skipped (or reported when you try to load it).
+On Linux the native hosts keep their own sidecar caches next to it (`clap-cache.json`, `lv2-native-cache.json`, `vst3-native-cache.json`), rebuilt by the same **Scan plugins** button. Existing XML sidecars are imported once only when the matching JSON cache is absent; subsequent scans write JSON. The native LV2 scan reads only the bundles' manifests — it never loads the plugin binary, so a broken bundle cannot crash the scan; it is simply skipped (or reported when you try to load it).
 
 To re-scan on every launch, enable **Settings → General → Scan plugins on startup**. The startup scan runs in the background behind a progress window (it shows the plugin currently being scanned and a progress bar), so the app stays responsive instead of appearing to hang while a large collection is scanned.
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1411,7 +1411,7 @@ Plugin scan results are cached in:
 - macOS: `~/Library/Application Support/Dusk Studio/plugin-cache.xml`
 - Windows: `%APPDATA%\Dusk Studio\plugin-cache.xml`
 
-On Linux the native hosts keep their own sidecar caches next to it (`clap-cache.json`, `lv2-native-cache.json`, `vst3-native-cache.json`), rebuilt by the same **Scan plugins** button. Existing XML sidecars are imported once only when the matching JSON cache is absent; subsequent scans write JSON. The native LV2 scan reads only the bundles' manifests — it never loads the plugin binary, so a broken bundle cannot crash the scan; it is simply skipped (or reported when you try to load it).
+On Linux the native hosts keep their own sidecar caches next to it (`clap-cache.json`, `lv2-native-cache.json`, `vst3-native-cache.json`), rebuilt by the same **Scan plugins** button. Existing XML sidecars are used as a fallback whenever the matching JSON cache cannot be loaded, including when it is absent, malformed, or unusable; subsequent scans write JSON. The native LV2 scan reads only the bundles' manifests — it never loads the plugin binary, so a broken bundle cannot crash the scan; it is simply skipped (or reported when you try to load it).
 
 To re-scan on every launch, enable **Settings → General → Scan plugins on startup**. The startup scan runs in the background behind a progress window (it shows the plugin currently being scanned and a progress bar), so the app stays responsive instead of appearing to hang while a large collection is scanned.
 

--- a/docs/dejuce-campaign.md
+++ b/docs/dejuce-campaign.md
@@ -128,16 +128,27 @@ reimplemented.
    `juce_audio_formats` stay for AudioThumbnail — GUI tower unlinks those.
    Multi-PR tower, phases H1-H6 in
    [dejuce-hosting-plan.md](dejuce-hosting-plan.md).
-2. **GUI tower (finale)** — bespoke Wayland toolkit (xdg-shell; XWayland/
-   XEmbed for THIRD-PARTY plugin UIs only — hard constraint from Marc
-   2026-07-26: zero XWayland for anything Dusk-owned on a Wayland-only
-   session, so first-party DPF plugin UIs re-host their Dear-ImGui content
-   onto Dusk-toolkit EGL surfaces; 2D renderer TBD Blend2D/Skia,
-   HarfBuzz/FreeType, own widget layer; swap behind the existing
-   DuskComboBox/DuskContextMenu/LookAndFeel/EmbeddedModal seams; event loop =
-   rewrite of MessageThread.cpp, call sites already converged by the
-   events-remainder tower, PR #112). ~120 files, 50%+ of total effort,
-   multi-release. Unlinks everything else, `juce_core` last.
+2. **GUI tower (finale)** — framework decision (Marc, 2026-07-27): build on
+   the hard-forked DPF stack, not a bespoke retained toolkit. App UI =
+   Dear ImGui + DuskImGuiWidgets on EGL, over a Dusk-written **Wayland
+   backend for pugl** in the fork (xdg-shell surfaces, EGL contexts, input,
+   clipboard, cursors — pugl ships mac/win/X11 only today). The earlier
+   bespoke plan (2D renderer TBD Blend2D/Skia, HarfBuzz/FreeType, own
+   widget layer) is DROPPED. One UI stack across app and first-party
+   plugin UIs — the H1d embed becomes a plain in-process surface at end
+   state; zero XWayland for anything Dusk-owned on a Wayland-only session
+   (Marc, 2026-07-26); XWayland/XEmbed stays for THIRD-PARTY plugin
+   editors only. Consequences owned in the tower spec: per-view
+   immediate-mode rewrite (not a Component port), ImGui theme must
+   replicate the current LookAndFeel, accessibility needs a deliberate
+   bridge (current JUCE a11y handlers must not silently regress),
+   IME/DnD/multi-window land in the Wayland backend. Gate before lock-in:
+   a spike — app shell as a native Wayland window rendering one channel
+   strip in ImGui at 60 Hz with input. Swap still happens behind the
+   existing DuskComboBox/DuskContextMenu/LookAndFeel/EmbeddedModal seams;
+   event loop = rewrite of MessageThread.cpp, call sites already converged
+   by the events-remainder tower, PR #112. ~120 files, 50%+ of total
+   effort, multi-release. Unlinks everything else, `juce_core` last.
 
 Done since the last queue edit: events remainder (PR #112, zero gate
 movement by design), FFT (branch dejuce/fft — DpAligner + MasteringEqEditor

--- a/docs/dejuce-hosting-h4-descriptors.md
+++ b/docs/dejuce-hosting-h4-descriptors.md
@@ -9,9 +9,10 @@ re-scout was repeated on `698fd71`; the old 36-file table is obsolete.
 
 Validation: Release app and plugin-host builds completed without new warnings;
 the focused descriptor/session/slot/scan suite passed 478 assertions in 60
-cases; full CTest passed 488/488; private-Xvfb self-test passed; the synthetic
-full-range SFZ harness printed `VERDICT: AUDIO PRESENT`; and the plugin-picker
-screenshot passed visual review. Temporary validation assets were removed.
+cases; full CTest passed 493/493 after the review-fix pass; private-Xvfb
+self-test passed; the synthetic full-range SFZ harness printed
+`VERDICT: AUDIO PRESENT`; and the plugin-picker screenshot passed visual
+review. Temporary validation assets were removed.
 
 ## Goal
 
@@ -157,9 +158,9 @@ H4 does not change which host processes audio or which native rung wins.
   malformed-legacy preservation, failed/offline reference preservation,
   unsupported-platform native-key preservation, and clone action
   perform/undo/redo.
-- App build completes with zero new warnings. Fresh configure/build commands
-  include
-  `-DDUSK_PLUGINS_PATH=/home/marc/projects/plugins-multicomp-core`.
+- App build completes with zero new warnings. Set `DUSK_PLUGINS_PATH` to the
+  donor checkout, then include
+  `-DDUSK_PLUGINS_PATH="${DUSK_PLUGINS_PATH}"` in fresh configure commands.
 - Full `ctest --output-on-failure` is green except the independently
   reproducible `ALSA seq backend does not report` environment flake. Do not
   waive any new failure.

--- a/docs/dejuce-hosting-h4-descriptors.md
+++ b/docs/dejuce-hosting-h4-descriptors.md
@@ -181,9 +181,10 @@ H4 does not change which host processes audio or which native rung wins.
 - AI-slop sweep the complete diff: remove change-narration comments,
   duplicated conversion helpers, dead compatibility branches, and
   speculative abstractions. `git diff --check` must be clean.
-- Audit `MANUAL.md`. H4 is internal plumbing and should need no manual prose
-  change; if picker behavior or visible labels moved, stop and document the
-  user-visible change plus updated screenshot instead of assuming it away.
+- Audit `MANUAL.md`. Cache-format and path migration documentation is expected,
+  including JSON sidecar filenames and the legacy-XML import/fallback behavior.
+  If picker behavior or visible labels moved, stop and document the user-visible
+  change plus updated screenshot instead of assuming it away.
 - Commit only after the reviewer and fresh-eyes rounds are clear. Zero
   attribution trailers. Stop before push.
 

--- a/docs/dejuce-hosting-h4-descriptors.md
+++ b/docs/dejuce-hosting-h4-descriptors.md
@@ -1,0 +1,200 @@
+# Hosting tower H4 — descriptor/plumbing de-JUCE (executable spec)
+
+Status: **IMPLEMENTED AND VALIDATED 2026-07-29 on
+`dejuce/hosting-h4`; not pushed.** Baseline is `main` at `64eb5a3`, plus the
+docs-only status commits `698fd71` and `28ac471`; gate 181 -> 179. One PR.
+H1d and H2 remain blocked on donor consolidation and are out of scope.
+Parent plan: [dejuce-hosting-plan.md](dejuce-hosting-plan.md). The post-H3
+re-scout was repeated on `698fd71`; the old 36-file table is obsolete.
+
+Validation: Release app and plugin-host builds completed without new warnings;
+the focused descriptor/session/slot/scan suite passed 478 assertions in 60
+cases; full CTest passed 488/488; private-Xvfb self-test passed; the synthetic
+full-range SFZ harness printed `VERDICT: AUDIO PRESENT`; and the plugin-picker
+screenshot passed visual review. Temporary validation assets were removed.
+
+## Goal
+
+Plugin metadata outside the surviving JUCE host implementation is owned by a
+Dusk `PluginDescriptor`, not `juce::PluginDescription` or
+`juce::KnownPluginList`. The picker, native scan rows and caches, scan-sandbox
+wire format, session references, offline placeholders, clone replay, and test
+harness fixtures all carry that type.
+
+The JUCE hosting path still exists until H6. H4 therefore creates a narrow,
+lossless conversion boundary: JUCE scanning/instantiation may convert at the
+inside edge of `PluginManager`, `PluginSlot`, and the scan child, but no
+picker, session, cache, or scan-protocol API exposes JUCE descriptor types.
+H4 does not change which host processes audio or which native rung wins.
+
+## Locked decisions
+
+- Add a JUCE-free `src/engine/PluginDescriptor.{h,cpp}`. It uses `std::string`
+  and fixed-width integers and contains:
+  - `name`, `descriptiveName`, `manufacturer`, `category`, `version`;
+  - `formatName` preserving the exact scanned format string;
+  - `PluginBackend { Native, JuceLegacy }`;
+  - `location` and a separate `pluginId` (no newline-packed native identity);
+  - `uniqueId`, `deprecatedUid`, input/output channel counts;
+  - file-modification and info-update times in milliseconds;
+  - `isInstrument`, `hasSharedContainer`, and `hasAraExtension`.
+  `formatName` stays a string rather than an enum so unknown/future JUCE
+  formats round-trip losslessly. Routing always checks backend plus format;
+  native rows never invent names such as `VST3-Native`.
+- The descriptor owns versioned nlohmann-JSON conversion. Missing optional
+  fields take the field defaults; wrong top-level types, unknown required
+  enum values, or malformed JSON fail without partially mutating the output.
+  Preserve every field through JSON and JUCE conversion. Do not add a new
+  JUCE-coupled adapter translation unit: conversions live in already-coupled
+  `PluginManager.cpp` / `PluginHostMain.cpp` boundaries so the gate cannot
+  rise.
+- `PluginManager` keeps `AudioPluginFormatManager`, `KnownPluginList`, its XML
+  cache, and `AudioPluginInstance` creation private as H6 implementation
+  residue. Public picker views return `std::vector<PluginDescriptor>`;
+  `getKnownPluginList()` is removed and its only caller uses
+  `getPluginCount()`. Load/create APIs that accept a description accept the
+  Dusk type, then convert immediately before calling JUCE. The conversion
+  copies all fields in both directions, including both UIDs, timestamps,
+  shell/ARA flags, and channel counts.
+- Native description storage in `PluginManager` becomes
+  `std::vector<PluginDescriptor>` under the existing lock. CLAP, LV2, and VST3
+  rows set `backend = Native`, use canonical format names `CLAP`, `LV2`, and
+  `VST3`, and store bundle/path and inner plugin ID separately.
+  `NativeScanRows.h` takes `std::filesystem::path` plus a descriptor vector
+  and becomes JUCE-free.
+- Native caches become versioned JSON descriptor arrays. Keep their existing
+  staleness checks: split identity is no longer needed, so check
+  `descriptor.location`. On first H4 launch, read the old native XML cache
+  best-effort through the private JUCE adapter when no JSON cache exists;
+  the next native scan/cache write emits JSON only. The JUCE-format
+  `plugin-cache.xml` remains unchanged and private until H6.
+- `PluginScanProtocol.h` becomes JUCE-free. Sentinel framing and crash
+  semantics are frozen:
+  - `makePayload(std::vector<PluginDescriptor>)` emits one compact,
+    versioned JSON payload between the existing begin/end sentinels;
+  - `extractPayload` ignores plugin stdout before the begin sentinel and
+    returns empty if either sentinel is absent;
+  - a framed empty descriptor array is a successful zero-result scan, not a
+    crash;
+  - malformed framed JSON parses to no rows and never appends partial rows;
+  - sandbox policy accepts `std::string_view`.
+  The JUCE `--scan` child converts scan results to Dusk rows only after JUCE
+  finishes probing. The parent's `KnownPluginList::CustomScanner` converts
+  parsed rows back only to satisfy that private JUCE callback. Native
+  `--scan-native` produces Dusk rows directly.
+- `PluginPickerPanel` and `PluginPickerHelpers` carry
+  `std::vector<PluginDescriptor>` through callbacks and entries. Preserve the
+  exact grouping, filtering, labels, ordering, scan/reopen flow, kind guard,
+  and modal lifetime behavior. Native selection routes by
+  `backend == Native` plus `formatName`; `location` and `pluginId` are passed
+  separately. When a native handler exists, remove only the matching
+  `JuceLegacy` LV2/VST3 rows. Browse-file behavior is unchanged.
+- Session persistence moves the remaining JUCE-hosted slot reference from
+  opaque XML to a structured `plugin_descriptor` object. Keep the existing
+  `plugin_state` base64 key.
+  - Track and aux models hold an optional Dusk descriptor, the state blob,
+    and a raw legacy XML fallback only when an old value cannot be parsed.
+  - Read `plugin_descriptor` first. If absent, read `plugin_desc_xml` and
+    convert the old JUCE attributes once. Successful conversion clears the
+    legacy string; the next save writes only `plugin_descriptor`.
+  - A missing descriptor and missing legacy fallback means an empty slot.
+  - A failed plugin restore retains descriptor and state byte-for-byte so an
+    autosave/manual save cannot erase an unavailable plugin.
+  - If legacy XML is malformed, retain and re-emit that raw
+    `plugin_desc_xml` plus state instead of destroying user data.
+  - Existing native CLAP/LV2/VST3/multisample keys, precedence, and
+    unsupported-platform round-trip behavior do not change in H4.
+- The legacy DuskMultisample migration consumes the converted Dusk
+  descriptor (`formatName == "DuskMultisample"`, `location` = soundfont)
+  before generic legacy-host restore. Preserve the H3 one-way migration and
+  state bytes.
+- `PluginSlot` exposes descriptor-named operations:
+  `loadFromDescriptor`, `loadFromDescriptorAsync`,
+  `getDescriptorForSave`, and descriptor-based restore. Cache the loaded
+  descriptor so instrument classification, OOP saves, offline display, and
+  Mac shell reload do not call `fillInPluginDescription` outside the private
+  conversion points. OOP `LoadPlugin` may continue sending JUCE XML to the
+  child in H4; generate it inside the legacy boundary. That control protocol
+  and child processor path die in H6.
+- Track clone/freeze replay stores the optional descriptor, raw legacy
+  fallback, and state, and restores exactly the same triple on
+  perform/undo/redo. `AudioEngine` save/restore and failure labels use the
+  descriptor directly. `DuskStudioApp` pipeline diagnostics report the
+  structured descriptor; the replace harness obtains and loads Dusk
+  descriptors.
+- `ScreenshotCapture` fake picker rows use `PluginDescriptor`; the rendered
+  plugin-picker figure must remain visually unchanged. Update stale
+  `KnownPluginList` / `PluginDescription` prose in `AppConfig.h`,
+  `AudioSettingsPanel.cpp`, picker docs/comments, and the affected harness
+  comments.
+- H4 deliberately leaves these processor/editor surfaces for H6:
+  - `PluginSlot` instance ownership, processing, state calls, parameter
+    listeners, editor shell, and raw `AudioPluginInstance` access used by the
+    UI;
+  - `PluginManager`'s private JUCE format/instance creation;
+  - `PluginHostMain --ipc-host`, `PluginIpc`, `RemotePluginConnection`, and
+    the IPC host self-test load payload;
+  - `ChannelStripComponent`, `AuxLaneComponent`, and
+    `PlatformWindowing_Mac.mm` editor-owner lifecycles;
+  - `MidiBindings` parameter-name lookup through the loaded processor;
+  - the `MasteringChain` compatibility accessor and processor-path comments.
+  Do not introduce a parameter facade or touch those lifecycles in this
+  mechanical descriptor phase.
+- No H1d, H2, H5, or H6 implementation; no donor edits; no DSP, routing,
+  editor, or scan-sandbox policy changes; no `release/0.12` changes.
+
+## Verify
+
+- Add focused descriptor tests: default/missing optional fields, malformed
+  rejection, every-field JSON round-trip, unknown format-name preservation,
+  and lossless Dusk↔JUCE adapter conversion.
+- Rewrite `tests/plugin_scan_protocol.cpp` around Dusk descriptors:
+  multi-row and empty-success round-trips, noisy stdout, missing/truncated
+  sentinels, malformed JSON, and exact `location`/`pluginId` preservation.
+- Cover native cache JSON round-trip, legacy-XML one-way import, and
+  stale-location pruning without loading a plugin.
+- Cover track and aux session round-trip, old `plugin_desc_xml` migration,
+  malformed-legacy preservation, failed/offline reference preservation,
+  unsupported-platform native-key preservation, and clone action
+  perform/undo/redo.
+- App build completes with zero new warnings. Fresh configure/build commands
+  include
+  `-DDUSK_PLUGINS_PATH=/home/marc/projects/plugins-multicomp-core`.
+- Full `ctest --output-on-failure` is green except the independently
+  reproducible `ALSA seq backend does not report` environment flake. Do not
+  waive any new failure.
+- `tools/juce-gate.sh` never rises. Expected result is 181 -> 179, with
+  `src/engine/NativeScanRows.h` and
+  `src/engine/ipc/PluginScanProtocol.h` leaving the allowlist. Any different
+  movement must be explained before commit; no new allowlist entry.
+- Run `DUSKSTUDIO_RUN_SELFTEST=1` only on a private Xvfb display with
+  `WAYLAND_DISPLAY` unset; require every printed self-test to pass.
+- Run the instrument harness under the same private display with a freshly
+  generated full-range synthetic `.sfz`; require the process output to print
+  the harness result and `VERDICT: AUDIO PRESENT`. A missing/silent file is
+  not a pass. Remove the temporary SFZ/sample directory afterward.
+- Run the screenshot harness into a temporary output directory under private
+  Xvfb. Inspect `pl-01-plugin-picker.png` visually for unchanged grouping,
+  labels, spacing, clipping, and buttons. Do not overwrite tracked manual
+  images.
+- AI-slop sweep the complete diff: remove change-narration comments,
+  duplicated conversion helpers, dead compatibility branches, and
+  speculative abstractions. `git diff --check` must be clean.
+- Audit `MANUAL.md`. H4 is internal plumbing and should need no manual prose
+  change; if picker behavior or visible labels moved, stop and document the
+  user-visible change plus updated screenshot instead of assuming it away.
+- Commit only after the reviewer and fresh-eyes rounds are clear. Zero
+  attribution trailers. Stop before push.
+
+## Owed to Marc's bench
+
+- Real installed-plugin smoke after the H4 commit: rescan, pick, save, reload,
+  and reopen one VST3 instrument and one LV2/CLAP effect, plus save/reload with
+  one plugin deliberately unavailable to confirm the offline reference
+  survives. The existing OOP third-party host smoke remains owed.
+
+## Resume phrase
+
+"Hosting H4, branch dejuce/hosting-h4, spec
+docs/dejuce-hosting-h4-descriptors.md — execute the descriptor/plumbing phase
+only, then review, validate, and commit locally; do not push."

--- a/docs/dejuce-hosting-plan.md
+++ b/docs/dejuce-hosting-plan.md
@@ -1,10 +1,11 @@
 # De-JUCE — plugin-hosting tower (campaign plan)
 
-Status: **H1a-c merged (PR #114); H3 merged (PR #118); H1d blocked on donor
-consolidation; H2 blocked on the donor multiband port; H4 next.** Marc's call on
+Status: **H1a-c merged (PR #114); H3 merged (PR #118); H4 complete locally
+on `dejuce/hosting-h4` and awaiting Marc's push word; H1d blocked on donor
+consolidation; H2 blocked on the donor multiband port.** Marc's call on
 2026-07-26 reversed the 2026-07-01 keep-JUCE-fallback decision: the JUCE
-plugin-hosting path gets deleted entirely; native hosting must cover
-VST3 + LV2 + CLAP on Linux, macOS, and Windows, plus AU on macOS.
+plugin-hosting path gets deleted entirely; native hosting must cover VST3 +
+LV2 + CLAP on Linux, macOS, and Windows, plus AU on macOS.
 Multi-PR tower (>15 files per phase, RT-risky and mechanical work mixed) —
 one PR per phase, sequenced below. Do not start phase N+1's PR before N
 merges. Read `docs/dejuce-campaign.md` + the memory ledger first.
@@ -87,11 +88,15 @@ merges. Read `docs/dejuce-campaign.md` + the memory ledger first.
   migration; format wrapper deleted (gate 183 -> 181); two-phase
   prime/commit keeps sfizz parses outside the engine gate; spec:
   [dejuce-hosting-h3-multisample.md](dejuce-hosting-h3-multisample.md).
-- **H4 — descriptor/plumbing de-JUCE.** Replace PluginDescription /
-  KnownPluginList surfaces with a dusk descriptor type: picker +
-  PluginPickerHelpers, NativeScanRows, scan caches, session references,
-  PluginScanProtocol wire format, ScreenshotCapture fake rows,
-  DuskStudioApp session-restore path. Mechanical but wide; re-scout first.
+- **H4 — descriptor/plumbing de-JUCE. DONE locally; not pushed.** Dusk
+  `PluginDescriptor` now owns picker, native scan/cache, scan-protocol,
+  session-reference, offline/clone, screenshot-fixture, and restore plumbing.
+  The private JUCE host boundary converts only where H6 still needs it.
+  Session schema v4 preserves structured descriptors and migrates legacy XML;
+  native sidecar caches are versioned JSON with one-way XML import. Gate
+  181 -> 179; full CTest 488/488 plus private-Xvfb self-test, synthetic SFZ
+  sound verdict, and picker screenshot review passed. Spec:
+  [dejuce-hosting-h4-descriptors.md](dejuce-hosting-h4-descriptors.md).
 - **H5 — platform ports (mac, win).** Flip CMake gates per-OS; loader
   shims (dlopen/LoadLibrary, mac bundle resolution); per-OS scan paths;
   editor embed variants (COCOA/HWND CLAP targets, kPlatformTypeNSView/HWND,

--- a/docs/dejuce-hosting-plan.md
+++ b/docs/dejuce-hosting-plan.md
@@ -94,7 +94,7 @@ merges. Read `docs/dejuce-campaign.md` + the memory ledger first.
   The private JUCE host boundary converts only where H6 still needs it.
   Session schema v4 preserves structured descriptors and migrates legacy XML;
   native sidecar caches are versioned JSON with one-way XML import. Gate
-  181 -> 179; full CTest 488/488 plus private-Xvfb self-test, synthetic SFZ
+  181 -> 179; full CTest 493/493 plus private-Xvfb self-test, synthetic SFZ
   sound verdict, and picker screenshot review passed. Spec:
   [dejuce-hosting-h4-descriptors.md](dejuce-hosting-h4-descriptors.md).
 - **H5 — platform ports (mac, win).** Flip CMake gates per-OS; loader

--- a/docs/dejuce-hosting-plan.md
+++ b/docs/dejuce-hosting-plan.md
@@ -1,6 +1,7 @@
 # De-JUCE — plugin-hosting tower (campaign plan)
 
-Status: **H1 executed on branch `dejuce/hosting`; H2-H6 planned.** Marc's call on
+Status: **H1a-c merged (PR #114); H3 merged (PR #118); H1d blocked on donor
+consolidation; H2 blocked on the donor multiband port; H4 next.** Marc's call on
 2026-07-26 reversed the 2026-07-01 keep-JUCE-fallback decision: the JUCE
 plugin-hosting path gets deleted entirely; native hosting must cover
 VST3 + LV2 + CLAP on Linux, macOS, and Windows, plus AU on macOS.
@@ -53,9 +54,10 @@ merges. Read `docs/dejuce-campaign.md` + the memory ledger first.
 - OOP host: JUCE audio path only + native scan sandbox (clap/vst3). After
   the drop it keeps only scanning; its juce_events dispatch loop goes with
   the JUCE path (also closes the events-tower out-of-scope items).
-- Deletion surface: 36 files typed against AudioProcessor /
+- Deletion surface: was 36 files typed against AudioProcessor /
   AudioPluginInstance / PluginDescription / KnownPluginList outside the
-  native dirs (scout table in session notes; re-scout at H4 kickoff).
+  native dirs; H1 and H3 removed several (tape donor, multisample format
+  wrapper) — the table is stale, RE-SCOUT at H4 kickoff.
 
 ## Phases
 
@@ -78,10 +80,13 @@ merges. Read `docs/dejuce-campaign.md` + the memory ledger first.
   UniversalCompressor/APVTS onto the new core; MasteringView native
   multiband panel replacing the embedded donor panel. A/B vs JUCE
   multiband.
-- **H3 — DuskMultisample re-home.** Off juce::AudioPluginInstance /
-  AudioProcessorEditor / AudioPluginFormat onto an internal-instrument seam
-  (its params are already plain atomics; sfizz does the DSP — coupling is
-  shim-shaped). Editor becomes a plain Component.
+- **H3 — DuskMultisample re-home. DONE (PR #118).**
+  DuskMultisampleProcessor implements hosting::INativeInstance; fourth
+  native rung (NativeMultisampleSlot, ladder CLAP > LV2 > VST3 > MS > JUCE);
+  session keys native_multisample_path/state with one-way legacy desc-XML
+  migration; format wrapper deleted (gate 183 -> 181); two-phase
+  prime/commit keeps sfizz parses outside the engine gate; spec:
+  [dejuce-hosting-h3-multisample.md](dejuce-hosting-h3-multisample.md).
 - **H4 — descriptor/plumbing de-JUCE.** Replace PluginDescription /
   KnownPluginList surfaces with a dusk descriptor type: picker +
   PluginPickerHelpers, NativeScanRows, scan caches, session references,

--- a/docs/dejuce-hosting-plan.md
+++ b/docs/dejuce-hosting-plan.md
@@ -55,10 +55,11 @@ merges. Read `docs/dejuce-campaign.md` + the memory ledger first.
 - OOP host: JUCE audio path only + native scan sandbox (clap/vst3). After
   the drop it keeps only scanning; its juce_events dispatch loop goes with
   the JUCE path (also closes the events-tower out-of-scope items).
-- Deletion surface: was 36 files typed against AudioProcessor /
-  AudioPluginInstance / PluginDescription / KnownPluginList outside the
-  native dirs; H1 and H3 removed several (tape donor, multisample format
-  wrapper) — the table is stale, RE-SCOUT at H4 kickoff.
+- Deletion surface: the completed post-H3 H4 re-scout covered the picker and
+  helpers, native scan rows and caches, session references, scan wire format,
+  screenshot fixtures, restore paths, and MIDI bindings. H4 moved descriptor
+  plumbing to the Dusk type; the remaining processor/editor ownership stays
+  explicitly deferred to H6.
 
 ## Phases
 

--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -647,7 +647,9 @@ static void runHeadlessPipelineTest (const juce::String& pluginPath)
         // with that descriptor would report a false restore failure.
         const bool legacyMultisample =
             soundfontPath.isEmpty()
-            && session->track (0).pluginDescriptionXml.contains ("DuskMultisample");
+            && ((session->track (0).pluginDescriptor.has_value()
+                 && session->track (0).pluginDescriptor->formatName == "DuskMultisample")
+                || session->track (0).pluginLegacyDescriptionXml.contains ("DuskMultisample"));
 #else
         const juce::String soundfontPath;
         const bool legacyMultisample = false;
@@ -662,16 +664,14 @@ static void runHeadlessPipelineTest (const juce::String& pluginPath)
         }
         else
         {
-            // Verify the description was deserialised before we ask the
-            // engine to consume it. Empty here = the JSON didn't contain
-            // plugin_desc_xml, which is a session-file regression.
-            const auto& descXml = session->track (0).pluginDescriptionXml;
+            const auto& descriptor = session->track (0).pluginDescriptor;
+            const auto& legacyXml = session->track (0).pluginLegacyDescriptionXml;
             const auto& stateB64 = session->track (0).pluginStateBase64;
             std::fprintf (stdout,
-                          "After SessionSerializer::load: track[0] descXml.len=%d  state.len=%d  "
-                          "descXml head=\"%.60s\"\n",
-                          descXml.length(), stateB64.length(),
-                          descXml.toRawUTF8());
+                          "After SessionSerializer::load: track[0] descriptor=\"%s\"  "
+                          "legacyXml.len=%d  state.len=%d\n",
+                          descriptor.has_value() ? descriptor->name.c_str() : "",
+                          legacyXml.length(), stateB64.length());
 
             if (legacyMultisample)
             {
@@ -687,7 +687,8 @@ static void runHeadlessPipelineTest (const juce::String& pluginPath)
                 // which is a no-op in release builds.
                 juce::String restoreErr;
                 const bool restored = engine->getStrip (0).getPluginSlot()
-                    .restoreFromSavedState (descXml, stateB64, restoreErr);
+                    .restoreFromSavedState (descriptor, legacyXml,
+                                            stateB64, restoreErr);
                 if (! restored)
                 {
                     std::fprintf (stderr, "FAIL: restoreFromSavedState: %s\n",
@@ -1995,7 +1996,7 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
 
     // DUSKSTUDIO_REPLACE_TEST=A.vst3:B.vst3 - exercises the Replace plugin...
     // swap pattern under live processing. Loads A, runs audio, swaps to
-    // B mid-stream via loadFromDescription, runs more audio. Mirrors the
+    // B mid-stream via loadFromDescriptor, runs more audio. Mirrors the
     // user's GUI flow: right-click slot button -> Replace plugin -> pick
     // a different plugin. The colon-separated form lets us test ACROSS
     // distinct plugins, which is the actual crashing case (a single
@@ -2027,14 +2028,14 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
 
         // Build a description for plugin B by scanning its file via the
         // PluginManager so it's resolved through the same path the GUI
-        // picker uses (cached KnownPluginList descriptions).
-        juce::PluginDescription descB;
+        // picker uses (cached descriptors).
+        PluginDescriptor descB;
         {
             auto& mgr = engine->getPluginManager();
             juce::String scanErr;
             auto probe = mgr.createPluginInstance (juce::File (pathB), sampleRate,
                                                      blockSize, scanErr);
-            if (probe != nullptr) probe->fillInPluginDescription (descB);
+            if (probe != nullptr) descB = mgr.descriptorForInstance (*probe);
             else
             {
                 std::fprintf (stderr, "FAIL: scan B: %s\n", scanErr.toRawUTF8());
@@ -2043,7 +2044,7 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
             }
             // probe goes out of scope - releases its instance immediately.
         }
-        std::fprintf (stdout, "[Replace] B = \"%s\"\n", descB.name.toRawUTF8());
+        std::fprintf (stdout, "[Replace] B = \"%s\"\n", descB.name.c_str());
 
         // I/O buffers
         std::vector<std::vector<float>> inputs (2, std::vector<float> (blockSize, 0.0f));
@@ -2052,7 +2053,7 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
         std::vector<float*> outputPtrs { outputs[0].data(), outputs[1].data() };
         duskstudio::device::CallbackContext ctx {};
 
-        // Drive audio callbacks, then loadFromDescription with plugin B
+        // Drive audio callbacks, then loadFromDescriptor with plugin B
         // mid-stream to swap. The previousInstance keep-alive in
         // PluginSlot defers A's destructor until the NEXT swap; an
         // immediate Diva->MininnDrum->ThirdPlugin sequence would
@@ -2066,15 +2067,13 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
             if (b == 50)
             {
                 std::fprintf (stdout, "[Replace] swap A -> B...\n");
-                if (! slot.loadFromDescription (descB, err))
+                if (! slot.loadFromDescriptor (descB, err))
                     std::fprintf (stderr, "FAIL: swap A->B: %s\n", err.toRawUTF8());
             }
             if (b == 120)
             {
                 std::fprintf (stdout, "[Replace] swap B -> A (forces A's prev destructor in PluginSlot)...\n");
-                juce::PluginDescription descA;
-                if (auto* p = slot.getInstance())
-                    p->fillInPluginDescription (descA);
+                PluginDescriptor descA;
                 // Re-resolve A via the manager so we have a clean desc.
                 auto& mgr = engine->getPluginManager();
                 juce::String scanErr;
@@ -2082,10 +2081,10 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
                                                           sampleRate, blockSize, scanErr);
                 if (probe != nullptr)
                 {
-                    probe->fillInPluginDescription (descA);
+                    descA = mgr.descriptorForInstance (*probe);
                     probe.reset();
                 }
-                if (! slot.loadFromDescription (descA, err))
+                if (! slot.loadFromDescriptor (descA, err))
                     std::fprintf (stderr, "FAIL: swap B->A: %s\n", err.toRawUTF8());
             }
         }

--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -2079,13 +2079,20 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
                 juce::String scanErr;
                 auto probe = mgr.createPluginInstance (juce::File (pathA),
                                                           sampleRate, blockSize, scanErr);
-                if (probe != nullptr)
+                if (probe == nullptr)
+                {
+                    err = scanErr;
+                    std::fprintf (stderr, "FAIL: swap B->A re-resolve: %s\n",
+                                  err.toRawUTF8());
+                }
+                else
                 {
                     descA = mgr.descriptorForInstance (*probe);
                     probe.reset();
+                    if (! slot.loadFromDescriptor (descA, err))
+                        std::fprintf (stderr, "FAIL: swap B->A: %s\n",
+                                      err.toRawUTF8());
                 }
-                if (! slot.loadFromDescriptor (descA, err))
-                    std::fprintf (stderr, "FAIL: swap B->A: %s\n", err.toRawUTF8());
             }
         }
         std::fprintf (stdout, "[Replace] survived 200 blocks across two swaps.\n");

--- a/src/engine/AtomicPark.h
+++ b/src/engine/AtomicPark.h
@@ -23,7 +23,7 @@ namespace duskstudio
 //      resumes normal use on its next callback.
 //
 // Used by PluginSlot to bracket getStateInformation /
-// fillInPluginDescription so the audio thread isn't inside processBlock
+// metadata/state reads so the audio thread isn't inside processBlock
 // on the same plugin while we're reading its state. JUCE's contract is
 // that processBlock and getStateInformation MUST NOT overlap; a number
 // of widely-used plugins crash hard when the host violates it. On

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -230,24 +230,20 @@ static void migrateLegacyMultisampleTrack (Track& track, PluginManager& manager)
     if (track.nativeMultisamplePath.isNotEmpty())
         return;
 
-    if (! track.pluginDescriptor.has_value()
-        && track.pluginLegacyDescriptionXml.isNotEmpty())
+    auto descriptor = track.pluginDescriptor;
+    if (! descriptor.has_value() && track.pluginLegacyDescriptionXml.isNotEmpty())
     {
         PluginDescriptor converted;
         if (manager.descriptorFromLegacyXml (track.pluginLegacyDescriptionXml, converted))
-        {
-            track.pluginDescriptor = std::move (converted);
-            track.pluginLegacyDescriptionXml.clear();
-        }
+            descriptor = std::move (converted);
     }
-    if (! track.pluginDescriptor.has_value()
-        || track.pluginDescriptor->formatName != "DuskMultisample")
+    if (! descriptor.has_value() || descriptor->formatName != "DuskMultisample")
         return;
     // No soundfont named: leave the legacy pair alone rather than clearing it -
     // wiping it here would destroy the blob on the next save and restore nothing.
-    if (track.pluginDescriptor->location.empty()) return;
+    if (descriptor->location.empty()) return;
 
-    track.nativeMultisamplePath        = track.pluginDescriptor->location;
+    track.nativeMultisamplePath        = descriptor->location;
     track.nativeMultisampleStateBase64 = track.pluginStateBase64;
     track.pluginDescriptor.reset();
     track.pluginLegacyDescriptionXml.clear();

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -222,24 +222,35 @@ static std::vector<uint8_t> decodeBase64Blob (const juce::String& s)
 
 #if DUSKSTUDIO_HAS_MULTISAMPLE
 // Sessions written while the multisample instrument was hosted as a JUCE plugin
-// carry it as a "DuskMultisample" PluginDescription whose fileOrIdentifier is the
+// carry a "DuskMultisample" descriptor whose location is the
 // soundfont path, plus the same ValueTree state blob the native rung reads. Move
 // those onto the native keys once; the next save writes only the native form.
-static void migrateLegacyMultisampleTrack (Track& track)
+static void migrateLegacyMultisampleTrack (Track& track, PluginManager& manager)
 {
-    if (track.nativeMultisamplePath.isNotEmpty() || track.pluginDescriptionXml.isEmpty())
+    if (track.nativeMultisamplePath.isNotEmpty())
         return;
-    auto xml = juce::XmlDocument::parse (track.pluginDescriptionXml);
-    if (xml == nullptr) return;
-    juce::PluginDescription desc;
-    if (! desc.loadFromXml (*xml) || desc.pluginFormatName != "DuskMultisample") return;
+
+    if (! track.pluginDescriptor.has_value()
+        && track.pluginLegacyDescriptionXml.isNotEmpty())
+    {
+        PluginDescriptor converted;
+        if (manager.descriptorFromLegacyXml (track.pluginLegacyDescriptionXml, converted))
+        {
+            track.pluginDescriptor = std::move (converted);
+            track.pluginLegacyDescriptionXml.clear();
+        }
+    }
+    if (! track.pluginDescriptor.has_value()
+        || track.pluginDescriptor->formatName != "DuskMultisample")
+        return;
     // No soundfont named: leave the legacy pair alone rather than clearing it -
     // wiping it here would destroy the blob on the next save and restore nothing.
-    if (desc.fileOrIdentifier.isEmpty()) return;
+    if (track.pluginDescriptor->location.empty()) return;
 
-    track.nativeMultisamplePath        = desc.fileOrIdentifier;
+    track.nativeMultisamplePath        = track.pluginDescriptor->location;
     track.nativeMultisampleStateBase64 = track.pluginStateBase64;
-    track.pluginDescriptionXml.clear();
+    track.pluginDescriptor.reset();
+    track.pluginLegacyDescriptionXml.clear();
     track.pluginStateBase64.clear();
 }
 #endif
@@ -1508,7 +1519,8 @@ void AudioEngine::publishPluginStateForSave (bool audioCallbackDetached)
         auto& track = session.track (t);
         auto& strip = strips[(size_t) t];
         auto& slot  = strip.getPluginSlot();
-        track.pluginDescriptionXml = slot.getDescriptionXmlForSave (parkSleepMs);
+        track.pluginDescriptor = slot.getDescriptorForSave (parkSleepMs);
+        track.pluginLegacyDescriptionXml = slot.getLegacyDescriptionXmlForSave();
         track.pluginStateBase64    = slot.getStateBase64ForSave   (parkSleepMs);
 
         // Native CLAP insert (parallel to the JUCE plugin; at most one is loaded).
@@ -1606,7 +1618,9 @@ void AudioEngine::publishPluginStateForSave (bool audioCallbackDetached)
         {
             auto& strip = auxLaneStrips[(size_t) a];
             auto& slot  = strip.getPluginSlot (s);
-            lane.pluginDescriptionXml[(size_t) s] = slot.getDescriptionXmlForSave (parkSleepMs);
+            lane.pluginDescriptor[(size_t) s] = slot.getDescriptorForSave (parkSleepMs);
+            lane.pluginLegacyDescriptionXml[(size_t) s]
+                = slot.getLegacyDescriptionXmlForSave();
             lane.pluginStateBase64[(size_t) s]    = slot.getStateBase64ForSave   (parkSleepMs);
 
             // Native CLAP slot (parallel to the JUCE plugin; at most one is loaded).
@@ -1752,14 +1766,14 @@ void AudioEngine::consumePluginStateAfterLoad()
     // mix is intact but the plugin chain it depended on is gone).
     lastPluginLoadFailures.clear();
 
-    auto parsePluginName = [] (const juce::String& descXml) -> juce::String
+    auto pluginName = [this] (const std::optional<PluginDescriptor>& descriptor,
+                              const juce::String& legacyXml) -> juce::String
     {
-        if (descXml.isEmpty()) return {};
-        if (auto xml = juce::XmlDocument::parse (descXml))
-        {
-            juce::PluginDescription desc;
-            if (desc.loadFromXml (*xml)) return desc.name;
-        }
+        if (descriptor.has_value())
+            return descriptor->name;
+        PluginDescriptor converted;
+        if (pluginManager.descriptorFromLegacyXml (legacyXml, converted))
+            return converted.name;
         return juce::String ("(unknown)");
     };
 
@@ -1890,7 +1904,7 @@ void AudioEngine::consumePluginStateAfterLoad()
         }
 #endif
 #if DUSKSTUDIO_HAS_MULTISAMPLE
-        migrateLegacyMultisampleTrack (track);
+        migrateLegacyMultisampleTrack (track, pluginManager);
         if (track.nativeMultisamplePath.isNotEmpty())
         {
             slot.unload();
@@ -1965,7 +1979,8 @@ void AudioEngine::consumePluginStateAfterLoad()
             strip.unloadNativeMultisample();
         }
 
-        if (track.pluginDescriptionXml.isEmpty())
+        if (! track.pluginDescriptor.has_value()
+            && track.pluginLegacyDescriptionXml.isEmpty())
         {
             slot.unload();   // session has no plugin here - clear any carried over from the prior one
             // Reconstruct the insert mode from session state so a strip that ran
@@ -1981,15 +1996,19 @@ void AudioEngine::consumePluginStateAfterLoad()
         // restore below fails) so a prior session's kInsertHardware can't linger.
         strip.insertMode.store (ChannelStrip::kInsertPlugin, std::memory_order_release);
         juce::String error;
-        if (! slot.restoreFromSavedState (track.pluginDescriptionXml,
-                                            track.pluginStateBase64, error))
+        if (! slot.restoreFromSavedState (track.pluginDescriptor,
+                                          track.pluginLegacyDescriptionXml,
+                                          track.pluginStateBase64, error))
         {
             DBG ("AudioEngine: failed to restore plugin on track " << (t + 1)
                   << ": " << error);
             lastPluginLoadFailures.push_back ({
                 "Track " + juce::String (t + 1),
-                parsePluginName (track.pluginDescriptionXml) });
+                pluginName (track.pluginDescriptor,
+                            track.pluginLegacyDescriptionXml) });
         }
+        track.pluginDescriptor = slot.getDescriptorForSave (0);
+        track.pluginLegacyDescriptionXml = slot.getLegacyDescriptionXmlForSave();
     }
     for (int a = 0; a < Session::kNumAuxLanes; ++a)
     {
@@ -2139,8 +2158,9 @@ void AudioEngine::consumePluginStateAfterLoad()
                 strip.unloadNativeVst3 (s);
             }
 
-            const auto& descXml = lane.pluginDescriptionXml[(size_t) s];
-            if (descXml.isEmpty())
+            auto& descriptor = lane.pluginDescriptor[(size_t) s];
+            auto& legacyXml = lane.pluginLegacyDescriptionXml[(size_t) s];
+            if (! descriptor.has_value() && legacyXml.isEmpty())
             {
                 // No plugin in this slot - unload any instance left from the
                 // prior session and route around it (or through the hardware
@@ -2161,15 +2181,17 @@ void AudioEngine::consumePluginStateAfterLoad()
             auxLaneStrips[(size_t) a].insertMode[(size_t) s].store (
                 AuxLaneStrip::kInsertPlugin, std::memory_order_release);
             juce::String error;
-            if (! slot.restoreFromSavedState (descXml,
-                                                lane.pluginStateBase64[(size_t) s], error))
+            if (! slot.restoreFromSavedState (descriptor, legacyXml,
+                                              lane.pluginStateBase64[(size_t) s], error))
             {
                 DBG ("AudioEngine: failed to restore plugin on aux lane " << (a + 1)
                       << " slot " << (s + 1) << ": " << error);
                 lastPluginLoadFailures.push_back ({
                     "Aux " + juce::String (a + 1) + " / slot " + juce::String (s + 1),
-                    parsePluginName (descXml) });
+                    pluginName (descriptor, legacyXml) });
             }
+            descriptor = slot.getDescriptorForSave (0);
+            legacyXml = slot.getLegacyDescriptionXmlForSave();
         }
     }
 }

--- a/src/engine/NativePluginCache.cpp
+++ b/src/engine/NativePluginCache.cpp
@@ -1,0 +1,58 @@
+#include "NativePluginCache.h"
+
+#include <nlohmann/json.hpp>
+
+namespace duskstudio::nativecache
+{
+namespace
+{
+constexpr int kCacheVersion = 1;
+}
+
+std::string serialize (const std::vector<PluginDescriptor>& descriptors)
+{
+    nlohmann::ordered_json root {
+        { "version", kCacheVersion },
+        { "descriptors", nlohmann::ordered_json::array() }
+    };
+    for (const auto& descriptor : descriptors)
+        root["descriptors"].push_back (
+            nlohmann::ordered_json::parse (descriptor.toJson()));
+    return root.dump();
+}
+
+bool parse (std::string_view source, const LocationExists& locationExists,
+            std::vector<PluginDescriptor>& out)
+{
+    const auto root = nlohmann::json::parse (source, nullptr, false);
+    if (! root.is_object())
+        return false;
+
+    const auto version = root.find ("version");
+    const auto descriptors = root.find ("descriptors");
+    if (version == root.end()
+        || descriptors == root.end() || ! descriptors->is_array())
+        return false;
+    const bool versionMatches = version->is_number_unsigned()
+        ? version->get<std::uint64_t>() == static_cast<std::uint64_t> (kCacheVersion)
+        : version->is_number_integer()
+            && version->get<std::int64_t>() == static_cast<std::int64_t> (kCacheVersion);
+    if (! versionMatches)
+        return false;
+
+    std::vector<PluginDescriptor> parsed;
+    parsed.reserve (descriptors->size());
+    for (const auto& value : *descriptors)
+    {
+        PluginDescriptor descriptor;
+        if (! PluginDescriptor::fromJson (value.dump(), descriptor))
+            continue;
+        if (locationExists && ! locationExists (descriptor.location))
+            continue;
+        parsed.push_back (std::move (descriptor));
+    }
+
+    out = std::move (parsed);
+    return true;
+}
+} // namespace duskstudio::nativecache

--- a/src/engine/NativePluginCache.h
+++ b/src/engine/NativePluginCache.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "PluginDescriptor.h"
+
+#include <functional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace duskstudio::nativecache
+{
+using LocationExists = std::function<bool (std::string_view)>;
+
+std::string serialize (const std::vector<PluginDescriptor>& descriptors);
+
+// Parses a complete cache document into `out`. Invalid cache schemas fail
+// without changing `out`; invalid descriptor rows and stale locations are
+// skipped independently so one bad plugin cannot discard the rest of a scan.
+bool parse (std::string_view source, const LocationExists& locationExists,
+            std::vector<PluginDescriptor>& out);
+} // namespace duskstudio::nativecache

--- a/src/engine/NativeScanRows.h
+++ b/src/engine/NativeScanRows.h
@@ -1,6 +1,9 @@
 #pragma once
 
-#include <juce_audio_processors/juce_audio_processors.h>
+#include "PluginDescriptor.h"
+
+#include <filesystem>
+#include <vector>
 
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
  #include "clap/ClapBundle.h"
@@ -8,58 +11,53 @@
 #if DUSKSTUDIO_HAS_NATIVE_VST3
  #include "vst3/Vst3Bundle.h"
 #endif
-#include "hosting/NativePluginId.h"
 
 namespace duskstudio::nativescan
 {
-// One bundle -> picker rows, shared verbatim by the sandboxed scan child
-// (dusk-studio-plugin-host --scan-native) and the parent's in-process fallback,
-// so both sides emit identical descriptions. Loading a bundle executes its code
-// (dlopen + factory read) - that is exactly what the sandbox exists for; call
-// these in-process only as the fallback when the child can't spawn.
-
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
-inline void appendClapRows (const juce::File& bundle,
-                            juce::Array<juce::PluginDescription>& into)
+inline void appendClapRows (const std::filesystem::path& bundle,
+                            std::vector<PluginDescriptor>& into)
 {
-    clap::ClapBundle b;
-    std::string err;
-    if (! b.load (bundle.getFullPathName().toStdString(), err))
+    clap::ClapBundle loaded;
+    std::string error;
+    if (! loaded.load (bundle.string(), error))
         return;
-    for (const auto& d : b.plugins())
+    for (const auto& plugin : loaded.plugins())
     {
-        juce::PluginDescription desc;
-        desc.name             = juce::String (juce::CharPointer_UTF8 (d.name.c_str()));
-        desc.manufacturerName = juce::String (juce::CharPointer_UTF8 (d.vendor.c_str()));
-        desc.version          = juce::String (juce::CharPointer_UTF8 (d.version.c_str()));
-        desc.pluginFormatName = "CLAP";
-        desc.fileOrIdentifier = hosting::joinNativeIdentifier (
-            bundle.getFullPathName(), juce::String (juce::CharPointer_UTF8 (d.id.c_str())));
-        desc.isInstrument     = d.isInstrument();
-        into.add (desc);
+        PluginDescriptor descriptor;
+        descriptor.name = plugin.name;
+        descriptor.manufacturer = plugin.vendor;
+        descriptor.version = plugin.version;
+        descriptor.formatName = "CLAP";
+        descriptor.backend = PluginBackend::Native;
+        descriptor.location = bundle.string();
+        descriptor.pluginId = plugin.id;
+        descriptor.isInstrument = plugin.isInstrument();
+        into.push_back (std::move (descriptor));
     }
 }
 #endif
 
 #if DUSKSTUDIO_HAS_NATIVE_VST3
-inline void appendVst3Rows (const juce::File& bundle,
-                            juce::Array<juce::PluginDescription>& into)
+inline void appendVst3Rows (const std::filesystem::path& bundle,
+                            std::vector<PluginDescriptor>& into)
 {
-    vst3::Vst3Bundle b;
-    std::string err;
-    if (! b.load (bundle.getFullPathName().toStdString(), err))
+    vst3::Vst3Bundle loaded;
+    std::string error;
+    if (! loaded.load (bundle.string(), error))
         return;
-    for (const auto& d : b.plugins())
+    for (const auto& plugin : loaded.plugins())
     {
-        juce::PluginDescription desc;
-        desc.name             = juce::String (juce::CharPointer_UTF8 (d.name.c_str()));
-        desc.manufacturerName = juce::String (juce::CharPointer_UTF8 (d.vendor.c_str()));
-        desc.version          = juce::String (juce::CharPointer_UTF8 (d.version.c_str()));
-        desc.pluginFormatName = "VST3-Native";
-        desc.fileOrIdentifier = hosting::joinNativeIdentifier (
-            bundle.getFullPathName(), juce::String (juce::CharPointer_UTF8 (d.id.c_str())));
-        desc.isInstrument     = d.isInstrument;
-        into.add (desc);
+        PluginDescriptor descriptor;
+        descriptor.name = plugin.name;
+        descriptor.manufacturer = plugin.vendor;
+        descriptor.version = plugin.version;
+        descriptor.formatName = "VST3";
+        descriptor.backend = PluginBackend::Native;
+        descriptor.location = bundle.string();
+        descriptor.pluginId = plugin.id;
+        descriptor.isInstrument = plugin.isInstrument;
+        into.push_back (std::move (descriptor));
     }
 }
 #endif

--- a/src/engine/NativeScanRows.h
+++ b/src/engine/NativeScanRows.h
@@ -18,9 +18,10 @@ namespace duskstudio::nativescan
 inline void appendClapRows (const std::filesystem::path& bundle,
                             std::vector<PluginDescriptor>& into)
 {
+    const auto bundlePath = bundle.u8string();
     clap::ClapBundle loaded;
     std::string error;
-    if (! loaded.load (bundle.string(), error))
+    if (! loaded.load (bundlePath, error))
         return;
     for (const auto& plugin : loaded.plugins())
     {
@@ -30,7 +31,7 @@ inline void appendClapRows (const std::filesystem::path& bundle,
         descriptor.version = plugin.version;
         descriptor.formatName = "CLAP";
         descriptor.backend = PluginBackend::Native;
-        descriptor.location = bundle.string();
+        descriptor.location = bundlePath;
         descriptor.pluginId = plugin.id;
         descriptor.isInstrument = plugin.isInstrument();
         into.push_back (std::move (descriptor));
@@ -42,9 +43,10 @@ inline void appendClapRows (const std::filesystem::path& bundle,
 inline void appendVst3Rows (const std::filesystem::path& bundle,
                             std::vector<PluginDescriptor>& into)
 {
+    const auto bundlePath = bundle.u8string();
     vst3::Vst3Bundle loaded;
     std::string error;
-    if (! loaded.load (bundle.string(), error))
+    if (! loaded.load (bundlePath, error))
         return;
     for (const auto& plugin : loaded.plugins())
     {
@@ -54,7 +56,7 @@ inline void appendVst3Rows (const std::filesystem::path& bundle,
         descriptor.version = plugin.version;
         descriptor.formatName = "VST3";
         descriptor.backend = PluginBackend::Native;
-        descriptor.location = bundle.string();
+        descriptor.location = bundlePath;
         descriptor.pluginId = plugin.id;
         descriptor.isInstrument = plugin.isInstrument;
         into.push_back (std::move (descriptor));

--- a/src/engine/PluginDescriptor.cpp
+++ b/src/engine/PluginDescriptor.cpp
@@ -86,7 +86,8 @@ std::string PluginDescriptor::toJson() const
         { "has_shared_container", hasSharedContainer },
         { "has_ara_extension", hasAraExtension }
     };
-    return value.dump();
+    return value.dump (-1, ' ', false,
+                       nlohmann::ordered_json::error_handler_t::replace);
 }
 
 bool PluginDescriptor::fromJson (const std::string& source, PluginDescriptor& out)

--- a/src/engine/PluginDescriptor.cpp
+++ b/src/engine/PluginDescriptor.cpp
@@ -62,10 +62,10 @@ bool readOptionalInteger (const nlohmann::json& object, const char* key, T& valu
 }
 } // namespace
 
-std::string PluginDescriptor::toJson() const
+nlohmann::ordered_json PluginDescriptor::toJsonObject() const
 {
     const auto backendName = backend == PluginBackend::Native ? "native" : "juce_legacy";
-    const nlohmann::ordered_json value {
+    return {
         { "version", kDescriptorVersion },
         { "name", name },
         { "descriptive_name", descriptiveName },
@@ -86,58 +86,90 @@ std::string PluginDescriptor::toJson() const
         { "has_shared_container", hasSharedContainer },
         { "has_ara_extension", hasAraExtension }
     };
-    return value.dump (-1, ' ', false,
-                       nlohmann::ordered_json::error_handler_t::replace);
 }
 
-bool PluginDescriptor::fromJson (const std::string& source, PluginDescriptor& out)
+std::string PluginDescriptor::toJson() const
 {
-    const auto value = nlohmann::json::parse (source, nullptr, false);
-    if (! value.is_object())
-        return false;
+    return toJsonObject().dump (
+        -1, ' ', false, nlohmann::ordered_json::error_handler_t::replace);
+}
 
-    const auto versionIt = value.find ("version");
-    const auto backendIt = value.find ("backend");
-    if (versionIt == value.end()
-        || (! versionIt->is_number_integer() && ! versionIt->is_number_unsigned())
-        || backendIt == value.end() || ! backendIt->is_string())
-        return false;
+bool PluginDescriptor::fromJsonObject (
+    const nlohmann::json& object, PluginDescriptor& out) noexcept
+{
+    try
+    {
+        if (! object.is_object())
+            return false;
 
-    PluginDescriptor parsed;
-    int descriptorVersion = 0;
-    if (! readOptionalInteger (value, "version", descriptorVersion)
-        || descriptorVersion != kDescriptorVersion)
-        return false;
+        const auto versionIt = object.find ("version");
+        const auto backendIt = object.find ("backend");
+        if (versionIt == object.end()
+            || (! versionIt->is_number_integer()
+                && ! versionIt->is_number_unsigned())
+            || backendIt == object.end() || ! backendIt->is_string())
+            return false;
 
-    const auto backendName = backendIt->get<std::string>();
-    if (backendName == "native")
-        parsed.backend = PluginBackend::Native;
-    else if (backendName == "juce_legacy")
-        parsed.backend = PluginBackend::JuceLegacy;
-    else
-        return false;
+        PluginDescriptor parsed;
+        int descriptorVersion = 0;
+        if (! readOptionalInteger (object, "version", descriptorVersion)
+            || descriptorVersion != kDescriptorVersion)
+            return false;
 
-    if (! readOptionalString (value, "name", parsed.name)
-        || ! readOptionalString (value, "descriptive_name", parsed.descriptiveName)
-        || ! readOptionalString (value, "manufacturer", parsed.manufacturer)
-        || ! readOptionalString (value, "category", parsed.category)
-        || ! readOptionalString (value, "plugin_version", parsed.version)
-        || ! readOptionalString (value, "format_name", parsed.formatName)
-        || ! readOptionalString (value, "location", parsed.location)
-        || ! readOptionalString (value, "plugin_id", parsed.pluginId)
-        || ! readOptionalInteger (value, "unique_id", parsed.uniqueId)
-        || ! readOptionalInteger (value, "deprecated_uid", parsed.deprecatedUid)
-        || ! readOptionalInteger (value, "num_input_channels", parsed.numInputChannels)
-        || ! readOptionalInteger (value, "num_output_channels", parsed.numOutputChannels)
-        || ! readOptionalInteger (value, "last_file_modification_ms", parsed.lastFileModificationMs)
-        || ! readOptionalInteger (value, "last_info_update_ms", parsed.lastInfoUpdateMs)
-        || ! readOptionalBool (value, "is_instrument", parsed.isInstrument)
-        || ! readOptionalBool (value, "has_shared_container", parsed.hasSharedContainer)
-        || ! readOptionalBool (value, "has_ara_extension", parsed.hasAraExtension))
-        return false;
+        const auto backendName = backendIt->get<std::string>();
+        if (backendName == "native")
+            parsed.backend = PluginBackend::Native;
+        else if (backendName == "juce_legacy")
+            parsed.backend = PluginBackend::JuceLegacy;
+        else
+            return false;
 
-    out = std::move (parsed);
-    return true;
+        if (! readOptionalString (object, "name", parsed.name)
+            || ! readOptionalString (
+                object, "descriptive_name", parsed.descriptiveName)
+            || ! readOptionalString (
+                object, "manufacturer", parsed.manufacturer)
+            || ! readOptionalString (object, "category", parsed.category)
+            || ! readOptionalString (
+                object, "plugin_version", parsed.version)
+            || ! readOptionalString (
+                object, "format_name", parsed.formatName)
+            || ! readOptionalString (object, "location", parsed.location)
+            || ! readOptionalString (object, "plugin_id", parsed.pluginId)
+            || ! readOptionalInteger (object, "unique_id", parsed.uniqueId)
+            || ! readOptionalInteger (
+                object, "deprecated_uid", parsed.deprecatedUid)
+            || ! readOptionalInteger (
+                object, "num_input_channels", parsed.numInputChannels)
+            || ! readOptionalInteger (
+                object, "num_output_channels", parsed.numOutputChannels)
+            || ! readOptionalInteger (
+                object, "last_file_modification_ms",
+                parsed.lastFileModificationMs)
+            || ! readOptionalInteger (
+                object, "last_info_update_ms", parsed.lastInfoUpdateMs)
+            || ! readOptionalBool (
+                object, "is_instrument", parsed.isInstrument)
+            || ! readOptionalBool (
+                object, "has_shared_container", parsed.hasSharedContainer)
+            || ! readOptionalBool (
+                object, "has_ara_extension", parsed.hasAraExtension))
+            return false;
+
+        out = std::move (parsed);
+        return true;
+    }
+    catch (...)
+    {
+        return false;
+    }
+}
+
+bool PluginDescriptor::fromJson (
+    const std::string& source, PluginDescriptor& out)
+{
+    const auto object = nlohmann::json::parse (source, nullptr, false);
+    return fromJsonObject (object, out);
 }
 
 PluginDescriptor mergeLoadedPluginDescriptor (

--- a/src/engine/PluginDescriptor.cpp
+++ b/src/engine/PluginDescriptor.cpp
@@ -1,0 +1,151 @@
+#include "PluginDescriptor.h"
+
+#include <nlohmann/json.hpp>
+#include <limits>
+#include <type_traits>
+
+namespace duskstudio
+{
+namespace
+{
+constexpr int kDescriptorVersion = 1;
+
+bool readOptionalString (const nlohmann::json& object, const char* key,
+                         std::string& value)
+{
+    const auto it = object.find (key);
+    if (it == object.end())
+        return true;
+    if (! it->is_string())
+        return false;
+    value = it->get<std::string>();
+    return true;
+}
+
+bool readOptionalBool (const nlohmann::json& object, const char* key, bool& value)
+{
+    const auto it = object.find (key);
+    if (it == object.end())
+        return true;
+    if (! it->is_boolean())
+        return false;
+    value = it->get<bool>();
+    return true;
+}
+
+template <typename T>
+bool readOptionalInteger (const nlohmann::json& object, const char* key, T& value)
+{
+    static_assert (std::is_integral_v<T> && std::is_signed_v<T>);
+
+    const auto it = object.find (key);
+    if (it == object.end())
+        return true;
+    if (! it->is_number_integer() && ! it->is_number_unsigned())
+        return false;
+
+    if (it->is_number_unsigned())
+    {
+        const auto candidate = it->get<std::uint64_t>();
+        if (candidate > static_cast<std::uint64_t> (std::numeric_limits<T>::max()))
+            return false;
+        value = static_cast<T> (candidate);
+        return true;
+    }
+
+    const auto candidate = it->get<std::int64_t>();
+    if (candidate < static_cast<std::int64_t> (std::numeric_limits<T>::min())
+        || candidate > static_cast<std::int64_t> (std::numeric_limits<T>::max()))
+        return false;
+    value = static_cast<T> (candidate);
+    return true;
+}
+} // namespace
+
+std::string PluginDescriptor::toJson() const
+{
+    const auto backendName = backend == PluginBackend::Native ? "native" : "juce_legacy";
+    const nlohmann::ordered_json value {
+        { "version", kDescriptorVersion },
+        { "name", name },
+        { "descriptive_name", descriptiveName },
+        { "manufacturer", manufacturer },
+        { "category", category },
+        { "plugin_version", version },
+        { "format_name", formatName },
+        { "backend", backendName },
+        { "location", location },
+        { "plugin_id", pluginId },
+        { "unique_id", uniqueId },
+        { "deprecated_uid", deprecatedUid },
+        { "num_input_channels", numInputChannels },
+        { "num_output_channels", numOutputChannels },
+        { "last_file_modification_ms", lastFileModificationMs },
+        { "last_info_update_ms", lastInfoUpdateMs },
+        { "is_instrument", isInstrument },
+        { "has_shared_container", hasSharedContainer },
+        { "has_ara_extension", hasAraExtension }
+    };
+    return value.dump();
+}
+
+bool PluginDescriptor::fromJson (const std::string& source, PluginDescriptor& out)
+{
+    const auto value = nlohmann::json::parse (source, nullptr, false);
+    if (! value.is_object())
+        return false;
+
+    const auto versionIt = value.find ("version");
+    const auto backendIt = value.find ("backend");
+    if (versionIt == value.end()
+        || (! versionIt->is_number_integer() && ! versionIt->is_number_unsigned())
+        || backendIt == value.end() || ! backendIt->is_string())
+        return false;
+
+    PluginDescriptor parsed;
+    int descriptorVersion = 0;
+    if (! readOptionalInteger (value, "version", descriptorVersion)
+        || descriptorVersion != kDescriptorVersion)
+        return false;
+
+    const auto backendName = backendIt->get<std::string>();
+    if (backendName == "native")
+        parsed.backend = PluginBackend::Native;
+    else if (backendName == "juce_legacy")
+        parsed.backend = PluginBackend::JuceLegacy;
+    else
+        return false;
+
+    if (! readOptionalString (value, "name", parsed.name)
+        || ! readOptionalString (value, "descriptive_name", parsed.descriptiveName)
+        || ! readOptionalString (value, "manufacturer", parsed.manufacturer)
+        || ! readOptionalString (value, "category", parsed.category)
+        || ! readOptionalString (value, "plugin_version", parsed.version)
+        || ! readOptionalString (value, "format_name", parsed.formatName)
+        || ! readOptionalString (value, "location", parsed.location)
+        || ! readOptionalString (value, "plugin_id", parsed.pluginId)
+        || ! readOptionalInteger (value, "unique_id", parsed.uniqueId)
+        || ! readOptionalInteger (value, "deprecated_uid", parsed.deprecatedUid)
+        || ! readOptionalInteger (value, "num_input_channels", parsed.numInputChannels)
+        || ! readOptionalInteger (value, "num_output_channels", parsed.numOutputChannels)
+        || ! readOptionalInteger (value, "last_file_modification_ms", parsed.lastFileModificationMs)
+        || ! readOptionalInteger (value, "last_info_update_ms", parsed.lastInfoUpdateMs)
+        || ! readOptionalBool (value, "is_instrument", parsed.isInstrument)
+        || ! readOptionalBool (value, "has_shared_container", parsed.hasSharedContainer)
+        || ! readOptionalBool (value, "has_ara_extension", parsed.hasAraExtension))
+        return false;
+
+    out = std::move (parsed);
+    return true;
+}
+
+PluginDescriptor mergeLoadedPluginDescriptor (
+    const PluginDescriptor& reloadDescriptor,
+    PluginDescriptor instantiatedDescriptor)
+{
+    instantiatedDescriptor.backend = reloadDescriptor.backend;
+    instantiatedDescriptor.location = reloadDescriptor.location;
+    instantiatedDescriptor.pluginId = reloadDescriptor.pluginId;
+    return instantiatedDescriptor;
+}
+} // namespace duskstudio

--- a/src/engine/PluginDescriptor.h
+++ b/src/engine/PluginDescriptor.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <nlohmann/json.hpp>
+
 #include <cstdint>
 #include <string>
 
@@ -32,6 +34,9 @@ struct PluginDescriptor
     bool hasSharedContainer { false };
     bool hasAraExtension { false };
 
+    nlohmann::ordered_json toJsonObject() const;
+    static bool fromJsonObject (const nlohmann::json& object,
+                                PluginDescriptor& out) noexcept;
     std::string toJson() const;
     static bool fromJson (const std::string& source, PluginDescriptor& out);
 

--- a/src/engine/PluginDescriptor.h
+++ b/src/engine/PluginDescriptor.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace duskstudio
+{
+enum class PluginBackend
+{
+    Native,
+    JuceLegacy
+};
+
+struct PluginDescriptor
+{
+    std::string name;
+    std::string descriptiveName;
+    std::string manufacturer;
+    std::string category;
+    std::string version;
+    std::string formatName;
+    PluginBackend backend { PluginBackend::JuceLegacy };
+    std::string location;
+    std::string pluginId;
+    std::int32_t uniqueId { 0 };
+    std::int32_t deprecatedUid { 0 };
+    std::int32_t numInputChannels { 0 };
+    std::int32_t numOutputChannels { 0 };
+    std::int64_t lastFileModificationMs { 0 };
+    std::int64_t lastInfoUpdateMs { 0 };
+    bool isInstrument { false };
+    bool hasSharedContainer { false };
+    bool hasAraExtension { false };
+
+    std::string toJson() const;
+    static bool fromJson (const std::string& source, PluginDescriptor& out);
+
+    bool operator== (const PluginDescriptor& other) const noexcept
+    {
+        return name == other.name
+            && descriptiveName == other.descriptiveName
+            && manufacturer == other.manufacturer
+            && category == other.category
+            && version == other.version
+            && formatName == other.formatName
+            && backend == other.backend
+            && location == other.location
+            && pluginId == other.pluginId
+            && uniqueId == other.uniqueId
+            && deprecatedUid == other.deprecatedUid
+            && numInputChannels == other.numInputChannels
+            && numOutputChannels == other.numOutputChannels
+            && lastFileModificationMs == other.lastFileModificationMs
+            && lastInfoUpdateMs == other.lastInfoUpdateMs
+            && isInstrument == other.isInstrument
+            && hasSharedContainer == other.hasSharedContainer
+            && hasAraExtension == other.hasAraExtension;
+    }
+};
+
+// The instantiated plugin is authoritative for metadata/classification. The
+// reload descriptor remains authoritative only for identity fields that may
+// have been normalised before JUCE instantiation.
+PluginDescriptor mergeLoadedPluginDescriptor (
+    const PluginDescriptor& reloadDescriptor,
+    PluginDescriptor instantiatedDescriptor);
+} // namespace duskstudio

--- a/src/engine/PluginManager.cpp
+++ b/src/engine/PluginManager.cpp
@@ -169,10 +169,10 @@ public:
                              juce::OwnedArray<juce::PluginDescription>& result,
                              const juce::String& fileOrIdentifier) override
     {
-        // In-house formats are our own code and can't crash the host, so scan
-        // them in-process. Third-party binary formats are sandboxed - and for
-        // those we NEVER fall back to in-process: an unauthorized or crashy
-        // plugin scanned in-process takes down the whole app (issue #45).
+        // DuskMultisample is trusted in-house code and scans in-process. Every
+        // other format, including an unrecognized future format, is sandboxed.
+        // We NEVER fall back to in-process: an unauthorized or crashy plugin
+        // scanned in-process takes down the whole app (issue #45).
         if (! scanproto::formatRequiresSandbox (format.getName().toStdString()))
         {
             format.findAllTypesForFile (result, fileOrIdentifier);

--- a/src/engine/PluginManager.cpp
+++ b/src/engine/PluginManager.cpp
@@ -33,8 +33,19 @@ PluginDescriptor fromJuceDescription (const juce::PluginDescription& source)
     descriptor.category = source.category.toStdString();
     descriptor.version = source.version.toStdString();
     descriptor.formatName = source.pluginFormatName.toStdString();
-    descriptor.backend = PluginBackend::JuceLegacy;
-    descriptor.location = source.fileOrIdentifier.toStdString();
+    const auto nativeIdentifier = hosting::splitNativeIdentifier (
+        source.fileOrIdentifier);
+    if (nativeIdentifier.pluginId.isNotEmpty())
+    {
+        descriptor.backend = PluginBackend::Native;
+        descriptor.location = nativeIdentifier.bundlePath.toStdString();
+        descriptor.pluginId = nativeIdentifier.pluginId.toStdString();
+    }
+    else
+    {
+        descriptor.backend = PluginBackend::JuceLegacy;
+        descriptor.location = source.fileOrIdentifier.toStdString();
+    }
     descriptor.uniqueId = source.uniqueId;
     descriptor.deprecatedUid = source.deprecatedUid;
     descriptor.numInputChannels = source.numInputChannels;
@@ -56,7 +67,9 @@ juce::PluginDescription toJuceDescription (const PluginDescriptor& source)
     descriptor.category = source.category;
     descriptor.version = source.version;
     descriptor.pluginFormatName = source.formatName;
-    descriptor.fileOrIdentifier = source.location;
+    descriptor.fileOrIdentifier = source.backend == PluginBackend::Native
+        ? hosting::joinNativeIdentifier (source.location, source.pluginId)
+        : juce::String (source.location);
     descriptor.uniqueId = source.uniqueId;
     descriptor.deprecatedUid = source.deprecatedUid;
     descriptor.numInputChannels = source.numInputChannels;
@@ -69,14 +82,14 @@ juce::PluginDescription toJuceDescription (const PluginDescriptor& source)
     return descriptor;
 }
 
-std::vector<PluginDescriptor> importLegacyNativeCache (
+std::optional<std::vector<PluginDescriptor>> importLegacyNativeCache (
     const juce::String& xmlSource,
     const std::function<bool (const juce::File&)>& locationExists)
 {
     std::vector<PluginDescriptor> imported;
     const auto xml = juce::parseXML (xmlSource);
-    if (xml == nullptr)
-        return imported;
+    if (xml == nullptr || ! xml->hasTagName ("KNOWNPLUGINS"))
+        return std::nullopt;
 
     for (auto* child : xml->getChildIterator())
     {
@@ -94,6 +107,40 @@ std::vector<PluginDescriptor> importLegacyNativeCache (
             imported.push_back (std::move (descriptor));
     }
     return imported;
+}
+
+bool loadNativeCacheSources (
+    const std::optional<std::string>& jsonSource,
+    const std::optional<juce::String>& legacyXmlSource,
+    const std::function<bool (const juce::File&)>& locationExists,
+    std::vector<PluginDescriptor>& into)
+{
+    std::vector<PluginDescriptor> fresh;
+    if (jsonSource.has_value()
+        && nativecache::parse (*jsonSource,
+            [&locationExists] (std::string_view location)
+            {
+                const juce::File bundle (juce::String::fromUTF8 (
+                    location.data(), static_cast<int> (location.size())));
+                return ! locationExists || locationExists (bundle);
+            },
+            fresh))
+    {
+        into = std::move (fresh);
+        return true;
+    }
+
+    if (legacyXmlSource.has_value())
+    {
+        auto imported = importLegacyNativeCache (*legacyXmlSource, locationExists);
+        if (imported.has_value())
+        {
+            into = std::move (*imported);
+            return true;
+        }
+    }
+
+    return false;
 }
 } // namespace
 
@@ -217,10 +264,20 @@ public:
             return false;
         }
 
-        // A clean payload means the child completed the scan without crashing,
-        // so this is a successful scan even when the file legitimately yields
-        // zero descriptions. Only the crash (empty payload) / timeout cases fail.
-        for (const auto& descriptor : scanproto::parsePayload (payload))
+        const auto parsed = scanproto::parsePayload (payload);
+        if (! parsed.has_value())
+        {
+            knownList.addToBlacklist (fileOrIdentifier);
+            std::fprintf (stderr,
+                          "[Dusk Studio/scan] quarantined \"%s\": malformed scan payload\n",
+                          fileOrIdentifier.toRawUTF8());
+            std::fflush (stderr);
+            return false;
+        }
+
+        // A valid payload means the child completed the scan without crashing,
+        // so this is successful even when the file yields zero descriptions.
+        for (const auto& descriptor : *parsed)
             result.add (new juce::PluginDescription (toJuceDescription (descriptor)));
         return true;
     }
@@ -525,8 +582,15 @@ bool PluginManager::scanNativeBundleSandboxed (const char* format, const juce::F
         return true;
     }
     auto found = scanproto::parsePayload (payload);
-    into.insert (into.end(), std::make_move_iterator (found.begin()),
-                 std::make_move_iterator (found.end()));
+    if (! found.has_value())
+    {
+        std::fprintf (stderr,
+                      "[Dusk Studio/scan] native %s bundle skipped (malformed child payload): %s\n",
+                      format, bundle.getFullPathName().toRawUTF8());
+        return true;
+    }
+    into.insert (into.end(), std::make_move_iterator (found->begin()),
+                 std::make_move_iterator (found->end()));
     return true;
 }
 #endif
@@ -563,28 +627,30 @@ void PluginManager::loadNativeCache (std::vector<PluginDescriptor>& into,
                                      bool bundleIsDirectory)
 {
     std::vector<PluginDescriptor> fresh;
+    const auto locationExists = [bundleIsDirectory] (const juce::File& bundle)
+    {
+        return bundleIsDirectory ? bundle.isDirectory() : bundle.exists();
+    };
+    bool loaded = false;
     const auto jsonFile = nativeCacheFile (jsonFileName);
     if (jsonFile != juce::File() && jsonFile.existsAsFile())
     {
-        nativecache::parse (jsonFile.loadFileAsString().toStdString(),
-            [bundleIsDirectory] (std::string_view location)
-            {
-                const juce::File bundle (juce::String::fromUTF8 (
-                    location.data(), static_cast<int> (location.size())));
-                return bundleIsDirectory ? bundle.isDirectory() : bundle.exists();
-            },
-            fresh);
+        loaded = loadNativeCacheSources (
+            jsonFile.loadFileAsString().toStdString(), std::nullopt,
+            locationExists, fresh);
     }
-    else
+
+    if (! loaded)
     {
         const auto legacyFile = nativeCacheFile (legacyXmlFileName);
         if (legacyFile != juce::File() && legacyFile.existsAsFile())
-            fresh = importLegacyNativeCache (legacyFile.loadFileAsString(),
-                [bundleIsDirectory] (const juce::File& bundle)
-                {
-                    return bundleIsDirectory ? bundle.isDirectory() : bundle.exists();
-                });
+            loaded = loadNativeCacheSources (
+                std::nullopt, legacyFile.loadFileAsString(),
+                locationExists, fresh);
     }
+
+    if (! loaded)
+        return;
 
     const juce::ScopedLock sl (nativeDescriptionsLock);
     into.swap (fresh);
@@ -845,7 +911,18 @@ std::vector<PluginDescriptor> PluginManager::importLegacyNativeCacheForTest (
     const juce::String& xml,
     const std::function<bool (const juce::File&)>& locationExists)
 {
-    return importLegacyNativeCache (xml, locationExists);
+    return importLegacyNativeCache (xml, locationExists).value_or (
+        std::vector<PluginDescriptor> {});
+}
+
+bool PluginManager::loadNativeCacheSourcesForTest (
+    const std::optional<std::string>& jsonSource,
+    const std::optional<juce::String>& legacyXmlSource,
+    const std::function<bool (const juce::File&)>& locationExists,
+    std::vector<PluginDescriptor>& into)
+{
+    return loadNativeCacheSources (
+        jsonSource, legacyXmlSource, locationExists, into);
 }
 #endif
 } // namespace duskstudio

--- a/src/engine/PluginManager.cpp
+++ b/src/engine/PluginManager.cpp
@@ -2,6 +2,7 @@
 #include "JuceCompat.h"
 
 #include "ipc/PluginScanProtocol.h"
+#include "NativePluginCache.h"
 #include "PluginBackingCheck.h"
 #include "hosting/NativePluginId.h"
 #if DUSKSTUDIO_HAS_NATIVE_CLAP || DUSKSTUDIO_HAS_NATIVE_VST3
@@ -21,6 +22,81 @@
 
 namespace duskstudio
 {
+namespace
+{
+PluginDescriptor fromJuceDescription (const juce::PluginDescription& source)
+{
+    PluginDescriptor descriptor;
+    descriptor.name = source.name.toStdString();
+    descriptor.descriptiveName = source.descriptiveName.toStdString();
+    descriptor.manufacturer = source.manufacturerName.toStdString();
+    descriptor.category = source.category.toStdString();
+    descriptor.version = source.version.toStdString();
+    descriptor.formatName = source.pluginFormatName.toStdString();
+    descriptor.backend = PluginBackend::JuceLegacy;
+    descriptor.location = source.fileOrIdentifier.toStdString();
+    descriptor.uniqueId = source.uniqueId;
+    descriptor.deprecatedUid = source.deprecatedUid;
+    descriptor.numInputChannels = source.numInputChannels;
+    descriptor.numOutputChannels = source.numOutputChannels;
+    descriptor.lastFileModificationMs = source.lastFileModTime.toMilliseconds();
+    descriptor.lastInfoUpdateMs = source.lastInfoUpdateTime.toMilliseconds();
+    descriptor.isInstrument = source.isInstrument;
+    descriptor.hasSharedContainer = source.hasSharedContainer;
+    descriptor.hasAraExtension = source.hasARAExtension;
+    return descriptor;
+}
+
+juce::PluginDescription toJuceDescription (const PluginDescriptor& source)
+{
+    juce::PluginDescription descriptor;
+    descriptor.name = source.name;
+    descriptor.descriptiveName = source.descriptiveName;
+    descriptor.manufacturerName = source.manufacturer;
+    descriptor.category = source.category;
+    descriptor.version = source.version;
+    descriptor.pluginFormatName = source.formatName;
+    descriptor.fileOrIdentifier = source.location;
+    descriptor.uniqueId = source.uniqueId;
+    descriptor.deprecatedUid = source.deprecatedUid;
+    descriptor.numInputChannels = source.numInputChannels;
+    descriptor.numOutputChannels = source.numOutputChannels;
+    descriptor.lastFileModTime = juce::Time (source.lastFileModificationMs);
+    descriptor.lastInfoUpdateTime = juce::Time (source.lastInfoUpdateMs);
+    descriptor.isInstrument = source.isInstrument;
+    descriptor.hasSharedContainer = source.hasSharedContainer;
+    descriptor.hasARAExtension = source.hasAraExtension;
+    return descriptor;
+}
+
+std::vector<PluginDescriptor> importLegacyNativeCache (
+    const juce::String& xmlSource,
+    const std::function<bool (const juce::File&)>& locationExists)
+{
+    std::vector<PluginDescriptor> imported;
+    const auto xml = juce::parseXML (xmlSource);
+    if (xml == nullptr)
+        return imported;
+
+    for (auto* child : xml->getChildIterator())
+    {
+        juce::PluginDescription legacy;
+        if (! legacy.loadFromXml (*child))
+            continue;
+        auto descriptor = fromJuceDescription (legacy);
+        descriptor.backend = PluginBackend::Native;
+        if (descriptor.formatName == "LV2-Native") descriptor.formatName = "LV2";
+        if (descriptor.formatName == "VST3-Native") descriptor.formatName = "VST3";
+        const auto split = hosting::splitNativeIdentifier (legacy.fileOrIdentifier);
+        descriptor.location = split.bundlePath.toStdString();
+        descriptor.pluginId = split.pluginId.toStdString();
+        if (! locationExists || locationExists (juce::File (descriptor.location)))
+            imported.push_back (std::move (descriptor));
+    }
+    return imported;
+}
+} // namespace
+
 #if DUSKSTUDIO_HAS_OOP_PLUGINS
 namespace
 {
@@ -50,7 +126,7 @@ public:
         // them in-process. Third-party binary formats are sandboxed - and for
         // those we NEVER fall back to in-process: an unauthorized or crashy
         // plugin scanned in-process takes down the whole app (issue #45).
-        if (! scanproto::formatRequiresSandbox (format.getName()))
+        if (! scanproto::formatRequiresSandbox (format.getName().toStdString()))
         {
             format.findAllTypesForFile (result, fileOrIdentifier);
             return true;
@@ -124,9 +200,9 @@ public:
         // (return true) rather than blacklisting a plugin the user cancelled on.
         if (aborted) return true;
 
-        const juce::String payload = scanproto::extractPayload (captured.toString());
+        const auto payload = scanproto::extractPayload (captured.toString().toStdString());
 
-        if (timedOut || payload.isEmpty())
+        if (timedOut || payload.empty())
         {
             // A hang (timed out) or a crash (child died with no clean payload):
             // quarantine so the next scan skips it instead of re-hanging /
@@ -144,7 +220,8 @@ public:
         // A clean payload means the child completed the scan without crashing,
         // so this is a successful scan even when the file legitimately yields
         // zero descriptions. Only the crash (empty payload) / timeout cases fail.
-        scanproto::parsePayload (payload, result);
+        for (const auto& descriptor : scanproto::parsePayload (payload))
+            result.add (new juce::PluginDescription (toJuceDescription (descriptor)));
         return true;
     }
 
@@ -179,13 +256,14 @@ PluginManager::PluginManager()
     loadCache();
     // Restore native-format descriptions so the picker has them at launch.
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
-    loadNativeCache (clapDescriptions, "clap-cache.xml", false);
+    loadNativeCache (clapDescriptions, "clap-cache.json", "clap-cache.xml", false);
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_LV2
-    loadNativeCache (lv2Descriptions, "lv2-native-cache.xml", true);
+    loadNativeCache (lv2Descriptions, "lv2-native-cache.json", "lv2-native-cache.xml", true);
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_VST3
-    loadNativeCache (vst3NativeDescriptions, "vst3-native-cache.xml", false);
+    loadNativeCache (vst3NativeDescriptions, "vst3-native-cache.json",
+                     "vst3-native-cache.xml", false);
 #endif
 }
 
@@ -402,7 +480,7 @@ int PluginManager::scanInstalledPlugins (
 // or times out yields no payload and the bundle is skipped - re-probed next
 // scan, but never fatal.
 bool PluginManager::scanNativeBundleSandboxed (const char* format, const juce::File& bundle,
-                                               juce::Array<juce::PluginDescription>& into) const
+                                               std::vector<PluginDescriptor>& into) const
 {
     const juce::File hostExe (getHostExecutablePath());
     if (hostExe == juce::File() || ! hostExe.existsAsFile())
@@ -437,8 +515,8 @@ bool PluginManager::scanNativeBundleSandboxed (const char* format, const juce::F
         juce::Thread::sleep (5);
     }
 
-    const juce::String payload = scanproto::extractPayload (captured.toString());
-    if (payload.isEmpty())
+    const auto payload = scanproto::extractPayload (captured.toString().toStdString());
+    if (payload.empty())
     {
         // Crash / hang / no sentinels - treat as handled (skip the bundle) so the
         // caller doesn't re-execute the crashing code in-process.
@@ -446,10 +524,9 @@ bool PluginManager::scanNativeBundleSandboxed (const char* format, const juce::F
                       format, bundle.getFullPathName().toRawUTF8());
         return true;
     }
-    juce::OwnedArray<juce::PluginDescription> found;
-    scanproto::parsePayload (payload, found);
-    for (const auto* d : found)
-        into.add (*d);
+    auto found = scanproto::parsePayload (payload);
+    into.insert (into.end(), std::make_move_iterator (found.begin()),
+                 std::make_move_iterator (found.end()));
     return true;
 }
 #endif
@@ -460,18 +537,18 @@ void PluginManager::scanClapPlugins()
     // Discover OUTSIDE the lock (executes every bundle's factory - slow), swap
     // in under it. The cache write also stays outside so a picker open on the
     // message thread can't stall behind this thread's file I/O.
-    juce::Array<juce::PluginDescription> fresh;
+    std::vector<PluginDescriptor> fresh;
     for (const auto& path : clap::ClapScanner::findClapFiles (clap::ClapScanner::defaultSearchPaths()))
     {
         const juce::File file (juce::String::fromUTF8 (path.u8string().c_str()));
         if (! scanNativeBundleSandboxed ("clap", file, fresh))
-            nativescan::appendClapRows (file, fresh);   // no sandbox available - in-process
+            nativescan::appendClapRows (path, fresh);   // no sandbox available - in-process
     }
     {
         const juce::ScopedLock sl (nativeDescriptionsLock);
-        clapDescriptions.swapWith (fresh);
+        clapDescriptions.swap (fresh);
     }
-    saveNativeCache (clapDescriptions, "clap-cache.xml", "CLAP_PLUGINS");
+    saveNativeCache (clapDescriptions, "clap-cache.json");
 #endif
 }
 
@@ -481,73 +558,72 @@ juce::File PluginManager::nativeCacheFile (const char* fileName) const
     return base == juce::File() ? juce::File() : base.getSiblingFile (fileName);
 }
 
-void PluginManager::loadNativeCache (juce::Array<juce::PluginDescription>& into,
-                                     const char* fileName, bool bundleIsDirectory)
+void PluginManager::loadNativeCache (std::vector<PluginDescriptor>& into,
+                                     const char* jsonFileName, const char* legacyXmlFileName,
+                                     bool bundleIsDirectory)
 {
-    const auto file = nativeCacheFile (fileName);
-    if (file == juce::File() || ! file.existsAsFile())
-        return;
-
-    if (auto xml = juce::parseXML (file))
+    std::vector<PluginDescriptor> fresh;
+    const auto jsonFile = nativeCacheFile (jsonFileName);
+    if (jsonFile != juce::File() && jsonFile.existsAsFile())
     {
-        // Parse into a local first; only the swap-in holds nativeDescriptionsLock
-        // (the contract every access to the description arrays follows).
-        juce::Array<juce::PluginDescription> fresh;
-        for (auto* child : xml->getChildIterator())
-        {
-            juce::PluginDescription d;
-            if (! d.loadFromXml (*child))
-                continue;
-            // Drop entries whose bundle is gone since the cache was written, so
-            // the picker never offers a removed plugin until a rescan rebuilds it.
-            // fileOrIdentifier carries "bundle\npluginId" - check the bundle half.
-            const juce::File bundle (
-                hosting::splitNativeIdentifier (d.fileOrIdentifier).bundlePath);
-            if (bundleIsDirectory ? bundle.isDirectory() : bundle.exists())
-                fresh.add (d);
-        }
-        const juce::ScopedLock sl (nativeDescriptionsLock);
-        into.swapWith (fresh);
+        nativecache::parse (jsonFile.loadFileAsString().toStdString(),
+            [bundleIsDirectory] (std::string_view location)
+            {
+                const juce::File bundle (juce::String::fromUTF8 (
+                    location.data(), static_cast<int> (location.size())));
+                return bundleIsDirectory ? bundle.isDirectory() : bundle.exists();
+            },
+            fresh);
     }
+    else
+    {
+        const auto legacyFile = nativeCacheFile (legacyXmlFileName);
+        if (legacyFile != juce::File() && legacyFile.existsAsFile())
+            fresh = importLegacyNativeCache (legacyFile.loadFileAsString(),
+                [bundleIsDirectory] (const juce::File& bundle)
+                {
+                    return bundleIsDirectory ? bundle.isDirectory() : bundle.exists();
+                });
+    }
+
+    const juce::ScopedLock sl (nativeDescriptionsLock);
+    into.swap (fresh);
 }
 
-void PluginManager::saveNativeCache (const juce::Array<juce::PluginDescription>& from,
-                                     const char* fileName, const char* rootTag) const
+void PluginManager::saveNativeCache (const std::vector<PluginDescriptor>& from,
+                                     const char* jsonFileName) const
 {
-    const auto file = nativeCacheFile (fileName);
+    const auto file = nativeCacheFile (jsonFileName);
     if (file == juce::File())
         return;
 
     // Snapshot under the lock; serialize + write with it released so the picker
     // can't stall behind the file I/O.
-    juce::Array<juce::PluginDescription> snapshot;
+    std::vector<PluginDescriptor> snapshot;
     {
         const juce::ScopedLock sl (nativeDescriptionsLock);
         snapshot = from;
     }
-    juce::XmlElement root (rootTag);
-    for (const auto& d : snapshot)
-        root.addChildElement (d.createXml().release());
-    root.writeTo (file);
+    file.replaceWithText (nativecache::serialize (snapshot));
 }
 
-juce::Array<juce::PluginDescription> PluginManager::filterByInstrumentFlag (
-    const juce::Array<juce::PluginDescription>& source, bool wantInstrument) const
+std::vector<PluginDescriptor> PluginManager::filterByInstrumentFlag (
+    const std::vector<PluginDescriptor>& source, bool wantInstrument) const
 {
     const juce::ScopedLock sl (nativeDescriptionsLock);
-    juce::Array<juce::PluginDescription> out;
+    std::vector<PluginDescriptor> out;
     for (const auto& d : source)
         if (d.isInstrument == wantInstrument)
-            out.add (d);
+            out.push_back (d);
     return out;
 }
 
-juce::Array<juce::PluginDescription> PluginManager::getClapEffectDescriptions() const
+std::vector<PluginDescriptor> PluginManager::getClapEffectDescriptions() const
 {
     return filterByInstrumentFlag (clapDescriptions, false);
 }
 
-juce::Array<juce::PluginDescription> PluginManager::getClapInstrumentDescriptions() const
+std::vector<PluginDescriptor> PluginManager::getClapInstrumentDescriptions() const
 {
     return filterByInstrumentFlag (clapDescriptions, true);
 }
@@ -558,7 +634,7 @@ void PluginManager::scanLv2Plugins()
     const auto scanned = lv2::Lv2Scanner::scan();   // manifest parse outside the lock
     {
         const juce::ScopedLock sl (nativeDescriptionsLock);
-        lv2Descriptions.clearQuick();
+        lv2Descriptions.clear();
         for (const auto& s : scanned)
         {
             // Audio effects (audio in + out) and instruments (atom/MIDI in,
@@ -567,25 +643,26 @@ void PluginManager::scanLv2Plugins()
             const bool effect = s.desc.audioInputs > 0 && s.desc.audioOutputs > 0;
             if (! effect && ! s.desc.isInstrument)
                 continue;
-            juce::PluginDescription d;
-            d.name             = juce::String (juce::CharPointer_UTF8 (s.desc.name.c_str()));
-            d.pluginFormatName = "LV2-Native";
-            d.fileOrIdentifier = hosting::joinNativeIdentifier (
-                s.bundlePath, juce::String (juce::CharPointer_UTF8 (s.desc.uri.c_str())));
-            d.isInstrument     = s.desc.isInstrument;
-            lv2Descriptions.add (d);
+            PluginDescriptor descriptor;
+            descriptor.name = s.desc.name;
+            descriptor.formatName = "LV2";
+            descriptor.backend = PluginBackend::Native;
+            descriptor.location = s.bundlePath;
+            descriptor.pluginId = s.desc.uri;
+            descriptor.isInstrument = s.desc.isInstrument;
+            lv2Descriptions.push_back (std::move (descriptor));
         }
     }
-    saveNativeCache (lv2Descriptions, "lv2-native-cache.xml", "LV2_NATIVE_PLUGINS");
+    saveNativeCache (lv2Descriptions, "lv2-native-cache.json");
 #endif
 }
 
-juce::Array<juce::PluginDescription> PluginManager::getLv2EffectDescriptions() const
+std::vector<PluginDescriptor> PluginManager::getLv2EffectDescriptions() const
 {
     return filterByInstrumentFlag (lv2Descriptions, false);
 }
 
-juce::Array<juce::PluginDescription> PluginManager::getLv2InstrumentDescriptions() const
+std::vector<PluginDescriptor> PluginManager::getLv2InstrumentDescriptions() const
 {
     return filterByInstrumentFlag (lv2Descriptions, true);
 }
@@ -593,46 +670,46 @@ juce::Array<juce::PluginDescription> PluginManager::getLv2InstrumentDescriptions
 void PluginManager::scanVst3NativePlugins()
 {
 #if DUSKSTUDIO_HAS_NATIVE_VST3
-    juce::Array<juce::PluginDescription> fresh;
+    std::vector<PluginDescriptor> fresh;
     for (const auto& path : vst3::Vst3Scanner::findVst3Bundles (vst3::Vst3Scanner::defaultSearchPaths()))
     {
         const juce::File file (juce::String::fromUTF8 (path.u8string().c_str()));
         if (! scanNativeBundleSandboxed ("vst3", file, fresh))
-            nativescan::appendVst3Rows (file, fresh);   // no sandbox available - in-process
+            nativescan::appendVst3Rows (path, fresh);   // no sandbox available - in-process
     }
     {
         const juce::ScopedLock sl (nativeDescriptionsLock);
-        vst3NativeDescriptions.swapWith (fresh);
+        vst3NativeDescriptions.swap (fresh);
     }
-    saveNativeCache (vst3NativeDescriptions, "vst3-native-cache.xml", "VST3_NATIVE_PLUGINS");
+    saveNativeCache (vst3NativeDescriptions, "vst3-native-cache.json");
 #endif
 }
 
-juce::Array<juce::PluginDescription> PluginManager::getVst3NativeEffectDescriptions() const
+std::vector<PluginDescriptor> PluginManager::getVst3NativeEffectDescriptions() const
 {
     return filterByInstrumentFlag (vst3NativeDescriptions, false);
 }
 
-juce::Array<juce::PluginDescription> PluginManager::getVst3NativeInstrumentDescriptions() const
+std::vector<PluginDescriptor> PluginManager::getVst3NativeInstrumentDescriptions() const
 {
     return filterByInstrumentFlag (vst3NativeDescriptions, true);
 }
 
-juce::Array<juce::PluginDescription> PluginManager::getInstrumentDescriptions() const
+std::vector<PluginDescriptor> PluginManager::getInstrumentDescriptions() const
 {
-    juce::Array<juce::PluginDescription> instruments;
+    std::vector<PluginDescriptor> instruments;
     for (const auto& desc : knownPluginList.getTypes())
         if (desc.isInstrument)
-            instruments.add (desc);
+            instruments.push_back (fromJuceDescription (desc));
     return instruments;
 }
 
-juce::Array<juce::PluginDescription> PluginManager::getEffectDescriptions() const
+std::vector<PluginDescriptor> PluginManager::getEffectDescriptions() const
 {
-    juce::Array<juce::PluginDescription> effects;
+    std::vector<PluginDescriptor> effects;
     for (const auto& desc : knownPluginList.getTypes())
         if (! desc.isInstrument)
-            effects.add (desc);
+            effects.push_back (fromJuceDescription (desc));
     return effects;
 }
 
@@ -671,7 +748,8 @@ PluginManager::createPluginInstance (const juce::File& pluginFile,
             knownPluginList.addType (*desc);
     saveCache();
 
-    return createPluginInstance (*typesFound.getFirst(), sampleRate, blockSize, errorMessage);
+    return createPluginInstance (fromJuceDescription (*typesFound.getFirst()),
+                                 sampleRate, blockSize, errorMessage);
 }
 
 namespace
@@ -690,11 +768,12 @@ void applyDefaultBusLayout (juce::AudioPluginInstance& instance)
 } // namespace
 
 std::unique_ptr<juce::AudioPluginInstance>
-PluginManager::createPluginInstance (const juce::PluginDescription& desc,
+PluginManager::createPluginInstance (const PluginDescriptor& desc,
                                       double sampleRate, int blockSize,
                                       juce::String& errorMessage)
 {
-    auto instance = formatManager.createPluginInstance (desc, sampleRate, blockSize, errorMessage);
+    auto instance = formatManager.createPluginInstance (
+        toJuceDescription (desc), sampleRate, blockSize, errorMessage);
     if (instance == nullptr)
         return nullptr;
 
@@ -703,7 +782,7 @@ PluginManager::createPluginInstance (const juce::PluginDescription& desc,
 }
 
 void PluginManager::createPluginInstanceAsync (
-    const juce::PluginDescription& desc, double sampleRate, int blockSize,
+    const PluginDescriptor& desc, double sampleRate, int blockSize,
     std::function<void (std::unique_ptr<juce::AudioPluginInstance>, juce::String)> callback)
 {
     // Off-thread creation for slow-to-instantiate formats. JUCE runs the
@@ -711,7 +790,7 @@ void PluginManager::createPluginInstanceAsync (
     // requiresUnblockedMessageThreadDuringCreation() == false, then fires this
     // callback ON THE MESSAGE THREAD with the fully-built instance - so the
     // caller's swap-in logic stays single-threaded.
-    formatManager.createPluginInstanceAsync (desc, sampleRate, blockSize,
+    formatManager.createPluginInstanceAsync (toJuceDescription (desc), sampleRate, blockSize,
         [cb = std::move (callback)]
         (std::unique_ptr<juce::AudioPluginInstance> instance, const juce::String& err)
     {
@@ -720,4 +799,53 @@ void PluginManager::createPluginInstanceAsync (
         cb (std::move (instance), err);
     });
 }
+
+PluginDescriptor PluginManager::descriptorForInstance (juce::AudioPluginInstance& instance) const
+{
+    juce::PluginDescription descriptor;
+    instance.fillInPluginDescription (descriptor);
+    return fromJuceDescription (descriptor);
+}
+
+bool PluginManager::descriptorFromLegacyXml (const juce::String& source,
+                                             PluginDescriptor& out) const
+{
+    const auto xml = juce::XmlDocument::parse (source);
+    if (xml == nullptr)
+        return false;
+    juce::PluginDescription descriptor;
+    if (! descriptor.loadFromXml (*xml))
+        return false;
+    out = fromJuceDescription (descriptor);
+    return true;
+}
+
+juce::String PluginManager::descriptorToLegacyXml (const PluginDescriptor& source) const
+{
+    const auto xml = toJuceDescription (source).createXml();
+    return xml != nullptr
+        ? xml->toString (juce::XmlElement::TextFormat().singleLine())
+        : juce::String();
+}
+
+#if defined(DUSKSTUDIO_TESTS)
+PluginDescriptor PluginManager::descriptorFromJuceForTest (
+    const juce::PluginDescription& source)
+{
+    return fromJuceDescription (source);
+}
+
+juce::PluginDescription PluginManager::descriptorToJuceForTest (
+    const PluginDescriptor& source)
+{
+    return toJuceDescription (source);
+}
+
+std::vector<PluginDescriptor> PluginManager::importLegacyNativeCacheForTest (
+    const juce::String& xml,
+    const std::function<bool (const juce::File&)>& locationExists)
+{
+    return importLegacyNativeCache (xml, locationExists);
+}
+#endif
 } // namespace duskstudio

--- a/src/engine/PluginManager.h
+++ b/src/engine/PluginManager.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <juce_audio_processors/juce_audio_processors.h>
+
 #include "PluginDescriptor.h"
 
-#include <juce_audio_processors/juce_audio_processors.h>
 #include <atomic>
 #include <functional>
 #include <optional>

--- a/src/engine/PluginManager.h
+++ b/src/engine/PluginManager.h
@@ -1,155 +1,110 @@
 #pragma once
 
+#include "PluginDescriptor.h"
+
 #include <juce_audio_processors/juce_audio_processors.h>
 #include <atomic>
 #include <functional>
+#include <vector>
 
 namespace duskstudio
 {
-// Owns AudioPluginFormatManager + shared KnownPluginList. Channel strips
-// hold a PluginSlot that calls back here to instantiate plugins.
-// Message-thread only - audio thread never touches this class; it reads
-// the slot's atomic instance pointer instead.
+// Owns the private JUCE format manager and legacy plugin list. Public metadata
+// views use PluginDescriptor; JUCE conversion is confined to this host boundary.
 class PluginManager
 {
 public:
     PluginManager();
     ~PluginManager();
 
-    juce::AudioPluginFormatManager& getFormatManager() noexcept { return formatManager; }
-    juce::KnownPluginList&          getKnownPluginList() noexcept { return knownPluginList; }
+    int getPluginCount() const noexcept { return knownPluginList.getNumTypes(); }
 
-    // OOP toggle: when on, PluginSlot routes new loads through the
-    // dusk-studio-plugin-host child via RemotePluginConnection.
-    // Read at load time only; affects next load, not current ones.
     void setOopEnabled (bool enable) noexcept { oopEnabled = enable; }
     bool isOopEnabled() const noexcept       { return oopEnabled; }
 
-    // Number of third-party plugins the most recent scan left UNSCANNED because
-    // the OOP sandbox host was unavailable (missing binary / spawn failure).
-    // Zero on a healthy scan; surfaced by the scan-complete UI so the user knows
-    // some plugins were skipped rather than silently dropped.
     int getLastScanSandboxSkips() const noexcept
     { return lastScanSandboxSkips.load (std::memory_order_relaxed); }
 
-    // Path to the OOP child binary, alongside the running app. Empty when
-    // OOP isn't compiled in for this platform.
     juce::String getHostExecutablePath() const;
 
-    // Filtered views over the known list, used by the per-channel picker
-    // so MIDI tracks see instruments only and audio tracks see effects only.
-    juce::Array<juce::PluginDescription> getInstrumentDescriptions() const;
-    juce::Array<juce::PluginDescription> getEffectDescriptions() const;
+    std::vector<PluginDescriptor> getInstrumentDescriptions() const;
+    std::vector<PluginDescriptor> getEffectDescriptions() const;
 
-    // Native-CLAP plugins - scanned separately (CLAP is NOT a juce::AudioPluginFormat).
-    // Synthesised PluginDescriptions: pluginFormatName "CLAP", fileOrIdentifier = the
-    // .clap bundle path. The unified picker merges these in for surfaces that have a
-    // native CLAP host (aux lanes); routing keys on pluginFormatName == "CLAP".
-    juce::Array<juce::PluginDescription> getClapEffectDescriptions() const;
-    juce::Array<juce::PluginDescription> getClapInstrumentDescriptions() const;
-    // Rescan CLAP search paths (slow - loads each bundle). Folded into the Scan button
-    // via scanInstalledPlugins; result cached in memory for the session.
+    std::vector<PluginDescriptor> getClapEffectDescriptions() const;
+    std::vector<PluginDescriptor> getClapInstrumentDescriptions() const;
     void scanClapPlugins();
 
-    // Native-LV2 plugins, scanned separately from JUCE's LV2 format (which stays as
-    // the fallback host). pluginFormatName "LV2-Native", fileOrIdentifier = the .lv2
-    // bundle directory. Effects and instruments; discovery is manifest-only via lilv.
-    juce::Array<juce::PluginDescription> getLv2EffectDescriptions() const;
-    juce::Array<juce::PluginDescription> getLv2InstrumentDescriptions() const;
+    std::vector<PluginDescriptor> getLv2EffectDescriptions() const;
+    std::vector<PluginDescriptor> getLv2InstrumentDescriptions() const;
     void scanLv2Plugins();
 
-    // Native-VST3 plugins, scanned separately from JUCE's VST3 format (which stays
-    // as the fallback host). pluginFormatName "VST3-Native", fileOrIdentifier = the
-    // .vst3 bundle path. Effects and instruments; each module is dlopen'd (like CLAP).
-    juce::Array<juce::PluginDescription> getVst3NativeEffectDescriptions() const;
-    juce::Array<juce::PluginDescription> getVst3NativeInstrumentDescriptions() const;
+    std::vector<PluginDescriptor> getVst3NativeEffectDescriptions() const;
+    std::vector<PluginDescriptor> getVst3NativeInstrumentDescriptions() const;
     void scanVst3NativePlugins();
 
-    // Synchronous instantiation. May take 100s of ms. Returns nullptr on
-    // failure and sets errorMessage. Caller runs prepareToPlay before
-    // processing audio. Success adds the description to knownPluginList.
     std::unique_ptr<juce::AudioPluginInstance>
     createPluginInstance (const juce::File& pluginFile,
-                           double sampleRate, int blockSize,
-                           juce::String& errorMessage);
+                          double sampleRate, int blockSize,
+                          juce::String& errorMessage);
 
-    // Resolve by description (used at session restore when the path may
-    // have moved but the uid + format still match).
     std::unique_ptr<juce::AudioPluginInstance>
-    createPluginInstance (const juce::PluginDescription& desc,
-                           double sampleRate, int blockSize,
-                           juce::String& errorMessage);
+    createPluginInstance (const PluginDescriptor& descriptor,
+                          double sampleRate, int blockSize,
+                          juce::String& errorMessage);
 
-    // Off-thread variant: creates the instance on a background thread (for
-    // formats that allow it - e.g. the multisample player's slow sample
-    // decode) and invokes `callback` ON THE MESSAGE THREAD with the finished
-    // instance (or nullptr + error). Keeps the UI responsive during load.
     void createPluginInstanceAsync (
-        const juce::PluginDescription& desc, double sampleRate, int blockSize,
+        const PluginDescriptor& descriptor, double sampleRate, int blockSize,
         std::function<void (std::unique_ptr<juce::AudioPluginInstance>, juce::String)> callback);
 
-    // Cache file under userApplicationDataDirectory. Auto-saved on every
-    // successful add; loaded best-effort at construction.
-    juce::File getCacheFile() const;
+    // Conversion helpers used by PluginSlot at the private legacy-host edge.
+    PluginDescriptor descriptorForInstance (juce::AudioPluginInstance&) const;
+    bool descriptorFromLegacyXml (const juce::String&, PluginDescriptor&) const;
+    juce::String descriptorToLegacyXml (const PluginDescriptor&) const;
 
-    // Dead-man's-pedal alongside the cache. PluginDirectoryScanner records
-    // the file it is about to probe here and clears it on success, so a scan
-    // that crashes the whole app quarantines the culprit on the next run.
+   #if defined(DUSKSTUDIO_TESTS)
+    static PluginDescriptor descriptorFromJuceForTest (
+        const juce::PluginDescription&);
+    static juce::PluginDescription descriptorToJuceForTest (
+        const PluginDescriptor&);
+    static std::vector<PluginDescriptor> importLegacyNativeCacheForTest (
+        const juce::String& xml,
+        const std::function<bool (const juce::File&)>& locationExists);
+   #endif
+
+    juce::File getCacheFile() const;
     juce::File getDeadMansPedalFile() const;
 
-    // Scans default install locations across every supported format.
-    // Synchronous, 10-30 s first run - run it on a background thread (see
-    // PluginScanModal) and surface progress, otherwise the app looks frozen.
     int scanInstalledPlugins();
-
-    // Progress-reporting variant. onProgress(fraction 0..1, currentPluginName)
-    // is invoked on the CALLING thread once per scanned file; return false from
-    // it to stop early. `abort`, if non-null, is polled mid-file (between the
-    // child-process reads) so a cancel / app-shutdown doesn't wait out a slow
-    // plugin's full 30 s timeout. Safe to call from a background thread:
-    // KnownPluginList serialises its own mutations and nothing else touches it
-    // during a scan.
     int scanInstalledPlugins (std::function<bool (float, const juce::String&)> onProgress,
                               const std::atomic<bool>* abort = nullptr);
 
 private:
     juce::AudioPluginFormatManager formatManager;
-    juce::KnownPluginList          knownPluginList;
-    // Native-format descriptions. scanInstalledPlugins runs on a background
-    // thread (PluginScanModal) and repopulates these while the message thread
-    // may be reading them for the picker - every access goes through this lock.
-    mutable juce::CriticalSection nativeDescriptionsLock;
-    juce::Array<juce::PluginDescription> clapDescriptions;       // native CLAP (scanned separately)
-    juce::Array<juce::PluginDescription> lv2Descriptions;        // native LV2 (scanned separately)
-    juce::Array<juce::PluginDescription> vst3NativeDescriptions; // native VST3 (scanned separately)
-    bool                           oopEnabled { false };
-    // Written on the scan (background) thread at the end of scanInstalledPlugins,
-    // read on the message thread by the scan-complete UI. The read is fenced by
-    // the modal's scanDone release/acquire; atomic keeps it race-free regardless.
-    std::atomic<int>               lastScanSandboxSkips { 0 };
+    juce::KnownPluginList knownPluginList;
 
-    juce::Array<juce::PluginDescription> filterByInstrumentFlag (
-        const juce::Array<juce::PluginDescription>& source, bool wantInstrument) const;
+    mutable juce::CriticalSection nativeDescriptionsLock;
+    std::vector<PluginDescriptor> clapDescriptions;
+    std::vector<PluginDescriptor> lv2Descriptions;
+    std::vector<PluginDescriptor> vst3NativeDescriptions;
+    bool oopEnabled { false };
+    std::atomic<int> lastScanSandboxSkips { 0 };
+
+    std::vector<PluginDescriptor> filterByInstrumentFlag (
+        const std::vector<PluginDescriptor>& source, bool wantInstrument) const;
 
     void loadCache();
     void saveCache() const;
 
-    // Native-format descriptions persist in their own sidecar caches next to the
-    // JUCE cache (knownPluginList is JUCE-formats only). Loaded at construction,
-    // rewritten after each scan. `bundleIsDirectory` selects the staleness check
-    // (LV2 bundles are directories; CLAP/VST3 accept files or bundle dirs).
     juce::File nativeCacheFile (const char* fileName) const;
 #if DUSKSTUDIO_HAS_NATIVE_CLAP || DUSKSTUDIO_HAS_NATIVE_VST3
-    // Enumerate one native bundle via the sandbox child (--scan-native). False =
-    // child couldn't spawn (caller falls back in-process); crash/timeout inside
-    // the child skips the bundle and still returns true.
     bool scanNativeBundleSandboxed (const char* format, const juce::File& bundle,
-                                    juce::Array<juce::PluginDescription>& into) const;
+                                    std::vector<PluginDescriptor>& into) const;
 #endif
-    void loadNativeCache (juce::Array<juce::PluginDescription>& into,
-                          const char* fileName, bool bundleIsDirectory);
-    void saveNativeCache (const juce::Array<juce::PluginDescription>& from,
-                          const char* fileName, const char* rootTag) const;
+    void loadNativeCache (std::vector<PluginDescriptor>& into,
+                          const char* jsonFileName, const char* legacyXmlFileName,
+                          bool bundleIsDirectory);
+    void saveNativeCache (const std::vector<PluginDescriptor>& from,
+                          const char* jsonFileName) const;
 };
 
 inline juce::String PluginManager::getHostExecutablePath() const
@@ -157,10 +112,6 @@ inline juce::String PluginManager::getHostExecutablePath() const
    #if DUSKSTUDIO_HAS_OOP_PLUGINS
     auto exe = juce::File::getSpecialLocation (juce::File::currentExecutableFile);
    #if JUCE_WINDOWS
-    // CreateProcess (lpApplicationName) and File::existsAsFile both require the
-    // explicit .exe on Windows - without it the sandbox host is never found and
-    // third-party scanning silently falls through to the crash-prone in-process
-    // path (issue #45).
     const char* const childName = "dusk-studio-plugin-host.exe";
    #else
     const char* const childName = "dusk-studio-plugin-host";

--- a/src/engine/PluginManager.h
+++ b/src/engine/PluginManager.h
@@ -5,6 +5,8 @@
 #include <juce_audio_processors/juce_audio_processors.h>
 #include <atomic>
 #include <functional>
+#include <optional>
+#include <string>
 #include <vector>
 
 namespace duskstudio
@@ -69,6 +71,11 @@ public:
     static std::vector<PluginDescriptor> importLegacyNativeCacheForTest (
         const juce::String& xml,
         const std::function<bool (const juce::File&)>& locationExists);
+    static bool loadNativeCacheSourcesForTest (
+        const std::optional<std::string>& jsonSource,
+        const std::optional<juce::String>& legacyXmlSource,
+        const std::function<bool (const juce::File&)>& locationExists,
+        std::vector<PluginDescriptor>& into);
    #endif
 
     juce::File getCacheFile() const;

--- a/src/engine/PluginSlot.cpp
+++ b/src/engine/PluginSlot.cpp
@@ -257,9 +257,9 @@ void PluginSlot::clearAutoBypass() noexcept
    #if DUSKSTUDIO_HAS_OOP_PLUGINS
     // Clearing crashed state too: if the user explicitly asks to
     // re-enable a crashed slot, drop the dead connection so the next
-    // load (or processBlock attempt) doesn't see a stale carcass. The
-    // Same deferred-destruction shape as the
-    // swap paths: hand off into previousRemote so any audio block
+    // load (or processBlock attempt) doesn't see a stale carcass. Use the
+    // same deferred-destruction shape as the swap paths: hand off
+    // into previousRemote so any audio block
     // that's still holding a freshly-null'd currentRemote pointer
     // can complete safely.
     if (remoteCrashed.load (std::memory_order_relaxed))
@@ -476,14 +476,15 @@ void PluginSlot::setOfflineForCapture (const juce::String& displayName)
         offlineDescriptor.reset();
         offlineLegacyDescriptionXml.clear();
         offlineStateBase64.clear();
+        offlineCapturePlaceholder = false;
         return;
     }
     PluginDescriptor descriptor;
     descriptor.name = displayName.toStdString();
-    descriptor.formatName = "VST3";
     offlineDescriptor = std::move (descriptor);
     offlineLegacyDescriptionXml.clear();
     offlineStateBase64.clear();
+    offlineCapturePlaceholder = true;
 }
 
 #if defined(DUSKSTUDIO_TESTS)
@@ -602,6 +603,7 @@ bool PluginSlot::loadFromFile (const juce::File& pluginFile, juce::String& error
     offlineDescriptor.reset();
     offlineLegacyDescriptionXml.clear();
     offlineStateBase64.clear();
+    offlineCapturePlaceholder = false;
     lastKnownStateBase64.clear();
     return true;
 }
@@ -739,6 +741,7 @@ bool PluginSlot::loadFromDescriptor (const PluginDescriptor& descriptor,
                     offlineDescriptor.reset();
                     offlineLegacyDescriptionXml.clear();
                     offlineStateBase64.clear();
+                    offlineCapturePlaceholder = false;
                     lastKnownStateBase64.clear();
                     return true;
                 }
@@ -805,6 +808,7 @@ bool PluginSlot::installInProcessInstance (std::unique_ptr<juce::AudioPluginInst
     offlineDescriptor.reset();
     offlineLegacyDescriptionXml.clear();
     offlineStateBase64.clear();
+    offlineCapturePlaceholder = false;
     lastKnownStateBase64.clear();
     return true;
 }
@@ -958,6 +962,7 @@ void PluginSlot::unload()
     offlineDescriptor.reset();
     offlineLegacyDescriptionXml.clear();
     offlineStateBase64.clear();
+    offlineCapturePlaceholder = false;
     lastKnownStateBase64.clear();
 }
 
@@ -966,12 +971,15 @@ std::optional<PluginDescriptor> PluginSlot::getDescriptorForSave (int parkSleepM
     juce::ignoreUnused (parkSleepMs);
     if (loadedDescriptor.has_value())
         return loadedDescriptor;
+    if (offlineCapturePlaceholder)
+        return std::nullopt;
     return offlineDescriptor;
 }
 
 juce::String PluginSlot::getLegacyDescriptionXmlForSave() const
 {
-    if (loadedDescriptor.has_value() || offlineDescriptor.has_value())
+    if (loadedDescriptor.has_value()
+        || (offlineDescriptor.has_value() && ! offlineCapturePlaceholder))
         return {};
     return offlineLegacyDescriptionXml;
 }
@@ -1104,6 +1112,7 @@ bool PluginSlot::restoreFromSavedState (
         offlineDescriptor.reset();
         offlineLegacyDescriptionXml = legacyDescriptionXml;
         offlineStateBase64 = stateBase64;
+        offlineCapturePlaceholder = false;
         errorMessage = "Saved plugin description is not valid legacy XML";
         return false;
     }
@@ -1113,6 +1122,7 @@ bool PluginSlot::restoreFromSavedState (
     offlineDescriptor = persistedDescriptor;
     offlineLegacyDescriptionXml.clear();
     offlineStateBase64 = stateBase64;
+    offlineCapturePlaceholder = false;
     lastKnownStateBase64 = stateBase64;
 
     // Try the OOP path first if enabled. On any failure we fall through
@@ -1145,6 +1155,7 @@ bool PluginSlot::restoreFromSavedState (
             offlineDescriptor.reset();
             offlineLegacyDescriptionXml.clear();
             offlineStateBase64.clear();
+            offlineCapturePlaceholder = false;
             lastKnownStateBase64 = stateBase64;
             return true;
         }
@@ -1209,6 +1220,7 @@ bool PluginSlot::restoreFromSavedState (
     offlineDescriptor.reset();
     offlineLegacyDescriptionXml.clear();
     offlineStateBase64.clear();
+    offlineCapturePlaceholder = false;
     lastKnownStateBase64 = stateBase64;
     return true;
 }

--- a/src/engine/PluginSlot.cpp
+++ b/src/engine/PluginSlot.cpp
@@ -60,7 +60,7 @@ void disableAuxiliaryBuses (juce::AudioPluginInstance& instance)
 // AudioPluginFormatManager's findFormatForDescription gates on
 // `format->fileMightContainThisPluginType`, which for VST3 demands the
 // path end in `.vst3`. So a session that round-trips Diva's description
-// through getDescriptionXmlForSave -> JSON -> loadFromXml fails to load
+// through session persistence fails to load
 // with "No compatible plug-in format exists for this plug-in", AND a
 // freshly-picked-from-cache description has the same problem because the
 // scanned descriptions in KnownPluginList carry the same inner-.so path.
@@ -68,37 +68,44 @@ void disableAuxiliaryBuses (juce::AudioPluginInstance& instance)
 // Walk parents until we find a `.vst3` ancestor and rewrite the path.
 // No-op when the path is already a `.vst3` (macOS / non-Linux / future
 // JUCE that fixes this).
-void normalizeVst3FileOrIdentifier (juce::PluginDescription& desc)
+void normalizeVst3Location (PluginDescriptor& descriptor)
 {
-    if (desc.pluginFormatName != "VST3") return;
-    if (juce::File (desc.fileOrIdentifier).hasFileExtension (".vst3")) return;
+    if (descriptor.formatName != "VST3") return;
+    if (juce::File (descriptor.location).hasFileExtension (".vst3")) return;
 
-    for (auto walk = juce::File (desc.fileOrIdentifier).getParentDirectory();
+    for (auto walk = juce::File (descriptor.location).getParentDirectory();
          walk.exists() && walk.getFullPathName().isNotEmpty();
          walk = walk.getParentDirectory())
     {
         if (walk.hasFileExtension (".vst3"))
         {
-            desc.fileOrIdentifier = walk.getFullPathName();
+            descriptor.location = walk.getFullPathName().toStdString();
             return;
         }
         if (walk.getParentDirectory() == walk) break;  // hit fs root
     }
 }
 
+PluginDescriptor refreshFromInstance (PluginManager& manager,
+                                      juce::AudioPluginInstance& instance,
+                                      const PluginDescriptor& reloadDescriptor)
+{
+    return mergeLoadedPluginDescriptor (
+        reloadDescriptor, manager.descriptorForInstance (instance));
+}
+
 // One-shot diagnostic so the user (and we) can see exactly what JUCE is
 // reporting after load + bus-layout pass. Helps debug "plugin loaded but
 // silent" cases like an instrument that ends up looking like an effect
 // because of an auto-enabled sidechain bus.
-void logLoadedPlugin (const juce::AudioPluginInstance& instance)
+void logLoadedPlugin (const juce::AudioPluginInstance& instance,
+                      const PluginDescriptor& descriptor)
 {
-    juce::PluginDescription desc;
-    instance.fillInPluginDescription (desc);
     std::fprintf (stderr,
                   "[Dusk Studio/PluginSlot] Loaded \"%s\" (instrument=%d) - "
                   "totalIn=%d totalOut=%d busesIn=%d busesOut=%d latency=%d\n",
-                  desc.name.toRawUTF8(),
-                  (int) desc.isInstrument,
+                  descriptor.name.c_str(),
+                  (int) descriptor.isInstrument,
                   instance.getTotalNumInputChannels(),
                   instance.getTotalNumOutputChannels(),
                   instance.getBusCount (true),
@@ -251,8 +258,7 @@ void PluginSlot::clearAutoBypass() noexcept
     // Clearing crashed state too: if the user explicitly asks to
     // re-enable a crashed slot, drop the dead connection so the next
     // load (or processBlock attempt) doesn't see a stale carcass. The
-    // saved description XML stays so a subsequent restoreFromSavedState
-    // can re-spawn cleanly. Same deferred-destruction shape as the
+    // Same deferred-destruction shape as the
     // swap paths: hand off into previousRemote so any audio block
     // that's still holding a freshly-null'd currentRemote pointer
     // can complete safely.
@@ -416,7 +422,12 @@ void PluginSlot::releaseResources()
 
     currentInstance.store (nullptr, std::memory_order_release);
     if (ownedInstance != nullptr)
+    {
         ownedInstance->releaseResources();
+        juce::MemoryBlock state;
+        ownedInstance->getStateInformation (state);
+        lastKnownStateBase64 = state.toBase64Encoding();
+    }
 
    #if DUSKSTUDIO_HAS_OOP_PLUGINS
     reaperTimer.stopTimer();
@@ -424,6 +435,11 @@ void PluginSlot::releaseResources()
     if (ownedRemote != nullptr)
     {
         std::string err;
+        std::vector<std::uint8_t> state;
+        if (ownedRemote->getState (state, err))
+            lastKnownStateBase64 = state.empty()
+                ? juce::String()
+                : juce::MemoryBlock (state.data(), state.size()).toBase64Encoding();
         // release() asks the child to drop its plugin instance but keeps
         // the SHM + child process alive, so a subsequent load doesn't
         // pay the fork+exec cost again.
@@ -443,57 +459,47 @@ bool PluginSlot::isLoaded() const noexcept
 
 juce::String PluginSlot::getLoadedName() const
 {
-    if (auto* p = currentInstance.load (std::memory_order_acquire))
-        return p->getName();
-   #if DUSKSTUDIO_HAS_OOP_PLUGINS
-    if (currentRemote.load (std::memory_order_acquire) != nullptr)
-    {
-        // Parse the cached description XML for the plugin's display
-        // name. Cheap (a few hundred bytes of XML) and avoids an IPC
-        // round-trip just for a label.
-        if (savedDescriptionXml.isNotEmpty())
-            if (auto xml = juce::XmlDocument::parse (savedDescriptionXml))
-            {
-                juce::PluginDescription desc;
-                if (desc.loadFromXml (*xml))
-                    return desc.name;
-            }
-    }
-   #endif
+    if (loadedDescriptor.has_value())
+        return loadedDescriptor->name;
     return {};
 }
 
 bool PluginSlot::isOffline() const noexcept
 {
-    if (isLoaded()) return false;
-    return offlineDescriptionXml.isNotEmpty();
+    return offlineDescriptor.has_value() || offlineLegacyDescriptionXml.isNotEmpty();
 }
 
 void PluginSlot::setOfflineForCapture (const juce::String& displayName)
 {
     if (displayName.isEmpty())
     {
-        offlineDescriptionXml.clear();
+        offlineDescriptor.reset();
+        offlineLegacyDescriptionXml.clear();
         offlineStateBase64.clear();
         return;
     }
-    juce::PluginDescription desc;
-    desc.name             = displayName;
-    desc.pluginFormatName = "VST3";
-    if (auto xml = desc.createXml())
-        offlineDescriptionXml = xml->toString();
+    PluginDescriptor descriptor;
+    descriptor.name = displayName.toStdString();
+    descriptor.formatName = "VST3";
+    offlineDescriptor = std::move (descriptor);
+    offlineLegacyDescriptionXml.clear();
     offlineStateBase64.clear();
 }
 
+#if defined(DUSKSTUDIO_TESTS)
+void PluginSlot::setTemporarilyInactivePersistenceForTest (
+    PluginDescriptor descriptor, const juce::String& stateBase64)
+{
+    unload();
+    loadedDescriptor = std::move (descriptor);
+    lastKnownStateBase64 = stateBase64;
+}
+#endif
+
 juce::String PluginSlot::getOfflineName() const
 {
-    if (offlineDescriptionXml.isEmpty()) return {};
-    if (auto xml = juce::XmlDocument::parse (offlineDescriptionXml))
-    {
-        juce::PluginDescription desc;
-        if (desc.loadFromXml (*xml))
-            return desc.name;
-    }
+    if (offlineDescriptor.has_value())
+        return offlineDescriptor->name;
     return {};
 }
 
@@ -548,6 +554,8 @@ bool PluginSlot::loadFromFile (const juce::File& pluginFile, juce::String& error
     previousInstances[1] = std::move (previousInstances[0]);
     previousInstances[0] = std::move (ownedInstance);
     ownedInstance.reset();
+    loadedDescriptor.reset();
+    lastKnownStateBase64.clear();
 
     auto fresh = manager->createPluginInstance (pluginFile,
                                                   preparedSampleRate,
@@ -569,7 +577,9 @@ bool PluginSlot::loadFromFile (const juce::File& pluginFile, juce::String& error
                                   preparedBlockSize);
     if (preparedSampleRate > 0.0)
         fresh->prepareToPlay (preparedSampleRate, preparedBlockSize);
-    logLoadedPlugin (*fresh);
+    auto descriptor = manager->descriptorForInstance (*fresh);
+    normalizeVst3Location (descriptor);
+    logLoadedPlugin (*fresh, descriptor);
 
     ownedInstance = std::move (fresh);
     blocksSinceLoad     = 0;
@@ -588,13 +598,16 @@ bool PluginSlot::loadFromFile (const juce::File& pluginFile, juce::String& error
     for (auto* p : ownedInstance->getParameters())
         if (p != nullptr) p->addListener (lastTouchedListener.get());
     currentInstance.store (ownedInstance.get(), std::memory_order_release);
-    offlineDescriptionXml.clear();
+    loadedDescriptor = std::move (descriptor);
+    offlineDescriptor.reset();
+    offlineLegacyDescriptionXml.clear();
     offlineStateBase64.clear();
+    lastKnownStateBase64.clear();
     return true;
 }
 
-bool PluginSlot::loadFromDescription (const juce::PluginDescription& desc,
-                                        juce::String& errorMessage)
+bool PluginSlot::loadFromDescriptor (const PluginDescriptor& descriptor,
+                                     juce::String& errorMessage)
 {
     if (manager == nullptr)
     {
@@ -619,8 +632,8 @@ bool PluginSlot::loadFromDescription (const juce::PluginDescription& desc,
 
     // Normalize the path - cached KnownPluginList descriptions on Linux
     // carry the inner-.so path which findFormatForDescription rejects.
-    juce::PluginDescription fixedDesc = desc;
-    normalizeVst3FileOrIdentifier (fixedDesc);
+    PluginDescriptor fixedDescriptor = descriptor;
+    normalizeVst3Location (fixedDescriptor);
 
     // Same swap-load shape as loadFromFile; rotates through the
     // two-deep keep-alive ring so the deposed instance survives TWO
@@ -644,6 +657,8 @@ bool PluginSlot::loadFromDescription (const juce::PluginDescription& desc,
     previousInstances[1] = std::move (previousInstances[0]);
     previousInstances[0] = std::move (ownedInstance);
     ownedInstance.reset();
+    loadedDescriptor.reset();
+    lastKnownStateBase64.clear();
 
    #if DUSKSTUDIO_HAS_OOP_PLUGINS
     // Tear down any prior OOP slot before deciding which path the new
@@ -661,7 +676,6 @@ bool PluginSlot::loadFromDescription (const juce::PluginDescription& desc,
     previousRemotes[1] = std::move (previousRemotes[0]);
     previousRemotes[0] = std::move (ownedRemote);
     remoteCrashed.store (false, std::memory_order_relaxed);
-    savedDescriptionXml.clear();
 
     const bool tryOop = manager->isOopEnabled()
                          && preparedBlockSize > 0
@@ -690,14 +704,13 @@ bool PluginSlot::loadFromDescription (const juce::PluginDescription& desc,
             }
             else
             {
-                auto descXml = fixedDesc.createXml();
-                const auto descXmlStr = descXml != nullptr
-                    ? descXml->toString (juce::XmlElement::TextFormat().singleLine())
-                    : juce::String();
+                const auto descXmlStr = manager->descriptorToLegacyXml (fixedDescriptor);
                 int  numIn = 0, numOut = 0, latency = 0;
+                bool isInstrument = false;
                 if (! remote->loadPlugin (descXmlStr.toStdString(),
                                             preparedSampleRate, preparedBlockSize,
-                                            numIn, numOut, latency, err))
+                                            numIn, numOut, latency,
+                                            isInstrument, err))
                 {
                     std::fprintf (stderr,
                                   "[Dusk Studio/PluginSlot] OOP loadPlugin failed (%s); "
@@ -708,20 +721,25 @@ bool PluginSlot::loadFromDescription (const juce::PluginDescription& desc,
                 {
                     remoteNumIn .store (numIn,  std::memory_order_relaxed);
                     remoteNumOut.store (numOut, std::memory_order_relaxed);
-                    remoteIsInstrument.store (numIn == 0,
+                    remoteIsInstrument.store (isInstrument,
                                                 std::memory_order_relaxed);
                     cachedLatencySamples.store (latency, std::memory_order_relaxed);
                     blocksSinceLoad     = 0;
                     consecutiveOverruns = 0;
                     autoBypassed .store (false, std::memory_order_relaxed);
                     remoteCrashed.store (false, std::memory_order_relaxed);
-                    savedDescriptionXml = descXmlStr;
                     ownedRemote = std::move (remote);
                     currentRemote.store (ownedRemote.get(),
                                             std::memory_order_release);
                     reaperTimer.startTimer (kReaperPeriodMs);
-                    offlineDescriptionXml.clear();
+                    fixedDescriptor.isInstrument = isInstrument;
+                    fixedDescriptor.numInputChannels = numIn;
+                    fixedDescriptor.numOutputChannels = numOut;
+                    loadedDescriptor = fixedDescriptor;
+                    offlineDescriptor.reset();
+                    offlineLegacyDescriptionXml.clear();
                     offlineStateBase64.clear();
+                    lastKnownStateBase64.clear();
                     return true;
                 }
             }
@@ -731,7 +749,7 @@ bool PluginSlot::loadFromDescription (const juce::PluginDescription& desc,
     }
    #endif
 
-    auto fresh = manager->createPluginInstance (fixedDesc, preparedSampleRate,
+    auto fresh = manager->createPluginInstance (fixedDescriptor, preparedSampleRate,
                                                   preparedBlockSize, errorMessage);
     if (fresh == nullptr)
     {
@@ -741,15 +759,16 @@ bool PluginSlot::loadFromDescription (const juce::PluginDescription& desc,
         return false;
     }
 
-    return installInProcessInstance (std::move (fresh));
+    return installInProcessInstance (std::move (fresh), std::move (fixedDescriptor));
 }
 
-// Message-thread install tail shared by the synchronous loadFromDescription and
-// the off-thread loadFromDescriptionAsync completion. Primes the freshly-built
+// Message-thread install tail shared by synchronous and off-thread descriptor
+// loads. Primes the freshly-built
 // instance, then atomically swaps it into currentInstance - the audio thread
 // reads via acquire. Caller has already rotated the keep-alive ring + nulled
 // currentInstance, so this only installs the new owner.
-bool PluginSlot::installInProcessInstance (std::unique_ptr<juce::AudioPluginInstance> fresh)
+bool PluginSlot::installInProcessInstance (std::unique_ptr<juce::AudioPluginInstance> fresh,
+                                           PluginDescriptor descriptor)
 {
     if (fresh == nullptr) return false;
 
@@ -766,7 +785,8 @@ bool PluginSlot::installInProcessInstance (std::unique_ptr<juce::AudioPluginInst
                                   preparedBlockSize);
     if (preparedSampleRate > 0.0)
         fresh->prepareToPlay (preparedSampleRate, preparedBlockSize);
-    logLoadedPlugin (*fresh);
+    descriptor = refreshFromInstance (*manager, *fresh, descriptor);
+    logLoadedPlugin (*fresh, descriptor);
 
     ownedInstance = std::move (fresh);
     blocksSinceLoad     = 0;
@@ -781,13 +801,16 @@ bool PluginSlot::installInProcessInstance (std::unique_ptr<juce::AudioPluginInst
     for (auto* p : ownedInstance->getParameters())
         if (p != nullptr) p->addListener (lastTouchedListener.get());
     currentInstance.store (ownedInstance.get(), std::memory_order_release);
-    offlineDescriptionXml.clear();
+    loadedDescriptor = std::move (descriptor);
+    offlineDescriptor.reset();
+    offlineLegacyDescriptionXml.clear();
     offlineStateBase64.clear();
+    lastKnownStateBase64.clear();
     return true;
 }
 
-void PluginSlot::loadFromDescriptionAsync (const juce::PluginDescription& desc,
-                                           std::function<void (bool, juce::String)> onDone)
+void PluginSlot::loadFromDescriptorAsync (const PluginDescriptor& descriptor,
+                                          std::function<void (bool, juce::String)> onDone)
 {
     if (manager == nullptr)
     {
@@ -802,7 +825,7 @@ void PluginSlot::loadFromDescriptionAsync (const juce::PluginDescription& desc,
     if (manager->isOopEnabled())
     {
         juce::String err;
-        const bool ok = loadFromDescription (desc, err);
+        const bool ok = loadFromDescriptor (descriptor, err);
         if (onDone) onDone (ok, err);
         return;
     }
@@ -817,12 +840,12 @@ void PluginSlot::loadFromDescriptionAsync (const juce::PluginDescription& desc,
     releaseShellInstance();
    #endif
 
-    juce::PluginDescription fixedDesc = desc;
-    normalizeVst3FileOrIdentifier (fixedDesc);
+    PluginDescriptor fixedDescriptor = descriptor;
+    normalizeVst3Location (fixedDescriptor);
 
     // Rotate the keep-alive ring + null currentInstance now - the slot goes
     // silent for the duration of the off-thread load. Same shape as the
-    // synchronous path's pre-swap rotation (loadFromDescription).
+    // synchronous path's pre-swap rotation.
     if (ownedInstance != nullptr && lastTouchedListener != nullptr)
         for (auto* p : ownedInstance->getParameters())
             if (p != nullptr) p->removeListener (lastTouchedListener.get());
@@ -838,13 +861,15 @@ void PluginSlot::loadFromDescriptionAsync (const juce::PluginDescription& desc,
     previousInstances[1] = std::move (previousInstances[0]);
     previousInstances[0] = std::move (ownedInstance);
     ownedInstance.reset();
+    loadedDescriptor.reset();
+    lastKnownStateBase64.clear();
 
    #if DUSKSTUDIO_HAS_OOP_PLUGINS
     // A prior load may have been OOP (mode is per-load). Mirror the sync path's
     // remote teardown so processBlock stops routing to the remote before the
     // in-process instance becomes the active processor - without this the slot
     // keeps playing the OOP plugin after currentInstance is nulled. Two-deep
-    // deferred-destruction ring, same as loadFromDescription / unload.
+    // deferred-destruction ring, same as descriptor load / unload.
     reaperTimer.stopTimer();
     currentRemote.store (nullptr, std::memory_order_release);
     previousRemotes[1].reset();
@@ -857,9 +882,9 @@ void PluginSlot::loadFromDescriptionAsync (const juce::PluginDescription& desc,
     // to lifeToken guards against the slot being destroyed mid-load (token dies
     // with the slot -> weak_ptr expires -> bail before touching `this`).
     std::weak_ptr<char> life = lifeToken;
-    manager->createPluginInstanceAsync (fixedDesc, preparedSampleRate, preparedBlockSize,
-        [this, life, epoch, onDone] (std::unique_ptr<juce::AudioPluginInstance> inst,
-                                      juce::String err)
+    manager->createPluginInstanceAsync (fixedDescriptor, preparedSampleRate, preparedBlockSize,
+        [this, life, epoch, onDone, fixedDescriptor]
+        (std::unique_ptr<juce::AudioPluginInstance> inst, juce::String err)
     {
         if (! life.lock()) return;                      // slot destroyed mid-load
         if (currentLoadEpoch.load (std::memory_order_relaxed) != epoch)
@@ -873,7 +898,7 @@ void PluginSlot::loadFromDescriptionAsync (const juce::PluginDescription& desc,
                                                         : juce::String ("plugin creation failed"));
             return;
         }
-        const bool ok = installInProcessInstance (std::move (inst));
+        const bool ok = installInProcessInstance (std::move (inst), fixedDescriptor);
         if (onDone) onDone (ok, ok ? juce::String() : juce::String ("install failed"));
     });
 }
@@ -918,7 +943,7 @@ void PluginSlot::unload()
 
    #if DUSKSTUDIO_HAS_OOP_PLUGINS
     // Two-deep deferred-destruction via previousRemotes ring; see
-    // loadFromDescription for the rationale.
+    // descriptor load for the rationale.
     reaperTimer.stopTimer();
     currentRemote.store (nullptr, std::memory_order_release);
     previousRemotes[1].reset();
@@ -928,50 +953,27 @@ void PluginSlot::unload()
     remoteNumOut.store (0, std::memory_order_relaxed);
     remoteIsInstrument.store (false, std::memory_order_relaxed);
     remoteCrashed.store (false, std::memory_order_relaxed);
-    savedDescriptionXml.clear();
    #endif
-    offlineDescriptionXml.clear();
+    loadedDescriptor.reset();
+    offlineDescriptor.reset();
+    offlineLegacyDescriptionXml.clear();
     offlineStateBase64.clear();
+    lastKnownStateBase64.clear();
 }
 
-juce::String PluginSlot::getDescriptionXmlForSave (int parkSleepMs)
+std::optional<PluginDescriptor> PluginSlot::getDescriptorForSave (int parkSleepMs)
 {
-   #if DUSKSTUDIO_HAS_OOP_PLUGINS
-    if (currentRemote.load (std::memory_order_acquire) != nullptr
-        && savedDescriptionXml.isNotEmpty())
-    {
-        // Saved at load time. The XML is already path-normalized
-        // (PluginManager's caller passed a normalized desc, or
-        // loadFromDescription's normalization ran).
-        return savedDescriptionXml;
-    }
-   #endif
+    juce::ignoreUnused (parkSleepMs);
+    if (loadedDescriptor.has_value())
+        return loadedDescriptor;
+    return offlineDescriptor;
+}
 
-    // Slot is empty in-process but holds an offline placeholder from a
-    // failed restoreFromSavedState. Return the stashed XML so the next
-    // save round-trips the user's data instead of wiping it.
-    if (currentInstance.load (std::memory_order_acquire) == nullptr
-        && offlineDescriptionXml.isNotEmpty())
-        return offlineDescriptionXml;
-
-    juce::PluginDescription desc;
-    bool ok = false;
-    // fillInPluginDescription is metadata-only (uid + format + path + name)
-    // and does NOT race the renderer. No releaseResources/prepareToPlay
-    // needed - atomic-park alone is sufficient.
-    withParkedAtomicPointer (currentInstance, [&] (juce::AudioPluginInstance& p)
-    {
-        p.fillInPluginDescription (desc);
-        ok = true;
-    }, parkSleepMs);
-    if (! ok) return {};
-    // JUCE's Linux VST3 wrapper fills the description with the inner-.so
-    // path. Normalize back to the bundle path so the saved session loads
-    // cleanly without relying on restoreFromSavedState's recovery walk.
-    normalizeVst3FileOrIdentifier (desc);
-    if (auto xml = desc.createXml())
-        return xml->toString (juce::XmlElement::TextFormat().singleLine());
-    return {};
+juce::String PluginSlot::getLegacyDescriptionXmlForSave() const
+{
+    if (loadedDescriptor.has_value() || offlineDescriptor.has_value())
+        return {};
+    return offlineLegacyDescriptionXml;
 }
 
 bool PluginSlot::isLoadedPluginInstrument() const
@@ -981,11 +983,7 @@ bool PluginSlot::isLoadedPluginInstrument() const
         return remoteIsInstrument.load (std::memory_order_relaxed);
    #endif
 
-    auto* p = currentInstance.load (std::memory_order_acquire);
-    if (p == nullptr) return false;
-    juce::PluginDescription desc;
-    p->fillInPluginDescription (desc);
-    return desc.isInstrument;
+    return loadedDescriptor.has_value() && loadedDescriptor->isInstrument;
 }
 
 juce::String PluginSlot::getStateBase64ForSave (int parkSleepMs)
@@ -1005,12 +1003,17 @@ juce::String PluginSlot::getStateBase64ForSave (int parkSleepMs)
             std::fprintf (stderr,
                           "[Dusk Studio/PluginSlot] OOP getState failed: %s\n",
                           err.c_str());
-            return {};
+            return lastKnownStateBase64;
         }
-        if (blob.empty()) return {};
-        return juce::MemoryBlock (blob.data(), blob.size()).toBase64Encoding();
+        lastKnownStateBase64 = blob.empty()
+            ? juce::String()
+            : juce::MemoryBlock (blob.data(), blob.size()).toBase64Encoding();
+        return lastKnownStateBase64;
     }
     juce::ignoreUnused (parkSleepMs);
+
+    if (ownedRemote != nullptr && loadedDescriptor.has_value())
+        return lastKnownStateBase64;
    #endif
 
     // Slot is empty but holds an offline placeholder. Round-trip the
@@ -1019,6 +1022,15 @@ juce::String PluginSlot::getStateBase64ForSave (int parkSleepMs)
     if (currentInstance.load (std::memory_order_acquire) == nullptr
         && offlineStateBase64.isNotEmpty())
         return offlineStateBase64;
+
+    if (currentInstance.load (std::memory_order_acquire) == nullptr
+        && ownedInstance != nullptr && loadedDescriptor.has_value())
+    {
+        juce::MemoryBlock inactiveState;
+        ownedInstance->getStateInformation (inactiveState);
+        lastKnownStateBase64 = inactiveState.toBase64Encoding();
+        return lastKnownStateBase64;
+    }
 
     juce::MemoryBlock mb;
     // Atomic-park alone is NOT sufficient for state capture: it tells the
@@ -1051,40 +1063,28 @@ juce::String PluginSlot::getStateBase64ForSave (int parkSleepMs)
             }
         },
         parkSleepMs);
-    if (p == nullptr) return {};
-    return mb.toBase64Encoding();
+    if (p == nullptr) return lastKnownStateBase64;
+    lastKnownStateBase64 = mb.toBase64Encoding();
+    return lastKnownStateBase64;
 }
 
-bool PluginSlot::restoreFromSavedState (const juce::String& descriptionXml,
-                                          const juce::String& stateBase64,
-                                          juce::String& errorMessage)
+bool PluginSlot::restoreFromSavedState (
+    const std::optional<PluginDescriptor>& descriptor,
+    const juce::String& legacyDescriptionXml,
+    const juce::String& stateBase64,
+    juce::String& errorMessage)
 {
-    if (descriptionXml.isEmpty())
+    if (! descriptor.has_value() && legacyDescriptionXml.isEmpty())
     {
-        // Saved session had no plugin on this slot - make sure the slot is
-        // empty. Returning success because "no plugin to restore" is the
-        // valid steady state, not an error.
         unload();
         return true;
     }
 
-    // Session-load is a plugin swap from the user's point of view -
-    // bump the epoch + invalidate Mac shell the same way as
-    // loadFromDescription.
     currentLoadEpoch.fetch_add (1, std::memory_order_release);
 
    #if JUCE_MAC && DUSKSTUDIO_HAS_OOP_PLUGINS
     releaseShellInstance();
    #endif
-
-    // Stash the inputs up front. On any failure path below the slot
-    // ends up empty, but these copies survive so getDescriptionXmlForSave
-    // / getStateBase64ForSave still return the user's saved data - a
-    // subsequent autosave or manual save then round-trips it instead of
-    // wiping it because the plugin happened to be unavailable. Cleared
-    // by every success path and by unload().
-    offlineDescriptionXml = descriptionXml;
-    offlineStateBase64    = stateBase64;
 
     if (manager == nullptr)
     {
@@ -1092,21 +1092,28 @@ bool PluginSlot::restoreFromSavedState (const juce::String& descriptionXml,
         return false;
     }
 
-    // Parse the description.
-    auto xml = juce::XmlDocument::parse (descriptionXml);
-    if (xml == nullptr)
+    PluginDescriptor persistedDescriptor;
+    if (descriptor.has_value())
     {
-        errorMessage = "Saved plugin description is not valid XML";
-        return false;
+        persistedDescriptor = *descriptor;
     }
-    juce::PluginDescription desc;
-    if (! desc.loadFromXml (*xml))
+    else if (! manager->descriptorFromLegacyXml (legacyDescriptionXml,
+                                                  persistedDescriptor))
     {
-        errorMessage = "Saved plugin description failed to deserialise";
+        unload();
+        offlineDescriptor.reset();
+        offlineLegacyDescriptionXml = legacyDescriptionXml;
+        offlineStateBase64 = stateBase64;
+        errorMessage = "Saved plugin description is not valid legacy XML";
         return false;
     }
 
-    normalizeVst3FileOrIdentifier (desc);
+    PluginDescriptor descriptorToLoad = persistedDescriptor;
+    normalizeVst3Location (descriptorToLoad);
+    offlineDescriptor = persistedDescriptor;
+    offlineLegacyDescriptionXml.clear();
+    offlineStateBase64 = stateBase64;
+    lastKnownStateBase64 = stateBase64;
 
     // Try the OOP path first if enabled. On any failure we fall through
     // to the in-process load below - the user's session restore should
@@ -1117,10 +1124,7 @@ bool PluginSlot::restoreFromSavedState (const juce::String& descriptionXml,
         && preparedBlockSize > 0
         && preparedBlockSize <= duskstudio::ipc::kMaxBlock)
     {
-        // Use the standard load path, then setState. loadFromDescription
-        // handles parking, swap, and OOP/in-process choice; on success,
-        // currentRemote is non-null when the OOP path took.
-        if (loadFromDescription (desc, errorMessage))
+        if (loadFromDescriptor (descriptorToLoad, errorMessage))
         {
             if (auto* r = currentRemote.load (std::memory_order_acquire);
                 r != nullptr && stateBase64.isNotEmpty())
@@ -1138,16 +1142,16 @@ bool PluginSlot::restoreFromSavedState (const juce::String& descriptionXml,
                     }
                 }
             }
-            offlineDescriptionXml.clear();
+            offlineDescriptor.reset();
+            offlineLegacyDescriptionXml.clear();
             offlineStateBase64.clear();
+            lastKnownStateBase64 = stateBase64;
             return true;
         }
-        // loadFromDescription set errorMessage; fall through to retry
-        // in-process so the user's session still loads.
     }
    #endif
 
-    // Same swap-load shape as loadFromFile/loadFromDescription, with the
+    // Same swap-load shape as loadFromFile/loadFromDescriptor, with the
     // same two-deep deferred-destruction-via-previousInstances ring and
     // the same detach-listener-before-rotate discipline (see
     // loadFromFile for the rationale).
@@ -1164,7 +1168,7 @@ bool PluginSlot::restoreFromSavedState (const juce::String& descriptionXml,
     previousInstances[0] = std::move (ownedInstance);
     ownedInstance.reset();
 
-    auto fresh = manager->createPluginInstance (desc, preparedSampleRate,
+    auto fresh = manager->createPluginInstance (descriptorToLoad, preparedSampleRate,
                                                   preparedBlockSize, errorMessage);
     if (fresh == nullptr)
         return false;
@@ -1175,7 +1179,8 @@ bool PluginSlot::restoreFromSavedState (const juce::String& descriptionXml,
                                   preparedSampleRate, preparedBlockSize);
     if (preparedSampleRate > 0.0)
         fresh->prepareToPlay (preparedSampleRate, preparedBlockSize);
-    logLoadedPlugin (*fresh);
+    auto loaded = refreshFromInstance (*manager, *fresh, descriptorToLoad);
+    logLoadedPlugin (*fresh, loaded);
 
     // Apply the saved state blob (if any).
     if (stateBase64.isNotEmpty())
@@ -1200,8 +1205,11 @@ bool PluginSlot::restoreFromSavedState (const juce::String& descriptionXml,
     for (auto* p : ownedInstance->getParameters())
         if (p != nullptr) p->addListener (lastTouchedListener.get());
     currentInstance.store (ownedInstance.get(), std::memory_order_release);
-    offlineDescriptionXml.clear();
+    loadedDescriptor = std::move (loaded);
+    offlineDescriptor.reset();
+    offlineLegacyDescriptionXml.clear();
     offlineStateBase64.clear();
+    lastKnownStateBase64 = stateBase64;
     return true;
 }
 
@@ -1733,7 +1741,7 @@ void PluginSlot::applyParamWriteOnMessageThread (const ParamWrite& pw) noexcept
     // applies it on its DSP-side instance via the existing
     // SetParam -> callAsync -> setValueNotifyingHost path. Acquire
     // load pairs with the message-thread release stores in
-    // loadFromDescription / unload that swap currentRemote.
+    // descriptor load / unload that swap currentRemote.
     if (auto* r = currentRemote.load (std::memory_order_acquire))
         (void) r->setRemoteParam (pw.paramIndex, pw.value);
    #endif
@@ -1755,32 +1763,18 @@ bool PluginSlot::ensureShellInstanceForEditor (juce::String& err)
         err = "PluginSlot has no PluginManager bound";
         return false;
     }
-    if (savedDescriptionXml.isEmpty())
+    if (! loadedDescriptor.has_value())
     {
         err = "No plugin loaded - nothing to host in the shell";
         return false;
     }
 
-    // Parse the saved description (populated by loadFromDescription's
-    // OOP path) and load a fresh in-process instance against the same
+    // Load a fresh in-process instance against the same
     // file. The instance is editor-only: prepareToPlay is called so
     // the editor's bounds + initial parameter snapshot match the
     // engine's current SR/BS, but processBlock is NEVER invoked on
     // this instance - DSP runs in the OOP child.
-    auto xml = juce::XmlDocument::parse (savedDescriptionXml);
-    if (xml == nullptr)
-    {
-        err = "Saved plugin description is not valid XML";
-        return false;
-    }
-    juce::PluginDescription desc;
-    if (! desc.loadFromXml (*xml))
-    {
-        err = "Saved plugin description failed to deserialise";
-        return false;
-    }
-
-    auto fresh = manager->createPluginInstance (desc,
+    auto fresh = manager->createPluginInstance (*loadedDescriptor,
                                                   preparedSampleRate > 0.0
                                                        ? preparedSampleRate : 48000.0,
                                                   preparedBlockSize  > 0

--- a/src/engine/PluginSlot.h
+++ b/src/engine/PluginSlot.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "PluginDescriptor.h"
 #include <juce_audio_processors/juce_audio_processors.h>
 #include <juce_gui_basics/juce_gui_basics.h>
 #include "../foundation/MessageThread.h"
@@ -7,6 +8,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <optional>
 
 #if DUSKSTUDIO_HAS_OOP_PLUGINS
  #include "ipc/RemotePluginConnection.h"
@@ -64,16 +66,16 @@ public:
     void leakInstanceForShutdown();
 
     bool loadFromFile (const juce::File& pluginFile, juce::String& errorMessage);
-    bool loadFromDescription (const juce::PluginDescription& desc,
-                                juce::String& errorMessage);
+    bool loadFromDescriptor (const PluginDescriptor& descriptor,
+                             juce::String& errorMessage);
 
     // Off-thread load (in-process only - OOP falls back to the sync path).
     // Creates the instance on a background thread so a slow sample decode never
     // freezes the UI, then swaps it in + fires onDone(success, error) ON THE
     // MESSAGE THREAD. Safe against the slot being destroyed or a newer
     // load/unload arriving mid-load (weak-token + load-epoch guards).
-    void loadFromDescriptionAsync (
-        const juce::PluginDescription& desc,
+    void loadFromDescriptorAsync (
+        const PluginDescriptor& descriptor,
         std::function<void (bool success, juce::String error)> onDone);
 
     void unload();
@@ -176,12 +178,14 @@ public:
     // so the audio thread observes the parked pointer. Default 25 ms
     // covers a 1024-sample block at 44.1 kHz. Pass 0 only when the
     // audio callback is already detached (shutdown).
-    juce::String getDescriptionXmlForSave (int parkSleepMs = 25);
+    std::optional<PluginDescriptor> getDescriptorForSave (int parkSleepMs = 25);
+    juce::String getLegacyDescriptionXmlForSave() const;
     juce::String getStateBase64ForSave   (int parkSleepMs = 25);
 
-    bool restoreFromSavedState (const juce::String& descriptionXml,
-                                  const juce::String& stateBase64,
-                                  juce::String& errorMessage);
+    bool restoreFromSavedState (const std::optional<PluginDescriptor>& descriptor,
+                                const juce::String& legacyDescriptionXml,
+                                const juce::String& stateBase64,
+                                juce::String& errorMessage);
 
     // True when restore couldn't re-instantiate (plugin missing /
     // moved / unsupported). Saved description + state are preserved so
@@ -195,6 +199,13 @@ public:
     // figure can be captured without a real missing-plugin session). Pass an
     // empty string to clear it again. Never called in normal operation.
     void setOfflineForCapture (const juce::String& displayName);
+
+   #if defined(DUSKSTUDIO_TESTS)
+    // Persistence-only seam: models an instantiated slot whose audio pointer is
+    // temporarily unpublished (device inactive or OOP child already gone).
+    void setTemporarilyInactivePersistenceForTest (
+        PluginDescriptor descriptor, const juce::String& stateBase64);
+   #endif
 
    #if JUCE_MAC && DUSKSTUDIO_HAS_OOP_PLUGINS
     // Mac dual-load shell-instance API. Loads a parent-process copy of
@@ -233,10 +244,11 @@ public:
    #endif
 
 private:
-    // Message-thread install tail shared by loadFromDescription (sync) and
-    // loadFromDescriptionAsync's completion. Primes + atomically swaps in the
+    // Message-thread install tail shared by descriptor-based sync and async
+    // loads. Primes + atomically swaps in the
     // already-built instance; caller has already rotated the keep-alive ring.
-    bool installInProcessInstance (std::unique_ptr<juce::AudioPluginInstance> fresh);
+    bool installInProcessInstance (std::unique_ptr<juce::AudioPluginInstance> fresh,
+                                   PluginDescriptor descriptor);
 
     // Liveness token for async-load completions: a completion captures a
     // weak_ptr to this and bails if it has expired (slot destroyed mid-load).
@@ -325,10 +337,6 @@ private:
     // (which the in-process JUCE path still needs). Pre-sized in prepareToPlay.
     dusk::MidiBuffer oopMidiScratch;
 
-    // Cached for getDescriptionXmlForSave (which can't
-    // fillInPluginDescription on a remote instance).
-    juce::String savedDescriptionXml;
-
     static constexpr int kReaperPeriodMs = 1000;
     class ReaperTimer final : public dusk::Timer
     {
@@ -345,8 +353,11 @@ private:
     // Stashed when restoreFromSavedState fails so a subsequent save
     // round-trips the original blob. Outside the OOP gate because
     // macOS has no OOP impl yet but offline restore is cross-platform.
-    juce::String offlineDescriptionXml;
+    std::optional<PluginDescriptor> loadedDescriptor;
+    std::optional<PluginDescriptor> offlineDescriptor;
+    juce::String offlineLegacyDescriptionXml;
     juce::String offlineStateBase64;
+    juce::String lastKnownStateBase64;
 
    #if JUCE_MAC && DUSKSTUDIO_HAS_OOP_PLUGINS
     // Mac dual-load shell-instance state. Loaded lazily on first editor

--- a/src/engine/PluginSlot.h
+++ b/src/engine/PluginSlot.h
@@ -1,19 +1,20 @@
 #pragma once
 
-#include "PluginDescriptor.h"
 #include <juce_audio_processors/juce_audio_processors.h>
 #include <juce_gui_basics/juce_gui_basics.h>
+
+#include "PluginDescriptor.h"
 #include "../foundation/MessageThread.h"
+
+#if DUSKSTUDIO_HAS_OOP_PLUGINS
+ #include "ipc/RemotePluginConnection.h"
+#endif
+
 #include <array>
 #include <atomic>
 #include <functional>
 #include <memory>
 #include <optional>
-
-#if DUSKSTUDIO_HAS_OOP_PLUGINS
- #include "ipc/RemotePluginConnection.h"
- #include <memory>
-#endif
 
 namespace duskstudio
 {
@@ -357,6 +358,7 @@ private:
     std::optional<PluginDescriptor> offlineDescriptor;
     juce::String offlineLegacyDescriptionXml;
     juce::String offlineStateBase64;
+    bool offlineCapturePlaceholder { false };
     juce::String lastKnownStateBase64;
 
    #if JUCE_MAC && DUSKSTUDIO_HAS_OOP_PLUGINS

--- a/src/engine/ipc/IpcSelfTest.cpp
+++ b/src/engine/ipc/IpcSelfTest.cpp
@@ -192,8 +192,9 @@ int runIpcHostTest (const std::string& hostExecutablePath,
         std::fprintf (stderr, "FAIL: loadPlugin: %s\n", err.c_str());
         return 13;
     }
-    std::fprintf (stdout, "loaded: numIn=%d numOut=%d latency=%d\n",
-                  numIn, numOut, latency);
+    std::fprintf (stdout,
+                  "loaded: numIn=%d numOut=%d latency=%d isInstrument=%s\n",
+                  numIn, numOut, latency, isInstrument ? "true" : "false");
 
     // Some plugins are output-only (instruments, numIn=0). For those we
     // can still run processBlock - the child fills the input buffer

--- a/src/engine/ipc/IpcSelfTest.cpp
+++ b/src/engine/ipc/IpcSelfTest.cpp
@@ -184,9 +184,10 @@ int runIpcHostTest (const std::string& hostExecutablePath,
     // 3) Load the plugin in the child.
     constexpr double kSampleRate = 48000.0;
     int numIn = 0, numOut = 0, latency = 0;
+    bool isInstrument = false;
     if (! conn.loadPlugin (descXmlStr.toStdString(),
                             kSampleRate, numSamples,
-                            numIn, numOut, latency, err))
+                            numIn, numOut, latency, isInstrument, err))
     {
         std::fprintf (stderr, "FAIL: loadPlugin: %s\n", err.c_str());
         return 13;
@@ -199,8 +200,6 @@ int runIpcHostTest (const std::string& hostExecutablePath,
     // with our data which the plugin ignores - but the "output != input"
     // assertion is meaningless. Skip the change-detection check for
     // instrument plugins.
-    const bool isInstrument = (numIn == 0);
-
     // 4) Run process-block round-trips. Generate deterministic non-zero
     // input so an effect plugin must alter it (an EQ at non-flat settings
     // / a comp / a reverb all will).

--- a/src/engine/ipc/PluginHostMain.cpp
+++ b/src/engine/ipc/PluginHostMain.cpp
@@ -9,8 +9,8 @@
 //                 thread, services control RPCs on a separate socket-
 //                 reader thread, runs the JUCE message loop on main.
 //   --scan      : one-shot crash-isolated plugin discovery. Scans a single
-//                 file/identifier for one format, prints its
-//                 PluginDescription(s) as XML to stdout, exits. A plugin
+//                 file/identifier for one format, prints versioned Dusk
+//                 descriptors as JSON between sentinels, exits. A plugin
 //                 that crashes the scan takes down only this process; the
 //                 parent blacklists the file and carries on. See runScan.
 //
@@ -46,6 +46,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <signal.h>
 
 #include <algorithm>
@@ -420,7 +421,9 @@ std::uint32_t handleLoadPlugin (HostState& host,
     reply.numInChans     = fresh->getTotalNumInputChannels();
     reply.numOutChans    = fresh->getTotalNumOutputChannels();
     reply.latencySamples = fresh->getLatencySamples();
-    reply.reserved       = 0;
+    juce::PluginDescription loadedDescription;
+    fresh->fillInPluginDescription (loadedDescription);
+    reply.isInstrument = loadedDescription.isInstrument ? 1u : 0u;
     replyOut.resize (sizeof (reply));
     std::memcpy (replyOut.data(), &reply, sizeof (reply));
 
@@ -896,13 +899,44 @@ int runIpcHost (int argc, const char* const* argv) noexcept
 //   dusk-studio-plugin-host --scan <formatName> <fileOrIdentifier>
 //
 // We instantiate the plugin just far enough to read its PluginDescription(s)
-// and print them as XML between sentinel markers on stdout. If the plugin
+// and print Dusk descriptors between sentinel markers on stdout. If the plugin
 // segfaults or hangs in findAllTypesForFile, only THIS process dies - the
 // parent times it out / sees the crash, blacklists the file, and keeps
 // running. The plugin's own stdout chatter (if any) is emitted by its init
 // code, which runs BEFORE we print kScanPayloadBegin, so the parent's
 // extract-between-sentinels parse skips it.
 //
+std::vector<duskstudio::PluginDescriptor> descriptorsFromJuce (
+    const juce::OwnedArray<juce::PluginDescription>& found)
+{
+    std::vector<duskstudio::PluginDescriptor> rows;
+    rows.reserve ((size_t) found.size());
+    for (const auto* source : found)
+    {
+        if (source == nullptr) continue;
+        duskstudio::PluginDescriptor descriptor;
+        descriptor.name = source->name.toStdString();
+        descriptor.descriptiveName = source->descriptiveName.toStdString();
+        descriptor.manufacturer = source->manufacturerName.toStdString();
+        descriptor.category = source->category.toStdString();
+        descriptor.version = source->version.toStdString();
+        descriptor.formatName = source->pluginFormatName.toStdString();
+        descriptor.backend = duskstudio::PluginBackend::JuceLegacy;
+        descriptor.location = source->fileOrIdentifier.toStdString();
+        descriptor.uniqueId = source->uniqueId;
+        descriptor.deprecatedUid = source->deprecatedUid;
+        descriptor.numInputChannels = source->numInputChannels;
+        descriptor.numOutputChannels = source->numOutputChannels;
+        descriptor.lastFileModificationMs = source->lastFileModTime.toMilliseconds();
+        descriptor.lastInfoUpdateMs = source->lastInfoUpdateTime.toMilliseconds();
+        descriptor.isInstrument = source->isInstrument;
+        descriptor.hasSharedContainer = source->hasSharedContainer;
+        descriptor.hasAraExtension = source->hasARAExtension;
+        rows.push_back (std::move (descriptor));
+    }
+    return rows;
+}
+
 #if DUSKSTUDIO_HAS_NATIVE_CLAP || DUSKSTUDIO_HAS_NATIVE_VST3
 // Sandboxed native-format discovery: load ONE bundle through the native host's
 // own loader and print the resulting picker rows between the scan sentinels.
@@ -923,18 +957,18 @@ int runScanNative (int argc, const char* const* argv) noexcept
 
     juce::ScopedJuceInitialiser_GUI juceInit;
 
-    juce::Array<juce::PluginDescription> rows;
+    std::vector<duskstudio::PluginDescriptor> rows;
+    const auto bundlePath = std::filesystem::u8path (
+        bundle.getFullPathName().toStdString());
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
-    if (format == "clap") duskstudio::nativescan::appendClapRows (bundle, rows);
+    if (format == "clap") duskstudio::nativescan::appendClapRows (bundlePath, rows);
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_VST3
-    if (format == "vst3") duskstudio::nativescan::appendVst3Rows (bundle, rows);
+    if (format == "vst3") duskstudio::nativescan::appendVst3Rows (bundlePath, rows);
 #endif
 
-    juce::OwnedArray<juce::PluginDescription> found;
-    for (const auto& r : rows)
-        found.add (new juce::PluginDescription (r));
-    std::fputs (duskstudio::scanproto::makePayload (found).toRawUTF8(), stdout);
+    const auto payload = duskstudio::scanproto::makePayload (rows);
+    std::fwrite (payload.data(), 1, payload.size(), stdout);
     std::fflush (stdout);
     return 0;
 }
@@ -983,7 +1017,9 @@ int runScan (int argc, const char* const* argv) noexcept
     juce::OwnedArray<juce::PluginDescription> found;
     chosen->findAllTypesForFile (found, fileOrId);   // may crash/hang - that is the point
 
-    std::fputs (duskstudio::scanproto::makePayload (found).toRawUTF8(), stdout);
+    const auto payload = duskstudio::scanproto::makePayload (
+        descriptorsFromJuce (found));
+    std::fwrite (payload.data(), 1, payload.size(), stdout);
     std::fflush (stdout);
     return 0;
 }

--- a/src/engine/ipc/PluginIpc.h
+++ b/src/engine/ipc/PluginIpc.h
@@ -118,7 +118,7 @@ struct LoadPluginReply
     std::int32_t  numInChans;
     std::int32_t  numOutChans;
     std::int32_t  latencySamples;
-    std::uint32_t reserved;
+    std::uint32_t isInstrument;
 };
 
 struct PrepareToPlayPayload

--- a/src/engine/ipc/PluginIpc.h
+++ b/src/engine/ipc/PluginIpc.h
@@ -23,9 +23,9 @@ namespace duskstudio::ipc
 {
 
 constexpr std::uint32_t kMagic     = 0x46434C30;  // 'FCL0'
-constexpr std::uint32_t kVersion   = 1;
+constexpr std::uint32_t kVersion   = 2;
 constexpr int           kMaxBlock  = 1024;        // upper bound on numSamples per block
-constexpr int           kMaxChans  = 2;           // stereo plenty for v1
+constexpr int           kMaxChans  = 2;           // stereo plenty for this host
 constexpr std::size_t   kMidiBytes = 16 * 1024;   // serialised MIDI-block byte cap
 constexpr std::size_t   kStateBytes = 4 * 1024 * 1024; // up to 4 MB plugin state blob
 // Hard cap on a single control-socket payload. Legit payloads are small

--- a/src/engine/ipc/PluginScanProtocol.h
+++ b/src/engine/ipc/PluginScanProtocol.h
@@ -3,6 +3,7 @@
 #include "../PluginDescriptor.h"
 
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -54,22 +55,22 @@ inline std::string extractPayload (std::string_view childStdout)
     return std::string (payload);
 }
 
-inline std::vector<PluginDescriptor> parsePayload (std::string_view payload)
+inline std::optional<std::vector<PluginDescriptor>> parsePayload (std::string_view payload)
 {
     const auto root = nlohmann::json::parse (payload, nullptr, false);
     if (! root.is_object())
-        return {};
+        return std::nullopt;
     const auto version = root.find ("version");
     const auto descriptors = root.find ("descriptors");
     if (version == root.end()
         || descriptors == root.end() || ! descriptors->is_array())
-        return {};
+        return std::nullopt;
     const bool versionMatches = version->is_number_unsigned()
         ? version->get<std::uint64_t>() == 1u
         : version->is_number_integer()
             && version->get<std::int64_t>() == 1;
     if (! versionMatches)
-        return {};
+        return std::nullopt;
 
     std::vector<PluginDescriptor> parsed;
     parsed.reserve (descriptors->size());
@@ -77,7 +78,7 @@ inline std::vector<PluginDescriptor> parsePayload (std::string_view payload)
     {
         PluginDescriptor descriptor;
         if (! PluginDescriptor::fromJson (value.dump(), descriptor))
-            return {};
+            return std::nullopt;
         parsed.push_back (std::move (descriptor));
     }
     return parsed;

--- a/src/engine/ipc/PluginScanProtocol.h
+++ b/src/engine/ipc/PluginScanProtocol.h
@@ -15,10 +15,7 @@ inline constexpr std::string_view kPayloadEnd   = "==DUSK_SCAN_END==";
 
 inline bool formatRequiresSandbox (std::string_view formatName)
 {
-    return formatName == "VST3"
-        || formatName == "LV2"
-        || formatName == "AudioUnit"
-        || formatName == "VST";
+    return formatName != "DuskMultisample";
 }
 
 inline std::string makePayload (const std::vector<PluginDescriptor>& found)

--- a/src/engine/ipc/PluginScanProtocol.h
+++ b/src/engine/ipc/PluginScanProtocol.h
@@ -1,30 +1,18 @@
 #pragma once
 
-#include <juce_audio_processors/juce_audio_processors.h>
-#include <memory>
+#include "../PluginDescriptor.h"
 
-// Wire protocol for out-of-process plugin scanning. The parent
-// (PluginManager's OutOfProcessPluginScanner) spawns dusk-studio-plugin-host
-// with `--scan <format> <file>`; the child instantiates the plugin just far
-// enough to read its PluginDescription(s) and prints them between sentinel
-// markers on stdout. A plugin that crashes / hangs during the scan dies in
-// the child, leaving no payload - the parent treats that as a failed scan and
-// blacklists the file.
-//
-// Both sides go through this one header so the sentinels + serialisation can
-// never drift out of sync, and so the parse path is unit-testable without
-// spawning a subprocess.
+#include <nlohmann/json.hpp>
+#include <string>
+#include <string_view>
+#include <vector>
+
 namespace duskstudio::scanproto
 {
-inline constexpr const char* kPayloadBegin = "==DUSK_SCAN_BEGIN==";
-inline constexpr const char* kPayloadEnd   = "==DUSK_SCAN_END==";
+inline constexpr std::string_view kPayloadBegin = "==DUSK_SCAN_BEGIN==";
+inline constexpr std::string_view kPayloadEnd   = "==DUSK_SCAN_END==";
 
-// Scan-sandbox policy: which formats load third-party binary code and therefore
-// MUST be probed out-of-process - an unauthorized or crashy plugin scanned
-// in-process takes down the whole app. Anything else (our own in-house code,
-// unknown names) is trusted and scans in-process. Centralised here so the
-// scanner's routing and its unit test read from one list.
-inline bool formatRequiresSandbox (const juce::String& formatName)
+inline bool formatRequiresSandbox (std::string_view formatName)
 {
     return formatName == "VST3"
         || formatName == "LV2"
@@ -32,49 +20,66 @@ inline bool formatRequiresSandbox (const juce::String& formatName)
         || formatName == "VST";
 }
 
-// Child side: serialise the discovered descriptions into the stdout payload.
-// The plugin's own stdout chatter (if any) is emitted by its init code, which
-// runs BEFORE this is printed, so it lands ahead of kPayloadBegin and the
-// parent's extract step skips it.
-inline juce::String makePayload (const juce::OwnedArray<juce::PluginDescription>& found)
+inline std::string makePayload (const std::vector<PluginDescriptor>& found)
 {
-    juce::XmlElement root ("PLUGINS");
-    for (auto* d : found)
-        if (d != nullptr)
-            root.addChildElement (d->createXml().release());
+    nlohmann::ordered_json root {
+        { "version", 1 },
+        { "descriptors", nlohmann::ordered_json::array() }
+    };
+    for (const auto& descriptor : found)
+        root["descriptors"].push_back (
+            nlohmann::ordered_json::parse (descriptor.toJson()));
 
-    juce::String s;
-    s << kPayloadBegin << "\n"
-      << root.toString (juce::XmlElement::TextFormat().singleLine()) << "\n"
-      << kPayloadEnd << "\n";
-    return s;
+    return std::string (kPayloadBegin) + "\n" + root.dump() + "\n"
+        + std::string (kPayloadEnd) + "\n";
 }
 
-// Parent side: pull the XML bytes between the sentinels out of the child's
-// captured stdout. Returns empty when either sentinel is missing (child
-// crashed / hung before completing the print) - the caller treats empty as a
-// failed scan.
-inline juce::String extractPayload (const juce::String& childStdout)
+inline std::string extractPayload (std::string_view childStdout)
 {
-    const int b = childStdout.indexOf (kPayloadBegin);
-    if (b < 0) return {};
-    const int from = b + juce::String (kPayloadBegin).length();
-    const int e = childStdout.indexOf (from, kPayloadEnd);
-    if (e < 0) return {};
-    return childStdout.substring (from, e).trim();
+    const auto begin = childStdout.find (kPayloadBegin);
+    if (begin == std::string_view::npos)
+        return {};
+    const auto from = begin + kPayloadBegin.size();
+    const auto end = childStdout.find (kPayloadEnd, from);
+    if (end == std::string_view::npos)
+        return {};
+
+    auto payload = childStdout.substr (from, end - from);
+    while (! payload.empty() && (payload.front() == '\n' || payload.front() == '\r'
+                                  || payload.front() == ' ' || payload.front() == '\t'))
+        payload.remove_prefix (1);
+    while (! payload.empty() && (payload.back() == '\n' || payload.back() == '\r'
+                                  || payload.back() == ' ' || payload.back() == '\t'))
+        payload.remove_suffix (1);
+    return std::string (payload);
 }
 
-// Parent side: parse an extracted payload into descriptions. No-op (leaves
-// `out` untouched) on malformed XML.
-inline void parsePayload (const juce::String& payload,
-                          juce::OwnedArray<juce::PluginDescription>& out)
+inline std::vector<PluginDescriptor> parsePayload (std::string_view payload)
 {
-    if (auto xml = juce::parseXML (payload))
-        for (auto* e : xml->getChildIterator())
-        {
-            auto desc = std::make_unique<juce::PluginDescription>();
-            if (desc->loadFromXml (*e))
-                out.add (desc.release());
-        }
+    const auto root = nlohmann::json::parse (payload, nullptr, false);
+    if (! root.is_object())
+        return {};
+    const auto version = root.find ("version");
+    const auto descriptors = root.find ("descriptors");
+    if (version == root.end()
+        || descriptors == root.end() || ! descriptors->is_array())
+        return {};
+    const bool versionMatches = version->is_number_unsigned()
+        ? version->get<std::uint64_t>() == 1u
+        : version->is_number_integer()
+            && version->get<std::int64_t>() == 1;
+    if (! versionMatches)
+        return {};
+
+    std::vector<PluginDescriptor> parsed;
+    parsed.reserve (descriptors->size());
+    for (const auto& value : *descriptors)
+    {
+        PluginDescriptor descriptor;
+        if (! PluginDescriptor::fromJson (value.dump(), descriptor))
+            return {};
+        parsed.push_back (std::move (descriptor));
+    }
+    return parsed;
 }
 } // namespace duskstudio::scanproto

--- a/src/engine/ipc/RemotePluginConnection.cpp
+++ b/src/engine/ipc/RemotePluginConnection.cpp
@@ -343,7 +343,8 @@ bool RemotePluginConnection::ping (int timeoutMs, std::string& errorOut)
 bool RemotePluginConnection::loadPlugin (const std::string& pluginDescriptionXml,
                                           double sampleRate, int blockSize,
                                           int& numInOut, int& numOutOut,
-                                          int& latencyOut, std::string& errorOut)
+                                          int& latencyOut, bool& isInstrumentOut,
+                                          std::string& errorOut)
 {
     PrepareToPlayPayload header {};
     header.sampleRate = sampleRate;
@@ -381,6 +382,7 @@ bool RemotePluginConnection::loadPlugin (const std::string& pluginDescriptionXml
     numInOut    = r.numInChans;
     numOutOut   = r.numOutChans;
     latencyOut  = r.latencySamples;
+    isInstrumentOut = r.isInstrument != 0;
     return true;
 }
 

--- a/src/engine/ipc/RemotePluginConnection.h
+++ b/src/engine/ipc/RemotePluginConnection.h
@@ -64,11 +64,13 @@ public:
 
     // Load a plugin from its PluginDescription XML string at the given
     // sample rate / block size. Fills `numInOut`
-    // with the plugin's reported channel layout and `latencyOut` with
-    // its reported latency in samples.
+    // with the plugin's reported channel layout, `latencyOut` with its
+    // reported latency, and `isInstrumentOut` with the instantiated
+    // plugin description's classification.
     bool loadPlugin (const std::string& pluginDescriptionXml,
                       double sampleRate, int blockSize,
                       int& numInOut, int& numOutOut, int& latencyOut,
+                      bool& isInstrumentOut,
                       std::string& errorOut);
 
     // Re-prepare the loaded plugin (sample-rate or block-size change).

--- a/src/session/RegionEditActions.cpp
+++ b/src/session/RegionEditActions.cpp
@@ -539,9 +539,9 @@ void applyTrack (Track& t, AudioEngine& engine, int idx,
 
     // Plugin: replay through the live slot.
     juce::String err;
-    engine.getStrip (idx).getPluginSlot().restoreFromSavedState (
-        s.plugin.descriptor, s.plugin.legacyDescriptionXml, s.plugin.stateBase64, err);
-    if (err.isNotEmpty())
+    if (! engine.getStrip (idx).getPluginSlot().restoreFromSavedState (
+            s.plugin.descriptor, s.plugin.legacyDescriptionXml,
+            s.plugin.stateBase64, err))
     {
         DBG ("CloneTrackAction: plugin restore failed on strip " << idx
               << ": " << err);

--- a/src/session/RegionEditActions.cpp
+++ b/src/session/RegionEditActions.cpp
@@ -325,8 +325,7 @@ bool DeleteMidiRegionAction::undo()
 
 // POD snapshot of every per-track field the clone should duplicate.
 // Atomics are loaded into plain values; vectors are copied by value.
-// Plugin state is captured as the (descriptionXml, stateBase64) pair the
-// session-restore path already understands.
+// Plugin state is captured as one descriptor/legacy-fallback/state unit.
 struct CloneTrackAction::Impl
 {
     juce::String name;
@@ -365,9 +364,8 @@ struct CloneTrackAction::Impl
     int   inputSource = -2, inputSourceR = -2;
     int   midiInputIndex = -1, midiChannel = 0;
 
-    // Plugin slot - description + state captured live from the engine.
-    juce::String pluginDescXml;
-    juce::String pluginStateB64;
+    // Plugin slot - descriptor, raw legacy fallback, and state captured live.
+    ClonePluginSnapshot plugin;
 
 #if DUSKSTUDIO_HAS_MULTISAMPLE
     // Native multisample instrument - not a JUCE-hosted plugin, so it needs
@@ -447,8 +445,9 @@ CloneTrackAction::Impl captureTrack (Track& t, AudioEngine& engine, int idx)
     // Plugin: pull from the live slot, not the (potentially stale)
     // session.json fields. Those are only kept fresh during save.
     auto& slot = engine.getStrip (idx).getPluginSlot();
-    s.pluginDescXml  = slot.getDescriptionXmlForSave();
-    s.pluginStateB64 = slot.getStateBase64ForSave();
+    s.plugin.descriptor = slot.getDescriptorForSave();
+    s.plugin.legacyDescriptionXml = slot.getLegacyDescriptionXmlForSave();
+    s.plugin.stateBase64 = slot.getStateBase64ForSave();
 
 #if DUSKSTUDIO_HAS_MULTISAMPLE
     auto& msSlot = engine.getStrip (idx).getNativeMultisampleSlot();
@@ -538,15 +537,15 @@ void applyTrack (Track& t, AudioEngine& engine, int idx,
     // and silently bail.
     engine.getSession().recomputeRtCounters();
 
-    // Plugin: replay through the live slot. Empty descriptionXml
-    // legitimately means "no plugin" - restoreFromSavedState handles
-    // that as the unloaded steady state.
+    // Plugin: replay through the live slot.
     juce::String err;
     engine.getStrip (idx).getPluginSlot().restoreFromSavedState (
-        s.pluginDescXml, s.pluginStateB64, err);
+        s.plugin.descriptor, s.plugin.legacyDescriptionXml, s.plugin.stateBase64, err);
     if (err.isNotEmpty())
+    {
         DBG ("CloneTrackAction: plugin restore failed on strip " << idx
-              << " (" << s.pluginDescXml << "): " << err);
+              << ": " << err);
+    }
 
     t.regions = s.regions;
     t.midiRegions.publish (std::make_unique<std::vector<MidiRegion>> (s.midiRegions));
@@ -555,8 +554,7 @@ void applyTrack (Track& t, AudioEngine& engine, int idx,
     // after a clone (with no manual edits in between) round-trips
     // correctly. publishPluginStateForSave does this for ALL slots; for
     // a single track we mirror by hand.
-    t.pluginDescriptionXml = s.pluginDescXml;
-    t.pluginStateBase64    = s.pluginStateB64;
+    s.plugin.publishTo (t);
 
 #if DUSKSTUDIO_HAS_MULTISAMPLE
     // After the JUCE replay: a multisample load evicts the JUCE slot, so doing

--- a/src/session/RegionEditActions.h
+++ b/src/session/RegionEditActions.h
@@ -8,6 +8,37 @@ namespace duskstudio
 {
 class AudioEngine;
 
+// The plugin portion of a clone snapshot is one indivisible replay unit.
+// Keeping the structured descriptor, malformed legacy fallback, and state
+// together prevents perform/undo/redo from dropping one representation.
+struct ClonePluginSnapshot
+{
+    std::optional<PluginDescriptor> descriptor;
+    juce::String legacyDescriptionXml;
+    juce::String stateBase64;
+
+    static ClonePluginSnapshot fromTrack (const Track& track)
+    {
+        return { track.pluginDescriptor,
+                 track.pluginLegacyDescriptionXml,
+                 track.pluginStateBase64 };
+    }
+
+    void publishTo (Track& track) const
+    {
+        track.pluginDescriptor = descriptor;
+        track.pluginLegacyDescriptionXml = legacyDescriptionXml;
+        track.pluginStateBase64 = stateBase64;
+    }
+
+    bool operator== (const ClonePluginSnapshot& other) const
+    {
+        return descriptor == other.descriptor
+            && legacyDescriptionXml == other.legacyDescriptionXml
+            && stateBase64 == other.stateBase64;
+    }
+};
+
 // Replaces a single AudioRegion's fields with new values. Used for the move
 // and trim drags, all of which collapse to "region X is now Y". perform()
 // applies the new state; undo() restores the original.
@@ -244,10 +275,10 @@ private:
 // (description + state). Undo restores the destination's previous state
 // captured at first perform().
 //
-// Plugin replay: copying pluginDescriptionXml / pluginStateBase64 onto
+// Plugin replay: copying the descriptor / legacy fallback / state onto
 // the destination Track isn't enough on its own - the live PluginSlot
 // owned by AudioEngine has to re-instantiate. perform() reads source's
-// live slot via getDescriptionXmlForSave / getStateBase64ForSave and
+// live slot via getDescriptorForSave / getStateBase64ForSave and
 // asks the destination slot to restoreFromSavedState. Undo replays the
 // captured before-state through the same path so the dest slot returns
 // to whatever plugin (if any) was loaded before.

--- a/src/session/Session.h
+++ b/src/session/Session.h
@@ -11,6 +11,7 @@
 #include <vector>
 #include "AtomicSnapshot.h"
 #include "MidiBindings.h"
+#include "../engine/PluginDescriptor.h"
 
 namespace duskstudio
 {
@@ -801,9 +802,10 @@ struct Track
     std::vector<AudioRegion>                regions;
     AtomicSnapshot<std::vector<MidiRegion>> midiRegions;
 
-    // Populated by AudioEngine::publishPluginStateForSave before save;
-    // consumed by consumePluginStateAfterLoad. Empty = no plugin.
-    juce::String pluginDescriptionXml;
+    // Populated by AudioEngine::publishPluginStateForSave before save and
+    // consumed by consumePluginStateAfterLoad.
+    std::optional<PluginDescriptor> pluginDescriptor;
+    juce::String pluginLegacyDescriptionXml;
     juce::String pluginStateBase64;
 
     // Native insert alternatives to the JUCE plugin above. An insert hosts at
@@ -972,7 +974,8 @@ struct AuxLane
 
     // Per-slot plugin state. Slot's audio mode (Plugin vs Hardware)
     // lives on the strip; Session just persists param values.
-    std::array<juce::String, AuxLaneParams::kMaxLanePlugins> pluginDescriptionXml;
+    std::array<std::optional<PluginDescriptor>, AuxLaneParams::kMaxLanePlugins> pluginDescriptor;
+    std::array<juce::String, AuxLaneParams::kMaxLanePlugins> pluginLegacyDescriptionXml;
     std::array<juce::String, AuxLaneParams::kMaxLanePlugins> pluginStateBase64;
 
     // Native host alternatives to the JUCE plugin above. A slot is JUCE /

--- a/src/session/SessionSerializer.cpp
+++ b/src/session/SessionSerializer.cpp
@@ -839,7 +839,8 @@ JObj busToObject (const Bus& a)
     return obj;
 }
 
-void restoreTrack (Track& t, const nlohmann::json& v, double defaultRecordBpm,
+void restoreTrack (Track& t, int trackIndex, const nlohmann::json& v,
+                   double defaultRecordBpm,
                    const juce::File& sessionDir,
                    std::vector<juce::String>& missingFiles)
 {
@@ -850,7 +851,15 @@ void restoreTrack (Track& t, const nlohmann::json& v, double defaultRecordBpm,
     t.pluginDescriptor.reset();
     if (const auto it = v.find ("plugin_descriptor");
         it != v.end() && it->is_object())
+    {
         t.pluginDescriptor = descriptorFromObject (*it);
+        if (! t.pluginDescriptor.has_value())
+            std::fprintf (
+                stderr,
+                "[Dusk Studio/session] rejected plugin_descriptor for track %d; "
+                "using plugin_desc_xml fallback when present\n",
+                trackIndex + 1);
+    }
     t.pluginLegacyDescriptionXml = t.pluginDescriptor.has_value()
         ? juce::String() : json::getString (v, "plugin_desc_xml");
     t.pluginStateBase64    = json::getString (v, "plugin_state");
@@ -1765,7 +1774,7 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
         // automation mode, plugin state).
         const nlohmann::json emptyTrack = nlohmann::json::object();
         for (int i = 0; i < Session::kNumTracks; ++i)
-            restoreTrack (s.track (i),
+            restoreTrack (s.track (i), i,
                           i < (int) tracks.size() ? tracks[(size_t) i] : emptyTrack,
                           sessionLoadBpm, s.getSessionDirectory(),
                           s.missingAudioFilesAfterLoad);
@@ -1808,7 +1817,16 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
                     lane.pluginDescriptor[(size_t) p].reset();
                     if (const auto it = sv.find ("plugin_descriptor");
                         it != sv.end() && it->is_object())
+                    {
                         lane.pluginDescriptor[(size_t) p] = descriptorFromObject (*it);
+                        if (! lane.pluginDescriptor[(size_t) p].has_value())
+                            std::fprintf (
+                                stderr,
+                                "[Dusk Studio/session] rejected plugin_descriptor "
+                                "for aux %d slot %d; using plugin_desc_xml fallback "
+                                "when present\n",
+                                i + 1, p + 1);
+                    }
                     lane.pluginLegacyDescriptionXml[(size_t) p]
                         = lane.pluginDescriptor[(size_t) p].has_value()
                             ? juce::String() : json::getString (sv, "plugin_desc_xml");

--- a/src/session/SessionSerializer.cpp
+++ b/src/session/SessionSerializer.cpp
@@ -39,15 +39,16 @@ inline std::string toStd (const juce::String& s) { return s.toStdString(); }
 
 inline JObj descriptorToObject (const PluginDescriptor& descriptor)
 {
-    return JObj::parse (descriptor.toJson());
+    return descriptor.toJsonObject();
 }
 
-inline std::optional<PluginDescriptor> descriptorFromObject (const nlohmann::json& value)
+inline std::optional<PluginDescriptor> descriptorFromObject (
+    const nlohmann::json& value) noexcept
 {
     PluginDescriptor descriptor;
-    if (! PluginDescriptor::fromJson (value.dump(), descriptor))
-        return std::nullopt;
-    return descriptor;
+    if (PluginDescriptor::fromJsonObject (value, descriptor))
+        return descriptor;
+    return std::nullopt;
 }
 
 // Bump whenever the JSON shape gains a NEW required field or changes
@@ -1647,7 +1648,8 @@ juce::String SessionSerializer::serialize (const Session& s)
     tport["oversampling_factor"] = s.oversamplingFactor.load();
     root["transport"] = std::move (tport);
 
-    return juce::String (root.dump (2));
+    return juce::String (root.dump (
+        2, ' ', false, JObj::error_handler_t::replace));
 }
 
 bool SessionSerializer::writeAtomic (const juce::File& target, const juce::String& json)

--- a/src/session/SessionSerializer.cpp
+++ b/src/session/SessionSerializer.cpp
@@ -37,6 +37,19 @@ using JObj = nlohmann::ordered_json;
 
 inline std::string toStd (const juce::String& s) { return s.toStdString(); }
 
+inline JObj descriptorToObject (const PluginDescriptor& descriptor)
+{
+    return JObj::parse (descriptor.toJson());
+}
+
+inline std::optional<PluginDescriptor> descriptorFromObject (const nlohmann::json& value)
+{
+    PluginDescriptor descriptor;
+    if (! PluginDescriptor::fromJson (value.dump(), descriptor))
+        return std::nullopt;
+    return descriptor;
+}
+
 // Bump whenever the JSON shape gains a NEW required field or changes
 // the meaning of an existing one. Adding optional fields that default
 // sensibly when absent does NOT require a bump - the load path
@@ -44,7 +57,7 @@ inline std::string toStd (const juce::String& s) { return s.toStdString(); }
 // Loader rejects sessions with version > kFormatVersion (newer Dusk Studio
 // can read older files via migrateSession; older Dusk Studio refusing
 // newer files is safer than silently dropping fields).
-constexpr int kFormatVersion = 3;
+constexpr int kFormatVersion = 4;
 
 // Store a float from JSON only when it's finite, so a corrupt or hand-edited
 // session.json can't push NaN / inf into a DSP parameter - the in-memory
@@ -230,6 +243,17 @@ bool migrateSession (nlohmann::json& root, int from)
                 ++v;
                 break;
 
+            case 3:
+                // v3 -> v4: plugin references may now be stored as structured
+                // plugin_descriptor objects. Existing v3 files keep their
+                // plugin_desc_xml values and are converted by the host restore
+                // boundary; stamping v4 makes pre-H4 readers refuse new
+                // structured saves instead of silently dropping plugin slots.
+                if (root.is_object())
+                    root["version"] = 4;
+                ++v;
+                break;
+
             default:
                 std::fprintf (stderr,
                               "[Dusk Studio/SessionSerializer] no migrator from v%d to v%d\n",
@@ -411,11 +435,10 @@ JObj trackToObject (const Track& t, const juce::File& sessionDir)
     obj["name"]   = toStd (t.name);
     obj["colour"] = toStd (colourToHex (t.colour));
 
-    // Plugin-slot persistence. Empty strings (no plugin loaded) are written
-    // verbatim - round-trip restoreFromSavedState treats empty as "no
-    // plugin", which is the correct steady state for unused slots.
-    if (t.pluginDescriptionXml.isNotEmpty())
-        obj["plugin_desc_xml"] = toStd (t.pluginDescriptionXml);
+    if (t.pluginDescriptor.has_value())
+        obj["plugin_descriptor"] = descriptorToObject (*t.pluginDescriptor);
+    else if (t.pluginLegacyDescriptionXml.isNotEmpty())
+        obj["plugin_desc_xml"] = toStd (t.pluginLegacyDescriptionXml);
     if (t.pluginStateBase64.isNotEmpty())
         obj["plugin_state"] = toStd (t.pluginStateBase64);
     if (t.nativeClapPath.isNotEmpty())
@@ -824,10 +847,12 @@ void restoreTrack (Track& t, const nlohmann::json& v, double defaultRecordBpm,
     if (auto s = json::getString (v, "name");   ! s.empty()) t.name = s;
     if (auto s = json::getString (v, "colour"); ! s.empty()) t.colour = hexToColour (s, t.colour);
 
-    // Plugin slot - strings remain empty when the property is absent (older
-    // sessions or unused slots). AudioEngine::consumePluginStateAfterLoad
-    // reads these back and asks each PluginSlot to reinstantiate.
-    t.pluginDescriptionXml = json::getString (v, "plugin_desc_xml");
+    t.pluginDescriptor.reset();
+    if (const auto it = v.find ("plugin_descriptor");
+        it != v.end() && it->is_object())
+        t.pluginDescriptor = descriptorFromObject (*it);
+    t.pluginLegacyDescriptionXml = t.pluginDescriptor.has_value()
+        ? juce::String() : json::getString (v, "plugin_desc_xml");
     t.pluginStateBase64    = json::getString (v, "plugin_state");
     t.nativeClapPath        = json::getString (v, "native_clap_path");
     t.nativeClapPluginId    = json::getString (v, "native_clap_plugin");
@@ -1324,13 +1349,17 @@ juce::String SessionSerializer::serialize (const Session& s)
         obj["return_level_db"] = lane.params.returnLevelDb.load();
         obj["mute"]            = lane.params.mute.load();
         obj["output_pair"]     = lane.params.outputPair.load();
-        // Per-slot plugin state. Empty strings serialise as empty - same
-        // pattern as Track.
+        // Per-slot plugin state.
         JObj slots = JObj::array();
         for (int p = 0; p < AuxLaneParams::kMaxLanePlugins; ++p)
         {
             JObj slot;
-            slot["plugin_desc_xml"] = toStd (lane.pluginDescriptionXml[(size_t) p]);
+            if (lane.pluginDescriptor[(size_t) p].has_value())
+                slot["plugin_descriptor"] = descriptorToObject (
+                    *lane.pluginDescriptor[(size_t) p]);
+            else if (lane.pluginLegacyDescriptionXml[(size_t) p].isNotEmpty())
+                slot["plugin_desc_xml"] = toStd (
+                    lane.pluginLegacyDescriptionXml[(size_t) p]);
             slot["plugin_state"]    = toStd (lane.pluginStateBase64[(size_t) p]);
 
             // Native CLAP slot (mutually exclusive with the JUCE plugin). Only emit
@@ -1776,7 +1805,13 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
                 {
                     const auto& sv = slots[(size_t) p];
                     if (! sv.is_object()) continue;
-                    lane.pluginDescriptionXml[(size_t) p] = json::getString (sv, "plugin_desc_xml");
+                    lane.pluginDescriptor[(size_t) p].reset();
+                    if (const auto it = sv.find ("plugin_descriptor");
+                        it != sv.end() && it->is_object())
+                        lane.pluginDescriptor[(size_t) p] = descriptorFromObject (*it);
+                    lane.pluginLegacyDescriptionXml[(size_t) p]
+                        = lane.pluginDescriptor[(size_t) p].has_value()
+                            ? juce::String() : json::getString (sv, "plugin_desc_xml");
                     lane.pluginStateBase64[(size_t) p]    = json::getString (sv, "plugin_state");
                     lane.nativeClapPath[(size_t) p]        = json::getString (sv, "native_clap_path");
                     lane.nativeClapPluginId[(size_t) p]    = json::getString (sv, "native_clap_plugin");

--- a/src/ui/AppConfig.h
+++ b/src/ui/AppConfig.h
@@ -21,7 +21,7 @@ float getUiScaleOverride();
 void  setUiScaleOverride (float scale);
 
 // Scan installed plugin formats on every app launch (synchronous). When
-// false (default) the cached KnownPluginList is used as-is and the user
+// false (default) the cached plugin descriptor list is used as-is and the user
 // runs scans manually from the plugin picker's "Scan plugins" button.
 // Persisted per-machine so the choice survives session changes.
 bool getScanPluginsOnStartup();

--- a/src/ui/AudioSettingsPanel.cpp
+++ b/src/ui/AudioSettingsPanel.cpp
@@ -386,7 +386,7 @@ AudioSettingsPanel::AudioSettingsPanel (device::DeviceManager& dm,
     scanOnStartupToggle.setTooltip (
         "When on, every app launch synchronously scans every "
         "installed plugin format and refreshes the cached "
-        "KnownPluginList. Saved per-machine; takes effect on next "
+        "plugin cache. Saved per-machine; takes effect on next "
         "launch. Stderr logs an [Dusk Studio] Scan-on-startup line "
         "with the added / total counts.");
     scanOnStartupToggle.onClick = [this]

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -1800,7 +1800,7 @@ void ChannelStripComponent::openPluginPicker()
             self->loadNativeClapForChannel (f, id);
     };
 #endif
-    // Native LV2 route - same shape; LV2-Native rows replace the JUCE LV2 rows.
+    // Native LV2 route - same shape; native rows replace the JUCE LV2 rows.
     std::function<void (const juce::File&, const juce::String&)> onLv2;
 #if DUSKSTUDIO_HAS_NATIVE_LV2
     onLv2 = [safe] (const juce::File& f, const juce::String& id)
@@ -1809,7 +1809,7 @@ void ChannelStripComponent::openPluginPicker()
             self->loadNativeLv2ForChannel (f, id);
     };
 #endif
-    // Native VST3 route - same shape; VST3-Native rows replace the JUCE VST3 rows.
+    // Native VST3 route - same shape; native rows replace the JUCE VST3 rows.
     std::function<void (const juce::File&, const juce::String&)> onVst3;
 #if DUSKSTUDIO_HAS_NATIVE_VST3
     onVst3 = [safe] (const juce::File& f, const juce::String& id)

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -3098,8 +3098,8 @@ bool MainComponent::finishLoadingSessionFrom (const juce::File& sourceJson,
     // Seeding it here would miss those fields and the first autosave tick
     // would still fire (snapshot mismatch). The seed lives at the tail.
 
-    // After deserialisation, the Track::pluginDescriptionXml /
-    // pluginStateBase64 fields are populated; ask the engine to
+    // After deserialisation, the track descriptor/state fields are populated;
+    // ask the engine to
     // re-instantiate each track's plugin from those.
     // Drop the prior session's undo stack BEFORE consuming plugin
     // state. Without this, hitting Cmd+Z right after a session load
@@ -3287,7 +3287,8 @@ bool MainComponent::finishLoadingSessionFrom (const juce::File& sourceJson,
             const auto& lane = self->session.auxLane (a);
             for (int s = 0; s < AuxLaneParams::kMaxLanePlugins; ++s)
                 if (lane.nativeClapPath[(size_t) s].isNotEmpty()
-                    || lane.pluginDescriptionXml[(size_t) s].isNotEmpty())
+                    || lane.pluginDescriptor[(size_t) s].has_value()
+                    || lane.pluginLegacyDescriptionXml[(size_t) s].isNotEmpty())
                 { anyAuxInsert = true; break; }
         }
         if (anyAuxInsert)

--- a/src/ui/PluginPickerHelpers.cpp
+++ b/src/ui/PluginPickerHelpers.cpp
@@ -5,7 +5,6 @@
 #include "PluginPickerPanel.h"
 #include "../engine/PluginManager.h"
 #include "../engine/PluginSlot.h"
-#include "../engine/hosting/NativePluginId.h"
 #include <algorithm>
 #if DUSKSTUDIO_HAS_MULTISAMPLE
  #include "../engine/multisample/AriaBank.h"
@@ -202,7 +201,7 @@ void runScanModal (PluginManager& manager, juce::Component* parent,
             auto message = juce::String::formatted (
                 "Added %d plugin%s to the picker. (Total known: %d)",
                 added, added == 1 ? "" : "s",
-                manager.getKnownPluginList().getNumTypes());
+                manager.getPluginCount());
 
             if (const int skipped = manager.getLastScanSandboxSkips(); skipped > 0)
                 message << juce::String::formatted (
@@ -227,7 +226,7 @@ namespace
 // Returns true when the plugin currently loaded into `slot` matches the
 // expected kind. Empty slot returns false (caller decides whether to
 // treat that as success or failure). Message-thread only - calls into
-// the plugin via fillInPluginDescription.
+// the plugin through its cached descriptor.
 bool loadedKindMatches (PluginSlot& slot, PluginKind kind)
 {
     if (! slot.isLoaded()) return false;
@@ -388,30 +387,53 @@ void openPickerMenu (PluginSlot& slot,
 
     // Merge native-CLAP plugins into the unified list when the caller can host them.
     if (onPickNativeClap)
-        descriptions.addArray (kind == PluginKind::Effects
-                                 ? manager.getClapEffectDescriptions()
-                                 : manager.getClapInstrumentDescriptions());
+    {
+        auto native = kind == PluginKind::Effects
+                        ? manager.getClapEffectDescriptions()
+                        : manager.getClapInstrumentDescriptions();
+        descriptions.insert (descriptions.end(),
+                             std::make_move_iterator (native.begin()),
+                             std::make_move_iterator (native.end()));
+    }
 
     // Native-LV2 rows replace the JUCE-hosted LV2 rows for both kinds (same
     // plugins, better host) so each plugin appears once. JUCE LV2 stays the
     // fallback when unset.
     if (onPickNativeLv2)
     {
-        descriptions.removeIf ([] (const juce::PluginDescription& d)
-                               { return d.pluginFormatName == "LV2"; });
-        descriptions.addArray (kind == PluginKind::Effects
-                                 ? manager.getLv2EffectDescriptions()
-                                 : manager.getLv2InstrumentDescriptions());
+        descriptions.erase (
+            std::remove_if (descriptions.begin(), descriptions.end(),
+                [] (const PluginDescriptor& descriptor)
+                {
+                    return descriptor.backend == PluginBackend::JuceLegacy
+                        && descriptor.formatName == "LV2";
+                }),
+            descriptions.end());
+        auto native = kind == PluginKind::Effects
+                        ? manager.getLv2EffectDescriptions()
+                        : manager.getLv2InstrumentDescriptions();
+        descriptions.insert (descriptions.end(),
+                             std::make_move_iterator (native.begin()),
+                             std::make_move_iterator (native.end()));
     }
 
     // Native-VST3 rows replace the JUCE-hosted VST3 rows for both kinds.
     if (onPickNativeVst3)
     {
-        descriptions.removeIf ([] (const juce::PluginDescription& d)
-                               { return d.pluginFormatName == "VST3"; });
-        descriptions.addArray (kind == PluginKind::Effects
-                                 ? manager.getVst3NativeEffectDescriptions()
-                                 : manager.getVst3NativeInstrumentDescriptions());
+        descriptions.erase (
+            std::remove_if (descriptions.begin(), descriptions.end(),
+                [] (const PluginDescriptor& descriptor)
+                {
+                    return descriptor.backend == PluginBackend::JuceLegacy
+                        && descriptor.formatName == "VST3";
+                }),
+            descriptions.end());
+        auto native = kind == PluginKind::Effects
+                        ? manager.getVst3NativeEffectDescriptions()
+                        : manager.getVst3NativeInstrumentDescriptions();
+        descriptions.insert (descriptions.end(),
+                             std::make_move_iterator (native.begin()),
+                             std::make_move_iterator (native.end()));
     }
 
     auto* parent = target.getTopLevelComponent();
@@ -496,7 +518,7 @@ void openPickerMenu (PluginSlot& slot,
 
     cb.onPickPlugin = [closeModal, slotPtr, safeTarget, safeParent, onChange, kind,
                        onPickNativeClap, onPickNativeLv2, onPickNativeVst3]
-                        (const juce::PluginDescription& desc) mutable
+                        (const PluginDescriptor& desc) mutable
     {
         closeModal();
         if (safeTarget.getComponent() == nullptr) return;
@@ -506,24 +528,21 @@ void openPickerMenu (PluginSlot& slot,
         // so DON'T also fire the generic onChange here - on a failed load it would
         // refresh state as if the slot loaded (the JUCE path only refreshes on a
         // successful async load).
-        if (desc.pluginFormatName == "CLAP"
-            || desc.pluginFormatName == "LV2-Native"
-            || desc.pluginFormatName == "VST3-Native")
+        if (desc.backend == PluginBackend::Native)
         {
-            // fileOrIdentifier carries "bundle\npluginId" so a row picks ITS
-            // plugin out of a multi-plugin bundle, not the bundle's first.
-            const auto ident = hosting::splitNativeIdentifier (desc.fileOrIdentifier);
-            if (desc.pluginFormatName == "CLAP")
-            { if (onPickNativeClap) onPickNativeClap (juce::File (ident.bundlePath), ident.pluginId); }
-            else if (desc.pluginFormatName == "LV2-Native")
-            { if (onPickNativeLv2)  onPickNativeLv2  (juce::File (ident.bundlePath), ident.pluginId); }
-            else
-            { if (onPickNativeVst3) onPickNativeVst3 (juce::File (ident.bundlePath), ident.pluginId); }
+            const juce::File bundle (desc.location);
+            const juce::String pluginId (desc.pluginId);
+            if (desc.formatName == "CLAP")
+            { if (onPickNativeClap) onPickNativeClap (bundle, pluginId); }
+            else if (desc.formatName == "LV2")
+            { if (onPickNativeLv2)  onPickNativeLv2  (bundle, pluginId); }
+            else if (desc.formatName == "VST3")
+            { if (onPickNativeVst3) onPickNativeVst3 (bundle, pluginId); }
             return;
         }
 
         // Defence-in-depth: getInstrument/EffectDescriptions already
-        // filtered by kind, but a stale KnownPluginList entry could slip
+        // filtered by kind, but a stale cache entry could slip
         // through (plugin reclassified by vendor since last scan).
         const bool descMatches = (kind == PluginKind::Instruments)
                                    ? desc.isInstrument
@@ -539,7 +558,7 @@ void openPickerMenu (PluginSlot& slot,
         // the UI. The completion runs on the message thread, and only if the
         // slot is still alive (PluginSlot's internal guard), so slotPtr is safe
         // to deref here.
-        slotPtr->loadFromDescriptionAsync (desc,
+        slotPtr->loadFromDescriptorAsync (desc,
             [slotPtr, safeParent, onChange, kind] (bool ok, juce::String error) mutable
         {
             if (! ok)

--- a/src/ui/PluginPickerHelpers.h
+++ b/src/ui/PluginPickerHelpers.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <juce_audio_processors/juce_audio_processors.h>
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <functional>
 #include <memory>
@@ -14,7 +13,7 @@ class PluginSlot;
 // slots. The picker, scan, and file-chooser flows are identical between the
 // two surfaces; the only differences are which PluginSlot they target and
 // what to refresh on success. Keeping the implementation here avoids two
-// slowly-diverging copies of the same menu-building / load-from-description
+// slowly-diverging copies of the same menu-building / descriptor-load
 // code.
 namespace pluginpicker
 {
@@ -27,7 +26,7 @@ namespace pluginpicker
 enum class PluginKind { Effects, Instruments };
 
 // Open a popup menu of installed plugins anchored on `target`. On selection:
-//   - 1..N -> resolves to KnownPluginList types and loadFromDescription.
+//   - 1..N -> resolves to cached descriptors and loads the selected plugin.
 //   - "Scan plugins" -> runs the synchronous scan + reopens the picker.
 //   - "Browse for file..." -> opens the in-window DuskFileBrowser.
 // `onChange` runs on every successful change to the slot.
@@ -51,11 +50,11 @@ enum class PluginKind { Effects, Instruments };
 // bundle path) instead of the JUCE loader. Used by every surface with a native CLAP
 // host - aux lanes AND channel-strip effect slots - which expose CLAP rows alongside
 // their JUCE-hosted VST3/LV2/AU. Unset -> no CLAP rows (surfaces without a native host).
-// `onPickNativeLv2` is the LV2 twin: merges "LV2-Native" rows (bundle-directory
+// `onPickNativeLv2` is the LV2 twin: merges native LV2 rows (bundle-directory
 // paths) and routes their selection here. When set, JUCE-format "LV2" effect rows
 // are hidden so each plugin appears once, hosted natively; unset -> JUCE LV2 rows
 // stay as the fallback host.
-// `onPickNativeVst3` is the VST3 twin: merges "VST3-Native" rows (.vst3 bundle
+// `onPickNativeVst3` is the VST3 twin: merges native VST3 rows (.vst3 bundle
 // paths), hides the JUCE-format "VST3" effect rows, and routes selection here.
 // `onPickSoundfont`, when set, adds the "Soundfont" button to an instrument
 // picker and hands the chosen .sfz / .sf2 to the caller's multisample rung.

--- a/src/ui/PluginPickerPanel.cpp
+++ b/src/ui/PluginPickerPanel.cpp
@@ -14,8 +14,8 @@ class PluginPickerPanel::ListBody final : public juce::Component
 public:
     enum class Group { Manufacturer, Type };
 
-    ListBody (juce::Array<juce::PluginDescription> descs,
-              std::function<void (const juce::PluginDescription&)> picker)
+    ListBody (std::vector<PluginDescriptor> descs,
+              std::function<void (const PluginDescriptor&)> picker)
         : rawDescs (std::move (descs)), onPick (std::move (picker))
     {
         rebuild();
@@ -29,16 +29,16 @@ public:
     }
 
     // Header key a description sorts/groups under, per current group mode.
-    static juce::String groupKeyFor (const juce::PluginDescription& d, Group g)
+    static juce::String groupKeyFor (const PluginDescriptor& d, Group g)
     {
         if (g == Group::Manufacturer)
-            return d.manufacturerName.isEmpty() ? juce::String ("(unknown)")
-                                                : d.manufacturerName;
+            return d.manufacturer.empty() ? juce::String ("(unknown)")
+                                          : juce::String (d.manufacturer);
 
         // Type: the plugin category, reduced to its most specific token
         // ("Fx|EQ" -> "EQ"). Falls back to instrument/effect when the
         // scanned description carries no category (e.g. native CLAP).
-        auto cat = d.category.trim();
+        auto cat = juce::String (d.category).trim();
         if (cat.containsChar ('|'))
             cat = cat.fromLastOccurrenceOf ("|", false, false).trim();
         if (cat.isNotEmpty())
@@ -51,20 +51,20 @@ public:
         auto descs = rawDescs;
         const auto g = group;
         std::sort (descs.begin(), descs.end(),
-            [g] (const juce::PluginDescription& a, const juce::PluginDescription& b)
+            [g] (const PluginDescriptor& a, const PluginDescriptor& b)
             {
                 const auto ka = groupKeyFor (a, g);
                 const auto kb = groupKeyFor (b, g);
                 if (ka != kb) return ka.compareIgnoreCase (kb) < 0;
-                return a.name.compareIgnoreCase (b.name) < 0;
+                return juce::String (a.name).compareIgnoreCase (juce::String (b.name)) < 0;
             });
 
         allEntries.clear();
         juce::String currentKey;
         bool first = true;
-        for (int i = 0; i < descs.size(); ++i)
+        for (size_t i = 0; i < descs.size(); ++i)
         {
-            const auto& d = descs.getReference (i);
+            const auto& d = descs[i];
             const auto key = groupKeyFor (d, g);
             if (first || key != currentKey)
             {
@@ -72,9 +72,16 @@ public:
                 currentKey = key;
                 first = false;
             }
-            juce::String label = d.name;
-            if (d.pluginFormatName.isNotEmpty())
-                label += "  (" + d.pluginFormatName + ")";
+            juce::String label (d.name);
+            if (! d.formatName.empty())
+            {
+                auto visibleFormat = juce::String (d.formatName);
+                if (d.backend == PluginBackend::Native && d.formatName == "LV2")
+                    visibleFormat = "LV2-Native";
+                else if (d.backend == PluginBackend::Native && d.formatName == "VST3")
+                    visibleFormat = "VST3-Native";
+                label += "  (" + visibleFormat + ")";
+            }
             allEntries.push_back ({ false, label, d });
         }
         applyFilter (currentFilter);
@@ -211,7 +218,7 @@ private:
     {
         bool isHeader;
         juce::String text;
-        juce::PluginDescription desc;
+        PluginDescriptor desc;
     };
 
     static constexpr int kRowH       = 22;
@@ -256,16 +263,16 @@ private:
         g.fillRect (x + 1, thumbY, kScrollbarW - 2, thumbH);
     }
 
-    juce::Array<juce::PluginDescription> rawDescs;
+    std::vector<PluginDescriptor> rawDescs;
     Group group = Group::Manufacturer;
     juce::String currentFilter;
     std::vector<Entry> allEntries;
     std::vector<Entry> visibleEntries;
-    std::function<void (const juce::PluginDescription&)> onPick;
+    std::function<void (const PluginDescriptor&)> onPick;
     int scrollOffset = 0;
 };
 
-PluginPickerPanel::PluginPickerPanel (juce::Array<juce::PluginDescription> descriptions,
+PluginPickerPanel::PluginPickerPanel (std::vector<PluginDescriptor> descriptions,
                                         Kind kind, Callbacks cb)
     : kind_ (kind), callbacks_ (std::move (cb))
 {
@@ -327,7 +334,7 @@ PluginPickerPanel::PluginPickerPanel (juce::Array<juce::PluginDescription> descr
     if (callbacks_.onHardwareInsert) addAndMakeVisible (hwInsertBtn);
     if (callbacks_.onLoadSoundfont)  addAndMakeVisible (soundfontBtn);
 
-    auto pickFn = [this] (const juce::PluginDescription& desc)
+    auto pickFn = [this] (const PluginDescriptor& desc)
     {
         if (callbacks_.onPickPlugin) callbacks_.onPickPlugin (desc);
     };

--- a/src/ui/PluginPickerPanel.h
+++ b/src/ui/PluginPickerPanel.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include "../engine/PluginDescriptor.h"
 #include <juce_gui_basics/juce_gui_basics.h>
+
+#include "../engine/PluginDescriptor.h"
+
 #include <functional>
 #include <vector>
 

--- a/src/ui/PluginPickerPanel.h
+++ b/src/ui/PluginPickerPanel.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include "../engine/PluginDescriptor.h"
 #include <juce_gui_basics/juce_gui_basics.h>
-#include <juce_audio_processors/juce_audio_processors.h>
 #include <functional>
+#include <vector>
 
 namespace duskstudio
 {
@@ -28,7 +29,7 @@ public:
     {
         // Fired on row click. Description is owned by the panel; copy if
         // you need it past the callback's stack frame.
-        std::function<void (const juce::PluginDescription&)> onPickPlugin;
+        std::function<void (const PluginDescriptor&)> onPickPlugin;
         std::function<void()> onScan;
         std::function<void()> onBrowseFile;
         std::function<void()> onHardwareInsert;   // null -> omit button
@@ -36,7 +37,7 @@ public:
         std::function<void()> onCancel;
     };
 
-    PluginPickerPanel (juce::Array<juce::PluginDescription> descriptions,
+    PluginPickerPanel (std::vector<PluginDescriptor> descriptions,
                        Kind kind,
                        Callbacks cb);
     ~PluginPickerPanel() override;

--- a/src/ui/ScreenshotCapture.cpp
+++ b/src/ui/ScreenshotCapture.cpp
@@ -410,12 +410,12 @@ void MainComponent::captureScreenshots (const juce::File& outDir)
         // Plugin picker with a synthetic effect list (no real scan in capture mode).
         auto mk = [] (const char* n, const char* mfr, const char* cat)
         {
-            juce::PluginDescription d;
-            d.name = n; d.manufacturerName = mfr; d.category = cat;
-            d.pluginFormatName = "VST3"; d.version = "1.0";
+            PluginDescriptor d;
+            d.name = n; d.manufacturer = mfr; d.category = cat;
+            d.formatName = "VST3"; d.version = "1.0";
             return d;
         };
-        juce::Array<juce::PluginDescription> descs {
+        std::vector<PluginDescriptor> descs {
             mk ("Ambience",        "Smartelectronix", "Reverb"),
             mk ("TAL-Chorus-LX",   "TAL",             "Modulation"),
             mk ("Dragonfly Hall",  "Michael Willis",  "Reverb"),

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,14 @@ add_executable(dusk-studio-tests
     hosting_insert_adapter.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/hosting/InsertAdapter.cpp
     # Native CLAP tests + sources are Linux-only (dlopen/poll) — added conditionally below.
+    plugin_descriptor.cpp
+    ${CMAKE_SOURCE_DIR}/src/engine/PluginDescriptor.cpp
+    plugin_manager_descriptor.cpp
+    plugin_slot_persistence.cpp
+    ${CMAKE_SOURCE_DIR}/src/engine/PluginManager.cpp
+    ${CMAKE_SOURCE_DIR}/src/engine/PluginSlot.cpp
+    native_plugin_cache.cpp
+    ${CMAKE_SOURCE_DIR}/src/engine/NativePluginCache.cpp
     plugin_scan_protocol.cpp
     plugin_backing_check.cpp
     session_tick_conversion.cpp
@@ -29,6 +37,7 @@ add_executable(dusk-studio-tests
     snap_helpers.cpp
     fade_shapes.cpp
     crossfade.cpp
+    clone_plugin_snapshot.cpp
     fade_curve_path.cpp
     file_importer_audio.cpp
     hardware_insert.cpp
@@ -225,7 +234,8 @@ if(DUSKSTUDIO_NATIVE_LV2)
         lv2_instance_process.cpp
         lv2_native_slot.cpp
         ${CMAKE_SOURCE_DIR}/src/engine/lv2/Lv2Bundle.cpp
-        ${CMAKE_SOURCE_DIR}/src/engine/lv2/Lv2Instance.cpp)
+        ${CMAKE_SOURCE_DIR}/src/engine/lv2/Lv2Instance.cpp
+        ${CMAKE_SOURCE_DIR}/src/engine/lv2/Lv2Scanner.cpp)
     target_link_libraries(dusk-studio-tests PRIVATE PkgConfig::LILV PkgConfig::SUIL PkgConfig::LV2)
     target_compile_definitions(dusk-studio-tests PRIVATE DUSKSTUDIO_HAS_NATIVE_LV2=1)
 endif()
@@ -256,6 +266,7 @@ target_link_libraries(dusk-studio-tests PRIVATE
     ${CMAKE_DL_LIBS}   # dl: ClapBundle dlopen
     juce::juce_audio_basics
     juce::juce_audio_formats
+    juce::juce_audio_processors
     # juce_data_structures brings in juce::ValueTree, which carries the
     # multisample state blob.
     juce::juce_data_structures
@@ -307,12 +318,15 @@ if (_duskstudio_ipc_test_enabled)
         ${CMAKE_SOURCE_DIR}/src/engine/ipc/RemotePluginConnection.cpp
         ${_duskstudio_ipc_test_sources})
     target_compile_definitions(dusk-studio-tests PRIVATE
+        DUSKSTUDIO_HAS_OOP_PLUGINS=1
         DUSKSTUDIO_PLUGIN_HOST_PATH="$<TARGET_FILE:dusk-studio-plugin-host>")
     if (WIN32)
         target_link_libraries(dusk-studio-tests PRIVATE synchronization)
     endif()
     add_dependencies(dusk-studio-tests dusk-studio-plugin-host)
 endif()
+
+target_compile_definitions(dusk-studio-tests PRIVATE DUSKSTUDIO_TESTS=1)
 
 # UniversalCompressor (multi-comp donor) tests — gated on the donor being
 # available. Mirrors the main app's DUSK_PLUGINS_PATH wiring exactly so the

--- a/tests/atomic_park.cpp
+++ b/tests/atomic_park.cpp
@@ -5,7 +5,7 @@
 #include <atomic>
 
 // withParkedAtomicPointer is the bracketing primitive that guards
-// PluginSlot::getStateBase64ForSave / getDescriptionXmlForSave from
+// PluginSlot::getStateBase64ForSave from
 // racing the audio thread inside the plugin. Phase A of the Mutter-
 // safety work moved it here so it's testable without needing a real
 // plugin instance.

--- a/tests/clone_plugin_snapshot.cpp
+++ b/tests/clone_plugin_snapshot.cpp
@@ -1,0 +1,35 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "session/RegionEditActions.h"
+
+using namespace duskstudio;
+
+namespace
+{
+ClonePluginSnapshot snapshot (std::string name, juce::String legacy,
+                              juce::String state)
+{
+    PluginDescriptor descriptor;
+    descriptor.name = std::move (name);
+    descriptor.formatName = "Future";
+    descriptor.location = "/missing/plugin";
+    return { descriptor, std::move (legacy), std::move (state) };
+}
+} // namespace
+
+TEST_CASE ("clone plugin snapshot replays descriptor legacy fallback and state")
+{
+    Track destination;
+    const auto before = snapshot ("Before", "<BROKEN before", "YmVmb3Jl");
+    const auto after = snapshot ("After", "<BROKEN after", "YWZ0ZXI=");
+    before.publishTo (destination);
+
+    after.publishTo (destination);   // perform
+    CHECK (ClonePluginSnapshot::fromTrack (destination) == after);
+
+    before.publishTo (destination);  // undo
+    CHECK (ClonePluginSnapshot::fromTrack (destination) == before);
+
+    after.publishTo (destination);   // redo
+    CHECK (ClonePluginSnapshot::fromTrack (destination) == after);
+}

--- a/tests/native_plugin_cache.cpp
+++ b/tests/native_plugin_cache.cpp
@@ -1,0 +1,64 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/NativePluginCache.h"
+#include <nlohmann/json.hpp>
+
+using namespace duskstudio;
+
+namespace
+{
+PluginDescriptor descriptorAt (std::string location)
+{
+    PluginDescriptor descriptor;
+    descriptor.name = "Native";
+    descriptor.formatName = "CLAP";
+    descriptor.backend = PluginBackend::Native;
+    descriptor.location = std::move (location);
+    descriptor.pluginId = "org.dusk.native";
+    return descriptor;
+}
+} // namespace
+
+TEST_CASE ("native plugin cache round-trips descriptors and prunes stale locations")
+{
+    const auto present = descriptorAt ("/plugins/present.clap");
+    const auto stale = descriptorAt ("/plugins/stale.clap");
+    const auto payload = nativecache::serialize ({ present, stale });
+
+    std::vector<PluginDescriptor> parsed;
+    REQUIRE (nativecache::parse (payload,
+        [] (std::string_view location) { return location == "/plugins/present.clap"; },
+        parsed));
+    REQUIRE (parsed.size() == 1);
+    CHECK (parsed.front() == present);
+}
+
+TEST_CASE ("native plugin cache malformed schema never throws or mutates output")
+{
+    std::vector<PluginDescriptor> parsed { descriptorAt ("/keep.clap") };
+    CHECK_FALSE (nativecache::parse (R"({"version":"1"})", {}, parsed));
+    REQUIRE (parsed.size() == 1);
+    CHECK (parsed.front().location == "/keep.clap");
+
+    CHECK_FALSE (nativecache::parse (R"({"version":1,"descriptors":{}})", {}, parsed));
+    REQUIRE (parsed.size() == 1);
+    CHECK (parsed.front().location == "/keep.clap");
+
+    CHECK_FALSE (nativecache::parse (R"({"version":-1,"descriptors":[]})", {}, parsed));
+    REQUIRE (parsed.size() == 1);
+    CHECK (parsed.front().location == "/keep.clap");
+}
+
+TEST_CASE ("native plugin cache skips malformed descriptor rows best-effort")
+{
+    auto root = nlohmann::json::parse (
+        nativecache::serialize ({ descriptorAt ("/valid.clap") }));
+    root["descriptors"].push_back (
+        nlohmann::json::object ({ { "version", 1 }, { "backend", "native" },
+                                  { "unique_id", 4.5 } }));
+
+    std::vector<PluginDescriptor> parsed;
+    REQUIRE (nativecache::parse (root.dump(), {}, parsed));
+    REQUIRE (parsed.size() == 1);
+    CHECK (parsed.front().location == "/valid.clap");
+}

--- a/tests/native_plugin_cache.cpp
+++ b/tests/native_plugin_cache.cpp
@@ -35,18 +35,29 @@ TEST_CASE ("native plugin cache round-trips descriptors and prunes stale locatio
 
 TEST_CASE ("native plugin cache malformed schema never throws or mutates output")
 {
-    std::vector<PluginDescriptor> parsed { descriptorAt ("/keep.clap") };
-    CHECK_FALSE (nativecache::parse (R"({"version":"1"})", {}, parsed));
-    REQUIRE (parsed.size() == 1);
-    CHECK (parsed.front().location == "/keep.clap");
-
-    CHECK_FALSE (nativecache::parse (R"({"version":1,"descriptors":{}})", {}, parsed));
-    REQUIRE (parsed.size() == 1);
-    CHECK (parsed.front().location == "/keep.clap");
-
-    CHECK_FALSE (nativecache::parse (R"({"version":-1,"descriptors":[]})", {}, parsed));
-    REQUIRE (parsed.size() == 1);
-    CHECK (parsed.front().location == "/keep.clap");
+    SECTION ("version has the wrong type")
+    {
+        std::vector<PluginDescriptor> parsed { descriptorAt ("/keep.clap") };
+        CHECK_FALSE (nativecache::parse (R"({"version":"1"})", {}, parsed));
+        REQUIRE (parsed.size() == 1);
+        CHECK (parsed.front().location == "/keep.clap");
+    }
+    SECTION ("descriptors has the wrong shape")
+    {
+        std::vector<PluginDescriptor> parsed { descriptorAt ("/keep.clap") };
+        CHECK_FALSE (nativecache::parse (
+            R"({"version":1,"descriptors":{}})", {}, parsed));
+        REQUIRE (parsed.size() == 1);
+        CHECK (parsed.front().location == "/keep.clap");
+    }
+    SECTION ("version is unsupported")
+    {
+        std::vector<PluginDescriptor> parsed { descriptorAt ("/keep.clap") };
+        CHECK_FALSE (nativecache::parse (
+            R"({"version":-1,"descriptors":[]})", {}, parsed));
+        REQUIRE (parsed.size() == 1);
+        CHECK (parsed.front().location == "/keep.clap");
+    }
 }
 
 TEST_CASE ("native plugin cache skips malformed descriptor rows best-effort")

--- a/tests/plugin_descriptor.cpp
+++ b/tests/plugin_descriptor.cpp
@@ -1,0 +1,98 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/PluginDescriptor.h"
+
+using namespace duskstudio;
+
+TEST_CASE ("plugin descriptor supplies defaults for missing optional fields")
+{
+    PluginDescriptor descriptor;
+    REQUIRE (PluginDescriptor::fromJson (
+        R"({"version":1,"backend":"juce_legacy","format_name":"Future"})",
+        descriptor));
+    CHECK (descriptor.formatName == "Future");
+    CHECK (descriptor.name.empty());
+    CHECK (descriptor.uniqueId == 0);
+    CHECK_FALSE (descriptor.isInstrument);
+}
+
+TEST_CASE ("plugin descriptor rejects malformed input without mutation")
+{
+    PluginDescriptor descriptor;
+    descriptor.name = "keep";
+    CHECK_FALSE (PluginDescriptor::fromJson ("[]", descriptor));
+    CHECK_FALSE (PluginDescriptor::fromJson (
+        R"({"version":1,"backend":"alien"})", descriptor));
+    CHECK_FALSE (PluginDescriptor::fromJson (
+        R"({"version":1,"backend":"native","unique_id":"bad"})", descriptor));
+    CHECK_FALSE (PluginDescriptor::fromJson (
+        R"({"version":1,"backend":"native","unique_id":1.5})", descriptor));
+    CHECK_FALSE (PluginDescriptor::fromJson (
+        R"({"version":1,"backend":"native","unique_id":2147483648})", descriptor));
+    CHECK_FALSE (PluginDescriptor::fromJson (
+        R"({"version":1,"backend":"native","deprecated_uid":-2147483649})", descriptor));
+    CHECK_FALSE (PluginDescriptor::fromJson (
+        R"({"version":1,"backend":"native","last_info_update_ms":9223372036854775808})",
+        descriptor));
+    CHECK_FALSE (PluginDescriptor::fromJson (
+        R"({"version":1,"backend":"native","num_input_channels":true})", descriptor));
+    CHECK_FALSE (PluginDescriptor::fromJson (
+        R"({"version":1,"backend":"native","is_instrument":1})", descriptor));
+    CHECK (descriptor.name == "keep");
+}
+
+TEST_CASE ("plugin descriptor preserves every field and unknown format names")
+{
+    PluginDescriptor descriptor;
+    descriptor.name = "Name";
+    descriptor.descriptiveName = "Descriptive";
+    descriptor.manufacturer = "Maker";
+    descriptor.category = "Category";
+    descriptor.version = "9.8.7";
+    descriptor.formatName = "FutureFormat";
+    descriptor.backend = PluginBackend::Native;
+    descriptor.location = "/bundle";
+    descriptor.pluginId = "inner.id";
+    descriptor.uniqueId = 123;
+    descriptor.deprecatedUid = -456;
+    descriptor.numInputChannels = 7;
+    descriptor.numOutputChannels = 8;
+    descriptor.lastFileModificationMs = 1234567890123;
+    descriptor.lastInfoUpdateMs = 2234567890123;
+    descriptor.isInstrument = true;
+    descriptor.hasSharedContainer = true;
+    descriptor.hasAraExtension = true;
+
+    PluginDescriptor restored;
+    REQUIRE (PluginDescriptor::fromJson (descriptor.toJson(), restored));
+    CHECK (restored == descriptor);
+}
+
+TEST_CASE ("loaded descriptor trusts instantiated classification but preserves reload identity")
+{
+    PluginDescriptor scanned;
+    scanned.name = "Scanned Effect";
+    scanned.formatName = "VST3";
+    scanned.backend = PluginBackend::JuceLegacy;
+    scanned.location = "/plugins/Shell.vst3";
+    scanned.pluginId = "shell-child";
+    scanned.isInstrument = false;
+
+    PluginDescriptor instantiated;
+    instantiated.name = "Actual Instrument";
+    instantiated.formatName = "VST3";
+    instantiated.location =
+        "/plugins/Shell.vst3/Contents/x86_64-linux/Shell.so";
+    instantiated.isInstrument = true;
+    instantiated.numInputChannels = 0;
+    instantiated.numOutputChannels = 2;
+
+    const auto merged = mergeLoadedPluginDescriptor (scanned, instantiated);
+    CHECK (merged.name == "Actual Instrument");
+    CHECK (merged.isInstrument);
+    CHECK (merged.numInputChannels == 0);
+    CHECK (merged.numOutputChannels == 2);
+    CHECK (merged.location == "/plugins/Shell.vst3");
+    CHECK (merged.pluginId == "shell-child");
+    CHECK (merged.backend == PluginBackend::JuceLegacy);
+}

--- a/tests/plugin_descriptor.cpp
+++ b/tests/plugin_descriptor.cpp
@@ -68,6 +68,20 @@ TEST_CASE ("plugin descriptor preserves every field and unknown format names")
     CHECK (restored == descriptor);
 }
 
+TEST_CASE ("plugin descriptor replaces invalid UTF-8 while serializing")
+{
+    PluginDescriptor descriptor;
+    descriptor.name = "Invalid ";
+    descriptor.name.push_back (static_cast<char> (0xff));
+
+    std::string serialized;
+    REQUIRE_NOTHROW (serialized = descriptor.toJson());
+
+    PluginDescriptor restored;
+    REQUIRE (PluginDescriptor::fromJson (serialized, restored));
+    CHECK (restored.name == std::string ("Invalid \xef\xbf\xbd"));
+}
+
 TEST_CASE ("loaded descriptor trusts instantiated classification but preserves reload identity")
 {
     PluginDescriptor scanned;

--- a/tests/plugin_descriptor.cpp
+++ b/tests/plugin_descriptor.cpp
@@ -2,6 +2,8 @@
 
 #include "engine/PluginDescriptor.h"
 
+#include <nlohmann/json.hpp>
+
 using namespace duskstudio;
 
 TEST_CASE ("plugin descriptor supplies defaults for missing optional fields")
@@ -20,25 +22,62 @@ TEST_CASE ("plugin descriptor rejects malformed input without mutation")
 {
     PluginDescriptor descriptor;
     descriptor.name = "keep";
-    CHECK_FALSE (PluginDescriptor::fromJson ("[]", descriptor));
-    CHECK_FALSE (PluginDescriptor::fromJson (
-        R"({"version":1,"backend":"alien"})", descriptor));
-    CHECK_FALSE (PluginDescriptor::fromJson (
-        R"({"version":1,"backend":"native","unique_id":"bad"})", descriptor));
-    CHECK_FALSE (PluginDescriptor::fromJson (
-        R"({"version":1,"backend":"native","unique_id":1.5})", descriptor));
-    CHECK_FALSE (PluginDescriptor::fromJson (
-        R"({"version":1,"backend":"native","unique_id":2147483648})", descriptor));
-    CHECK_FALSE (PluginDescriptor::fromJson (
-        R"({"version":1,"backend":"native","deprecated_uid":-2147483649})", descriptor));
-    CHECK_FALSE (PluginDescriptor::fromJson (
-        R"({"version":1,"backend":"native","last_info_update_ms":9223372036854775808})",
-        descriptor));
-    CHECK_FALSE (PluginDescriptor::fromJson (
-        R"({"version":1,"backend":"native","num_input_channels":true})", descriptor));
-    CHECK_FALSE (PluginDescriptor::fromJson (
-        R"({"version":1,"backend":"native","is_instrument":1})", descriptor));
-    CHECK (descriptor.name == "keep");
+    SECTION ("top-level array")
+    {
+        CHECK_FALSE (PluginDescriptor::fromJson ("[]", descriptor));
+        CHECK (descriptor.name == "keep");
+    }
+    SECTION ("unknown backend")
+    {
+        CHECK_FALSE (PluginDescriptor::fromJson (
+            R"({"version":1,"backend":"alien"})", descriptor));
+        CHECK (descriptor.name == "keep");
+    }
+    SECTION ("string integer field")
+    {
+        CHECK_FALSE (PluginDescriptor::fromJson (
+            R"({"version":1,"backend":"native","unique_id":"bad"})", descriptor));
+        CHECK (descriptor.name == "keep");
+    }
+    SECTION ("fractional integer field")
+    {
+        CHECK_FALSE (PluginDescriptor::fromJson (
+            R"({"version":1,"backend":"native","unique_id":1.5})", descriptor));
+        CHECK (descriptor.name == "keep");
+    }
+    SECTION ("positive 32-bit overflow")
+    {
+        CHECK_FALSE (PluginDescriptor::fromJson (
+            R"({"version":1,"backend":"native","unique_id":2147483648})", descriptor));
+        CHECK (descriptor.name == "keep");
+    }
+    SECTION ("negative 32-bit overflow")
+    {
+        CHECK_FALSE (PluginDescriptor::fromJson (
+            R"({"version":1,"backend":"native","deprecated_uid":-2147483649})",
+            descriptor));
+        CHECK (descriptor.name == "keep");
+    }
+    SECTION ("64-bit overflow")
+    {
+        CHECK_FALSE (PluginDescriptor::fromJson (
+            R"({"version":1,"backend":"native","last_info_update_ms":9223372036854775808})",
+            descriptor));
+        CHECK (descriptor.name == "keep");
+    }
+    SECTION ("boolean integer field")
+    {
+        CHECK_FALSE (PluginDescriptor::fromJson (
+            R"({"version":1,"backend":"native","num_input_channels":true})",
+            descriptor));
+        CHECK (descriptor.name == "keep");
+    }
+    SECTION ("integer boolean field")
+    {
+        CHECK_FALSE (PluginDescriptor::fromJson (
+            R"({"version":1,"backend":"native","is_instrument":1})", descriptor));
+        CHECK (descriptor.name == "keep");
+    }
 }
 
 TEST_CASE ("plugin descriptor preserves every field and unknown format names")
@@ -63,9 +102,40 @@ TEST_CASE ("plugin descriptor preserves every field and unknown format names")
     descriptor.hasSharedContainer = true;
     descriptor.hasAraExtension = true;
 
-    PluginDescriptor restored;
-    REQUIRE (PluginDescriptor::fromJson (descriptor.toJson(), restored));
-    CHECK (restored == descriptor);
+    SECTION ("object API")
+    {
+        const auto object = descriptor.toJsonObject();
+        REQUIRE (object.is_object());
+        REQUIRE_FALSE (object.empty());
+        CHECK (object.begin().key() == "version");
+        CHECK (object.rbegin().key() == "has_ara_extension");
+
+        PluginDescriptor restored;
+        const nlohmann::json objectForRead = object;
+        REQUIRE (PluginDescriptor::fromJsonObject (objectForRead, restored));
+        CHECK (restored == descriptor);
+    }
+
+    SECTION ("string compatibility API")
+    {
+        PluginDescriptor restored;
+        REQUIRE (PluginDescriptor::fromJson (descriptor.toJson(), restored));
+        CHECK (restored == descriptor);
+    }
+}
+
+TEST_CASE ("plugin descriptor object API rejects malformed data without mutation")
+{
+    PluginDescriptor descriptor;
+    descriptor.name = "keep";
+    const nlohmann::json malformed {
+        { "version", 1 },
+        { "backend", "native" },
+        { "is_instrument", 1 }
+    };
+
+    CHECK_FALSE (PluginDescriptor::fromJsonObject (malformed, descriptor));
+    CHECK (descriptor.name == "keep");
 }
 
 TEST_CASE ("plugin descriptor replaces invalid UTF-8 while serializing")

--- a/tests/plugin_manager_descriptor.cpp
+++ b/tests/plugin_manager_descriptor.cpp
@@ -1,0 +1,69 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/PluginManager.h"
+
+using namespace duskstudio;
+
+namespace
+{
+PluginDescriptor completeDescriptor()
+{
+    PluginDescriptor descriptor;
+    descriptor.name = "Adapter";
+    descriptor.descriptiveName = "Adapter Long Name";
+    descriptor.manufacturer = "Dusk";
+    descriptor.category = "Fx|Delay";
+    descriptor.version = "4.2.1";
+    descriptor.formatName = "VST3";
+    descriptor.backend = PluginBackend::JuceLegacy;
+    descriptor.location = "/plugins/Adapter.vst3";
+    descriptor.uniqueId = 1234567;
+    descriptor.deprecatedUid = -7654321;
+    descriptor.numInputChannels = 2;
+    descriptor.numOutputChannels = 4;
+    descriptor.lastFileModificationMs = 1700000000123;
+    descriptor.lastInfoUpdateMs = 1700000000456;
+    descriptor.isInstrument = true;
+    descriptor.hasSharedContainer = true;
+    descriptor.hasAraExtension = true;
+    return descriptor;
+}
+} // namespace
+
+TEST_CASE ("PluginManager JUCE adapter round-trips every representable field")
+{
+    const auto expected = completeDescriptor();
+    const auto juceDescriptor = PluginManager::descriptorToJuceForTest (expected);
+    const auto restored = PluginManager::descriptorFromJuceForTest (juceDescriptor);
+    CHECK (restored == expected);
+}
+
+TEST_CASE ("PluginManager imports a legacy native XML cache once and prunes stale rows")
+{
+    auto present = PluginManager::descriptorToJuceForTest (completeDescriptor());
+    present.name = "Present";
+    present.pluginFormatName = "LV2-Native";
+    present.fileOrIdentifier = "/plugins/present.lv2\nhttps://dusk.audio/present";
+
+    auto stale = present;
+    stale.name = "Stale";
+    stale.fileOrIdentifier = "/plugins/stale.lv2\nhttps://dusk.audio/stale";
+
+    juce::XmlElement root ("KNOWNPLUGINS");
+    root.addChildElement (present.createXml().release());
+    root.addChildElement (stale.createXml().release());
+
+    const auto imported = PluginManager::importLegacyNativeCacheForTest (
+        root.toString (juce::XmlElement::TextFormat().singleLine()),
+        [] (const juce::File& location)
+        {
+            return location.getFullPathName() == "/plugins/present.lv2";
+        });
+
+    REQUIRE (imported.size() == 1);
+    CHECK (imported.front().name == "Present");
+    CHECK (imported.front().backend == PluginBackend::Native);
+    CHECK (imported.front().formatName == "LV2");
+    CHECK (imported.front().location == "/plugins/present.lv2");
+    CHECK (imported.front().pluginId == "https://dusk.audio/present");
+}

--- a/tests/plugin_manager_descriptor.cpp
+++ b/tests/plugin_manager_descriptor.cpp
@@ -91,7 +91,7 @@ TEST_CASE ("PluginManager imports a legacy native XML cache once and prunes stal
         root.toString (juce::XmlElement::TextFormat().singleLine()),
         [] (const juce::File& location)
         {
-            return location.getFullPathName() == "/plugins/present.lv2";
+            return location.getFileName() == "present.lv2";
         });
 
     REQUIRE (imported.size() == 1);
@@ -115,23 +115,32 @@ TEST_CASE ("PluginManager falls back from malformed native JSON without erasing 
         juce::XmlElement::TextFormat().singleLine());
     const auto locationExists = [] (const juce::File&) { return true; };
 
-    std::vector<PluginDescriptor> loaded { completeDescriptor() };
-    REQUIRE (PluginManager::loadNativeCacheSourcesForTest (
-        std::string ("{not json"), legacyXml, locationExists, loaded));
-    REQUIRE (loaded.size() == 1);
-    CHECK (loaded.front().name == "Legacy fallback");
-    CHECK (loaded.front().pluginId == "https://dusk.audio/fallback");
+    SECTION ("malformed JSON falls back to legacy XML")
+    {
+        std::vector<PluginDescriptor> loaded { completeDescriptor() };
+        REQUIRE (PluginManager::loadNativeCacheSourcesForTest (
+            std::string ("{not json"), legacyXml, locationExists, loaded));
+        REQUIRE (loaded.size() == 1);
+        CHECK (loaded.front().name == "Legacy fallback");
+        CHECK (loaded.front().pluginId == "https://dusk.audio/fallback");
+    }
 
-    loaded = { completeDescriptor() };
-    CHECK_FALSE (PluginManager::loadNativeCacheSourcesForTest (
-        std::string ("{not json"), juce::String ("<broken"),
-        locationExists, loaded));
-    REQUIRE (loaded.size() == 1);
-    CHECK (loaded.front() == completeDescriptor());
+    SECTION ("failed JSON and XML preserve the existing cache")
+    {
+        std::vector<PluginDescriptor> loaded { completeDescriptor() };
+        CHECK_FALSE (PluginManager::loadNativeCacheSourcesForTest (
+            std::string ("{not json"), juce::String ("<broken"),
+            locationExists, loaded));
+        REQUIRE (loaded.size() == 1);
+        CHECK (loaded.front() == completeDescriptor());
+    }
 
-    loaded = { completeDescriptor() };
-    REQUIRE (PluginManager::loadNativeCacheSourcesForTest (
-        std::string (R"({"version":1,"descriptors":[]})"),
-        legacyXml, locationExists, loaded));
-    CHECK (loaded.empty());
+    SECTION ("valid empty JSON overrides legacy XML")
+    {
+        std::vector<PluginDescriptor> loaded { completeDescriptor() };
+        REQUIRE (PluginManager::loadNativeCacheSourcesForTest (
+            std::string (R"({"version":1,"descriptors":[]})"),
+            legacyXml, locationExists, loaded));
+        CHECK (loaded.empty());
+    }
 }

--- a/tests/plugin_manager_descriptor.cpp
+++ b/tests/plugin_manager_descriptor.cpp
@@ -38,6 +38,40 @@ TEST_CASE ("PluginManager JUCE adapter round-trips every representable field")
     CHECK (restored == expected);
 }
 
+TEST_CASE ("PluginManager JUCE adapter preserves native inner plugin identity")
+{
+    auto first = completeDescriptor();
+    first.backend = PluginBackend::Native;
+    first.location = "/plugins/Shell.vst3";
+    first.pluginId = "shell.first";
+
+    auto second = first;
+    second.pluginId = "shell.second";
+
+    const auto firstJuce = PluginManager::descriptorToJuceForTest (first);
+    const auto secondJuce = PluginManager::descriptorToJuceForTest (second);
+    CHECK (firstJuce.fileOrIdentifier == "/plugins/Shell.vst3\nshell.first");
+    CHECK (secondJuce.fileOrIdentifier == "/plugins/Shell.vst3\nshell.second");
+    CHECK (firstJuce.fileOrIdentifier != secondJuce.fileOrIdentifier);
+    CHECK (PluginManager::descriptorFromJuceForTest (firstJuce) == first);
+    CHECK (PluginManager::descriptorFromJuceForTest (secondJuce) == second);
+}
+
+TEST_CASE ("PluginManager JUCE adapter leaves legacy identifiers unchanged")
+{
+    auto legacy = completeDescriptor();
+    legacy.backend = PluginBackend::JuceLegacy;
+    legacy.location = "legacy-format-specific-identifier";
+
+    const auto juceDescriptor = PluginManager::descriptorToJuceForTest (legacy);
+    CHECK (juceDescriptor.fileOrIdentifier.toStdString() == legacy.location);
+
+    const auto restored = PluginManager::descriptorFromJuceForTest (juceDescriptor);
+    CHECK (restored.backend == PluginBackend::JuceLegacy);
+    CHECK (restored.location == legacy.location);
+    CHECK (restored.pluginId.empty());
+}
+
 TEST_CASE ("PluginManager imports a legacy native XML cache once and prunes stale rows")
 {
     auto present = PluginManager::descriptorToJuceForTest (completeDescriptor());
@@ -66,4 +100,38 @@ TEST_CASE ("PluginManager imports a legacy native XML cache once and prunes stal
     CHECK (imported.front().formatName == "LV2");
     CHECK (imported.front().location == "/plugins/present.lv2");
     CHECK (imported.front().pluginId == "https://dusk.audio/present");
+}
+
+TEST_CASE ("PluginManager falls back from malformed native JSON without erasing cache")
+{
+    auto legacy = PluginManager::descriptorToJuceForTest (completeDescriptor());
+    legacy.name = "Legacy fallback";
+    legacy.pluginFormatName = "LV2-Native";
+    legacy.fileOrIdentifier = "/plugins/fallback.lv2\nhttps://dusk.audio/fallback";
+
+    juce::XmlElement root ("KNOWNPLUGINS");
+    root.addChildElement (legacy.createXml().release());
+    const auto legacyXml = root.toString (
+        juce::XmlElement::TextFormat().singleLine());
+    const auto locationExists = [] (const juce::File&) { return true; };
+
+    std::vector<PluginDescriptor> loaded { completeDescriptor() };
+    REQUIRE (PluginManager::loadNativeCacheSourcesForTest (
+        std::string ("{not json"), legacyXml, locationExists, loaded));
+    REQUIRE (loaded.size() == 1);
+    CHECK (loaded.front().name == "Legacy fallback");
+    CHECK (loaded.front().pluginId == "https://dusk.audio/fallback");
+
+    loaded = { completeDescriptor() };
+    CHECK_FALSE (PluginManager::loadNativeCacheSourcesForTest (
+        std::string ("{not json"), juce::String ("<broken"),
+        locationExists, loaded));
+    REQUIRE (loaded.size() == 1);
+    CHECK (loaded.front() == completeDescriptor());
+
+    loaded = { completeDescriptor() };
+    REQUIRE (PluginManager::loadNativeCacheSourcesForTest (
+        std::string (R"({"version":1,"descriptors":[]})"),
+        legacyXml, locationExists, loaded));
+    CHECK (loaded.empty());
 }

--- a/tests/plugin_scan_protocol.cpp
+++ b/tests/plugin_scan_protocol.cpp
@@ -2,122 +2,87 @@
 
 #include "engine/ipc/PluginScanProtocol.h"
 
-using namespace duskstudio::scanproto;
+using namespace duskstudio;
 
 namespace
 {
-juce::PluginDescription makeDesc (const juce::String& name,
-                                  const juce::String& format,
-                                  juce::uint32 uid,
-                                  bool isInstrument)
+PluginDescriptor makeDescriptor (std::string name, std::string location,
+                                 std::string pluginId)
 {
-    juce::PluginDescription d;
-    d.name             = name;
-    d.descriptiveName  = name;
-    d.pluginFormatName = format;
-    d.manufacturerName = "Acme";
-    d.fileOrIdentifier = "/some/path/" + name + ".vst3";
-    d.uniqueId         = (int) uid;
-    d.isInstrument     = isInstrument;
-    d.numInputChannels  = isInstrument ? 0 : 2;
-    d.numOutputChannels = 2;
-    return d;
+    PluginDescriptor descriptor;
+    descriptor.name = std::move (name);
+    descriptor.formatName = "VST3";
+    descriptor.backend = PluginBackend::Native;
+    descriptor.location = std::move (location);
+    descriptor.pluginId = std::move (pluginId);
+    descriptor.uniqueId = 0x123456;
+    descriptor.isInstrument = true;
+    return descriptor;
 }
 } // namespace
 
-TEST_CASE ("scan protocol round-trips plugin descriptions", "[scanproto]")
+TEST_CASE ("plugin scan protocol round-trips multiple descriptors")
 {
-    juce::OwnedArray<juce::PluginDescription> in;
-    in.add (new juce::PluginDescription (makeDesc ("Reverb",  "VST3", 0xabc123, false)));
-    in.add (new juce::PluginDescription (makeDesc ("Synth X", "VST3", 0x00ff01, true)));
-
-    const juce::String stdoutBytes = makePayload (in);
-
-    const juce::String payload = extractPayload (stdoutBytes);
-    REQUIRE (payload.isNotEmpty());
-
-    juce::OwnedArray<juce::PluginDescription> out;
-    parsePayload (payload, out);
-
-    REQUIRE (out.size() == 2);
-    CHECK (out[0]->name             == "Reverb");
-    CHECK (out[0]->pluginFormatName == "VST3");
-    CHECK (out[0]->uniqueId         == (int) 0xabc123);
-    CHECK (out[0]->isInstrument     == false);
-    CHECK (out[1]->name             == "Synth X");   // name with a space survives
-    CHECK (out[1]->isInstrument     == true);
-    CHECK (out[1]->uniqueId         == (int) 0x00ff01);
+    const std::vector<PluginDescriptor> input {
+        makeDescriptor ("Reverb", "/plugins/Reverb.vst3", "com.dusk.reverb"),
+        makeDescriptor ("Synth X", "/plugins/Synth X.vst3", "com.dusk.synth")
+    };
+    const auto framed = scanproto::makePayload (input);
+    const auto payload = scanproto::extractPayload (framed);
+    REQUIRE_FALSE (payload.empty());
+    REQUIRE (scanproto::parsePayload (payload) == input);
 }
 
-TEST_CASE ("scan protocol: clean empty result is not a crash", "[scanproto]")
+TEST_CASE ("plugin scan protocol distinguishes empty success from missing framing")
 {
-    // A search-path file that is not actually a plugin: the child finds zero
-    // descriptions but exits cleanly. The payload must still be extractable
-    // (so the parent does NOT blacklist it) and parse to zero descriptions.
-    juce::OwnedArray<juce::PluginDescription> none;
-    const juce::String payload = extractPayload (makePayload (none));
-    REQUIRE (payload.isNotEmpty());
-
-    juce::OwnedArray<juce::PluginDescription> out;
-    parsePayload (payload, out);
-    CHECK (out.isEmpty());
+    const auto framed = scanproto::makePayload ({});
+    const auto payload = scanproto::extractPayload (framed);
+    REQUIRE_FALSE (payload.empty());
+    REQUIRE (scanproto::parsePayload (payload).empty());
+    REQUIRE (scanproto::extractPayload ("plugin output only").empty());
+    REQUIRE (scanproto::extractPayload (
+        R"({"version":1,"descriptors":[]})==DUSK_SCAN_END==").empty());
+    REQUIRE (scanproto::extractPayload (
+        std::string (scanproto::kPayloadBegin) + "\n{}").empty());
+    REQUIRE (scanproto::extractPayload (
+        std::string (scanproto::kPayloadBegin) + "\n"
+        R"({"version":1,"descriptors":[]})"
+        "\n==DUSK_SCAN_EN").empty());
 }
 
-TEST_CASE ("scan protocol: missing/truncated payload reads as failure", "[scanproto]")
+TEST_CASE ("plugin scan protocol ignores output before its begin sentinel")
 {
-    SECTION ("no sentinels at all (child crashed before printing)")
-    {
-        CHECK (extractPayload ("").isEmpty());
-        CHECK (extractPayload ("Segmentation fault\n").isEmpty());
-    }
-    SECTION ("begin sentinel but no end (crashed mid-print)")
-    {
-        const juce::String truncated =
-            juce::String (kPayloadBegin) + "\n<PLUGINS><PLUGIN name=\"x\"";
-        CHECK (extractPayload (truncated).isEmpty());
-    }
-    SECTION ("end sentinel but no begin")
-    {
-        CHECK (extractPayload (juce::String ("noise ") + kPayloadEnd).isEmpty());
-    }
+    const auto row = makeDescriptor ("Delay", "/plugins/delay.vst3", "delay.inner");
+    const auto payload = scanproto::extractPayload (
+        std::string ("plugin wrote this first\n") + scanproto::makePayload ({ row }));
+    const auto parsed = scanproto::parsePayload (payload);
+    REQUIRE (parsed.size() == 1);
+    CHECK (parsed.front().location == "/plugins/delay.vst3");
+    CHECK (parsed.front().pluginId == "delay.inner");
 }
 
-TEST_CASE ("scan protocol: plugin stdout chatter before the payload is skipped", "[scanproto]")
+TEST_CASE ("plugin scan protocol rejects malformed JSON without partial rows")
 {
-    juce::OwnedArray<juce::PluginDescription> in;
-    in.add (new juce::PluginDescription (makeDesc ("Delay", "VST3", 0x42, false)));
-
-    // Plugins commonly spew banner / licence lines to stdout during init,
-    // which run before the payload is printed. extractPayload must skip them.
-    const juce::String noisy = "lib v1.2 loaded\n[plugin] hello world\n"
-                             + makePayload (in);
-
-    juce::OwnedArray<juce::PluginDescription> out;
-    parsePayload (extractPayload (noisy), out);
-    REQUIRE (out.size() == 1);
-    CHECK (out[0]->name == "Delay");
+    const auto valid = makeDescriptor ("Valid", "/valid.vst3", "valid");
+    auto root = nlohmann::json::parse (scanproto::extractPayload (
+        scanproto::makePayload ({ valid })));
+    root["descriptors"].push_back ("not an object");
+    REQUIRE (scanproto::parsePayload (root.dump()).empty());
+    REQUIRE (scanproto::parsePayload ("{not json").empty());
 }
 
-TEST_CASE ("scan protocol: malformed payload XML parses to nothing", "[scanproto]")
+TEST_CASE ("plugin scan protocol rejects an out-of-range schema version")
 {
-    juce::OwnedArray<juce::PluginDescription> out;
-    parsePayload ("<PLUGINS><PLUGIN garbled", out);   // not well-formed
-    CHECK (out.isEmpty());
+    REQUIRE (scanproto::parsePayload (
+        R"({"version":18446744073709551615,"descriptors":[]})").empty());
 }
 
-TEST_CASE ("scan sandbox policy: third-party formats are sandboxed, in-house is not",
-           "[scanproto]")
+TEST_CASE ("plugin scan sandbox policy")
 {
-    // Third-party binary formats load foreign code and MUST be scanned
-    // out-of-process — this is the decision that keeps an unauthorized / crashy
-    // plugin from taking down the app (issue #45).
-    CHECK (formatRequiresSandbox ("VST3"));
-    CHECK (formatRequiresSandbox ("VST"));
-    CHECK (formatRequiresSandbox ("LV2"));
-    CHECK (formatRequiresSandbox ("AudioUnit"));
-
-    // Everything else scans in-process: an unknown name defaults to in-process
-    // (never sandboxed by accident — but also never a third-party crash vector).
-    CHECK_FALSE (formatRequiresSandbox (""));
-    CHECK_FALSE (formatRequiresSandbox ("CLAP"));   // native CLAP has its own sandbox path
+    CHECK (scanproto::formatRequiresSandbox ("VST3"));
+    CHECK (scanproto::formatRequiresSandbox ("LV2"));
+    CHECK (scanproto::formatRequiresSandbox ("AudioUnit"));
+    CHECK (scanproto::formatRequiresSandbox ("VST"));
+    CHECK_FALSE (scanproto::formatRequiresSandbox ("DuskMultisample"));
+    CHECK_FALSE (scanproto::formatRequiresSandbox ("UnknownFutureFormat"));
 }

--- a/tests/plugin_scan_protocol.cpp
+++ b/tests/plugin_scan_protocol.cpp
@@ -37,21 +37,35 @@ TEST_CASE ("plugin scan protocol round-trips multiple descriptors")
 
 TEST_CASE ("plugin scan protocol distinguishes empty success from missing framing")
 {
-    const auto framed = scanproto::makePayload ({});
-    const auto payload = scanproto::extractPayload (framed);
-    REQUIRE_FALSE (payload.empty());
-    const auto parsed = scanproto::parsePayload (payload);
-    REQUIRE (parsed.has_value());
-    REQUIRE (parsed->empty());
-    REQUIRE (scanproto::extractPayload ("plugin output only").empty());
-    REQUIRE (scanproto::extractPayload (
-        R"scan({"version":1,"descriptors":[]}==DUSK_SCAN_END==)scan").empty());
-    REQUIRE (scanproto::extractPayload (
-        std::string (scanproto::kPayloadBegin) + "\n{}").empty());
-    REQUIRE (scanproto::extractPayload (
-        std::string (scanproto::kPayloadBegin) + "\n"
-        R"({"version":1,"descriptors":[]})"
-        "\n==DUSK_SCAN_EN").empty());
+    SECTION ("valid empty scan")
+    {
+        const auto payload = scanproto::extractPayload (scanproto::makePayload ({}));
+        REQUIRE_FALSE (payload.empty());
+        const auto parsed = scanproto::parsePayload (payload);
+        REQUIRE (parsed.has_value());
+        REQUIRE (parsed->empty());
+    }
+    SECTION ("no framing")
+    {
+        REQUIRE (scanproto::extractPayload ("plugin output only").empty());
+    }
+    SECTION ("end sentinel only")
+    {
+        REQUIRE (scanproto::extractPayload (
+            R"scan({"version":1,"descriptors":[]}==DUSK_SCAN_END==)scan").empty());
+    }
+    SECTION ("begin sentinel only")
+    {
+        REQUIRE (scanproto::extractPayload (
+            std::string (scanproto::kPayloadBegin) + "\n{}").empty());
+    }
+    SECTION ("truncated end sentinel")
+    {
+        REQUIRE (scanproto::extractPayload (
+            std::string (scanproto::kPayloadBegin) + "\n"
+            R"({"version":1,"descriptors":[]})"
+            "\n==DUSK_SCAN_EN").empty());
+    }
 }
 
 TEST_CASE ("plugin scan protocol ignores output before its begin sentinel")
@@ -68,12 +82,18 @@ TEST_CASE ("plugin scan protocol ignores output before its begin sentinel")
 
 TEST_CASE ("plugin scan protocol rejects malformed JSON without partial rows")
 {
-    const auto valid = makeDescriptor ("Valid", "/valid.vst3", "valid");
-    auto root = nlohmann::json::parse (scanproto::extractPayload (
-        scanproto::makePayload ({ valid })));
-    root["descriptors"].push_back ("not an object");
-    REQUIRE_FALSE (scanproto::parsePayload (root.dump()).has_value());
-    REQUIRE_FALSE (scanproto::parsePayload ("{not json").has_value());
+    SECTION ("malformed descriptor row")
+    {
+        const auto valid = makeDescriptor ("Valid", "/valid.vst3", "valid");
+        auto root = nlohmann::json::parse (scanproto::extractPayload (
+            scanproto::makePayload ({ valid })));
+        root["descriptors"].push_back ("not an object");
+        REQUIRE_FALSE (scanproto::parsePayload (root.dump()).has_value());
+    }
+    SECTION ("invalid raw JSON")
+    {
+        REQUIRE_FALSE (scanproto::parsePayload ("{not json").has_value());
+    }
 }
 
 TEST_CASE ("plugin scan protocol rejects an out-of-range schema version")
@@ -89,5 +109,5 @@ TEST_CASE ("plugin scan sandbox policy")
     CHECK (scanproto::formatRequiresSandbox ("AudioUnit"));
     CHECK (scanproto::formatRequiresSandbox ("VST"));
     CHECK_FALSE (scanproto::formatRequiresSandbox ("DuskMultisample"));
-    CHECK_FALSE (scanproto::formatRequiresSandbox ("UnknownFutureFormat"));
+    CHECK (scanproto::formatRequiresSandbox ("UnknownFutureFormat"));
 }

--- a/tests/plugin_scan_protocol.cpp
+++ b/tests/plugin_scan_protocol.cpp
@@ -30,7 +30,9 @@ TEST_CASE ("plugin scan protocol round-trips multiple descriptors")
     const auto framed = scanproto::makePayload (input);
     const auto payload = scanproto::extractPayload (framed);
     REQUIRE_FALSE (payload.empty());
-    REQUIRE (scanproto::parsePayload (payload) == input);
+    const auto parsed = scanproto::parsePayload (payload);
+    REQUIRE (parsed.has_value());
+    REQUIRE (*parsed == input);
 }
 
 TEST_CASE ("plugin scan protocol distinguishes empty success from missing framing")
@@ -38,10 +40,12 @@ TEST_CASE ("plugin scan protocol distinguishes empty success from missing framin
     const auto framed = scanproto::makePayload ({});
     const auto payload = scanproto::extractPayload (framed);
     REQUIRE_FALSE (payload.empty());
-    REQUIRE (scanproto::parsePayload (payload).empty());
+    const auto parsed = scanproto::parsePayload (payload);
+    REQUIRE (parsed.has_value());
+    REQUIRE (parsed->empty());
     REQUIRE (scanproto::extractPayload ("plugin output only").empty());
     REQUIRE (scanproto::extractPayload (
-        R"({"version":1,"descriptors":[]})==DUSK_SCAN_END==").empty());
+        R"scan({"version":1,"descriptors":[]}==DUSK_SCAN_END==)scan").empty());
     REQUIRE (scanproto::extractPayload (
         std::string (scanproto::kPayloadBegin) + "\n{}").empty());
     REQUIRE (scanproto::extractPayload (
@@ -56,9 +60,10 @@ TEST_CASE ("plugin scan protocol ignores output before its begin sentinel")
     const auto payload = scanproto::extractPayload (
         std::string ("plugin wrote this first\n") + scanproto::makePayload ({ row }));
     const auto parsed = scanproto::parsePayload (payload);
-    REQUIRE (parsed.size() == 1);
-    CHECK (parsed.front().location == "/plugins/delay.vst3");
-    CHECK (parsed.front().pluginId == "delay.inner");
+    REQUIRE (parsed.has_value());
+    REQUIRE (parsed->size() == 1);
+    CHECK (parsed->front().location == "/plugins/delay.vst3");
+    CHECK (parsed->front().pluginId == "delay.inner");
 }
 
 TEST_CASE ("plugin scan protocol rejects malformed JSON without partial rows")
@@ -67,14 +72,14 @@ TEST_CASE ("plugin scan protocol rejects malformed JSON without partial rows")
     auto root = nlohmann::json::parse (scanproto::extractPayload (
         scanproto::makePayload ({ valid })));
     root["descriptors"].push_back ("not an object");
-    REQUIRE (scanproto::parsePayload (root.dump()).empty());
-    REQUIRE (scanproto::parsePayload ("{not json").empty());
+    REQUIRE_FALSE (scanproto::parsePayload (root.dump()).has_value());
+    REQUIRE_FALSE (scanproto::parsePayload ("{not json").has_value());
 }
 
 TEST_CASE ("plugin scan protocol rejects an out-of-range schema version")
 {
-    REQUIRE (scanproto::parsePayload (
-        R"({"version":18446744073709551615,"descriptors":[]})").empty());
+    REQUIRE_FALSE (scanproto::parsePayload (
+        R"({"version":18446744073709551615,"descriptors":[]})").has_value());
 }
 
 TEST_CASE ("plugin scan sandbox policy")

--- a/tests/plugin_slot_persistence.cpp
+++ b/tests/plugin_slot_persistence.cpp
@@ -1,0 +1,91 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/PluginManager.h"
+#include "engine/PluginSlot.h"
+
+using namespace duskstudio;
+
+TEST_CASE ("PluginSlot preserves identity and last-known state while temporarily inactive")
+{
+    PluginDescriptor descriptor;
+    descriptor.name = "Temporarily inactive";
+    descriptor.formatName = "VST3";
+    descriptor.location = "/plugins/Inactive.vst3";
+    descriptor.uniqueId = 42;
+
+    PluginSlot slot;
+    slot.setTemporarilyInactivePersistenceForTest (descriptor, "c3RhdGU=");
+
+    CHECK_FALSE (slot.isLoaded());
+    CHECK_FALSE (slot.isOffline());
+    REQUIRE (slot.getDescriptorForSave (0).has_value());
+    CHECK (*slot.getDescriptorForSave (0) == descriptor);
+    CHECK (slot.getStateBase64ForSave (0) == "c3RhdGU=");
+}
+
+TEST_CASE ("PluginSlot crash-like inactive persistence survives until explicit unload")
+{
+    PluginDescriptor descriptor;
+    descriptor.name = "Crashed child";
+    descriptor.formatName = "VST3";
+    descriptor.location = "/plugins/Crashed.vst3";
+
+    PluginSlot slot;
+    slot.setTemporarilyInactivePersistenceForTest (descriptor, "bGFzdC1rbm93bg==");
+    REQUIRE (slot.getDescriptorForSave (0).has_value());
+    CHECK (slot.getStateBase64ForSave (0) == "bGFzdC1rbm93bg==");
+
+    slot.unload();
+    CHECK_FALSE (slot.getDescriptorForSave (0).has_value());
+    CHECK (slot.getStateBase64ForSave (0).isEmpty());
+}
+
+TEST_CASE ("PluginSlot failed restore preserves the exact unnormalised reference and state")
+{
+    PluginDescriptor descriptor;
+    descriptor.name = "Missing VST3";
+    descriptor.formatName = "VST3";
+    descriptor.location =
+        "/definitely/missing/Missing.vst3/Contents/x86_64-linux/Missing.so";
+    descriptor.uniqueId = 9876;
+    const juce::String state = "ZXhhY3Qtc3RhdGU=";
+
+    PluginManager manager;
+    PluginSlot slot;
+    slot.setManager (manager);
+    juce::String error;
+    CHECK_FALSE (slot.restoreFromSavedState (descriptor, {}, state, error));
+    REQUIRE (slot.getDescriptorForSave (0).has_value());
+    CHECK (*slot.getDescriptorForSave (0) == descriptor);
+    CHECK (slot.getStateBase64ForSave (0) == state);
+    CHECK (slot.isOffline());
+}
+
+TEST_CASE ("PluginSlot migrates valid legacy XML to a structured offline descriptor")
+{
+    PluginDescriptor legacy;
+    legacy.name = "Legacy Missing";
+    legacy.manufacturer = "Dusk";
+    legacy.formatName = "VST3";
+    legacy.location = "/definitely/missing/Legacy.vst3";
+    legacy.uniqueId = 12345;
+    legacy.numInputChannels = 2;
+    legacy.numOutputChannels = 2;
+    const auto xml = PluginManager::descriptorToJuceForTest (legacy).createXml();
+    REQUIRE (xml != nullptr);
+
+    PluginManager manager;
+    PluginSlot slot;
+    slot.setManager (manager);
+    juce::String error;
+    CHECK_FALSE (slot.restoreFromSavedState (
+        std::nullopt,
+        xml->toString (juce::XmlElement::TextFormat().singleLine()),
+        "bGVnYWN5LXN0YXRl",
+        error));
+
+    REQUIRE (slot.getDescriptorForSave (0).has_value());
+    CHECK (*slot.getDescriptorForSave (0) == legacy);
+    CHECK (slot.getLegacyDescriptionXmlForSave().isEmpty());
+    CHECK (slot.getStateBase64ForSave (0) == "bGVnYWN5LXN0YXRl");
+}

--- a/tests/plugin_slot_persistence.cpp
+++ b/tests/plugin_slot_persistence.cpp
@@ -5,6 +5,18 @@
 
 using namespace duskstudio;
 
+TEST_CASE ("PluginSlot capture placeholder is visible but never persisted")
+{
+    PluginSlot slot;
+    slot.setOfflineForCapture ("Screenshot Only");
+
+    CHECK (slot.isOffline());
+    CHECK (slot.getOfflineName() == "Screenshot Only");
+    CHECK_FALSE (slot.getDescriptorForSave (0).has_value());
+    CHECK (slot.getLegacyDescriptionXmlForSave().isEmpty());
+    CHECK (slot.getStateBase64ForSave (0).isEmpty());
+}
+
 TEST_CASE ("PluginSlot preserves identity and last-known state while temporarily inactive")
 {
     PluginDescriptor descriptor;

--- a/tests/session_format_version.cpp
+++ b/tests/session_format_version.cpp
@@ -25,7 +25,7 @@ void writeRaw (const juce::File& target, const juce::String& contents)
 } // namespace
 
 // Format-version contract:
-//   * Manual save writes "version": kFormatVersion (currently 1).
+//   * Manual save writes "version": kFormatVersion (currently 4).
 //   * Load rejects sessions whose version is HIGHER than the build's
 //     kFormatVersion — newer Dusk Studio can read older sessions (via the
 //     migrateSession switch) but older Dusk Studio must refuse newer ones
@@ -87,7 +87,7 @@ TEST_CASE ("SessionSerializer round-trip preserves version field",
     auto root = juce::JSON::parse (target);
     REQUIRE (root.isObject());
     REQUIRE (root.hasProperty ("version"));
-    REQUIRE ((int) root["version"] >= 1);
+    REQUIRE ((int) root["version"] == 4);
 
     dir.deleteRecursively();
 }

--- a/tests/session_missing_sections.cpp
+++ b/tests/session_missing_sections.cpp
@@ -32,13 +32,13 @@ TEST_CASE ("loading a session without section keys resets those sections",
         r.file            = s.getAudioDirectory().getChildFile ("ghost.wav");
         r.lengthInSamples = 1000;
         s.track (3).regions.push_back (r);
-        s.track (3).pluginDescriptionXml = "<PLUGIN/>";
+        s.track (3).pluginLegacyDescriptionXml = "<PLUGIN/>";
         s.track (3).pluginStateBase64    = "ABCD";
 
         s.bus (1).strip.faderDb.store (-12.0f);
         s.bus (1).strip.compEnabled.store (true);
 
-        s.auxLane (0).pluginDescriptionXml[0] = "<PLUGIN/>";
+        s.auxLane (0).pluginLegacyDescriptionXml[0] = "<PLUGIN/>";
         s.auxLane (0).pluginStateBase64[0]    = "ABCD";
         s.auxLane (0).nativeClapPath[0]       = "/tmp/ghost.clap";
         s.auxLane (0).params.returnLevelDb.store (-6.0f);
@@ -62,13 +62,15 @@ TEST_CASE ("loading a session without section keys resets those sections",
     REQUIRE (SessionSerializer::load (s, target));
 
     REQUIRE (s.track (3).regions.empty());
-    REQUIRE (s.track (3).pluginDescriptionXml.isEmpty());
+    REQUIRE_FALSE (s.track (3).pluginDescriptor.has_value());
+    REQUIRE (s.track (3).pluginLegacyDescriptionXml.isEmpty());
     REQUIRE (s.track (3).pluginStateBase64.isEmpty());
 
     REQUIRE_THAT (s.bus (1).strip.faderDb.load(), WithinAbs (0.0f, 1e-6f));
     REQUIRE_FALSE (s.bus (1).strip.compEnabled.load());
 
-    REQUIRE (s.auxLane (0).pluginDescriptionXml[0].isEmpty());
+    REQUIRE_FALSE (s.auxLane (0).pluginDescriptor[0].has_value());
+    REQUIRE (s.auxLane (0).pluginLegacyDescriptionXml[0].isEmpty());
     REQUIRE (s.auxLane (0).pluginStateBase64[0].isEmpty());
     REQUIRE (s.auxLane (0).nativeClapPath[0].isEmpty());
     REQUIRE_THAT (s.auxLane (0).params.returnLevelDb.load(), WithinAbs (0.0f, 1e-6f));

--- a/tests/session_round_trip.cpp
+++ b/tests/session_round_trip.cpp
@@ -5,6 +5,7 @@
 #include "session/SessionSerializer.h"
 
 #include <juce_core/juce_core.h>
+#include <nlohmann/json.hpp>
 
 using Catch::Matchers::WithinAbs;
 
@@ -332,6 +333,43 @@ TEST_CASE ("SessionSerializer round-trips structured plugin descriptors and lega
     CHECK (restored->track (1).pluginLegacyDescriptionXml
            == "<BROKEN legacy=\"keep me\"");
     CHECK (restored->track (1).pluginStateBase64 == "bGVnYWN5");
+
+    dir.deleteRecursively();
+}
+
+TEST_CASE ("SessionSerializer preserves XML fallback for rejected structured descriptors",
+           "[session][serializer][plugin-descriptor]")
+{
+    using duskstudio::Session;
+    using duskstudio::SessionSerializer;
+
+    const auto dir = makeTempSessionDir();
+    const auto target = dir.getChildFile ("session.json");
+    const juce::String trackFallback ("<PLUGIN name=\"track fallback\"/>");
+    const juce::String auxFallback ("<PLUGIN name=\"aux fallback\"/>");
+
+    auto source = std::make_unique<Session>();
+    source->track (0).pluginLegacyDescriptionXml = trackFallback;
+    source->auxLane (0).pluginLegacyDescriptionXml[0] = auxFallback;
+    REQUIRE (SessionSerializer::save (*source, target));
+
+    auto document = nlohmann::json::parse (
+        target.loadFileAsString().toStdString());
+    const auto rejected = nlohmann::json {
+        { "version", 1 },
+        { "backend", "native" },
+        { "unique_id", "not an integer" }
+    };
+    document["tracks"][0]["plugin_descriptor"] = rejected;
+    document["aux_lanes"][0]["plugin_slots"][0]["plugin_descriptor"] = rejected;
+    REQUIRE (target.replaceWithText (document.dump()));
+
+    auto restored = std::make_unique<Session>();
+    REQUIRE (SessionSerializer::load (*restored, target));
+    CHECK_FALSE (restored->track (0).pluginDescriptor.has_value());
+    CHECK (restored->track (0).pluginLegacyDescriptionXml == trackFallback);
+    CHECK_FALSE (restored->auxLane (0).pluginDescriptor[0].has_value());
+    CHECK (restored->auxLane (0).pluginLegacyDescriptionXml[0] == auxFallback);
 
     dir.deleteRecursively();
 }

--- a/tests/session_round_trip.cpp
+++ b/tests/session_round_trip.cpp
@@ -222,6 +222,30 @@ TEST_CASE ("SessionSerializer round-trips native-VST3 slots", "[session][seriali
     dir.deleteRecursively();
 }
 
+TEST_CASE ("SessionSerializer round-trips native multisample references",
+           "[session][serializer][multisample]")
+{
+    using duskstudio::Session;
+    using duskstudio::SessionSerializer;
+
+    const auto dir = makeTempSessionDir();
+    const auto target = dir.getChildFile ("session.json");
+
+    Session source;
+    source.track (3).nativeMultisamplePath = "/banks/portable/full-range.sfz";
+    source.track (3).nativeMultisampleStateBase64 = "bXVsdGlzYW1wbGU=";
+    REQUIRE (SessionSerializer::save (source, target));
+
+    Session restored;
+    REQUIRE (SessionSerializer::load (restored, target));
+    CHECK (restored.track (3).nativeMultisamplePath
+           == "/banks/portable/full-range.sfz");
+    CHECK (restored.track (3).nativeMultisampleStateBase64
+           == "bXVsdGlzYW1wbGU=");
+
+    dir.deleteRecursively();
+}
+
 // The canonical session sample rate must survive save/load, reset to 0 when
 // absent (legacy file), and reject garbage — the load UI keys the device-
 // switch / mismatch warning off it.
@@ -251,6 +275,63 @@ TEST_CASE ("SessionSerializer round-trips the session sample rate", "[session][s
     target.replaceWithText (R"({"version":3,"session_sample_rate":1e40,"tracks":[],"buses":[],"aux_lanes":[]})");
     REQUIRE (SessionSerializer::load (b, target));
     REQUIRE (b.sessionSampleRate == 0.0);
+
+    dir.deleteRecursively();
+}
+
+TEST_CASE ("SessionSerializer round-trips structured plugin descriptors and legacy fallback",
+           "[session][serializer][plugin-descriptor]")
+{
+    using duskstudio::PluginBackend;
+    using duskstudio::PluginDescriptor;
+    using duskstudio::Session;
+    using duskstudio::SessionSerializer;
+
+    const auto dir = makeTempSessionDir();
+    const auto target = dir.getChildFile ("session.json");
+
+    PluginDescriptor descriptor;
+    descriptor.name = "Offline Synth";
+    descriptor.manufacturer = "Dusk";
+    descriptor.formatName = "FutureFormat";
+    descriptor.backend = PluginBackend::JuceLegacy;
+    descriptor.location = "/missing/Offline.future";
+    descriptor.pluginId = "inner.plugin";
+    descriptor.uniqueId = 1234;
+    descriptor.deprecatedUid = 4321;
+    descriptor.numInputChannels = 0;
+    descriptor.numOutputChannels = 2;
+    descriptor.lastFileModificationMs = 987654321;
+    descriptor.lastInfoUpdateMs = 123456789;
+    descriptor.isInstrument = true;
+    descriptor.hasSharedContainer = true;
+    descriptor.hasAraExtension = true;
+
+    auto source = std::make_unique<Session>();
+    source->track (0).pluginDescriptor = descriptor;
+    source->track (0).pluginStateBase64 = "c3RhdGU=";
+    source->auxLane (0).pluginDescriptor[0] = descriptor;
+    source->auxLane (0).pluginStateBase64[0] = "YXV4";
+    source->track (1).pluginLegacyDescriptionXml = "<BROKEN legacy=\"keep me\"";
+    source->track (1).pluginStateBase64 = "bGVnYWN5";
+
+    REQUIRE (SessionSerializer::save (*source, target));
+    const auto saved = target.loadFileAsString();
+    CHECK (saved.contains ("\"plugin_descriptor\""));
+    CHECK_FALSE (saved.contains ("Offline.future\\ninner.plugin"));
+
+    auto restored = std::make_unique<Session>();
+    REQUIRE (SessionSerializer::load (*restored, target));
+    REQUIRE (restored->track (0).pluginDescriptor.has_value());
+    CHECK (*restored->track (0).pluginDescriptor == descriptor);
+    CHECK (restored->track (0).pluginStateBase64 == "c3RhdGU=");
+    REQUIRE (restored->auxLane (0).pluginDescriptor[0].has_value());
+    CHECK (*restored->auxLane (0).pluginDescriptor[0] == descriptor);
+    CHECK (restored->auxLane (0).pluginStateBase64[0] == "YXV4");
+    CHECK_FALSE (restored->track (1).pluginDescriptor.has_value());
+    CHECK (restored->track (1).pluginLegacyDescriptionXml
+           == "<BROKEN legacy=\"keep me\"");
+    CHECK (restored->track (1).pluginStateBase64 == "bGVnYWN5");
 
     dir.deleteRecursively();
 }

--- a/tests/session_schema_migration.cpp
+++ b/tests/session_schema_migration.cpp
@@ -5,7 +5,7 @@
 // session JSON. Confirms:
 //   1. migrateSession returns false + does not advance when asked to
 //      migrate from an unknown lower version (safety branch).
-//   2. migrateSession advances v1 → kFormatVersion (currently v2) on a
+//   2. migrateSession advances v1 → the current kFormatVersion on a
 //      well-formed root object, and the "version" property on `root` is
 //      bumped to match.
 //   3. End-to-end: a v1-tagged session.json on disk loads cleanly,
@@ -23,6 +23,7 @@
 
 #include <juce_core/juce_core.h>
 #include <nlohmann/json.hpp>
+#include <memory>
 
 namespace duskstudio
 {
@@ -79,10 +80,10 @@ TEST_CASE ("migrateSession advances a mock v1 root to the current schema",
     // version field must now match the current build's kFormatVersion.
     // We don't reach kFormatVersion symbolically from the test (it's
     // in an anonymous namespace inside the .cpp), so we check the
-    // post-migrate value is at least 2 + the original payload survived.
+    // H4 owns version 4; the original payload must survive every step.
     REQUIRE (root.is_object());
     REQUIRE (root.contains ("version"));
-    REQUIRE (root["version"].get<int>() >= 2);
+    REQUIRE (root["version"].get<int>() == 4);
     REQUIRE (root.contains ("tempo"));
     REQUIRE (root["tempo"].get<double>() == 98.5);
 }
@@ -105,14 +106,50 @@ TEST_CASE ("SessionSerializer loads a v1-tagged session file end-to-end",
     REQUIRE (SessionSerializer::load (s, target));
 
     // Save back + verify the file is now tagged with the current
-    // kFormatVersion. Without re-reading SessionSerializer's
-    // kFormatVersion constant directly, we settle for ">= 2" (the
-    // version this migrator case targets).
+    // kFormatVersion.
     REQUIRE (SessionSerializer::save (s, target));
     auto root = nlohmann::json::parse (target.loadFileAsString().toStdString(), nullptr, false);
     REQUIRE (root.is_object());
     REQUIRE (root.contains ("version"));
-    REQUIRE (root["version"].get<int>() >= 2);
+    REQUIRE (root["version"].get<int>() == 4);
+
+    dir.deleteRecursively();
+}
+
+TEST_CASE ("SessionSerializer migrates a v3 legacy plugin reference to a v4 save",
+           "[session][serializer][migration][plugin-descriptor]")
+{
+    using duskstudio::Session;
+    using duskstudio::SessionSerializer;
+
+    const auto dir = makeTempMigrationDir();
+    const auto target = dir.getChildFile ("session.json");
+    const std::string legacyXml =
+        R"(<PLUGIN name="Legacy Synth" descriptiveName="Legacy Synth" format="VST3" file="/plugins/Legacy.vst3" uid="1234" manufacturer="Dusk" version="1.0" isInstrument="1"/>)";
+    nlohmann::json root {
+        { "version", 3 },
+        { "tracks", nlohmann::json::array ({
+            { { "name", "Legacy" },
+              { "plugin_desc_xml", legacyXml },
+              { "plugin_state", "bGVnYWN5LXN0YXRl" } }
+        }) }
+    };
+    writeRaw (target, root.dump());
+
+    auto session = std::make_unique<Session>();
+    REQUIRE (SessionSerializer::load (*session, target));
+    CHECK_FALSE (session->track (0).pluginDescriptor.has_value());
+    CHECK (session->track (0).pluginLegacyDescriptionXml.toStdString() == legacyXml);
+    CHECK (session->track (0).pluginStateBase64 == "bGVnYWN5LXN0YXRl");
+
+    REQUIRE (SessionSerializer::save (*session, target));
+    const auto saved = nlohmann::json::parse (
+        target.loadFileAsString().toStdString(), nullptr, false);
+    REQUIRE (saved.is_object());
+    CHECK (saved["version"].get<int>() == 4);
+    CHECK (saved["tracks"][0]["plugin_desc_xml"].get<std::string>() == legacyXml);
+    CHECK (saved["tracks"][0]["plugin_state"].get<std::string>()
+           == "bGVnYWN5LXN0YXRl");
 
     dir.deleteRecursively();
 }

--- a/tests/session_track_shrink.cpp
+++ b/tests/session_track_shrink.cpp
@@ -34,7 +34,7 @@ TEST_CASE ("loading a session with fewer tracks blanks the surplus slots",
         r.lengthInSamples = 1000;
         s.track (5).regions.push_back (r);
 
-        s.track (5).pluginDescriptionXml = "<PLUGIN/>";
+        s.track (5).pluginLegacyDescriptionXml = "<PLUGIN/>";
         s.track (5).pluginStateBase64    = "ABCD";
 
         s.track (5).midiRegions.publish (
@@ -53,7 +53,8 @@ TEST_CASE ("loading a session with fewer tracks blanks the surplus slots",
     // Slot 5 is not in the JSON, so it must come back blank — no ghosts.
     REQUIRE (s.track (5).regions.empty());
     REQUIRE (s.track (5).midiRegions.current().empty());
-    REQUIRE (s.track (5).pluginDescriptionXml.isEmpty());
+    REQUIRE_FALSE (s.track (5).pluginDescriptor.has_value());
+    REQUIRE (s.track (5).pluginLegacyDescriptionXml.isEmpty());
     REQUIRE (s.track (5).pluginStateBase64.isEmpty());
     REQUIRE (s.track (5).automationLanes[0].pointsConst().empty());
 }

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -22,7 +22,6 @@ src/engine/FileImporter.h
 src/engine/JuceCompat.h
 src/engine/MasteringPlayer.cpp
 src/engine/MasteringPlayer.h
-src/engine/NativeScanRows.h
 src/engine/PlaybackEngine.cpp
 src/engine/PlaybackEngine.h
 src/engine/PluginManager.cpp
@@ -36,7 +35,6 @@ src/engine/device/DeviceManagerJuce.cpp
 src/engine/hosting/NativePluginId.h
 src/engine/ipc/IpcSelfTest.cpp
 src/engine/ipc/PluginHostMain.cpp
-src/engine/ipc/PluginScanProtocol.h
 src/engine/midi/JuceMidiBackend.cpp
 src/engine/midi/JuceMidiBackend.h
 src/engine/multisample/AriaBank.cpp


### PR DESCRIPTION
keep on trucking...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured plugin descriptors for discovery, loading, picker display, and session persistence.
  * Native plugin caches and scan payloads now use versioned JSON.
  * Added migration support for legacy XML plugin data and session files.
  * Improved out-of-process scanning and instrument detection.

* **Bug Fixes**
  * Preserved plugin identity and state more reliably during reloads, cloning, undo/redo, and failed restores.
  * Stale native cache entries are filtered during scanning.

* **Documentation**
  * Updated plugin cache behavior and hosting roadmap documentation.

* **Tests**
  * Added coverage for descriptors, caches, scanning, persistence, migration, and plugin snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->