### PR TITLE
Dejuce/hosting h5a

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -38,13 +38,13 @@ jobs:
           # Test CI never pushes — don't leave the token in git config.
           persist-credentials: false
 
-      - name: Install ninja + ccache
+      - name: Install build dependencies
         # Ninja: parallel, low-overhead generator (much faster than the
         # default Makefiles on this many TUs). ccache: object cache that
         # survives across runs via the actions/cache step below, so an
         # unchanged TU isn't recompiled on the next push.
         # lame: libmp3lame for MP3 bounce/export (CMake auto-detects it).
-        run: brew install ninja ccache lame libsndfile
+        run: brew install ninja ccache lame libsndfile lilv suil lv2
 
       - name: Cache ccache objects
         uses: actions/cache@v6
@@ -79,11 +79,19 @@ jobs:
 
       - name: Configure (Release)
         run: |
+          set -euo pipefail
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_PREFIX_PATH="$(brew --prefix)" \
             -DJUCE_PATH="${RUNNER_TEMP}/JUCE" \
-            -DDUSK_PLUGINS_PATH="${RUNNER_TEMP}/plugins-main"
+            -DDUSK_PLUGINS_PATH="${RUNNER_TEMP}/plugins-main" \
+            -DDUSKSTUDIO_NATIVE_CLAP=ON \
+            -DDUSKSTUDIO_NATIVE_LV2=ON \
+            -DDUSKSTUDIO_NATIVE_VST3=ON
+          for option in DUSKSTUDIO_NATIVE_CLAP DUSKSTUDIO_NATIVE_LV2 DUSKSTUDIO_NATIVE_VST3; do
+            grep -q "^${option}:BOOL=ON$" build/CMakeCache.txt || {
+              echo "::error::${option} was not enabled in the app configure" >&2; exit 1; }
+          done
 
       - name: Build (Release)
         run: cmake --build build -j
@@ -93,12 +101,20 @@ jobs:
 
       - name: Configure + build + run tests
         run: |
+          set -euo pipefail
           cmake -S . -B build-tests -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_PREFIX_PATH="$(brew --prefix)" \
             -DDUSKSTUDIO_BUILD_TESTS=ON \
             -DJUCE_PATH="${RUNNER_TEMP}/JUCE" \
-            -DDUSK_PLUGINS_PATH="${RUNNER_TEMP}/plugins-main"
+            -DDUSK_PLUGINS_PATH="${RUNNER_TEMP}/plugins-main" \
+            -DDUSKSTUDIO_NATIVE_CLAP=ON \
+            -DDUSKSTUDIO_NATIVE_LV2=ON \
+            -DDUSKSTUDIO_NATIVE_VST3=ON
+          for option in DUSKSTUDIO_NATIVE_CLAP DUSKSTUDIO_NATIVE_LV2 DUSKSTUDIO_NATIVE_VST3; do
+            grep -q "^${option}:BOOL=ON$" build-tests/CMakeCache.txt || {
+              echo "::error::${option} was not enabled in the test configure" >&2; exit 1; }
+          done
           cmake --build build-tests --target dusk-studio-tests -j
           ctest --test-dir build-tests --output-on-failure
 

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -57,9 +57,9 @@ jobs:
           [[ "v$(tr -d '[:space:]' < VERSION)" == "${GITHUB_REF_NAME}" ]] || {
             echo "Tag ${GITHUB_REF_NAME} != VERSION v$(tr -d '[:space:]' < VERSION)"; exit 1; }
 
-      - name: Install ninja + ccache + lame
+      - name: Install build dependencies
         # lame: libmp3lame for MP3 bounce/export (CMake auto-detects it).
-        run: brew install ninja ccache lame libsndfile
+        run: brew install ninja ccache lame libsndfile lilv suil lv2
 
       - name: Cache ccache objects
         uses: actions/cache@v6
@@ -131,6 +131,7 @@ jobs:
 
       - name: Configure (Release)
         run: |
+          set -euo pipefail
           # Ad-hoc codesign identity "-" — free, and required for the .app
           # (plus the bundled dusk-studio-plugin-host helper) to launch on
           # Apple Silicon. No Developer ID, no Hardened Runtime, no notary.
@@ -139,7 +140,14 @@ jobs:
             -DCMAKE_PREFIX_PATH="$(brew --prefix)" \
             -DJUCE_PATH="${RUNNER_TEMP}/JUCE" \
             -DDUSK_PLUGINS_PATH="${RUNNER_TEMP}/plugins-main" \
-            -DDUSKSTUDIO_CODESIGN_IDENTITY="-"
+            -DDUSKSTUDIO_CODESIGN_IDENTITY="-" \
+            -DDUSKSTUDIO_NATIVE_CLAP=ON \
+            -DDUSKSTUDIO_NATIVE_LV2=ON \
+            -DDUSKSTUDIO_NATIVE_VST3=ON
+          for option in DUSKSTUDIO_NATIVE_CLAP DUSKSTUDIO_NATIVE_LV2 DUSKSTUDIO_NATIVE_VST3; do
+            grep -q "^${option}:BOOL=ON$" build/CMakeCache.txt || {
+              echo "::error::${option} was not enabled in the app configure" >&2; exit 1; }
+          done
 
       - name: Build (Release)
         run: cmake --build build -j
@@ -147,12 +155,20 @@ jobs:
       - name: Build + run tests (release gate)
         # No DMG ships unless the full Catch2 suite passes.
         run: |
+          set -euo pipefail
           cmake -S . -B build-tests -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_PREFIX_PATH="$(brew --prefix)" \
             -DDUSKSTUDIO_BUILD_TESTS=ON \
             -DJUCE_PATH="${RUNNER_TEMP}/JUCE" \
-            -DDUSK_PLUGINS_PATH="${RUNNER_TEMP}/plugins-main"
+            -DDUSK_PLUGINS_PATH="${RUNNER_TEMP}/plugins-main" \
+            -DDUSKSTUDIO_NATIVE_CLAP=ON \
+            -DDUSKSTUDIO_NATIVE_LV2=ON \
+            -DDUSKSTUDIO_NATIVE_VST3=ON
+          for option in DUSKSTUDIO_NATIVE_CLAP DUSKSTUDIO_NATIVE_LV2 DUSKSTUDIO_NATIVE_VST3; do
+            grep -q "^${option}:BOOL=ON$" build-tests/CMakeCache.txt || {
+              echo "::error::${option} was not enabled in the test configure" >&2; exit 1; }
+          done
           cmake --build build-tests --target dusk-studio-tests -j
           ctest --test-dir build-tests --output-on-failure
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,29 +20,43 @@ file(READ "${CMAKE_CURRENT_SOURCE_DIR}/VERSION" DUSKSTUDIO_VERSION_RAW)
 string(STRIP "${DUSKSTUDIO_VERSION_RAW}" DUSKSTUDIO_VERSION)
 project(DuskStudio VERSION ${DUSKSTUDIO_VERSION} LANGUAGES C CXX)
 
-# Native CLAP host (src/engine/clap/ + the X11 editor) is POSIX + X11 — Linux only.
-# Default ON for Linux, OFF elsewhere; can be forced off on Linux for testing the
-# gated (DUSKSTUDIO_HAS_NATIVE_CLAP) build path with -DDUSKSTUDIO_NATIVE_CLAP=OFF.
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    option(DUSKSTUDIO_NATIVE_CLAP "Build the native CLAP plugin host (Linux/X11 only)" ON)
+if(APPLE)
+    enable_language(OBJCXX)
+endif()
+
+# Native CLAP host (src/engine/clap/) is available on Linux and macOS. Default
+# ON there, OFF elsewhere; it can be forced off to test the feature-gated path.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR APPLE)
+    option(DUSKSTUDIO_NATIVE_CLAP "Build the native CLAP plugin host (Linux/macOS)" ON)
 else()
     set(DUSKSTUDIO_NATIVE_CLAP OFF)
 endif()
 
-# Native LV2 host (src/engine/lv2/) via lilv + suil (both ISC). Linux-only, ON when
-# the dev libraries are present (like the optional LAME dep); OFF otherwise. The
-# pkg_check_modules IMPORTED_TARGETs (PkgConfig::LILV etc.) are linked further down.
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+# Native LV2 host (src/engine/lv2/) via lilv + suil (both ISC). On Linux it
+# remains optional when the development libraries are absent. On macOS CI
+# explicitly requests it, so a missing requested dependency must fail configure.
+# The pkg_check_modules IMPORTED_TARGETs are linked further down.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR APPLE)
     find_package(PkgConfig QUIET)
     if(PkgConfig_FOUND)
         # GLOBAL so the imported targets are visible in the tests/ subdirectory too.
         pkg_check_modules(LILV IMPORTED_TARGET GLOBAL lilv-0)
         pkg_check_modules(SUIL IMPORTED_TARGET GLOBAL suil-0)
         pkg_check_modules(LV2  IMPORTED_TARGET GLOBAL lv2)
-        pkg_check_modules(PIPEWIRE IMPORTED_TARGET GLOBAL libpipewire-0.3)
+        if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+            pkg_check_modules(PIPEWIRE IMPORTED_TARGET GLOBAL libpipewire-0.3)
+        endif()
     endif()
-    if(LILV_FOUND AND SUIL_FOUND AND LV2_FOUND)
-        option(DUSKSTUDIO_NATIVE_LV2 "Build the native LV2 plugin host (Linux, needs lilv/suil)" ON)
+    if(APPLE)
+        option(DUSKSTUDIO_NATIVE_LV2
+               "Build the native LV2 plugin host (Linux/macOS, needs lilv/suil/lv2)" ON)
+        if(DUSKSTUDIO_NATIVE_LV2 AND NOT (LILV_FOUND AND SUIL_FOUND AND LV2_FOUND))
+            message(FATAL_ERROR
+                "Native LV2 host was explicitly requested, but lilv/suil/lv2 were not all found")
+        endif()
+    elseif(LILV_FOUND AND SUIL_FOUND AND LV2_FOUND)
+        option(DUSKSTUDIO_NATIVE_LV2
+               "Build the native LV2 plugin host (Linux/macOS, needs lilv/suil/lv2)" ON)
     else()
         set(DUSKSTUDIO_NATIVE_LV2 OFF)
         message(STATUS "Native LV2 host: lilv/suil/lv2 not all found - disabled")
@@ -53,11 +67,18 @@ endif()
 
 # Native VST3 host — Steinberg SDK hosting subset from the Dusk-owned mirror
 # (external/vst3sdk submodule, tag dusk-vst3sdk-v1; see DUSK-MIRROR.md there).
