### PR TITLE
fix(alsa,ui,docs): hw: prefix guard, real device reopen for period ch…

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1424,7 +1424,7 @@ Dusk Studio scans and hosts:
 - **LV2** on Linux and macOS. Effects and instruments load through Dusk Studio's own native LV2 host (rows tagged **LV2-Native**). If a plugin update adds new instruments, run **Scan plugins** for them to appear.
 - **CLAP** on Linux and macOS, through the native host — effects and instruments.
 - **AU** on macOS only, through Dusk Studio's native Audio Unit host — effects and instruments.
-- **Native multi-sampler** (`.sfz` and `.sf2` files, both via the built-in sfizz engine — SF2 is converted to SFZ on load) on all platforms.
+- **Native multi-sampler** (`.sfz`, `.sf2`, and ARIA `.bank.xml` files via the built-in sfizz engine — SF2 is converted to SFZ on load, while a bank manifest opens its first program) on all platforms.
 
 There is no VST2 support. See *Native plugin hosting (Linux and macOS)* below for what the native hosts change.
 
@@ -1455,10 +1455,10 @@ On Linux and macOS, both the effect and instrument pickers list LV2 and VST3 plu
 
 The picker filters by intent: only effect plugins appear when you're loading onto a channel insert or aux lane; only instruments appear when you're loading onto a MIDI track.
 
-At the bottom of the picker are alternative buttons:
+The insert chooser and the bottom of the picker also provide these actions where applicable:
 
 - **Hardware insert**: configure the slot as an external hardware insert instead of a plugin.
-- **Load Soundfont**: open a file chooser for `.sfz`, `.sf2`, and `.bank.xml` files. Shown on the instrument picker only - see *Multi-sample instruments*.
+- **Soundfont (.sfz / .sf2 / .bank.xml)**: open a soundfont directly. Choosing this on an audio track converts the track to MIDI; see *Multi-sample instruments*.
 - **Browse file…**: load a plugin by file path (useful for plugins not yet in the scan cache).
 - **Scan plugins**: re-scan.
 
@@ -1494,7 +1494,7 @@ OOP is supported on:
 - **Windows**: always.
 - **macOS**: requires macOS 14.4 or later. The plugin **editor** is hosted in-process via a shell instance and embeds as a centred modal like the other platforms — see *Opening the editor* above.
 
-Plugins run **in-process by default** — it gives the most responsive plugin editors and the lowest CPU cost. To run third-party binary plugins in the OOP sandbox instead, launch with `DUSKSTUDIO_USE_OOP_PLUGINS=1`; a plugin that crashes or hangs then takes down only the host child, not Dusk Studio. The variable applies to standard-hosted plugins only: on Linux, rows tagged **CLAP**, **LV2-Native**, or **VST3-Native** go through Dusk Studio's own hosts and always run in-process regardless of the setting (see *Native plugin hosting*). The switch reaches **standard-host rows only** on platforms where a format still uses that layer. Native rows — **CLAP**, **LV2-Native**, and **VST3-Native** on Linux and macOS, plus **AudioUnit** on macOS — always run in-process and ignore it, as *Native plugin hosting* above says. If the `dusk-studio-plugin-host` binary is missing the loader falls back to in-process automatically. Standard-host plugin **scanning** runs in the sandboxed child, so a plugin that crashes while being probed is blacklisted instead of crashing the app; native scanning follows the format-specific rules described under *Scanning*. (Dusk Studio's own bundled plugins always run in-process.)
+Plugins run **in-process by default** — it gives the most responsive plugin editors and the lowest CPU cost. To run third-party binary plugins in the OOP sandbox instead, launch with `DUSKSTUDIO_USE_OOP_PLUGINS=1`; a plugin that crashes or hangs then takes down only the host child, not Dusk Studio. The switch reaches standard-host rows only. Native rows — **CLAP**, **LV2-Native**, and **VST3-Native** on Linux and macOS, plus **AudioUnit** on macOS — always run in-process and ignore it, as *Native plugin hosting* above says. If the `dusk-studio-plugin-host` binary is missing the loader falls back to in-process automatically. Standard-host plugin **scanning** runs in the sandboxed child, so a plugin that crashes while being probed is blacklisted instead of crashing the app; native scanning follows the format-specific rules described under *Scanning*. (Dusk Studio's own bundled plugins always run in-process.)
 
 When a plugin crashes in OOP mode:
 
@@ -1519,7 +1519,7 @@ When you load a session:
 
 ## Multi-sample instruments
 
-Click a MIDI track's **Insert** slot and choose **Load Soundfont** to load one through the **sfizz** engine. The chooser accepts `.sfz`, `.sf2`, and `.bank.xml` (an ARIA bank manifest, which Dusk Studio resolves to the bank's first program). Most SoundFont and SFZ instrument libraries work directly. The processor exposes three runtime overrides:
+Click a track's **Insert** slot and choose **Soundfont (.sfz / .sf2 / .bank.xml)** to load one through the **sfizz** engine. If the track is not already MIDI, Dusk Studio converts it automatically. An ARIA bank manifest resolves to the bank's first program. Most SoundFont and SFZ instrument libraries work directly. The processor exposes three runtime overrides:
 
 - **Master volume**: −60 to +12 dB.
 - **Master tune**: −100 to +100 cents.
