### PR TITLE
0.12.7 critical wave, batch 1: session data integrity

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -73,8 +73,8 @@ Open **Settings → Audio…**. Choose your interface, sample rate, and block si
 
 ![Audio device panel with a real interface selected.](docs/images/qg-02-audio-settings.png)
 
-On Linux, PipeWire is accessed through the "JACK" backend; select the
-listed JACK device or ports for your interface.
+On Linux, both PipeWire and native JACK show up under the "JACK" backend;
+select the listed JACK device or ports for your interface.
 
 If your interface has more than two inputs, the channel pickers on each track's input block will populate automatically; no extra routing dialog is needed.
 

--- a/src/engine/RecordManager.cpp
+++ b/src/engine/RecordManager.cpp
@@ -34,6 +34,14 @@ RecordManager::~RecordManager()
     // audio-thread caller that already entered, then discard the uncommitted
     // capture. The normal stopRecording path mutates the session by creating
     // regions, which must only happen through an explicit engine stop.
+    //
+    // The wait is deliberately unbounded, unlike stopRecording's capped spin.
+    // stopRecording can bail past its cap because it leaves writers[] /
+    // midiCaptures[] alive for later reclaim; a destructor cannot - every
+    // member (including the audioInFlight atomic the in-flight thread still
+    // decrements) is destroyed when it returns, so proceeding would trade
+    // the wait for a use-after-free. By this point the engine has detached
+    // the audio callback, so the drain is at most one block.
     active.store (false, std::memory_order_release);
     while (audioInFlight.load (std::memory_order_acquire) > 0)
         std::this_thread::yield();

--- a/src/engine/multisample/DuskMultisampleProcessor.cpp
+++ b/src/engine/multisample/DuskMultisampleProcessor.cpp
@@ -174,7 +174,7 @@ void DuskMultisampleProcessor::clearLoadedFile()
         const juce::ScopedLock sl (sf2PresetsLock);
         sf2Presets.clear();
     }
-    sf2PresetIndex = -1;
+    sf2PresetIndex.store (-1, std::memory_order_relaxed);
     loadedFilePath.clear();
     lastLoadError.clear();
 }
@@ -335,7 +335,8 @@ bool DuskMultisampleProcessor::applySf2Preset (const juce::File& sf2,
         const juce::ScopedLock sl (sf2PresetsLock);
         presetCount = (int) sf2Presets.size();
     }
-    sf2PresetIndex = juce::jlimit (0, juce::jmax (0, presetCount - 1), presetIndex);
+    sf2PresetIndex.store (juce::jlimit (0, juce::jmax (0, presetCount - 1), presetIndex),
+                          std::memory_order_relaxed);
     loadedFilePath = sf2.getFullPathName();
     lastLoadError.clear();
     return true;
@@ -395,7 +396,7 @@ bool DuskMultisampleProcessor::loadSfzFile (const juce::File& sfz,
         const juce::ScopedLock sl (sf2PresetsLock);
         sf2Presets.clear();
     }
-    sf2PresetIndex = -1;
+    sf2PresetIndex.store (-1, std::memory_order_relaxed);
     loadedFilePath = sfz.getFullPathName();
     lastLoadError.clear();
     return true;
@@ -518,7 +519,7 @@ void DuskMultisampleProcessor::getStateInformation (juce::MemoryBlock& block)
     state.setProperty ("polyphony",
                         overrides.polyphony.load (std::memory_order_relaxed),
                         nullptr);
-    state.setProperty ("sf2Preset", sf2PresetIndex, nullptr);
+    state.setProperty ("sf2Preset", sf2PresetIndex.load (std::memory_order_relaxed), nullptr);
 
     // Persist any CC the UI has set (custom-UI knob/fader positions).
     // Only non-default (>= 0) entries are written so the blob stays

--- a/src/engine/multisample/DuskMultisampleProcessor.h
+++ b/src/engine/multisample/DuskMultisampleProcessor.h
@@ -85,7 +85,7 @@ public:
         const juce::ScopedLock sl (sf2PresetsLock);
         return sf2Presets;
     }
-    int getSf2PresetIndex() const noexcept { return sf2PresetIndex; }
+    int getSf2PresetIndex() const noexcept { return sf2PresetIndex.load (std::memory_order_relaxed); }
 
     // True if a soundfont has been loaded. Used by editor UI to show
     // "(no file)" vs the loaded file name.
