### PR TITLE
0.13 bug wave: gate ratchet + session load hardening (#145)

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -82,8 +82,46 @@ Verify the contract, do not assume the common case:
   child's. JUCE's peer view is flipped, so top-left coordinates already land
   correctly - a claim that placement is inverted needs that checked first.
 
+## Session load (`SessionSerializer::load`)
+
+`load()` mutates the **live** Session rather than constructing a fresh one, and
+almost every setter is `if (json::has (v, key))`. Two consequences that have
+each shipped as a bug:
+
+- **An empty object does not blank a slot.** Driving a surplus track/bus/aux
+  slot through restore with `{}` clears the things written unconditionally
+  (regions, MIDI, automation, plugin state) and leaves everything conditional -
+  name, colour, fader, pan, sends, hardware routing - holding the *previous*
+  session's values. Blank a slot from the serialized default object, not `{}`.
+  A partially-populated slot object has the same hole for its absent keys.
+- **A newly persisted field must reset when absent**, or the previous session's
+  value survives into a file that predates the key. Write
+  `store (has (k) ? v : modelDefault)`, and pin it with a test that loads a
+  cut-down `{"version":N,"transport":{}}` after setting the live value.
+
+Anything a corrupt file can reach that feeds DSP needs a finite guard **and** a
+range clamp - `std::clamp` passes NaN straight through, so clamping alone is
+not sanitising. Clamp to the range the corresponding control enforces, not an
+invented one.
+
+## Deferred callbacks on the engine
+
+`AudioEngine` posts to the message thread with `dusk::callAsync` from paths that
+can outlive it (device error from the I/O thread, hot-unplug from a change
+broadcast). The house pattern is a `std::shared_ptr<std::atomic<bool>>` latch
+captured by value - `midiHotplugAlive`, `changeListenersAlive`,
+`deviceCallbacksAlive` - cleared first thing in `~AudioEngine`, with the lambda
+checking it before touching `this`. A new deferral needs one of these; adding a
+fresh mechanism alongside them is the review finding, not the fix.
+
 ## Tests
 
+- **A read issued straight after `preparePlayback()` races the prefetch.**
+  `BufferedFileReader::prefetch` only wakes a background worker, and `readRt`
+  returns silence on a miss rather than blocking, so an immediate assertion is
+  a flake that looks like a DSP bug. The loop-start pre-cache is filled
+  synchronously in `primeLoopCaches`, so a test that needs deterministic samples
+  enables a loop over the region and reads through the cache.
 - Temp directories must be **created atomically**, not merely named uniquely:
   `mkdtemp`, or `create_directory` whose false return means someone else won
   the name, and retry with a fresh candidate. ctest runs cases as parallel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,10 @@ Dusk Studio is being re-platformed to remove **all** JUCE by 1.0, incrementally,
 
 **The gate.** [tools/juce-gate.sh](tools/juce-gate.sh) (CI, via `linux-build.yml`) is a ratchet over `src/`, enforcing three one-way rules against `tools/juce-allowlist.txt` (`path<TAB>count`, one line per coupled file):
 - A *clean* file that gains `juce::`/`<juce_` and isn't listed **fails the build**.
-- A listed file that carries **more** occurrences than its recorded count **fails the build**. Most feature work lands in already-coupled files (AudioEngine, Session, `src/ui/*`), which is where new JUCE actually accumulates — the count is what stops it. Use the seam instead; `tools/juce-gate.sh --update` re-records the numbers and every one of them must go **down** in the diff.
+- A listed file that carries **more** occurrences than its recorded count **fails the build**. Most feature work lands in already-coupled files (AudioEngine, Session, `src/ui/*`), which is where new JUCE actually accumulates — the count is what stops it. Use the seam instead.
 - A listed file that is now JUCE-free must be deleted from the list. Files leave and never rejoin.
+
+`tools/juce-gate.sh --update` re-records the list after migration work, and is itself a ratchet: it **refuses** to add a path or raise a count, so the command everyone runs after a migration can't launder a regression into the baseline. An addition that is genuinely unavoidable is a hand edit to the allowlist, which then shows up in review as its own line and needs justifying in the PR body. The allowlist must hold exactly one `path<TAB>count` record per file, counts decimal with no leading zero — anything else fails closed rather than silently skipping that file's ceiling.
 
 Two things the gate still can't catch — you must:
 - **Never write the literal `juce::` token in a comment** — the gate greps text, so `// mirrors juce::Foo` trips it. Write "JUCE's Foo" by name instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,12 @@ Dusk Studio is a portastudio-style DAW for Linux, C++17. It is being actively de
 
 Dusk Studio is being re-platformed to remove **all** JUCE by 1.0, incrementally, tower by tower (campaign map + tower order in [docs/dejuce-campaign.md](docs/dejuce-campaign.md); live state in the [de-JUCE roadmap memory](../../.claude/projects/-home-marc-projects-DuskStudio/memory/project_dejuce_roadmap.md)). Much of the code documented below still uses `juce::` — that is the *migration surface*, not a pattern to copy. **New code must not add JUCE.** Reach for the JUCE-free seam first; fall back to `juce::` only inside a file that is already coupled and has no seam yet.
 
-**The gate.** [tools/juce-gate.sh](tools/juce-gate.sh) (CI, via `linux-build.yml`) is a ratchet over `src/`: a *clean* file that gains `juce::`/`<juce_` and isn't on `tools/juce-allowlist.txt` **fails the build**, and allowlisted files may only leave the list, never rejoin. Two things the gate can't catch — you must:
-- **Don't pile more `juce::` into an already-allowlisted file.** The gate is silent there (the file is already coupled), yet most feature work lands in coupled files (AudioEngine, Session, `src/ui/*`) — exactly where new JUCE sneaks in. Use the seam anyway.
+**The gate.** [tools/juce-gate.sh](tools/juce-gate.sh) (CI, via `linux-build.yml`) is a ratchet over `src/`, enforcing three one-way rules against `tools/juce-allowlist.txt` (`path<TAB>count`, one line per coupled file):
+- A *clean* file that gains `juce::`/`<juce_` and isn't listed **fails the build**.
+- A listed file that carries **more** occurrences than its recorded count **fails the build**. Most feature work lands in already-coupled files (AudioEngine, Session, `src/ui/*`), which is where new JUCE actually accumulates — the count is what stops it. Use the seam instead; `tools/juce-gate.sh --update` re-records the numbers and every one of them must go **down** in the diff.
+- A listed file that is now JUCE-free must be deleted from the list. Files leave and never rejoin.
+
+Two things the gate still can't catch — you must:
 - **Never write the literal `juce::` token in a comment** — the gate greps text, so `// mirrors juce::Foo` trips it. Write "JUCE's Foo" by name instead.
 - The gate scans `src/` only. `tests/` may reference JUCE (the A/B-vs-JUCE parity tests need it); `tools/` and `packaging/` should not gain it.
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -449,6 +449,8 @@ A single button opens the **MIDI Bindings** panel, which lists every CC-to-contr
 - **Emit MTC**: emit MTC quarter-frame messages.
 - **MTC frame rate**: 24, 25, 29.97 drop-frame, or 30 frames per second.
 
+All seven are saved with the session, so a project that syncs to an external clock reopens ready to sync.
+
 ### General
 
 - **UI scale**: a global zoom factor for the entire interface. Restart Dusk Studio after changing this for best results.

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -1255,6 +1255,7 @@ AudioEngine::~AudioEngine()
     // remove it. Clearing the flag makes it land on a no-op.
     midiHotplugAlive->store (false, std::memory_order_release);
     changeListenersAlive->store (false, std::memory_order_release);
+    deviceCallbacksAlive->store (false, std::memory_order_release);
     changeListeners.clear();
     midiHotplugTimer.stopTimer();
     diagTimer.stopTimer();
@@ -2741,8 +2742,9 @@ void AudioEngine::audioDeviceError (const std::string& message)
                   message.c_str());
 
     dusk::callAsync (
-        [this, message]
+        [this, alive = deviceCallbacksAlive, message]
         {
+            if (! alive->load (std::memory_order_acquire)) return;
             juce::Logger::writeToLog (juce::String ("[Dusk Studio/AudioEngine] audioDeviceError: ")
                                           + juce::String (message));
             audioDeviceStopped();
@@ -2840,8 +2842,9 @@ void AudioEngine::onDeviceManagerChanged()
     // later.
     const bool fromDeliberateChange = deviceManager.isDeviceChangePending();
 
-    dusk::callAsync ([this, fromDeliberateChange]
+    dusk::callAsync ([this, alive = deviceCallbacksAlive, fromDeliberateChange]
     {
+        if (! alive->load (std::memory_order_acquire)) return;
         if (deviceManager.getCurrentDevice() != nullptr) return;
         if (! hadLiveDevice_.load (std::memory_order_acquire)) return;
         if (fromDeliberateChange) return;

--- a/src/engine/AudioEngine.h
+++ b/src/engine/AudioEngine.h
@@ -832,6 +832,13 @@ private:
     std::atomic<bool> changeBroadcastPending { false };
     std::shared_ptr<std::atomic<bool>> changeListenersAlive
         { std::make_shared<std::atomic<bool>> (true) };
+
+    // Same latch for the two device-callback deferrals. audioDeviceError fires
+    // from the I/O thread as the device dies, and the hot-unplug detector posts
+    // from a change broadcast; either can be sitting in the queue when a quit
+    // tears the engine down.
+    std::shared_ptr<std::atomic<bool>> deviceCallbacksAlive
+        { std::make_shared<std::atomic<bool>> (true) };
     void broadcastChange();
     void fireChangeListeners();
 

--- a/src/engine/AudioPipelineSelfTest.cpp
+++ b/src/engine/AudioPipelineSelfTest.cpp
@@ -1523,7 +1523,12 @@ std::string AudioPipelineSelfTest::runAll()
 
     report.push_back (testBackendsOpenCleanly());
     report.push_back ("");
+   #if defined(__linux__)
+    // Selects the ALSA device type by name and reopens real hw: PCMs. There is
+    // no such type on macOS / Windows, so the probe would churn the user's
+    // device for a report it cannot produce.
     report.push_back (probeUMC1820AlsaFormat());
+   #endif
 
     // Probe done (devices opened/closed) - reinstate the user's real session.
     restoreState (savedSession);

--- a/src/engine/PlaybackEngine.cpp
+++ b/src/engine/PlaybackEngine.cpp
@@ -110,6 +110,7 @@ void PlaybackEngine::preparePlayback()
 
             auto rawReader = dusk::audio::FileReader::open (audioPath (region.file));
             if (rawReader == nullptr) continue;
+            const auto sourceInfo = rawReader->info();
 
             // 96000 frames is ~1 s at 96 kHz / ~2 s at 44.1 kHz - generous
             // given block sizes are 256-2048 - but a region shorter than that
@@ -140,7 +141,12 @@ void PlaybackEngine::preparePlayback()
             rs.fadeOutSamples  = std::max ((std::int64_t) 0, region.fadeOutSamples);
             rs.fadeInShape     = region.fadeInShape;
             rs.fadeOutShape    = region.fadeOutShape;
-            rs.numChannels     = std::clamp (region.numChannels, 1, 2);
+            // Channel count comes from the DECODED file, not the model's copy:
+            // region.numChannels can disagree with what is on disk (hand-edited
+            // session, file replaced), and reading by it either truncates a
+            // stereo take to its left channel or asks a mono file for a right
+            // one. Captured before the reader moves into the buffering wrapper.
+            rs.numChannels     = std::clamp (sourceInfo.numChannels, 1, 2);
             // Convert dB once on the message thread; the audio loop
             // multiplies by the linear factor per sample. Clamp the
             // dB at extreme values to avoid wild values from a hand-

--- a/src/session/SessionSerializer.cpp
+++ b/src/session/SessionSerializer.cpp
@@ -165,6 +165,18 @@ inline float finiteFloatOr (const nlohmann::json& src, float fallback) noexcept
     return fallback;
 }
 
+// Finite-guard AND range-clamp in one step, for the mixer parameters that feed
+// DSP directly. Clamping alone is not enough: a non-finite value passes through
+// std::clamp unchanged (NaN compares false against both bounds), and the
+// fallback covers the case where the value is not a number at all.
+inline void storeFiniteClampedFloat (std::atomic<float>& dst,
+                                     const nlohmann::json& src,
+                                     float fallback, float minimum, float maximum) noexcept
+{
+    dst.store (std::clamp (finiteFloatOr (src, fallback), minimum, maximum),
+               std::memory_order_relaxed);
+}
+
 // Parse one automation point from JSON, hardening every field against a
 // hand-edited or truncated file: timeSamples >= 0 and recordedAtBPM finite.
 // The lane evaluator's binary search assumes non-negative, sorted times, and
@@ -883,9 +895,11 @@ void restoreTrack (Track& t, int trackIndex, const nlohmann::json& v,
     t.nativeMultisamplePath        = json::getString (v, "native_multisample_path");
     t.nativeMultisampleStateBase64 = json::getString (v, "native_multisample_state");
 
-    auto setFloat = [&v] (std::atomic<float>& a, const char* key)
+    auto setFloat = [&v] (std::atomic<float>& a, const char* key,
+                          float fallback, float minimum, float maximum)
     {
-        if (json::has (v, key)) a.store (json::getFloat (v, key, 0.0f), std::memory_order_relaxed);
+        if (json::has (v, key))
+            storeFiniteClampedFloat (a, v[key], fallback, minimum, maximum);
     };
     auto setBool = [&v] (std::atomic<bool>& a, const char* key)
     {
@@ -896,8 +910,9 @@ void restoreTrack (Track& t, int trackIndex, const nlohmann::json& v,
         if (json::has (v, key)) a.store (json::getInt (v, key, 0), std::memory_order_relaxed);
     };
 
-    setFloat (t.strip.faderDb,      "fader_db");
-    setFloat (t.strip.pan,          "pan");
+    setFloat (t.strip.faderDb, "fader_db", 0.0f,
+              ChannelStripParams::kFaderMinDb, ChannelStripParams::kFaderMaxDb);
+    setFloat (t.strip.pan, "pan", 0.0f, -1.0f, 1.0f);
     setBool  (t.strip.mute,         "mute");
     setBool  (t.strip.solo,         "solo");
     setBool  (t.strip.phaseInvert,  "phase_invert");
@@ -981,6 +996,8 @@ void restoreTrack (Track& t, int trackIndex, const nlohmann::json& v,
 
     {
         const auto& buses = json::array (v, "bus_assign");
+        for (auto& assigned : t.strip.busAssign)
+            assigned.store (false, std::memory_order_relaxed);
         const int n = std::min (ChannelStripParams::kNumBuses, (int) buses.size());
         for (int i = 0; i < n; ++i)
             t.strip.busAssign[(size_t) i].store (buses[(size_t) i].is_boolean() && buses[(size_t) i].get<bool>(),
@@ -989,14 +1006,29 @@ void restoreTrack (Track& t, int trackIndex, const nlohmann::json& v,
 
     {
         const auto& auxLevels = json::array (v, "aux_send_db");
+        for (auto& level : t.strip.auxSendDb)
+            level.store (ChannelStripParams::kAuxSendOffDb, std::memory_order_relaxed);
         const int n = std::min (ChannelStripParams::kNumAuxSends, (int) auxLevels.size());
         for (int i = 0; i < n; ++i)
-            t.strip.auxSendDb[(size_t) i].store (auxLevels[(size_t) i].is_number()
-                                                     ? (float) auxLevels[(size_t) i].get<double>() : 0.0f,
-                                                 std::memory_order_relaxed);
+        {
+            // A junk entry means OFF, not 0 dB: unity is the loudest useful send
+            // and the old fallback turned a corrupt file into a feedback-loud mix.
+            // At or below the knob floor collapses to the OFF sentinel, matching
+            // what the strip's own fully-CCW position stores.
+            const float loaded = finiteFloatOr (auxLevels[(size_t) i],
+                                                ChannelStripParams::kAuxSendOffDb);
+            const float level = loaded <= ChannelStripParams::kAuxSendMinDb + 0.01f
+                                  ? ChannelStripParams::kAuxSendOffDb
+                                  : std::clamp (loaded,
+                                                ChannelStripParams::kAuxSendMinDb,
+                                                ChannelStripParams::kAuxSendMaxDb);
+            t.strip.auxSendDb[(size_t) i].store (level, std::memory_order_relaxed);
+        }
     }
     {
         const auto& auxPrePost = json::array (v, "aux_send_pre_fader");
+        for (auto& preFader : t.strip.auxSendPreFader)
+            preFader.store (false, std::memory_order_relaxed);
         const int n = std::min (ChannelStripParams::kNumAuxSends, (int) auxPrePost.size());
         for (int i = 0; i < n; ++i)
             t.strip.auxSendPreFader[(size_t) i].store (auxPrePost[(size_t) i].is_boolean()
@@ -1007,13 +1039,21 @@ void restoreTrack (Track& t, int trackIndex, const nlohmann::json& v,
     {
         const auto& hpf = json::child (v, "hpf");
         if (json::has (hpf, "enabled")) t.strip.hpfEnabled.store (json::getBool (hpf, "enabled", false));
-        if (json::has (hpf, "freq"))    t.strip.hpfFreq.store (json::getFloat (hpf, "freq", 0.0f));
+        if (json::has (hpf, "freq"))
+            storeFiniteClampedFloat (t.strip.hpfFreq, hpf["freq"],
+                                     ChannelStripParams::kHpfOffHz,
+                                     ChannelStripParams::kHpfMinHz,
+                                     ChannelStripParams::kHpfMaxHz);
     }
 
     {
         const auto& lpf = json::child (v, "lpf");
         if (json::has (lpf, "enabled")) t.strip.lpfEnabled.store (json::getBool (lpf, "enabled", false));
-        if (json::has (lpf, "freq"))    t.strip.lpfFreq.store (json::getFloat (lpf, "freq", 0.0f));
+        if (json::has (lpf, "freq"))
+            storeFiniteClampedFloat (t.strip.lpfFreq, lpf["freq"],
+                                     ChannelStripParams::kLpfOffHz,
+                                     ChannelStripParams::kLpfMinHz,
+                                     ChannelStripParams::kLpfMaxHz);
     }
 
     {
@@ -1023,28 +1063,44 @@ void restoreTrack (Track& t, int trackIndex, const nlohmann::json& v,
             t.strip.eqBlackMode.store (type == "black");
 
         auto restoreBand = [&eq] (const char* key, std::atomic<float>* gain,
-                                   std::atomic<float>* freq, std::atomic<float>* q)
+                                   std::atomic<float>* freq, std::atomic<float>* q,
+                                   float freqDefault, float freqMin, float freqMax)
         {
             const auto& b = json::child (eq, key);
-            if (gain && json::has (b, "gain")) storeFiniteFloat (*gain, b["gain"]);
-            if (freq && json::has (b, "freq")) storeFiniteFloat (*freq, b["freq"]);
-            if (q    && json::has (b, "q"))    storeFiniteFloat (*q,    b["q"]);
+            if (gain && json::has (b, "gain"))
+                storeFiniteClampedFloat (*gain, b["gain"], 0.0f,
+                                         ChannelStripParams::kBandGainMin,
+                                         ChannelStripParams::kBandGainMax);
+            if (freq && json::has (b, "freq"))
+                storeFiniteClampedFloat (*freq, b["freq"], freqDefault, freqMin, freqMax);
+            if (q && json::has (b, "q"))
+                storeFiniteClampedFloat (*q, b["q"], 0.7f,
+                                         ChannelStripParams::kBandQMin,
+                                         ChannelStripParams::kBandQMax);
         };
-        restoreBand ("lf", &t.strip.lfGainDb, &t.strip.lfFreq, nullptr);
-        restoreBand ("lm", &t.strip.lmGainDb, &t.strip.lmFreq, &t.strip.lmQ);
-        restoreBand ("hm", &t.strip.hmGainDb, &t.strip.hmFreq, &t.strip.hmQ);
-        restoreBand ("hf", &t.strip.hfGainDb, &t.strip.hfFreq, nullptr);
+        restoreBand ("lf", &t.strip.lfGainDb, &t.strip.lfFreq, nullptr, 100.0f,
+                     ChannelStripParams::kLfFreqMin, ChannelStripParams::kLfFreqMax);
+        restoreBand ("lm", &t.strip.lmGainDb, &t.strip.lmFreq, &t.strip.lmQ, 600.0f,
+                     ChannelStripParams::kLmFreqMin, ChannelStripParams::kLmFreqMax);
+        restoreBand ("hm", &t.strip.hmGainDb, &t.strip.hmFreq, &t.strip.hmQ, 2000.0f,
+                     ChannelStripParams::kHmFreqMin, ChannelStripParams::kHmFreqMax);
+        restoreBand ("hf", &t.strip.hfGainDb, &t.strip.hfFreq, nullptr, 8000.0f,
+                     ChannelStripParams::kHfFreqMin, ChannelStripParams::kHfFreqMax);
     }
 
     {
         const auto& comp = json::child (v, "comp");
-        auto loadF = [&] (const char* key, std::atomic<float>& dst)
+        auto loadF = [&] (const char* key, std::atomic<float>& dst,
+                          float fallback, float minimum, float maximum)
         {
-            if (json::has (comp, key)) dst.store (json::getFloat (comp, key, 0.0f));
+            if (json::has (comp, key))
+                storeFiniteClampedFloat (dst, comp[key], fallback, minimum, maximum);
         };
-        auto loadI = [&] (const char* key, std::atomic<int>& dst)
+        auto loadI = [&] (const char* key, std::atomic<int>& dst,
+                          int fallback, int minimum, int maximum)
         {
-            if (json::has (comp, key)) dst.store (json::getInt (comp, key, 0));
+            if (json::has (comp, key))
+                dst.store (std::clamp (json::getInt (comp, key, fallback), minimum, maximum));
         };
         auto loadB = [&] (const char* key, std::atomic<bool>& dst)
         {
@@ -1052,22 +1108,22 @@ void restoreTrack (Track& t, int trackIndex, const nlohmann::json& v,
         };
         loadB ("enabled",     t.strip.compEnabled);
         loadB ("mode_picked", t.strip.compModePicked);
-        loadI ("mode",        t.strip.compMode);
-        loadF ("threshold_db", t.strip.compThresholdDb);
-        loadF ("opto_peak_red", t.strip.compOptoPeakRed);
-        loadF ("opto_gain",     t.strip.compOptoGain);
+        loadI ("mode", t.strip.compMode, 0, 0, 2);
+        loadF ("threshold_db", t.strip.compThresholdDb, 0.0f, -60.0f, 0.0f);
+        loadF ("opto_peak_red", t.strip.compOptoPeakRed, 0.0f, 0.0f, 100.0f);
+        loadF ("opto_gain", t.strip.compOptoGain, 50.0f, 0.0f, 100.0f);
         loadB ("opto_limit",    t.strip.compOptoLimit);
-        loadF ("fet_input",        t.strip.compFetInput);
-        loadF ("fet_output",       t.strip.compFetOutput);
-        loadF ("fet_attack",       t.strip.compFetAttack);
-        loadF ("fet_release",      t.strip.compFetRelease);
-        loadI ("fet_ratio",        t.strip.compFetRatio);
-        loadF ("fet_threshold_db", t.strip.compFetThresholdDb);
-        loadF ("vca_thresh_db", t.strip.compVcaThreshDb);
-        loadF ("vca_ratio",     t.strip.compVcaRatio);
-        loadF ("vca_attack",    t.strip.compVcaAttack);
-        loadF ("vca_release",   t.strip.compVcaRelease);
-        loadF ("vca_output",    t.strip.compVcaOutput);
+        loadF ("fet_input", t.strip.compFetInput, 0.0f, -20.0f, 40.0f);
+        loadF ("fet_output", t.strip.compFetOutput, 0.0f, -20.0f, 20.0f);
+        loadF ("fet_attack", t.strip.compFetAttack, 0.2f, 0.02f, 80.0f);
+        loadF ("fet_release", t.strip.compFetRelease, 400.0f, 50.0f, 1100.0f);
+        loadI ("fet_ratio", t.strip.compFetRatio, 0, 0, 4);
+        loadF ("fet_threshold_db", t.strip.compFetThresholdDb, -10.0f, -60.0f, 0.0f);
+        loadF ("vca_thresh_db", t.strip.compVcaThreshDb, 12.0f, -38.0f, 12.0f);
+        loadF ("vca_ratio", t.strip.compVcaRatio, 4.0f, 1.0f, 120.0f);
+        loadF ("vca_attack", t.strip.compVcaAttack, 1.0f, 0.1f, 50.0f);
+        loadF ("vca_release", t.strip.compVcaRelease, 100.0f, 10.0f, 5000.0f);
+        loadF ("vca_output", t.strip.compVcaOutput, 0.0f, -20.0f, 20.0f);
         loadB ("vca_overeasy",  t.strip.compVcaOverEasy);
         loadB ("vca_detector_classic", t.strip.compVcaDetectorClassic);
     }
@@ -1092,9 +1148,14 @@ void restoreTrack (Track& t, int trackIndex, const nlohmann::json& v,
         if (json::has (hwi, "format"))          fresh->format         = json::getInt (hwi, "format", 0);
         t.hardwareInsert.routing.publish (std::move (fresh));
 
-        if (json::has (hwi, "output_gain_db")) t.hardwareInsert.outputGainDb.store (json::getFloat (hwi, "output_gain_db", 0.0f));
-        if (json::has (hwi, "input_gain_db"))  t.hardwareInsert.inputGainDb .store (json::getFloat (hwi, "input_gain_db", 0.0f));
-        if (json::has (hwi, "dry_wet"))        t.hardwareInsert.dryWet      .store (json::getFloat (hwi, "dry_wet", 0.0f));
+        if (json::has (hwi, "output_gain_db"))
+            storeFiniteClampedFloat (t.hardwareInsert.outputGainDb, hwi["output_gain_db"],
+                                     0.0f, -24.0f, 12.0f);
+        if (json::has (hwi, "input_gain_db"))
+            storeFiniteClampedFloat (t.hardwareInsert.inputGainDb, hwi["input_gain_db"],
+                                     0.0f, -24.0f, 12.0f);
+        if (json::has (hwi, "dry_wet"))
+            storeFiniteClampedFloat (t.hardwareInsert.dryWet, hwi["dry_wet"], 1.0f, 0.0f, 1.0f);
     }
 
     // Automation - per-strip mode + per-param point arrays. Each lane gets
@@ -1288,23 +1349,33 @@ void restoreBus (Bus& a, const nlohmann::json& v, double defaultRecordBpm)
     if (! v.is_object()) return;
     if (auto s = json::getString (v, "name");   ! s.empty()) a.name = s;
     if (auto s = json::getString (v, "colour"); ! s.empty()) a.colour = hexToColour (s, a.colour);
-    if (json::has (v, "fader_db")) a.strip.faderDb.store (json::getFloat (v, "fader_db", 0.0f));
-    if (json::has (v, "pan"))      a.strip.pan.store     (json::getFloat (v, "pan", 0.0f));
+    if (json::has (v, "fader_db"))
+        storeFiniteClampedFloat (a.strip.faderDb, v["fader_db"], 0.0f, -100.0f, 12.0f);
+    if (json::has (v, "pan"))
+        storeFiniteClampedFloat (a.strip.pan, v["pan"], 0.0f, -1.0f, 1.0f);
     if (json::has (v, "mute"))     a.strip.mute.store (json::getBool (v, "mute", false));
     if (json::has (v, "solo"))     a.strip.solo.store (json::getBool (v, "solo", false));
 
     if (json::has (v, "eq_enabled")) a.strip.eqEnabled.store (json::getBool (v, "eq_enabled", false));
-    if (json::has (v, "eq_lf_db"))   storeFiniteFloat (a.strip.eqLfGainDb,  v["eq_lf_db"]);
-    if (json::has (v, "eq_mid_db"))  storeFiniteFloat (a.strip.eqMidGainDb, v["eq_mid_db"]);
-    if (json::has (v, "eq_hf_db"))   storeFiniteFloat (a.strip.eqHfGainDb,  v["eq_hf_db"]);
+    if (json::has (v, "eq_lf_db"))
+        storeFiniteClampedFloat (a.strip.eqLfGainDb,  v["eq_lf_db"],  0.0f, -9.0f, 9.0f);
+    if (json::has (v, "eq_mid_db"))
+        storeFiniteClampedFloat (a.strip.eqMidGainDb, v["eq_mid_db"], 0.0f, -9.0f, 9.0f);
+    if (json::has (v, "eq_hf_db"))
+        storeFiniteClampedFloat (a.strip.eqHfGainDb,  v["eq_hf_db"],  0.0f, -9.0f, 9.0f);
 
     if (json::has (v, "comp_enabled"))     a.strip.compEnabled  .store (json::getBool (v, "comp_enabled", false));
-    if (json::has (v, "comp_thresh_db"))   a.strip.compThreshDb .store (json::getFloat (v, "comp_thresh_db", 0.0f));
-    if (json::has (v, "comp_ratio"))       a.strip.compRatio    .store (json::getFloat (v, "comp_ratio", 0.0f));
-    if (json::has (v, "comp_attack_ms"))   a.strip.compAttackMs .store (json::getFloat (v, "comp_attack_ms", 0.0f));
-    if (json::has (v, "comp_release_ms"))  a.strip.compReleaseMs.store (json::getFloat (v, "comp_release_ms", 0.0f));
+    if (json::has (v, "comp_thresh_db"))
+        storeFiniteClampedFloat (a.strip.compThreshDb, v["comp_thresh_db"], 0.0f, -60.0f, 0.0f);
+    if (json::has (v, "comp_ratio"))
+        storeFiniteClampedFloat (a.strip.compRatio, v["comp_ratio"], 4.0f, 1.0f, 10.0f);
+    if (json::has (v, "comp_attack_ms"))
+        storeFiniteClampedFloat (a.strip.compAttackMs, v["comp_attack_ms"], 10.0f, 0.1f, 50.0f);
+    if (json::has (v, "comp_release_ms"))
+        storeFiniteClampedFloat (a.strip.compReleaseMs, v["comp_release_ms"], 100.0f, 50.0f, 1000.0f);
     if (json::has (v, "comp_release_auto")) a.strip.compReleaseAuto.store (json::getBool (v, "comp_release_auto", false));
-    if (json::has (v, "comp_makeup_db"))   a.strip.compMakeupDb .store (json::getFloat (v, "comp_makeup_db", 0.0f));
+    if (json::has (v, "comp_makeup_db"))
+        storeFiniteClampedFloat (a.strip.compMakeupDb, v["comp_makeup_db"], 0.0f, -10.0f, 20.0f);
 
     // Automation - mirror restoreTrack: exactly one publish per lane (empty
     // when absent), then release-store the mode. Only FaderDb / Pan / Mute
@@ -1606,6 +1677,9 @@ juce::String SessionSerializer::serialize (const Session& s)
     tport["sync_chase_transport"] = s.externalSyncChasesTransport.load();
     tport["sync_output"]         = toStd (s.syncOutputIdentifier);
     tport["sync_emit_clock"]     = s.syncOutputEmitClock.load();
+    tport["sync_chase_timecode"] = s.externalTimeCodeChasesTransport.load();
+    tport["sync_emit_timecode"]  = s.syncOutputEmitTimeCode.load();
+    tport["sync_timecode_frame_rate"] = s.syncOutputTimeCodeFrameRate.load();
 
     // Mackie Control Universal device pair + last-used assign mode.
     // Bank + selectedChannel are session-runtime state and intentionally
@@ -1787,12 +1861,23 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
                             [] (const nlohmann::json& v) { return ! v.is_object(); });
     };
     nlohmann::json sectionDefaults;
-    if (json::array (root, "tracks").empty()
+    if ((int) json::array (root, "tracks").size() < Session::kNumTracks
         || (int) json::array (root, "buses").size() < Session::kNumBuses
         || (int) json::array (root, "aux_lanes").size() < Session::kNumAuxLanes
+        || hasNonObject (json::array (root, "tracks"))
         || hasNonObject (json::array (root, "buses"))
         || hasNonObject (json::array (root, "aux_lanes")))
+    {
         sectionDefaults = nlohmann::json::parse (serialize (Session{}).toStdString(), nullptr, false);
+        // Re-parsing our own output cannot fail in practice, but a discarded
+        // value degrades straight back into the ghost-content bug the defaults
+        // exist to prevent, so say so rather than letting it pass unremarked.
+        if (sectionDefaults.is_discarded())
+            std::fprintf (stderr,
+                          "[Dusk Studio/SessionSerializer] the default-session template failed "
+                          "to parse; slots this file does not describe keep the previously "
+                          "loaded session's state\n");
+    }
 
     {
         const auto& tracks = ! json::array (root, "tracks").empty()
@@ -1801,17 +1886,17 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
         // with fewer tracks than this build (hand-edited, or written by a tool
         // like the DP importer) must blank the surplus slots - otherwise they
         // keep the PREVIOUS session's regions / MIDI / automation / plugin, i.e.
-        // ghost content that still plays back. Driving an absent slot through
-        // restoreTrack with an empty object runs the same unconditional clears
-        // the present-track path uses (regions, midiRegions, automation lanes,
-        // automation mode, plugin state). A slot that IS listed but isn't an
-        // object (e.g. "tracks": [null]) takes the same route - restoreTrack
-        // returns early on a non-object, which would leave the slot ghosted.
-        const nlohmann::json emptyTrack = nlohmann::json::object();
+        // ghost content that still plays back. An empty object is not enough:
+        // every mixer setter here is conditional on its key being present, so a
+        // slot driven from {} keeps the prior session's name, colour, fader, pan,
+        // sends and hardware routing. Drive it from the serialized default track,
+        // which carries every key at its model default. A slot that IS listed but
+        // isn't an object ("tracks": [null]) takes the same route.
+        const auto& trackDefaults = json::array (sectionDefaults, "tracks");
         for (int i = 0; i < Session::kNumTracks; ++i)
             restoreTrack (s.track (i), i,
                           i < (int) tracks.size() && tracks[(size_t) i].is_object()
-                              ? tracks[(size_t) i] : emptyTrack,
+                              ? tracks[(size_t) i] : trackDefaults[(size_t) i],
                           sessionLoadBpm, s.getSessionDirectory(),
                           s.missingAudioFilesAfterLoad);
     }
@@ -1897,9 +1982,14 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
                         if (json::has (hwi, "format"))          fresh->format         = json::getInt (hwi, "format", 0);
                         hw.routing.publish (std::move (fresh));
 
-                        if (json::has (hwi, "output_gain_db")) hw.outputGainDb.store (json::getFloat (hwi, "output_gain_db", 0.0f));
-                        if (json::has (hwi, "input_gain_db"))  hw.inputGainDb .store (json::getFloat (hwi, "input_gain_db", 0.0f));
-                        if (json::has (hwi, "dry_wet"))        hw.dryWet      .store (json::getFloat (hwi, "dry_wet", 0.0f));
+                        if (json::has (hwi, "output_gain_db"))
+                            storeFiniteClampedFloat (hw.outputGainDb, hwi["output_gain_db"],
+                                                     0.0f, -24.0f, 12.0f);
+                        if (json::has (hwi, "input_gain_db"))
+                            storeFiniteClampedFloat (hw.inputGainDb, hwi["input_gain_db"],
+                                                     0.0f, -24.0f, 12.0f);
+                        if (json::has (hwi, "dry_wet"))
+                            storeFiniteClampedFloat (hw.dryWet, hwi["dry_wet"], 1.0f, 0.0f, 1.0f);
                     }
                 }
             }
@@ -2134,6 +2224,13 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
         if (json::has (mast, "target_preset"))
             m.targetPresetIndex.store (json::getInt (mast, "target_preset", 0));
     }
+    // Reset-when-absent: these are newer than most sessions on disk, and the
+    // load reuses the live Session, so a conditional store would leave the
+    // previously loaded session's MTC settings in place.
+    s.externalTimeCodeChasesTransport.store (false, std::memory_order_relaxed);
+    s.syncOutputEmitTimeCode.store (false, std::memory_order_relaxed);
+    s.syncOutputTimeCodeFrameRate.store (3, std::memory_order_relaxed);
+
     if (json::has (root, "transport"))
     {
         const auto& tport = json::child (root, "transport");
@@ -2205,6 +2302,14 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
             s.syncOutputIdentifier = json::getString (tport, "sync_output");
         if (json::has (tport, "sync_emit_clock"))
             s.syncOutputEmitClock.store (json::getBool (tport, "sync_emit_clock", false));
+        s.externalTimeCodeChasesTransport.store (
+            json::getBool (tport, "sync_chase_timecode", false), std::memory_order_relaxed);
+        s.syncOutputEmitTimeCode.store (
+            json::getBool (tport, "sync_emit_timecode", false), std::memory_order_relaxed);
+        // 0..3 = 24 / 25 / 29.97 DF / 30, matching the settings combo.
+        s.syncOutputTimeCodeFrameRate.store (
+            std::clamp (json::getInt (tport, "sync_timecode_frame_rate", 3), 0, 3),
+            std::memory_order_relaxed);
         if (json::has (tport, "mcu_input_id"))
             s.mcu.inputIdentifier = json::getString (tport, "mcu_input_id");
         if (json::has (tport, "mcu_output_id"))

--- a/tests/playback_loop_read.cpp
+++ b/tests/playback_loop_read.cpp
@@ -93,3 +93,110 @@ TEST_CASE ("loop-aware readForTrack wraps at the loop boundary",
 
     pe.stopPlayback();
 }
+
+namespace
+{
+// numCh-channel WAV where channel c holds the constant level[c]. Constants (not
+// a ramp) so a channel swap or a silent channel is unambiguous in the assert.
+juce::File writeConstantWav (const juce::File& dir, const juce::String& name,
+                             const std::vector<float>& level, int numFrames)
+{
+    const auto wav = dir.getChildFile ("audio").getChildFile (name);
+    wav.getParentDirectory().createDirectory();
+    juce::WavAudioFormat fmt;
+    std::unique_ptr<juce::AudioFormatWriter> writer (
+        fmt.createWriterFor (wav.createOutputStream().release(),
+                              48000.0, (unsigned) level.size(), 24, {}, 0));
+    REQUIRE (writer != nullptr);
+    juce::AudioBuffer<float> buf ((int) level.size(), numFrames);
+    for (size_t c = 0; c < level.size(); ++c)
+        for (int n = 0; n < numFrames; ++n)
+            buf.setSample ((int) c, n, level[c]);
+    REQUIRE (writer->writeFromAudioSampleBuffer (buf, 0, numFrames));
+    return wav;
+}
+} // namespace
+
+// The channel count that decides whether the right channel is read comes from
+// the decoded file, not AudioRegion::numChannels. The model's copy can disagree
+// with what is on disk (hand-edited session, replaced take), and believing it
+// either truncates a stereo take to its left channel or asks a mono file for a
+// right one it does not have.
+//
+// Read through the loop-start pre-cache: primeLoopCaches fills it synchronously
+// on the message thread, whereas the reader's own window is warmed by a
+// background worker that a read issued immediately after preparePlayback would
+// race (returning silence, not a channel bug). The cache fill consults the same
+// per-region channel count, so it pins the same decision deterministically.
+TEST_CASE ("readForTrack takes the channel count from the file, not the region",
+           "[playback][channels]")
+{
+    constexpr int kFrames = 4096;
+    constexpr int kBlock  = 256;
+
+    const auto dir = juce::File::getSpecialLocation (juce::File::tempDirectory)
+                        .getChildFile ("dusk-chan-"
+                                         + juce::String (juce::Random::getSystemRandom().nextInt()));
+    dir.createDirectory();
+    const struct ScopedDir { juce::File d; ~ScopedDir() { d.deleteRecursively(); } } scopedDir { dir };
+
+    SECTION ("mono file, region claims stereo - duplicated to both outputs")
+    {
+        const auto wav = writeConstantWav (dir, "mono.wav", { 0.5f }, kFrames);
+
+        Session session;
+        session.setSessionDirectory (dir);
+        AudioRegion r;
+        r.file            = wav;
+        r.timelineStart   = 0;
+        r.lengthInSamples = kFrames;
+        r.numChannels     = 2;   // wrong on purpose
+        session.track (0).regions.push_back (r);
+
+        Transport transport;
+        transport.setLoopRange (0, kFrames);
+        transport.setLoopEnabled (true);
+        PlaybackEngine pe (session);
+        pe.bindTransport (transport);
+        pe.prepare (kBlock);
+        pe.preparePlayback();
+
+        std::vector<float> outL ((size_t) kBlock, -1.0f), outR ((size_t) kBlock, -1.0f);
+        pe.readForTrack (0, 0, outL.data(), outR.data(), kBlock, 0, kFrames);
+
+        // A mono source must land on BOTH outputs, not leave the right silent.
+        REQUIRE_THAT (outL[kBlock / 2], WithinAbs (0.5f, 2e-4f));
+        REQUIRE_THAT (outR[kBlock / 2], WithinAbs (0.5f, 2e-4f));
+        pe.stopPlayback();
+    }
+
+    SECTION ("stereo file, region claims mono - channels stay independent")
+    {
+        const auto wav = writeConstantWav (dir, "stereo.wav", { 0.5f, -0.25f }, kFrames);
+
+        Session session;
+        session.setSessionDirectory (dir);
+        AudioRegion r;
+        r.file            = wav;
+        r.timelineStart   = 0;
+        r.lengthInSamples = kFrames;
+        r.numChannels     = 1;   // wrong on purpose
+        session.track (0).regions.push_back (r);
+
+        Transport transport;
+        transport.setLoopRange (0, kFrames);
+        transport.setLoopEnabled (true);
+        PlaybackEngine pe (session);
+        pe.bindTransport (transport);
+        pe.prepare (kBlock);
+        pe.preparePlayback();
+
+        std::vector<float> outL ((size_t) kBlock, 0.0f), outR ((size_t) kBlock, 0.0f);
+        pe.readForTrack (0, 0, outL.data(), outR.data(), kBlock, 0, kFrames);
+
+        // Reading by the region's claim would have duplicated L over R.
+        REQUIRE_THAT (outL[kBlock / 2], WithinAbs ( 0.5f,  2e-4f));
+        REQUIRE_THAT (outR[kBlock / 2], WithinAbs (-0.25f, 2e-4f));
+        pe.stopPlayback();
+    }
+}

--- a/tests/session_clamp_corrupt_values.cpp
+++ b/tests/session_clamp_corrupt_values.cpp
@@ -227,3 +227,66 @@ TEST_CASE ("SessionSerializer::load treats a non-object master as absent",
 
     target.getParentDirectory().deleteRecursively();
 }
+
+// Strip, comp and hardware-insert values feed DSP directly. A hand-edited file
+// can carry a fader of 1e39 (inf once narrowed), a pan of 3.0, or an aux send
+// that is not a number at all. None of them may reach the mix, and a junk aux
+// send in particular must resolve to OFF: 0 dB is a unity send, so the corrupt
+// file would come back feedback-loud.
+TEST_CASE ("SessionSerializer::load clamps corrupt strip and hardware values",
+           "[session][serializer][corruption]")
+{
+    const auto target = writeSession (R"JSON(
+    {
+      "version": 3,
+      "tracks": [
+        {
+          "fader_db": 1e40,
+          "pan": 3.0,
+          "bus_assign": [true],
+          "aux_send_db": ["bad", -12.0, 1e40, -60.0],
+          "hpf": { "freq": -5.0 },
+          "lpf": { "freq": 1e40 },
+          "comp": { "mode": 99, "vca_ratio": 500.0, "fet_attack": 0.0 },
+          "hardware_insert": { "output_gain_db": 100.0, "dry_wet": -1.0 }
+        }
+      ],
+      "buses": [ { "fader_db": -200.0, "comp_ratio": 99.0, "eq_lf_db": 50.0 } ]
+    }
+    )JSON");
+
+    Session s;
+    auto& track = s.track (0);
+    for (auto& assigned : track.strip.busAssign) assigned.store (true);
+    for (auto& level : track.strip.auxSendDb)    level.store (-6.0f);
+
+    REQUIRE (SessionSerializer::load (s, target));
+
+    REQUIRE_THAT (track.strip.faderDb.load(), WithinAbs (0.0f, 1e-6f));
+    REQUIRE_THAT (track.strip.pan.load(), WithinAbs (1.0f, 1e-6f));
+    REQUIRE (track.strip.busAssign[0].load());
+    for (size_t i = 1; i < track.strip.busAssign.size(); ++i)
+        REQUIRE_FALSE (track.strip.busAssign[i].load());
+
+    // "bad" and the overflowing literal collapse to OFF, not unity. -60 sits AT
+    // the knob floor, which the strip itself stores as the OFF sentinel.
+    REQUIRE_THAT (track.strip.auxSendDb[0].load(), WithinAbs (-100.0f, 1e-6f));
+    REQUIRE_THAT (track.strip.auxSendDb[1].load(), WithinAbs (-12.0f, 1e-6f));
+    REQUIRE_THAT (track.strip.auxSendDb[2].load(), WithinAbs (-100.0f, 1e-6f));
+    REQUIRE_THAT (track.strip.auxSendDb[3].load(), WithinAbs (-100.0f, 1e-6f));
+
+    REQUIRE_THAT (track.strip.hpfFreq.load(), WithinAbs (20.0f, 1e-6f));
+    REQUIRE_THAT (track.strip.lpfFreq.load(), WithinAbs (20000.0f, 1e-3f));
+    REQUIRE (track.strip.compMode.load() == 2);
+    REQUIRE_THAT (track.strip.compVcaRatio.load(), WithinAbs (120.0f, 1e-6f));
+    REQUIRE_THAT (track.strip.compFetAttack.load(), WithinAbs (0.02f, 1e-6f));
+    REQUIRE_THAT (track.hardwareInsert.outputGainDb.load(), WithinAbs (12.0f, 1e-6f));
+    REQUIRE_THAT (track.hardwareInsert.dryWet.load(), WithinAbs (0.0f, 1e-6f));
+
+    const auto& bus = s.bus (0).strip;
+    REQUIRE_THAT (bus.faderDb.load(), WithinAbs (-100.0f, 1e-6f));
+    REQUIRE_THAT (bus.compRatio.load(), WithinAbs (10.0f, 1e-6f));
+    REQUIRE_THAT (bus.eqLfGainDb.load(), WithinAbs (9.0f, 1e-6f));
+
+    target.getParentDirectory().deleteRecursively();
+}

--- a/tests/session_round_trip.cpp
+++ b/tests/session_round_trip.cpp
@@ -104,6 +104,44 @@ TEST_CASE ("SessionSerializer round-trip preserves transport + per-track state",
     dir.deleteRecursively();
 }
 
+// The MTC settings were written by the Audio Settings panel but never
+// serialized, so chase / emit / frame rate reset on every reload. Absent keys
+// must reset to the model default rather than inherit the previous session's.
+TEST_CASE ("SessionSerializer round-trips the MTC sync settings",
+           "[session][serializer][sync]")
+{
+    using duskstudio::Session;
+    using duskstudio::SessionSerializer;
+
+    const auto dir = juce::File::getSpecialLocation (juce::File::tempDirectory)
+                        .getChildFile ("dusk-mtc-"
+                                         + juce::String (juce::Random::getSystemRandom().nextInt()));
+    dir.createDirectory();
+    const struct ScopedDir { juce::File d; ~ScopedDir() { d.deleteRecursively(); } } scopedDir { dir };
+    const auto target = dir.getChildFile ("session.json");
+
+    Session a;
+    a.setSessionDirectory (dir);
+    a.externalTimeCodeChasesTransport.store (true, std::memory_order_relaxed);
+    a.syncOutputEmitTimeCode.store (true, std::memory_order_relaxed);
+    a.syncOutputTimeCodeFrameRate.store (2, std::memory_order_relaxed);
+    REQUIRE (SessionSerializer::save (a, target));
+
+    Session b;
+    b.setSessionDirectory (dir);
+    REQUIRE (SessionSerializer::load (b, target));
+    REQUIRE (b.externalTimeCodeChasesTransport.load (std::memory_order_relaxed));
+    REQUIRE (b.syncOutputEmitTimeCode.load (std::memory_order_relaxed));
+    REQUIRE (b.syncOutputTimeCodeFrameRate.load (std::memory_order_relaxed) == 2);
+
+    // A session predating the keys resets to the defaults, not the live values.
+    REQUIRE (target.replaceWithText (R"({"version":3,"transport":{}})"));
+    REQUIRE (SessionSerializer::load (b, target));
+    REQUIRE_FALSE (b.externalTimeCodeChasesTransport.load (std::memory_order_relaxed));
+    REQUIRE_FALSE (b.syncOutputEmitTimeCode.load (std::memory_order_relaxed));
+    REQUIRE (b.syncOutputTimeCodeFrameRate.load (std::memory_order_relaxed) == 3);
+}
+
 TEST_CASE ("SessionSerializer save is atomic - tmp file gone after success",
            "[session][serializer]")
 {

--- a/tests/session_track_shrink.cpp
+++ b/tests/session_track_shrink.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include "session/Session.h"
 #include "session/SessionSerializer.h"
@@ -6,6 +7,7 @@
 #include <juce_core/juce_core.h>
 
 using namespace duskstudio;
+using Catch::Matchers::WithinAbs;
 
 // Loading a session must REPLACE the model, not merge into it. A session.json
 // with fewer tracks than this build (hand-edited, or written by a tool like the
@@ -101,15 +103,18 @@ TEST_CASE ("loading a session with fewer tracks blanks the surplus mixer state",
     const auto& t = s.track (5);
     REQUIRE (t.name == defaultName);
     REQUIRE (t.colour == defaultColour);
-    REQUIRE (t.strip.faderDb.load() == 0.0f);
-    REQUIRE (t.strip.pan.load() == 0.0f);
+    REQUIRE_THAT (t.strip.faderDb.load(), WithinAbs (0.0f, 1e-6f));
+    REQUIRE_THAT (t.strip.pan.load(), WithinAbs (0.0f, 1e-6f));
     REQUIRE_FALSE (t.strip.mute.load());
     REQUIRE_FALSE (t.strip.busAssign[2].load());
-    REQUIRE (t.strip.auxSendDb[1].load() == ChannelStripParams::kAuxSendOffDb);
+    REQUIRE_THAT (t.strip.auxSendDb[1].load(),
+                  WithinAbs (ChannelStripParams::kAuxSendOffDb, 1e-6f));
     REQUIRE_FALSE (t.strip.auxSendPreFader[1].load());
-    REQUIRE (t.strip.hpfFreq.load() == ChannelStripParams::kHpfOffHz);
-    REQUIRE (t.strip.lpfFreq.load() == ChannelStripParams::kLpfOffHz);
+    REQUIRE_THAT (t.strip.hpfFreq.load(),
+                  WithinAbs (ChannelStripParams::kHpfOffHz, 1e-6f));
+    REQUIRE_THAT (t.strip.lpfFreq.load(),
+                  WithinAbs (ChannelStripParams::kLpfOffHz, 1e-3f));
     REQUIRE_FALSE (t.hardwareInsert.enabled.load());
-    REQUIRE (t.hardwareInsert.outputGainDb.load() == 0.0f);
-    REQUIRE (t.hardwareInsert.dryWet.load() == 1.0f);
+    REQUIRE_THAT (t.hardwareInsert.outputGainDb.load(), WithinAbs (0.0f, 1e-6f));
+    REQUIRE_THAT (t.hardwareInsert.dryWet.load(), WithinAbs (1.0f, 1e-6f));
 }

--- a/tests/session_track_shrink.cpp
+++ b/tests/session_track_shrink.cpp
@@ -58,3 +58,58 @@ TEST_CASE ("loading a session with fewer tracks blanks the surplus slots",
     REQUIRE (s.track (5).pluginStateBase64.isEmpty());
     REQUIRE (s.track (5).automationLanes[0].pointsConst().empty());
 }
+
+// The mixer half of the same contract. Every setter in restoreTrack is
+// conditional on its key being present, so driving a surplus slot from an empty
+// object cleared the regions but left the previous session's name, colour,
+// fader, sends and hardware routing on the strip.
+TEST_CASE ("loading a session with fewer tracks blanks the surplus mixer state",
+           "[session][serializer][paths]")
+{
+    const auto dir = juce::File::getSpecialLocation (juce::File::tempDirectory)
+                        .getChildFile ("dusk-shrink-mixer-"
+                                         + juce::String (juce::Random::getSystemRandom().nextInt()));
+    dir.createDirectory();
+    const struct ScopedDir { juce::File d; ~ScopedDir() { d.deleteRecursively(); } } scopedDir { dir };
+
+    Session s;
+    s.setSessionDirectory (dir);
+
+    const auto defaultName   = s.track (5).name;
+    const auto defaultColour = s.track (5).colour;
+
+    auto& ghost = s.track (5);
+    ghost.name = "Ghost";
+    ghost.colour = juce::Colours::red;
+    ghost.strip.faderDb.store (-18.0f);
+    ghost.strip.pan.store (0.75f);
+    ghost.strip.mute.store (true);
+    ghost.strip.busAssign[2].store (true);
+    ghost.strip.auxSendDb[1].store (-12.0f);
+    ghost.strip.auxSendPreFader[1].store (true);
+    ghost.strip.hpfFreq.store (120.0f);
+    ghost.strip.lpfFreq.store (8000.0f);
+    ghost.hardwareInsert.enabled.store (true);
+    ghost.hardwareInsert.outputGainDb.store (6.0f);
+    ghost.hardwareInsert.dryWet.store (0.5f);
+
+    const auto target = dir.getChildFile ("session.json");
+    REQUIRE (target.replaceWithText (R"({"version":3,"tracks":[{"name":"A"},{"name":"B"}]})"));
+
+    REQUIRE (SessionSerializer::load (s, target));
+
+    const auto& t = s.track (5);
+    REQUIRE (t.name == defaultName);
+    REQUIRE (t.colour == defaultColour);
+    REQUIRE (t.strip.faderDb.load() == 0.0f);
+    REQUIRE (t.strip.pan.load() == 0.0f);
+    REQUIRE_FALSE (t.strip.mute.load());
+    REQUIRE_FALSE (t.strip.busAssign[2].load());
+    REQUIRE (t.strip.auxSendDb[1].load() == ChannelStripParams::kAuxSendOffDb);
+    REQUIRE_FALSE (t.strip.auxSendPreFader[1].load());
+    REQUIRE (t.strip.hpfFreq.load() == ChannelStripParams::kHpfOffHz);
+    REQUIRE (t.strip.lpfFreq.load() == ChannelStripParams::kLpfOffHz);
+    REQUIRE_FALSE (t.hardwareInsert.enabled.load());
+    REQUIRE (t.hardwareInsert.outputGainDb.load() == 0.0f);
+    REQUIRE (t.hardwareInsert.dryWet.load() == 1.0f);
+}

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -1,179 +1,179 @@
-src/DuskStudioApp.cpp
-src/DuskStudioApp.h
-src/dsp/AuxLaneStrip.cpp
-src/dsp/AuxLaneStrip.h
-src/dsp/ChannelStrip.cpp
-src/dsp/ChannelStrip.h
-src/dsp/MasterBus.cpp
-src/dsp/MasterBus.h
-src/dsp/MasteringChain.h
-src/engine/AudioEngine.cpp
-src/engine/AudioEngine.h
-src/engine/AudioPipelineSelfTest.cpp
-src/engine/BounceEngine.cpp
-src/engine/BounceEngine.h
-src/engine/DpAligner.cpp
-src/engine/DpAligner.h
-src/engine/DpImporter.cpp
-src/engine/DpImporter.h
-src/engine/DuskStudioPlayHead.h
-src/engine/FileImporter.cpp
-src/engine/FileImporter.h
-src/engine/JuceCompat.h
-src/engine/MasteringPlayer.cpp
-src/engine/MasteringPlayer.h
-src/engine/PlaybackEngine.cpp
-src/engine/PlaybackEngine.h
-src/engine/PluginManager.cpp
-src/engine/PluginManager.h
-src/engine/PluginSlot.cpp
-src/engine/PluginSlot.h
-src/engine/RecordManager.cpp
-src/engine/RecordManager.h
-src/engine/device/DeviceManager.h
-src/engine/device/DeviceManagerJuce.cpp
-src/engine/hosting/NativePluginId.h
-src/engine/ipc/IpcSelfTest.cpp
-src/engine/ipc/PluginHostMain.cpp
-src/engine/midi/JuceMidiBackend.cpp
-src/engine/midi/JuceMidiBackend.h
-src/engine/multisample/AriaBank.cpp
-src/engine/multisample/AriaBank.h
-src/engine/multisample/AriaGui.cpp
-src/engine/multisample/AriaGui.h
-src/engine/multisample/DuskMultisampleProcessor.cpp
-src/engine/multisample/DuskMultisampleProcessor.h
-src/engine/multisample/Sf2ToSfz.cpp
-src/engine/multisample/Sf2ToSfz.h
-src/foundation/MessageThread.cpp
-src/session/MarkerEditActions.h
-src/session/MidiBindings.cpp
-src/session/MidiBindings.h
-src/session/ParamEditAction.h
-src/session/RegionEditActions.cpp
-src/session/RegionEditActions.h
-src/session/Session.cpp
-src/session/Session.h
-src/session/SessionSerializer.cpp
-src/session/SessionSerializer.h
-src/session/SessionTemplates.cpp
-src/ui/AnalogVuMeter.cpp
-src/ui/AnalogVuMeter.h
-src/ui/AudioRegionEditor.cpp
-src/ui/AudioRegionEditor.h
-src/ui/AudioSettingsPanel.cpp
-src/ui/AudioSettingsPanel.h
-src/ui/AuxLaneComponent.cpp
-src/ui/AuxLaneComponent.h
-src/ui/AuxView.cpp
-src/ui/AuxView.h
-src/ui/BounceDialog.cpp
-src/ui/BounceDialog.h
-src/ui/BusComponent.cpp
-src/ui/BusComponent.h
-src/ui/ChannelCompEditor.cpp
-src/ui/ChannelCompEditor.h
-src/ui/ChannelEqEditor.cpp
-src/ui/ChannelEqEditor.h
-src/ui/ChannelStripComponent.cpp
-src/ui/ChannelStripComponent.h
-src/ui/ClapPluginEditorComponent.cpp
-src/ui/ClapPluginEditorComponent.h
-src/ui/CompBypassLed.h
-src/ui/CompHeaderButton.h
-src/ui/CompMeterStrip.cpp
-src/ui/CompMeterStrip.h
-src/ui/ConsoleView.cpp
-src/ui/ConsoleView.h
-src/ui/CursorOverlay.cpp
-src/ui/CursorOverlay.h
-src/ui/DimOverlay.cpp
-src/ui/DimOverlay.h
-src/ui/DpImportDialog.h
-src/ui/DuskAlerts.cpp
-src/ui/DuskAlerts.h
-src/ui/DuskAudioDeviceSelector.cpp
-src/ui/DuskAudioDeviceSelector.h
-src/ui/DuskComboBox.cpp
-src/ui/DuskComboBox.h
-src/ui/DuskContextMenu.cpp
-src/ui/DuskContextMenu.h
-src/ui/DuskFileBrowser.cpp
-src/ui/DuskFileBrowser.h
-src/ui/DuskLabelEditor.h
-src/ui/DuskMenuBar.h
-src/ui/DuskStudioLookAndFeel.h
-src/ui/EditCursors.cpp
-src/ui/EditCursors.h
-src/ui/EditModeToolbar.cpp
-src/ui/EditModeToolbar.h
-src/ui/EmbeddedModal.h
-src/ui/FadeCurve.h
-src/ui/FreezeDialog.cpp
-src/ui/FreezeDialog.h
-src/ui/HardwareInsertEditor.cpp
-src/ui/HardwareInsertEditor.h
-src/ui/ImportTargetPicker.cpp
-src/ui/ImportTargetPicker.h
-src/ui/Lv2PluginEditorComponent.cpp
-src/ui/Lv2PluginEditorComponent.h
-src/ui/MainComponent.cpp
-src/ui/MainComponent.h
-src/ui/MasterStripComponent.cpp
-src/ui/MasterStripComponent.h
-src/ui/MasteringEqEditor.cpp
-src/ui/MasteringEqEditor.h
-src/ui/MasteringLimiterEditor.cpp
-src/ui/MasteringLimiterEditor.h
-src/ui/MasteringView.cpp
-src/ui/MasteringView.h
-src/ui/MidiBindingsPanel.cpp
-src/ui/MidiBindingsPanel.h
-src/ui/MiniTimelineStrip.cpp
-src/ui/MiniTimelineStrip.h
-src/ui/MultiImportTargetPicker.cpp
-src/ui/MultiImportTargetPicker.h
-src/ui/NativeEditorEmbedScale.h
-src/ui/PianoRollComponent.cpp
-src/ui/PianoRollComponent.h
-src/ui/PlatformWindowing.h
-src/ui/PlatformWindowing_Linux.cpp
-src/ui/PlatformWindowing_Mac.mm
-src/ui/PlatformWindowing_Windows.cpp
-src/ui/PluginPickerHelpers.cpp
-src/ui/PluginPickerHelpers.h
-src/ui/PluginPickerPanel.cpp
-src/ui/PluginPickerPanel.h
-src/ui/PluginScanModal.cpp
-src/ui/PluginScanModal.h
-src/ui/ScreenshotCapture.cpp
-src/ui/SectionPillButton.h
-src/ui/SelfTestPanel.cpp
-src/ui/SelfTestPanel.h
-src/ui/ShortcutsPanel.h
-src/ui/StartupDialog.cpp
-src/ui/StartupDialog.h
-src/ui/SteppedKnob.h
-src/ui/SupportersPanel.h
-src/ui/SystemStatusBar.cpp
-src/ui/SystemStatusBar.h
-src/ui/TapePanel.cpp
-src/ui/TapePanel.h
-src/ui/TapeStrip.cpp
-src/ui/TapeStrip.h
-src/ui/TransportBar.cpp
-src/ui/TransportBar.h
-src/ui/TunerOverlay.h
-src/ui/UpdateChecker.h
-src/ui/VirtualKeyboardComponent.cpp
-src/ui/VirtualKeyboardComponent.h
-src/ui/Vst3PluginEditorComponent.cpp
-src/ui/Vst3PluginEditorComponent.h
-src/ui/WindowState.cpp
-src/ui/WindowState.h
-src/ui/multisample/AriaGuiComponent.cpp
-src/ui/multisample/AriaGuiComponent.h
-src/ui/multisample/DuskMultisampleEditor.cpp
-src/ui/multisample/DuskMultisampleEditor.h
-src/util/CrashHandler.cpp
-src/util/CrashHandler.h
+src/DuskStudioApp.cpp	130
+src/DuskStudioApp.h	7
+src/dsp/AuxLaneStrip.cpp	20
+src/dsp/AuxLaneStrip.h	26
+src/dsp/ChannelStrip.cpp	34
+src/dsp/ChannelStrip.h	32
+src/dsp/MasterBus.cpp	3
+src/dsp/MasterBus.h	7
+src/dsp/MasteringChain.h	5
+src/engine/AudioEngine.cpp	140
+src/engine/AudioEngine.h	20
+src/engine/AudioPipelineSelfTest.cpp	26
+src/engine/BounceEngine.cpp	47
+src/engine/BounceEngine.h	18
+src/engine/DpAligner.cpp	5
+src/engine/DpAligner.h	3
+src/engine/DpImporter.cpp	41
+src/engine/DpImporter.h	6
+src/engine/DuskStudioPlayHead.h	4
+src/engine/FileImporter.cpp	20
+src/engine/FileImporter.h	4
+src/engine/JuceCompat.h	5
+src/engine/MasteringPlayer.cpp	3
+src/engine/MasteringPlayer.h	8
+src/engine/PlaybackEngine.cpp	6
+src/engine/PlaybackEngine.h	4
+src/engine/PluginManager.cpp	112
+src/engine/PluginManager.h	29
+src/engine/PluginSlot.cpp	73
+src/engine/PluginSlot.h	42
+src/engine/RecordManager.cpp	4
+src/engine/RecordManager.h	5
+src/engine/device/DeviceManager.h	3
+src/engine/device/DeviceManagerJuce.cpp	46
+src/engine/hosting/NativePluginId.h	8
+src/engine/ipc/IpcSelfTest.cpp	5
+src/engine/ipc/PluginHostMain.cpp	52
+src/engine/midi/JuceMidiBackend.cpp	14
+src/engine/midi/JuceMidiBackend.h	3
+src/engine/multisample/AriaBank.cpp	12
+src/engine/multisample/AriaBank.h	9
+src/engine/multisample/AriaGui.cpp	23
+src/engine/multisample/AriaGui.h	18
+src/engine/multisample/DuskMultisampleProcessor.cpp	70
+src/engine/multisample/DuskMultisampleProcessor.h	25
+src/engine/multisample/Sf2ToSfz.cpp	9
+src/engine/multisample/Sf2ToSfz.h	4
+src/foundation/MessageThread.cpp	4
+src/session/MarkerEditActions.h	4
+src/session/MidiBindings.cpp	47
+src/session/MidiBindings.h	10
+src/session/ParamEditAction.h	2
+src/session/RegionEditActions.cpp	36
+src/session/RegionEditActions.h	16
+src/session/Session.cpp	10
+src/session/Session.h	76
+src/session/SessionSerializer.cpp	83
+src/session/SessionSerializer.h	13
+src/session/SessionTemplates.cpp	3
+src/ui/AnalogVuMeter.cpp	113
+src/ui/AnalogVuMeter.h	7
+src/ui/AudioRegionEditor.cpp	339
+src/ui/AudioRegionEditor.h	86
+src/ui/AudioSettingsPanel.cpp	96
+src/ui/AudioSettingsPanel.h	39
+src/ui/AuxLaneComponent.cpp	168
+src/ui/AuxLaneComponent.h	28
+src/ui/AuxView.cpp	60
+src/ui/AuxView.h	5
+src/ui/BounceDialog.cpp	45
+src/ui/BounceDialog.h	12
+src/ui/BusComponent.cpp	329
+src/ui/BusComponent.h	47
+src/ui/ChannelCompEditor.cpp	133
+src/ui/ChannelCompEditor.h	20
+src/ui/ChannelEqEditor.cpp	93
+src/ui/ChannelEqEditor.h	13
+src/ui/ChannelStripComponent.cpp	786
+src/ui/ChannelStripComponent.h	111
+src/ui/ClapPluginEditorComponent.cpp	11
+src/ui/ClapPluginEditorComponent.h	7
+src/ui/CompBypassLed.h	10
+src/ui/CompHeaderButton.h	35
+src/ui/CompMeterStrip.cpp	53
+src/ui/CompMeterStrip.h	14
+src/ui/ConsoleView.cpp	4
+src/ui/ConsoleView.h	4
+src/ui/CursorOverlay.cpp	18
+src/ui/CursorOverlay.h	13
+src/ui/DimOverlay.cpp	3
+src/ui/DimOverlay.h	4
+src/ui/DpImportDialog.h	46
+src/ui/DuskAlerts.cpp	100
+src/ui/DuskAlerts.h	19
+src/ui/DuskAudioDeviceSelector.cpp	20
+src/ui/DuskAudioDeviceSelector.h	8
+src/ui/DuskComboBox.cpp	190
+src/ui/DuskComboBox.h	5
+src/ui/DuskContextMenu.cpp	51
+src/ui/DuskContextMenu.h	8
+src/ui/DuskFileBrowser.cpp	75
+src/ui/DuskFileBrowser.h	13
+src/ui/DuskLabelEditor.h	3
+src/ui/DuskMenuBar.h	29
+src/ui/DuskStudioLookAndFeel.h	119
+src/ui/EditCursors.cpp	58
+src/ui/EditCursors.h	7
+src/ui/EditModeToolbar.cpp	48
+src/ui/EditModeToolbar.h	10
+src/ui/EmbeddedModal.h	68
+src/ui/FadeCurve.h	10
+src/ui/FreezeDialog.cpp	36
+src/ui/FreezeDialog.h	9
+src/ui/HardwareInsertEditor.cpp	86
+src/ui/HardwareInsertEditor.h	23
+src/ui/ImportTargetPicker.cpp	97
+src/ui/ImportTargetPicker.h	11
+src/ui/Lv2PluginEditorComponent.cpp	3
+src/ui/Lv2PluginEditorComponent.h	4
+src/ui/MainComponent.cpp	472
+src/ui/MainComponent.h	57
+src/ui/MasterStripComponent.cpp	402
+src/ui/MasterStripComponent.h	59
+src/ui/MasteringEqEditor.cpp	112
+src/ui/MasteringEqEditor.h	18
+src/ui/MasteringLimiterEditor.cpp	144
+src/ui/MasteringLimiterEditor.h	15
+src/ui/MasteringView.cpp	148
+src/ui/MasteringView.h	28
+src/ui/MidiBindingsPanel.cpp	49
+src/ui/MidiBindingsPanel.h	15
+src/ui/MiniTimelineStrip.cpp	19
+src/ui/MiniTimelineStrip.h	10
+src/ui/MultiImportTargetPicker.cpp	78
+src/ui/MultiImportTargetPicker.h	11
+src/ui/NativeEditorEmbedScale.h	12
+src/ui/PianoRollComponent.cpp	381
+src/ui/PianoRollComponent.h	61
+src/ui/PlatformWindowing.h	14
+src/ui/PlatformWindowing_Linux.cpp	16
+src/ui/PlatformWindowing_Mac.mm	19
+src/ui/PlatformWindowing_Windows.cpp	7
+src/ui/PluginPickerHelpers.cpp	136
+src/ui/PluginPickerHelpers.h	23
+src/ui/PluginPickerPanel.cpp	70
+src/ui/PluginPickerPanel.h	13
+src/ui/PluginScanModal.cpp	28
+src/ui/PluginScanModal.h	10
+src/ui/ScreenshotCapture.cpp	31
+src/ui/SectionPillButton.h	7
+src/ui/SelfTestPanel.cpp	10
+src/ui/SelfTestPanel.h	7
+src/ui/ShortcutsPanel.h	37
+src/ui/StartupDialog.cpp	104
+src/ui/StartupDialog.h	32
+src/ui/SteppedKnob.h	12
+src/ui/SupportersPanel.h	42
+src/ui/SystemStatusBar.cpp	31
+src/ui/SystemStatusBar.h	11
+src/ui/TapePanel.cpp	77
+src/ui/TapePanel.h	14
+src/ui/TapeStrip.cpp	351
+src/ui/TapeStrip.h	53
+src/ui/TransportBar.cpp	183
+src/ui/TransportBar.h	32
+src/ui/TunerOverlay.h	58
+src/ui/UpdateChecker.h	27
+src/ui/VirtualKeyboardComponent.cpp	78
+src/ui/VirtualKeyboardComponent.h	15
+src/ui/Vst3PluginEditorComponent.cpp	8
+src/ui/Vst3PluginEditorComponent.h	7
+src/ui/WindowState.cpp	7
+src/ui/WindowState.h	5
+src/ui/multisample/AriaGuiComponent.cpp	90
+src/ui/multisample/AriaGuiComponent.h	17
+src/ui/multisample/DuskMultisampleEditor.cpp	71
+src/ui/multisample/DuskMultisampleEditor.h	21
+src/util/CrashHandler.cpp	32
+src/util/CrashHandler.h	4

--- a/tools/juce-gate.sh
+++ b/tools/juce-gate.sh
@@ -10,13 +10,13 @@
 #   3. A listed file that is now JUCE-free must be removed from the list.
 #
 # Migration work shrinks counts and deletes lines. tools/juce-gate.sh --update
-# rewrites the file to match reality; review that diff, every number must go
-# down. One sanctioned exception raises a count: a genuinely new UI source file,
-# which has no JUCE-free option until the GUI tower lands its toolkit - call it
-# out in the PR body.
+# re-records reality, but it is a ratchet too: it refuses to add a path or raise
+# a count, so it cannot be used to launder a regression into the baseline. A
+# genuinely unavoidable addition is a hand edit to the allowlist, which shows up
+# in review as its own line.
 #
 #   tools/juce-gate.sh            check (CI + pre-push)
-#   tools/juce-gate.sh --update   rewrite the allowlist to match reality
+#   tools/juce-gate.sh --update   re-record the allowlist (downwards only)
 set -euo pipefail
 export LC_ALL=C   # sort and comm must agree on collation
 
@@ -46,13 +46,17 @@ scan() {
 
 current="$(scan)"
 
-if [[ "${1:-}" == "--update" ]]; then
+write_allow() {
     printf '%s\n' "$current" > "$ALLOW"
     echo "juce-allowlist.txt updated: $(grep -c . "$ALLOW" || true) files, $(awk -F'\t' '{ n += $2 } END { print n+0 }' "$ALLOW") juce:: occurrences."
-    exit 0
-fi
+}
 
+# Bootstrap: with no allowlist there is nothing to ratchet against.
 if [[ ! -f "$ALLOW" ]]; then
+    if [[ "${1:-}" == "--update" ]]; then
+        write_allow
+        exit 0
+    fi
     echo "ERROR: $ALLOW missing. Run: tools/juce-gate.sh --update" >&2
     exit 2
 fi
@@ -61,15 +65,20 @@ fi
 # ratchet coverage for that file (the count lookup below yields nothing and the
 # check is skipped), which would let anyone disable rule 2 for a file by
 # deleting one field - and is also what a rebase onto the pre-count allowlist
-# format looks like.
-malformed="$(awk -F'\t' 'NF == 0 { next }
-                         (NF != 2 || $1 == "" || $2 !~ /^[0-9]+$/) \
-                             { printf "  line %d: %s\n", NR, $0 }' "$ALLOW")"
+# format looks like. A duplicate path hides the same way: the lookup takes the
+# first record, so a second, higher entry is never compared. Counts are decimal
+# with no leading zero, because bash arithmetic reads 010 as octal 8.
+malformed="$(awk -F'\t' '
+    NF == 0 { next }
+    (NF != 2 || $1 == "" || $2 !~ /^(0|[1-9][0-9]*)$/) {
+        printf "  line %d: malformed record: %s\n", NR, $0; next
+    }
+    seen[$1]++ { printf "  line %d: duplicate path: %s\n", NR, $1 }
+' "$ALLOW")"
 if [[ -n "$malformed" ]]; then
-    echo "ERROR: $ALLOW has malformed records (want: path<TAB>count):" >&2
+    echo "ERROR: $ALLOW has bad records (want one path<TAB>count per file):" >&2
     printf '%s\n' "$malformed" >&2
-    echo "Fix them, or run tools/juce-gate.sh --update once you have checked the" >&2
-    echo "counts only go down." >&2
+    echo "Fix them by hand; --update refuses to run against an unreadable list." >&2
     exit 2
 fi
 
@@ -80,6 +89,34 @@ allowPaths="$(printf '%s\n' "$allow"   | cut -f1 | grep -v '^$' || true)"
 
 new="$(comm -23 <(printf '%s\n' "$currentPaths") <(printf '%s\n' "$allowPaths"))"
 stale="$(comm -13 <(printf '%s\n' "$currentPaths") <(printf '%s\n' "$allowPaths"))"
+
+# Rule 2. Only files present in both lists; rules 1 and 3 already report the
+# rest, and reporting them twice buries the real regression.
+grown=""
+while IFS=$'\t' read -r path count; do
+    [[ -z "$path" ]] && continue
+    ceiling="$(printf '%s\n' "$allow" | awk -F'\t' -v p="$path" '$1 == p { print $2; exit }')"
+    [[ -z "$ceiling" ]] && continue
+    if (( count > ceiling )); then
+        grown+="  ~ $path: $ceiling -> $count"$'\n'
+    fi
+done < <(printf '%s\n' "$current")
+
+# --update re-records reality, but only downwards. Letting it absorb a new path
+# or a raised count would turn the one command everybody runs after a migration
+# into the way regressions enter the baseline.
+if [[ "${1:-}" == "--update" ]]; then
+    if [[ -n "$new" || -n "$grown" ]]; then
+        echo "ERROR: --update only ratchets DOWN, and this tree adds coupling:" >&2
+        [[ -n "$new" ]]   && printf '  + %s\n' $new >&2
+        [[ -n "$grown" ]] && printf '%s' "$grown" >&2
+        echo "Remove the new uses first. An addition that is genuinely unavoidable is a" >&2
+        echo "hand edit to $ALLOW, so it lands in review as its own line." >&2
+        exit 2
+    fi
+    write_allow
+    exit 0
+fi
 
 rc=0
 if [[ -n "$new" ]]; then
@@ -94,18 +131,6 @@ if [[ -n "$stale" ]]; then
     echo "Delete them from $ALLOW (or run tools/juce-gate.sh --update). The list only shrinks." >&2
     rc=1
 fi
-
-# Rule 2. Only files present in both lists; rules 1 and 3 already reported the
-# rest, and reporting them twice buries the real regression.
-grown=""
-while IFS=$'\t' read -r path count; do
-    [[ -z "$path" ]] && continue
-    ceiling="$(printf '%s\n' "$allow" | awk -F'\t' -v p="$path" '$1 == p { print $2; exit }')"
-    [[ -z "$ceiling" ]] && continue
-    if (( count > ceiling )); then
-        grown+="  ~ $path: $ceiling -> $count"$'\n'
-    fi
-done < <(printf '%s\n' "$current")
 
 if [[ -n "$grown" ]]; then
     echo "FAIL: these files gained JUCE uses (allowlisted files ratchet DOWN only):" >&2

--- a/tools/juce-gate.sh
+++ b/tools/juce-gate.sh
@@ -1,25 +1,44 @@
 #!/usr/bin/env bash
-# De-JUCE ratchet. Fails if any src/ file gains a JUCE dependency unless it is
-# already on tools/juce-allowlist.txt, and fails if a listed file has since
-# been cleaned (so the list can only shrink). Migration PRs delete allowlist
-# lines. One sanctioned exception adds them: a genuinely new UI source file,
-# which has no JUCE-free option until the GUI tower lands its toolkit - each
-# such addition must be called out in its PR body.
+# De-JUCE ratchet. Three rules, all one-way:
+#
+#   1. No src/ file may gain a JUCE dependency unless it is already listed in
+#      tools/juce-allowlist.txt.
+#   2. No listed file may carry MORE `juce::` / `<juce_` occurrences than the
+#      count recorded beside it. Rule 1 alone only guards files that are already
+#      clean, so new coupling lands in the listed files instead - which is how
+#      most of it actually arrives.
+#   3. A listed file that is now JUCE-free must be removed from the list.
+#
+# Migration work shrinks counts and deletes lines. tools/juce-gate.sh --update
+# rewrites the file to match reality; review that diff, every number must go
+# down. One sanctioned exception raises a count: a genuinely new UI source file,
+# which has no JUCE-free option until the GUI tower lands its toolkit - call it
+# out in the PR body.
 #
 #   tools/juce-gate.sh            check (CI + pre-push)
-#   tools/juce-gate.sh --update   rewrite the allowlist to match reality,
-#                                  only after a file was legitimately cleaned
+#   tools/juce-gate.sh --update   rewrite the allowlist to match reality
 set -euo pipefail
 export LC_ALL=C   # sort and comm must agree on collation
 
 cd "$(dirname "$0")/.."
 ALLOW=tools/juce-allowlist.txt
 
-current="$(grep -rlE 'juce::|<juce_' src | sort || true)"
+# Occurrences, not matching lines: a single line can introduce several uses, and
+# grep -c would score it as one.
+juce_count() { grep -oE 'juce::|<juce_' "$1" 2>/dev/null | wc -l | tr -d ' '; }
+
+scan() {
+    local f
+    grep -rlE 'juce::|<juce_' src | sort | while IFS= read -r f; do
+        printf '%s\t%s\n' "$f" "$(juce_count "$f")"
+    done
+}
+
+current="$(scan)"
 
 if [[ "${1:-}" == "--update" ]]; then
     printf '%s\n' "$current" > "$ALLOW"
-    echo "juce-allowlist.txt updated: $(wc -l < "$ALLOW") files still JUCE-coupled."
+    echo "juce-allowlist.txt updated: $(grep -c . "$ALLOW" || true) files, $(awk -F'\t' '{ n += $2 } END { print n+0 }' "$ALLOW") juce:: occurrences."
     exit 0
 fi
 
@@ -30,8 +49,11 @@ fi
 
 allow="$(sort "$ALLOW")"
 
-new="$(comm -23 <(printf '%s\n' "$current") <(printf '%s\n' "$allow"))"
-stale="$(comm -13 <(printf '%s\n' "$current") <(printf '%s\n' "$allow"))"
+currentPaths="$(printf '%s\n' "$current" | cut -f1 | grep -v '^$' || true)"
+allowPaths="$(printf '%s\n' "$allow"   | cut -f1 | grep -v '^$' || true)"
+
+new="$(comm -23 <(printf '%s\n' "$currentPaths") <(printf '%s\n' "$allowPaths"))"
+stale="$(comm -13 <(printf '%s\n' "$currentPaths") <(printf '%s\n' "$allowPaths"))"
 
 rc=0
 if [[ -n "$new" ]]; then
@@ -47,6 +69,30 @@ if [[ -n "$stale" ]]; then
     rc=1
 fi
 
-count="$(printf '%s\n' "$current" | grep -c . || true)"
-echo "JUCE-coupled src files: $count"
+# Rule 2. Only files present in both lists; rules 1 and 3 already reported the
+# rest, and reporting them twice buries the real regression.
+grown=""
+while IFS=$'\t' read -r path count; do
+    [[ -z "$path" ]] && continue
+    ceiling="$(printf '%s\n' "$allow" | awk -F'\t' -v p="$path" '$1 == p { print $2; exit }')"
+    [[ -z "$ceiling" ]] && continue
+    if (( count > ceiling )); then
+        grown+="  ~ $path: $ceiling -> $count"$'\n'
+    fi
+done < <(printf '%s\n' "$current")
+
+if [[ -n "$grown" ]]; then
+    echo "FAIL: these files gained JUCE uses (allowlisted files ratchet DOWN only):" >&2
+    printf '%s' "$grown" >&2
+    echo "Use the dusk:: seams in src/foundation (Fs.h, Text.h, Json.h, MidiBuffer.h," >&2
+    echo "SmoothedValue.h, Decibels.h) or a std:: equivalent. Common swaps:" >&2
+    echo "  juce::jlimit -> std::clamp                juce::Array<T> -> std::vector<T>" >&2
+    echo "  juce::Thread::sleep -> std::this_thread::sleep_for" >&2
+    echo "  juce::String member -> std::string        juce::exactlyEqual(a,0) -> a<0||a>0" >&2
+    rc=1
+fi
+
+files="$(printf '%s\n' "$currentPaths" | grep -c . || true)"
+uses="$(printf '%s\n' "$current" | awk -F'\t' 'NF > 1 { n += $2 } END { print n+0 }')"
+echo "JUCE-coupled src files: $files ($uses uses)"
 exit $rc

--- a/tools/juce-gate.sh
+++ b/tools/juce-gate.sh
@@ -28,8 +28,18 @@ ALLOW=tools/juce-allowlist.txt
 juce_count() { grep -oE 'juce::|<juce_' "$1" 2>/dev/null | wc -l | tr -d ' '; }
 
 scan() {
-    local f
-    grep -rlE 'juce::|<juce_' src | sort | while IFS= read -r f; do
+    local files rc f
+    files="$(grep -rlE 'juce::|<juce_' src)" && rc=0 || rc=$?
+    # grep exits 1 for "no match", which is the end state this whole campaign is
+    # aiming at, not a failure - under set -e that would abort the run and take
+    # --update with it. Anything above 1 (unreadable path, bad regex) is real.
+    if (( rc > 1 )); then
+        echo "ERROR: scanning src/ failed (grep exit $rc)" >&2
+        return "$rc"
+    fi
+    [[ -z "$files" ]] && return 0
+
+    printf '%s\n' "$files" | sort | while IFS= read -r f; do
         printf '%s\t%s\n' "$f" "$(juce_count "$f")"
     done
 }
@@ -44,6 +54,22 @@ fi
 
 if [[ ! -f "$ALLOW" ]]; then
     echo "ERROR: $ALLOW missing. Run: tools/juce-gate.sh --update" >&2
+    exit 2
+fi
+
+# Fail closed on a malformed record. A line without its count silently loses
+# ratchet coverage for that file (the count lookup below yields nothing and the
+# check is skipped), which would let anyone disable rule 2 for a file by
+# deleting one field - and is also what a rebase onto the pre-count allowlist
+# format looks like.
+malformed="$(awk -F'\t' 'NF == 0 { next }
+                         (NF != 2 || $1 == "" || $2 !~ /^[0-9]+$/) \
+                             { printf "  line %d: %s\n", NR, $0 }' "$ALLOW")"
+if [[ -n "$malformed" ]]; then
+    echo "ERROR: $ALLOW has malformed records (want: path<TAB>count):" >&2
+    printf '%s\n' "$malformed" >&2
+    echo "Fix them, or run tools/juce-gate.sh --update once you have checked the" >&2
+    echo "counts only go down." >&2
     exit 2
 fi
 


### PR DESCRIPTION
First slice of the 0.13 bug wave: harden the de-JUCE gate so the rest of the wave is actually protected by it, then close #145.

## Gate

The file-level ratchet only guarded files that were already clean, so new coupling landed in the 179 files already on the allowlist - AudioEngine, Session and `src/ui` are where feature work goes, and the gate was silent there. The allowlist now carries a per-file occurrence count and any file over its ceiling fails.

Three follow-on fixes to the gate itself:

- `grep` exits 1 when nothing matches, which under `set -euo pipefail` aborted the run the moment `src/` carried no JUCE. The end state the campaign is working towards would have failed the build, and taken `--update` with it.
- A record missing its count made the ceiling lookup yield nothing and the ratchet skip that file, so dropping one field silently disabled enforcement for it. That is also what a rebase onto the pre-count allowlist looks like. Records are now validated up front, including duplicate paths (the lookup takes the first, so a second higher entry was never compared) and leading-zero counts (bash arithmetic reads `010` as octal).
- `--update` is itself a ratchet now: it refuses to add a path or raise a count, so the command run after every migration cannot launder a regression into the baseline. An unavoidable addition is a hand edit that lands in review as its own line. The old "new UI file" exception is removed - the ImGui toolkit shipped with the notepad, so the "no JUCE-free option" premise no longer holds.

Baseline recorded at 179 files / 9257 occurrences. Everything in this PR added zero.

## Session load (#145)

Verified all six sub-items against main first; two were already fixed there (`compMakeupDb` is serialized, master `automation_mode` is unconditional). The rest:

- Track and bus fader/pan, HPF/LPF frequency, the comp block, EQ bands and hardware-insert gains loaded through a bare cast with no finite or range guard. A hand-edited `fader_db` of 1e39 narrowed to inf and propagated NaN through the mix. All now reject non-finite input and clamp to the range the corresponding control enforces.
- A non-number `aux_send_db` fell back to 0 dB, a unity send, so a corrupt file came back feedback-loud. It resolves to the OFF sentinel, and a value at or below the knob floor collapses to OFF the same way the strip does.
- Loading a session with fewer than 24 tracks drove the surplus slots from an empty object, which cleared regions and automation but left the previous session's name, colour, fader, sends and hardware routing live. They now come from the serialized default track, matching what buses and aux lanes already did.
- The MTC settings were written by the Audio Settings panel but never serialized, so they reset on every reload.

The remaining partial-slot-object gap is filed separately as #161.

## Engine

- `audioDeviceError` and the hot-unplug detector posted to the message thread capturing the engine bare; both now hold the same alive latch the MIDI hot-plug and change-fanout deferrals use.
- Region playback took its channel count from `AudioRegion::numChannels`, the model's copy, which can disagree with the file on disk. A stereo source read as mono lost its right channel. Taken from the decoded `FileInfo` instead.
- The UMC1820 probe selects the ALSA device type by name and reopens hw: PCMs, so it is Linux-only; guarded at the call site like the ALSA backend self-test above it.

## Validation

521 tests pass (4 new). Gate green. App builds clean, self-test completes under Xvfb. The playback channel test was verified to fail without its fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session loading by validating values, restoring defaults for missing data, and preventing invalid settings from reaching audio processing.
  * Fixed stale mixer settings when loading sessions with fewer tracks.
  * Improved playback channel handling for mono and stereo files.
  * Prevented deferred audio-device callbacks from running after shutdown.
  * Limited platform-specific audio self-tests to supported systems.

* **New Features**
  * MIDI synchronization settings, including chase, output, and frame rate, now persist across sessions.

* **Documentation**
  * Clarified JUCE usage tracking rules and MIDI synchronization persistence.

* **Tests**
  * Added coverage for corrupted values, synchronization persistence, and track removal during session loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
