### PR TITLE
Bound the LUFS gating scan and gate over 400 ms windows (#146)

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -972,6 +972,8 @@ Right of the chain are three loudness readouts:
 
 A streaming-platform preset picker (Spotify, Apple Music, YouTube, Netflix, etc.) colour-codes the integrated LUFS and true-peak readings according to that platform's target. Pressing **Reset integrated** clears the integrated reading so you can re-measure from a known point.
 
+The integrated reading measures up to an hour of program. Past that it holds where it is rather than continuing to absorb material, so for anything longer, reset it and measure the section you actually care about.
+
 ## Exporting the master
 
 **Export master…** renders the mastering chain offline. Pick a delivery preset first — **WAV 24-bit at the session rate** (archive/streaming), **WAV 16-bit 44.1 kHz with TPDF dither** (CD spec), or **MP3 320 kbps** — then a destination (defaults to `master.wav` / `master.mp3` in the session folder). A progress dialog shows the output path and a bar; the render runs as fast as the CPU allows and you can cancel mid-render.

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -972,7 +972,7 @@ Right of the chain are three loudness readouts:
 
 A streaming-platform preset picker (Spotify, Apple Music, YouTube, Netflix, etc.) colour-codes the integrated LUFS and true-peak readings according to that platform's target. Pressing **Reset integrated** clears the integrated reading so you can re-measure from a known point.
 
-The integrated reading measures up to an hour of program. Past that it holds where it is rather than continuing to absorb material, so for anything longer, reset it and measure the section you actually care about.
+The integrated reading measures up to an hour of material loud enough to count. Silence and anything below −70 LUFS is discarded by the standard's gate and does not use up that hour, so leaving the meter running between takes costs you nothing. Past the hour it holds where it is rather than continuing to absorb material, so for anything longer, reset it and measure the section you actually care about.
 
 ## Exporting the master
 

--- a/src/dsp/BrickwallLimiter.cpp
+++ b/src/dsp/BrickwallLimiter.cpp
@@ -46,8 +46,10 @@ void BrickwallLimiter::prepare (double sampleRate, int maxBlockSize, double init
     const int bs = std::max (1, maxBlockSize);
 
     // Linear-phase halfband FIR so the limiter doesn't smear transients with
-    // phase distortion; the group delay is a whole number of base-rate samples
-    // so delay compensation stays exact.
+    // phase distortion. At 4x the round trip is 26.5 base-rate samples, which
+    // integer PDC cannot express: osLatencyBase rounds to 27, so the reported
+    // latency runs half a sample long. The lookahead below is quantised in
+    // base-rate samples to keep from adding any more.
     oversampler.setFactor (osFactor);
     oversampler.prepare (bs);
 

--- a/src/dsp/LoudnessMeter.cpp
+++ b/src/dsp/LoudnessMeter.cpp
@@ -131,14 +131,6 @@ void LoudnessMeter::finishBlock()
     // Mean squared over this 100 ms block (sum of L^2 + R^2 across both
     // channels, normalized by samples × 2 channels of weight 1.0).
     const double ms = blockSumSquared / std::max (1, blockSize);
-    if (ms > kAbsoluteGateMS)
-    {
-        absoluteGateSum += ms;
-        ++absoluteGateCount;
-        const int bin = gateBinFor (ms);
-        gateBinSum   [(size_t) bin] += ms;
-        gateBinCount [(size_t) bin] += 1;
-    }
 
     momentaryRingMS [(size_t) (ringWritePos % kMomentaryBlocks)] = ms;
     shortTermRingMS [(size_t) (ringWritePos % kShortTermBlocks)] = ms;
@@ -155,6 +147,20 @@ void LoudnessMeter::finishBlock()
     const double sMean = mean (shortTermRingMS, kShortTermBlocks);
     momentaryLufs.store (msToLUFS (mMean), std::memory_order_relaxed);
     shortTermLufs.store (msToLUFS (sMean), std::memory_order_relaxed);
+
+    // BS.1770-4 gates 400 ms blocks overlapping by 75 %, i.e. one gating block
+    // per 100 ms step once a full window exists. The sub-blocks are equal
+    // length, so the mean of the momentary ring IS that window's mean square -
+    // gating the 100 ms sub-blocks directly instead discards short dips that
+    // the 400 ms window rides over, and disagrees with R128 compliance meters.
+    if (ringWritePos >= kMomentaryBlocks && mMean > kAbsoluteGateMS)
+    {
+        absoluteGateSum += mMean;
+        ++absoluteGateCount;
+        const int bin = gateBinFor (mMean);
+        gateBinSum   [(size_t) bin] += mMean;
+        gateBinCount [(size_t) bin] += 1;
+    }
 
     publishIntegrated();
 

--- a/src/dsp/LoudnessMeter.cpp
+++ b/src/dsp/LoudnessMeter.cpp
@@ -43,8 +43,8 @@ inline double lufsToMS (double lufs)
     return std::pow (10.0, (lufs + 0.691) / 10.0);
 }
 
-// BS.1770-4's absolute gate. Blocks below it are excluded for good, so they
-// never enter the histogram.
+// BS.1770-4's absolute gate. Windows below it are excluded for good, so they
+// are never retained.
 const double kAbsoluteGateMS = lufsToMS (-70.0);
 } // namespace
 
@@ -59,6 +59,8 @@ void LoudnessMeter::prepare (double sampleRate, int maxBlockSize)
     preparedMaxBlockSize = std::max (1, maxBlockSize);
     oversampler.setFactor (4);   // ITU BS.1770 Annex 2 true-peak
     oversampler.prepare (preparedMaxBlockSize);
+
+    windowMS.assign ((size_t) kMaxWindows, 0.0);
 
     const auto s1 = makeKStage1 (sampleRate);
     const auto s2 = makeKStage2 (sampleRate);
@@ -75,10 +77,11 @@ void LoudnessMeter::reset()
 
     blockSamplesRemaining = blockSize;
     blockSumSquared = 0.0;
-    for (auto& v : gateBinSum)   v = 0.0;
-    for (auto& v : gateBinCount) v = 0;
+    windowCount       = 0;
     absoluteGateSum   = 0.0;
     absoluteGateCount = 0;