@@ -185,7 +185,9 @@ private:
     // snapshot getSf2Presets() copies out on the message thread.
     std::vector<Sf2PresetInfo> sf2Presets;
     juce::CriticalSection      sf2PresetsLock;
-    int                        sf2PresetIndex { 0 };
+    // Written by the loadPool thread, read by the message thread
+    // (getStateInformation, editor polls) - atomic, no ordering needed.
+    std::atomic<int>           sf2PresetIndex { 0 };
 
     // CC control plumbing. ccCache holds the last value the UI set per
     // CC (-1 = unset) for read-back + state save. ccFifo carries

--- a/src/session/RegionEditActions.cpp
+++ b/src/session/RegionEditActions.cpp
@@ -81,13 +81,24 @@ MidiRegionEditAction::MidiRegionEditAction (Session& s, AudioEngine& e,
       beforeState (b), afterState (a)
 {}
 
+// Assigning a whole MidiRegion frees the old notes/ccs storage, so this
+// must swap-publish like Create/RecordCommit - currentMutable() is only
+// safe for value edits inside existing entries.
 bool MidiRegionEditAction::perform()
 {
     if (trackIdx < 0 || trackIdx >= Session::kNumTracks) return false;
     if (frozenLocked (session, trackIdx)) return false;
-    auto& v = session.track (trackIdx).midiRegions.currentMutable();
-    if (regionIdx < 0 || regionIdx >= (int) v.size()) return false;
-    v[(size_t) regionIdx] = afterState;
+    bool applied = false;
+    session.track (trackIdx).midiRegions.mutate (
+        [this, &applied] (std::vector<MidiRegion>& mregs)
+        {
+            if (regionIdx >= 0 && regionIdx < (int) mregs.size())
+            {
+                mregs[(size_t) regionIdx] = afterState;
+                applied = true;
+            }
+        });
+    if (! applied) return false;
     rebuildPlaybackIfStopped (engine);
     return true;
 }
@@ -96,9 +107,17 @@ bool MidiRegionEditAction::undo()
 {
     if (trackIdx < 0 || trackIdx >= Session::kNumTracks) return false;
     if (frozenLocked (session, trackIdx)) return false;
-    auto& v = session.track (trackIdx).midiRegions.currentMutable();
-    if (regionIdx < 0 || regionIdx >= (int) v.size()) return false;
-    v[(size_t) regionIdx] = beforeState;
+    bool applied = false;
+    session.track (trackIdx).midiRegions.mutate (
+        [this, &applied] (std::vector<MidiRegion>& mregs)
+        {
+            if (regionIdx >= 0 && regionIdx < (int) mregs.size())
+            {
+                mregs[(size_t) regionIdx] = beforeState;
+                applied = true;
+            }
+        });
+    if (! applied) return false;
     rebuildPlaybackIfStopped (engine);
     return true;
 }
@@ -293,11 +312,19 @@ bool DeleteMidiRegionAction::perform()
 {
     if (trackIdx < 0 || trackIdx >= Session::kNumTracks) return false;
     if (frozenLocked (session, trackIdx)) return false;
-    auto& v = session.track (trackIdx).midiRegions.currentMutable();
-    if (regionIdx < 0 || regionIdx >= (int) v.size()) return false;
-    removed = v[(size_t) regionIdx];
-    haveRemoved = true;
-    v.erase (v.begin() + regionIdx);
+    bool erased = false;
+    session.track (trackIdx).midiRegions.mutate (
+        [this, &erased] (std::vector<MidiRegion>& mregs)
+        {
+            if (regionIdx >= 0 && regionIdx < (int) mregs.size())
+            {
+                removed = mregs[(size_t) regionIdx];
+                haveRemoved = true;
+                mregs.erase (mregs.begin() + regionIdx);
+                erased = true;
+            }
+        });
+    if (! erased) return false;
     rebuildPlaybackIfStopped (engine);
     return true;
 }
@@ -307,9 +334,12 @@ bool DeleteMidiRegionAction::undo()
     if (! haveRemoved) return false;
     if (trackIdx < 0 || trackIdx >= Session::kNumTracks) return false;
     if (frozenLocked (session, trackIdx)) return false;
-    auto& v = session.track (trackIdx).midiRegions.currentMutable();
-    const int insertAt = juce::jmin (regionIdx, (int) v.size());
-    v.insert (v.begin() + insertAt, removed);
+    session.track (trackIdx).midiRegions.mutate (
+        [this] (std::vector<MidiRegion>& mregs)
+        {
+            const int insertAt = juce::jmin (regionIdx, (int) mregs.size());
+            mregs.insert (mregs.begin() + insertAt, removed);
+        });
     rebuildPlaybackIfStopped (engine);
     return true;
 }
