### PR TITLE
0.12.7 critical wave, batch 2: DSP and engine RT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ interfaces that misreport their round-trip latency.
   interfaces whose reported latency leaves overdubs drifting. Count-in, the
   write gate, and MIDI placement are unaffected; a shift that would cross
   timeline zero trims the take's head instead of playing it late, and a take
-  fully consumed by the offset is surfaced rather than silently discarded.
+  fully consumed by the offset is discarded with a visible warning rather
+  than silently.
 - **Sample readout in the region editor.** The status bar shows the cursor
   position - or range start and length - in raw samples, so a loopback
   calibration recording can be measured directly.

--- a/src/dsp/ChannelStrip.cpp
+++ b/src/dsp/ChannelStrip.cpp
@@ -557,11 +557,15 @@ void ChannelStrip::relatchPdcIfDrained (float blockPeakAbs, int numSamples) noex
     // change to its next silent gap (latency edits happen on plugin load, which
     // is normally done with the transport stopped -> silent -> immediate).
     constexpr float kSilenceEps = 1.0e-6f;
+    const bool drainedBeforeBlock =
+        pdcSilentRun >= (std::int64_t) pdcAppliedSamples;
     if (blockPeakAbs < kSilenceEps) pdcSilentRun += numSamples;
     else                            pdcSilentRun = 0;
 
     const int target = pdcTargetSamples.load (std::memory_order_relaxed);
-    if (target != pdcAppliedSamples && pdcSilentRun >= (std::int64_t) pdcAppliedSamples)
+    if (target != pdcAppliedSamples
+        && (drainedBeforeBlock
+            || pdcSilentRun >= (std::int64_t) pdcAppliedSamples))
     {
         pdcDelayL.setDelay ((float) target);
         pdcDelayR.setDelay ((float) target);
@@ -690,17 +694,20 @@ void ChannelStrip::processAndAccumulate (const float* inL,
             for (auto& s : auxSendGain) s.getNextValue();
         }
         // The PDC lines still hold the last pdcAppliedSamples of pre-skip
-        // audio; a plain return would freeze it there and replay it into the
-        // mix on the next passing block (un-mute / un-solo). Output is cut
-        // for the whole skip, so the tail is dropped: clear the lines once
-        // and mark them drained, which also lets relatchPdcIfDrained take a
-        // pending latency retarget click-free on the next full pass.
-        // pdcSilentRun doubles as the once-latch - the full path zeroes it
-        // again on the first loud block.
-        if (pdcAppliedSamples > 0 && pdcSilentRun < (std::int64_t) kMaxPdcSamples)
+        // audio (and the oversampler's half-band FIRs hold osLatencySamples
+        // more); a plain return would freeze that there and replay it into
+        // the mix on the next passing block (un-mute / un-solo). Output is
+        // cut for the whole skip, so the tail is dropped: clear the lines
+        // and FIR history once and mark them drained, which also lets
+        // relatchPdcIfDrained take a pending latency retarget click-free on
+        // the next full pass. pdcSilentRun doubles as the once-latch - the
+        // full path zeroes it again on the first loud block.
+        if ((pdcAppliedSamples > 0 || osLatencySamples > 0)
+            && pdcSilentRun < (std::int64_t) kMaxPdcSamples)
         {
             pdcDelayL.reset();
             pdcDelayR.reset();
+            oversampler.reset();
             pdcSilentRun = (std::int64_t) kMaxPdcSamples;
         }
         return;

--- a/src/dsp/ChannelStrip.cpp
+++ b/src/dsp/ChannelStrip.cpp
@@ -689,6 +689,20 @@ void ChannelStrip::processAndAccumulate (const float* inL,
             for (auto& s : busGain)     s.getNextValue();
             for (auto& s : auxSendGain) s.getNextValue();
         }
+        // The PDC lines still hold the last pdcAppliedSamples of pre-skip
+        // audio; a plain return would freeze it there and replay it into the
+        // mix on the next passing block (un-mute / un-solo). Output is cut
+        // for the whole skip, so the tail is dropped: clear the lines once
+        // and mark them drained, which also lets relatchPdcIfDrained take a
+        // pending latency retarget click-free on the next full pass.
+        // pdcSilentRun doubles as the once-latch - the full path zeroes it
+        // again on the first loud block.
+        if (pdcAppliedSamples > 0 && pdcSilentRun < (std::int64_t) kMaxPdcSamples)
+        {
+            pdcDelayL.reset();
+            pdcDelayR.reset();
+            pdcSilentRun = (std::int64_t) kMaxPdcSamples;
+        }
         return;
     }
 