-# GPL-3.0 arm of the SDK's dual license — see LICENSES.txt. Linux-only like the
-# other native hosts.
-if(UNIX AND NOT APPLE)
-    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/vst3sdk/pluginterfaces/base/funknown.cpp")
-        option(DUSKSTUDIO_NATIVE_VST3 "Build the native VST3 plugin host (Linux)" ON)
+# GPL-3.0 arm of the SDK's dual license — see LICENSES.txt.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR APPLE)
+    if(APPLE)
+        option(DUSKSTUDIO_NATIVE_VST3 "Build the native VST3 plugin host (Linux/macOS)" ON)
+        if(DUSKSTUDIO_NATIVE_VST3
+           AND NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/vst3sdk/pluginterfaces/base/funknown.cpp")
+            message(FATAL_ERROR
+                "Native VST3 host was explicitly requested, but external/vst3sdk is missing "
+                "(run: git submodule update --init external/vst3sdk)")
+        endif()
+    elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/vst3sdk/pluginterfaces/base/funknown.cpp")
+        option(DUSKSTUDIO_NATIVE_VST3 "Build the native VST3 plugin host (Linux/macOS)" ON)
     else()
         set(DUSKSTUDIO_NATIVE_VST3 OFF)
         message(STATUS "Native VST3 host: external/vst3sdk submodule missing - disabled "
@@ -315,8 +336,7 @@ target_sources(DuskStudio PRIVATE
     src/DuskStudioApp.cpp
     src/foundation/Fft.cpp
     src/foundation/MessageThread.cpp
-    # Native CLAP host is Linux-only (dlopen + poll + X11 editor) — added in the
-    # UNIX-AND-NOT-APPLE block below, gated by DUSKSTUDIO_HAS_NATIVE_CLAP.
+    # Native CLAP sources are added below, gated by DUSKSTUDIO_HAS_NATIVE_CLAP.
     src/engine/AudioEngine.cpp
     src/engine/AudioWorkerPool.cpp
     src/engine/BounceEngine.cpp
@@ -620,28 +640,36 @@ if(DUSKSTUDIO_NATIVE_CLAP OR DUSKSTUDIO_NATIVE_LV2 OR DUSKSTUDIO_NATIVE_VST3
     target_sources(DuskStudio PRIVATE src/engine/hosting/InsertAdapter.cpp)
 endif()
 
-# Native CLAP host — POSIX (dlopen/poll) + X11 editor embed. Gated by DUSKSTUDIO_NATIVE_CLAP
-# (ON for Linux). DUSKSTUDIO_HAS_NATIVE_CLAP guards every #if in the source.
+# Native CLAP host, gated by DUSKSTUDIO_NATIVE_CLAP. DUSKSTUDIO_HAS_NATIVE_CLAP
+# guards every conditional native-host path in the source.
 if(DUSKSTUDIO_NATIVE_CLAP)
     target_sources(DuskStudio PRIVATE
         src/engine/clap/ClapBundle.cpp
         src/engine/clap/ClapHost.cpp
         src/engine/clap/ClapInstance.cpp
-        src/engine/clap/ClapEditor.cpp
         src/engine/clap/ClapScanner.cpp
         src/ui/ClapPluginEditorComponent.cpp)
+    if(APPLE)
+        target_sources(DuskStudio PRIVATE src/engine/clap/ClapEditor_Mac.mm)
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        target_sources(DuskStudio PRIVATE src/engine/clap/ClapEditor.cpp)
+    endif()
     target_compile_definitions(DuskStudio PRIVATE DUSKSTUDIO_HAS_NATIVE_CLAP=1)
 endif()
 
 # Native LV2 host — lilv (discovery/instantiation) + suil (UI embed), both ISC.
-# Gated by DUSKSTUDIO_NATIVE_LV2 (ON on Linux when the dev libs are present).
+# Gated by DUSKSTUDIO_NATIVE_LV2 (ON on Linux/macOS when the dev libs are present).
 if(DUSKSTUDIO_NATIVE_LV2)
     target_sources(DuskStudio PRIVATE
         src/engine/lv2/Lv2Bundle.cpp
-        src/engine/lv2/Lv2Editor.cpp
         src/engine/lv2/Lv2Instance.cpp
         src/engine/lv2/Lv2Scanner.cpp
         src/ui/Lv2PluginEditorComponent.cpp)
+    if(APPLE)
+        target_sources(DuskStudio PRIVATE src/engine/lv2/Lv2Editor_Mac.mm)
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        target_sources(DuskStudio PRIVATE src/engine/lv2/Lv2Editor.cpp)
+    endif()
     target_link_libraries(DuskStudio PRIVATE PkgConfig::LILV PkgConfig::SUIL PkgConfig::LV2)
     target_compile_definitions(DuskStudio PRIVATE DUSKSTUDIO_HAS_NATIVE_LV2=1)
 endif()
@@ -672,30 +700,52 @@ if(DUSKSTUDIO_NATIVE_VST3)
         ${VST3SDK_DIR}/public.sdk/source/vst/vstinitiids.cpp
         ${VST3SDK_DIR}/public.sdk/source/common/commonstringconvert.cpp
         ${VST3SDK_DIR}/public.sdk/source/common/memorystream.cpp
-        ${VST3SDK_DIR}/public.sdk/source/common/threadchecker_linux.cpp
         ${VST3SDK_DIR}/public.sdk/source/vst/hosting/connectionproxy.cpp
         ${VST3SDK_DIR}/public.sdk/source/vst/hosting/eventlist.cpp
         ${VST3SDK_DIR}/public.sdk/source/vst/hosting/hostclasses.cpp
         ${VST3SDK_DIR}/public.sdk/source/vst/hosting/module.cpp
-        ${VST3SDK_DIR}/public.sdk/source/vst/hosting/module_linux.cpp
         ${VST3SDK_DIR}/public.sdk/source/vst/hosting/parameterchanges.cpp
         ${VST3SDK_DIR}/public.sdk/source/vst/hosting/pluginterfacesupport.cpp
         ${VST3SDK_DIR}/public.sdk/source/vst/hosting/plugprovider.cpp
         ${VST3SDK_DIR}/public.sdk/source/vst/hosting/processdata.cpp
         ${VST3SDK_DIR}/public.sdk/source/vst/utility/stringconvert.cpp)
+    if(APPLE)
+        set(VST3SDK_MACOS_SOURCES
+            ${VST3SDK_DIR}/public.sdk/source/common/threadchecker_mac.mm
+            ${VST3SDK_DIR}/public.sdk/source/vst/hosting/module_mac.mm)
+        target_sources(dusk-vst3-hosting PRIVATE ${VST3SDK_MACOS_SOURCES})
+        set_source_files_properties(${VST3SDK_MACOS_SOURCES}
+            PROPERTIES COMPILE_OPTIONS "-fobjc-arc")
+        find_library(DUSKSTUDIO_COCOA_FRAMEWORK Cocoa REQUIRED)
+        find_library(DUSKSTUDIO_COREFOUNDATION_FRAMEWORK CoreFoundation REQUIRED)
+        target_link_libraries(dusk-vst3-hosting PUBLIC
+            ${DUSKSTUDIO_COCOA_FRAMEWORK}
+            ${DUSKSTUDIO_COREFOUNDATION_FRAMEWORK})
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        target_sources(dusk-vst3-hosting PRIVATE
+            ${VST3SDK_DIR}/public.sdk/source/common/threadchecker_linux.cpp
+            ${VST3SDK_DIR}/public.sdk/source/vst/hosting/module_linux.cpp)
+    endif()
     target_include_directories(dusk-vst3-hosting SYSTEM PUBLIC ${VST3SDK_DIR})
     target_compile_definitions(dusk-vst3-hosting PUBLIC
         $<$<CONFIG:Debug>:DEVELOPMENT=1>
         $<$<NOT:$<CONFIG:Debug>>:RELEASE=1>)
-    target_compile_options(dusk-vst3-hosting PRIVATE -w)
+    target_compile_options(dusk-vst3-hosting PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/w>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,AppleClang,Clang,GNU>:-w>"
+        "$<$<COMPILE_LANG_AND_ID:OBJCXX,AppleClang,Clang,GNU>:-w>")
     target_link_libraries(dusk-vst3-hosting PUBLIC ${CMAKE_DL_LIBS})
     target_sources(DuskStudio PRIVATE
         src/engine/vst3/Vst3Bundle.cpp
-        src/engine/vst3/Vst3Editor.cpp
         src/engine/vst3/Vst3HostContext.cpp
         src/engine/vst3/Vst3Instance.cpp
         src/engine/vst3/Vst3Scanner.cpp
         src/ui/Vst3PluginEditorComponent.cpp)
+    if(APPLE)
+        target_sources(DuskStudio PRIVATE src/engine/vst3/Vst3Editor_Mac.mm)
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        target_sources(DuskStudio PRIVATE src/engine/vst3/Vst3Editor.cpp)
+    endif()
     target_link_libraries(DuskStudio PRIVATE dusk-vst3-hosting)
     target_compile_definitions(DuskStudio PRIVATE DUSKSTUDIO_HAS_NATIVE_VST3=1)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,11 +48,22 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR APPLE)
         endif()
     endif()
     if(APPLE)
+        # The default follows the dev libs, as on Linux, so a Mac without them
+        # still configures. An EXPLICIT -DDUSKSTUDIO_NATIVE_LV2=ON with them
+        # missing (what CI passes) stays a configure error - a green build with
+        # the format silently OFF is not verification.
+        set(DUSKSTUDIO_LV2_DEPS_FOUND OFF)
+        if(LILV_FOUND AND SUIL_FOUND AND LV2_FOUND)
+            set(DUSKSTUDIO_LV2_DEPS_FOUND ON)
+        endif()
         option(DUSKSTUDIO_NATIVE_LV2
-               "Build the native LV2 plugin host (Linux/macOS, needs lilv/suil/lv2)" ON)
-        if(DUSKSTUDIO_NATIVE_LV2 AND NOT (LILV_FOUND AND SUIL_FOUND AND LV2_FOUND))
+               "Build the native LV2 plugin host (Linux/macOS, needs lilv/suil/lv2)"
+               ${DUSKSTUDIO_LV2_DEPS_FOUND})
+        if(DUSKSTUDIO_NATIVE_LV2 AND NOT DUSKSTUDIO_LV2_DEPS_FOUND)
             message(FATAL_ERROR
                 "Native LV2 host was explicitly requested, but lilv/suil/lv2 were not all found")
+        elseif(NOT DUSKSTUDIO_LV2_DEPS_FOUND)
+            message(STATUS "Native LV2 host: lilv/suil/lv2 not all found - disabled")
         endif()
     elseif(LILV_FOUND AND SUIL_FOUND AND LV2_FOUND)
         option(DUSKSTUDIO_NATIVE_LV2
@@ -69,15 +80,24 @@ endif()
 # (external/vst3sdk submodule, tag dusk-vst3sdk-v1; see DUSK-MIRROR.md there).
 # GPL-3.0 arm of the SDK's dual license — see LICENSES.txt.
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR APPLE)
+    set(DUSKSTUDIO_VST3_SDK_PRESENT OFF)
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/vst3sdk/pluginterfaces/base/funknown.cpp")
+        set(DUSKSTUDIO_VST3_SDK_PRESENT ON)
+    endif()
     if(APPLE)
-        option(DUSKSTUDIO_NATIVE_VST3 "Build the native VST3 plugin host (Linux/macOS)" ON)
-        if(DUSKSTUDIO_NATIVE_VST3
-           AND NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/vst3sdk/pluginterfaces/base/funknown.cpp")
+        # Same rule as the LV2 gate above: default follows the submodule, an
+        # explicit request without it is fatal.
+        option(DUSKSTUDIO_NATIVE_VST3 "Build the native VST3 plugin host (Linux/macOS)"
+               ${DUSKSTUDIO_VST3_SDK_PRESENT})
+        if(DUSKSTUDIO_NATIVE_VST3 AND NOT DUSKSTUDIO_VST3_SDK_PRESENT)
             message(FATAL_ERROR
                 "Native VST3 host was explicitly requested, but external/vst3sdk is missing "
                 "(run: git submodule update --init external/vst3sdk)")
+        elseif(NOT DUSKSTUDIO_VST3_SDK_PRESENT)
+            message(STATUS "Native VST3 host: external/vst3sdk submodule missing - disabled "
+                           "(git submodule update --init external/vst3sdk)")
         endif()
-    elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/vst3sdk/pluginterfaces/base/funknown.cpp")
+    elseif(DUSKSTUDIO_VST3_SDK_PRESENT)
         option(DUSKSTUDIO_NATIVE_VST3 "Build the native VST3 plugin host (Linux/macOS)" ON)
     else()
         set(DUSKSTUDIO_NATIVE_VST3 OFF)

--- a/docs/dejuce-hosting-h5-platform.md
+++ b/docs/dejuce-hosting-h5-platform.md
@@ -1,0 +1,374 @@
+# Hosting tower H5 — native platform ports + AU (executable spec)
+
+Status: **SCOUTED 2026-07-29; MARC DECISIONS LOCKED; H5a.0 COMPLETE LOCALLY;
+H5a.1 NEXT.** H4 is merged as PR #119 at `3c5c901`. The H5 scout verified the
+live source/CMake/CI surface from that baseline. Windows LV2 is deferred. H5 is
+three sequential PRs: H5a macOS CLAP/LV2/VST3, H5b macOS AU, H5c Windows
+CLAP/VST3. No H5 branch is pushed without Marc's word.
+
+Parent plan: [dejuce-hosting-plan.md](dejuce-hosting-plan.md). Campaign ritual:
+[dejuce-campaign.md](dejuce-campaign.md). H1d and H2 remain blocked on donor
+consolidation and are not part of H5.
+
+## Goal
+
+Make the existing native CLAP, LV2, and VST3 hosts first-class on macOS; add a
+native Audio Unit host on macOS; then make CLAP and VST3 first-class on Windows.
+H5 leaves Linux behaviour unchanged and gives H6 enough native coverage to
+delete the JUCE hosting path without removing plugin hosting from a shipping
+platform.
+
+H5 does not unlink a JUCE module. H6 performs the deletion and globally unlinks
+`juce_audio_processors`.
+
+## Locked decisions
+
+- PR sequence is H5a macOS ports -> H5b AU -> H5c Windows ports -> H6. One PR
+  open at a time. Each PR must merge before the next branch starts.
+- Windows LV2 is deferred. H5c does not vendor suil and does not ship a
+  parameters-only LV2 tier. As verified at scout time, vcpkg has lilv but no
+  suil port. Linux and macOS keep full LV2 hosting, including embedded UIs.
+- H5a enables native CLAP, LV2, and VST3 by default on macOS. CI must request
+  all three options explicitly and fail configure if a requested dependency or
+  submodule is absent. A green build with the native formats silently OFF is not
+  H5 verification.
+- Linux native hosting is an invariant: same search paths, bundle semantics,
+  X11 editors, CLAP POSIX-fd support, VST3 Linux run loop, LV2 behaviour, audio
+  results, and current tests.
+- Platform code stays behind the existing format abstractions. Do not fork
+  `ClapInstance`, `Lv2Instance`, `Vst3Instance`, `NativeInsertSlot`, picker,
+  session, or engine audio behaviour merely to select a window or loader API.
+- Platform editor handles are pointer-width-safe. Do not carry the Linux
+  `unsigned long` X11 handle into a cross-platform interface; Windows LLP64
+  would truncate `HWND`.
+- macOS CLAP and VST3 editor sizes are logical coordinates. Linux X11 remains
+  physical pixels. The JUCE peer already returns `NSView*` on macOS and `HWND`
+  on Windows; the editor layer owns a native child container at the component's
+  bounds and gives that container to the plugin.
+- macOS LV2 uses lilv for discovery/instances and suil with a Cocoa container
+  for embedded UIs. Headless LV2 plugins remain loadable. A missing compatible
+  UI is an editor-only failure, not a plugin-load failure.
+- CLAP advertises `CLAP_EXT_POSIX_FD_SUPPORT` on Linux and macOS. H5c must not
+  advertise or compile that extension on Windows; CLAP timer support remains.
+- VST3 `Steinberg::Linux::IRunLoop` exists only on Linux. The macOS/Windows host
+  object exposes the portable host application, component-handler, and
+  plug-frame facets; `pump()` has no Linux fd/timer registry there.
+- Scanning a native bundle continues through the sandbox child where the
+  current scanner does so. H5 must not regress crash/timeout isolation.
+- AU is a new native layer in H5b, not a JUCE wrapper. It uses
+  AudioComponent/AudioUnit APIs and implements `hosting::INativeInstance`.
+- Runtime sign-off for all macOS/Windows formats and native editors is owed to
+  Marc's real machines. Linux-only development cannot claim it.
+- Zero attribution trailers. Commit locally; never push without Marc's word.
+
+## Scout ground truth
+
+- `CMakeLists.txt` currently forces native CLAP/LV2/VST3 OFF outside Linux and
+  compiles VST3's `threadchecker_linux.cpp` + `module_linux.cpp`.
+- The VST3 SDK mirror contains `module_mac.mm`, `module_win32.cpp`,
+  `threadchecker_mac.mm`, and `threadchecker_win32.cpp`.
+- `ClapBundle.cpp` is a direct `dlopen`/`dlsym`/`dlclose` loader. A macOS
+  `.clap` is normally a directory bundle whose executable must be resolved
+  before loading while the original bundle path is retained for identity and
+  `clap_entry::init`.
+- `ClapScanner` only collects regular `*.clap` files today, so it misses macOS
+  bundle directories. Its defaults are Linux FHS paths.
+- `ClapEditor`, `Lv2Editor`, and `Vst3Editor`, plus their JUCE wrapper
+  components, are X11-specific today.
+- `Vst3Bundle` already delegates loading to the SDK's `Hosting::Module`; its
+  main port is selecting the SDK platform source. `Vst3HostContext` and
+  `Vst3Editor` are still structurally Linux-only.
+- macOS CI installs neither lilv nor suil today. Homebrew currently provides
+  both. Windows CI currently installs neither, and H5c will not add them.
+- Existing macOS/Windows green jobs prove only the feature-OFF paths until H5
+  explicitly enables and asserts the native options.
+- AU has no native bundle, host, instance, editor, scanner, slot, persistence,
+  tests, or CMake target today.
+
+## H5a — macOS CLAP/LV2/VST3
+
+Branch: `dejuce/hosting-h5a`. One PR. Execute the increments below in order.
+Each implementation increment touches at most five files, gets its own focused
+verification, and pauses for campaign-manager review before the next.
+
+### H5a.0 — build gates + CI dependencies
+
+Files:
+
+1. `CMakeLists.txt`
+2. `tests/CMakeLists.txt`
+3. `.github/workflows/macos-build.yml`
+4. `.github/workflows/macos-release.yml`
+5. `docs/dejuce-hosting-plan.md`
+
+Work:
+
+- Enable Objective-C++ only on Apple.
+- Make native CLAP and VST3 available on Linux and macOS. Select the VST3 SDK's
+  Linux or macOS module/thread-checker sources per platform; compile the macOS
+  Objective-C++ sources with ARC and link the SDK-required Cocoa frameworks.
+- Pre-route each native editor source by platform in CMake: compile the
+  existing `*Editor.cpp` on Linux and the future `*Editor_Mac.mm` on Apple, so
+  H5a.2, H5a.3, and H5a.5 stay within their five-file increment limits.
+- Detect lilv/suil/lv2 through pkg-config on macOS as well as Linux. Preserve
+  Linux's existing optional-dependency behaviour; on macOS, an explicitly ON
+  native-LV2 option with a missing dependency is a configure error.
+- Keep third-party warning suppression compiler-correct (`-w` for Clang/GCC,
+  `/w` for MSVC in H5c).
+- Make native-host test sources follow the same feature gates. Keep
+  `vst3_hostcontext_runloop.cpp` Linux-only.
+- Install lilv/suil/lv2 in both macOS build and release workflows. Configure
+  with `DUSKSTUDIO_NATIVE_CLAP=ON`, `DUSKSTUDIO_NATIVE_LV2=ON`, and
+  `DUSKSTUDIO_NATIVE_VST3=ON`; assert the three cache values after configure.
+- Refresh the parent plan's stale H4 status and record the locked H5 split and
+  Windows-LV2 decision.
+
+Verify: Linux configure/build remains unchanged with all three native formats
+ON. A macOS configure cannot silently turn a requested format OFF.
+
+### H5a.1 — portable discovery + CLAP bundle loading
+
+Files:
+
+1. `src/engine/clap/ClapBundle.cpp`
+2. `src/engine/clap/ClapScanner.cpp`
+3. `src/engine/vst3/Vst3Scanner.cpp`
+4. `tests/clap_bundle_load.cpp`
+5. `tests/clap_scanner.cpp`
+
+Work:
+
+- Keep Linux CLAP loading byte-for-byte equivalent. On macOS, accept a direct
+  dynamic library or a `.clap` directory, resolve the directory's executable
+  with CoreFoundation bundle APIs, load it with local/now symbol visibility,
+  and retain the original bundle path for identity and entry initialisation.
+  Every failure must unload partially-created state and report a reason.
+- Discover `.clap` files on Linux and `.clap` directory bundles on macOS.
+  Never descend into a matched bundle. Deduplicate absolute paths.
+- macOS CLAP defaults:
+  `~/Library/Audio/Plug-Ins/CLAP`,
+  `/Library/Audio/Plug-Ins/CLAP`.
+  Keep `$CLAP_PATH` ahead of defaults and POSIX `:` separation.
+- macOS VST3 defaults:
+  `~/Library/Audio/Plug-Ins/VST3`,
+  `/Library/Audio/Plug-Ins/VST3`.
+  Reuse the current file-or-directory bundle collector and `$VST3_PATH`.
+- Extend negative-path and directory-bundle tests without requiring a
+  third-party plugin. Live load/enumeration remains environment-gated.
+
+Verify: focused scanner/loader tests; full Linux native tests; no scan cache or
+descriptor schema change.
+
+### H5a.2 — CLAP Cocoa editor
+
+Files:
+
+1. `src/engine/clap/ClapEditor.h`
+2. `src/engine/clap/ClapEditor.cpp` (retain as the Linux implementation)
+3. `src/engine/clap/ClapEditor_Mac.mm` (new)
+4. `src/ui/ClapPluginEditorComponent.h`
+5. `src/ui/ClapPluginEditorComponent.cpp`
+
+Work:
+
+- Make the public editor boundary native-handle-neutral and pointer-width-safe.
+  Preserve Linux's X11 implementation in its platform translation unit.
+- On macOS, create an `NSView` child container beneath the JUCE peer, request
+  `CLAP_WINDOW_API_COCOA`, pass the container through `clap_window`, and preserve
+  the current create -> parent -> show lifecycle.
+- Resize/move/show/hide/close the container on the message thread. Preserve
+  plugin resize/show/hide/closed callbacks and the shutdown leak escape hatch.
+- Use logical coordinates on Cocoa; retain the current physical-pixel scale and
+  geometry-drift checks on X11.
+- `ClapHost::pumpGui` continues to drive callbacks, POSIX fds, and timers on
+  macOS.
+
+Verify: Linux CLAP editor compiles and existing tests stay green; macOS app
+compiles the Cocoa translation unit with no X11 dependency.
+
+### H5a.3 — VST3 portable host context + Cocoa editor core
+
+Files:
+
+1. `src/engine/vst3/Vst3HostContext.h`
+2. `src/engine/vst3/Vst3HostContext.cpp`
+3. `src/engine/vst3/Vst3Editor.h`
+4. `src/engine/vst3/Vst3Editor.cpp` (retain as the Linux implementation)
+5. `src/engine/vst3/Vst3Editor_Mac.mm` (new)
+
+Work:
+
+- Compile the `Linux::IRunLoop` facet, `poll`, fd handlers, timers, and their QI
+  only on Linux. Keep the portable host application, component-handler, and
+  plug-frame facets on every platform.
+- Keep the existing Linux run-loop API/test observable. On macOS, `pump()` has
+  no Linux registry to service.
+- On macOS, create an `NSView` child container and attach `IPlugView` with
+  `kPlatformTypeNSView`; wire `IPlugFrame` before attach; round-trip
+  `resizeView`, `onSize`, visibility, and removal in logical coordinates.
+- Preserve Linux X11 attachment and content-scale behaviour.
+
+Verify: Linux run-loop test remains unchanged and green; macOS compiles without
+Linux interface or `poll.h` references.
+
+### H5a.4 — VST3 Cocoa wrapper + cross-platform tests
+
+Files:
+
+1. `src/ui/Vst3PluginEditorComponent.h`
+2. `src/ui/Vst3PluginEditorComponent.cpp`
+3. `tests/vst3_hostcontext_runloop.cpp`
+4. `tests/vst3_scanner.cpp`
+5. `tests/vst3_bundle_load.cpp`
+
+Work:
+
+- Route the JUCE wrapper through the neutral native handle and use logical
+  component bounds on macOS while preserving X11 scale/geometry diagnostics.
+- Compile and run the run-loop test only on Linux.
+- Make scanner shape/default tests platform-aware. Keep live module tests
+  environment-gated and the no-module failure path universal.
+
+Verify: focused VST3 tests on Linux; macOS CI compiles and runs the portable
+negative/discovery tests.
+
+### H5a.5 — LV2 Cocoa editor
+
+Files:
+
+1. `src/engine/lv2/Lv2Editor.h`
+2. `src/engine/lv2/Lv2Editor.cpp` (retain as the Linux implementation)
+3. `src/engine/lv2/Lv2Editor_Mac.mm` (new)
+4. `src/ui/Lv2PluginEditorComponent.h`
+5. `src/ui/Lv2PluginEditorComponent.cpp`
+
+Work:
+
+- Preserve lilv discovery, instance, state-path, parameter, and audio behaviour.
+  Lilv owns `$LV2_PATH` and platform default discovery.
+- Make the editor boundary pointer-width-safe. Preserve the X11+suil
+  implementation on Linux.
+- On macOS, discover a UI that suil can wrap for a `LV2_UI__CocoaUI` container,
+  create an `NSView` child container, pass `ui:parent` plus the existing
+  instance/data/resize/idle features, and instantiate through suil.
+- Keep resize, idle-close, show/hide, teardown, and shutdown-leak semantics.
+  Use logical Cocoa bounds.
+
+Verify: Linux LV2 tests and editor build remain green; macOS CI compiles lilv,
+suil, the instance tests, and the Cocoa editor.
+
+### H5a.6 — full closeout
+
+Review order: cavecrew reviewer -> fixes -> fresh-eyes reviewer -> fixes ->
+full validation -> commit. Do not push.
+
+Linux bar:
+
+```bash
+CCACHE_DISABLE=1 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
+  -DDUSK_PLUGINS_PATH=/home/marc/projects/plugins-multicomp-core
+CCACHE_DISABLE=1 cmake --build build -j"$(nproc)"
+CCACHE_DISABLE=1 cmake -S . -B build-tests -DCMAKE_BUILD_TYPE=Release \
+  -DDUSKSTUDIO_BUILD_TESTS=ON \
+  -DDUSK_PLUGINS_PATH=/home/marc/projects/plugins-multicomp-core
+CCACHE_DISABLE=1 cmake --build build-tests --target dusk-studio-tests -j"$(nproc)"
+ctest --test-dir build-tests --output-on-failure
+tools/juce-gate.sh
+```
+
+Run the app self-test only on a private Xvfb display with
+`WAYLAND_DISPLAY` unset. Accept only the known environment flake
+`ALSA seq backend does not report`; investigate every other failure. Gate must
+stay at or below 179. Build must add zero warnings. Run diff/slop and MANUAL
+audits.
+
+After Marc says push, macOS CI must prove:
+
+- Release app and Catch2 suite compile with native CLAP/LV2/VST3 explicitly ON.
+- Cache assertions show all three enabled.
+- CLAP/VST3 negative loader and scanner tests run on macOS.
+- LV2 native instance tests compile/run with Homebrew lilv/suil/lv2.
+
+CI compile success is not runtime sign-off. Record the bench debt in the PR.
+
+## H5b — native AU
+
+Branch after H5a merges: `dejuce/hosting-h5b`. One PR, with bounded internal
+increments.
+
+- Add macOS-only `src/engine/au/`:
+  `AuBundle`, `AuHost`, `AuInstance`, `AuEditor`, `AuScanner`,
+  `NativeAuSlot`.
+- `AuBundle` resolves a stable AudioComponent identifier
+  (type/subtype/manufacturer) and component metadata.
+- `AuInstance` implements `hosting::INativeInstance` with AudioUnit
+  initialise/uninitialise, bus/stream-format negotiation, render, MIDI,
+  parameter enumeration/writes, state property-list round-trip, and latency.
+  No allocation, lock, Objective-C dispatch, or property query on the audio
+  thread.
+- `AuEditor` loads the Cocoa view factory and embeds its `NSView` through the
+  H5a Cocoa-container pattern.
+- `AuScanner` enumerates effects/instruments into native `PluginDescriptor`
+  rows and uses the existing cache/sandbox rules.
+- Add AU rungs to channel/aux slots, picker, editor-open flows, MIDI bindings,
+  latency, shutdown, session save/restore, and clone/offline plumbing. New
+  session keys are additive; legacy JUCE-AU descriptors migrate one way.
+- Add narrow tests for identifier round-trip, descriptor classification,
+  instance lifecycle/process, parameter/state/latency, slot persistence, and
+  scanner output. Real stock Apple units remain a bench check.
+
+## H5c — Windows CLAP/VST3
+
+Branch after H5b merges: `dejuce/hosting-h5c`. One PR, with bounded internal
+increments.
+
+- Enable CLAP/VST3 on Windows and select SDK `module_win32.cpp` +
+  `threadchecker_win32.cpp`.
+- CLAP dynamic loading uses `LoadLibraryW`/`GetProcAddress`/`FreeLibrary` with
+  UTF-16 paths and stable UTF-8 identity/error text.
+- Windows scan defaults and environment-list separator follow the CLAP/VST3
+  platform conventions.
+- CLAP editor uses `CLAP_WINDOW_API_WIN32`; VST3 uses
+  `kPlatformTypeHWND`. Both own child `HWND` containers and preserve lifecycle,
+  resizing, visibility, and teardown.
+- CLAP does not advertise or compile POSIX-fd support on Windows. Timers and
+  main-thread callbacks remain.
+- Windows LV2 remains OFF and absent from picker rows.
+- `windows-tests.yml` explicitly enables CLAP/VST3 and runs native-host tests.
+  `windows-build.yml` explicitly enables them and is dispatched after Marc's
+  push word. A vcpkg 504 is retried with `gh run rerun <id> --failed`.
+
+## Verify
+
+Each PR gets the Linux full bar before commit and its target-platform CI after
+Marc authorises a push. No phase may infer runtime success from cross-platform
+compilation.
+
+H5 is complete only when:
+
+- macOS natively scans, loads, processes, saves/restores, and embeds editors for
+  CLAP, LV2, VST3, and AU on Marc's bench;
+- Windows does the same for CLAP and VST3;
+- Linux CLAP/LV2/VST3 is unchanged and fully green;
+- sessions preserve native format, stable identifier, state, bypass, latency,
+  instrument/effect classification, and editor reopen;
+- the picker shows one native row per supported format and does not fall back to
+  the JUCE host for a format H5 owns;
+- gate is at or below 179 and module count remains 12 pending H6.
+
+## Owed to Marc's bench
+
+- macOS: scan/load/play/save/reload/bypass for real CLAP, LV2, VST3 effects and
+  instruments; editor open/resize/hide/reopen; plugin-reported latency; CLAP
+  fd/timer UI; stock Apple AU effect + instrument; signed/notarized app smoke.
+- Windows: the same CLAP/VST3 matrix in the full app, including editor DPI,
+  resize/reopen, state, latency, and ASIO playback.
+- Cross-platform session handoff: save native CLAP/VST3 on one OS, open on
+  another with the corresponding plugin installed, and verify stable-id restore
+  or a clear offline row.
+
+## Resume phrase
+
+"Hosting H5, spec docs/dejuce-hosting-h5-platform.md — on
+dejuce/hosting-h5a, execute the first incomplete H5a increment, review, validate,
+and commit locally; never push without Marc's word."

--- a/docs/dejuce-hosting-h5-platform.md
+++ b/docs/dejuce-hosting-h5-platform.md
@@ -202,7 +202,9 @@ Work:
 
 - Compile the `Linux::IRunLoop` facet, `poll`, fd handlers, timers, and their QI
   only on Linux. Keep the portable host application, component-handler, and
-  plug-frame facets on every platform.
+  plug-frame facets on every platform. DONE EARLY: the host-context split landed
+  with the H5a.1 macOS build fix, alongside a placeholder `Vst3Editor_Mac.mm`
+  whose `open()` reports no embeddable view. Only the Cocoa attach below remains.
 - Keep the existing Linux run-loop API/test observable. On macOS, `pump()` has
   no Linux registry to service.
 - On macOS, create an `NSView` child container and attach `IPlugView` with
@@ -249,7 +251,9 @@ Work:
 - Preserve lilv discovery, instance, state-path, parameter, and audio behaviour.
   Lilv owns `$LV2_PATH` and platform default discovery.
 - Make the editor boundary pointer-width-safe. Preserve the X11+suil
-  implementation on Linux.
+  implementation on Linux. `Lv2Editor_Mac.mm` already exists as a placeholder
+  from the H5a.1 macOS build fix (`open()` reports no embeddable UI); replace
+  its body rather than creating the file.
 - On macOS, discover a UI that suil can wrap for a `LV2_UI__CocoaUI` container,
   create an `NSView` child container, pass `ui:parent` plus the existing
   instance/data/resize/idle features, and instantiate through suil.

--- a/docs/dejuce-hosting-h5-platform.md
+++ b/docs/dejuce-hosting-h5-platform.md
@@ -1,10 +1,10 @@
 # Hosting tower H5 — native platform ports + AU (executable spec)
 
-Status: **SCOUTED 2026-07-29; MARC DECISIONS LOCKED; H5a.0 COMPLETE LOCALLY;
-H5a.1 NEXT.** H4 is merged as PR #119 at `3c5c901`. The H5 scout verified the
-live source/CMake/CI surface from that baseline. Windows LV2 is deferred. H5 is
-three sequential PRs: H5a macOS CLAP/LV2/VST3, H5b macOS AU, H5c Windows
-CLAP/VST3. No H5 branch is pushed without Marc's word.
+Status: **SCOUTED 2026-07-29; MARC DECISIONS LOCKED; H5a.0-H5a.1 COMPLETE
+LOCALLY; H5a.2 NEXT.** H4 is merged as PR #119 at `3c5c901`. The H5 scout
+verified the live source/CMake/CI surface from that baseline. Windows LV2 is
+deferred. H5 is three sequential PRs: H5a macOS CLAP/LV2/VST3, H5b macOS AU,
+H5c Windows CLAP/VST3. No H5 branch is pushed without Marc's word.
 
 Parent plan: [dejuce-hosting-plan.md](dejuce-hosting-plan.md). Campaign ritual:
 [dejuce-campaign.md](dejuce-campaign.md). H1d and H2 remain blocked on donor

--- a/docs/dejuce-hosting-h5-platform.md
+++ b/docs/dejuce-hosting-h5-platform.md
@@ -1,7 +1,7 @@
 # Hosting tower H5 — native platform ports + AU (executable spec)
 
-Status: **SCOUTED 2026-07-29; MARC DECISIONS LOCKED; H5a.0-H5a.1 COMPLETE
-LOCALLY; H5a.2 NEXT.** H4 is merged as PR #119 at `3c5c901`. The H5 scout
+Status: **SCOUTED 2026-07-29; MARC DECISIONS LOCKED; H5a.0-H5a.2 COMPLETE
+LOCALLY; H5a.3 NEXT.** H4 is merged as PR #119 at `3c5c901`. The H5 scout
 verified the live source/CMake/CI surface from that baseline. Windows LV2 is
 deferred. H5 is three sequential PRs: H5a macOS CLAP/LV2/VST3, H5b macOS AU,
 H5c Windows CLAP/VST3. No H5 branch is pushed without Marc's word.

--- a/docs/dejuce-hosting-h5-platform.md
+++ b/docs/dejuce-hosting-h5-platform.md
@@ -202,9 +202,9 @@ Work:
 
 - Compile the `Linux::IRunLoop` facet, `poll`, fd handlers, timers, and their QI
   only on Linux. Keep the portable host application, component-handler, and
-  plug-frame facets on every platform. DONE EARLY: the host-context split landed
-  with the H5a.1 macOS build fix, alongside a placeholder `Vst3Editor_Mac.mm`
-  whose `open()` reports no embeddable view. Only the Cocoa attach below remains.
+  plug-frame facets on every platform. DONE: this split landed with the macOS
+  build fix, alongside a placeholder `Vst3Editor_Mac.mm` whose `open()` reports
+  no embeddable view. Only the Cocoa attach below remains.
 - Keep the existing Linux run-loop API/test observable. On macOS, `pump()` has
   no Linux registry to service.
 - On macOS, create an `NSView` child container and attach `IPlugView` with
@@ -252,8 +252,8 @@ Work:
   Lilv owns `$LV2_PATH` and platform default discovery.
 - Make the editor boundary pointer-width-safe. Preserve the X11+suil
   implementation on Linux. `Lv2Editor_Mac.mm` already exists as a placeholder
-  from the H5a.1 macOS build fix (`open()` reports no embeddable UI); replace
-  its body rather than creating the file.
+  from the macOS build fix (`open()` reports no embeddable UI); replace its
+  body rather than creating the file.
 - On macOS, discover a UI that suil can wrap for a `LV2_UI__CocoaUI` container,
   create an `NSView` child container, pass `ui:parent` plus the existing
   instance/data/resize/idle features, and instantiate through suil.

--- a/docs/dejuce-hosting-h5-platform.md
+++ b/docs/dejuce-hosting-h5-platform.md
@@ -104,9 +104,11 @@ Files:
 Work:
 
 - Enable Objective-C++ only on Apple.
-- Make native CLAP and VST3 available on Linux and macOS. Select the VST3 SDK's
-  Linux or macOS module/thread-checker sources per platform; compile the macOS
-  Objective-C++ sources with ARC and link the SDK-required Cocoa frameworks.
+- Make native CLAP, LV2, and VST3 all available on Linux and macOS - every
+  one of the three needs its option, target, and gate wired on macOS; omitting
+  any of them fails H5a.0. Select the VST3 SDK's Linux or macOS
+  module/thread-checker sources per platform; compile the macOS Objective-C++
+  sources with ARC and link the SDK-required Cocoa frameworks.
 - Pre-route each native editor source by platform in CMake: compile the
   existing `*Editor.cpp` on Linux and the future `*Editor_Mac.mm` on Apple, so
   H5a.2, H5a.3, and H5a.5 stay within their five-file increment limits.

--- a/docs/dejuce-hosting-plan.md
+++ b/docs/dejuce-hosting-plan.md
@@ -1,11 +1,11 @@
 # De-JUCE — plugin-hosting tower (campaign plan)
 
-Status: **H1a-c merged (PR #114); H3 merged (PR #118); H4 complete locally
-on `dejuce/hosting-h4` and awaiting Marc's push word; H1d blocked on donor
+Status: **H1a-c merged (PR #114); H3 merged (PR #118); H4 merged (PR #119,
+`3c5c901`); H5 scout complete; H5a ready on `dejuce/hosting-h5a`; H1d blocked on donor
 consolidation; H2 blocked on the donor multiband port.** Marc's call on
 2026-07-26 reversed the 2026-07-01 keep-JUCE-fallback decision: the JUCE
-plugin-hosting path gets deleted entirely; native hosting must cover VST3 +
-LV2 + CLAP on Linux, macOS, and Windows, plus AU on macOS.
+plugin-hosting path gets deleted entirely; native hosting must cover CLAP and
+VST3 on Linux, macOS, and Windows, LV2 on Linux and macOS, plus AU on macOS.
 Multi-PR tower (>15 files per phase, RT-risky and mechanical work mixed) —
 one PR per phase, sequenced below. Do not start phase N+1's PR before N
 merges. Read `docs/dejuce-campaign.md` + the memory ledger first.
@@ -49,9 +49,8 @@ merges. Read `docs/dejuce-campaign.md` + the memory ledger first.
   CLAP posix-fd ext (absent on Windows by spec — timers only), VST3
   Linux::IRunLoop (collapses away on mac/win), CMake gates (Linux-only
   conditions today; vst3sdk ships module_mac.mm / module_win32.cpp).
-- LV2-on-Windows risk: no vcpkg suil port. Options when H5 lands: vendor
-  suil, or ship LV2 headless-params-only on Windows first. Decision
-  deferred to H5 spec.
+- LV2 on Windows is deferred: vcpkg has lilv but no suil port, and H5c will
+  neither vendor suil nor ship a parameters-only LV2 tier.
 - OOP host: JUCE audio path only + native scan sandbox (clap/vst3). After
   the drop it keeps only scanning; its juce_events dispatch loop goes with
   the JUCE path (also closes the events-tower out-of-scope items).
@@ -89,7 +88,7 @@ merges. Read `docs/dejuce-campaign.md` + the memory ledger first.
   migration; format wrapper deleted (gate 183 -> 181); two-phase
   prime/commit keeps sfizz parses outside the engine gate; spec:
   [dejuce-hosting-h3-multisample.md](dejuce-hosting-h3-multisample.md).
-- **H4 — descriptor/plumbing de-JUCE. DONE locally; not pushed.** Dusk
+- **H4 — descriptor/plumbing de-JUCE. DONE (PR #119, `3c5c901`).** Dusk
   `PluginDescriptor` now owns picker, native scan/cache, scan-protocol,
   session-reference, offline/clone, screenshot-fixture, and restore plumbing.
   The private JUCE host boundary converts only where H6 still needs it.
@@ -98,16 +97,17 @@ merges. Read `docs/dejuce-campaign.md` + the memory ledger first.
   181 -> 179; full CTest 493/493 plus private-Xvfb self-test, synthetic SFZ
   sound verdict, and picker screenshot review passed. Spec:
   [dejuce-hosting-h4-descriptors.md](dejuce-hosting-h4-descriptors.md).
-- **H5 — platform ports (mac, win).** Flip CMake gates per-OS; loader
-  shims (dlopen/LoadLibrary, mac bundle resolution); per-OS scan paths;
-  editor embed variants (COCOA/HWND CLAP targets, kPlatformTypeNSView/HWND,
-  suil Cocoa/Windows hosts); CLAP fd-ext gated off on win; VST3 host
-  context minus IRunLoop; AU layer cloned from the CLAP template
-  (ClapBundle/Host/Instance/Editor/Scanner + NativeInsertSlot traits,
-  ~1.3k LOC) on AudioComponent/AudioUnit APIs, macOS only. Verified via
-  macos-build.yml per push (full app + tests) and windows-tests.yml;
-  windows-build.yml full app needs workflow_dispatch. Runtime sign-off =
-  Marc's Mac/Windows bench, first-class TODO.
+- **H5 — platform ports (three sequential PRs; H5a is READY).** H5a ports
+  CLAP/LV2/VST3 to macOS, including bundle discovery/loading, Cocoa editor
+  embeds, and the portable VST3 host context. H5b adds the native macOS AU
+  layer on AudioComponent/AudioUnit APIs. H5c ports CLAP/VST3 to Windows,
+  with CLAP POSIX-fd support absent and VST3's Linux IRunLoop removed.
+  Windows LV2 stays deferred. H5a must merge before H5b starts, and H5b must
+  merge before H5c starts. Executable spec:
+  [dejuce-hosting-h5-platform.md](dejuce-hosting-h5-platform.md). Verification
+  runs through macos-build.yml and windows-tests.yml; windows-build.yml's full
+  app remains workflow_dispatch. Runtime sign-off is owed to Marc's real
+  Mac/Windows bench.
 - **H6 — the drop.** Delete the JUCE hosting path everywhere at once (H5
   made mac/win self-sufficient), unlink juce_audio_processors on all
   platforms, retire tsan suppressions tied to deleted primitives in the
@@ -124,7 +124,7 @@ gates H2's app half, not the other phases.
   session.
 - Marc bench: tape null-listen, multiband null-listen, mac/win native
   hosting with real third-party plugins, AU with stock Apple units.
-- LV2-on-Windows suil decision at H5.
+- Windows LV2 is deferred beyond H5; H5c ships CLAP/VST3 only.
 - DUSK_PLUGINS_PATH still points at the plugins-multicomp-core worktree;
   donor consolidation (merge core work to donor main, retire worktree,
   repoint) should happen at H2's donor step.

--- a/docs/dejuce-hosting-plan.md
+++ b/docs/dejuce-hosting-plan.md
@@ -105,9 +105,9 @@ merges. Read `docs/dejuce-campaign.md` + the memory ledger first.
   Windows LV2 stays deferred. H5a must merge before H5b starts, and H5b must
   merge before H5c starts. Executable spec:
   [dejuce-hosting-h5-platform.md](dejuce-hosting-h5-platform.md). Verification
-  runs through macos-build.yml and windows-tests.yml; windows-build.yml's full
-  app remains workflow_dispatch. Runtime sign-off is owed to Marc's real
-  Mac/Windows bench.
+  runs through macos-build.yml, macos-release.yml, and windows-tests.yml;
+  windows-build.yml's full app remains workflow_dispatch. Runtime sign-off is
+  owed to Marc's real Mac/Windows bench.
 - **H6 — the drop.** Delete the JUCE hosting path everywhere at once (H5
   made mac/win self-sufficient), unlink juce_audio_processors on all
   platforms, retire tsan suppressions tied to deleted primitives in the

--- a/docs/dejuce-remaining-phase-prompts.md
+++ b/docs/dejuce-remaining-phase-prompts.md
@@ -1,0 +1,357 @@
+# De-JUCE campaign — handoff prompts for remaining phases
+
+One prompt per remaining phase, each written for a fresh context window
+(Opus execution sessions per [dejuce-campaign.md](dejuce-campaign.md)
+§Model/token policy; prompt 10 is a Fable spec session). Snapshot date:
+2026-07-30. If phase statuses have moved since, trust the tower specs'
+status lines and `git log` over this file.
+
+## State at time of writing
+
+- Merged on `main`: hosting H1a–c (PR #114), H3 (PR #118), H4 (PR #119),
+  plus everything in the campaign doc's Done list.
+- In flight: H5a on `dejuce/hosting-h5a` — H5a.0–H5a.2 complete, H5a.3
+  next. The H5 spec `docs/dejuce-hosting-h5-platform.md` exists only on
+  that branch until H5a merges.
+- Gate allowlist: 179 files. JUCE modules linked: 12.
+- The memory ledger `project_dejuce_roadmap.md` exists only on the Linux
+  machine; sessions on other machines fall back to repo docs + git log.
+
+## Dependency order
+
+```
+H5a (in flight) → H5b → H5c
+Donor consolidation → H1d
+                   → H2-donor → H2-app
+H6 requires H5a+H5b+H5c and H2-app merged
+GUI spike → GUI tower spec → GUI tower execution (finale)
+```
+
+One PR open at a time (campaign ritual rule 2). H1d is order-independent
+of H5/H6 but must land before the GUI tower.
+
+---
+
+## Prompt 1 — H5a remainder (macOS CLAP/LV2/VST3 ports)
+
+```
+You are executing one phase of the Dusk Studio de-JUCE campaign in
+/Users/marckorte/projects/DuskStudio (or /home/marc/projects/DuskStudio on the
+Linux box). Read, in order: docs/dejuce-campaign.md (ritual + working
+agreement), then check out the existing branch dejuce/hosting-h5a from origin
+and read docs/dejuce-hosting-h5-platform.md ON THAT BRANCH (it is not on main
+yet). If the memory ledger project_dejuce_roadmap.md exists in this machine's
+memory dir, read it; if absent, trust the spec's status line and git log.
+
+State: H5a.0 (build gates + CI dependencies), H5a.1 (portable discovery + CLAP
+bundle loading), and H5a.2 (CLAP Cocoa editor) are complete on the branch;
+H5a.3's host-context split already landed with the macOS build fix, so only its
+Cocoa attach remains. Execute the first incomplete increment (H5a.3 VST3
+portable host context + Cocoa editor core, then H5a.4 VST3 Cocoa wrapper +
+cross-platform tests, H5a.5 LV2 Cocoa editor, H5a.6 closeout) — ONE increment
+per session, max five files each, exactly as the spec's per-increment file
+lists and work items dictate. Pause for review after each increment.
+
+Rules: commit locally, NEVER push without Marc's word; no attribution trailers;
+Linux native hosting behaviour is an invariant; keep platform code behind the
+existing format abstractions; editor handles pointer-width-safe. Verify per the
+spec's per-increment bar; at H5a.6 run the full Linux bar (CCACHE_DISABLE=1
+builds, ctest, tools/juce-gate.sh ≤ 179, selftest only under private Xvfb with
+WAYLAND_DISPLAY unset). On the Mac, a local Release configure+build with
+DUSKSTUDIO_NATIVE_CLAP/LV2/VST3=ON is the compile check (DUSK_PLUGINS_PATH=
+/Users/marckorte/projects/dusk-audio-plugins-pinned); macOS CI proof and Marc's
+bench sign-off happen after Marc authorises the push. End your session by
+updating the spec's status line and stating the resume phrase from the spec.
+```
+
+## Prompt 2 — H5b (native Audio Unit host, macOS)
+
+```
+You are executing one phase of the Dusk Studio de-JUCE campaign. Precondition:
+the H5a PR (branch dejuce/hosting-h5a) is MERGED — verify with git log before
+starting; if not merged, stop and report. Read, in order:
+docs/dejuce-campaign.md, docs/dejuce-hosting-plan.md,
+docs/dejuce-hosting-h5-platform.md §H5b (on main once H5a merges), and the
+memory ledger project_dejuce_roadmap.md if present on this machine.
+
+Create branch dejuce/hosting-h5b. Build the macOS-only native AU layer in
+src/engine/au/ — AuBundle (stable type/subtype/manufacturer identifier),
+AuHost, AuInstance (implements hosting::INativeInstance: init/uninit,
+bus/stream-format negotiation, render, MIDI, parameter enumeration/writes,
+state property-list round-trip, latency; NO allocation, lock, Objective-C
+dispatch, or property query on the audio thread), AuEditor (Cocoa view factory
+embedded via the H5a NSView-container pattern), AuScanner (native
+PluginDescriptor rows, existing cache/sandbox rules), NativeAuSlot. Wire AU
+rungs into channel/aux slots, picker, editor-open flows, MIDI bindings,
+latency, shutdown, session save/restore, clone/offline plumbing. Session keys
+additive; legacy JUCE-AU descriptors migrate one way. Narrow Catch2 tests per
+the spec's H5b list. Work in bounded increments (≤5 files), one PR total.
+
+Rules: commit locally, never push without Marc's word; no attribution
+trailers; Linux behaviour untouched. Verify: Linux full bar before commit
+(build, ctest, juce-gate ≤ current count, Xvfb selftest), macOS compile with
+all native formats ON; real stock Apple AU units are Marc's bench debt —
+record it in the PR body. Update spec status line; end with the spec's resume
+phrase.
+```
+
+## Prompt 3 — H5c (Windows CLAP/VST3 ports)
+
+```
+You are executing one phase of the Dusk Studio de-JUCE campaign. Precondition:
+H5b PR merged — verify with git log; if not, stop. Read, in order:
+docs/dejuce-campaign.md, docs/dejuce-hosting-plan.md,
+docs/dejuce-hosting-h5-platform.md §H5c, and the memory ledger if present.
+
+Create branch dejuce/hosting-h5c. Enable native CLAP/VST3 on Windows: CMake
+selects the VST3 SDK's module_win32.cpp + threadchecker_win32.cpp; CLAP
+loading via LoadLibraryW/GetProcAddress/FreeLibrary with UTF-16 paths and
+stable UTF-8 identity/error text; Windows scan defaults + environment-list
+separator per CLAP/VST3 platform conventions; CLAP editor via
+CLAP_WINDOW_API_WIN32, VST3 via kPlatformTypeHWND, both owning child HWND
+containers with lifecycle/resize/visibility/teardown preserved; CLAP POSIX-fd
+extension NOT advertised or compiled on Windows (timers + main-thread
+callbacks remain); Windows LV2 stays OFF and absent from picker rows (locked
+decision — do not vendor suil). windows-tests.yml explicitly enables CLAP/VST3
+and runs native-host tests; windows-build.yml explicitly enables them and is
+dispatched only after Marc's push word (vcpkg 504 → gh run rerun <id>
+--failed).
+
+Rules: commit locally, never push without Marc's word; no attribution
+trailers; Linux and macOS behaviour untouched; handles pointer-width-safe
+(LLP64: never carry unsigned long X11 handles into shared interfaces). Verify:
+Linux full bar; Windows CI after authorised push; real-plugin matrix including
+ASIO playback and editor DPI is Marc's bench debt — record in PR body. Update
+spec status; end with resume phrase.
+```
+
+## Prompt 4 — Donor consolidation (plugins repo; unblocks H1d + H2)
+
+```
+You are executing the donor-consolidation step of the Dusk Studio de-JUCE
+hosting tower (see docs/dejuce-hosting-plan.md §Standing risks and §H1d
+version-prerequisite, plus docs/dejuce-hosting-h1-tape.md §H1d, in
+/home/marc/projects/DuskStudio). Work happens primarily in the DONOR plugins
+repo (Linux: /home/marc/projects/plugins with the multicomp-core worktree at
+/home/marc/projects/plugins-multicomp-core; Mac mirror:
+/Users/marckorte/projects/dusk-audio-plugins).
+
+Goal: end the split-donor state so H1d and H2 can proceed from ONE donor rev.
+Steps: (1) merge the plugins-multicomp-core branch into donor main (its core
+scope is LOCKED and excludes Multiband — nothing new rides along); (2) bump
+DONOR_REV in all 8 Dusk Studio workflows together, in one commit; (3) retire
+the plugins-multicomp-core worktree and repoint DUSK_PLUGINS_PATH in both
+build caches (build/, build-tests/) back to the consolidated donor main —
+CLAUDE.md documents the single-checkout convention; (4) confirm Dusk Studio
+builds + full ctest green against the consolidated donor on Linux, and that
+tests/tape_core_ab.cpp and the console_saturation A/B still pass (pinned rev
+69f0431 semantics must survive the merge — if the tape A/B breaks, stop and
+report the param-surface delta rather than re-baselining silently).
+
+Rules: campaign ritual applies in both repos — branch first, commit locally,
+never push without Marc's word, no attribution trailers. Record in the ledger
+(or the hosting plan's status line if the ledger is absent) that donor
+consolidation is done and H1d + H2 are unblocked.
+```
+
+## Prompt 5 — H2-donor (Multiband compressor DPF port, plugins repo)
+
+```
+You are executing the donor half of hosting-tower phase H2 of the Dusk Studio
+de-JUCE campaign. Precondition: donor consolidation done (one donor rev, no
+multicomp-core worktree) — verify; if not, stop and run that step first. Read
+docs/dejuce-campaign.md and docs/dejuce-hosting-plan.md §H2 in the DuskStudio
+repo, then work in the donor plugins repo.
+
+Goal: port UniversalCompressor mode 7 (Multiband) into a JUCE-free core —
+extend the multi-comp/core scope or create a sibling MultibandCompressorDSP,
+following the established donor DPF-core pattern (TapeMachine/core
+TapeMachineDSP is the reference: plain C++ core, atomic setters, PORT_NOTES.md
+documenting semantics). Marc's direction: "Multicomp will need to be ported to
+DPF". The Dusk Studio consumer surface to design against: MasteringChain
+bindCompParams and MasteringView's embedded donor MultibandCompressorPanel
+writing mb_* APVTS params — enumerate those params first and give the core an
+equivalent setter surface. A/B parity harness vs the JUCE UniversalCompressor
+Multiband mode belongs in the donor repo's test convention (null or bounded
+residual, documented tolerance).
+
+After the core lands on donor main: bump DONOR_REV in all 8 Dusk Studio
+workflows. Rules: branch first, commit locally, never push without Marc's
+word, no attribution trailers. The app-side flip (MasteringChain/MasteringView)
+is a SEPARATE session — do not start it here. Record status in the hosting
+plan and ledger.
+```
+
+## Prompt 6 — H2-app (MasteringChain + MasteringView flip)
+
+```
+You are executing the app half of hosting-tower phase H2 of the Dusk Studio
+de-JUCE campaign in the DuskStudio repo. Precondition: the donor Multiband
+core is merged to donor main and DONOR_REV is bumped — verify; if not, stop.
+Read docs/dejuce-campaign.md, docs/dejuce-hosting-plan.md §H2, the memory
+ledger if present, and the donor core's PORT_NOTES.
+
+Create branch dejuce/hosting-h2. Flip MasteringChain off
+UniversalCompressor/APVTS onto the new JUCE-free Multiband core, following the
+H1a house pattern (docs/dejuce-hosting-h1-tape.md): session-level atomic
+params per Session.h convention #1, UI writes atoms, chain pushes all live
+params to core setters per block (lock-free stores), one-way migration from
+any persisted APVTS state, latency reported from the core. Replace
+MasteringView's embedded donor MultibandCompressorPanel with a native panel in
+the existing embedded-modal house style (MasteringLimiterEditor /
+BusCompEditorPanel are the references). Remove the donor multicomp JUCE
+sources from the app target in CMakeLists. Tests: A/B vs JUCE multiband
+(tolerance documented), silence-in/silence-out, latency match — follow
+tests/tape_core_ab.cpp's DUSK_PLUGINS_PATH gating.
+
+Rules: audio-thread rules in CLAUDE.md are mandatory; commit locally, never
+push without Marc's word; no attribution trailers. Verify: full Linux bar
+(build zero new warnings, ctest, juce-gate — expect movement as donor JUCE
+sources leave, record the number; Xvfb selftest), screenshot review of the new
+panel, MANUAL.md audit, multiband null-listen recorded as Marc's bench debt.
+Session compatibility: test the one-way migration with a real 0.12 session.
+Update spec status; end with resume phrase.
+```
+
+## Prompt 7 — H1d (TapeMachine2 DPF UI embed)
+
+```
+You are executing hosting-tower phase H1d of the Dusk Studio de-JUCE campaign
+on the LINUX machine (X11 embed work; /home/marc/projects/DuskStudio).
+Precondition: donor consolidation done (UI and core MUST come from one donor
+rev — the pinned 69f0431 predates TM2's current param surface) — verify; if
+not, stop. Read docs/dejuce-campaign.md, docs/dejuce-hosting-h1-tape.md §H1d
+(the executable spec for this phase), and the memory ledger — it holds the
+2026-07-26 feasibility-spike recipe and param-delta table; if the ledger is
+absent on this machine, say so and reconstruct the delta by diffing
+TapeMachineParams.hpp between 69f0431 and donor main.
+
+Create a branch (dejuce/hosting-h1d). Work: extend session TapeParams + core
+setters to TM2's current param surface (head width, gain link, wow/flutter
+enable, advanced page, preset bar); compile the TM2 DPF UI stack
+(TapeMachineUI.cpp + DuskImGuiWidgets + DGL-OpenGL) into Dusk Studio; embed
+its DGL window as an X11 child using the ClapPluginEditorComponent
+reparent/embed pattern. Bridges: UI→engine via DPF setParameterValue mapped
+through the TapeMachineParams enum onto session TapeParams atoms
+(arm-on-touch preserved); engine→UI via a 30 Hz atom-diff sync calling
+parameterChanged; meters via strong definitions of the DuskAccessBridge weak
+symbols (tapeMachineGetVuL/R, InVuL/R) returning the in-process core's
+followers, getPluginInstancePointer supplying the core. Then DELETE the
+interim JUCE TapePanel, recapture the fx-03 manual figure, and note that TM2's
+own preset system reverses the earlier "presets dropped" behaviour change.
+
+Hard constraint (Marc, 2026-07-26): the param/meter/lifecycle bridges must be
+windowing-independent — no Xlib types outside the one window-shim TU; this
+embed is INTERIM and re-hosts onto the Wayland/EGL surface at the GUI tower.
+Rules: commit locally, never push without Marc's word; no attribution
+trailers. Verify: full Linux bar, tape A/B still green, Xvfb selftest,
+screenshot review of the embedded UI, gate movement recorded (TapePanel files
+leave the allowlist), MANUAL.md audit. TM2-embed usability pass is Marc's
+bench debt. Update both hosting docs' status lines.
+```
+
+## Prompt 8 — H6 (the drop: delete the JUCE hosting path)
+
+```
+You are executing hosting-tower phase H6 — the drop — of the Dusk Studio
+de-JUCE campaign. Preconditions (verify each in git log; stop if any missing):
+H5a, H5b, H5c merged (native CLAP/LV2/VST3 on Linux+macOS, AU on macOS,
+CLAP/VST3 on Windows) AND H2-app merged (no JUCE donor processors left in the
+app). Read docs/dejuce-campaign.md, docs/dejuce-hosting-plan.md (§End-state is
+the checklist), docs/dejuce-hosting-h5-platform.md, and the ledger if present.
+
+Create branch dejuce/hosting-h6. Delete the JUCE hosting path everywhere at
+once: PluginSlot, PluginManager's JUCE half (AudioPluginFormatManager /
+KnownPluginList / createPluginInstance), JuceCompat.h,
+PluginHostMain's JUCE message loop + MessageManagerLock sites (the OOP child
+shrinks to the native scan sandbox — shm/futex layer is already
+tri-platform), JUCE_PLUGINHOST_* defines, and every JUCE-host fallback rung in
+the slot ladders (ladder becomes CLAP > LV2 > VST3 > MS [> AU on mac]).
+Unlink juce_audio_processors from CMake on ALL THREE platforms (module count
+12 → 11 — the campaign's first global unlink; juce_audio_utils and
+juce_audio_formats stay for AudioThumbnail until the GUI tower). Retire
+tools/tsan_suppressions.txt entries tied to deleted primitives in the SAME PR.
+Update tools/juce-allowlist.txt — expect a large ratchet drop; record
+before/after. Sweep per CLAUDE.md rule 10: grep for every deleted symbol
+across src/, tests/, session serializer string literals, MIDI bindings,
+CMakeLists, and the OOP scan wire format.
+
+Session compatibility: sessions saved with JUCE-host descriptors must restore
+through the H4 migration onto native rungs or surface a clear offline row —
+test with a real 0.12 session. Rules: commit locally, never push without
+Marc's word; no attribution trailers. Verify: full Linux bar, macOS +
+Windows CI after authorised push, real-plugin restore matrix on Marc's bench
+(record as debt). Update campaign doc: hosting tower DONE, module count 11,
+GUI tower is next. End with the campaign resume state written down.
+```
+
+## Prompt 9 — GUI tower spike (gate before lock-in)
+
+```
+You are executing the GUI-tower entry gate of the Dusk Studio de-JUCE campaign
+on the LINUX machine (Wayland work). Read docs/dejuce-campaign.md §Remaining
+towers item 2 — it records Marc's 2026-07-27 framework decision: app UI =
+Dear ImGui + DuskImGuiWidgets on EGL over a Dusk-written Wayland backend for
+pugl in the hard-forked DPF stack (pugl ships mac/win/X11 only today; the
+bespoke-toolkit plan is DROPPED). The gate: a spike proving the app shell as a
+native Wayland window rendering ONE channel strip in ImGui at 60 Hz with
+working input.
+
+Scope: in the DPF fork, implement enough of a pugl Wayland backend to open an
+xdg-shell toplevel with an EGL context, pump input (pointer + keyboard), and
+run the ImGui frame loop; then render one Dusk channel strip (fader, pan, EQ
+knobs, meters — DuskImGuiWidgets where they exist) bound to a stub or live
+param struct. Measure and report: sustained frame rate, input latency feel,
+CPU cost, and which pugl API surfaces the backend still lacks (clipboard,
+cursors, IME, DnD, multi-window — enumerate, don't build). This is a SPIKE:
+throwaway-quality code on a spike branch is acceptable, but the findings
+report is the deliverable — it feeds the GUI tower spec. Do not touch Dusk
+Studio's shipping UI. Rules: separate branch(es) in each repo touched, commit
+locally, never push without Marc's word, no attribution trailers. End with a
+GO/NO-GO recommendation on the ImGui+pugl-Wayland lock-in, and file the
+findings in the ledger and a docs/ spike note.
+```
+
+## Prompt 10 — GUI tower spec (Fable session, after spike GO)
+
+```
+You are writing the executable spec for the FINAL tower of the Dusk Studio
+de-JUCE campaign: the GUI tower. This is a Fable-tier planning session per
+docs/dejuce-campaign.md §Model/token policy (spec-writing, not execution).
+Preconditions: hosting tower complete (H6 merged, module count 11), GUI spike
+returned GO with a findings report — read both, plus docs/dejuce-campaign.md
+§Remaining towers item 2 (the locked framework decision and its owned
+consequences) and the DuskStudio.md spec sections covering the UI.
+
+Produce docs/dejuce-gui-plan.md in the house style of
+docs/dejuce-hosting-h5-platform.md (status line, locked decisions, scout
+ground truth, phased increments with ≤5-file lists, per-phase verification,
+bench debts, resume phrase). The spec must own, at minimum: completing the
+pugl Wayland backend (xdg-shell, EGL, input, clipboard, cursors, IME, DnD,
+multi-window) in the DPF fork; the MessageThread.cpp event-loop rewrite (call
+sites already converged by PR #112); per-view immediate-mode rewrites of ~120
+files behind the existing DuskComboBox / DuskContextMenu / LookAndFeel /
+EmbeddedModal seams; an ImGui theme replicating the current LookAndFeel
+(screenshot-parity bar); a deliberate accessibility bridge (current JUCE a11y
+handlers must not silently regress — inventory them first); AudioThumbnail
+replacement (unlinks juce_audio_utils + juce_audio_formats); re-hosting the
+H1d TM2 ImGui content onto the in-process Wayland/EGL surface; XWayland
+retained ONLY for third-party plugin editors; macOS/Windows window backends
+(pugl already ships those) so the tower stays tri-platform; and the module
+unlink order for the remaining 11, juce_core last, with the String/File/
+Colour/UndoableAction/Logger remnants (see the dissolved string-floor tower
+note) dying with their anchor files. Multi-release: slice phases so the app
+ships between them. Scout with Explore agents before writing; do not edit
+code. Deliverable: the spec plus an updated campaign doc queue.
+```
+
+---
+
+## Machine routing
+
+- Prompts 1–2: runnable on the Mac for compile checks; closeout needs the
+  Linux full bar. Mac plugin path:
+  `/Users/marckorte/projects/dusk-audio-plugins-pinned`.
+- Prompts 4–9: Linux machine (donor worktree, Xvfb selftest, X11 embed,
+  Wayland spike).
+- Prompt 3: Linux bar locally; Windows proof is CI + Marc's bench.

--- a/src/engine/PluginManager.cpp
+++ b/src/engine/PluginManager.cpp
@@ -144,13 +144,21 @@ bool loadNativeCacheSources (
 }
 } // namespace
 
-#if DUSKSTUDIO_HAS_OOP_PLUGINS
+// Shared by both sandboxed scan paths - the OOP JUCE scanner below and the
+// native-bundle child further down, which are gated independently (macOS
+// without OOP support still scans native bundles through the child).
+#if DUSKSTUDIO_HAS_OOP_PLUGINS || DUSKSTUDIO_HAS_NATIVE_CLAP || DUSKSTUDIO_HAS_NATIVE_VST3
 namespace
 {
 // A plugin can take a few seconds to instantiate on a cold cache; give a
 // generous ceiling and treat anything past it as a hang.
 constexpr int kScanTimeoutMs = 30000;
+} // namespace
+#endif
 
+#if DUSKSTUDIO_HAS_OOP_PLUGINS
+namespace
+{
 // Routes third-party-binary plugin discovery through the dusk-studio-plugin-host
 // child so a plugin that segfaults or hangs in findAllTypesForFile takes down
 // only the child, not the app. Installed on knownPluginList for the duration

--- a/src/engine/clap/ClapBundle.cpp
+++ b/src/engine/clap/ClapBundle.cpp
@@ -4,8 +4,80 @@
 
 #include <dlfcn.h>
 
+#if defined(__APPLE__)
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <filesystem>
+#endif
+
 namespace duskstudio::clap
 {
+#if defined(__APPLE__)
+namespace
+{
+bool resolveBundleExecutable (const std::string& path,
+                              std::string& executablePath,
+                              std::string& errorOut)
+{
+    std::error_code ec;
+    if (! std::filesystem::is_directory (std::filesystem::u8path (path), ec))
+    {
+        executablePath = path;
+        return true;
+    }
+
+    const auto* bytes = reinterpret_cast<const UInt8*> (path.data());
+    auto* bundleUrl = CFURLCreateFromFileSystemRepresentation (
+        kCFAllocatorDefault, bytes, static_cast<CFIndex> (path.size()), true);
+    if (bundleUrl == nullptr)
+    {
+        errorOut = "could not create a URL for the CLAP bundle";
+        return false;
+    }
+
+    auto* bundle = CFBundleCreate (kCFAllocatorDefault, bundleUrl);
+    CFRelease (bundleUrl);
+    if (bundle == nullptr)
+    {
+        errorOut = "could not open the CLAP bundle";
+        return false;
+    }
+
+    auto* executableUrl = CFBundleCopyExecutableURL (bundle);
+    CFRelease (bundle);
+    if (executableUrl == nullptr)
+    {
+        errorOut = "CLAP bundle has no executable";
+        return false;
+    }
+
+    auto* executableString = CFURLCopyFileSystemPath (executableUrl, kCFURLPOSIXPathStyle);
+    CFRelease (executableUrl);
+    if (executableString == nullptr)
+    {
+        errorOut = "could not resolve the CLAP bundle executable path";
+        return false;
+    }
+
+    const auto capacity = CFStringGetMaximumSizeForEncoding (
+                              CFStringGetLength (executableString), kCFStringEncodingUTF8)
+                          + 1;
+    std::vector<char> utf8Path (static_cast<std::size_t> (capacity));
+    const bool converted = CFStringGetCString (
+        executableString, utf8Path.data(), capacity, kCFStringEncodingUTF8);
+    CFRelease (executableString);
+    if (! converted)
+    {
+        errorOut = "CLAP bundle executable path is not valid UTF-8";
+        return false;
+    }
+
+    executablePath = utf8Path.data();
+    return true;
+}
+} // namespace
+#endif
+
 bool PluginDesc::isInstrument() const
 {
     for (const auto& f : features)
@@ -20,9 +92,21 @@ bool ClapBundle::load (const std::string& path, std::string& errorOut)
     unload();
     bundlePath = path;
 
+#if defined(__APPLE__)
+    std::string executablePath;
+    if (! resolveBundleExecutable (path, executablePath, errorOut))
+    {
+        unload();
+        return false;
+    }
+    const char* libraryPath = executablePath.c_str();
+#else
+    const char* libraryPath = path.c_str();
+#endif
+
     // RTLD_LOCAL so a plugin's symbols don't leak into our (or another plugin's)
     // global namespace; RTLD_NOW so missing symbols surface here, not mid-process.
-    handle = dlopen (path.c_str(), RTLD_LOCAL | RTLD_NOW);
+    handle = dlopen (libraryPath, RTLD_LOCAL | RTLD_NOW);
     if (handle == nullptr)
     {
         const char* e = dlerror();

--- a/src/engine/clap/ClapBundle.cpp
+++ b/src/engine/clap/ClapBundle.cpp
@@ -7,6 +7,7 @@
 #if defined(__APPLE__)
 #include <CoreFoundation/CoreFoundation.h>
 
+#include <climits>
 #include <filesystem>
 #endif
 
@@ -51,28 +52,20 @@ bool resolveBundleExecutable (const std::string& path,
         return false;
     }
 
-    auto* executableString = CFURLCopyFileSystemPath (executableUrl, kCFURLPOSIXPathStyle);
+    // Against the base: CFBundleCopyExecutableURL hands back a URL relative to the
+    // bundle, so a plain CFURLCopyFileSystemPath yields the bare executable NAME -
+    // dlopen would then search the dyld paths instead of the bundle.
+    UInt8 executableBuffer[PATH_MAX] {};
+    const bool resolved = CFURLGetFileSystemRepresentation (
+        executableUrl, true, executableBuffer, static_cast<CFIndex> (sizeof executableBuffer));
     CFRelease (executableUrl);
-    if (executableString == nullptr)
+    if (! resolved)
     {
         errorOut = "could not resolve the CLAP bundle executable path";
         return false;
     }
 
-    const auto capacity = CFStringGetMaximumSizeForEncoding (
-                              CFStringGetLength (executableString), kCFStringEncodingUTF8)
-                          + 1;
-    std::vector<char> utf8Path (static_cast<std::size_t> (capacity));
-    const bool converted = CFStringGetCString (
-        executableString, utf8Path.data(), capacity, kCFStringEncodingUTF8);
-    CFRelease (executableString);
-    if (! converted)
-    {
-        errorOut = "CLAP bundle executable path is not valid UTF-8";
-        return false;
-    }
-
-    executablePath = utf8Path.data();
+    executablePath = reinterpret_cast<const char*> (executableBuffer);
     return true;
 }
 } // namespace

--- a/src/engine/clap/ClapEditor.cpp
+++ b/src/engine/clap/ClapEditor.cpp
@@ -37,13 +37,13 @@ bool ClapEditor::open (const ::clap_plugin* p, ClapHost& host, std::string& erro
     return true;
 }
 
-bool ClapEditor::embed (unsigned long parentX11, int x, int y, int w, int h, std::string& errorOut)
+bool ClapEditor::embed (void* parentHandle, int x, int y, int w, int h, std::string& errorOut)
 {
     if (! created) { errorOut = "gui not created"; return false; }
 
     auto* dpy = XOpenDisplay (nullptr);
     if (dpy == nullptr) { errorOut = "XOpenDisplay failed"; return false; }
-    display = dpy;
+    platformContext = dpy;
 
     const int ww = w > 0 ? w : (prefW > 0 ? prefW : 400);
     const int hh = h > 0 ? h : (prefH > 0 ? prefH : 300);
@@ -60,20 +60,21 @@ bool ClapEditor::embed (unsigned long parentX11, int x, int y, int w, int h, std
     // x11-frames a managed adoption detaches the compositor-side surface
     // from the X-space parent-child position.
     swa.override_redirect = True;
-    hostWindow = XCreateWindow (dpy, (Window) parentX11, x, y,
-                                (unsigned) ww, (unsigned) hh, 0,
-                                CopyFromParent, InputOutput, CopyFromParent,
-                                CWBackPixel | CWBorderPixel | CWEventMask | CWOverrideRedirect, &swa);
+    containerHandle = (std::uintptr_t) XCreateWindow (
+        dpy, (Window) (std::uintptr_t) parentHandle, x, y,
+        (unsigned) ww, (unsigned) hh, 0,
+        CopyFromParent, InputOutput, CopyFromParent,
+        CWBackPixel | CWBorderPixel | CWEventMask | CWOverrideRedirect, &swa);
     // Map the host window BEFORE set_parent: some plugins (u-he Satin) abort() when
     // reparented into a non-viewable window. tryEmbed only runs when this component is
     // on-screen, so showing the host now is correct - it sits at the lane's coords with
     // a solid bg until the plugin paints (no stale content, no stray-window flash).
-    XMapWindow (dpy, hostWindow);
+    XMapWindow (dpy, (Window) containerHandle);
     XSync (dpy, False);
 
     clap_window_t win {};
     win.api = CLAP_WINDOW_API_X11;
-    win.x11 = (clap_xwnd) hostWindow;
+    win.x11 = (clap_xwnd) containerHandle;
     if (gui->set_parent == nullptr || ! gui->set_parent (plugin, &win))
     { errorOut = "gui set_parent() failed"; close(); return false; }
 
@@ -88,26 +89,26 @@ bool ClapEditor::embed (unsigned long parentX11, int x, int y, int w, int h, std
 
 void ClapEditor::setBounds (int x, int y, int w, int h)
 {
-    if (display == nullptr || hostWindow == 0) return;
-    auto* dpy = (Display*) display;
-    XMoveResizeWindow (dpy, hostWindow, x, y,
+    if (platformContext == nullptr || containerHandle == 0) return;
+    auto* dpy = (Display*) platformContext;
+    XMoveResizeWindow (dpy, (Window) containerHandle, x, y,
                        (unsigned) std::max (1, w), (unsigned) std::max (1, h));
     if (resizable && gui != nullptr && gui->set_size != nullptr && w > 0 && h > 0)
         gui->set_size (plugin, (uint32_t) w, (uint32_t) h);
     XFlush (dpy);
 }
 
-bool ClapEditor::getRootRelativePosition (unsigned long referenceWindow,
+bool ClapEditor::getRootRelativePosition (void* referenceHandle,
                                            int& relX, int& relY) const
 {
-    if (! embedded || display == nullptr || hostWindow == 0)
+    if (! embedded || platformContext == nullptr || containerHandle == 0)
         return false;
-    auto* dpy = (Display*) display;
+    auto* dpy = (Display*) platformContext;
     ::Window dummy {};
     int hx = 0, hy = 0, rx = 0, ry = 0;
-    if (! XTranslateCoordinates (dpy, (Window) hostWindow,
+    if (! XTranslateCoordinates (dpy, (Window) containerHandle,
                                  DefaultRootWindow (dpy), 0, 0, &hx, &hy, &dummy)
-        || ! XTranslateCoordinates (dpy, (Window) referenceWindow,
+        || ! XTranslateCoordinates (dpy, (Window) (std::uintptr_t) referenceHandle,
                                     DefaultRootWindow (dpy), 0, 0, &rx, &ry, &dummy))
         return false;
     relX = hx - rx; relY = hy - ry;
@@ -116,11 +117,11 @@ bool ClapEditor::getRootRelativePosition (unsigned long referenceWindow,
 
 bool ClapEditor::getActualGeometry (int& x, int& y, int& w, int& h) const
 {
-    if (! embedded || display == nullptr || hostWindow == 0)
+    if (! embedded || platformContext == nullptr || containerHandle == 0)
         return false;
     ::Window root {};
     unsigned int uw = 0, uh = 0, border = 0, depth = 0;
-    if (XGetGeometry ((Display*) display, (Window) hostWindow,
+    if (XGetGeometry ((Display*) platformContext, (Window) containerHandle,
                       &root, &x, &y, &uw, &uh, &border, &depth) == 0)
         return false;
     w = (int) uw; h = (int) uh;
@@ -129,17 +130,17 @@ bool ClapEditor::getActualGeometry (int& x, int& y, int& w, int& h) const
 
 void ClapEditor::reveal()
 {
-    if (display == nullptr || hostWindow == 0 || mapped) return;
-    XMapWindow ((Display*) display, hostWindow);
-    XFlush ((Display*) display);
+    if (platformContext == nullptr || containerHandle == 0 || mapped) return;
+    XMapWindow ((Display*) platformContext, (Window) containerHandle);
+    XFlush ((Display*) platformContext);
     mapped = true;
 }
 
 void ClapEditor::hide()
 {
-    if (display == nullptr || hostWindow == 0 || ! mapped) return;
-    XUnmapWindow ((Display*) display, hostWindow);
-    XFlush ((Display*) display);
+    if (platformContext == nullptr || containerHandle == 0 || ! mapped) return;
+    XUnmapWindow ((Display*) platformContext, (Window) containerHandle);
+    XFlush ((Display*) platformContext);
     mapped = false;
 }
 
@@ -153,16 +154,17 @@ void ClapEditor::close()
         if (gui->destroy != nullptr) gui->destroy (plugin);
     }
     if (hostPtr != nullptr) { hostPtr->setCallbacks (nullptr); hostPtr = nullptr; }
-    if (display != nullptr)
+    if (platformContext != nullptr)
     {
-        if (hostWindow != 0) XDestroyWindow ((Display*) display, hostWindow);
+        if (containerHandle != 0)
+            XDestroyWindow ((Display*) platformContext, (Window) containerHandle);
         // Let the server process the destroy (against a still-valid parent peer)
         // before we drop this connection - avoids a cross-connection teardown hang.
-        XSync ((Display*) display, False);
-        XCloseDisplay ((Display*) display);
-        display = nullptr;
+        XSync ((Display*) platformContext, False);
+        XCloseDisplay ((Display*) platformContext);
+        platformContext = nullptr;
     }
-    hostWindow = 0;
+    containerHandle = 0;
     gui = nullptr;
     plugin = nullptr;
     created = embedded = mapped = false;
@@ -200,8 +202,8 @@ void ClapEditor::drainPendingCallbacks()
         const int w = pendingW.load (std::memory_order_relaxed);
         const int h = pendingH.load (std::memory_order_relaxed);
         prefW = w; prefH = h;
-        if (display != nullptr && hostWindow != 0)
-            XResizeWindow ((Display*) display, hostWindow,
+        if (platformContext != nullptr && containerHandle != 0)
+            XResizeWindow ((Display*) platformContext, (Window) containerHandle,
                            (unsigned) std::max (1, w), (unsigned) std::max (1, h));
         if (onResize) onResize (w, h);
     }
@@ -219,9 +221,9 @@ void ClapEditor::pump (double elapsedMs)
     // Drain our host-window connection so its event queue (ConfigureNotify, etc.)
     // doesn't grow unbounded. The plugin's own window events ride its own fd,
     // pumped above via on_fd.
-    if (display != nullptr)
+    if (platformContext != nullptr)
     {
-        auto* dpy = (Display*) display;
+        auto* dpy = (Display*) platformContext;
         while (XPending (dpy) > 0)
         {
             XEvent e;

--- a/src/engine/clap/ClapEditor.h
+++ b/src/engine/clap/ClapEditor.h
@@ -3,18 +3,18 @@
 #include "ClapHost.h"
 
 #include <atomic>
+#include <cstdint>
 #include <functional>
 #include <string>
 
 namespace duskstudio::clap
 {
-// Native X11 editor embed for a CLAP plugin (Linux). Owns a host X11 window
-// created UNMAPPED as a child of the app's window; the plugin embeds its GUI into
-// it (set_parent + show), and we XMapWindow it ONLY on reveal() - so the first
-// open is an instant map with no stray-window flash, by construction. Drives the
-// plugin's fd/timer event pump (via ClapHost) on the message thread.
+// Native embedded editor for a CLAP plugin. The platform translation unit owns
+// an X11 child window on Linux or an NSView child container on macOS. Drives the
+// plugin's fd/timer event pump through ClapHost on the message thread.
 //
-// No X11 headers leak here: the host window + display are opaque handles.
+// Platform headers do not leak through this boundary. Native parent handles are
+// opaque pointers, so the API also remains safe on pointer-width Windows handles.
 class ClapEditor : public ClapHost::Callbacks
 {
 public:
@@ -23,24 +23,24 @@ public:
     ClapEditor (const ClapEditor&)            = delete;
     ClapEditor& operator= (const ClapEditor&) = delete;
 
-    // The plugin must be created + activated. Creates the embedded-X11 CLAP GUI
-    // and queries its preferred size. False (+errorOut) if the plugin has no
-    // embedded-X11 GUI or create() fails.
+    // The plugin must be created + activated. Creates the platform CLAP GUI and
+    // queries its preferred size. False (+errorOut) if no compatible embedded
+    // GUI exists or create() fails.
     bool open (const ::clap_plugin* plugin, ClapHost& host, std::string& errorOut);
 
-    // Create our host X11 window under parentX11 at (x,y,w,h) UNMAPPED, embed the
-    // plugin into it, and show() the plugin. Nothing is mapped on-screen yet.
-    bool embed (unsigned long parentX11, int x, int y, int w, int h, std::string& errorOut);
+    // Create a native child container under parentHandle at (x,y,w,h), embed the
+    // plugin into it, and call the plugin's show(). reveal() controls whether the
+    // container itself is visible.
+    bool embed (void* parentHandle, int x, int y, int w, int h, std::string& errorOut);
 
     void setBounds (int x, int y, int w, int h);
-    void reveal();   // XMapWindow - the instant first-open
-    void hide();     // XUnmapWindow
+    void reveal();
+    void hide();
     void close();
 
-    // The host window's REAL geometry (position relative to its X11 parent +
-    // size), so the owner can detect and correct drift the message flow
-    // missed. False when not embedded or the window is gone.
-    bool getRootRelativePosition (unsigned long referenceWindow,
+    // Linux geometry diagnostics. macOS uses logical component bounds directly,
+    // so these return false there.
+    bool getRootRelativePosition (void* referenceHandle,
                                   int& relX, int& relY) const;
     bool getActualGeometry (int& x, int& y, int& w, int& h) const;
 
@@ -49,7 +49,8 @@ public:
     // quit. close() then skips gui->hide/gui->destroy; the process is exiting anyway.
     void setLeakOnClose (bool b) noexcept { leakOnClose = b; }
 
-    // Message thread, ~60 Hz: pump the plugin's fds/timers + drain our X events.
+    // Message thread, ~60 Hz: apply queued GUI callbacks, pump the plugin's
+    // fds/timers, and drain any platform editor events.
     void pump (double elapsedMs);
 
     int  preferredWidth()  const noexcept { return prefW; }
@@ -71,15 +72,16 @@ private:
     // The plugin's gui host callbacks are [thread-safe] - it may call request_resize/
     // show/hide/closed from a non-message thread. Those handlers only stash these
     // atomics; drainPendingCallbacks() (from pump(), on the message thread) does all
-    // the X11 + JUCE work, so nothing touches Xlib / a JUCE Component off-thread.
+    // the native + JUCE work, so nothing touches a native view or a JUCE
+    // Component off-thread.
     void drainPendingCallbacks();
 
     const ::clap_plugin*     plugin = nullptr;
     const clap_plugin_gui_t* gui    = nullptr;
     ClapHost* hostPtr = nullptr;
 
-    void*         display    = nullptr;   // Display* (opaque)
-    unsigned long hostWindow = 0;         // Window
+    void*          platformContext = nullptr; // Display* on Linux; parent NSView* on macOS
+    std::uintptr_t containerHandle = 0;       // X11 Window or owned NSView*
     int  prefW = 0, prefH = 0;
     bool created = false, embedded = false, mapped = false;
     bool resizable = false;   // gui->can_resize: calling set_size when false aborts some plugins (u-he)

--- a/src/engine/clap/ClapEditor_Mac.mm
+++ b/src/engine/clap/ClapEditor_Mac.mm
@@ -1,0 +1,208 @@
+#include "ClapEditor.h"
+
+#import <AppKit/AppKit.h>
+
+#include <algorithm>
+
+namespace duskstudio::clap
+{
+namespace
+{
+NSView* containerView (std::uintptr_t handle) noexcept
+{
+    return reinterpret_cast<NSView*> (handle);
+}
+} // namespace
+
+ClapEditor::~ClapEditor() { close(); }
+
+bool ClapEditor::open (const ::clap_plugin* p, ClapHost& host, std::string& errorOut)
+{
+    if (p == nullptr) { errorOut = "null plugin"; return false; }
+
+    gui = static_cast<const clap_plugin_gui_t*> (p->get_extension (p, CLAP_EXT_GUI));
+    if (gui == nullptr) { errorOut = "plugin has no gui extension"; return false; }
+    if (gui->is_api_supported == nullptr
+        || ! gui->is_api_supported (p, CLAP_WINDOW_API_COCOA, false))
+    { errorOut = "plugin has no embedded-Cocoa GUI"; gui = nullptr; return false; }
+    if (gui->create == nullptr || ! gui->create (p, CLAP_WINDOW_API_COCOA, false))
+    { errorOut = "gui create() failed"; gui = nullptr; return false; }
+
+    plugin  = p;
+    hostPtr = &host;
+    host.setPlugin (p);
+    host.setCallbacks (this);
+    created = true;
+
+    resizable = (gui->can_resize != nullptr) && gui->can_resize (p);
+
+    uint32_t w = 0, h = 0;
+    if (gui->get_size != nullptr && gui->get_size (p, &w, &h))
+    { prefW = (int) w; prefH = (int) h; }
+    return true;
+}
+
+bool ClapEditor::embed (void* parentHandle, int x, int y, int w, int h,
+                        std::string& errorOut)
+{
+    if (! created) { errorOut = "gui not created"; return false; }
+    if (parentHandle == nullptr) { errorOut = "null parent view"; return false; }
+
+    auto* parent = static_cast<NSView*> (parentHandle);
+    const int ww = w > 0 ? w : (prefW > 0 ? prefW : 400);
+    const int hh = h > 0 ? h : (prefH > 0 ? prefH : 300);
+
+    auto* container = [[NSView alloc] initWithFrame:NSMakeRect (
+        (CGFloat) x, (CGFloat) y, (CGFloat) ww, (CGFloat) hh)];
+    if (container == nil) { errorOut = "could not create Cocoa container"; return false; }
+    [container setAutoresizingMask:NSViewNotSizable];
+    [container setHidden:YES];
+    [parent addSubview:container];
+
+    platformContext = parent;
+    containerHandle = reinterpret_cast<std::uintptr_t> (container);
+
+    clap_window_t win {};
+    win.api = CLAP_WINDOW_API_COCOA;
+    win.cocoa = (clap_nsview) container;
+    if (gui->set_parent == nullptr || ! gui->set_parent (plugin, &win))
+    { errorOut = "gui set_parent() failed"; close(); return false; }
+
+    if (resizable && gui->set_size != nullptr)
+        gui->set_size (plugin, (uint32_t) ww, (uint32_t) hh);
+    if (gui->show != nullptr && ! gui->show (plugin))
+    { errorOut = "gui show() failed"; close(); return false; }
+
+    embedded = true;
+    return true;
+}
+
+void ClapEditor::setBounds (int x, int y, int w, int h)
+{
+    auto* container = containerView (containerHandle);
+    if (container == nil) return;
+
+    const int ww = std::max (1, w);
+    const int hh = std::max (1, h);
+    [container setFrame:NSMakeRect ((CGFloat) x, (CGFloat) y, (CGFloat) ww, (CGFloat) hh)];
+    if (resizable && gui != nullptr && gui->set_size != nullptr && w > 0 && h > 0)
+        gui->set_size (plugin, (uint32_t) w, (uint32_t) h);
+}
+
+bool ClapEditor::getRootRelativePosition (void*, int&, int&) const
+{
+    return false;
+}
+
+bool ClapEditor::getActualGeometry (int&, int&, int&, int&) const
+{
+    return false;
+}
+
+void ClapEditor::reveal()
+{
+    auto* container = containerView (containerHandle);
+    if (container == nil || mapped) return;
+    [container setHidden:NO];
+    mapped = true;
+}
+
+void ClapEditor::hide()
+{
+    auto* container = containerView (containerHandle);
+    if (container == nil || ! mapped) return;
+    [container setHidden:YES];
+    mapped = false;
+}
+
+void ClapEditor::close()
+{
+    if (plugin != nullptr && gui != nullptr && ! leakOnClose)
+    {
+        if (gui->hide != nullptr)    gui->hide (plugin);
+        if (gui->destroy != nullptr) gui->destroy (plugin);
+    }
+    if (hostPtr != nullptr) { hostPtr->setCallbacks (nullptr); hostPtr = nullptr; }
+
+    if (auto* container = containerView (containerHandle); container != nil)
+    {
+        [container removeFromSuperview];
+        [container release];
+    }
+    platformContext = nullptr;
+    containerHandle = 0;
+    gui = nullptr;
+    plugin = nullptr;
+    created = embedded = mapped = false;
+}
+
+void ClapEditor::drainPendingCallbacks()
+{
+    if (pendingClosed.exchange (false))
+    {
+        if (pendingClosedWasDestroyed.load())
+        {
+            if (plugin != nullptr && gui != nullptr && gui->destroy != nullptr)
+                gui->destroy (plugin);
+            gui = nullptr;
+            created = embedded = false;
+            hide();
+        }
+        if (onClosed) onClosed();
+        pendingResize.exchange (false);
+        pendingShow.exchange (false);
+        pendingHide.exchange (false);
+        return;
+    }
+
+    if (pendingResize.exchange (false))
+    {
+        const int w = pendingW.load (std::memory_order_relaxed);
+        const int h = pendingH.load (std::memory_order_relaxed);
+        prefW = w; prefH = h;
+        if (auto* container = containerView (containerHandle); container != nil)
+        {
+            auto frame = [container frame];
+            frame.size = NSMakeSize ((CGFloat) std::max (1, w),
+                                     (CGFloat) std::max (1, h));
+            [container setFrame:frame];
+        }
+        if (onResize) onResize (w, h);
+    }
+
+    if (pendingShow.exchange (false)) reveal();
+    if (pendingHide.exchange (false)) hide();
+}
+
+void ClapEditor::pump (double elapsedMs)
+{
+    drainPendingCallbacks();
+    if (hostPtr != nullptr) hostPtr->pumpGui (elapsedMs);
+}
+
+bool ClapEditor::onRequestResize (uint32_t w, uint32_t h)
+{
+    pendingW.store ((int) w, std::memory_order_relaxed);
+    pendingH.store ((int) h, std::memory_order_relaxed);
+    pendingResize.store (true, std::memory_order_release);
+    return true;
+}
+
+bool ClapEditor::onRequestShow()
+{
+    pendingShow.store (true, std::memory_order_release);
+    return true;
+}
+
+bool ClapEditor::onRequestHide()
+{
+    pendingHide.store (true, std::memory_order_release);
+    return true;
+}
+
+void ClapEditor::onGuiClosed (bool wasDestroyed)
+{
+    pendingClosedWasDestroyed.store (wasDestroyed, std::memory_order_relaxed);
+    pendingClosed.store (true, std::memory_order_release);
+}
+} // namespace duskstudio::clap

--- a/src/engine/clap/ClapScanner.cpp
+++ b/src/engine/clap/ClapScanner.cpp
@@ -44,13 +44,11 @@ std::vector<stdfs::path> ClapScanner::findClapFiles (const std::vector<stdfs::pa
 {
     std::vector<stdfs::path> files;
     std::error_code ec;
-#if defined(__APPLE__)
     auto add = [&] (const stdfs::path& bundle)
     {
         for (const auto& existing : files) if (existing == bundle) return;
         files.push_back (bundle);
     };
-#endif
 
     for (const auto& dirIn : dirs)
     {
@@ -71,11 +69,7 @@ std::vector<stdfs::path> ClapScanner::findClapFiles (const std::vector<stdfs::pa
         }
 #else
         for (const auto& f : dusk::fs::findChildFiles (dir, "*.clap", true))
-        {
-            bool seen = false;
-            for (const auto& g : files) if (g == f) { seen = true; break; }
-            if (! seen) files.push_back (f);
-        }
+            add (f);
 #endif
     }
     return files;

--- a/src/engine/clap/ClapScanner.cpp
+++ b/src/engine/clap/ClapScanner.cpp
@@ -29,9 +29,14 @@ std::vector<stdfs::path> ClapScanner::defaultSearchPaths()
             if (! trimmed.empty()) add (stdfs::u8path (trimmed));
         }
 
+#if defined(__APPLE__)
+    add (dusk::fs::userHomeDir() / "Library/Audio/Plug-Ins/CLAP");
+    add ("/Library/Audio/Plug-Ins/CLAP");
+#else
     add (dusk::fs::userHomeDir() / ".clap");
     add ("/usr/lib/clap");
     add ("/usr/local/lib/clap");
+#endif
     return dirs;
 }
 
@@ -39,18 +44,39 @@ std::vector<stdfs::path> ClapScanner::findClapFiles (const std::vector<stdfs::pa
 {
     std::vector<stdfs::path> files;
     std::error_code ec;
+#if defined(__APPLE__)
+    auto add = [&] (const stdfs::path& bundle)
+    {
+        for (const auto& existing : files) if (existing == bundle) return;
+        files.push_back (bundle);
+    };
+#endif
+
     for (const auto& dirIn : dirs)
     {
         // Absolute so a cached bundle path (and its native identifier) stays
         // stable regardless of cwd, even for a relative $CLAP_PATH entry.
         const auto dir = stdfs::absolute (dirIn, ec);
         if (ec || ! stdfs::is_directory (dir, ec)) continue;
+#if defined(__APPLE__)
+        std::error_code walkEc, entryEc;
+        for (auto it = stdfs::recursive_directory_iterator (dir, walkEc);
+             ! walkEc && it != stdfs::recursive_directory_iterator(); it.increment (walkEc))
+        {
+            if (! it->is_directory (entryEc) || ! dusk::fs::hasExtension (it->path(), "clap"))
+                continue;
+
+            add (it->path());
+            it.disable_recursion_pending();
+        }
+#else
         for (const auto& f : dusk::fs::findChildFiles (dir, "*.clap", true))
         {
             bool seen = false;
             for (const auto& g : files) if (g == f) { seen = true; break; }
             if (! seen) files.push_back (f);
         }
+#endif
     }
     return files;
 }

--- a/src/engine/lv2/Lv2Editor_Mac.mm
+++ b/src/engine/lv2/Lv2Editor_Mac.mm
@@ -1,0 +1,45 @@
+#include "Lv2Editor.h"
+
+// macOS LV2 editor. The suil Cocoa embed is not implemented: open() reports no
+// embeddable UI, so an LV2 plugin loads and processes on macOS but has no
+// editor. The Linux X11+suil implementation lives in Lv2Editor.cpp.
+namespace duskstudio::lv2
+{
+namespace
+{
+constexpr const char* kNoCocoaUi = "LV2 plugin UIs are not embeddable on macOS yet";
+} // namespace
+
+struct Lv2Editor::Impl {};
+
+Lv2Editor::Lv2Editor()  = default;
+Lv2Editor::~Lv2Editor() = default;
+
+bool Lv2Editor::open (Lv2Instance&, std::string& errorOut)
+{
+    errorOut = kNoCocoaUi;
+    return false;
+}
+
+bool Lv2Editor::embed (unsigned long, int, int, int, int, std::string& errorOut)
+{
+    errorOut = kNoCocoaUi;
+    return false;
+}
+
+void Lv2Editor::setBounds (int, int, int, int) {}
+void Lv2Editor::reveal() {}
+void Lv2Editor::hide() {}
+void Lv2Editor::close() {}
+
+bool Lv2Editor::getRootRelativePosition (unsigned long, int&, int&) const { return false; }
+bool Lv2Editor::getActualGeometry (int&, int&, int&, int&) const { return false; }
+
+void Lv2Editor::setLeakOnClose (bool) noexcept {}
+void Lv2Editor::pump() {}
+
+int  Lv2Editor::preferredWidth()  const noexcept { return 0; }
+int  Lv2Editor::preferredHeight() const noexcept { return 0; }
+bool Lv2Editor::isOpen()     const noexcept { return false; }
+bool Lv2Editor::isEmbedded() const noexcept { return false; }
+} // namespace duskstudio::lv2

--- a/src/engine/vst3/Vst3Editor_Mac.mm
+++ b/src/engine/vst3/Vst3Editor_Mac.mm
@@ -1,0 +1,45 @@
+#include "Vst3Editor.h"
+
+// macOS VST3 editor. The kPlatformTypeNSView attach is not implemented: open()
+// reports no embeddable view, so a VST3 plugin loads and processes on macOS but
+// has no editor. The Linux X11 implementation lives in Vst3Editor.cpp.
+namespace duskstudio::vst3
+{
+namespace
+{
+constexpr const char* kNoCocoaView = "VST3 plugin editors are not embeddable on macOS yet";
+} // namespace
+
+struct Vst3Editor::Impl {};
+
+Vst3Editor::Vst3Editor()  = default;
+Vst3Editor::~Vst3Editor() = default;
+
+bool Vst3Editor::open (Vst3Instance&, std::string& errorOut)
+{
+    errorOut = kNoCocoaView;
+    return false;
+}
+
+bool Vst3Editor::embed (unsigned long, int, int, int, int, std::string& errorOut)
+{
+    errorOut = kNoCocoaView;
+    return false;
+}
+
+void Vst3Editor::setBounds (int, int, int, int) {}
+void Vst3Editor::setContentScale (float) {}
+void Vst3Editor::reveal() {}
+void Vst3Editor::hide() {}
+void Vst3Editor::close() {}
+
+bool Vst3Editor::getRootRelativePosition (unsigned long, int&, int&) const { return false; }
+bool Vst3Editor::getActualGeometry (int&, int&, int&, int&) const { return false; }
+
+void Vst3Editor::pump (double) {}
+
+int  Vst3Editor::preferredWidth()  const noexcept { return 0; }
+int  Vst3Editor::preferredHeight() const noexcept { return 0; }
+bool Vst3Editor::isOpen()     const noexcept { return false; }
+bool Vst3Editor::isEmbedded() const noexcept { return false; }
+} // namespace duskstudio::vst3

--- a/src/engine/vst3/Vst3HostContext.cpp
+++ b/src/engine/vst3/Vst3HostContext.cpp
@@ -4,7 +4,9 @@
 #include <pluginterfaces/gui/iplugview.h>
 #include <pluginterfaces/vst/ivsteditcontroller.h>
 
+#if defined(__linux__)
 #include <poll.h>
+#endif
 
 #include <algorithm>
 #include <vector>
@@ -18,10 +20,15 @@ using namespace Steinberg;
 // One COM object exposing every host facet. Lifetime is the owning
 // Vst3HostContext (plugins addRef/release freely against the SDK's FUnknown
 // refcount from HostApplication, which never reaches zero while we hold ours).
+// Steinberg::Linux::IRunLoop is a Linux-only facet of the VST3 API: off Linux the
+// host object exposes only the portable host-application / component-handler /
+// plug-frame facets and keeps no fd or timer registry.
 class HostObject final : public Vst::HostApplication,
                          public Vst::IComponentHandler,
-                         public IPlugFrame,
-                         public Linux::IRunLoop
+                         public IPlugFrame
+#if defined(__linux__)
+                       , public Linux::IRunLoop
+#endif
 {
 public:
     explicit HostObject (Vst3HostContext::Callbacks*& cb) : callbacks (cb) {}
@@ -31,7 +38,9 @@ public:
     {
         QUERY_INTERFACE (iid, obj, Vst::IComponentHandler::iid, Vst::IComponentHandler)
         QUERY_INTERFACE (iid, obj, IPlugFrame::iid, IPlugFrame)
+#if defined(__linux__)
         QUERY_INTERFACE (iid, obj, Linux::IRunLoop::iid, Linux::IRunLoop)
+#endif
         return Vst::HostApplication::queryInterface (iid, obj);
     }
     uint32 PLUGIN_API addRef() override  { return Vst::HostApplication::addRef(); }
@@ -76,6 +85,7 @@ public:
         return ok ? kResultOk : kResultFalse;
     }
 
+#if defined(__linux__)
     // Linux::IRunLoop (fd + timer registry, pumped from the message thread)
     tresult PLUGIN_API registerEventHandler (Linux::IEventHandler* handler,
                                              Linux::FileDescriptor fd) override
@@ -125,9 +135,11 @@ public:
         }
         return found ? kResultOk : kResultFalse;
     }
+#endif
 
-    void pump (double elapsedMs)
+    void pump ([[maybe_unused]] double elapsedMs)
     {
+#if defined(__linux__)
         // Snapshot both registries before dispatching: a handler may
         // register/unregister from inside its own callback.
         if (! fdHandlers.empty())
@@ -158,20 +170,29 @@ public:
                 live->handler->onTimer();
             }
         }
+#endif
     }
 
     void teardown()
     {
+#if defined(__linux__)
         for (auto& e : fdHandlers) e.handler->release();
         for (auto& t : timers)     t.handler->release();
         fdHandlers.clear();
         timers.clear();
+#endif
     }
 
+#if defined(__linux__)
     int numEventHandlers() const { return (int) fdHandlers.size(); }
     int numTimerHandlers() const { return (int) timers.size(); }
+#else
+    int numEventHandlers() const { return 0; }
+    int numTimerHandlers() const { return 0; }
+#endif
 
 private:
+#if defined(__linux__)
     struct FdEntry    { Linux::IEventHandler* handler; Linux::FileDescriptor fd; };
     struct TimerEntry { Linux::ITimerHandler* handler; double intervalMs; double accumMs; };
 
@@ -186,9 +207,11 @@ private:
         return nullptr;
     }
 
-    Vst3HostContext::Callbacks*& callbacks;
     std::vector<FdEntry>    fdHandlers;
     std::vector<TimerEntry> timers;
+#endif
+
+    Vst3HostContext::Callbacks*& callbacks;
 };
 } // namespace
 
@@ -224,7 +247,11 @@ void* Vst3HostContext::plugFrame() const noexcept
 }
 void* Vst3HostContext::runLoop() const noexcept
 {
+#if defined(__linux__)
     return static_cast<Steinberg::Linux::IRunLoop*> (impl->host.get());
+#else
+    return nullptr;
+#endif
 }
 
 void Vst3HostContext::pump (double elapsedMs)     { impl->host->pump (elapsedMs); }

--- a/src/engine/vst3/Vst3HostContext.h
+++ b/src/engine/vst3/Vst3HostContext.h
@@ -44,7 +44,7 @@ public:
     void* hostApplication() const noexcept;   // Steinberg::Vst::IHostApplication*
     void* componentHandler() const noexcept;  // Steinberg::Vst::IComponentHandler*
     void* plugFrame() const noexcept;         // Steinberg::IPlugFrame*
-    void* runLoop() const noexcept;           // Steinberg::Linux::IRunLoop*
+    void* runLoop() const noexcept;           // Steinberg::Linux::IRunLoop*, nullptr off Linux
 
     // Message thread, ~60 Hz: poll the registered fds (dispatching onFDIsSet) and
     // advance the timers by elapsedMs (dispatching onTimerFired on cadence).

--- a/src/engine/vst3/Vst3Scanner.cpp
+++ b/src/engine/vst3/Vst3Scanner.cpp
@@ -29,9 +29,14 @@ std::vector<stdfs::path> Vst3Scanner::defaultSearchPaths()
             if (! trimmed.empty()) add (stdfs::u8path (trimmed));
         }
 
+#if defined(__APPLE__)
+    add (dusk::fs::userHomeDir() / "Library/Audio/Plug-Ins/VST3");
+    add ("/Library/Audio/Plug-Ins/VST3");
+#else
     add (dusk::fs::userHomeDir() / ".vst3");
     add ("/usr/lib/vst3");
     add ("/usr/local/lib/vst3");
+#endif
     return dirs;
 }
 

--- a/src/ui/ClapPluginEditorComponent.cpp
+++ b/src/ui/ClapPluginEditorComponent.cpp
@@ -1,6 +1,8 @@
 #include "ClapPluginEditorComponent.h"
 #include "EmbeddedModal.h"   // kPluginEditorTag
+#if ! defined(__APPLE__)
 #include "NativeEditorEmbedScale.h"
+#endif
 
 #include <algorithm>
 
@@ -55,17 +57,17 @@ bool ClapPluginEditorComponent::openEditorOn (clap::ClapInstance& inst, juce::St
     editor.onResize = [this] (int w, int h)
     {
         if (w > 0 && h > 0)
-            setSize (embedscale::fromPhysical (*this, w),
-                     embedscale::fromPhysical (*this, h));
+            setSize (componentExtentFromEditor (w),
+                     componentExtentFromEditor (h));
     };
     // GUI was_destroyed: tear down our state fully. Leaving `loaded` set would let
     // tryEmbed()/the timer keep poking an already-destroyed editor.
     editor.onClosed = [this] { embedded = false; loaded = false; stopTimer(); };
 
     const int w = editor.preferredWidth()  > 0
-                    ? embedscale::fromPhysical (*this, editor.preferredWidth())  : 480;
+                    ? componentExtentFromEditor (editor.preferredWidth())  : 480;
     const int h = editor.preferredHeight() > 0
-                    ? embedscale::fromPhysical (*this, editor.preferredHeight()) : 320;
+                    ? componentExtentFromEditor (editor.preferredHeight()) : 320;
     setSize (w, h);
 
     loaded = true;
@@ -74,11 +76,30 @@ bool ClapPluginEditorComponent::openEditorOn (clap::ClapInstance& inst, juce::St
     return true;
 }
 
-unsigned long ClapPluginEditorComponent::peerX11() const
+void* ClapPluginEditorComponent::peerNativeHandle() const
 {
     if (auto* peer = getPeer())
-        return (unsigned long) (juce::pointer_sized_uint) peer->getNativeHandle();
-    return 0;
+        return peer->getNativeHandle();
+    return nullptr;
+}
+
+juce::Rectangle<int> ClapPluginEditorComponent::editorBoundsInPeer() const
+{
+    const auto logical = getTopLevelComponent()->getLocalArea (this, getLocalBounds());
+#if defined(__APPLE__)
+    return logical;
+#else
+    return embedscale::toPhysical (*this, logical);
+#endif
+}
+
+int ClapPluginEditorComponent::componentExtentFromEditor (int extent) const
+{
+#if defined(__APPLE__)
+    return std::max (1, extent);
+#else
+    return embedscale::fromPhysical (*this, extent);
+#endif
 }
 
 void ClapPluginEditorComponent::tryEmbed()
@@ -88,11 +109,10 @@ void ClapPluginEditorComponent::tryEmbed()
     // + map when shown, exactly like the JUCE editor path. The kept-alive remap on a
     // later tab switch keeps re-opens instant.
     if (! loaded || embedded || ! isShowing()) return;
-    const auto parent = peerX11();
-    if (parent == 0) return;
+    auto* parent = peerNativeHandle();
+    if (parent == nullptr) return;
 
-    const auto area = embedscale::toPhysical (
-        *this, getTopLevelComponent()->getLocalArea (this, getLocalBounds()));
+    const auto area = editorBoundsInPeer();
     std::string err;
     if (editor.embed (parent, area.getX(), area.getY(),
                       std::max (1, area.getWidth()), std::max (1, area.getHeight()), err))
@@ -125,8 +145,7 @@ void ClapPluginEditorComponent::pushBounds()
     // degenerates to (0,0), slamming the native window to the origin. Skip
     // while unparented; parentHierarchyChanged re-syncs once re-added.
     if (getParentComponent() == nullptr || getPeer() == nullptr) return;
-    const auto area = embedscale::toPhysical (
-        *this, getTopLevelComponent()->getLocalArea (this, getLocalBounds()));
+    const auto area = editorBoundsInPeer();
     editor.setBounds (area.getX(), area.getY(),
                       std::max (1, area.getWidth()), std::max (1, area.getHeight()));
 }
@@ -155,6 +174,7 @@ void ClapPluginEditorComponent::leakForShutdown()
     editor.setLeakOnClose (true);
 }
 
+#if defined(__linux__)
 void ClapPluginEditorComponent::verifyGeometry()
 {
     // The message flow can miss a move (compositor interference, an event
@@ -164,14 +184,13 @@ void ClapPluginEditorComponent::verifyGeometry()
     if (++geometryCheckTick < 20) return;
     geometryCheckTick = 0;
 
-    const auto area = embedscale::toPhysical (
-        *this, getTopLevelComponent()->getLocalArea (this, getLocalBounds()));
+    const auto area = editorBoundsInPeer();
     int ax = 0, ay = 0, aw = 0, ah = 0;
     if (! embedCheckLogged)
     {
         embedCheckLogged = true;
         int relX = 0, relY = 0;
-        if (editor.getRootRelativePosition (peerX11(), relX, relY))
+        if (editor.getRootRelativePosition (peerNativeHandle(), relX, relY))
             std::fprintf (stderr,
                 "[%s editor] embed check: host rel to peer (%d,%d), intended (%d,%d)\n",
                 "clap", relX, relY, area.getX(), area.getY());
@@ -198,18 +217,21 @@ void ClapPluginEditorComponent::verifyGeometry()
         pushBounds();
     }
 }
+#endif
 
 void ClapPluginEditorComponent::timerCallback()
 {
-    // Keep the native X11 window's mapped state in sync with our real on-screen
+    // Keep the native child container's visible state in sync with our real on-screen
     // visibility. visibilityChanged() does NOT fire for ancestor (aux-tab / stage)
-    // changes, so without this poll the window stays mapped - floating over whatever
-    // view replaced the aux lane. reveal()/hide() are idempotent (guarded by `mapped`).
+    // changes, so without this poll the container stays visible over whatever view
+    // replaced the aux lane. reveal()/hide() are idempotent.
     if (embedded)
     {
         if (isShowing()) editor.reveal();
         else             editor.hide();
+#if defined(__linux__)
         verifyGeometry();
+#endif
     }
 
     const auto now = juce::Time::getMillisecondCounter();

--- a/src/ui/ClapPluginEditorComponent.h
+++ b/src/ui/ClapPluginEditorComponent.h
@@ -10,10 +10,9 @@
 namespace duskstudio
 {
 // JUCE bridge for a natively-hosted CLAP plugin editor: loads a .clap, creates +
-// activates the instance, opens its embedded-X11 editor through our own host, and
-// ties the native host window to this Component's peer / bounds / visibility. The
-// editor is embedded once (unmapped) the first time we're on a realised peer, and
-// revealed (instant X map) when shown - no JUCE plugin-editor hosting involved.
+// activates the instance, opens its native embedded editor through our own host,
+// and ties the platform child container to this Component's peer, bounds, and
+// visibility. No JUCE plugin-editor hosting is involved.
 //
 // The reusable editor piece for aux-lane hosting; also driven by the
 // DUSKSTUDIO_CLAP_EDITOR_TEST launch path for live verification.
@@ -47,8 +46,12 @@ private:
     void timerCallback() override;
     void tryEmbed();
     void pushBounds();
+#if defined(__linux__)
     void verifyGeometry();
-    unsigned long peerX11() const;
+#endif
+    void* peerNativeHandle() const;
+    juce::Rectangle<int> editorBoundsInPeer() const;
+    int componentExtentFromEditor (int extent) const;
 
     bool openEditorOn (clap::ClapInstance& inst, juce::String& errorOut);
 
@@ -61,9 +64,11 @@ private:
     bool loaded   = false;
     bool embedded = false;
     std::uint32_t lastPumpMs = 0;
+#if defined(__linux__)
     int  geometryCheckTick = 0;
     int  driftLogsLeft     = 10;
     bool geometryLostLogged = false;
     bool embedCheckLogged   = false;
+#endif
 };
 } // namespace duskstudio

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,7 +13,7 @@ add_executable(dusk-studio-tests
     hosting_port_layout.cpp
     hosting_insert_adapter.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/hosting/InsertAdapter.cpp
-    # Native CLAP tests + sources are Linux-only (dlopen/poll) — added conditionally below.
+    # Native CLAP tests + sources are added conditionally below.
     plugin_descriptor.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/PluginDescriptor.cpp
     plugin_manager_descriptor.cpp
@@ -209,8 +209,8 @@ target_compile_definitions(dusk-studio-tests PRIVATE
     $<$<BOOL:${DUSKSTUDIO_JUCE_HAS_FREE_ADD_FORMATS}>:DUSKSTUDIO_JUCE_HAS_FREE_ADD_FORMATS=1>
     DUSKSTUDIO_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
 
-# Native CLAP host is Linux-only (dlopen/poll) — gate its tests + sources to match
-# the app build (DUSKSTUDIO_NATIVE_CLAP). clap_bundle_load also needs dladdr.
+# Gate native CLAP tests + sources to match the app build. The bundle-load test
+# follows the same platform implementation selected by DUSKSTUDIO_NATIVE_CLAP.
 if(DUSKSTUDIO_NATIVE_CLAP)
     target_sources(dusk-studio-tests PRIVATE
         clap_bundle_load.cpp
@@ -249,7 +249,6 @@ endif()
 if(DUSKSTUDIO_NATIVE_VST3)
     target_sources(dusk-studio-tests PRIVATE
         vst3_bundle_load.cpp
-        vst3_hostcontext_runloop.cpp
         vst3_instance_process.cpp
         vst3_native_slot.cpp
         vst3_scanner.cpp
@@ -259,6 +258,9 @@ if(DUSKSTUDIO_NATIVE_VST3)
         ${CMAKE_SOURCE_DIR}/src/engine/vst3/Vst3Scanner.cpp)
     target_link_libraries(dusk-studio-tests PRIVATE dusk-vst3-hosting)
     target_compile_definitions(dusk-studio-tests PRIVATE DUSKSTUDIO_HAS_NATIVE_VST3=1)
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        target_sources(dusk-studio-tests PRIVATE vst3_hostcontext_runloop.cpp)
+    endif()
 endif()
 
 target_link_libraries(dusk-studio-tests PRIVATE

--- a/tests/clap_bundle_load.cpp
+++ b/tests/clap_bundle_load.cpp
@@ -6,12 +6,15 @@
 #include "engine/clap/ClapBundle.h"
 
 #include <chrono>
+#include <cstdint>
 #include <cstdio>
 #include <dlfcn.h>
 #include <filesystem>
 #include <fstream>
 #include <stdexcept>
 #include <string>
+#include <unistd.h>
+#include <vector>
 
 #if defined(__APPLE__)
 #include <mach-o/dyld.h>
@@ -25,8 +28,11 @@ class TempDirectory
 public:
     explicit TempDirectory (const char* prefix)
     {
+        // pid + tick: ctest runs the test cases as parallel processes, whose
+        // steady_clock reads can land on the same tick.
         const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
-        value = stdfs::temp_directory_path() / (std::string (prefix) + std::to_string (unique));
+        value = stdfs::temp_directory_path()
+                / (std::string (prefix) + std::to_string (getpid()) + "_" + std::to_string (unique));
         std::error_code ec;
         if (! stdfs::create_directories (value, ec) || ec)
             throw std::runtime_error ("could not create test directory: " + ec.message());
@@ -120,7 +126,14 @@ TEST_CASE ("ClapBundle resolves a directory bundle executable", "[clap][bundle]"
     duskstudio::clap::ClapBundle b;
     std::string err;
     REQUIRE_FALSE (b.load (temp.u8string(), err));
-    REQUIRE ((err == "no clap_entry symbol" || err.rfind ("dlopen failed:", 0) == 0));
+    INFO ("load error: " << err);
+    // Either dlopen took the executable and found no entry point, or it refused
+    // it - and then the reason must name the full inner executable path, which is
+    // what catches a resolver handing dlopen a bundle-relative name. Matching the
+    // tail rather than the absolute path: the temp dir reaches dlopen in its
+    // /private/var form.
+    REQUIRE ((err == "no clap_entry symbol"
+              || err.find ("Test.clap/Contents/MacOS/TestClap") != std::string::npos));
     REQUIRE_FALSE (b.isLoaded());
     REQUIRE (b.getPath().empty());
 }

--- a/tests/clap_bundle_load.cpp
+++ b/tests/clap_bundle_load.cpp
@@ -1,14 +1,57 @@
-// Increment 0 of the native CLAP host: the ClapBundle loader compiles, links,
-// and fails cleanly on a bad path. A real load+enumerate test arrives with a
-// .clap fixture (DuskVerb-as-CLAP, increment 3). See docs/native-clap-host-plan.md.
+// CLAP loader failure paths run without a plugin fixture. Live bundle loading
+// remains covered by the environment-gated scanner test.
 
 #include <catch2/catch_test_macros.hpp>
 
 #include "engine/clap/ClapBundle.h"
 
+#include <chrono>
 #include <cstdio>
 #include <dlfcn.h>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
 #include <string>
+
+#if defined(__APPLE__)
+#include <mach-o/dyld.h>
+
+namespace
+{
+namespace stdfs = std::filesystem;
+
+class TempDirectory
+{
+public:
+    explicit TempDirectory (const char* prefix)
+    {
+        const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+        value = stdfs::temp_directory_path() / (std::string (prefix) + std::to_string (unique));
+        std::error_code ec;
+        if (! stdfs::create_directories (value, ec) || ec)
+            throw std::runtime_error ("could not create test directory: " + ec.message());
+    }
+
+    ~TempDirectory()
+    {
+        std::error_code ec;
+        stdfs::remove_all (value, ec);
+    }
+
+    const stdfs::path& path() const noexcept { return value; }
+
+private:
+    stdfs::path value;
+};
+
+bool writeText (const stdfs::path& path, const char* text)
+{
+    std::ofstream stream (path);
+    stream << text;
+    return stream.good();
+}
+} // namespace
+#endif
 
 TEST_CASE ("ClapBundle fails gracefully on a missing bundle", "[clap][bundle]")
 {
@@ -20,6 +63,7 @@ TEST_CASE ("ClapBundle fails gracefully on a missing bundle", "[clap][bundle]")
     REQUIRE_FALSE (b.isLoaded());
     REQUIRE (b.plugins().empty());
     REQUIRE (b.getFactory() == nullptr);
+    REQUIRE (b.getPath().empty());
 }
 
 TEST_CASE ("ClapBundle rejects a real shared object that is not a CLAP bundle", "[clap][bundle]")
@@ -40,3 +84,44 @@ TEST_CASE ("ClapBundle rejects a real shared object that is not a CLAP bundle", 
     REQUIRE_FALSE (err.empty());
     INFO ("rejection reason: " << err);
 }
+
+#if defined(__APPLE__)
+TEST_CASE ("ClapBundle resolves a directory bundle executable", "[clap][bundle]")
+{
+    TempDirectory parent ("dusk_clap_bundle_");
+    const auto temp = parent.path() / "Test.clap";
+    const auto contents = temp / "Contents";
+    const auto executableDir = contents / "MacOS";
+    std::error_code ec;
+    REQUIRE (std::filesystem::create_directories (executableDir, ec));
+    REQUIRE_FALSE (ec);
+    REQUIRE (writeText (contents / "Info.plist",
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" "
+        "\"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
+        "<plist version=\"1.0\"><dict>\n"
+        "<key>CFBundleExecutable</key><string>TestClap</string>\n"
+        "<key>CFBundleIdentifier</key><string>com.duskaudio.test-clap</string>\n"
+        "<key>CFBundlePackageType</key><string>BNDL</string>\n"
+        "</dict></plist>\n"));
+
+    const auto executable = executableDir / "TestClap";
+    std::vector<char> runningExecutable (1024);
+    auto pathSize = static_cast<std::uint32_t> (runningExecutable.size());
+    if (_NSGetExecutablePath (runningExecutable.data(), &pathSize) != 0)
+    {
+        runningExecutable.resize (pathSize);
+        REQUIRE (_NSGetExecutablePath (runningExecutable.data(), &pathSize) == 0);
+    }
+    std::filesystem::copy_file (std::filesystem::u8path (runningExecutable.data()), executable,
+                                std::filesystem::copy_options::overwrite_existing, ec);
+    REQUIRE_FALSE (ec);
+
+    duskstudio::clap::ClapBundle b;
+    std::string err;
+    REQUIRE_FALSE (b.load (temp.u8string(), err));
+    REQUIRE ((err == "no clap_entry symbol" || err.rfind ("dlopen failed:", 0) == 0));
+    REQUIRE_FALSE (b.isLoaded());
+    REQUIRE (b.getPath().empty());
+}
+#endif

--- a/tests/clap_scanner.cpp
+++ b/tests/clap_scanner.cpp
@@ -14,6 +14,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <unistd.h>
 
 using duskstudio::clap::ClapScanner;
 
@@ -26,8 +27,11 @@ class TempDirectory
 public:
     explicit TempDirectory (const char* prefix)
     {
+        // pid + tick: ctest runs the test cases as parallel processes, whose
+        // steady_clock reads can land on the same tick.
         const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
-        value = stdfs::temp_directory_path() / (std::string (prefix) + std::to_string (unique));
+        value = stdfs::temp_directory_path()
+                / (std::string (prefix) + std::to_string (getpid()) + "_" + std::to_string (unique));
         std::error_code ec;
         if (! stdfs::create_directories (value, ec) || ec)
             throw std::runtime_error ("could not create test directory: " + ec.message());
@@ -154,7 +158,12 @@ TEST_CASE ("ClapScanner discovers and describes a real CLAP bundle", "[clap][sca
     }
 
     std::error_code ec;
-    const auto bundle = stdfs::absolute (stdfs::u8path (path), ec);
+    // Normalised: the scanner's bundle paths carry no trailing separator or "."
+    // component, so an env value like ".../CLAP/Plugin.clap/" must not miss.
+    // lexically_normal() resolves the dot elements but KEEPS a trailing
+    // separator, which then shows up as an empty final filename.
+    auto bundle = stdfs::absolute (stdfs::u8path (path), ec).lexically_normal();
+    if (! bundle.has_filename()) bundle = bundle.parent_path();
     REQUIRE_FALSE (ec);
     REQUIRE (stdfs::exists (bundle));
 

--- a/tests/clap_scanner.cpp
+++ b/tests/clap_scanner.cpp
@@ -1,24 +1,80 @@
 // CLAP discovery: ClapScanner enumerates *.clap files + reads their descriptors.
 // The path-shape cases run everywhere; the live load+enumerate case is gated on
-// DUSKSTUDIO_TEST_CLAP=/path/to.clap (e.g. ~/.clap/DuskVerb.clap) so CI without a
-// CLAP plugin stays green. See docs/native-clap-host-plan.md.
+// DUSKSTUDIO_TEST_CLAP=/path/to/Plugin.clap so CI without a CLAP plugin stays
+// green. See docs/native-clap-host-plan.md.
 
 #include <catch2/catch_test_macros.hpp>
 
 #include "engine/clap/ClapScanner.h"
 
-#include <juce_core/juce_core.h>
-
+#include <chrono>
 #include <cstdlib>
 #include <filesystem>
+#include <fstream>
+#include <optional>
+#include <stdexcept>
+#include <string>
 
 using duskstudio::clap::ClapScanner;
 
 namespace
 {
-std::filesystem::path toPath (const juce::File& f)
+namespace stdfs = std::filesystem;
+
+class TempDirectory
 {
-    return std::filesystem::u8path (f.getFullPathName().toStdString());
+public:
+    explicit TempDirectory (const char* prefix)
+    {
+        const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+        value = stdfs::temp_directory_path() / (std::string (prefix) + std::to_string (unique));
+        std::error_code ec;
+        if (! stdfs::create_directories (value, ec) || ec)
+            throw std::runtime_error ("could not create test directory: " + ec.message());
+    }
+
+    ~TempDirectory()
+    {
+        std::error_code ec;
+        stdfs::remove_all (value, ec);
+    }
+
+    const stdfs::path& path() const noexcept { return value; }
+
+private:
+    stdfs::path value;
+};
+
+class ScopedEnvironment
+{
+public:
+    ScopedEnvironment (const char* variable, const std::string& value)
+        : name (variable)
+    {
+        if (const char* current = std::getenv (variable))
+            previous = current;
+        if (setenv (name.c_str(), value.c_str(), 1) != 0)
+            throw std::runtime_error ("could not set test environment variable");
+    }
+
+    ~ScopedEnvironment()
+    {
+        if (previous.has_value())
+            setenv (name.c_str(), previous->c_str(), 1);
+        else
+            unsetenv (name.c_str());
+    }
+
+private:
+    std::string name;
+    std::optional<std::string> previous;
+};
+
+bool writeText (const stdfs::path& path, const char* text)
+{
+    std::ofstream stream (path);
+    stream << text;
+    return stream.good();
 }
 } // namespace
 
@@ -28,18 +84,64 @@ TEST_CASE ("ClapScanner default search paths are existing directories", "[clap][
         REQUIRE (std::filesystem::is_directory (d));
 }
 
+TEST_CASE ("ClapScanner keeps CLAP_PATH ahead of platform defaults", "[clap][scan]")
+{
+    TempDirectory temp ("dusk_clap_scan_defaults_");
+    const auto overridePath = temp.path() / "override";
+    const auto home = temp.path() / "home";
+#if defined(__APPLE__)
+    const auto userDefault = home / "Library/Audio/Plug-Ins/CLAP";
+#else
+    const auto userDefault = home / ".clap";
+#endif
+
+    std::error_code ec;
+    REQUIRE (stdfs::create_directories (overridePath, ec));
+    REQUIRE_FALSE (ec);
+    REQUIRE (stdfs::create_directories (userDefault, ec));
+    REQUIRE_FALSE (ec);
+
+    ScopedEnvironment scopedHome ("HOME", home.u8string());
+    ScopedEnvironment scopedClapPath ("CLAP_PATH", overridePath.u8string());
+    const auto paths = ClapScanner::defaultSearchPaths();
+    REQUIRE (paths.size() >= 2);
+    REQUIRE (paths[0] == overridePath);
+    REQUIRE (paths[1] == userDefault);
+}
+
 TEST_CASE ("ClapScanner finds nothing in an empty directory", "[clap][scan]")
 {
-    auto tmp = juce::File::getSpecialLocation (juce::File::tempDirectory)
-                   .getChildFile ("dusk_clap_scan_empty_"
-                                    + juce::String (juce::Random::getSystemRandom().nextInt()));
-    tmp.deleteRecursively();
-    REQUIRE (tmp.createDirectory());
+    TempDirectory temp ("dusk_clap_scan_empty_");
+    REQUIRE (ClapScanner::findClapFiles ({ temp.path() }).empty());
+    REQUIRE (ClapScanner::scan ({ temp.path() }).empty());
+}
 
-    REQUIRE (ClapScanner::findClapFiles ({ toPath (tmp) }).empty());
-    REQUIRE (ClapScanner::scan ({ toPath (tmp) }).empty());
+TEST_CASE ("ClapScanner collects this platform's CLAP bundle shape once", "[clap][scan]")
+{
+    TempDirectory temp ("dusk_clap_scan_shape_");
+    const auto vendor = temp.path() / "Vendor";
+    std::error_code ec;
+    REQUIRE (stdfs::create_directory (vendor, ec));
+    REQUIRE_FALSE (ec);
 
-    tmp.deleteRecursively();
+#if defined(__APPLE__)
+    const auto bundle = vendor / "Outer.clap";
+    REQUIRE (stdfs::create_directory (bundle, ec));
+    REQUIRE_FALSE (ec);
+    REQUIRE (stdfs::create_directory (bundle / "Nested.clap", ec));
+    REQUIRE_FALSE (ec);
+    REQUIRE (writeText (temp.path() / "NotABundle.clap", "regular file"));
+#else
+    const auto bundle = vendor / "Plugin.clap";
+    REQUIRE (writeText (bundle, "not a loadable plugin"));
+    REQUIRE (stdfs::create_directory (temp.path() / "NotAPlugin.clap", ec));
+    REQUIRE_FALSE (ec);
+#endif
+
+    const auto found = ClapScanner::findClapFiles ({ temp.path(), temp.path() });
+    REQUIRE (found.size() == 1);
+    REQUIRE (found.front().is_absolute());
+    REQUIRE (found.front() == bundle);
 }
 
 TEST_CASE ("ClapScanner discovers and describes a real CLAP bundle", "[clap][scan]")
@@ -51,16 +153,18 @@ TEST_CASE ("ClapScanner discovers and describes a real CLAP bundle", "[clap][sca
         return;
     }
 
-    const juce::File bundle (juce::String (path).trim());
-    REQUIRE (bundle.existsAsFile());
+    std::error_code ec;
+    const auto bundle = stdfs::absolute (stdfs::u8path (path), ec);
+    REQUIRE_FALSE (ec);
+    REQUIRE (stdfs::exists (bundle));
 
-    const auto found = ClapScanner::scan ({ toPath (bundle.getParentDirectory()) });
+    const auto found = ClapScanner::scan ({ bundle.parent_path() });
     REQUIRE_FALSE (found.empty());
 
     bool sawBundle = false;
     for (const auto& s : found)
     {
-        if (s.bundlePath == bundle.getFullPathName().toStdString())
+        if (s.bundlePath == bundle.u8string())
         {
             sawBundle = true;
             REQUIRE_FALSE (s.desc.id.empty());     // a usable plugin id to instantiate


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added native CLAP, LV2, and VST3 hosting support on macOS.
  - Added macOS plugin discovery using standard user and system audio plug-in locations.
  - Added embedded macOS plug-in editor support for CLAP and VST3.
  - Expanded native hosting availability across supported Linux and macOS configurations.

- **Bug Fixes**
  - Improved loading of macOS CLAP bundles.
  - Added stricter build validation to prevent requested native plug-in formats from being silently disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->