@@ -650,8 +680,13 @@ bool JoinRegionsAction::perform()
 
     const auto firstStart = beforeRegions.front().timelineStart;
     const auto firstSrcOffset = beforeRegions.front().sourceOffset;
-    const auto lastEnd = beforeRegions.back().timelineStart
-                         + beforeRegions.back().lengthInSamples;
+    // Latest end over ALL regions, not back()'s end: regions are sorted by
+    // start, and an earlier-starting region can outlast the last-starting
+    // one (overlap/containment). back()'s end would undersize the slow
+    // path's mix buffer and the merged length.
+    std::int64_t lastEnd = firstStart;
+    for (const auto& r : beforeRegions)
+        lastEnd = std::max (lastEnd, r.timelineStart + r.lengthInSamples);
     const auto totalLen = lastEnd - firstStart;
 
     // Sort descending so the larger indices erase first and the smaller
@@ -672,13 +707,23 @@ bool JoinRegionsAction::perform()
         merged.fadeOutShape    = beforeRegions.back().fadeOutShape;
         merged.previousTakes   = beforeRegions.front().previousTakes;
 
+        // indices is timeline-sorted, so the lead (earliest-starting) region
+        // is not necessarily the lowest numeric index. Every erase below it
+        // shifts it down one slot - track that or the merged write lands on
+        // (or past) the wrong region and the join silently loses audio.
+        if (sortedDesc.front() >= (int) regs.size() || sortedDesc.back() < 0)
+            return false;
         const int leadIdx = indices.front();
+        int mergedIdx = leadIdx;
         for (int idx : sortedDesc)
             if (idx != leadIdx)
+            {
                 regs.erase (regs.begin() + idx);
-        resultInsertedAt = leadIdx;
-        if (resultInsertedAt >= 0 && resultInsertedAt < (int) regs.size())
-            regs[(size_t) resultInsertedAt] = merged;
+                if (idx < leadIdx)
+                    --mergedIdx;
+            }
+        resultInsertedAt = mergedIdx;
+        regs[(size_t) resultInsertedAt] = merged;
         rebuildPlaybackIfStopped (engine);
         return true;
     }
@@ -755,13 +800,20 @@ bool JoinRegionsAction::perform()
     merged.fadeOutShape    = beforeRegions.back().fadeOutShape;
     merged.previousTakes.clear();
 
+    // Same lead-index adjustment as the fast path above.
+    if (sortedDesc.front() >= (int) regs.size() || sortedDesc.back() < 0)
+        return false;
     const int leadIdx = indices.front();
+    int mergedIdx = leadIdx;
     for (int idx : sortedDesc)
         if (idx != leadIdx)
+        {
             regs.erase (regs.begin() + idx);
-    resultInsertedAt = leadIdx;
-    if (resultInsertedAt >= 0 && resultInsertedAt < (int) regs.size())
-        regs[(size_t) resultInsertedAt] = merged;
+            if (idx < leadIdx)
+                --mergedIdx;
+        }
+    resultInsertedAt = mergedIdx;
+    regs[(size_t) resultInsertedAt] = merged;
     rebuildPlaybackIfStopped (engine);
     return true;
 }

--- a/src/session/RegionEditActions.cpp
+++ b/src/session/RegionEditActions.cpp
@@ -683,10 +683,16 @@ bool JoinRegionsAction::perform()
     // Latest end over ALL regions, not back()'s end: regions are sorted by
     // start, and an earlier-starting region can outlast the last-starting
     // one (overlap/containment). back()'s end would undersize the slow
-    // path's mix buffer and the merged length.
+    // path's mix buffer and the merged length. The latest-ending region is
+    // also the one whose audio closes the merged result, so its fade-out is
+    // the one both paths carry over.
     std::int64_t lastEnd = firstStart;
+    const AudioRegion* latestEnding = &beforeRegions.front();
     for (const auto& r : beforeRegions)
-        lastEnd = std::max (lastEnd, r.timelineStart + r.lengthInSamples);
+    {
+        const auto end = r.timelineStart + r.lengthInSamples;
+        if (end > lastEnd) { lastEnd = end; latestEnding = &r; }
+    }
     const auto totalLen = lastEnd - firstStart;
 
     // Sort descending so the larger indices erase first and the smaller