@@ -1541,7 +1541,7 @@ A hardware insert routes a channel or aux's signal out through one of your audio
 
 Right-click any insert slot (channel or aux) → **Configure as hardware insert**, or click **Hardware insert** in the plugin picker.
 
-The configuration panel has six controls:
+The configuration panel has seven controls:
 
 - **Output channel**: which audio device output the channel's pre-insert signal is sent to. Stereo and Mid/Side send to an output pair; Mono sends to a single output (see **Format** below).
 - **Output volume**: a level trim on the send side, 0.0 to 1.0 (linear).

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1458,7 +1458,7 @@ The picker filters by intent: only effect plugins appear when you're loading ont
 At the bottom of the picker are alternative buttons:
 
 - **Hardware insert**: configure the slot as an external hardware insert instead of a plugin.
-- **Load Soundfont**: open a file chooser for `.sfz` or `.sf2` files.
+- **Load Soundfont**: open a file chooser for `.sfz`, `.sf2`, and `.bank.xml` files. Shown on the instrument picker only - see *Multi-sample instruments*.
 - **Browse file…**: load a plugin by file path (useful for plugins not yet in the scan cache).
 - **Scan plugins**: re-scan.
 
@@ -1494,7 +1494,7 @@ OOP is supported on:
 - **Windows**: always.
 - **macOS**: requires macOS 14.4 or later. The plugin **editor** is hosted in-process via a shell instance and embeds as a centred modal like the other platforms — see *Opening the editor* above.
 
-Plugins run **in-process by default** — it gives the most responsive plugin editors and the lowest CPU cost. To run third-party binary plugins in the OOP sandbox instead, launch with `DUSKSTUDIO_USE_OOP_PLUGINS=1`; a plugin that crashes or hangs then takes down only the host child, not Dusk Studio. The switch reaches **standard-host rows only** on platforms where a format still uses that layer. Native rows — **CLAP**, **LV2-Native**, and **VST3-Native** on Linux and macOS, plus **AudioUnit** on macOS — always run in-process and ignore it, as *Native plugin hosting* above says. If the `dusk-studio-plugin-host` binary is missing the loader falls back to in-process automatically. Standard-host plugin **scanning** runs in the sandboxed child, so a plugin that crashes while being probed is blacklisted instead of crashing the app; native scanning follows the format-specific rules described under *Scanning*. (Dusk Studio's own bundled plugins always run in-process.)
+Plugins run **in-process by default** — it gives the most responsive plugin editors and the lowest CPU cost. To run third-party binary plugins in the OOP sandbox instead, launch with `DUSKSTUDIO_USE_OOP_PLUGINS=1`; a plugin that crashes or hangs then takes down only the host child, not Dusk Studio. The variable applies to standard-hosted plugins only: on Linux, rows tagged **CLAP**, **LV2-Native**, or **VST3-Native** go through Dusk Studio's own hosts and always run in-process regardless of the setting (see *Native plugin hosting*). The switch reaches **standard-host rows only** on platforms where a format still uses that layer. Native rows — **CLAP**, **LV2-Native**, and **VST3-Native** on Linux and macOS, plus **AudioUnit** on macOS — always run in-process and ignore it, as *Native plugin hosting* above says. If the `dusk-studio-plugin-host` binary is missing the loader falls back to in-process automatically. Standard-host plugin **scanning** runs in the sandboxed child, so a plugin that crashes while being probed is blacklisted instead of crashing the app; native scanning follows the format-specific rules described under *Scanning*. (Dusk Studio's own bundled plugins always run in-process.)
 
 When a plugin crashes in OOP mode:
 
