### PR TITLE
Keep virtual-keyboard note keys off global shortcuts

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1334,6 +1334,8 @@ The note-creation grid is set from the toolbar dropdown; there is no keyboard sh
 
 Open the virtual keyboard from the transport bar (the keyboard icon, or **K**). Each note you press in the keyboard is entered at the current edit cursor. When all keys are released, the cursor advances by one snap step. This is the fastest way to enter a chord progression without playing in real time.
 
+While the keyboard is open, every letter and digit in its layout belongs to the keyboard, not to the shortcuts — **P** and **R** play their notes instead of toggling punch and record, at any octave (shift the octave high enough that a key runs past the top of the MIDI range and it simply does nothing). Keys outside the layout still work as usual, so **Space**, **.**, **L**, **[** / **]** keep driving the transport, and **K** or **Esc** closes the keyboard.
+
 ## Navigation
 
 - **Cmd/Ctrl+]** / **Cmd/Ctrl+[**: jump to the next / previous MIDI region on the same track.

--- a/src/ui/EmbeddedModal.h
+++ b/src/ui/EmbeddedModal.h
@@ -43,6 +43,17 @@ inline bool isModalForwardableShortcut (const juce::KeyPress& k) noexcept
         || k == juce::KeyPress::F11Key;
 }
 
+// Implemented by a modal body that binds bare typing keys to its own input -
+// the virtual keyboard's note letters. EmbeddedModal asks before forwarding a
+// shortcut, so a claimed key plays its note instead of toggling record / punch
+// on the arrangement behind the modal. keyCode is JUCE's key code; modifier
+// chords never reach here (isModalForwardableShortcut rejects them first).
+struct ModalKeyClaimant
+{
+    virtual ~ModalKeyClaimant() = default;
+    virtual bool claimsKeyCode (int keyCode) const = 0;
+};
+
 // Component-properties tag marking a plugin-editor component (JUCE editor, OOP
 // embed, native CLAP/LV2 editor). EmbeddedModal hides tagged components while a
 // modal is up - native editor windows otherwise paint above the modal regardless
@@ -590,6 +601,15 @@ private:
         // keys before this fires, so typing isn't affected.
         if (forwardShortcuts_ && isModalForwardableShortcut (k))
         {
+            // Returning false hands the key to the body's own keyPressed - and,
+            // if the body declines it, on up every ancestor to MainComponent,
+            // which is exactly the handler this forwarder targets. So a claimed
+            // key stays suppressed ONLY because the body consumes every code it
+            // claims: claim implies consume.
+            auto* claimant = dynamic_cast<ModalKeyClaimant*> (getBody());
+            if (claimant != nullptr && claimant->claimsKeyCode (k.getKeyCode()))
+                return false;
+
             if (auto* mc = focusRestoreTarget().getComponent())
                 return mc->keyPressed (k);
         }
@@ -743,9 +763,14 @@ public:
         return t;
     }
 
-    bool keyPressed (const juce::KeyPress& k, juce::Component*) override
+    bool keyPressed (const juce::KeyPress& k, juce::Component* target) override
     {
         if (! isModalForwardableShortcut (k)) return false;
+        // Same claim contract as EmbeddedModal's forwarder: a body that binds
+        // this key to its own input keeps it (and must consume it).
+        if (auto* claimant = dynamic_cast<ModalKeyClaimant*> (target))
+            if (claimant->claimsKeyCode (k.getKeyCode()))
+                return false;
         if (auto* mc = EmbeddedModal::focusRestoreTarget().getComponent())
             return mc->keyPressed (k);
         return false;

--- a/src/ui/VirtualKeyboardComponent.cpp
+++ b/src/ui/VirtualKeyboardComponent.cpp
@@ -49,6 +49,17 @@ const KeyMap& keyMap()
     return k;
 }
 
+// Layout membership, deliberately independent of centreNote: the octave decides
+// which note a key sounds, not whether the keyboard owns it. A key the centre
+// pushes past MIDI 127 must stay owned, or its app shortcut fires behind the
+// modal (see claimsKeyCode / keyPressed).
+bool isLayoutKeyCode (int keyCode) noexcept
+{
+    if (keyCode < 0 || keyCode >= (int) keyMap().offset.size())
+        return false;
+    return keyMap().offset[(size_t) keyCode] >= 0;
+}
+
 bool isBlackKey (int midiNote) noexcept
 {
     const int pc = ((midiNote % 12) + 12) % 12;
@@ -135,6 +146,11 @@ int VirtualKeyboardComponent::noteForKeyCode (int keyCode) const noexcept
     return note;
 }
 