@@ -697,14 +703,15 @@ bool JoinRegionsAction::perform()
     if (sameFile && abuts)
     {
         // Cheap merge: keep the leading region, extend its length, drop
-        // the rest. Outer fadeIn / fadeOutShape from first / last are
-        // preserved; inner fades vanish along with the joints.
+        // the rest. Outer fadeIn from the first and fadeOut from the
+        // latest-ending region are preserved; inner fades vanish along
+        // with the joints.
         AudioRegion merged = beforeRegions.front();
         merged.timelineStart   = firstStart;
         merged.sourceOffset    = firstSrcOffset;
         merged.lengthInSamples = totalLen;
-        merged.fadeOutSamples  = beforeRegions.back().fadeOutSamples;
-        merged.fadeOutShape    = beforeRegions.back().fadeOutShape;
+        merged.fadeOutSamples  = latestEnding->fadeOutSamples;
+        merged.fadeOutShape    = latestEnding->fadeOutShape;
         merged.previousTakes   = beforeRegions.front().previousTakes;
 
         // indices is timeline-sorted, so the lead (earliest-starting) region
@@ -796,8 +803,8 @@ bool JoinRegionsAction::perform()
     merged.numChannels     = chs;
     merged.fadeInSamples   = beforeRegions.front().fadeInSamples;
     merged.fadeInShape     = beforeRegions.front().fadeInShape;
-    merged.fadeOutSamples  = beforeRegions.back().fadeOutSamples;
-    merged.fadeOutShape    = beforeRegions.back().fadeOutShape;
+    merged.fadeOutSamples  = latestEnding->fadeOutSamples;
+    merged.fadeOutShape    = latestEnding->fadeOutShape;
     merged.previousTakes.clear();
 
     // Same lead-index adjustment as the fast path above.

--- a/src/session/RegionEditActions.h
+++ b/src/session/RegionEditActions.h
@@ -215,9 +215,9 @@ private:
     bool firstPerformDone = false;
 };
 