+    scanGateMS = scanSum = scanCredit = 0.0;
+    scanCount = scanPos = scanLimit = 0;
     for (auto& v : momentaryRingMS)  v = 0.0;
     for (auto& v : shortTermRingMS)  v = 0.0;
     ringWritePos = 0;
@@ -92,38 +95,50 @@ void LoudnessMeter::reset()
     truePeakDb.store    (-100.0f, std::memory_order_relaxed);
 }
 
-int LoudnessMeter::gateBinFor (double meanSquared) noexcept
+void LoudnessMeter::startRelativeScan() noexcept
 {
-    const double lufs = (double) msToLUFS (meanSquared);
-    const int bin = (int) std::floor ((lufs - kGateFloorLufs)
-                                        * (double) kGateBinsPerLu);
-    return std::clamp (bin, 0, kGateBins - 1);
-}
-
-void LoudnessMeter::publishIntegrated() noexcept
-{
-    if (absoluteGateCount == 0)
-    {
-        integratedLufs.store (-100.0f, std::memory_order_relaxed);
-        return;
-    }
-
     // Relative gate: 10 LU below the mean of everything above the absolute
     // gate. Both gates apply, so the effective threshold is the higher one.
+    // The mean is exact, so the threshold is too - only the window set below
+    // has to be recomputed.
     const double meanPass1 = absoluteGateSum / absoluteGateCount;
-    const double gateMS = std::max (kAbsoluteGateMS,
-                                      lufsToMS ((double) msToLUFS (meanPass1) - 10.0));
+    scanGateMS = std::max (kAbsoluteGateMS,
+                            lufsToMS ((double) msToLUFS (meanPass1) - 10.0));
+    scanSum    = 0.0;
+    scanCredit = 0.0;
+    scanCount  = 0;
+    scanPos    = 0;
+    scanLimit  = windowCount;
+}
 
-    double sum = 0.0;
-    int    count = 0;
-    for (int b = gateBinFor (gateMS); b < kGateBins; ++b)
+void LoudnessMeter::advanceRelativeScan (int numSamples) noexcept
+{
+    if (scanLimit <= 0) return;
+
+    // Budget the pass against elapsed audio so it lands inside one gating
+    // period whatever the buffer size, instead of one callback wearing all of
+    // it. Windows past scanLimit were appended mid-pass and wait for the next.
+    scanCredit += (double) scanLimit * (double) numSamples
+                    / (double) std::max (1, blockSize);
+    while (scanPos < scanLimit && scanCredit >= 1.0)
     {
-        sum   += gateBinSum   [(size_t) b];
-        count += gateBinCount [(size_t) b];
+        const double v = windowMS[(size_t) scanPos];
+        if (v > scanGateMS)
+        {
+            scanSum += v;
+            ++scanCount;
+        }
+        ++scanPos;
+        scanCredit -= 1.0;
     }
 
-    integratedLufs.store (count > 0 ? msToLUFS (sum / count) : -100.0f,
-                           std::memory_order_relaxed);
+    if (scanPos >= scanLimit)
+    {
+        integratedLufs.store (scanCount > 0 ? msToLUFS (scanSum / scanCount)
+                                            : -100.0f,
+                               std::memory_order_relaxed);
+        scanLimit = 0;
+    }
 }
 
 void LoudnessMeter::finishBlock()
@@ -153,16 +168,17 @@ void LoudnessMeter::finishBlock()
     // length, so the mean of the momentary ring IS that window's mean square -
     // gating the 100 ms sub-blocks directly instead discards short dips that
     // the 400 ms window rides over, and disagrees with R128 compliance meters.
-    if (ringWritePos >= kMomentaryBlocks && mMean > kAbsoluteGateMS)
+    if (ringWritePos >= kMomentaryBlocks && mMean > kAbsoluteGateMS
+        && windowCount < kMaxWindows)
     {
+        windowMS[(size_t) windowCount] = mMean;
+        ++windowCount;
         absoluteGateSum += mMean;
         ++absoluteGateCount;
-        const int bin = gateBinFor (mMean);
-        gateBinSum   [(size_t) bin] += mMean;
-        gateBinCount [(size_t) bin] += 1;
     }
 
-    publishIntegrated();
+    if (scanLimit == 0 && absoluteGateCount > 0)
+        startRelativeScan();
 
     blockSumSquared = 0.0;
     blockSamplesRemaining = blockSize;
@@ -172,8 +188,8 @@ void LoudnessMeter::process (const float* L, const float* R, int numSamples) noe
 {
     if (sr <= 0.0 || L == nullptr || R == nullptr) return;
 
-    // Deferred requestReset(): applied on this thread so the histogram and
-    // ring wipes never race a concurrent process() pass.
+    // Deferred requestReset(): applied on this thread so the window and ring
+    // wipes never race a concurrent process() pass.
     if (resetRequested.exchange (false, std::memory_order_acquire))
         reset();
 
@@ -186,6 +202,8 @@ void LoudnessMeter::process (const float* L, const float* R, int numSamples) noe
         blockSumSquared += (double) kL * kL + (double) kR * kR;
         if (--blockSamplesRemaining == 0) finishBlock();
     }
+
+    advanceRelativeScan (numSamples);
 
     // True-peak detection (4× oversampled)
     // Per ITU BS.1770 Annex 2, true-peak is measured on the 4×-upsampled

--- a/src/dsp/LoudnessMeter.cpp
+++ b/src/dsp/LoudnessMeter.cpp
@@ -37,6 +37,15 @@ inline float msToLUFS (double meanSquared)
     if (meanSquared <= 1.0e-10) return -100.0f;
     return (float) (-0.691 + 10.0 * std::log10 (meanSquared));
 }
+
+inline double lufsToMS (double lufs)
+{
+    return std::pow (10.0, (lufs + 0.691) / 10.0);
+}
+
+// BS.1770-4's absolute gate. Blocks below it are excluded for good, so they
+// never enter the histogram.
+const double kAbsoluteGateMS = lufsToMS (-70.0);
 } // namespace
 
 LoudnessMeter::LoudnessMeter() = default;
