### PR TITLE
Fix UI modal, CLAP editor, timer, and separator bugs

### DIFF
--- a/src/ui/AnalogVuMeter.cpp
+++ b/src/ui/AnalogVuMeter.cpp
@@ -125,7 +125,7 @@ AnalogVuMeter::AnalogVuMeter (const std::atomic<float>* l, const std::atomic<flo
     startTimerHz ((int) kRefreshHz);
 }
 
-AnalogVuMeter::~AnalogVuMeter() = default;
+AnalogVuMeter::~AnalogVuMeter() { stopTimer(); }
 
 void AnalogVuMeter::setReferenceLevelDb (float refDb)
 {

--- a/src/ui/ClapPluginEditorComponent.cpp
+++ b/src/ui/ClapPluginEditorComponent.cpp
@@ -108,14 +108,23 @@ void ClapPluginEditorComponent::tryEmbed()
     // to set_parent/show into a parent that isn't viewable yet - so no pre-warm: build
     // + map when shown, exactly like the JUCE editor path. The kept-alive remap on a
     // later tab switch keeps re-opens instant.
-    if (! loaded || embedded || ! isShowing()) return;
+    // `embedding` guards re-entry. Unlike LV2, a CLAP request_resize can't reach us
+    // synchronously - it only records atomics, and onResize dispatches later from
+    // drainPendingCallbacks() inside pump(). The vector here is the timer poll below:
+    // a plugin that spins a nested message dispatch inside gui->set_parent/show lets
+    // a tick re-enter tryEmbed while the first embed is still in flight, which would
+    // build a SECOND GUI and orphan the first (the LV2 black-rectangle bug).
+    if (! loaded || embedded || embedding || ! isShowing()) return;
     auto* parent = peerNativeHandle();
     if (parent == nullptr) return;
 
     const auto area = editorBoundsInPeer();
     std::string err;
-    if (editor.embed (parent, area.getX(), area.getY(),
-                      std::max (1, area.getWidth()), std::max (1, area.getHeight()), err))
+    embedding = true;
+    const bool ok = editor.embed (parent, area.getX(), area.getY(),
+                                  std::max (1, area.getWidth()), std::max (1, area.getHeight()), err);
+    embedding = false;
+    if (ok)
     {
         embedded = true;
         // Re-sync unconditionally: a synchronous gui resize during embed can
@@ -225,6 +234,10 @@ void ClapPluginEditorComponent::timerCallback()
     // visibility. visibilityChanged() does NOT fire for ancestor (aux-tab / stage)
     // changes, so without this poll the container stays visible over whatever view
     // replaced the aux lane. reveal()/hide() are idempotent.
+    // The un-embedded poll covers the mirror case: a component created while its
+    // lane was hidden (session restore lands before the AUX tab is first shown)
+    // gets no callback when an ANCESTOR becomes visible, so the first embed must
+    // also be polled. tryEmbed no-ops until showing.
     if (embedded)
     {
         if (isShowing()) editor.reveal();
@@ -232,6 +245,10 @@ void ClapPluginEditorComponent::timerCallback()
 #if defined(__linux__)
         verifyGeometry();
 #endif
+    }
+    else
+    {
+        tryEmbed();
     }
 
     const auto now = juce::Time::getMillisecondCounter();

--- a/src/ui/ClapPluginEditorComponent.h
+++ b/src/ui/ClapPluginEditorComponent.h
@@ -61,8 +61,9 @@ private:
     clap::ClapInstance instance;
     clap::ClapEditor   editor;
     bool ownsInstance = false;
-    bool loaded   = false;
-    bool embedded = false;
+    bool loaded    = false;
+    bool embedded  = false;
+    bool embedding = false;   // guards re-entry: a nested dispatch inside set_parent/show lets the timer poll re-enter tryEmbed
     std::uint32_t lastPumpMs = 0;
 #if defined(__linux__)
     int  geometryCheckTick = 0;

--- a/src/ui/CompMeterStrip.cpp
+++ b/src/ui/CompMeterStrip.cpp
@@ -119,7 +119,7 @@ CompMeterStrip::CompMeterStrip (Track& t)
 {
 }
 
-CompMeterStrip::~CompMeterStrip() = default;
+CompMeterStrip::~CompMeterStrip() { stopTimer(); }
 
 float CompMeterStrip::dbToFrac (float db) const noexcept
 {

--- a/src/ui/DuskContextMenu.cpp
+++ b/src/ui/DuskContextMenu.cpp
@@ -114,8 +114,8 @@ public:
             {
                 g.setColour (juce::Colour (0xff2a2a30));
                 g.drawHorizontalLine (y + kSepH / 2,
-                                        (float) getX() + 4.0f,
-                                        (float) getRight() - 4.0f);
+                                        4.0f,
+                                        (float) getWidth() - 4.0f);
                 y += kSepH;
                 continue;
             }

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -275,6 +275,10 @@ public:
         startTimerHz (20);
     }
 
+    // The base timer dtor runs after these members are gone; a 20 Hz tick landing
+    // in that window would read the freed job reference.
+    ~DpImportProgressPanel() override { stopTimer(); }
+
     std::function<void()> onFinished;
 
     void paint (juce::Graphics& g) override { g.fillAll (juce::Colour (0xff202024)); }
@@ -1021,9 +1025,11 @@ MainComponent::~MainComponent()
     // gone. AudioSettingsPanel's destructor removes listeners from both;
     // PluginScanModal's stops a worker that calls into the engine-owned
     // PluginManager; BounceDialog's cancels + joins a BounceEngine
-    // rendering through the engine. All of those must run while the
-    // engine is still alive. No body callback can be on the stack here
-    // (the dtor runs from app shutdown), so in-place destruction is safe.
+    // rendering through the engine; DpImportProgressPanel holds a
+    // DpImportJob& and a 20 Hz timer, so a leaked body outlives the job
+    // it polls. All of those must run while the engine is still alive.
+    // No body callback can be on the stack here (the dtor runs from app
+    // shutdown), so in-place destruction is safe.
     audioSettingsModal   .closeAndDeleteBodyNow();
     mixdownModal         .closeAndDeleteBodyNow();
     bounceModal          .closeAndDeleteBodyNow();
@@ -1034,6 +1040,7 @@ MainComponent::~MainComponent()
     importTargetModal    .closeAndDeleteBodyNow();
     shortcutsModal       .closeAndDeleteBodyNow();
     supportersModal      .closeAndDeleteBodyNow();
+    dpImportProgressModal.closeAndDeleteBodyNow();
 
     // Intentionally NO auto-save here. Standard DAW behavior is to require
     // an explicit Save before exit. The previous auto-save on destruct

--- a/src/ui/MiniTimelineStrip.cpp
+++ b/src/ui/MiniTimelineStrip.cpp
@@ -32,6 +32,7 @@ MiniTimelineStrip::MiniTimelineStrip (Session& s, AudioEngine& e)
 
 MiniTimelineStrip::~MiniTimelineStrip()
 {
+    stopTimer();
     engine.getUndoManager().removeChangeListener (this);
 }
 

--- a/src/ui/StartupDialog.cpp
+++ b/src/ui/StartupDialog.cpp
@@ -220,6 +220,10 @@ StartupDialog::StartupDialog (juce::Array<juce::File> r)
     setWantsKeyboardFocus (true);
 }
 