@@ -889,6 +903,12 @@ void ChannelStrip::processAndAccumulate (const float* inL,
                 for (int i = 0; i < numSamples; ++i)
                 {
                     pdcDelayL.pushSample (tempMono[(size_t) i]);
+                    // Keep the R line fed with the same signal: a mono ->
+                    // stereo width flip that keeps the PDC length (so
+                    // relatchPdcIfDrained never resets) would otherwise
+                    // replay the R line's stale tail.
+                    pdcDelayR.pushSample (tempMono[(size_t) i]);
+                    pdcDelayR.popSample();
                     tempMono[(size_t) i] = pdcDelayL.popSample();
                 }
         }

--- a/src/dsp/LoudnessMeter.cpp
+++ b/src/dsp/LoudnessMeter.cpp
@@ -152,6 +152,12 @@ void LoudnessMeter::process (const float* L, const float* R, int numSamples) noe
 {
     if (sr <= 0.0 || L == nullptr || R == nullptr) return;
 
+    // Deferred requestReset(): applied on this thread so the history clear
+    // and ring wipes never race a concurrent process() pass. prepare()'s
+    // reserve keeps the clear-and-refill allocation-free.
+    if (resetRequested.exchange (false, std::memory_order_acquire))
+        reset();
+
     // K-weighted block accumulation (LUFS)
     for (int i = 0; i < numSamples; ++i)
     {

--- a/src/dsp/LoudnessMeter.cpp
+++ b/src/dsp/LoudnessMeter.cpp
@@ -193,5 +193,11 @@ void LoudnessMeter::process (const float* L, const float* R, int numSamples) noe
                         ? dusk::audio::gainToDecibels (currentTruePeak, -100.0f)
                         : -100.0f,
                        std::memory_order_relaxed);
+
+    // Close the mid-block request window: finishBlock() and the true-peak
+    // publish above may have raced requestReset() after the entry check. Apply
+    // that request before returning so stale readings cannot reappear.
+    if (resetRequested.exchange (false, std::memory_order_acquire))
+        reset();
 }
 } // namespace duskstudio

--- a/src/dsp/LoudnessMeter.h
+++ b/src/dsp/LoudnessMeter.h
@@ -50,12 +50,15 @@ public:
     // and ring wipes never race the audio thread.
     void requestReset() noexcept
     {
+        // Publish the request first. process() checks again after publishing a
+        // block, so an in-flight pass reapplies a mid-block request before it
+        // returns.
+        resetRequested.store (true, std::memory_order_release);
         momentaryLufs.store (-100.0f, std::memory_order_relaxed);
         shortTermLufs.store (-100.0f, std::memory_order_relaxed);
         integratedLufs.store (-100.0f, std::memory_order_relaxed);
         truePeakDb.store    (-100.0f, std::memory_order_relaxed);
         integratedCapped.store (false, std::memory_order_relaxed);
-        resetRequested.store (true, std::memory_order_release);
     }
 
     // Audio thread. L and R must each be at least `numSamples` floats.

--- a/src/dsp/LoudnessMeter.h
+++ b/src/dsp/LoudnessMeter.h
@@ -31,7 +31,9 @@ namespace duskstudio
 //      the last reset.
 //
 // Threading:
-//   - prepare() / reset() - message thread.
+//   - prepare() / reset() - message thread with audio quiesced (prepare path).
+//   - requestReset()      - any thread while audio runs; the state reset is
+//                            deferred to the next process() block.
 //   - process()           - audio thread, no allocation.
 //   - getXxxLufs() / getSamplePeakDb() - atomic loads, any thread.
 class LoudnessMeter
@@ -39,9 +41,22 @@ class LoudnessMeter
 public:
     LoudnessMeter();
 
-    // Message thread.
+    // Message thread, audio quiesced.
     void prepare (double sampleRate, int maxBlockSize);
     void reset();
+
+    // Safe with audio running: zeroes the published readings immediately and
+    // defers the state reset to the next process() block, so the vector clear
+    // and ring wipes never race the audio thread.
+    void requestReset() noexcept
+    {
+        momentaryLufs.store (-100.0f, std::memory_order_relaxed);
+        shortTermLufs.store (-100.0f, std::memory_order_relaxed);
+        integratedLufs.store (-100.0f, std::memory_order_relaxed);
+        truePeakDb.store    (-100.0f, std::memory_order_relaxed);
+        integratedCapped.store (false, std::memory_order_relaxed);
+        resetRequested.store (true, std::memory_order_release);
+    }
 
     // Audio thread. L and R must each be at least `numSamples` floats.
     // `numSamples` may exceed an internal block boundary; we wrap through
@@ -106,5 +121,6 @@ private:
     // sets via relaxed store on the first overflow, UI polls via the
     // public accessor.
     std::atomic<bool>  integratedCapped { false };
+    std::atomic<bool>  resetRequested   { false };
 };
 } // namespace duskstudio

