### PR TITLE
hosting: embed VST3 editors on macOS

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,12 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(git fetch origin --prune)",
+      "Bash(git log origin/main --oneline -5)",
+      "Bash(git show origin/main:docs/dejuce-hosting-h5-platform.md)",
+      "Bash(git show --stat 2a8135d)"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/docs/dejuce-hosting-h5-platform.md
+++ b/docs/dejuce-hosting-h5-platform.md
@@ -1,10 +1,11 @@
 # Hosting tower H5 — native platform ports + AU (executable spec)
 
-Status: **SCOUTED 2026-07-29; MARC DECISIONS LOCKED; H5a.0-H5a.2 COMPLETE
-LOCALLY; H5a.3 NEXT.** H4 is merged as PR #119 at `3c5c901`. The H5 scout
-verified the live source/CMake/CI surface from that baseline. Windows LV2 is
-deferred. H5 is three sequential PRs: H5a macOS CLAP/LV2/VST3, H5b macOS AU,
-H5c Windows CLAP/VST3. No H5 branch is pushed without Marc's word.
+Status: **H5a.0-H5a.2 MERGED AS PR #120 AT `2a8135d`; H5a.3 COMPLETE LOCALLY
+ON `dejuce/hosting-h5a2`; H5a.4 NEXT.** H4 is merged as PR #119 at `3c5c901`.
+The H5 scout verified the live source/CMake/CI surface from that baseline.
+Windows LV2 is deferred. H5 is three sequential PRs: H5a macOS CLAP/LV2/VST3,
+H5b macOS AU, H5c Windows CLAP/VST3. No H5 branch is pushed without Marc's
+word.
 
 Parent plan: [dejuce-hosting-plan.md](dejuce-hosting-plan.md). Campaign ritual:
 [dejuce-campaign.md](dejuce-campaign.md). H1d and H2 remain blocked on donor
@@ -87,8 +88,9 @@ H5 does not unlink a JUCE module. H6 performs the deletion and globally unlinks
 
 ## H5a — macOS CLAP/LV2/VST3
 
-Branch: `dejuce/hosting-h5a`. One PR. Execute the increments below in order.
-Each implementation increment touches at most five files, gets its own focused
+H5a.0-H5a.2 merged from `dejuce/hosting-h5a`; the remainder continues on
+`dejuce/hosting-h5a2`. Execute the increments below in order. Each
+implementation increment touches at most five files, gets its own focused
 verification, and pauses for campaign-manager review before the next.
 
 ### H5a.0 — build gates + CI dependencies
@@ -376,5 +378,5 @@ H5 is complete only when:
 ## Resume phrase
 
 "Hosting H5, spec docs/dejuce-hosting-h5-platform.md — on
-dejuce/hosting-h5a, execute the first incomplete H5a increment, review, validate,
-and commit locally; never push without Marc's word."
+dejuce/hosting-h5a2, execute the first incomplete H5a increment, review,
+validate, and commit locally; never push without Marc's word."