-// MIDI counterpart to DeleteRegionAction. Mutates through the
-// AtomicSnapshot's currentMutable() since midiRegions is a swap-load
-// vector; same race profile every other piano-roll edit accepts.
+// MIDI counterpart to DeleteRegionAction. Erase/insert reshape the
+// vector, so both go through mutate() (copy + publish) - never
+// currentMutable() while the audio thread iterates the snapshot.
 class DeleteMidiRegionAction final : public juce::UndoableAction
 {
 public:

--- a/src/session/SessionSerializer.cpp
+++ b/src/session/SessionSerializer.cpp
@@ -994,25 +994,23 @@ void restoreTrack (Track& t, const nlohmann::json& v, double defaultRecordBpm,
         if (json::has (hwi, "dry_wet"))        t.hardwareInsert.dryWet      .store (json::getFloat (hwi, "dry_wet", 0.0f));
     }
 
-    // Automation - per-strip mode + per-param point arrays. Lanes not in
-    // the JSON stay empty (default-constructed). 3c-i loads only; 3c-ii
-    // adds Write which mutates lanes mid-play via an atomic-swap pattern.
+    // Automation - per-strip mode + per-param point arrays. Each lane gets
+    // exactly ONE publish per load (empty when absent from the JSON):
+    // AtomicSnapshot retires only one previous value, so a clear-then-
+    // publish pair on the same lane would free the pre-load vector the
+    // audio thread can still be reading.
     //
-    // Note: we mutate automationLanes BEFORE publishing the new
-    // automationMode. Publishing the mode first would let the audio
-    // thread observe Read/Touch and pull from a half-rebuilt lane
-    // vector (mid-clear / mid-push_back). Release-store of the mode
-    // after all lane mutations pairs with the engine's acquire-load
-    // gating lane reads.
-    for (auto& lane : t.automationLanes)
-        lane.publishPoints ({});
+    // Note: lanes publish BEFORE the new automationMode. Publishing the
+    // mode first would let the audio thread observe Read/Touch and pull
+    // from a not-yet-loaded lane. Release-store of the mode after all
+    // lane publishes pairs with the engine's acquire-load gating lane
+    // reads.
     {
         const auto& autoVar = json::child (v, "automation");
         for (int p = 0; p < kNumAutomationParams; ++p)
         {
             const char* key = automationParamKey ((AutomationParam) p);
             const auto& pts = json::array (autoVar, key);
-            if (pts.empty()) continue;
             std::vector<AutomationPoint> tmp;
             tmp.reserve (pts.size());
             for (const auto& pv : pts)
@@ -1205,18 +1203,15 @@ void restoreBus (Bus& a, const nlohmann::json& v, double defaultRecordBpm)
     if (json::has (v, "comp_release_auto")) a.strip.compReleaseAuto.store (json::getBool (v, "comp_release_auto", false));
     if (json::has (v, "comp_makeup_db"))   a.strip.compMakeupDb .store (json::getFloat (v, "comp_makeup_db", 0.0f));
 
-    // Automation - mirror restoreTrack: clear lanes, rebuild from JSON, then
-    // release-store the mode so the audio thread never reads a half-rebuilt
-    // lane vector. Only FaderDb / Pan / Mute lanes are ever populated.
-    for (auto& lane : a.strip.automationLanes)
-        lane.publishPoints ({});
+    // Automation - mirror restoreTrack: exactly one publish per lane (empty
+    // when absent), then release-store the mode. Only FaderDb / Pan / Mute
+    // lanes are ever populated.
     {
         const auto& autoVar = json::child (v, "automation");
         for (int p = 0; p < kNumAutomationParams; ++p)
         {
             const char* key = automationParamKey ((AutomationParam) p);
             const auto& pts = json::array (autoVar, key);
-            if (pts.empty()) continue;
             std::vector<AutomationPoint> tmp;
             tmp.reserve (pts.size());
             for (const auto& pv : pts)
@@ -1734,18 +1729,16 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
                 }
             }
 
-            // Mode publish happens AFTER lane mutations below - same
-            // ordering rationale as the track-load block: avoid the
-            // audio thread reading half-rebuilt lane vectors.
-            for (auto& al : lane.params.automationLanes)
-                al.publishPoints ({});
+            // Mode publish happens AFTER the lane publishes below - same
+            // ordering rationale as the track-load block, and exactly one
+            // publish per lane (empty when absent) per the AtomicSnapshot
+            // one-publish-behind contract.
             {
                 const auto& autoObj = json::child (v, "automation");
                 for (int p = 0; p < kNumAutomationParams; ++p)
                 {
                     const char* key = automationParamKey ((AutomationParam) p);
                     const auto& pts = json::array (autoObj, key);
-                    if (pts.empty()) continue;
                     std::vector<AutomationPoint> tmp;
                     tmp.reserve (pts.size());
                     for (const auto& pv : pts)
@@ -1832,17 +1825,15 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
         loadMasterFloat (s.master().compReleaseMs,    "comp_release_ms");
         loadMasterBool  (s.master().compReleaseAuto,  "comp_release_auto");
         loadMasterFloat (s.master().compMakeupDb,     "comp_makeup_db");
-        // Mode publish happens AFTER lane mutations below - same
-        // ordering rationale as the track-load + aux-load blocks.
-        for (auto& al : s.master().automationLanes)
-            al.publishPoints ({});
+        // Mode publish happens AFTER the lane publishes below - same
+        // ordering rationale as the track-load + aux-load blocks, and
+        // exactly one publish per lane (empty when absent).
         {
             const auto& autoObj = json::child (master, "automation");
             for (int p = 0; p < kNumAutomationParams; ++p)
             {
                 const char* key = automationParamKey ((AutomationParam) p);
                 const auto& pts = json::array (autoObj, key);
-                if (pts.empty()) continue;
                 std::vector<AutomationPoint> tmp;
                 tmp.reserve (pts.size());
                 for (const auto& pv : pts)

--- a/src/session/SessionSerializer.cpp
+++ b/src/session/SessionSerializer.cpp
@@ -1774,8 +1774,11 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
                 s.getMarkers()[(size_t) idx].colour = hexToColour (col, juce::Colour (0xffe0a050));
         }
     }
-    if (json::has (root, "master"))
     {
+        // json::child yields a shared empty object when "master" is absent,
+        // so a session without the key still resets master state and
+        // publishes every lane empty instead of inheriting the previously
+        // loaded session's.
         const auto& master = json::child (root, "master");
         // Reset to struct defaults when a key is absent - load() reuses the live
         // session (no pre-load reset), so a conditional store would inherit the
@@ -1849,9 +1852,11 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
                 s.master().automationLanes[(size_t) p].publishPoints (std::move (tmp));
             }
         }
-        if (json::has (master, "automation_mode"))
-            s.master().automationMode.store (json::getInt (master, "automation_mode", 0),
-                                              std::memory_order_release);
+        // Unconditional, matching the track / bus / aux paths: a strip left
+        // in Write by the prior session must not keep writing over the
+        // loaded session's lanes.
+        s.master().automationMode.store (json::getInt (master, "automation_mode", 0),
+                                          std::memory_order_release);
     }
     // Always reset: a session without a saved mastering source must not
     // inherit the previously loaded session's file.

--- a/src/ui/AudioRegionEditor.cpp
+++ b/src/ui/AudioRegionEditor.cpp
@@ -1591,6 +1591,7 @@ void AudioRegionEditor::mouseDown (const juce::MouseEvent& e)
         rangeEndSample   = rangeStartSample;
         rangeActive      = false;   // becomes true once the drag distance > 0
         dragMode         = DragMode::Range;
+        refreshStatusBarReadouts();
         repaint();
         return;
     }
@@ -1756,6 +1757,7 @@ void AudioRegionEditor::mouseDown (const juce::MouseEvent& e)
             rangeEndSample   = rangeStartSample;
             rangeActive      = false;
             dragMode         = DragMode::Range;
+            refreshStatusBarReadouts();
             repaint();
             return;
         }
@@ -2052,6 +2054,7 @@ void AudioRegionEditor::mouseDrag (const juce::MouseEvent& e)
         const auto snappedFileSample = snapFileSampleToTimelineGrid (sampleForX (e.x, waveArea));
         rangeEndSample = snappedFileSample;
         rangeActive = (rangeEndSample != rangeStartSample);
+        refreshStatusBarReadouts();
         repaint();
         return;
     }