@@ -1519,7 +1519,7 @@ When you load a session:
 
 ## Multi-sample instruments
 
-Click a MIDI track's **Insert** slot and choose **Load Soundfont** to pick a `.sfz` or `.sf2` file and load it through the **sfizz** engine. Most SoundFont and SFZ instrument libraries work directly. The processor exposes three runtime overrides:
+Click a MIDI track's **Insert** slot and choose **Load Soundfont** to load one through the **sfizz** engine. The chooser accepts `.sfz`, `.sf2`, and `.bank.xml` (an ARIA bank manifest, which Dusk Studio resolves to the bank's first program). Most SoundFont and SFZ instrument libraries work directly. The processor exposes three runtime overrides:
 
 - **Master volume**: −60 to +12 dB.
 - **Master tune**: −100 to +100 cents.
@@ -1543,7 +1543,7 @@ Right-click any insert slot (channel or aux) → **Configure as hardware insert*
 
 The configuration panel has six controls:
 
-- **Output channel**: which audio device output the channel's pre-insert signal is sent to. Choose a stereo pair on a stereo track; a single output on a mono track.
+- **Output channel**: which audio device output the channel's pre-insert signal is sent to. Stereo and Mid/Side send to an output pair; Mono sends to a single output (see **Format** below).
 - **Output volume**: a level trim on the send side, 0.0 to 1.0 (linear).
 - **Input channel**: which audio device input the returned signal is read from.
 - **Input volume**: a level trim on the return side, 0.0 to 1.0.