--- a/docs/dejuce-remaining-phase-prompts.md
+++ b/docs/dejuce-remaining-phase-prompts.md
@@ -9,10 +9,14 @@ status lines and `git log` over this file.
 ## State at time of writing
 
 - Merged on `main`: hosting H1a–c (PR #114), H3 (PR #118), H4 (PR #119),
-  plus everything in the campaign doc's Done list.
-- In flight: H5a on `dejuce/hosting-h5a` — H5a.0–H5a.2 complete, H5a.3
-  next. The H5 spec `docs/dejuce-hosting-h5-platform.md` exists only on
-  that branch until H5a merges.
+  H5a.0–H5a.2 (PR #120, squash-merged 2026-07-30; `origin/dejuce/hosting-h5a`
+  deleted), plus everything in the campaign doc's Done list.
+- Next: H5a.4–H5a.6 on `dejuce/hosting-h5a2`, where H5a.3 is already
+  committed locally and unpushed. The H5 spec
+  `docs/dejuce-hosting-h5-platform.md` is on `main` now; its status line is
+  authoritative. PR #120 shipped `Lv2Editor_Mac.mm` and `Vst3Editor_Mac.mm`
+  as compile stubs only — H5a.3 replaced the VST3 one, H5a.5 replaces the LV2
+  one.
 - Gate allowlist: 179 files. JUCE modules linked: 12.
 - The memory ledger `project_dejuce_roadmap.md` exists only on the Linux
   machine; sessions on other machines fall back to repo docs + git log.
@@ -20,7 +24,7 @@ status lines and `git log` over this file.
 ## Dependency order
 
 ```
-H5a (in flight) → H5b → H5c
+H5a remainder (H5a.3–.6) → H5b → H5c
 Donor consolidation → H1d
                    → H2-donor → H2-app
 H6 requires H5a+H5b+H5c and H2-app merged
@@ -38,19 +42,24 @@ of H5/H6 but must land before the GUI tower.
 You are executing one phase of the Dusk Studio de-JUCE campaign in
 /Users/marckorte/projects/DuskStudio (or /home/marc/projects/DuskStudio on the
 Linux box). Read, in order: docs/dejuce-campaign.md (ritual + working
-agreement), then check out the existing branch dejuce/hosting-h5a from origin
-and read docs/dejuce-hosting-h5-platform.md ON THAT BRANCH (it is not on main
-yet). If the memory ledger project_dejuce_roadmap.md exists in this machine's
-memory dir, read it; if absent, trust the spec's status line and git log.
+agreement) and docs/dejuce-hosting-h5-platform.md (now on main; its status
+line is authoritative). If the memory ledger project_dejuce_roadmap.md exists
+in this machine's memory dir, read it; if absent, trust the spec's status line
+and git log.
 
 State: H5a.0 (build gates + CI dependencies), H5a.1 (portable discovery + CLAP
-bundle loading), and H5a.2 (CLAP Cocoa editor) are complete on the branch;
-H5a.3's host-context split already landed with the macOS build fix, so only its
-Cocoa attach remains. Execute the first incomplete increment (H5a.3 VST3
-portable host context + Cocoa editor core, then H5a.4 VST3 Cocoa wrapper +
-cross-platform tests, H5a.5 LV2 Cocoa editor, H5a.6 closeout) — ONE increment
-per session, max five files each, exactly as the spec's per-increment file
-lists and work items dictate. Pause for review after each increment.
+bundle loading), and H5a.2 (CLAP Cocoa editor) are MERGED to main as PR #120
+(squash commit 2a8135d); origin/dejuce/hosting-h5a is deleted. PR #120 shipped
+Lv2Editor_Mac.mm and Vst3Editor_Mac.mm as compile stubs only. H5a.3 (VST3
+portable host context + Cocoa editor core) is COMMITTED LOCALLY, unpushed, on
+branch dejuce/hosting-h5a2. Check that branch out and confirm its H5a.3 commit
+against the spec's status line before touching anything; only if the branch is
+gone or its H5a.3 work is absent, update local main, recreate
+dejuce/hosting-h5a2 off it, and redo H5a.3 first. Execute the first incomplete
+increment (H5a.4 VST3 Cocoa wrapper + cross-platform tests, then H5a.5 LV2
+Cocoa editor, H5a.6 closeout) — ONE increment per session, max five files
+each, exactly as the spec's per-increment file lists and work items dictate.
+Pause for review after each increment.
 
 Rules: commit locally, NEVER push without Marc's word; no attribution trailers;
 Linux native hosting behaviour is an invariant; keep platform code behind the
@@ -68,11 +77,12 @@ updating the spec's status line and stating the resume phrase from the spec.
 
 ```
 You are executing one phase of the Dusk Studio de-JUCE campaign. Precondition:
-the H5a PR (branch dejuce/hosting-h5a) is MERGED — verify with git log before
-starting; if not merged, stop and report. Read, in order:
+ALL of H5a is merged — both PR #120 (H5a.0–.2) and the H5a-remainder PR
+(H5a.3–.6); verify with git log and the H5 spec's status line before starting;
+if not fully merged, stop and report. Read, in order:
 docs/dejuce-campaign.md, docs/dejuce-hosting-plan.md,
-docs/dejuce-hosting-h5-platform.md §H5b (on main once H5a merges), and the
-memory ledger project_dejuce_roadmap.md if present on this machine.
+docs/dejuce-hosting-h5-platform.md §H5b, and the memory ledger
+project_dejuce_roadmap.md if present on this machine.
 
 Create branch dejuce/hosting-h5b. Build the macOS-only native AU layer in
 src/engine/au/ — AuBundle (stable type/subtype/manufacturer identifier),

--- a/src/engine/vst3/Vst3Editor.cpp
+++ b/src/engine/vst3/Vst3Editor.cpp
@@ -97,7 +97,8 @@ bool Vst3Editor::open (Vst3Instance& inst, std::string& errorOut)
     return true;
 }
 
