### PR TITLE
Fill a partial session slot's absent keys from the model default (#161)

### DIFF
--- a/src/session/SessionSerializer.cpp
+++ b/src/session/SessionSerializer.cpp
@@ -857,6 +857,44 @@ JObj busToObject (const Bus& a)
     return obj;
 }
 
+// RFC 7396 reads a null member as "delete this key". Here a null can only mean
+// "unspecified", and deleting the key would drop the slot back onto whatever
+// the previously loaded session left in the live Session - the exact hole the
+// overlay exists to close. Objects are filtered recursively; arrays pass
+// through untouched so they keep replacing wholesale.
+nlohmann::json withoutNulls (const nlohmann::json& v)
+{
+    if (! v.is_object()) return v;
+    nlohmann::json out = nlohmann::json::object();
+    for (auto it = v.begin(); it != v.end(); ++it)
+        if (! it.value().is_null())
+            out[it.key()] = withoutNulls (it.value());
+    return out;
+}
+
+const nlohmann::json& objectAt (const nlohmann::json& arr, int index)
+{
+    static const nlohmann::json empty = nlohmann::json::object();
+    return index >= 0 && index < (int) arr.size() && arr[(size_t) index].is_object()
+               ? arr[(size_t) index] : empty;
+}
+
+// Every mixer setter in the restore path is conditional on its key being
+// present, so a slot that omits one keeps the previously loaded session's
+// value for it. Overlay what the file gives on the serialized model default,
+// which carries every key, so an absent key resolves to the model default
+// instead of to live state. A slot that is missing, not an object, or empty
+// comes back as the default whole.
+nlohmann::json slotWithDefaults (const nlohmann::json& defaults,
+                                 const nlohmann::json& arr, int index)
+{
+    nlohmann::json merged = objectAt (defaults, index);
+    const auto& fromFile = objectAt (arr, index);
+    if (! fromFile.empty())
+        merged.merge_patch (withoutNulls (fromFile));
+    return merged;
+}
+
 void restoreTrack (Track& t, int trackIndex, const nlohmann::json& v,
                    double defaultRecordBpm,
                    const juce::File& sessionDir,
@@ -929,9 +967,13 @@ void restoreTrack (Track& t, int trackIndex, const nlohmann::json& v,
     // unrouted rather than pointing at whatever now sits at the old slot. The
     // legacy raw int is still honoured for sessions saved before identifiers
     // existed.
-    if (json::has (v, "midi_input_id"))
+    // Keyed on a NON-EMPTY identifier, not on the key being present: an unrouted
+    // track serializes midi_input_id as "", so presence alone would send a
+    // session that only carries the legacy index down the identifier path and
+    // discard the index.
+    if (auto id = json::getString (v, "midi_input_id"); ! id.empty())
     {
-        t.midiInputIdentifier = json::getString (v, "midi_input_id");
+        t.midiInputIdentifier = id;
         t.midiInputIndex.store (-1, std::memory_order_relaxed);
     }
     else
@@ -940,9 +982,9 @@ void restoreTrack (Track& t, int trackIndex, const nlohmann::json& v,
         t.midiInputIdentifier = juce::String();
     }
     // Same shape on the external-MIDI-output side.
-    if (json::has (v, "midi_output_id"))
+    if (auto id = json::getString (v, "midi_output_id"); ! id.empty())
     {
-        t.midiOutputIdentifier = json::getString (v, "midi_output_id");
+        t.midiOutputIdentifier = id;
         t.midiOutputIndex.store (-1, std::memory_order_relaxed);
     }
     else
@@ -1855,29 +1897,19 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
     // default.
     // A listed-but-non-object bus / aux entry ("buses": [null]) is restored from
     // the defaults too, so the default sections have to be there for it as well.
-    const auto hasNonObject = [] (const nlohmann::json& arr)
-    {
-        return std::any_of (arr.begin(), arr.end(),
-                            [] (const nlohmann::json& v) { return ! v.is_object(); });
-    };
-    nlohmann::json sectionDefaults;
-    if ((int) json::array (root, "tracks").size() < Session::kNumTracks
-        || (int) json::array (root, "buses").size() < Session::kNumBuses
-        || (int) json::array (root, "aux_lanes").size() < Session::kNumAuxLanes
-        || hasNonObject (json::array (root, "tracks"))
-        || hasNonObject (json::array (root, "buses"))
-        || hasNonObject (json::array (root, "aux_lanes")))
-    {
-        sectionDefaults = nlohmann::json::parse (serialize (Session{}).toStdString(), nullptr, false);
-        // Re-parsing our own output cannot fail in practice, but a discarded
-        // value degrades straight back into the ghost-content bug the defaults
-        // exist to prevent, so say so rather than letting it pass unremarked.
-        if (sectionDefaults.is_discarded())
-            std::fprintf (stderr,
-                          "[Dusk Studio/SessionSerializer] the default-session template failed "
-                          "to parse; slots this file does not describe keep the previously "
-                          "loaded session's state\n");
-    }
+    // Built for every load, not just short files: a slot that IS listed can be
+    // partially populated, and each key it omits needs the same model default a
+    // missing slot gets.
+    nlohmann::json sectionDefaults = nlohmann::json::parse (
+        serialize (Session{}).toStdString(), nullptr, false);
+    // Re-parsing our own output cannot fail in practice, but a discarded
+    // value degrades straight back into the ghost-content bug the defaults
+    // exist to prevent, so say so rather than letting it pass unremarked.
+    if (sectionDefaults.is_discarded())
+        std::fprintf (stderr,
+                      "[Dusk Studio/SessionSerializer] the default-session template failed "
+                      "to parse; keys this file does not describe keep the previously "
+                      "loaded session's state\n");
 
     {
         const auto& tracks = ! json::array (root, "tracks").empty()
@@ -1891,12 +1923,13 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
         // slot driven from {} keeps the prior session's name, colour, fader, pan,
         // sends and hardware routing. Drive it from the serialized default track,
         // which carries every key at its model default. A slot that IS listed but
-        // isn't an object ("tracks": [null]) takes the same route.
+        // isn't an object ("tracks": [null]) takes the same route, and one that is
+        // listed but only partially populated gets the default for each key it
+        // leaves out.
         const auto& trackDefaults = json::array (sectionDefaults, "tracks");
         for (int i = 0; i < Session::kNumTracks; ++i)
             restoreTrack (s.track (i), i,
-                          i < (int) tracks.size() && tracks[(size_t) i].is_object()
-                              ? tracks[(size_t) i] : trackDefaults[(size_t) i],
+                          slotWithDefaults (trackDefaults, tracks, i),
                           sessionLoadBpm, s.getSessionDirectory(),
                           s.missingAudioFilesAfterLoad);
     }
@@ -1905,9 +1938,7 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
                                      ? json::array (root, "buses") : json::array (sectionDefaults, "buses");
         const auto& busDefaults = json::array (sectionDefaults, "buses");
         for (int i = 0; i < Session::kNumBuses; ++i)
-            restoreBus (s.bus (i),
-                        i < (int) busesArr.size() && busesArr[(size_t) i].is_object()
-                            ? busesArr[(size_t) i] : busDefaults[(size_t) i],
+            restoreBus (s.bus (i), slotWithDefaults (busDefaults, busesArr, i),
                         sessionLoadBpm);
     }
     {
@@ -1916,8 +1947,7 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
         const auto& auxDefaults  = json::array (sectionDefaults, "aux_lanes");
         for (int i = 0; i < Session::kNumAuxLanes; ++i)
         {
-            const auto& v = i < (int) auxLanesArr.size() && auxLanesArr[(size_t) i].is_object()
-                                ? auxLanesArr[(size_t) i] : auxDefaults[(size_t) i];
+            const auto v = slotWithDefaults (auxDefaults, auxLanesArr, i);
             auto& lane = s.auxLane (i);
             if (auto str = json::getString (v, "name");   ! str.empty()) lane.name   = str;
             if (auto str = json::getString (v, "colour"); ! str.empty()) lane.colour = hexToColour (str, lane.colour);

--- a/src/session/SessionSerializer.cpp
+++ b/src/session/SessionSerializer.cpp
@@ -20,6 +20,8 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <utility>
+#include <vector>
 
 namespace duskstudio
 {
@@ -857,19 +859,28 @@ JObj busToObject (const Bus& a)
     return obj;
 }
 
-// RFC 7396 reads a null member as "delete this key". Here a null can only mean
-// "unspecified", and deleting the key would drop the slot back onto whatever
-// the previously loaded session left in the live Session - the exact hole the
-// overlay exists to close. Objects are filtered recursively; arrays pass
-// through untouched so they keep replacing wholesale.
-nlohmann::json withoutNulls (const nlohmann::json& v)
+// Copying a slot and filling it both recurse once per nesting level, and a
+// hand-edited file can nest one as deep as it likes. Nothing this serializer
+// writes goes past aux_lane -> plugin_slots -> hardware_insert, so a slot
+// nested past this bound holds nothing the restore path reads: treat it as
+// unusable rather than running the stack out on it. The depth walk is itself
+// iterative for the same reason.
+constexpr int kMaxSlotDepth = 32;
+
+bool withinSlotDepth (const nlohmann::json& v)
 {
-    if (! v.is_object()) return v;
-    nlohmann::json out = nlohmann::json::object();
-    for (auto it = v.begin(); it != v.end(); ++it)
-        if (! it.value().is_null())
-            out[it.key()] = withoutNulls (it.value());
-    return out;
+    std::vector<std::pair<const nlohmann::json*, int>> pending { { &v, 0 } };
+    while (! pending.empty())
+    {
+        const auto* node  = pending.back().first;
+        const int   depth = pending.back().second;
+        pending.pop_back();
+        if (! node->is_structured()) continue;
+        if (depth >= kMaxSlotDepth) return false;
+        for (const auto& child : *node)
+            pending.push_back ({ &child, depth + 1 });
+    }
+    return true;
 }
 
 const nlohmann::json& objectAt (const nlohmann::json& arr, int index)
@@ -879,19 +890,44 @@ const nlohmann::json& objectAt (const nlohmann::json& arr, int index)
                ? arr[(size_t) index] : empty;
 }
 
+// RFC 7396 reads a null member as "delete this key". Here a null can only mean
+// "unspecified", and a key the merged slot lacks leaves its setter skipped,
+// dropping the slot back onto whatever the previously loaded session left in
+// the live Session - the exact hole the fill exists to close. So a null is
+// erased and then refilled from the default like any other absent key. Arrays
+// are values rather than maps: the file's array stands as it is, replacing the
+// default's wholesale.
+void fillFromDefaults (nlohmann::json& slot, const nlohmann::json& defaults)
+{
+    for (auto it = slot.begin(); it != slot.end(); )
+    {
+        if (it.value().is_null()) { it = slot.erase (it); continue; }
+        if (it.value().is_object())
+            fillFromDefaults (it.value(), json::child (defaults, it.key().c_str()));
+        ++it;
+    }
+    for (auto it = defaults.begin(); it != defaults.end(); ++it)
+        if (! slot.contains (it.key()))
+            slot[it.key()] = it.value();
+}
+
 // Every mixer setter in the restore path is conditional on its key being
 // present, so a slot that omits one keeps the previously loaded session's
-// value for it. Overlay what the file gives on the serialized model default,
-// which carries every key, so an absent key resolves to the model default
-// instead of to live state. A slot that is missing, not an object, or empty
-// comes back as the default whole.
+// value for it. Fill each key the file leaves out from the serialized model
+// default, which carries every one, so an absent key resolves to the model
+// default instead of to live state. The file's slot is copied once and filled
+// in place - it carries the regions, MIDI and takes, and load runs this for
+// every slot in the session. A slot that is missing, not an object, empty, or
+// nested past the depth bound comes back as the default whole.
 nlohmann::json slotWithDefaults (const nlohmann::json& defaults,
                                  const nlohmann::json& arr, int index)
 {
-    nlohmann::json merged = objectAt (defaults, index);
     const auto& fromFile = objectAt (arr, index);
-    if (! fromFile.empty())
-        merged.merge_patch (withoutNulls (fromFile));
+    if (fromFile.empty() || ! withinSlotDepth (fromFile))
+        return objectAt (defaults, index);
+
+    nlohmann::json merged = fromFile;
+    fillFromDefaults (merged, objectAt (defaults, index));
     return merged;
 }
 
@@ -2130,11 +2166,12 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
                 migrateTapeStateBlob (json::getString (master, "tape_state"), t);
         }
 
-        // With the master section present, a missing individual key keeps
-        // the in-memory value (matches the per-track / per-bus pattern);
-        // with the whole section absent, every field resets to the model
-        // default so nothing inherits the previously loaded session's
-        // master chain. Present-but-invalid values fall to the default too.
+        // Master deliberately diverges from the per-track / per-bus default
+        // fill: with the section present, a key it omits keeps the in-memory
+        // value instead of resetting to the model default - the clamp tests
+        // pin that retention. Only a wholly absent section resets every field,
+        // so nothing inherits the previously loaded session's master chain.
+        // Present-but-invalid values fall to the default too.
         // Mirror json::child's resolution above: it yields the shared empty
         // object unless "master" is an object, so a non-object must count as
         // absent here or every field silently inherits.

--- a/src/session/SessionSerializer.cpp
+++ b/src/session/SessionSerializer.cpp
@@ -1960,12 +1960,17 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
             else
                 lane.params.outputPair.store (-1);   // model default: Master only
             {
-                const auto& slots = json::array (v, "plugin_slots");
-                const int sn = std::min (AuxLaneParams::kMaxLanePlugins, (int) slots.size());
-                for (int p = 0; p < sn; ++p)
+                // Drive every slot position, overlaying each on the matching
+                // default rather than stopping at what the array happens to
+                // carry: "plugin_slots": [] or [null] otherwise leaves the
+                // position holding the previous session's plugin, state blob,
+                // native paths and insert routing.
+                const auto& slots        = json::array (v, "plugin_slots");
+                const auto& slotDefaults = json::array (objectAt (auxDefaults, i),
+                                                        "plugin_slots");
+                for (int p = 0; p < AuxLaneParams::kMaxLanePlugins; ++p)
                 {
-                    const auto& sv = slots[(size_t) p];
-                    if (! sv.is_object()) continue;
+                    const auto sv = slotWithDefaults (slotDefaults, slots, p);
                     lane.pluginDescriptor[(size_t) p].reset();
                     if (const auto it = sv.find ("plugin_descriptor");
                         it != sv.end() && it->is_object())

--- a/src/session/SessionSerializer.cpp
+++ b/src/session/SessionSerializer.cpp
@@ -897,13 +897,31 @@ const nlohmann::json& objectAt (const nlohmann::json& arr, int index)
 // erased and then refilled from the default like any other absent key. Arrays
 // are values rather than maps: the file's array stands as it is, replacing the
 // default's wholesale.
+//
+// A member the default carries as an OBJECT but the file gives as something
+// else ("hardware_insert": 42) diverges from RFC 7396 the same way: the section
+// resolves to the shared empty object, every setter inside it is skipped, and
+// the live state survives just as an absent key would. The default object
+// replaces it wholesale rather than a scalar standing where a section belongs.
 void fillFromDefaults (nlohmann::json& slot, const nlohmann::json& defaults)
 {
+    static const nlohmann::json noDefault = nlohmann::json::object();
+
     for (auto it = slot.begin(); it != slot.end(); )
     {
         if (it.value().is_null()) { it = slot.erase (it); continue; }
-        if (it.value().is_object())
-            fillFromDefaults (it.value(), json::child (defaults, it.key().c_str()));
+
+        // Resolved off `defaults` directly: json::child answers the shared
+        // empty object for a missing or non-object member, which reads as
+        // "there is an object default here" for every key.
+        const auto def = defaults.find (it.key());
+        const bool defaultIsObject = def != defaults.end() && def->is_object();
+
+        if (defaultIsObject && ! it.value().is_object())
+            it.value() = *def;
+        else if (it.value().is_object())
+            fillFromDefaults (it.value(), defaultIsObject ? *def : noDefault);
+
         ++it;
     }
     for (auto it = defaults.begin(); it != defaults.end(); ++it)

--- a/tests/session_missing_sections.cpp
+++ b/tests/session_missing_sections.cpp
@@ -230,6 +230,54 @@ TEST_CASE ("a null member in a partial slot resolves to the model default",
     REQUIRE (s.track (0).inputSource.load() == -2);
 }
 
+// A section the file gives as a scalar reaches the restore path as the shared
+// empty object, which passes the section's presence check and then skips every
+// conditional setter inside it - the previously loaded session's routing and
+// trims survive a slot that never described them. A type that contradicts the
+// default is no more readable than an absent key, so the default section
+// replaces it.
+TEST_CASE ("a non-object where the default holds a section resets that section",
+           "[session][serializer]")
+{
+    ScopedTempDir tmp { "dusk-type-mismatch-" };
+    const auto& dir = tmp.dir;
+
+    Session s;
+    s.setSessionDirectory (dir);
+
+    {
+        auto ghostRouting = std::make_unique<HardwareInsertRouting>();
+        ghostRouting->outputChL      = 6;
+        ghostRouting->outputChR      = 7;
+        ghostRouting->inputChL       = 8;
+        ghostRouting->inputChR       = 9;
+        ghostRouting->latencySamples = 512;
+        ghostRouting->format         = 1;
+        s.track (0).hardwareInsert.routing.publish (std::move (ghostRouting));
+    }
+    s.track (0).hardwareInsert.outputGainDb.store (-6.0f);
+    s.track (0).hardwareInsert.inputGainDb .store ( 3.0f);
+    s.track (0).hardwareInsert.dryWet      .store (0.25f);
+
+    const auto target = dir.getChildFile ("session.json");
+    target.replaceWithText (R"({"version":3,"tracks":[{"hardware_insert":42}]})");
+
+    REQUIRE (SessionSerializer::load (s, target));
+
+    const HardwareInsertRouting defaults;
+    const auto routing = s.track (0).hardwareInsert.routing.current();
+    REQUIRE (routing.outputChL      == defaults.outputChL);
+    REQUIRE (routing.outputChR      == defaults.outputChR);
+    REQUIRE (routing.inputChL       == defaults.inputChL);
+    REQUIRE (routing.inputChR       == defaults.inputChR);
+    REQUIRE (routing.latencySamples == defaults.latencySamples);
+    REQUIRE (routing.format         == defaults.format);
+
+    REQUIRE_THAT (s.track (0).hardwareInsert.outputGainDb.load(), WithinAbs (0.0f, 1e-6f));
+    REQUIRE_THAT (s.track (0).hardwareInsert.inputGainDb .load(), WithinAbs (0.0f, 1e-6f));
+    REQUIRE_THAT (s.track (0).hardwareInsert.dryWet      .load(), WithinAbs (1.0f, 1e-6f));
+}
+
 // The stable identifier wins when there is one, but an unrouted track
 // serializes midi_input_id as "", so the fill hands every slot that key.
 // Keying the identifier path on presence would swallow a session carrying only

--- a/tests/session_missing_sections.cpp
+++ b/tests/session_missing_sections.cpp
@@ -141,3 +141,129 @@ TEST_CASE ("loading a session with non-object bus / aux slots resets them",
     REQUIRE (s.auxLane (0).pluginStateBase64[0].isEmpty());
     REQUIRE (s.auxLane (0).nativeClapPath[0].isEmpty());
 }
+
+// #145 closed the case of a slot that is missing or not an object. A slot that
+// IS listed but only partially populated has the same hole: every mixer setter
+// is conditional on its key being present, so each key the file leaves out kept
+// the previously loaded session's value. The file's slot is now overlaid on the
+// serialized model default, so an absent key resolves to the default instead.
+TEST_CASE ("loading a session with a partial track slot resets its absent keys",
+           "[session][serializer]")
+{
+    const auto dir = juce::File::getSpecialLocation (juce::File::tempDirectory)
+                        .getChildFile ("dusk-partial-track-"
+                                         + juce::String (juce::Random::getSystemRandom().nextInt()));
+    dir.createDirectory();
+    const struct ScopedDir { juce::File d; ~ScopedDir() { d.deleteRecursively(); } } scopedDir { dir };
+
+    Session s;
+    s.setSessionDirectory (dir);
+
+    s.track (0).name = "ghost";
+    s.track (0).strip.faderDb.store (-12.0f);
+    s.track (0).strip.pan.store (0.75f);
+    s.track (0).strip.mute.store (true);
+    {
+        auto ghostRouting = std::make_unique<HardwareInsertRouting>();
+        ghostRouting->outputChL     = 6;
+        ghostRouting->inputChL      = 7;
+        ghostRouting->latencySamples = 512;
+        s.track (0).hardwareInsert.routing.publish (std::move (ghostRouting));
+    }
+
+    const auto target = dir.getChildFile ("session.json");
+    target.replaceWithText (R"({"version":3,"tracks":[{"name":"A"}]})");
+
+    REQUIRE (SessionSerializer::load (s, target));
+
+    // What the file specified survives; everything it omitted comes back at the
+    // model default rather than the previous session's value.
+    REQUIRE (s.track (0).name == "A");
+    REQUIRE_THAT (s.track (0).strip.faderDb.load(), WithinAbs (0.0f, 1e-6f));
+    REQUIRE_THAT (s.track (0).strip.pan.load(),     WithinAbs (0.0f, 1e-6f));
+    REQUIRE_FALSE (s.track (0).strip.mute.load());
+
+    const auto routing = s.track (0).hardwareInsert.routing.current();
+    REQUIRE (routing.outputChL      == -1);
+    REQUIRE (routing.inputChL       == -1);
+    REQUIRE (routing.latencySamples == 0);
+}
+
+// RFC 7396 reads an explicit null as "delete this key", which would drop the
+// key out of the overlay and land the slot back on the live value - the exact
+// failure the overlay exists to prevent. Here a null can only mean unspecified.
+TEST_CASE ("a null member in a partial slot resolves to the model default",
+           "[session][serializer]")
+{
+    const auto dir = juce::File::getSpecialLocation (juce::File::tempDirectory)
+                        .getChildFile ("dusk-null-member-"
+                                         + juce::String (juce::Random::getSystemRandom().nextInt()));
+    dir.createDirectory();
+    const struct ScopedDir { juce::File d; ~ScopedDir() { d.deleteRecursively(); } } scopedDir { dir };
+
+    Session s;
+    s.setSessionDirectory (dir);
+    s.track (0).strip.faderDb.store (-12.0f);
+    s.bus (0).strip.faderDb.store (-9.0f);
+
+    const auto target = dir.getChildFile ("session.json");
+    target.replaceWithText (
+        R"({"version":3,"tracks":[{"fader_db":null}],"buses":[{"fader_db":null}]})");
+
+    REQUIRE (SessionSerializer::load (s, target));
+
+    REQUIRE_THAT (s.track (0).strip.faderDb.load(), WithinAbs (0.0f, 1e-6f));
+    REQUIRE_THAT (s.bus (0).strip.faderDb.load(),   WithinAbs (0.0f, 1e-6f));
+}
+
+// The overlay must not merge arrays element-wise: a shorter bus_assign has to
+// replace the default outright, or a slot that assigns nothing would inherit
+// assignments from the default's longer array.
+TEST_CASE ("a partial slot's arrays replace rather than merge", "[session][serializer]")
+{
+    const auto dir = juce::File::getSpecialLocation (juce::File::tempDirectory)
+                        .getChildFile ("dusk-array-replace-"
+                                         + juce::String (juce::Random::getSystemRandom().nextInt()));
+    dir.createDirectory();
+    const struct ScopedDir { juce::File d; ~ScopedDir() { d.deleteRecursively(); } } scopedDir { dir };
+
+    Session s;
+    s.setSessionDirectory (dir);
+
+    AudioRegion r;
+    r.file            = s.getAudioDirectory().getChildFile ("ghost.wav");
+    r.lengthInSamples = 1000;
+    s.track (0).regions.push_back (r);
+
+    const auto target = dir.getChildFile ("session.json");
+    target.replaceWithText (R"({"version":3,"tracks":[{"regions":[]}]})");
+
+    REQUIRE (SessionSerializer::load (s, target));
+    REQUIRE (s.track (0).regions.empty());
+}
+
+// The stable identifier wins when there is one, but an unrouted track
+// serializes midi_input_id as "", so the overlay hands every slot that key.
+// Keying the identifier path on presence would swallow a session carrying only
+// the legacy raw index.
+TEST_CASE ("a legacy MIDI index survives the default overlay", "[session][serializer]")
+{
+    const auto dir = juce::File::getSpecialLocation (juce::File::tempDirectory)
+                        .getChildFile ("dusk-legacy-midi-"
+                                         + juce::String (juce::Random::getSystemRandom().nextInt()));
+    dir.createDirectory();
+    const struct ScopedDir { juce::File d; ~ScopedDir() { d.deleteRecursively(); } } scopedDir { dir };
+
+    Session s;
+    s.setSessionDirectory (dir);
+
+    const auto target = dir.getChildFile ("session.json");
+    target.replaceWithText (
+        R"({"version":3,"tracks":[{"midi_input_idx":2,"midi_output_idx":3}]})");
+
+    REQUIRE (SessionSerializer::load (s, target));
+
+    REQUIRE (s.track (0).midiInputIndex.load (std::memory_order_acquire)  == 2);
+    REQUIRE (s.track (0).midiOutputIndex.load (std::memory_order_acquire) == 3);
+    REQUIRE (s.track (0).midiInputIdentifier.isEmpty());
+}

--- a/tests/session_missing_sections.cpp
+++ b/tests/session_missing_sections.cpp
@@ -6,8 +6,30 @@
 
 #include <juce_core/juce_core.h>
 
+#include <string>
+
 using namespace duskstudio;
 using Catch::Matchers::WithinAbs;
+
+namespace
+{
+// ctest runs the cases as parallel processes, so a unique name is not enough on
+// its own - the directory has to actually be created, and the failure to create
+// it has to stop the case rather than leave it writing into a shared parent.
+struct ScopedTempDir
+{
+    juce::File dir;
+
+    explicit ScopedTempDir (const juce::String& prefix)
+        : dir (juce::File::getSpecialLocation (juce::File::tempDirectory)
+                   .getChildFile (prefix + juce::Uuid().toDashedString()))
+    {
+        REQUIRE (dir.createDirectory().wasOk());
+    }
+
+    ~ScopedTempDir() { dir.deleteRecursively(); }
+};
+}
 
 // A truncated / hand-edited session.json can lack whole section keys
 // ("tracks", "buses", "aux_lanes"). Loading such a file over a populated
@@ -17,11 +39,8 @@ using Catch::Matchers::WithinAbs;
 TEST_CASE ("loading a session without section keys resets those sections",
            "[session][serializer]")
 {
-    const auto dir = juce::File::getSpecialLocation (juce::File::tempDirectory)
-                        .getChildFile ("dusk-missing-sections-"
-                                         + juce::String (juce::Random::getSystemRandom().nextInt()));
-    dir.createDirectory();
-    const struct ScopedDir { juce::File d; ~ScopedDir() { d.deleteRecursively(); } } scopedDir { dir };
+    ScopedTempDir tmp { "dusk-missing-sections-" };
+    const auto& dir = tmp.dir;
 
     Session s;
     s.setSessionDirectory (dir);
@@ -82,11 +101,8 @@ TEST_CASE ("loading a session without section keys resets those sections",
 TEST_CASE ("loading a session with a non-object track slot resets that slot",
            "[session][serializer]")
 {
-    const auto dir = juce::File::getSpecialLocation (juce::File::tempDirectory)
-                        .getChildFile ("dusk-null-track-"
-                                         + juce::String (juce::Random::getSystemRandom().nextInt()));
-    dir.createDirectory();
-    const struct ScopedDir { juce::File d; ~ScopedDir() { d.deleteRecursively(); } } scopedDir { dir };
+    ScopedTempDir tmp { "dusk-null-track-" };
+    const auto& dir = tmp.dir;
 
     Session s;
     s.setSessionDirectory (dir);
@@ -115,11 +131,8 @@ TEST_CASE ("loading a session with a non-object track slot resets that slot",
 TEST_CASE ("loading a session with non-object bus / aux slots resets them",
            "[session][serializer]")
 {
-    const auto dir = juce::File::getSpecialLocation (juce::File::tempDirectory)
-                        .getChildFile ("dusk-null-bus-"
-                                         + juce::String (juce::Random::getSystemRandom().nextInt()));
-    dir.createDirectory();
-    const struct ScopedDir { juce::File d; ~ScopedDir() { d.deleteRecursively(); } } scopedDir { dir };
+    ScopedTempDir tmp { "dusk-null-bus-" };
+    const auto& dir = tmp.dir;
 
     Session s;
     s.setSessionDirectory (dir);
@@ -142,19 +155,16 @@ TEST_CASE ("loading a session with non-object bus / aux slots resets them",
     REQUIRE (s.auxLane (0).nativeClapPath[0].isEmpty());
 }
 
-// #145 closed the case of a slot that is missing or not an object. A slot that
-// IS listed but only partially populated has the same hole: every mixer setter
-// is conditional on its key being present, so each key the file leaves out kept
-// the previously loaded session's value. The file's slot is now overlaid on the
-// serialized model default, so an absent key resolves to the default instead.
+// A slot that IS listed but only partially populated is the same ghost hazard
+// as one that is missing: every mixer setter is conditional on its key being
+// present, so a key the file leaves out would keep the previously loaded
+// session's value. Each one the slot lacks is filled from the serialized model
+// default instead.
 TEST_CASE ("loading a session with a partial track slot resets its absent keys",
            "[session][serializer]")
 {
-    const auto dir = juce::File::getSpecialLocation (juce::File::tempDirectory)
-                        .getChildFile ("dusk-partial-track-"
-                                         + juce::String (juce::Random::getSystemRandom().nextInt()));
-    dir.createDirectory();
-    const struct ScopedDir { juce::File d; ~ScopedDir() { d.deleteRecursively(); } } scopedDir { dir };
+    ScopedTempDir tmp { "dusk-partial-track-" };
+    const auto& dir = tmp.dir;
 
     Session s;
     s.setSessionDirectory (dir);
@@ -189,70 +199,45 @@ TEST_CASE ("loading a session with a partial track slot resets its absent keys",
     REQUIRE (routing.latencySamples == 0);
 }
 
-// RFC 7396 reads an explicit null as "delete this key", which would drop the
-// key out of the overlay and land the slot back on the live value - the exact
-// failure the overlay exists to prevent. Here a null can only mean unspecified.
+// RFC 7396 reads an explicit null as "delete this key", which would leave the
+// key out of the merged slot, skip its setter and land the slot back on the
+// live value - the exact failure the fill exists to prevent. Handing the null
+// through to the setter instead is no better: the setter's own fallback is not
+// always the model default. Here a null can only mean unspecified.
 TEST_CASE ("a null member in a partial slot resolves to the model default",
            "[session][serializer]")
 {
-    const auto dir = juce::File::getSpecialLocation (juce::File::tempDirectory)
-                        .getChildFile ("dusk-null-member-"
-                                         + juce::String (juce::Random::getSystemRandom().nextInt()));
-    dir.createDirectory();
-    const struct ScopedDir { juce::File d; ~ScopedDir() { d.deleteRecursively(); } } scopedDir { dir };
+    ScopedTempDir tmp { "dusk-null-member-" };
+    const auto& dir = tmp.dir;
 
     Session s;
     s.setSessionDirectory (dir);
-    s.track (0).strip.faderDb.store (-12.0f);
-    s.bus (0).strip.faderDb.store (-9.0f);
+    s.track (0).strip.mute.store (true);
+    s.track (0).inputSource.store (5);
+    s.bus (0).strip.mute.store (true);
 
     const auto target = dir.getChildFile ("session.json");
     target.replaceWithText (
-        R"({"version":3,"tracks":[{"fader_db":null}],"buses":[{"fader_db":null}]})");
+        R"({"version":3,"tracks":[{"mute":null,"input_source":null}],)"
+        R"("buses":[{"mute":null}]})");
 
     REQUIRE (SessionSerializer::load (s, target));
 
-    REQUIRE_THAT (s.track (0).strip.faderDb.load(), WithinAbs (0.0f, 1e-6f));
-    REQUIRE_THAT (s.bus (0).strip.faderDb.load(),   WithinAbs (0.0f, 1e-6f));
-}
-
-// The overlay must not merge arrays element-wise: a shorter bus_assign has to
-// replace the default outright, or a slot that assigns nothing would inherit
-// assignments from the default's longer array.
-TEST_CASE ("a partial slot's arrays replace rather than merge", "[session][serializer]")
-{
-    const auto dir = juce::File::getSpecialLocation (juce::File::tempDirectory)
-                        .getChildFile ("dusk-array-replace-"
-                                         + juce::String (juce::Random::getSystemRandom().nextInt()));
-    dir.createDirectory();
-    const struct ScopedDir { juce::File d; ~ScopedDir() { d.deleteRecursively(); } } scopedDir { dir };
-
-    Session s;
-    s.setSessionDirectory (dir);
-
-    AudioRegion r;
-    r.file            = s.getAudioDirectory().getChildFile ("ghost.wav");
-    r.lengthInSamples = 1000;
-    s.track (0).regions.push_back (r);
-
-    const auto target = dir.getChildFile ("session.json");
-    target.replaceWithText (R"({"version":3,"tracks":[{"regions":[]}]})");
-
-    REQUIRE (SessionSerializer::load (s, target));
-    REQUIRE (s.track (0).regions.empty());
+    REQUIRE_FALSE (s.track (0).strip.mute.load());
+    REQUIRE_FALSE (s.bus (0).strip.mute.load());
+    // The setter's fallback for a junk input_source is 0; the model default is
+    // -2, so only a null that resolved to the default lands here.
+    REQUIRE (s.track (0).inputSource.load() == -2);
 }
 
 // The stable identifier wins when there is one, but an unrouted track
-// serializes midi_input_id as "", so the overlay hands every slot that key.
+// serializes midi_input_id as "", so the fill hands every slot that key.
 // Keying the identifier path on presence would swallow a session carrying only
 // the legacy raw index.
-TEST_CASE ("a legacy MIDI index survives the default overlay", "[session][serializer]")
+TEST_CASE ("a legacy MIDI index survives the default fill", "[session][serializer]")
 {
-    const auto dir = juce::File::getSpecialLocation (juce::File::tempDirectory)
-                        .getChildFile ("dusk-legacy-midi-"
-                                         + juce::String (juce::Random::getSystemRandom().nextInt()));
-    dir.createDirectory();
-    const struct ScopedDir { juce::File d; ~ScopedDir() { d.deleteRecursively(); } } scopedDir { dir };
+    ScopedTempDir tmp { "dusk-legacy-midi-" };
+    const auto& dir = tmp.dir;
 
     Session s;
     s.setSessionDirectory (dir);
@@ -271,15 +256,12 @@ TEST_CASE ("a legacy MIDI index survives the default overlay", "[session][serial
 // plugin_slots is an array, so it replaces the default wholesale. Stopping the
 // restore at whatever the file's array carries therefore left a position the
 // file does not describe holding the previous session's plugin. Every position
-// is driven, each overlaid on the matching default.
+// is driven, each filled from the matching default.
 TEST_CASE ("an aux lane's undescribed plugin slot drops the previous plugin",
            "[session][serializer]")
 {
-    const auto dir = juce::File::getSpecialLocation (juce::File::tempDirectory)
-                        .getChildFile ("dusk-aux-slot-"
-                                         + juce::String (juce::Random::getSystemRandom().nextInt()));
-    dir.createDirectory();
-    const struct ScopedDir { juce::File d; ~ScopedDir() { d.deleteRecursively(); } } scopedDir { dir };
+    ScopedTempDir tmp { "dusk-aux-slot-" };
+    const auto& dir = tmp.dir;
 
     Session s;
     s.setSessionDirectory (dir);
@@ -313,4 +295,36 @@ TEST_CASE ("an aux lane's undescribed plugin slot drops the previous plugin",
     const auto routing = s.auxLane (0).hardwareInserts[0].routing.current();
     REQUIRE (routing.outputChL == -1);
     REQUIRE (routing.inputChL  == -1);
+}
+
+// A hand-edited slot can nest itself deeper than any walk over it can recurse.
+// Past the bound the slot is unusable rather than fatal: it restores from the
+// model default, and the surrounding session still loads.
+TEST_CASE ("a pathologically nested track slot falls back to the default",
+           "[session][serializer]")
+{
+    ScopedTempDir tmp { "dusk-deep-slot-" };
+    const auto& dir = tmp.dir;
+
+    Session s;
+    s.setSessionDirectory (dir);
+    s.track (0).name = "ghost";
+    s.track (0).strip.faderDb.store (-12.0f);
+
+    constexpr int kNesting = 50000;
+    std::string deep;
+    deep.reserve ((size_t) kNesting * 6 + 1);
+    for (int i = 0; i < kNesting; ++i) deep += R"({"a":)";
+    deep += "1";
+    deep.append ((size_t) kNesting, '}');
+
+    const auto target = dir.getChildFile ("session.json");
+    target.replaceWithText (R"({"version":3,"tracks":[{"name":"A","deep":)"
+                             + juce::String (deep) + R"(}]})");
+
+    REQUIRE (SessionSerializer::load (s, target));
+
+    const Session defaults;
+    REQUIRE (s.track (0).name == defaults.track (0).name);
+    REQUIRE_THAT (s.track (0).strip.faderDb.load(), WithinAbs (0.0f, 1e-6f));
 }

--- a/tests/session_missing_sections.cpp
+++ b/tests/session_missing_sections.cpp
@@ -267,3 +267,50 @@ TEST_CASE ("a legacy MIDI index survives the default overlay", "[session][serial
     REQUIRE (s.track (0).midiOutputIndex.load (std::memory_order_acquire) == 3);
     REQUIRE (s.track (0).midiInputIdentifier.isEmpty());
 }
+
+// plugin_slots is an array, so it replaces the default wholesale. Stopping the
+// restore at whatever the file's array carries therefore left a position the
+// file does not describe holding the previous session's plugin. Every position
+// is driven, each overlaid on the matching default.
+TEST_CASE ("an aux lane's undescribed plugin slot drops the previous plugin",
+           "[session][serializer]")
+{
+    const auto dir = juce::File::getSpecialLocation (juce::File::tempDirectory)
+                        .getChildFile ("dusk-aux-slot-"
+                                         + juce::String (juce::Random::getSystemRandom().nextInt()));
+    dir.createDirectory();
+    const struct ScopedDir { juce::File d; ~ScopedDir() { d.deleteRecursively(); } } scopedDir { dir };
+
+    Session s;
+    s.setSessionDirectory (dir);
+
+    s.auxLane (0).pluginLegacyDescriptionXml[0] = "<PLUGIN/>";
+    s.auxLane (0).pluginStateBase64[0]          = "ABCD";
+    s.auxLane (0).nativeClapPath[0]             = "/tmp/ghost.clap";
+    s.auxLane (0).nativeClapPluginId[0]         = "com.ghost.plugin";
+    {
+        auto ghostRouting = std::make_unique<HardwareInsertRouting>();
+        ghostRouting->outputChL = 6;
+        ghostRouting->inputChL  = 7;
+        s.auxLane (0).hardwareInserts[0].routing.publish (std::move (ghostRouting));
+        s.auxLane (0).hardwareInserts[0].enabled.store (true);
+    }
+
+    // The lane is described, but its plugin slot is not.
+    const auto target = dir.getChildFile ("session.json");
+    target.replaceWithText (
+        R"({"version":3,"aux_lanes":[{"name":"A","plugin_slots":[]}]})");
+
+    REQUIRE (SessionSerializer::load (s, target));
+
+    REQUIRE (s.auxLane (0).name == "A");
+    REQUIRE (s.auxLane (0).pluginLegacyDescriptionXml[0].isEmpty());
+    REQUIRE (s.auxLane (0).pluginStateBase64[0].isEmpty());
+    REQUIRE (s.auxLane (0).nativeClapPath[0].isEmpty());
+    REQUIRE (s.auxLane (0).nativeClapPluginId[0].isEmpty());
+    REQUIRE_FALSE (s.auxLane (0).hardwareInserts[0].enabled.load());
+
+    const auto routing = s.auxLane (0).hardwareInserts[0].routing.current();
+    REQUIRE (routing.outputChL == -1);
+    REQUIRE (routing.inputChL  == -1);
+}


### PR DESCRIPTION
Closes #161.

Every mixer setter in `restoreTrack` / `restoreBus` / the aux-lane path is conditional on its key being present, so a slot that is listed but only partially populated kept the previously loaded session's value for each key it omitted:

```json
{"version":3,"tracks":[{"name":"A"}]}
```

Track 0 took its name from the file and its fader, pan, mute, sends, EQ, comp and hardware-insert routing from whatever session was open before. #145 closed the same hole for slots that are missing or not an object; this is the case it left.

## Approach

The file's slot is overlaid on the serialized model default (RFC 7396 `merge_patch`), so a key the file omits resolves to the model default instead of to live state. The default sections are therefore built for every load rather than only for short files.

Scoped to tracks, buses and aux lanes. Master deliberately retains the live value for an absent key, which `session_clamp_corrupt_values` pins, so it is left alone.

## The two things the overlay would otherwise have broken

Both were caught by working through the caveats on the issue, and both have a test that fails without the guard.

**Nulls are stripped before merging.** RFC 7396 reads a null member as "delete this key", so `{"fader_db": null}` would remove the key from the overlay and land straight back on the live value. Verified: with the strip removed, the null test fails with the live -12.0 dB surviving. Here a null can only mean "unspecified".

**The MIDI identifier path is keyed on a non-empty identifier, not on the key being present.** An unrouted track serializes `midi_input_id` as `""`, so once the overlay hands every slot that key, presence alone routes a legacy session carrying only `midi_input_idx` down the identifier path and discards its index. Verified: with the old `json::has` guard plus the overlay, the legacy index loads as -1 instead of 2. This is a regression the overlay would have introduced silently.

Arrays keep replacing wholesale, which is what regions, automation and `bus_assign` want.

## Tests

Four new cases in `session_missing_sections.cpp`, alongside the #145 ones:

- a partial track slot resets its absent keys (fails without the overlay)
- a null member resolves to the model default (fails without null stripping)
- a partial slot's arrays replace rather than merge
- a legacy MIDI index survives the overlay (fails with the presence-based guard)

The arrays case is a contract test rather than a bug reproduction: `merge_patch` never merges arrays, so it does not fail against the current code. It is here because the issue asked for wholesale replacement to be asserted rather than assumed, and it would catch a future switch to a hand-rolled deep merge that unions them.

531/531 pass, no new warnings, JUCE gate unchanged at 179 / 9257.

## Cost

`serialize (Session{})` plus a parse now runs on every load instead of only for short files. Each session test does a full load and still completes in 0.01 s wall clock including process startup, so it is not material next to the file I/O and plugin restore a real load does.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session loading for incomplete, malformed, or deeply nested data.
  * Restored defaults for missing or invalid track, bus, auxiliary, and plugin-slot settings.
  * Preserved explicitly configured values and correctly handled null properties and arrays.
  * Prevented prior-session settings from carrying over unexpectedly.
  * Maintained legacy MIDI index behavior when no device identifier is provided.
  * Improved handling of missing or invalid master-section data.

* **Tests**
  * Added coverage for partial sessions, null properties, defaults, malformed data, deep nesting, and MIDI compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->