@@ -66,8 +75,10 @@ void LoudnessMeter::reset()
 
     blockSamplesRemaining = blockSize;
     blockSumSquared = 0.0;
-    blockHistory.clear();
-    blockHistory.reserve ((size_t) kMaxHistoryBlocks);
+    for (auto& v : gateBinSum)   v = 0.0;
+    for (auto& v : gateBinCount) v = 0;
+    absoluteGateSum   = 0.0;
+    absoluteGateCount = 0;
     for (auto& v : momentaryRingMS)  v = 0.0;
     for (auto& v : shortTermRingMS)  v = 0.0;
     ringWritePos = 0;
@@ -79,7 +90,40 @@ void LoudnessMeter::reset()
     shortTermLufs.store (-100.0f, std::memory_order_relaxed);
     integratedLufs.store (-100.0f, std::memory_order_relaxed);
     truePeakDb.store    (-100.0f, std::memory_order_relaxed);
-    integratedCapped.store (false, std::memory_order_relaxed);
+}
+
+int LoudnessMeter::gateBinFor (double meanSquared) noexcept
+{
+    const double lufs = (double) msToLUFS (meanSquared);
+    const int bin = (int) std::floor ((lufs - kGateFloorLufs)
+                                        * (double) kGateBinsPerLu);
+    return std::clamp (bin, 0, kGateBins - 1);
+}
+
+void LoudnessMeter::publishIntegrated() noexcept
+{
+    if (absoluteGateCount == 0)
+    {
+        integratedLufs.store (-100.0f, std::memory_order_relaxed);
+        return;
+    }
+
+    // Relative gate: 10 LU below the mean of everything above the absolute
+    // gate. Both gates apply, so the effective threshold is the higher one.
+    const double meanPass1 = absoluteGateSum / absoluteGateCount;
+    const double gateMS = std::max (kAbsoluteGateMS,
+                                      lufsToMS ((double) msToLUFS (meanPass1) - 10.0));
+
+    double sum = 0.0;
+    int    count = 0;
+    for (int b = gateBinFor (gateMS); b < kGateBins; ++b)
+    {
+        sum   += gateBinSum   [(size_t) b];
+        count += gateBinCount [(size_t) b];
+    }
+
+    integratedLufs.store (count > 0 ? msToLUFS (sum / count) : -100.0f,
+                           std::memory_order_relaxed);
 }
 
 void LoudnessMeter::finishBlock()
@@ -87,11 +131,13 @@ void LoudnessMeter::finishBlock()
     // Mean squared over this 100 ms block (sum of L^2 + R^2 across both
     // channels, normalized by samples × 2 channels of weight 1.0).
     const double ms = blockSumSquared / std::max (1, blockSize);
-    if (blockHistory.size() < (size_t) kMaxHistoryBlocks)
+    if (ms > kAbsoluteGateMS)
     {
-        blockHistory.push_back (ms);
-        if (blockHistory.size() == (size_t) kMaxHistoryBlocks)
-            integratedCapped.store (true, std::memory_order_relaxed);
+        absoluteGateSum += ms;
+        ++absoluteGateCount;
+        const int bin = gateBinFor (ms);
+        gateBinSum   [(size_t) bin] += ms;
+        gateBinCount [(size_t) bin] += 1;
     }
 
     momentaryRingMS [(size_t) (ringWritePos % kMomentaryBlocks)] = ms;
@@ -110,39 +156,7 @@ void LoudnessMeter::finishBlock()
     momentaryLufs.store (msToLUFS (mMean), std::memory_order_relaxed);
     shortTermLufs.store (msToLUFS (sMean), std::memory_order_relaxed);
 
-    // Integrated - gated mean of all blocks. First gate: absolute,
-    // -70 LUFS. Then compute mean of those blocks; second gate: relative,
-    // -10 LU below the first-pass mean. Final integrated = mean of blocks
-    // passing both gates.
-    const double absoluteMS = std::pow (10.0, (-70.0 + 0.691) / 10.0);
-    double sumPass1 = 0.0;
-    int    countPass1 = 0;
-    for (auto v : blockHistory)
-        if (v > absoluteMS) { sumPass1 += v; ++countPass1; }
-
-    if (countPass1 == 0)
-    {
-        integratedLufs.store (-100.0f, std::memory_order_relaxed);
-    }
-    else
-    {
-        const double meanPass1 = sumPass1 / countPass1;
-        const double relativeGateLUFS = msToLUFS (meanPass1) - 10.0;
-        const double relativeMS = std::pow (10.0,
-                                              (relativeGateLUFS + 0.691) / 10.0);
-        const double gateMS = std::max (absoluteMS, relativeMS);
-
-        double sumPass2 = 0.0;
-        int    countPass2 = 0;
-        for (auto v : blockHistory)
-            if (v > gateMS) { sumPass2 += v; ++countPass2; }
-
-        if (countPass2 == 0)
-            integratedLufs.store (-100.0f, std::memory_order_relaxed);
-        else
-            integratedLufs.store (msToLUFS (sumPass2 / countPass2),
-                                   std::memory_order_relaxed);
-    }
+    publishIntegrated();
 
     blockSumSquared = 0.0;
     blockSamplesRemaining = blockSize;