+// Dismissing the dialog inside the ~5 s update-banner blink would otherwise leave
+// the timer live until the base dtor, after updateLabel is gone.
+StartupDialog::~StartupDialog() { stopTimer(); }
+
 bool StartupDialog::keyPressed (const juce::KeyPress& key)
 {
     // Banner activation only while the banner itself holds focus - Return

--- a/src/ui/StartupDialog.h
+++ b/src/ui/StartupDialog.h
@@ -21,6 +21,7 @@ class StartupDialog final : public juce::Component,
 {
 public:
     explicit StartupDialog (juce::Array<juce::File> recentSessions);
+    ~StartupDialog() override;
 
     void resized() override;
     void paint (juce::Graphics&) override;

--- a/src/ui/TapeStrip.cpp
+++ b/src/ui/TapeStrip.cpp
@@ -259,6 +259,7 @@ TapeStrip::TapeStrip (Session& s, AudioEngine& e)
 
 TapeStrip::~TapeStrip()
 {
+    stopTimer();
     showAllToggle.setLookAndFeel (nullptr);
     engine.getUndoManager().removeChangeListener (this);
 }


### PR DESCRIPTION
## Summary

- tear down the DP import progress modal during shutdown and stop six timer-backed components before their own members are destroyed
- make CLAP editor embedding retry safely when visibility changes, with a re-entry guard around the native embed path
- paint context-menu separators in component-local coordinates

## Why

These gaps could leave modal or timer-owned state alive past its intended lifetime, prevent a CLAP editor from embedding after an ancestor became visible, and draw separators at the wrong horizontal position.

## Validation

- application build passed before publication
- full ctest suite passed before publication
- tools/juce-gate.sh passes with no count increases or allowlist additions

Fixes #149

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CLAP editor loading to prevent duplicate windows and support embedding after the surrounding interface becomes visible.
  - Corrected context-menu separator positioning in panel-based layouts.
  - Improved shutdown reliability by ensuring background updates stop cleanly as dialogs, meters, timelines, and other interface components close.
  - Reduced the risk of crashes or unexpected behavior during application exit and interface teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->