--- a/src/engine/alsa/AlsaAudioIODevice.cpp
+++ b/src/engine/alsa/AlsaAudioIODevice.cpp
@@ -664,7 +664,12 @@ std::string AlsaAudioIODevice::open (const device::ChannelSet& inputChannels,
         // drift this guard exists to prevent.
         if (! outCard.empty() && outCard == inCard)
         {
-            snd_pcm_link (outHandle, inHandle);
+            const int linkResult = snd_pcm_link (outHandle, inHandle);
+            if (linkResult < 0)
+                std::fprintf (stderr,
+                              "[Dusk Studio/ALSA] WARNING: could not link input \"%s\" "
+                              "and output \"%s\": %s. Starting them independently.\n",
+                              inputId.c_str(), outputId.c_str(), snd_strerror (linkResult));
         }
         else
         {
@@ -863,7 +868,21 @@ void AlsaAudioIODevice::start (device::IODeviceCallback* newCallback)
     if (startHandle != nullptr
         && snd_pcm_state (startHandle) != SND_PCM_STATE_RUNNING)
     {
-        snd_pcm_start (startHandle);
+        const int startResult = snd_pcm_start (startHandle);
+        if (startResult < 0)
+            std::fprintf (stderr, "[Dusk Studio/ALSA] WARNING: stream start failed: %s\n",
+                          snd_strerror (startResult));
+    }
+
+    // Cross-card duplex is intentionally unlinked, and a same-card link can be
+    // rejected by the driver. In either case starting playback does not start
+    // capture, so make sure the input is running before its first wait.
+    if (inHandle != nullptr && snd_pcm_state (inHandle) != SND_PCM_STATE_RUNNING)
+    {
+        const int inputStartResult = snd_pcm_start (inHandle);
+        if (inputStartResult < 0)
+            std::fprintf (stderr, "[Dusk Studio/ALSA] WARNING: capture start failed: %s\n",
+                          snd_strerror (inputStartResult));
     }
 
     // The I/O thread self-promotes to SCHED_RR as its first act (see

--- a/src/engine/alsa/AlsaAudioIODevice.cpp
+++ b/src/engine/alsa/AlsaAudioIODevice.cpp
@@ -281,6 +281,10 @@ const int kCandidateBufferSizes[] = {
 // cross-card duplex doesn't silently drift), and exercised by runSelfTest().
 std::string cardOfHwId (const std::string& id)
 {
+    // Prefix test, not a substring search: "plughw:1,0" CONTAINS "hw:" at offset
+    // 4, so the search alone would parse it as card "1" and link a plug device
+    // to an unrelated raw one.
+    if (! dusk::text::startsWith (id, "hw:")) return {};
     return dusk::text::upToFirstOccurrenceOf (
                dusk::text::fromFirstOccurrenceOf (id, "hw:", false), ",", false);
 }
@@ -655,7 +659,10 @@ std::string AlsaAudioIODevice::open (const device::ChannelSet& inputChannels,
         const auto outCard = cardOfHwId (outputId);
         const auto inCard  = cardOfHwId (inputId);
 
-        if (outCard == inCard)
+        // An id we cannot resolve yields an empty card, and two of those would
+        // compare equal and link a pair whose clock domain is unknown - the exact
+        // drift this guard exists to prevent.
+        if (! outCard.empty() && outCard == inCard)
         {
             snd_pcm_link (outHandle, inHandle);
         }
@@ -1403,6 +1410,7 @@ std::string AlsaAudioIODevice::runSelfTest()
             { "hw:0,0",               "0"       },  // numeric card id
             { "hw:UMC1820,0,2",       "UMC1820" },  // sub-device suffix
             { "front:CARD=UMC1820",   ""        },  // not hw: -> reject
+            { "plughw:1,0",           ""        },  // CONTAINS hw: but isn't one
             { "",                     ""        },
         };
         bool allOk = true;

--- a/src/ui/AudioSettingsPanel.cpp
+++ b/src/ui/AudioSettingsPanel.cpp
@@ -2,6 +2,7 @@
 #include "AppConfig.h"
 #include <algorithm>
 #include <limits>
+#include <string>
 #include "DuskAlerts.h"
 #include "MidiBindingsPanel.h"
 #include "SelfTestPanel.h"
@@ -791,13 +792,25 @@ void AudioSettingsPanel::applyPeriodsChange()
 
     // The device would not come back at the new count. Put the count back and
     // reopen at the old one: the alternative is leaving the user closed, silent
-    // and uninformed because they touched a dropdown.
+    // and uninformed because they touched a dropdown. The rollback can fail too
+    // (the interface went away mid-change), and that outcome is worse than the
+    // one that started this, so it has to reach the user rather than the
+    // original error alone.
     AlsaAudioIODevice::setRequestedPeriods (previousPeriods);
+    const auto rollbackError = deviceManager.setSetup (setup, /*treatAsChosen*/ true);
     syncPeriodsComboFromRequested();
-    deviceManager.setSetup (setup, /*treatAsChosen*/ true);
+
+    std::string message = "Could not reopen the audio device with "
+                        + std::to_string (p) + " periods:\n\n" + error;
+    if (rollbackError.empty())
+        message += "\n\nReverted to " + std::to_string (previousPeriods) + " periods.";
+    else
+        message += "\n\nReverting to " + std::to_string (previousPeriods)
+                 + " periods also failed:\n\n" + rollbackError
+                 + "\n\nNo audio device is open. Pick one in Audio Settings.";
 
     if (auto* top = getTopLevelComponent())
-        showDuskAlert (*top, "Audio device error", error);
+        showDuskAlert (*top, "Audio device error", message);
 }
 #endif
 

--- a/src/ui/AudioSettingsPanel.cpp
+++ b/src/ui/AudioSettingsPanel.cpp
@@ -2,6 +2,7 @@
 #include "AppConfig.h"
 #include <algorithm>
 #include <limits>
+#include "DuskAlerts.h"
 #include "MidiBindingsPanel.h"
 #include "SelfTestPanel.h"
 #include "../engine/AudioEngine.h"
@@ -51,15 +52,7 @@ AudioSettingsPanel::AudioSettingsPanel (device::DeviceManager& dm,
     // latency but give the kernel more headroom against scheduler jitter.
     for (int p : { 2, 3, 4, 8, 16 })
         periodsCombo.addItem (juce::String (p), p);
-    {
-        // getRequestedPeriods() is clamped to [2,16] but the combo only exposes
-        // a discrete subset; fall back to 4 (JUCE default) for any value that
-        // doesn't have a corresponding item, otherwise the combo renders blank.
-        const int requested = AlsaAudioIODevice::getRequestedPeriods();
-        const bool inSet = (requested == 2 || requested == 3 || requested == 4
-                            || requested == 8 || requested == 16);
-        periodsCombo.setSelectedId (inSet ? requested : 4, juce::dontSendNotification);
-    }
+    syncPeriodsComboFromRequested();
     periodsCombo.setTooltip ("ALSA period count. Only applies to ALSA backend. "
                               "Increase if you hear xruns or distortion at low "
                               "buffer sizes; decrease for lower latency.");
@@ -758,11 +751,23 @@ void AudioSettingsPanel::applyRescan()
 }
 
 #if defined(__linux__)
+void AudioSettingsPanel::syncPeriodsComboFromRequested()
+{
+    // getRequestedPeriods() is clamped to [2,16] but the combo only exposes a
+    // discrete subset; fall back to 4 for any value with no matching item,
+    // otherwise the combo renders blank.
+    const int requested = AlsaAudioIODevice::getRequestedPeriods();
+    const bool inSet = (requested == 2 || requested == 3 || requested == 4
+                        || requested == 8 || requested == 16);
+    periodsCombo.setSelectedId (inSet ? requested : 4, juce::dontSendNotification);
+}
+
 void AudioSettingsPanel::applyPeriodsChange()
 {
     const int p = periodsCombo.getSelectedId();
     if (p <= 0) return;
 
+    const int previousPeriods = AlsaAudioIODevice::getRequestedPeriods();
     AlsaAudioIODevice::setRequestedPeriods (p);
 
     // The period count is read in AlsaAudioIODevice::open(), so the device has
@@ -774,10 +779,25 @@ void AudioSettingsPanel::applyPeriodsChange()
     // be an audible interruption for nothing.
     const auto* type = deviceManager.getCurrentDeviceType();
     if (type == nullptr || type->getTypeName() != "ALSA") return;
+    // With nothing open there is nothing to recreate, and the reopen below would
+    // START a device the user never asked this panel to start.
+    if (deviceManager.getCurrentDevice() == nullptr) return;
 
     const auto setup = deviceManager.getSetup();
     deviceManager.closeDevice();
+
+    const auto error = deviceManager.setSetup (setup, /*treatAsChosen*/ true);
+    if (error.empty()) return;
+
+    // The device would not come back at the new count. Put the count back and
+    // reopen at the old one: the alternative is leaving the user closed, silent
+    // and uninformed because they touched a dropdown.
+    AlsaAudioIODevice::setRequestedPeriods (previousPeriods);
+    syncPeriodsComboFromRequested();
     deviceManager.setSetup (setup, /*treatAsChosen*/ true);
+
+    if (auto* top = getTopLevelComponent())
+        showDuskAlert (*top, "Audio device error", error);
 }
 #endif
 

--- a/src/ui/AudioSettingsPanel.cpp
+++ b/src/ui/AudioSettingsPanel.cpp
@@ -765,10 +765,18 @@ void AudioSettingsPanel::applyPeriodsChange()
 
     AlsaAudioIODevice::setRequestedPeriods (p);
 
-    // Re-open the device with the same setup so setParameters() runs and
-    // picks up the new period count. Without this, the change only takes
-    // effect on the next manual device switch.
-    auto setup = deviceManager.getSetup();
+    // The period count is read in AlsaAudioIODevice::open(), so the device has
+    // to be recreated for it to apply. Re-submitting the SAME setup does not do
+    // that: setSetup short-circuits when the setup matches and the device is
+    // live, so the change silently waited for the next manual device switch.
+    // Closing first makes the re-apply a real open - but only for ALSA. On the
+    // PipeWire/JACK backend the setting is inert, and dropping the device would
+    // be an audible interruption for nothing.
+    const auto* type = deviceManager.getCurrentDeviceType();
+    if (type == nullptr || type->getTypeName() != "ALSA") return;
+
+    const auto setup = deviceManager.getSetup();
+    deviceManager.closeDevice();
     deviceManager.setSetup (setup, /*treatAsChosen*/ true);
 }
 #endif

--- a/src/ui/AudioSettingsPanel.cpp
+++ b/src/ui/AudioSettingsPanel.cpp
@@ -754,10 +754,10 @@ void AudioSettingsPanel::applyRescan()
 #if defined(__linux__)
 void AudioSettingsPanel::syncPeriodsComboFromRequested()
 {
-    // Select the count actually in force, or nothing. getRequestedPeriods() is
+    // Select the requested count, or nothing. getRequestedPeriods() is
     // clamped to [2,16] while the menu carries a curated subset, and pointing at
-    // a nearby item instead would state a period count the device is not
-    // running. Only this panel and the built-in default of 3 ever write the
+    // a nearby item would misstate the setting used for the next ALSA open.
+    // Only this panel and the built-in default of 3 ever write the
     // value, so every write today is already a menu id; leaving the no-match
     // case blank keeps it honest rather than confident if that changes.
     const int requested = AlsaAudioIODevice::getRequestedPeriods();

--- a/src/ui/AudioSettingsPanel.cpp
+++ b/src/ui/AudioSettingsPanel.cpp
@@ -754,13 +754,17 @@ void AudioSettingsPanel::applyRescan()
 #if defined(__linux__)
 void AudioSettingsPanel::syncPeriodsComboFromRequested()
 {
-    // getRequestedPeriods() is clamped to [2,16] but the combo only exposes a
-    // discrete subset; fall back to 4 for any value with no matching item,
-    // otherwise the combo renders blank.
+    // Select the count actually in force, or nothing. getRequestedPeriods() is
+    // clamped to [2,16] while the menu carries a curated subset, and pointing at
+    // a nearby item instead would state a period count the device is not
+    // running. Only this panel and the built-in default of 3 ever write the
+    // value, so every write today is already a menu id; leaving the no-match
+    // case blank keeps it honest rather than confident if that changes.
     const int requested = AlsaAudioIODevice::getRequestedPeriods();
-    const bool inSet = (requested == 2 || requested == 3 || requested == 4
-                        || requested == 8 || requested == 16);
-    periodsCombo.setSelectedId (inSet ? requested : 4, juce::dontSendNotification);
+    int matchIndex = -1;
+    for (int i = 0; i < periodsCombo.getNumItems(); ++i)
+        if (periodsCombo.getItemId (i) == requested) { matchIndex = i; break; }
+    periodsCombo.setSelectedItemIndex (matchIndex, juce::dontSendNotification);
 }
 
 void AudioSettingsPanel::applyPeriodsChange()

--- a/src/ui/AudioSettingsPanel.h
+++ b/src/ui/AudioSettingsPanel.h
@@ -144,9 +144,8 @@ private:
 
 #if defined(__linux__)
     void applyPeriodsChange();
-    // Point the combo at whatever period count is actually in force. Shared by
-    // construction and by the rollback when a reopen at a new count fails, so
-    // the dropdown never advertises a value the device is not running.
+    // Point the combo at the period count requested for the next ALSA open.
+    // Shared by construction and rollback so the dropdown follows the setting.
     void syncPeriodsComboFromRequested();
 #endif
     void applyOversamplingChange();

--- a/src/ui/AudioSettingsPanel.h
+++ b/src/ui/AudioSettingsPanel.h
@@ -144,6 +144,10 @@ private:
 
 #if defined(__linux__)
     void applyPeriodsChange();
+    // Point the combo at whatever period count is actually in force. Shared by
+    // construction and by the rollback when a reopen at a new count fails, so
+    // the dropdown never advertises a value the device is not running.
+    void syncPeriodsComboFromRequested();
 #endif
     void applyOversamplingChange();
     void applyMulticoreChange();


### PR DESCRIPTION
…anges

cardOfHwId searched for "hw:" anywhere in the device id, so "plughw:1,0" matched at offset 4 and parsed as card "1". That let snd_pcm_link pair a plug device with an unrelated raw one, whose clocks are not shared. Require the prefix, and cover the near miss in the self-test table, which only had an obviously-unrelated negative before.

The ALSA period count is read in open(), so applying a change means recreating the device. Re-submitting the same setup does not: setSetup short-circuits when the setup matches and the device is live, so the new count silently waited for the next manual device switch. Close first, then re-apply.

MANUAL: the hardware-insert picker only ever offers output pairs, so the mono-track single-output instruction described something the UI cannot do. The soundfont chooser also accepts .bank.xml, and DUSKSTUDIO_USE_OOP_PLUGINS reaches standard-hosted plugins only, which the OOP section did not say.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ALSA device identification to prevent incorrect hardware routing.
  * Prevented audio links between devices with unresolved or mismatched clock domains.
  * Improved ALSA period-setting recovery when reopening a device fails, including restoring the previous setting and displaying an error alert.
  * Added clearer synchronization of the audio period selection.

* **Documentation**
  * Documented `.bank.xml` SoundFont loading and program selection.
  * Clarified OOP sandbox host behavior and hardware-insert output formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->