@@ -152,9 +166,8 @@ void LoudnessMeter::process (const float* L, const float* R, int numSamples) noe
 {
     if (sr <= 0.0 || L == nullptr || R == nullptr) return;
 
-    // Deferred requestReset(): applied on this thread so the history clear
-    // and ring wipes never race a concurrent process() pass. prepare()'s
-    // reserve keeps the clear-and-refill allocation-free.
+    // Deferred requestReset(): applied on this thread so the histogram and
+    // ring wipes never race a concurrent process() pass.
     if (resetRequested.exchange (false, std::memory_order_acquire))
         reset();
 

--- a/src/dsp/LoudnessMeter.h
+++ b/src/dsp/LoudnessMeter.h
@@ -5,7 +5,6 @@
 #include <dsp/DuskFilters.hpp>
 
 #include <atomic>
-#include <vector>
 
 namespace duskstudio
 {
@@ -46,8 +45,8 @@ public:
     void reset();
 
     // Safe with audio running: zeroes the published readings immediately and
-    // defers the state reset to the next process() block, so the vector clear
-    // and ring wipes never race the audio thread.
+    // defers the state reset to the next process() block, so the histogram and
+    // ring wipes never race the audio thread.
     void requestReset() noexcept
     {
         // Publish the request first. process() checks again after publishing a
@@ -58,7 +57,6 @@ public:
         shortTermLufs.store (-100.0f, std::memory_order_relaxed);
         integratedLufs.store (-100.0f, std::memory_order_relaxed);
         truePeakDb.store    (-100.0f, std::memory_order_relaxed);
-        integratedCapped.store (false, std::memory_order_relaxed);
     }
 
     // Audio thread. L and R must each be at least `numSamples` floats.
@@ -71,14 +69,11 @@ public:
     float getShortTermLufs() const noexcept   { return shortTermLufs.load (std::memory_order_relaxed); }
     float getIntegratedLufs() const noexcept  { return integratedLufs.load (std::memory_order_relaxed); }
     float getTruePeakDb() const noexcept      { return truePeakDb.load (std::memory_order_relaxed); }
-    // True once the block-history ring has hit kMaxHistoryBlocks (1 hour
-    // at 100 ms per block). After that the integrated reading stops
-    // absorbing new blocks. UI surfaces this so the user knows the
-    // integrated value is frozen rather than silently inaccurate.
-    bool isIntegratedCapped() const noexcept  { return integratedCapped.load (std::memory_order_relaxed); }
 
 private:
     void finishBlock();
+    void publishIntegrated() noexcept;
+    static int gateBinFor (double meanSquared) noexcept;
 
     static constexpr int kMomentaryBlocks  = 4;    // 4 × 100 ms = 400 ms
     static constexpr int kShortTermBlocks  = 30;   // 30 × 100 ms = 3 s
@@ -94,13 +89,29 @@ private:
     int    blockSize             = 0;        // samples per 100 ms block
     double blockSumSquared       = 0.0;       // sum of (L^2 + R^2) of K-weighted samples
 
-    // Block history. Stored as MS-per-block; LUFS is computed on demand
-    // from sliding-window means. Capped at kMaxHistoryBlocks (1 hour at
-    // 100 ms per block) so the audio-thread push_back in finishBlock never
-    // reallocates. Sessions longer than an hour silently saturate - the
-    // integrated reading stops absorbing new blocks past the cap.
-    static constexpr int kMaxHistoryBlocks = 36000;
-    std::vector<double> blockHistory;
+    // Integrated gating. The absolute (-70 LUFS) gate is a fixed threshold, so
+    // the blocks passing it accumulate into a running sum. The relative gate
+    // moves with the program mean, so its block set cannot: publishing needs
+    // the summed energy of every block above a threshold only known at publish
+    // time. A histogram over block loudness keeps that lookup at kGateBins, so
+    // the callback's cost per block is fixed rather than growing with program
+    // length - holding one entry per block instead means scanning 36000 of
+    // them, twice, an hour into a session.
+    //
+    // Bins carry the true summed energy of the blocks in them, so every bin
+    // except the gate's own is exact; blocks sharing the gate's bin are decided
+    // as a group. Measured against the exact two-pass form, the worst case over
+    // uniform, two-level, lognormal, long-fade and gate-straddling programs is
+    // 0.03 LU, inside EBU Tech 3341's +/-0.1 LU meter tolerance.
+    static constexpr int    kGateBinsPerLu = 10;                      // 0.1 LU
+    static constexpr double kGateFloorLufs = -70.0;                   // absolute gate
+    static constexpr int    kGateBins      = 94 * kGateBinsPerLu + 1; // to +24 LUFS
+
+    double gateBinSum       [kGateBins] = {};
+    int    gateBinCount     [kGateBins] = {};
+    double absoluteGateSum   = 0.0;
+    int    absoluteGateCount = 0;
+
     double  momentaryRingMS [kMomentaryBlocks] = {};
     double  shortTermRingMS [kShortTermBlocks] = {};
     int     ringWritePos = 0;
@@ -119,11 +130,6 @@ private:
     std::atomic<float> shortTermLufs   { -100.0f };
     std::atomic<float> integratedLufs  { -100.0f };
     std::atomic<float> truePeakDb      { -100.0f };
-    // Set once when blockHistory hits kMaxHistoryBlocks; the integrated
-    // reading stops absorbing new blocks past that point. Audio thread
-    // sets via relaxed store on the first overflow, UI polls via the
-    // public accessor.
-    std::atomic<bool>  integratedCapped { false };
     std::atomic<bool>  resetRequested   { false };
 };
 } // namespace duskstudio

--- a/src/dsp/LoudnessMeter.h
+++ b/src/dsp/LoudnessMeter.h
@@ -5,6 +5,7 @@
 #include <dsp/DuskFilters.hpp>
 
 #include <atomic>