+bool VirtualKeyboardComponent::claimsKeyCode (int keyCode) const
+{
+    return isLayoutKeyCode (keyCode);
+}
+
 bool VirtualKeyboardComponent::keyPressed (const juce::KeyPress& k)
 {
     const int code = k.getKeyCode();
@@ -156,11 +172,20 @@ bool VirtualKeyboardComponent::keyPressed (const juce::KeyPress& k)
         return true;
     }
 
+    // Claim implies consume, so no claimed code may fall out here: every layout
+    // key has to be indexable in `held` or it would escape to MainComponent.
+    static_assert (std::tuple_size<decltype (KeyMap::offset)>::value
+                       <= std::tuple_size<decltype (held)>::value,
+                   "layout table must fit the held-note slots");
     if (code < 0 || code >= (int) held.size())
         return false;
 
+    // A layout key the octave pushed past MIDI 127 sounds nothing but must
+    // still die here: an unconsumed key walks the parent chain, and the modal
+    // body is a direct child of MainComponent, so M / X / S / P / R would drop
+    // a marker / mute / solo / punch / record instead.
     const int note = noteForKeyCode (code);
-    if (note < 0) return false;
+    if (note < 0) return isLayoutKeyCode (code);
 
     // keyPressed fires again for an already-held key from two sources:
     //   - auto-repeat - the key never left the board; silentScans stays 0

--- a/src/ui/VirtualKeyboardComponent.h
+++ b/src/ui/VirtualKeyboardComponent.h
@@ -2,6 +2,7 @@
 
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <array>
+#include "EmbeddedModal.h"
 #include "../engine/AudioEngine.h"
 #include "../foundation/MessageThread.h"
 
@@ -39,6 +40,7 @@ namespace duskstudio
 // auto-repeat keyPressed resets it as a "still-held" heartbeat for the
 // fallback path.
 class VirtualKeyboardComponent final : public juce::Component,
+                                          public ModalKeyClaimant,
                                           private dusk::Timer
 {
 public:
@@ -51,6 +53,14 @@ public:
     void mouseDown (const juce::MouseEvent&) override;
     void mouseDrag (const juce::MouseEvent&) override;
     void mouseUp   (const juce::MouseEvent&) override;
+
+    // The layout's letters overlap single-key app shortcuts (P punch, R
+    // record); claiming them keeps the modal from forwarding those keys, so
+    // they reach keyPressed. Claim is layout membership, not the note the
+    // current octave resolves to - keyPressed swallows a key shifted past MIDI
+    // 127 rather than let its shortcut through. Keys outside the layout stay
+    // unclaimed, so Space / '.' / L / brackets still drive the transport.
+    bool claimsKeyCode (int keyCode) const override;
 
     // Fired immediately after a Note On / Note Off is queued into
     // the engine's collector. Used by step-record into the piano


### PR DESCRIPTION
## Summary

- let modal bodies claim keys they handle themselves before global shortcut forwarding
- claim the virtual keyboard layout keys independently of the currently resolved MIDI note
- consume layout keys shifted above MIDI note 127 so they cannot escape to transport shortcuts

## Why

The shortcut forwarder ran before the virtual keyboard body, so note keys such as P and R could trigger punch or record instead of sounding notes. The claim-then-consume invariant keeps all keyboard layout keys inside the instrument modal.

## Validation

- application build passed
- 533/533 Catch2 tests passed
- tools/juce-gate.sh passes with no count increases or allowlist additions
- live Wayland keyboard verification remains a manual follow-up

Fixes #91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented piano-roll keyboard notes from triggering conflicting global shortcuts while the virtual keyboard is open.
  * Keys within the keyboard layout are consistently consumed, including those that cannot produce a valid note.
  * Shortcuts outside the keyboard layout continue to work normally.
  * `K` and `Esc` continue to close the virtual keyboard.

* **Documentation**
  * Clarified virtual-keyboard shortcut behavior in the piano-roll step-recording guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->