--- a/src/dsp/MasteringChain.cpp
+++ b/src/dsp/MasteringChain.cpp
@@ -83,7 +83,10 @@ int MasteringChain::readScopeLatest (float* dest, int count) const noexcept
 
 void MasteringChain::resetLoudness()
 {
-    loudnessMeter.reset();
+    // Message-thread entry (MasteringView's Reset I button) while the audio
+    // thread may be inside loudnessMeter.process() - defer, never reset
+    // directly.
+    loudnessMeter.requestReset();
 }
 
 #if DUSKSTUDIO_HAS_DUSK_DSP

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -330,7 +330,7 @@ public:
         // consumeLatencyChanged flags stay set, so the cycle runs on the
         // first tick after the render ends.
         if (sr > 0.0 && block > 0
-            && ! engine.offlineRenderActive.load (std::memory_order_relaxed))
+            && ! engine.offlineRenderActive.load (std::memory_order_acquire))
         {
             auto cycle = [&] (auto& slot)
             {
@@ -3782,9 +3782,8 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
 
     // Offline renders must be deterministic - live input never prints. An offline
     // bounce/stem/freeze drives this callback from a worker thread while the MIDI
-    // input path stays open, so this latch gates every live-MIDI pull below. Read
-    // once per callback (relaxed: the render worker sets it and drives this call).
-    const bool offlineRender = offlineRenderActive.load (std::memory_order_relaxed);
+    // input path stays open, so this latch gates every live-MIDI pull below.
+    const bool offlineRender = offlineRenderActive.load (std::memory_order_acquire);
 
     // Loop-aware disk reads: mirrors the wrap gate at the bottom of the
     // callback (plain playback only - recording keeps the playhead linear).

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -325,7 +325,12 @@ public:
         bool anyLatencyChanged = false;
         const double sr    = engine.getCurrentSampleRate();
         const int    block = engine.getCurrentBlockSize();
-        if (sr > 0.0 && block > 0)
+        // Deferred while an offline bounce drives the callback: the
+        // suspendProcessing below would gate the render into silent blocks.
+        // consumeLatencyChanged flags stay set, so the cycle runs on the
+        // first tick after the render ends.
+        if (sr > 0.0 && block > 0
+            && ! engine.offlineRenderActive.load (std::memory_order_relaxed))
         {
             auto cycle = [&] (auto& slot)
             {
@@ -2639,6 +2644,7 @@ void AudioEngine::audioDeviceIOCallbackWithContext (const float* const* inputCha
     if (processingSuspended.load (std::memory_order_acquire))
     {
         callbacksInFlight.fetch_sub (1, std::memory_order_acq_rel);
+        earlyOutBlocks.fetch_add (1, std::memory_order_relaxed);
         clearOutputs();
         return;
     }

--- a/src/engine/AudioEngine.h
+++ b/src/engine/AudioEngine.h
@@ -307,11 +307,11 @@ public:
     // callback on its worker thread, the live MIDI-input path stays open (the
     // input devices are never closed) - so without this, live controller notes
     // arriving during a render would print into the deterministic file. Set true
-    // for the full duration of every offline render loop, false otherwise. Read
-    // relaxed on the driving thread: the render worker both sets it and drives
-    // the callback, and the live device path never sees it true.
+    // for the full duration of every offline render loop, false otherwise. The
+    // message-thread NativeParamDrain also reads it before a VST3 reactivation,
+    // so publish/consume it across threads.
     void setOfflineRenderActive (bool active) noexcept
-        { offlineRenderActive.store (active, std::memory_order_relaxed); }
+        { offlineRenderActive.store (active, std::memory_order_release); }
 
     // Cross-track Plugin Delay Compensation. Reads each track's reported insert
     // latency (plugin OR hardware, gated by mode; MIDI tracks count 0 because

--- a/src/engine/AudioEngine.h
+++ b/src/engine/AudioEngine.h
@@ -75,6 +75,15 @@ public:
     void suspendProcessing();
     void resumeProcessing() noexcept;
 
+    // Count of callbacks the process gate turned into silent early-outs.
+    // BounceEngine compares it around each offline-render callback: a gated
+    // block wrote silence without advancing engine state and must be re-run,
+    // not committed to the file.
+    std::int64_t getGatedBlockCount() const noexcept
+    {
+        return earlyOutBlocks.load (std::memory_order_relaxed);
+    }
+
     // Test-only. Immediately stop+start the pool to `n` workers. Safe only when
     // no audio callback is concurrently in runBlock() - the offline self-test
     // drives the callback synchronously, so the A/B harness can flip the count

--- a/src/engine/BounceEngine.cpp
+++ b/src/engine/BounceEngine.cpp
@@ -394,9 +394,20 @@ void BounceEngine::run()
         // Reset outputs each block.
         for (auto& o : outputs) std::fill (o.begin(), o.end(), 0.0f);
 
+        // A message-thread suspendProcessing (plugin load, device change)
+        // makes the callback clear the outputs and return without advancing
+        // engine state; committing that block would splice silence into the
+        // bounce at the correct length with no error. Detect the gated
+        // callback and re-run the block once the gate reopens.
+        const auto gatedBefore = engine.getGatedBlockCount();
         engine.audioDeviceIOCallbackWithContext (inputPtrs.data(), kNumIn,
                                                    outputPtrs.data(), kNumChannels,
                                                    remaining, ctx);
+        if (engine.getGatedBlockCount() != gatedBefore)
+        {
+            juce::Thread::sleep (1);
+            continue;
+        }
 
         // Drop the leading PDC samples, then write the rest.
         int writeStart = 0;

--- a/src/engine/BounceEngine.cpp
+++ b/src/engine/BounceEngine.cpp
@@ -79,6 +79,31 @@ bool BounceEngine::runOnMessageThread (std::function<void()> fn)
     return true;
 }
 
+bool BounceEngine::processOfflineBlock (
+    const float* const* inputChannelData,
+    int numInputChannels,
+    float* const* outputChannelData,
+    int numOutputChannels,
+    int numSamples,
+    const juce::AudioIODeviceCallbackContext& context)
+{
+    while (! cancelRequested.load (std::memory_order_relaxed))
+    {
+        const auto gatedBefore = engine.getGatedBlockCount();
+        engine.audioDeviceIOCallbackWithContext (inputChannelData,
+                                                  numInputChannels,
+                                                  outputChannelData,
+                                                  numOutputChannels,
+                                                  numSamples,
+                                                  context);
+        if (engine.getGatedBlockCount() == gatedBefore)
+            return true;
+
+        juce::Thread::sleep (1);
+    }
+    return false;
+}
+
 std::unique_ptr<juce::AudioFormatWriter>
 BounceEngine::makeWriter (std::unique_ptr<juce::FileOutputStream> outStream,
                             juce::String& errOut) const
@@ -394,20 +419,10 @@ void BounceEngine::run()
         // Reset outputs each block.
         for (auto& o : outputs) std::fill (o.begin(), o.end(), 0.0f);
 
-        // A message-thread suspendProcessing (plugin load, device change)
-        // makes the callback clear the outputs and return without advancing
-        // engine state; committing that block would splice silence into the
-        // bounce at the correct length with no error. Detect the gated
-        // callback and re-run the block once the gate reopens.
-        const auto gatedBefore = engine.getGatedBlockCount();
-        engine.audioDeviceIOCallbackWithContext (inputPtrs.data(), kNumIn,
-                                                   outputPtrs.data(), kNumChannels,
-                                                   remaining, ctx);
-        if (engine.getGatedBlockCount() != gatedBefore)
-        {
-            juce::Thread::sleep (1);
-            continue;
-        }
+        if (! processOfflineBlock (inputPtrs.data(), kNumIn,
+                                    outputPtrs.data(), kNumChannels,
+                                    remaining, ctx))
+            break;
 
         // Drop the leading PDC samples, then write the rest.
         int writeStart = 0;
@@ -572,9 +587,10 @@ bool BounceEngine::renderOneStem (const juce::File& outFile,
 
         for (auto& o : outputs) std::fill (o.begin(), o.end(), 0.0f);
 
-        engine.audioDeviceIOCallbackWithContext (inputPtrs.data(), kNumIn,
-                                                   outputPtrs.data(), kNumChannels,
-                                                   remaining, ctx);
+        if (! processOfflineBlock (inputPtrs.data(), kNumIn,
+                                    outputPtrs.data(), kNumChannels,
+                                    remaining, ctx))
+            break;
 
         int writeStart = 0;
         if (dropped < leadIn)
@@ -885,9 +901,10 @@ bool BounceEngine::renderFreezeTrack (int trackIndex, const juce::File& outFile,
         std::fill (capL.begin(), capL.end(), 0.0f);
         std::fill (capR.begin(), capR.end(), 0.0f);
 
-        engine.audioDeviceIOCallbackWithContext (inputPtrs.data(), kNumIn,
-                                                   outputPtrs.data(), kNumChannels,
-                                                   remaining, ctx);
+        if (! processOfflineBlock (inputPtrs.data(), kNumIn,
+                                    outputPtrs.data(), kNumChannels,
+                                    remaining, ctx))
+            break;
 
         int writeStart = 0;
         if (dropped < leadIn)

--- a/src/engine/BounceEngine.h
+++ b/src/engine/BounceEngine.h
@@ -151,6 +151,16 @@ private:
     // must unwind without touching engine state.
     bool runOnMessageThread (std::function<void()> fn);
 
+    // Drive one offline callback block. A concurrent process-gate early-out
+    // does not advance engine state, so wait for the gate and retry instead of
+    // committing its silent output. Returns false only when cancelled.
+    bool processOfflineBlock (const float* const* inputChannelData,
+                              int numInputChannels,
+                              float* const* outputChannelData,
+                              int numOutputChannels,
+                              int numSamples,
+                              const juce::AudioIODeviceCallbackContext& context);
+
     AudioEngine& engine;
     Session&     session;
     juce::AudioDeviceManager& deviceManager;

--- a/src/engine/PlaybackEngine.cpp
+++ b/src/engine/PlaybackEngine.cpp
@@ -350,10 +350,13 @@ void PlaybackEngine::readForTrack (int trackIndex,
         {
             const int idx = seam - i;
             if (idx < 0) break;
+            // g rises with distance from the seam: ~0 at the sample next to
+            // the wrap, 1 at the far edge of the fade window - so multiply by
+            // g directly to silence the seam and leave the far edge untouched.
             const float g = 0.5f - 0.5f * std::cos (juce::MathConstants<float>::pi
                                                      * (float) i / (float) kLoopSeamFade);
-            outL[idx] *= 1.0f - g;
-            if (outR != nullptr) outR[idx] *= 1.0f - g;
+            outL[idx] *= g;
+            if (outR != nullptr) outR[idx] *= g;
         }
         for (int i = 0; i < kLoopSeamFade; ++i)
         {

--- a/src/engine/PluginSlot.cpp
+++ b/src/engine/PluginSlot.cpp
@@ -1181,27 +1181,35 @@ bool PluginSlot::restoreFromSavedState (const juce::String& descriptionXml,
     }
 
     ownedInstance = std::move (fresh);
-    // Same watchdog reset as loadFromFile / installInProcessInstance -
-    // autoBypassed is cleared nowhere else, so without this a slot whose
-    // plugin tripped the time-budget watchdog stays silently bypassed
-    // across a session load.
-    blocksSinceLoad     = 0;
-    consecutiveOverruns = 0;
-    autoBypassed.store (false, std::memory_order_relaxed);
-    if (hostPlayHead != nullptr)
-        ownedInstance->setPlayHead (hostPlayHead);
-    cachedLatencySamples.store (ownedInstance->getLatencySamples(),
-                                  std::memory_order_relaxed);
-    // Re-install the last-touched listener on the restored instance so
-    // MIDI Learn's "last-touched parameter" works after session reload.
-    // Pre-existing miss: the OOP path inherits its own listener
-    // machinery on the child side, but the in-process fallback dropped
-    // it on the floor.
-    lastTouchedParamIndex.store (-1, std::memory_order_relaxed);
-    lastTouchedListener = std::make_unique<LastTouchedListener> (lastTouchedParamIndex);
-    for (auto* p : ownedInstance->getParameters())
-        if (p != nullptr) p->addListener (lastTouchedListener.get());
-    currentInstance.store (ownedInstance.get(), std::memory_order_release);
+    {
+        // Same watchdog reset as loadFromFile / installInProcessInstance -
+        // autoBypassed is cleared nowhere else, so without this a slot whose
+        // plugin tripped the time-budget watchdog stays silently bypassed
+        // across a session load. Blocking-acquire the process lock so an
+        // audio block still running against the parked instance drains
+        // first; its overrun accounting could otherwise land after the
+        // clear and re-bypass the freshly restored plugin. Held through the
+        // publish; the audio side only try-locks, so it dry-passes instead
+        // of spinning.
+        const juce::SpinLock::ScopedLockType processGuard (processLock);
+        blocksSinceLoad     = 0;
+        consecutiveOverruns = 0;
+        autoBypassed.store (false, std::memory_order_relaxed);
+        if (hostPlayHead != nullptr)
+            ownedInstance->setPlayHead (hostPlayHead);
+        cachedLatencySamples.store (ownedInstance->getLatencySamples(),
+                                      std::memory_order_relaxed);
+        // Re-install the last-touched listener on the restored instance so
+        // MIDI Learn's "last-touched parameter" works after session reload.
+        // Pre-existing miss: the OOP path inherits its own listener
+        // machinery on the child side, but the in-process fallback dropped
+        // it on the floor.
+        lastTouchedParamIndex.store (-1, std::memory_order_relaxed);
+        lastTouchedListener = std::make_unique<LastTouchedListener> (lastTouchedParamIndex);
+        for (auto* p : ownedInstance->getParameters())
+            if (p != nullptr) p->addListener (lastTouchedListener.get());
+        currentInstance.store (ownedInstance.get(), std::memory_order_release);
+    }
     offlineDescriptionXml.clear();
     offlineStateBase64.clear();
     return true;

--- a/src/engine/PluginSlot.cpp
+++ b/src/engine/PluginSlot.cpp
@@ -1181,6 +1181,13 @@ bool PluginSlot::restoreFromSavedState (const juce::String& descriptionXml,
     }
 
     ownedInstance = std::move (fresh);
+    // Same watchdog reset as loadFromFile / installInProcessInstance -
+    // autoBypassed is cleared nowhere else, so without this a slot whose
+    // plugin tripped the time-budget watchdog stays silently bypassed
+    // across a session load.
+    blocksSinceLoad     = 0;
+    consecutiveOverruns = 0;
+    autoBypassed.store (false, std::memory_order_relaxed);
     if (hostPlayHead != nullptr)
         ownedInstance->setPlayHead (hostPlayHead);
     cachedLatencySamples.store (ownedInstance->getLatencySamples(),

--- a/src/session/RegionEditActions.cpp
+++ b/src/session/RegionEditActions.cpp
@@ -712,6 +712,7 @@ bool JoinRegionsAction::perform()
         merged.lengthInSamples = totalLen;
         merged.fadeOutSamples  = latestEnding->fadeOutSamples;
         merged.fadeOutShape    = latestEnding->fadeOutShape;
+        merged.fadeOutAuto     = latestEnding->fadeOutAuto;
         merged.previousTakes   = beforeRegions.front().previousTakes;
 
         // indices is timeline-sorted, so the lead (earliest-starting) region
@@ -805,6 +806,7 @@ bool JoinRegionsAction::perform()
     merged.fadeInShape     = beforeRegions.front().fadeInShape;
     merged.fadeOutSamples  = latestEnding->fadeOutSamples;
     merged.fadeOutShape    = latestEnding->fadeOutShape;
+    merged.fadeOutAuto     = latestEnding->fadeOutAuto;
     merged.previousTakes.clear();
 
     // Same lead-index adjustment as the fast path above.

--- a/tests/dsp_loudness_meter.cpp
+++ b/tests/dsp_loudness_meter.cpp
@@ -78,3 +78,33 @@ TEST_CASE ("LoudnessMeter true peak tracks a hot signal", "[dsp][loudness]")
     REQUIRE (m.getTruePeakDb() < 1.5f);
     REQUIRE (m.getMomentaryLufs() > -30.0f);   // a hot tone is loud
 }
+
+TEST_CASE ("LoudnessMeter requestReset zeroes readings and drops the history", "[dsp][loudness]")
+{
+    constexpr double sr     = 48000.0;
+    constexpr double kTwoPi = 6.283185307179586476925286766559;
+    constexpr int    kSecond = 48000;
+    duskstudio::LoudnessMeter m;
+    m.prepare (sr, 512);
+
+    std::vector<float> L ((size_t) kSecond), R ((size_t) kSecond);
+    for (int i = 0; i < kSecond; ++i)
+        L[(size_t) i] = R[(size_t) i] = 0.5f * (float) std::sin (kTwoPi * 997.0 * i / sr);
+    for (int off = 0; off < kSecond; off += 512)
+        m.process (L.data() + off, R.data() + off, std::min (512, kSecond - off));
+    const float loud = m.getIntegratedLufs();
+    REQUIRE (loud > -40.0f);
+
+    // Published readings zero immediately, before any further processing.
+    m.requestReset();
+    REQUIRE_THAT (m.getIntegratedLufs(), WithinAbs (-100.0f, 1e-6f));
+    REQUIRE_THAT (m.getTruePeakDb(),     WithinAbs (-100.0f, 1e-6f));
+
+    // Quiet program after the reset: integrated must reflect only the new
+    // material (fresh block history), not an average with pre-reset blocks.
+    for (auto& v : L) v *= 0.01f;
+    for (auto& v : R) v *= 0.01f;
+    for (int off = 0; off < kSecond; off += 512)
+        m.process (L.data() + off, R.data() + off, std::min (512, kSecond - off));
+    REQUIRE (m.getIntegratedLufs() < loud - 20.0f);
+}

--- a/tests/playback_loop_read.cpp
+++ b/tests/playback_loop_read.cpp
@@ -79,5 +79,15 @@ TEST_CASE ("loop-aware readForTrack wraps at the loop boundary",
     // Seam declick: the first wrapped sample is fully faded in by +64.
     REQUIRE (std::abs (out[200]) < 1e-4f);
 
+    // Fade-out direction: attenuation deepens INTO the seam. The sample
+    // adjacent to the wrap (offset 199) is silenced, the far edge of the
+    // 64-sample window (offset 136) keeps full level, and the ramp between
+    // is monotonic. An inverted ramp leaves the seam discontinuity intact
+    // and swells backwards instead.
+    REQUIRE (std::abs (out[199]) < 1e-3f);
+    REQUIRE_THAT (out[136], WithinAbs (8936.0f * 1e-5f, 2e-3f));
+    REQUIRE (std::abs (out[199]) < std::abs (out[168]));
+    REQUIRE (std::abs (out[168]) < std::abs (out[136]));
+
     pe.stopPlayback();
 }


### PR DESCRIPTION
Batch 2 of the criticals-first wave. Five audio-path fixes plus review-round hardening. Targets release/0.12 for 0.12.7.

## Fixes

- Loop-seam declick faded the wrong direction: the pre-seam half multiplied by 1-g, leaving the sample next to the wrap at full level (the click intact) and silencing the far edge as a reverse swell. Now multiplies by g; the fade direction is pinned in the loop-read test. Refs #132.
- Watchdog auto-bypass survived session restore: restoreFromSavedState skipped the reset both sibling load paths perform, so a plugin that once tripped the time-budget watchdog came back from a session load silently bypassed. The restore tail also blocking-acquires the process lock across the reset and instance publish so an in-flight audio block cannot re-bypass the restored plugin. Refs #140.
- Loudness reset raced the audio thread: MasteringView's Reset I ran LoudnessMeter::reset on the message thread against a concurrent process() (vector clear vs push_back, unguarded rings/biquads/oversampler). requestReset now zeroes the published readings immediately and defers the state reset to the audio thread, with a second consume point closing the mid-block window. Regression test covers immediate zeroing and fresh history. Refs #130.
- PDC replay on un-mute: the not-passing skip froze up to 341 ms of pre-mute audio in the PDC delay lines and replayed it on the next passing block. The skip now clears the lines and the oversampler FIR history once (latched via pdcSilentRun, which also lets a pending latency retarget land click-free). The mono path feeds the R line too, closing the stale-tail-on-width-flip hole. Refs #139.
- Silence spliced into offline renders: a message-thread suspendProcessing (NativeParamDrain's VST3 latency cycle at 30 Hz, plugin loads, device changes) made the callback emit a gated silent block that the render committed at the correct length with no error. Two layers: the latency cycle defers while a render is active, and processOfflineBlock detects any gated callback via the early-out counter and re-runs the block - covering the main bounce, stem renders, and track freezes. offlineRenderActive is now published/consumed with release/acquire. Refs #141.

## Verification

- App build with zero new warnings (per-TU rebuild check on every touched file).
- ctest 386/386, including two new regression tests (seam fade direction, loudness requestReset).
- Headless self-test under Xvfb ran to completion with zero FAIL markers.

## Owed to the bench

- Real-plugin bounce via DUSKSTUDIO_BOUNCE_TEST to exercise the gated-block retry path.
- ChannelStrip perf suite before/after for the PDC skip change (added work is two delay-line ops per sample, only on mono strips with nonzero plugin latency).

Remaining wave batches, separate PRs: devices/hosts/multisample/MIDI (#131, #133, #134, #135, #136), UI/app/CI (#137, #138, #142, #143).