+#include <vector>
 
 namespace duskstudio
 {
@@ -45,7 +46,7 @@ public:
     void reset();
 
     // Safe with audio running: zeroes the published readings immediately and
-    // defers the state reset to the next process() block, so the histogram and
+    // defers the state reset to the next process() block, so the window and
     // ring wipes never race the audio thread.
     void requestReset() noexcept
     {
@@ -72,8 +73,8 @@ public:
 
 private:
     void finishBlock();
-    void publishIntegrated() noexcept;
-    static int gateBinFor (double meanSquared) noexcept;
+    void startRelativeScan() noexcept;
+    void advanceRelativeScan (int numSamples) noexcept;
 
     static constexpr int kMomentaryBlocks  = 4;    // 4 × 100 ms = 400 ms
     static constexpr int kShortTermBlocks  = 30;   // 30 × 100 ms = 3 s
@@ -90,27 +91,41 @@ private:
     double blockSumSquared       = 0.0;       // sum of (L^2 + R^2) of K-weighted samples
 
     // Integrated gating. The absolute (-70 LUFS) gate is a fixed threshold, so
-    // the blocks passing it accumulate into a running sum. The relative gate
-    // moves with the program mean, so its block set cannot: publishing needs
-    // the summed energy of every block above a threshold only known at publish
-    // time. A histogram over block loudness keeps that lookup at kGateBins, so
-    // the callback's cost per block is fixed rather than growing with program
-    // length - holding one entry per block instead means scanning 36000 of
-    // them, twice, an hour into a session.
+    // the windows passing it accumulate into running sums, exactly and in O(1).
+    // The relative gate moves with the program mean, so its window set has to
+    // be recomputed against a threshold only known at publish time.
     //
-    // Bins carry the true summed energy of the blocks in them, so every bin
-    // except the gate's own is exact; blocks sharing the gate's bin are decided
-    // as a group. Measured against the exact two-pass form, the worst case over
-    // uniform, two-level, lognormal, long-fade and gate-straddling programs is
-    // 0.03 LU, inside EBU Tech 3341's +/-0.1 LU meter tolerance.
-    static constexpr int    kGateBinsPerLu = 10;                      // 0.1 LU
-    static constexpr double kGateFloorLufs = -70.0;                   // absolute gate
-    static constexpr int    kGateBins      = 94 * kGateBinsPerLu + 1; // to +24 LUFS
+    // That second pass reads every retained window rather than a bucketed
+    // summary of them. Bucketing bounds the work but cannot be made exact: the
+    // gate can fall inside a bucket, and the windows sharing it then have to be
+    // included or excluded as a group. On a program whose quiet material sits
+    // at the gate - a single loud window against ten 0.01 LU below it - that is
+    // 10 LU of error, and no choice of bucket edge or width fixes it, since
+    // equal-valued windows always share a bucket.
+    //
+    // Scanning is what costs, so the scan is spread across callbacks in
+    // proportion to elapsed audio (the budgeting the hardware-insert ping
+    // uses), completing inside one 100 ms gating period. One unamortised pass
+    // measures 27 us, which is 16 % of a 16-sample callback at 96 kHz.
+    static constexpr int kMaxWindows = 36000;   // 1 hour at one per 100 ms
 
-    double gateBinSum       [kGateBins] = {};
-    int    gateBinCount     [kGateBins] = {};
+    // Sized once in prepare() so reset() - which runs on the audio thread for a
+    // deferred requestReset - never allocates. Saturating at kMaxWindows freezes
+    // the integrated reading rather than dropping the oldest material, which
+    // would silently redefine "entire program".
+    std::vector<double> windowMS;
+    int    windowCount       = 0;
     double absoluteGateSum   = 0.0;
     int    absoluteGateCount = 0;
+
+    // In-flight relative-gate scan over windowMS[0, scanLimit). scanLimit == 0
+    // means idle; finishBlock starts the next pass once one completes.
+    double scanGateMS = 0.0;
+    double scanSum    = 0.0;
+    double scanCredit = 0.0;
+    int    scanCount  = 0;
+    int    scanPos    = 0;
+    int    scanLimit  = 0;
 
     double  momentaryRingMS [kMomentaryBlocks] = {};
     double  shortTermRingMS [kShortTermBlocks] = {};

--- a/src/dsp/LoudnessMeter.h
+++ b/src/dsp/LoudnessMeter.h
@@ -107,7 +107,11 @@ private:
     // proportion to elapsed audio (the budgeting the hardware-insert ping
     // uses), completing inside one 100 ms gating period. One unamortised pass
     // measures 27 us, which is 16 % of a 16-sample callback at 96 kHz.
-    static constexpr int kMaxWindows = 36000;   // 1 hour at one per 100 ms
+    // Capacity for RETAINED windows. Anything under the absolute gate is never
+    // retained, so this bounds an hour of material that counts toward the
+    // reading rather than an hour of wall clock - a session left running
+    // between takes keeps integrating instead of freezing on elapsed time.
+    static constexpr int kMaxWindows = 36000;   // 1 hour of gated-in windows
 
     // Sized once in prepare() so reset() - which runs on the audio thread for a
     // deferred requestReset - never allocates. Saturating at kMaxWindows freezes

--- a/src/dsp/LoudnessMeter.h
+++ b/src/dsp/LoudnessMeter.h
@@ -26,8 +26,8 @@ namespace duskstudio
 //      atomic unit of BS.1770 measurement.
 //   3. Each completed block is pushed into a ring buffer; sliding-window
 //      means over the last 4 blocks (M) and 30 blocks (S) give those
-//      readings. The integrated reading averages all gated blocks since
-//      the last reset.
+//      readings. The integrated reading averages the gated 400 ms windows
+//      (the M window, one per 100 ms step) since the last reset.
 //
 // Threading:
 //   - prepare() / reset() - message thread with audio quiesced (prepare path).

--- a/tests/dsp_loudness_meter.cpp
+++ b/tests/dsp_loudness_meter.cpp
@@ -108,3 +108,59 @@ TEST_CASE ("LoudnessMeter requestReset zeroes readings and drops the history", "
         m.process (L.data() + off, R.data() + off, std::min (512, kSecond - off));
     REQUIRE (m.getIntegratedLufs() < loud - 20.0f);
 }
+
+namespace
+{
+// Feeds `blocks` x 100 ms of a 997 Hz sine at `amp`, in 480-sample chunks so
+// every chunk divides the 4800-sample gating block exactly.
+void feedTone (duskstudio::LoudnessMeter& m, double sr, float amp, int blocks)
+{
+    constexpr double twoPi = 6.283185307179586476925286766559;
+    const int chunk = 480;
+    const int total = blocks * (int) (sr * 0.1);
+    std::vector<float> L ((size_t) chunk), R ((size_t) chunk);
+    for (int done = 0; done < total; done += chunk)
+    {
+        for (int i = 0; i < chunk; ++i)
+            L[(size_t) i] = R[(size_t) i] =
+                amp * (float) std::sin (twoPi * 997.0 * (done + i) / sr);
+        m.process (L.data(), R.data(), chunk);
+    }
+}
+} // namespace
+
+// The integrated reading is gated, and the gating runs off a loudness
+// histogram rather than a per-block scan. Both gates have to keep behaving:
+// a histogram that mis-bins puts the relative gate on the wrong side of the
+// quiet material and the reading silently drifts.
+TEST_CASE ("LoudnessMeter integrated gating", "[dsp][loudness]")
+{
+    constexpr double sr = 48000.0;
+
+    SECTION ("uniform program reads the same integrated as momentary")
+    {
+        duskstudio::LoudnessMeter m;
+        m.prepare (sr, 480);
+        feedTone (m, sr, 0.5f, 12);
+
+        // Every block carries the same energy, so the relative gate lands 10 LU
+        // below all of them and excludes nothing.
+        const float momentary = m.getMomentaryLufs();
+        REQUIRE (momentary > -40.0f);
+        REQUIRE_THAT (m.getIntegratedLufs(), WithinAbs (momentary, 0.1f));
+    }
+
+    SECTION ("relative gate excludes quiet material")
+    {
+        duskstudio::LoudnessMeter m;
+        m.prepare (sr, 480);
+        feedTone (m, sr, 0.5f, 12);
+        const float loud = m.getMomentaryLufs();
+
+        // 20 dB down: above the -70 LUFS absolute gate, so these blocks reach
+        // the histogram, but below the relative gate once the loud half sets
+        // the mean. Averaging them in instead would read ~2.97 LU lower.
+        feedTone (m, sr, 0.05f, 12);
+        REQUIRE_THAT (m.getIntegratedLufs(), WithinAbs (loud, 0.3f));
+    }
+}

--- a/tests/dsp_loudness_meter.cpp
+++ b/tests/dsp_loudness_meter.cpp
@@ -6,6 +6,7 @@
 #include <dsp/DuskFilters.hpp>
 #include <juce_dsp/juce_dsp.h>
 
+#include <algorithm>
 #include <cmath>
 #include <random>
 #include <vector>
@@ -111,11 +112,12 @@ TEST_CASE ("LoudnessMeter requestReset zeroes readings and drops the history", "
 
 namespace
 {
+constexpr double kTau = 6.283185307179586476925286766559;
+
 // Feeds `blocks` x 100 ms of a 997 Hz sine at `amp`, in 480-sample chunks so
 // every chunk divides the 4800-sample gating block exactly.
 void feedTone (duskstudio::LoudnessMeter& m, double sr, float amp, int blocks)
 {
-    constexpr double twoPi = 6.283185307179586476925286766559;
     const int chunk = 480;
     const int total = blocks * (int) (sr * 0.1);
     std::vector<float> L ((size_t) chunk), R ((size_t) chunk);
@@ -123,52 +125,135 @@ void feedTone (duskstudio::LoudnessMeter& m, double sr, float amp, int blocks)
     {
         for (int i = 0; i < chunk; ++i)
             L[(size_t) i] = R[(size_t) i] =
-                amp * (float) std::sin (twoPi * 997.0 * (done + i) / sr);
+                amp * (float) std::sin (kTau * 997.0 * (done + i) / sr);
         m.process (L.data(), R.data(), chunk);
+    }
+}
+
+double msToLufsT (double ms) { return ms <= 1.0e-10 ? -100.0
+                                                    : -0.691 + 10.0 * std::log10 (ms); }
+double lufsToMsT (double l)  { return std::pow (10.0, (l + 0.691) / 10.0); }
+
+struct GateResult
+{
+    double lufs;             // exact gated mean of the windows
+    double nearestToGateLu;  // closest any retained window sits to the threshold
+};
+
+// BS.1770-4 gating applied straight to the window list with no bucketing:
+// absolute gate at -70 LUFS, then 10 LU below the mean of what survives it.
+GateResult exactGating (const std::vector<double>& windows)
+{
+    const double absGate = lufsToMsT (-70.0);
+    double s1 = 0.0;
+    int    c1 = 0;
+    for (double v : windows)
+        if (v > absGate) { s1 += v; ++c1; }
+    if (c1 == 0) return { -100.0, 1.0e9 };
+
+    const double gate = std::max (absGate, lufsToMsT (msToLufsT (s1 / c1) - 10.0));
+    double s2 = 0.0;
+    int    c2 = 0;
+    double nearest = 1.0e9;
+    for (double v : windows)
+    {
+        if (v <= absGate) continue;
+        nearest = std::min (nearest, std::fabs (msToLufsT (v) - msToLufsT (gate)));
+        if (v > gate) { s2 += v; ++c2; }
+    }
+    return { c2 > 0 ? msToLufsT (s2 / c2) : -100.0, nearest };
+}
+
+// Drives the meter one 100 ms gating step at a time, collecting the 400 ms
+// windows it gates on. Momentary IS that window, so the meter hands back its
+// own gating input and the test can re-gate it independently.
+void feedSteps (duskstudio::LoudnessMeter& m, double sr, float amp, int steps,
+                std::vector<double>& windows, int& step)
+{
+    const int len = (int) (sr * 0.1);
+    std::vector<float> L ((size_t) len), R ((size_t) len);
+    for (int s = 0; s < steps; ++s)
+    {
+        for (int i = 0; i < len; ++i)
+            L[(size_t) i] = R[(size_t) i] =
+                amp * (float) std::sin (kTau * 997.0 * (step * len + i) / sr);
+        m.process (L.data(), R.data(), len);
+        ++step;
+        if (step >= 4) windows.push_back (lufsToMsT ((double) m.getMomentaryLufs()));
     }
 }
 } // namespace
 
-// The integrated reading is gated, and the gating runs off a loudness
-// histogram rather than a per-block scan. Both gates have to keep behaving:
-// a histogram that mis-bins puts the relative gate on the wrong side of the
-// quiet material and the reading silently drifts.
-TEST_CASE ("LoudnessMeter integrated gating", "[dsp][loudness]")
+TEST_CASE ("LoudnessMeter integrated equals momentary on a uniform program",
+            "[dsp][loudness]")
+{
+    duskstudio::LoudnessMeter m;
+    m.prepare (48000.0, 480);
+    feedTone (m, 48000.0, 0.5f, 12);
+
+    // Every block carries the same energy, so the relative gate lands 10 LU
+    // below all of them and excludes nothing.
+    const float momentary = m.getMomentaryLufs();
+    REQUIRE (momentary > -40.0f);
+    REQUIRE_THAT (m.getIntegratedLufs(), WithinAbs (momentary, 0.1f));
+}
+
+TEST_CASE ("LoudnessMeter relative gate excludes quiet material", "[dsp][loudness]")
 {
     constexpr double sr = 48000.0;
+    duskstudio::LoudnessMeter m;
+    m.prepare (sr, 480);
+    feedTone (m, sr, 0.5f, 12);
+    const float loud = m.getMomentaryLufs();
 
-    SECTION ("uniform program reads the same integrated as momentary")
+    // 20 dB down: above the -70 LUFS absolute gate, so these windows are
+    // retained, but below the relative gate once the loud half sets the mean.
+    feedTone (m, sr, 0.05f, 12);
+
+    // Gating windows are 400 ms stepping 100 ms, so three of them straddle the
+    // level change and survive the relative gate alongside the fully loud ones,
+    // landing ~0.6 LU below the loud passage. The bounds bracket that: gating
+    // 100 ms sub-blocks directly would sit back up at `loud`, and averaging the
+    // quiet half in ungated would read ~3 LU lower.
+    const float integrated = m.getIntegratedLufs();
+    REQUIRE (integrated < loud - 0.3f);
+    REQUIRE (integrated > loud - 1.0f);
+}
+
+// The relative threshold is only known at publish time, so the second pass has
+// to apply it to the windows themselves. Summarising them into buckets bounds
+// the work but decides the bucket holding the threshold as a group, which for a
+// quiet passage landing inside it is ~10 LU of error. Sweep the quiet level
+// across the threshold and require the meter to agree with an independent exact
+// gating of the very windows it measured.
+TEST_CASE ("LoudnessMeter gating is exact for windows sitting on the threshold",
+            "[dsp][loudness]")
+{
+    constexpr double sr = 48000.0;
+    bool sawNearThreshold = false;
+
+    for (int stepDb = 0; stepDb <= 30; ++stepDb)
     {
-        duskstudio::LoudnessMeter m;
-        m.prepare (sr, 480);
-        feedTone (m, sr, 0.5f, 12);
+        const double quietDb = -16.0 + 0.1 * stepDb;
+        const float  quietAmp = 0.5f * (float) std::pow (10.0, quietDb / 20.0);
 
-        // Every block carries the same energy, so the relative gate lands 10 LU
-        // below all of them and excludes nothing.
-        const float momentary = m.getMomentaryLufs();
-        REQUIRE (momentary > -40.0f);
-        REQUIRE_THAT (m.getIntegratedLufs(), WithinAbs (momentary, 0.1f));
+        duskstudio::LoudnessMeter m;
+        m.prepare (sr, (int) (sr * 0.1));
+
+        std::vector<double> windows;
+        int step = 0;
+        feedSteps (m, sr, 0.5f, 10, windows, step);
+        feedSteps (m, sr, quietAmp, 20, windows, step);
+        // Silence drains the in-flight pass. Pure-silence windows fall below
+        // the absolute gate, so they move neither the meter nor the reference.
+        feedSteps (m, sr, 0.0f, 8, windows, step);
+
+        const auto ref = exactGating (windows);
+        if (ref.nearestToGateLu < 0.1) sawNearThreshold = true;
+        REQUIRE_THAT ((double) m.getIntegratedLufs(), WithinAbs (ref.lufs, 0.01));
     }
 
-    SECTION ("relative gate excludes quiet material")
-    {
-        duskstudio::LoudnessMeter m;
-        m.prepare (sr, 480);
-        feedTone (m, sr, 0.5f, 12);
-        const float loud = m.getMomentaryLufs();
-
-        // 20 dB down: above the -70 LUFS absolute gate, so these windows reach
-        // the histogram, but below the relative gate once the loud half sets
-        // the mean.
-        feedTone (m, sr, 0.05f, 12);
-
-        // Gating windows are 400 ms stepping 100 ms, so three of them straddle
-        // the level change and survive the relative gate alongside the fully
-        // loud ones, landing ~0.6 LU below the loud passage. The bounds bracket
-        // that: gating 100 ms sub-blocks directly would sit back up at `loud`,
-        // and averaging the quiet half in ungated would read ~3 LU lower.
-        const float integrated = m.getIntegratedLufs();
-        REQUIRE (integrated < loud - 0.3f);
-        REQUIRE (integrated > loud - 1.0f);
-    }
+    // Without this the sweep could pass while never reaching the case that
+    // separates exact gating from a bucketed approximation.
+    REQUIRE (sawNearThreshold);
 }

--- a/tests/dsp_loudness_meter.cpp
+++ b/tests/dsp_loudness_meter.cpp
@@ -220,6 +220,27 @@ TEST_CASE ("LoudnessMeter relative gate excludes quiet material", "[dsp][loudnes
     REQUIRE (integrated > loud - 1.0f);
 }
 
+// Windows under the absolute gate are never retained, so the one-hour capacity
+// bounds an hour of material that counts rather than an hour of wall clock.
+// Any amount of trailing silence has to leave the reading exactly where it was.
+TEST_CASE ("LoudnessMeter silence does not consume integrated capacity",
+            "[dsp][loudness]")
+{
+    constexpr double sr = 48000.0;
+    auto readAfterSilence = [sr] (int silentBlocks)
+    {
+        duskstudio::LoudnessMeter m;
+        m.prepare (sr, 480);
+        feedTone (m, sr, 0.5f, 12);
+        feedTone (m, sr, 0.0f, silentBlocks);
+        return m.getIntegratedLufs();
+    };
+
+    const float brief = readAfterSilence (10);
+    REQUIRE (brief > -40.0f);
+    REQUIRE_THAT (readAfterSilence (120), WithinAbs (brief, 1.0e-4f));
+}
+
 // The relative threshold is only known at publish time, so the second pass has
 // to apply it to the windows themselves. Summarising them into buckets bounds
 // the work but decides the bucket holding the threshold as a group, which for a

--- a/tests/dsp_loudness_meter.cpp
+++ b/tests/dsp_loudness_meter.cpp
@@ -157,10 +157,18 @@ TEST_CASE ("LoudnessMeter integrated gating", "[dsp][loudness]")
         feedTone (m, sr, 0.5f, 12);
         const float loud = m.getMomentaryLufs();
 
-        // 20 dB down: above the -70 LUFS absolute gate, so these blocks reach
+        // 20 dB down: above the -70 LUFS absolute gate, so these windows reach
         // the histogram, but below the relative gate once the loud half sets
-        // the mean. Averaging them in instead would read ~2.97 LU lower.
+        // the mean.
         feedTone (m, sr, 0.05f, 12);
-        REQUIRE_THAT (m.getIntegratedLufs(), WithinAbs (loud, 0.3f));
+
+        // Gating windows are 400 ms stepping 100 ms, so three of them straddle
+        // the level change and survive the relative gate alongside the fully
+        // loud ones, landing ~0.6 LU below the loud passage. The bounds bracket
+        // that: gating 100 ms sub-blocks directly would sit back up at `loud`,
+        // and averaging the quiet half in ungated would read ~3 LU lower.
+        const float integrated = m.getIntegratedLufs();
+        REQUIRE (integrated < loud - 0.3f);
+        REQUIRE (integrated > loud - 1.0f);
     }
 }


### PR DESCRIPTION
Closes the remaining `src/dsp` items on #146.

Note on reading the history: the gating scan was first bounded with a loudness histogram (`87c7f92`), and review found a program shape where bucketing is ~10 LU wrong. `2934300` replaces the buckets with an exact scan, so the histogram does not survive into the final state. Reviewing the diff as a whole is more useful than commit by commit.

## Bound the gating scan (`87c7f92`, superseded in part by `2934300`)

`finishBlock` walked the whole block history twice per 100 ms block to apply BS.1770-4's two gates, so the audio callback's cost grew with program length: an hour in, 36000 doubles scanned twice, unbounded by buffer size.

The two gates behave differently, and the split is what the final design keeps:

- The **absolute** gate is a fixed -70 LUFS threshold. A window's verdict never changes, so its sum is incremental and exact, O(1).
- The **relative** gate moves with the program mean, so its window set has to be recomputed against a threshold only known at publish time.

## Apply the exact relative gate (`2934300`)

The first attempt summarised windows into 0.1 LU buckets to bound that second pass. That cannot be made exact: the threshold can fall inside a bucket, and the windows sharing it are then all included or all excluded. On a program whose quiet material lands there - one loud window against ten 0.01 LU below the threshold - that is **10 LU** of error. No bucket edge or width fixes it, verified:

| rule | reviewer's program | mirror (just above the gate) |
|---|---|---|
| include the threshold bucket | -10.0 LU | exact |
| exclude the threshold bucket | exact | +10.0 LU |
| `ceil` instead of `floor` | -10.0 LU | exact |
| 0.01 LU buckets | -10.0 LU | exact |

Equal-valued windows always share a bucket, so narrowing them does not help.

So the windows are retained and the threshold applied to them directly. Only the relative pass scans, and that scan is budgeted against elapsed audio the same way the hardware-insert ping correlator is, completing inside one 100 ms gating period without any callback carrying it. One unamortised pass measures 27 us, which is 16 % of a 16-sample callback at 96 kHz - that measurement is why it is amortised rather than simply left as one pass.

Retaining windows brings back the one-hour ceiling, which freezes the integrated reading rather than dropping the oldest material. Documented in MANUAL (`14c070c`); it was previously undocumented.

## Gate over 400 ms windows (`6adbda2`)

BS.1770-4 gates 400 ms blocks overlapping by 75 %, one per 100 ms step. The gating ran over the 100 ms sub-blocks instead, which discards short quiet dips that a 400 ms window rides over, so LUFS-I disagreed with R128 compliance meters.

No new state: the sub-blocks are equal length, so the mean of the momentary ring is exactly the 400 ms window's mean square. The first three sub-blocks produce no gating block. Momentary and short-term are unaffected.

MANUAL already claimed "gated per BS.1770", so the code caught up to the documentation rather than the reverse.

## Correct the limiter's group-delay claim (`11166a8`)

The issue reports a one-sample over-report. It is half a sample: `latency()` returns `23.0 + 3.5 = 26.5` at 4x, which integer PDC cannot express, so there is nothing to fix in the code. The stale part was the comment claiming the group delay is a whole number and compensation exact.

## Tests

Three cases, each verified to fail against the defect it guards:

- integrated equals momentary on a uniform program
- the relative gate excludes quiet material, bracketed so it fails both a regression to 100 ms gating (reads back at `loud`) and a broken relative gate (reads ~3 LU low)
- gating is exact for windows sitting on the threshold: gates the meter's own reported windows independently (momentary **is** the 400 ms gating window) across a sweep of quiet levels crossing the threshold, requiring agreement to 0.01 LU. The sweep asserts it reached a near-threshold case so it cannot pass vacuously; reinstating bucketed comparison fails it by 4 LU.

526/526 pass, no new warnings, JUCE gate unchanged at 179 / 9257.

## Review notes

- **API removal:** `isIntegratedCapped()` is gone. It had no callers in src, tests or MANUAL. The ceiling it reported still exists and is now documented in MANUAL instead.
- **Counter widths:** an earlier review round asked for 64-bit gating counters. `absoluteGateCount` increments only inside the `windowCount < kMaxWindows` guard, so it and every scan counter are structurally bounded at 36000. No overflow is reachable.
- **Absolute gate comparison** stays `>`, matching BS.1770-4 clause 3 (`l_j > the absolute threshold`).

## Not covered here

Two notes from the merged ping work (#165) are unaffected by this branch and remain open on #146: `kCorrelationMacsPerSecond` sitting ~30 % above the rate it replaced at 48 k/512, and the brute-force correlator that FFT correlation would cut ~100x.