@@ -2212,6 +2215,7 @@ void AudioRegionEditor::mouseUp (const juce::MouseEvent&)
         rangeActive = (rangeEndSample > rangeStartSample);
         dragMode = DragMode::None;
         snapGuideTimelineSample = -1;
+        refreshStatusBarReadouts();
         repaint();
         return;
     }
@@ -2566,6 +2570,7 @@ bool AudioRegionEditor::keyPressed (const juce::KeyPress& k)
         if (rangeActive)
         {
             rangeActive = false;
+            refreshStatusBarReadouts();
             repaint();
             return true;
         }

--- a/src/ui/AudioRegionEditor.cpp
+++ b/src/ui/AudioRegionEditor.cpp
@@ -1972,7 +1972,12 @@ void AudioRegionEditor::mouseDrag (const juce::MouseEvent& e)
     // file-sample-based, so we round-trip through the focused slice's
     // sourceOffset -> timelineStart mapping.
     const bool bypassSnap = e.mods.isCommandDown();
-    const double sampleRate = engine.getCurrentSampleRate();
+    // File-native SR like every other snap path (snapFileSampleToGrid,
+    // keyPressed) - the raw engine rate drifts the drag grid off the
+    // click/keyboard grid after a device hot-swap.
+    const double sampleRate = juce::jmax (1.0,
+        loadedFileSampleRate > 0.0 ? loadedFileSampleRate
+                                    : engine.getCurrentSampleRate());
 
     auto snapFileSampleToTimelineGrid = [&] (std::int64_t fileSample) -> std::int64_t
     {

--- a/src/ui/DuskComboBox.cpp
+++ b/src/ui/DuskComboBox.cpp
@@ -328,6 +328,12 @@ public:
     {
         if (useGrid)
         {
+            // The viewport width just changed; re-derive the scroll extent
+            // before clamping, or the clamp runs against the stale layout.
+            const int totalCols = (int) columns.size();
+            const int contentW  = totalCols > 0
+                                    ? totalCols * colWidth + (totalCols - 1) * kColGap : 0;
+            maxHScroll = juce::jmax (0, contentW - gridViewport().getWidth());
             setHScroll (hScroll);
             ensureColumnVisible (hoverCol);
         }

--- a/src/ui/EmbeddedModal.h
+++ b/src/ui/EmbeddedModal.h
@@ -506,6 +506,14 @@ private:
         if (hit != nullptr && hit->getScreenBounds().contains (e.getScreenPosition()))
             return;
 
+        // Every listening modal's global listener receives the same physical
+        // click, and once this layer pops itself off the stack the next
+        // listener's topmost guard passes too - one click would dismiss two
+        // stacked layers. Mark the event consumed so lower layers skip it.
+        static juce::Time lastConsumedOutsideClick;
+        if (e.eventTime == lastConsumedOutsideClick) return;
+        lastConsumedOutsideClick = e.eventTime;
+
         // Keep the callback alive across close(), which clears the dismiss
         // callbacks. Prefer the outside-click callback so the clicked control
         // keeps focus.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -107,6 +107,7 @@ add_executable(dusk-studio-tests
     ${CMAKE_SOURCE_DIR}/src/engine/MasteringPlayer.cpp
     session_missing_sections.cpp
     session_save_as_consolidation.cpp
+    session_automation_load_publish.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/MidiTimeCodeReceiver.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/MidiTimeCodeEmitter.cpp
     ${CMAKE_SOURCE_DIR}/src/session/Session.cpp

--- a/tests/session_automation_load_publish.cpp
+++ b/tests/session_automation_load_publish.cpp
@@ -1,0 +1,109 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "session/Session.h"
+#include "session/SessionSerializer.h"
+
+#include <juce_core/juce_core.h>
+
+using Catch::Matchers::WithinAbs;
+using duskstudio::AutomationParam;
+using duskstudio::AutomationPoint;
+using duskstudio::Session;
+using duskstudio::SessionSerializer;
+
+namespace
+{
+juce::File makeTempSessionDir()
+{
+    auto dir = juce::File::getSpecialLocation (juce::File::tempDirectory)
+                  .getChildFile ("dusk-studio-automation-load-"
+                                    + juce::String (juce::Random::getSystemRandom().nextInt()));
+    dir.createDirectory();
+    return dir;
+}
+
+AutomationPoint pt (juce::int64 t, float v)
+{
+    AutomationPoint p;
+    p.timeSamples   = t;
+    p.value         = v;
+    p.recordedAtBPM = 120.0f;
+    return p;
+}
+} // namespace
+
+// Loading a session into a Session whose lanes already hold points is the
+// mid-run "open another session" path: the audio thread can be holding a
+// lane's read() pointer across the load. AtomicSnapshot retires exactly one
+// previous value, so the load must publish each lane exactly ONCE - a
+// clear-then-publish pair on the same lane frees the pre-load vector while
+// it may still be read. This pins the observable half of that contract:
+// after a load, the pre-load vector must still be alive (retired, not
+// destroyed). Under the old double-publish load this dereference is
+// use-after-free - ASAN/TSan builds catch it even when a plain build
+// happens to pass.
+TEST_CASE ("Session load publishes each automation lane exactly once",
+           "[session][serializer][automation]")
+{
+    const auto dir = makeTempSessionDir();
+    const auto target = dir.getChildFile ("session.json");
+
+    Session a;
+    a.track (0).automationLanes[(size_t) AutomationParam::FaderDb]
+        .publishPoints ({ pt (0, 0.1f), pt (48000, 0.9f), pt (96000, 0.5f) });
+    a.master().automationLanes[(size_t) AutomationParam::FaderDb]
+        .publishPoints ({ pt (0, 0.7f) });
+    REQUIRE (SessionSerializer::save (a, target));
+
+    Session b;
+    auto& trackLaneLoaded = b.track (0).automationLanes[(size_t) AutomationParam::FaderDb];
+    auto& trackLaneAbsent = b.track (1).automationLanes[(size_t) AutomationParam::Pan];
+    auto& masterLane      = b.master().automationLanes[(size_t) AutomationParam::FaderDb];
+    auto& auxLaneAbsent   = b.auxLane (0).params.automationLanes[(size_t) AutomationParam::FaderDb];
+    auto& busLaneAbsent   = b.bus (0).strip.automationLanes[(size_t) AutomationParam::FaderDb];
+
+    trackLaneLoaded.publishPoints ({ pt (10, 0.2f), pt (20, 0.3f) });
+    trackLaneAbsent.publishPoints ({ pt (30, 0.4f) });
+    masterLane     .publishPoints ({ pt (40, 0.5f), pt (50, 0.6f), pt (60, 0.7f), pt (70, 0.8f) });
+    auxLaneAbsent  .publishPoints ({ pt (80, 0.9f) });
+    busLaneAbsent  .publishPoints ({ pt (90, 1.0f), pt (95, 0.0f) });
+
+    const auto* preTrackLoaded = trackLaneLoaded.snapshot.read();
+    const auto* preTrackAbsent = trackLaneAbsent.snapshot.read();
+    const auto* preMaster      = masterLane.snapshot.read();
+    const auto* preAux         = auxLaneAbsent.snapshot.read();
+    const auto* preBus         = busLaneAbsent.snapshot.read();
+
+    REQUIRE (SessionSerializer::load (b, target));
+
+    // Loaded contents are correct.
+    REQUIRE (trackLaneLoaded.pointsConst().size() == 3);
+    REQUIRE (trackLaneLoaded.pointsConst()[0].timeSamples == 0);
+    REQUIRE_THAT (trackLaneLoaded.pointsConst()[2].value, WithinAbs (0.5f, 1e-4f));
+    REQUIRE (masterLane.pointsConst().size() == 1);
+
+    // Lanes absent from the JSON come back empty - the load must still
+    // overwrite whatever the previous session left in them.
+    REQUIRE (trackLaneAbsent.pointsConst().empty());
+    REQUIRE (auxLaneAbsent.pointsConst().empty());
+    REQUIRE (busLaneAbsent.pointsConst().empty());
+
+    // Every touched lane swapped its audio-visible pointer once...
+    REQUIRE (trackLaneLoaded.snapshot.read() != preTrackLoaded);
+    REQUIRE (trackLaneAbsent.snapshot.read() != preTrackAbsent);
+    REQUIRE (masterLane.snapshot.read()      != preMaster);
+    REQUIRE (auxLaneAbsent.snapshot.read()   != preAux);
+    REQUIRE (busLaneAbsent.snapshot.read()   != preBus);
+
+    // ...and the pre-load vectors are still alive as the retired value:
+    // exactly one publish per lane. Sizes must match what was published
+    // before the load.
+    REQUIRE (preTrackLoaded->size() == 2);
+    REQUIRE (preTrackAbsent->size() == 1);
+    REQUIRE (preMaster->size() == 4);
+    REQUIRE (preAux->size() == 1);
+    REQUIRE (preBus->size() == 2);
+
+    dir.deleteRecursively();
+}


### PR DESCRIPTION
Batch 1 of the criticals-first wave from the 2026-07-31 full-codebase scan, plus two review-fix rounds. Targets release/0.12 for a 0.12.7 patch.

## Session data integrity
- Join regions: heap overflow on overlapping/contained regions (mix buffer was sized from the last-starting region's end) and permanent data loss when the earliest-starting region was not the lowest numeric index (merged write landed past the wrong slot, undo bailed). Refs #126, #127.
- MIDI region edit/delete actions reshaped the midiRegions vector through currentMutable() while the audio thread iterates the snapshot; both now copy-and-publish via mutate(). Refs #129.
- Automation lanes: load published each lane twice (empty, then parsed). AtomicSnapshot retires exactly one previous value, so the second publish freed a vector the audio thread could still be evaluating. One publish per lane now, regression test pins the retire contract. Refs #128.

## Review-round fixes
- Join fade-out carried from the latest-ending region in both paths.
- EmbeddedModal: one physical outside click could dismiss two stacked overlay-less popups; the event is marked consumed so lower layers skip it.
- DuskComboBox grid: horizontal scroll extent recomputed from the live viewport width in resized().
- AudioRegionEditor: status-bar sample readout refreshed on every range start/drag/release/Escape path; mouseDrag snapping uses the file-native sample rate like the click and keyboard paths.
- DuskMultisampleProcessor: sf2PresetIndex made atomic (loadPool-thread writes vs message-thread reads).
- SessionSerializer: master restore runs on an empty object when "master" is absent, so master state and lanes reset instead of inheriting the prior session's; master automation mode stored unconditionally like track/bus/aux.
- RecordManager: documented why the destructor's audioInFlight drain is deliberately unbounded.
- MANUAL.md: PipeWire and native JACK both appear under the "JACK" backend.

## Verification
- App build with zero new warnings (pre-existing warning counts confirmed against base via stash rebuild).
- ctest 385/385, including the new session_automation_load_publish regression test.
- Headless self-test under Xvfb ran to completion with zero FAIL markers.

Known gap: JoinRegionsAction has no unit test (needs a live AudioEngine; integration scope).

Remaining wave batches, separate PRs: DSP/engine RT (#130, #132, #139, #140, #141), devices/hosts/multisample/MIDI (#131, #133, #134, #135, #136), UI/app/CI (#137, #138, #142, #143).