### PR TITLE
DSP guards: empty-block, oversized-block, insert delay relatch (#146)

### DIFF
--- a/src/dsp/HardwareInsertSlot.cpp
+++ b/src/dsp/HardwareInsertSlot.cpp
@@ -173,6 +173,12 @@ void HardwareInsertSlot::processStereoBlock (float* L, float* R, int numSamples,
         cachedLatencySamples.store (requestedLatency, std::memory_order_relaxed);
         dryDelayL.setDelay (requestedLatency);
         dryDelayR.setDelay (requestedLatency);
+        // Moving the read head without clearing replays whatever history now
+        // sits at the new offset, which clicks on every drag of the latency
+        // setpoint. Dropping the line's contents costs the dry tail instead,
+        // the same trade ChannelStrip makes when it relatches its PDC.
+        dryDelayL.reset();
+        dryDelayR.reset();
     }
 
     // Pull the latest knob values onto the smoother targets.

--- a/src/dsp/MasterBus.cpp
+++ b/src/dsp/MasterBus.cpp
@@ -171,6 +171,10 @@ void MasterBus::processInPlace (float* L, float* R, int numSamples) noexcept
 {
     dusk::audio::ScopedNoDenormals noDenormals;
 
+    // JACK and the ALSA backend both hand out empty blocks across device
+    // transitions; the meter stores at the bottom would drop to -inf on one.
+    if (numSamples == 0) return;
+
     const bool tapeOn = paramsRef != nullptr
                        && paramsRef->tapeEnabled.load (std::memory_order_relaxed);
 

--- a/src/dsp/MasteringChain.cpp
+++ b/src/dsp/MasteringChain.cpp
@@ -169,8 +169,18 @@ void MasteringChain::processInPlace (float* L, float* R, int numSamples) noexcep
 {
     dusk::audio::ScopedNoDenormals noDenormals;
 
-    jassert (numSamples <= preparedBlockSize);
     if (numSamples == 0) return;
+    // A host block larger than what prepare() sized the scratch for cannot be
+    // processed in part: the smoothers and meters below would desync from the
+    // audio. Clear and skip, as AuxLaneStrip does on the identical contract -
+    // leaving the buffer untouched would leak the unprocessed mix to the output.
+    jassert (numSamples <= preparedBlockSize);
+    if (numSamples > preparedBlockSize)
+    {
+        std::memset (L, 0, sizeof (float) * (size_t) numSamples);
+        std::memset (R, 0, sizeof (float) * (size_t) numSamples);
+        return;
+    }
 
     // 5-band digital EQ - replaces the Tube EQ that the master strip
     // uses in Mixing. Mastering wants a clean parametric EQ.

--- a/src/dsp/PitchDetector.h
+++ b/src/dsp/PitchDetector.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <cmath>
 #include <algorithm>
+#include <limits>
 
 class PitchDetector
 {


### PR DESCRIPTION
First slice of #146. These are the four items in that issue that are self-contained guards; the two RT-budget items (the PitchDetector YIN scan and the hardware-insert chirp correlation) are algorithmic and want before/after numbers from the perf harness, so they are deliberately not here.

- **MasterBus had no empty-block early return.** Every sibling strip has one. JACK and the ALSA backend both hand out zero-sample blocks across device transitions, and the meter stores at the bottom of the function ran on one, flicking the master readout to -inf.

- **MasteringChain enforced its oversized-block contract with a `jassert` alone**, which is a no-op in Release. A host block larger than what `prepare()` sized the scratch for would process in part and desync the smoothers and meters from the audio. It now clears and skips, which is what `AuxLaneStrip` already does on the identical contract - leaving the buffer untouched would leak the unprocessed mix straight to the output.

- **The hardware insert moved its dry-path delay read head without clearing it.** Changing the latency setpoint repositioned the read head into unrelated history, so every drag of the slider clicked. Resetting costs the dry tail instead, the same trade `ChannelStrip` makes when it relatches its PDC.

- **PitchDetector used `std::numeric_limits` without including `<limits>`**, relying on a transitive include.

## Validation

521 tests pass, app builds clean, de-JUCE ratchet green at 179 files / 9257 uses (this branch adds none).

Partial fix for #146 - leaving the issue open for the RT-budget half.