-bool Vst3Editor::embed (unsigned long parentX11, int x, int y, int w, int h, std::string& errorOut)
+bool Vst3Editor::embed (std::uintptr_t parentHandle, int x, int y, int w, int h,
+                        std::string& errorOut)
 {
     if (! impl->view) { errorOut = "no view open"; return false; }
     if (impl->embedded) return true;
@@ -120,7 +121,7 @@ bool Vst3Editor::embed (unsigned long parentX11, int x, int y, int w, int h, std
     // x11-frames a managed adoption detaches the compositor-side surface
     // from the X-space parent-child position.
     swa.override_redirect = True;
-    impl->hostWindow = XCreateWindow (dpy, (Window) parentX11, x, y,
+    impl->hostWindow = XCreateWindow (dpy, (Window) parentHandle, x, y,
                                       (unsigned) ww, (unsigned) hh, 0,
                                       CopyFromParent, InputOutput, (Visual*) CopyFromParent,
                                       CWBackPixel | CWBorderPixel | CWEventMask | CWOverrideRedirect, &swa);
@@ -164,7 +165,7 @@ void Vst3Editor::setContentScale (float scale)
     impl->applyContentScale();
 }
 
-bool Vst3Editor::getRootRelativePosition (unsigned long referenceWindow,
+bool Vst3Editor::getRootRelativePosition (std::uintptr_t referenceHandle,
                                            int& relX, int& relY) const
 {
     if (! impl->embedded || impl->display == nullptr || impl->hostWindow == 0)
@@ -174,7 +175,7 @@ bool Vst3Editor::getRootRelativePosition (unsigned long referenceWindow,
     int hx = 0, hy = 0, rx = 0, ry = 0;
     if (! XTranslateCoordinates (dpy, (Window) impl->hostWindow,
                                  DefaultRootWindow (dpy), 0, 0, &hx, &hy, &dummy)
-        || ! XTranslateCoordinates (dpy, (Window) referenceWindow,
+        || ! XTranslateCoordinates (dpy, (Window) referenceHandle,
                                     DefaultRootWindow (dpy), 0, 0, &rx, &ry, &dummy))
         return false;
     relX = hx - rx; relY = hy - ry;

--- a/src/engine/vst3/Vst3Editor.h
+++ b/src/engine/vst3/Vst3Editor.h
@@ -33,8 +33,11 @@ public:
     // Keeps a reference to `inst` - the owner must keep it alive past this editor.
     bool open (Vst3Instance& inst, std::string& errorOut);
 
-    // Create a native child container under parentHandle at (x,y,w,h), attach
-    // the view into it, and make it ready for reveal().
+    // Create a native child container under parentHandle at (x,y,w,h) and
+    // attach the view into it. Visibility afterwards is platform-specific: the
+    // X11 host window is mapped here (toolkit editors can refuse to realise
+    // into an unmapped parent), while the Cocoa container stays hidden until
+    // reveal(). reveal()/hide() are idempotent on both.
     bool embed (std::uintptr_t parentHandle, int x, int y, int w, int h,
                 std::string& errorOut);
 

--- a/src/engine/vst3/Vst3Editor.h
+++ b/src/engine/vst3/Vst3Editor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
@@ -8,16 +9,17 @@ namespace duskstudio::vst3
 {
 class Vst3Instance;
 
-// Native X11 editor embed for a VST3 plugin view (Linux). Owns a host X11
-// window created as a child of the app's window; the controller's IPlugView
-// attaches to it via kPlatformTypeX11EmbedWindowID. Mirrors Lv2Editor's shape:
-// open() discovers/creates the view, embed() parents it on-screen.
+// Native editor embed for a VST3 plugin view. The platform translation unit
+// owns an X11 child window on Linux or an NSView child container on macOS.
+// open() discovers/creates the view; embed() attaches it to the native child.
 //
 // The frame is wired at open() - BEFORE attached() - so the view can reach the
-// IPlugFrame (and query the Linux IRunLoop through it) while attaching. Resize
-// requests round-trip resizeView -> host window resize -> onSize, per spec.
+// IPlugFrame while attaching. On Linux it can also query the IRunLoop. Resize
+// requests round-trip resizeView -> host container resize -> onSize, per spec.
 //
-// No X11 / Steinberg types leak here: everything lives behind the pImpl.
+// No platform / Steinberg types leak here: everything lives behind the pImpl.
+// Native handles use uintptr_t rather than X11's unsigned long, keeping the
+// boundary pointer-width-safe on every platform.
 class Vst3Editor
 {
 public:
@@ -27,29 +29,29 @@ public:
     Vst3Editor& operator= (const Vst3Editor&) = delete;
 
     // Create the controller's editor view and wire the frame + host callbacks.
-    // False (+errorOut) when the plugin ships no X11-embeddable editor. Keeps a
-    // reference to `inst` - the owner must keep it alive past this editor.
+    // False (+errorOut) when the plugin ships no compatible embedded editor.
+    // Keeps a reference to `inst` - the owner must keep it alive past this editor.
     bool open (Vst3Instance& inst, std::string& errorOut);
 
-    // Create the host X11 window under parentX11 at (x,y,w,h), attach the view
-    // into it, and map it.
-    bool embed (unsigned long parentX11, int x, int y, int w, int h, std::string& errorOut);
+    // Create a native child container under parentHandle at (x,y,w,h), attach
+    // the view into it, and make it ready for reveal().
+    bool embed (std::uintptr_t parentHandle, int x, int y, int w, int h,
+                std::string& errorOut);
 
     void setBounds (int x, int y, int w, int h);
     void setContentScale (float scale);
-    void reveal();   // XMapWindow (idempotent)
-    void hide();     // XUnmapWindow (idempotent)
+    void reveal();
+    void hide();
     void close();
 
-    // The host window's REAL geometry (position relative to its X11 parent +
-    // size), so the owner can detect and correct drift the message flow
-    // missed. False when not embedded or the window is gone.
-    bool getRootRelativePosition (unsigned long referenceWindow,
+    // Linux geometry diagnostics. macOS uses logical component bounds directly,
+    // so these return false there.
+    bool getRootRelativePosition (std::uintptr_t referenceHandle,
                                   int& relX, int& relY) const;
     bool getActualGeometry (int& x, int& y, int& w, int& h) const;
 
-    // Message thread, ~60 Hz: pump the instance's IRunLoop (fds + timers) and
-    // drain our X connection.
+    // Message thread, ~60 Hz: pump the instance's host context and drain any
+    // platform editor events.
     void pump (double elapsedMs);
 
     int  preferredWidth()  const noexcept;

--- a/src/engine/vst3/Vst3Editor_Mac.mm
+++ b/src/engine/vst3/Vst3Editor_Mac.mm
@@ -11,6 +11,8 @@
 #include <pluginterfaces/gui/iplugview.h>
 #include <pluginterfaces/vst/ivsteditcontroller.h>
 
+#pragma clang diagnostic pop
+
 #include <algorithm>
 
 namespace duskstudio::vst3
@@ -206,5 +208,3 @@ void Vst3Editor::pump (double elapsedMs)
         impl->host->pump (elapsedMs);
 }
 } // namespace duskstudio::vst3
-
-#pragma clang diagnostic pop

--- a/src/engine/vst3/Vst3Editor_Mac.mm
+++ b/src/engine/vst3/Vst3Editor_Mac.mm
@@ -1,45 +1,210 @@
 #include "Vst3Editor.h"
+#include "Vst3HostContext.h"
+#include "Vst3Instance.h"
 
-// macOS VST3 editor. The kPlatformTypeNSView attach is not implemented: open()
-// reports no embeddable view, so a VST3 plugin loads and processes on macOS but
-// has no editor. The Linux X11 implementation lives in Vst3Editor.cpp.
+#import <AppKit/AppKit.h>
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow-field-in-constructor"
+#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+
+#include <pluginterfaces/gui/iplugview.h>
+#include <pluginterfaces/vst/ivsteditcontroller.h>
+
+#include <algorithm>
+
 namespace duskstudio::vst3
 {
-namespace
+using namespace Steinberg;
+
+struct Vst3Editor::Impl
 {
-constexpr const char* kNoCocoaView = "VST3 plugin editors are not embeddable on macOS yet";
-} // namespace
+    Vst3Editor*      owner    = nullptr;
+    Vst3Instance*    instance = nullptr;
+    Vst3HostContext* host     = nullptr;
 
-struct Vst3Editor::Impl {};
+    IPtr<IPlugView> view;
+    NSView* container = nil;
 
-Vst3Editor::Vst3Editor()  = default;
-Vst3Editor::~Vst3Editor() = default;
+    int  prefW = 0, prefH = 0;
+    int  lastW = 0, lastH = 0;
+    bool embedded = false, visible = false;
 
-bool Vst3Editor::open (Vst3Instance&, std::string& errorOut)
+    void confirmSize (int w, int h)
+    {
+        if (! view || (w == lastW && h == lastH)) return;
+        lastW = w;
+        lastH = h;
+        ViewRect size (0, 0, w, h);
+        view->onSize (&size);
+    }
+
+    bool onResizeView (int w, int h)
+    {
+        if (w <= 0 || h <= 0 || ! view) return false;
+        prefW = w;
+        prefH = h;
+
+        if (container != nil)
+        {
+            auto frame = [container frame];
+            frame.size = NSMakeSize ((CGFloat) w, (CGFloat) h);
+            [container setFrame:frame];
+        }
+
+        if (owner->onResize)
+            owner->onResize (w, h);
+
+        confirmSize (w, h);
+        return true;
+    }
+};
+
+Vst3Editor::Vst3Editor() : impl (std::make_unique<Impl>()) { impl->owner = this; }
+Vst3Editor::~Vst3Editor() { close(); }
+
+int  Vst3Editor::preferredWidth()  const noexcept { return impl->prefW; }
+int  Vst3Editor::preferredHeight() const noexcept { return impl->prefH; }
+bool Vst3Editor::isOpen()     const noexcept { return impl->view != nullptr; }
+bool Vst3Editor::isEmbedded() const noexcept { return impl->embedded; }
+
+bool Vst3Editor::open (Vst3Instance& inst, std::string& errorOut)
 {
-    errorOut = kNoCocoaView;
-    return false;
+    if (impl->view) return true;
+
+    auto* controller = static_cast<Vst::IEditController*> (inst.editController());
+    if (controller == nullptr) { errorOut = "plugin has no edit controller"; return false; }
+
+    impl->view = owned (controller->createView (Vst::ViewType::kEditor));
+    if (! impl->view) { errorOut = "plugin has no editor view"; return false; }
+
+    if (impl->view->isPlatformTypeSupported (kPlatformTypeNSView) != kResultTrue)
+    {
+        errorOut = "editor does not support Cocoa embedding";
+        impl->view = nullptr;
+        return false;
+    }
+
+    impl->instance = &inst;
+    impl->host = &inst.getHost();
+    inst.setResizeViewHandler ([self = impl.get()] (int w, int h)
+                               { return self->onResizeView (w, h); });
+    impl->view->setFrame (static_cast<IPlugFrame*> (impl->host->plugFrame()));
+
+    ViewRect size {};
+    if (impl->view->getSize (&size) == kResultOk)
+    {
+        impl->prefW = size.getWidth();
+        impl->prefH = size.getHeight();
+    }
+    return true;
 }
 
-bool Vst3Editor::embed (unsigned long, int, int, int, int, std::string& errorOut)
+bool Vst3Editor::embed (std::uintptr_t parentHandle, int x, int y, int w, int h,
+                        std::string& errorOut)
 {
-    errorOut = kNoCocoaView;
-    return false;
+    if (! impl->view) { errorOut = "no view open"; return false; }
+    if (impl->embedded) return true;
+    if (parentHandle == 0) { errorOut = "null parent view"; return false; }
+
+    auto* parent = reinterpret_cast<NSView*> (parentHandle);
+    const int ww = w > 0 ? w : (impl->prefW > 0 ? impl->prefW : 480);
+    const int hh = h > 0 ? h : (impl->prefH > 0 ? impl->prefH : 320);
+
+    impl->container = [[NSView alloc] initWithFrame:NSMakeRect (
+        (CGFloat) x, (CGFloat) y, (CGFloat) ww, (CGFloat) hh)];
+    if (impl->container == nil)
+    {
+        errorOut = "could not create Cocoa container";
+        return false;
+    }
+    [impl->container setAutoresizingMask:NSViewNotSizable];
+    [impl->container setHidden:YES];
+    [parent addSubview:impl->container];
+
+    if (impl->view->attached (impl->container, kPlatformTypeNSView) != kResultOk)
+    {
+        errorOut = "IPlugView::attached failed";
+        close();
+        return false;
+    }
+
+    ViewRect size {};
+    if (impl->view->getSize (&size) == kResultOk
+        && size.getWidth() > 0 && size.getHeight() > 0)
+    {
+        impl->prefW = size.getWidth();
+        impl->prefH = size.getHeight();
+    }
+
+    impl->embedded = true;
+    return true;
 }
 
-void Vst3Editor::setBounds (int, int, int, int) {}
+void Vst3Editor::setBounds (int x, int y, int w, int h)
+{
+    if (impl->container == nil) return;
+    const int ww = std::max (1, w);
+    const int hh = std::max (1, h);
+    [impl->container setFrame:NSMakeRect (
+        (CGFloat) x, (CGFloat) y, (CGFloat) ww, (CGFloat) hh)];
+    if (impl->embedded)
+        impl->confirmSize (ww, hh);
+}
+
+// Cocoa's IPlugView coordinates are already logical; the backing NSView tracks
+// the screen scale without IPlugViewContentScaleSupport.
 void Vst3Editor::setContentScale (float) {}
-void Vst3Editor::reveal() {}
-void Vst3Editor::hide() {}
-void Vst3Editor::close() {}
 
-bool Vst3Editor::getRootRelativePosition (unsigned long, int&, int&) const { return false; }
+void Vst3Editor::reveal()
+{
+    if (impl->container == nil || impl->visible) return;
+    [impl->container setHidden:NO];
+    impl->visible = true;
+}
+
+void Vst3Editor::hide()
+{
+    if (impl->container == nil || ! impl->visible) return;
+    [impl->container setHidden:YES];
+    impl->visible = false;
+}
+
+void Vst3Editor::close()
+{
+    if (impl->view)
+    {
+        if (impl->embedded)
+            impl->view->removed();
+        impl->view->setFrame (nullptr);
+        impl->view = nullptr;
+    }
+    if (impl->instance != nullptr)
+    {
+        impl->instance->setResizeViewHandler (nullptr);
+        impl->instance = nullptr;
+    }
+    impl->host = nullptr;
+
+    if (impl->container != nil)
+    {
+        [impl->container removeFromSuperview];
+        [impl->container release];
+        impl->container = nil;
+    }
+
+    impl->embedded = impl->visible = false;
+    impl->prefW = impl->prefH = impl->lastW = impl->lastH = 0;
+}
+
+bool Vst3Editor::getRootRelativePosition (std::uintptr_t, int&, int&) const { return false; }
 bool Vst3Editor::getActualGeometry (int&, int&, int&, int&) const { return false; }
 
-void Vst3Editor::pump (double) {}
-
-int  Vst3Editor::preferredWidth()  const noexcept { return 0; }
-int  Vst3Editor::preferredHeight() const noexcept { return 0; }
-bool Vst3Editor::isOpen()     const noexcept { return false; }
-bool Vst3Editor::isEmbedded() const noexcept { return false; }
+void Vst3Editor::pump (double elapsedMs)
+{
+    if (impl->host != nullptr)
+        impl->host->pump (elapsedMs);
+}
 } // namespace duskstudio::vst3
+
+#pragma clang diagnostic pop


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added macOS support for embedding VST3 plugin editors in native host views.
  * Plugin editors now support visibility management, preferred sizing, and plugin-driven resizing.
  * Improved cross-platform native editor embedding and host integration.

* **Bug Fixes**
  * Added clearer handling for unsupported editor types and setup failures.

* **Documentation**
  * Updated H5 hosting progress and execution status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->