### PR TITLE
Fix console paging and hardware bank synchronization (#144)

### DIFF
--- a/src/session/Session.h
+++ b/src/session/Session.h
@@ -11,6 +11,7 @@
 #include <vector>
 #include "AtomicSnapshot.h"
 #include "MidiBindings.h"
+#include "SessionLayout.h"
 #include "../engine/PluginDescriptor.h"
 
 namespace duskstudio
@@ -1155,11 +1156,11 @@ struct MasteringParams
 class Session
 {
 public:
-    static constexpr int kNumTracks   = 24;  // three banks of 8
+    static constexpr int kNumTracks   = SessionLayout::kNumTracks;
     static constexpr int kNumBuses    = 4;
     static constexpr int kNumAuxLanes = 4;
-    static constexpr int kBankSize    = 8;
-    static constexpr int kNumBanks    = kNumTracks / kBankSize;
+    static constexpr int kBankSize    = SessionLayout::kBankSize;
+    static constexpr int kNumBanks    = SessionLayout::kNumBanks;
 
     Session();
 

--- a/src/session/SessionLayout.h
+++ b/src/session/SessionLayout.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace duskstudio
+{
+struct SessionLayout
+{
+    static constexpr int kNumTracks = 24;
+    static constexpr int kBankSize  = 8;
+    static constexpr int kNumBanks  = kNumTracks / kBankSize;
+};
+} // namespace duskstudio

--- a/src/ui/BankMapping.h
+++ b/src/ui/BankMapping.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "../session/Session.h"
+
+#include <algorithm>
+
+namespace duskstudio
+{
+// The console pages its 24 strips in width-derived screen pages (stride 6..24),
+// while bank-relative MIDI bindings and the MCU surface address a fixed
+// kNumBanks x kBankSize hardware bank. The two indices only coincide when the
+// stride happens to be kBankSize, so they must be translated, never shared:
+// a screen page index stored raw resolves to base tracks past kNumTracks and
+// leaves the surface on a bank that does not exist.
+
+inline int hardwareBankForScreenBank (int screenBank, int screenStride) noexcept
+{
+    if (screenStride <= 0) return 0;
+    const int firstTrack = std::max (0, screenBank) * screenStride;
+    return std::clamp (firstTrack / Session::kBankSize, 0, Session::kNumBanks - 1);
+}
+
+inline int screenBankForHardwareBank (int hardwareBank,
+                                      int screenStride,
+                                      int screenBankCount) noexcept
+{
+    if (screenStride <= 0 || screenBankCount <= 1) return 0;
+    const int firstTrack = std::clamp (hardwareBank, 0, Session::kNumBanks - 1)
+                         * Session::kBankSize;
+    return std::clamp (firstTrack / screenStride, 0, screenBankCount - 1);
+}
+} // namespace duskstudio

--- a/src/ui/BankMapping.h
+++ b/src/ui/BankMapping.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../session/Session.h"
+#include "../session/SessionLayout.h"
 
 #include <algorithm>
 
@@ -17,7 +17,9 @@ inline int hardwareBankForScreenBank (int screenBank, int screenStride) noexcept
 {
     if (screenStride <= 0) return 0;
     const int firstTrack = std::max (0, screenBank) * screenStride;
-    return std::clamp (firstTrack / Session::kBankSize, 0, Session::kNumBanks - 1);
+    return std::clamp (firstTrack / SessionLayout::kBankSize,
+                       0,
+                       SessionLayout::kNumBanks - 1);
 }
 
 inline int screenBankForHardwareBank (int hardwareBank,
@@ -25,8 +27,27 @@ inline int screenBankForHardwareBank (int hardwareBank,
                                       int screenBankCount) noexcept
 {
     if (screenStride <= 0 || screenBankCount <= 1) return 0;
-    const int firstTrack = std::clamp (hardwareBank, 0, Session::kNumBanks - 1)
-                         * Session::kBankSize;
+    const int firstTrack = std::clamp (hardwareBank, 0, SessionLayout::kNumBanks - 1)
+                         * SessionLayout::kBankSize;
     return std::clamp (firstTrack / screenStride, 0, screenBankCount - 1);
+}
+
+struct ScreenBankResizeState
+{
+    int currentBank;
+    int lastKnownMcuBank;
+    int activeBank;
+    int mcuBank;
+};
+
+inline ScreenBankResizeState screenBankStateAfterResize (int currentBank,
+                                                          int screenBankCount,
+                                                          int screenStride) noexcept
+{
+    const int clampedBank = std::clamp (currentBank,
+                                        0,
+                                        std::max (0, screenBankCount - 1));
+    const int hardwareBank = hardwareBankForScreenBank (clampedBank, screenStride);
+    return { clampedBank, hardwareBank, hardwareBank, hardwareBank };
 }
 } // namespace duskstudio

--- a/src/ui/ConsoleView.cpp
+++ b/src/ui/ConsoleView.cpp
@@ -1,5 +1,7 @@
 #include "ConsoleView.h"
 
+#include "BankMapping.h"
+
 #include <algorithm>
 
 namespace duskstudio
@@ -141,22 +143,38 @@ std::pair<int, int> ConsoleView::rangeForBank (int bankIndex) const noexcept
 
 void ConsoleView::setBank (int bankIndex)
 {
-    const int requested = bankIndex;
-    bankIndex = std::clamp (bankIndex, 0, std::max (0, numBanks() - 1));
+    const int pages = numBanks();
+    bankIndex = std::clamp (bankIndex, 0, std::max (0, pages - 1));
+    // Must stay a no-op when the page doesn't move: focusStrip calls this on
+    // every strip click and arrow-key move, naming the page already on screen.
+    // Moving the surface from there would snap it away under the user with no
+    // on-screen feedback, once per click.
     if (bankIndex == currentBank) return;
     currentBank = bankIndex;
-    // Publish the active bank to the audio thread so bank-relative MIDI
-    // bindings (TrackFaderBank etc.) resolve to the visible 8 tracks.
-    sessionRef.activeBank.store (bankIndex, std::memory_order_relaxed);
-    // Keep the MCU surface on the same bank ONLY when the requested bank was a
-    // valid screen bank (Cmd+1/2/3 within numBanks). The MCU has its own fixed
-    // 3-bank range (kNumBanks); when this call is the timer mirroring a
-    // hardware bank the screen can't show (numBanks collapsed because all
-    // tracks fit at once), the request clamps - writing the clamped value back
-    // would force the surface off banks 9-16/17-24. Skip the store then.
-    if (requested == bankIndex)
-        sessionRef.mcu.bank.store (bankIndex, std::memory_order_relaxed);
 
+    // A page is stride-wide (6..24); the surface and the bank-relative bindings
+    // are kBankSize-wide, so the page index is never a valid bank - publish the
+    // hardware bank holding the page's first track instead. With every track on
+    // screen there is only one page and it carries no bank opinion at all, so
+    // the surface keeps wherever its own Bank Left/Right left it.
+    if (pages > 1)
+    {
+        const int hardwareBank = hardwareBankForScreenBank (currentBank, bankStride());
+        // Latch before the store: timerCallback mirrors mcu.bank back into the
+        // screen page, and the hardware bank rarely lines up with the page.
+        // Without the latch our own store reads back as a surface move and
+        // drags the view off the page the user just picked.
+        lastKnownMcuBank = hardwareBank;
+        activeBankFollowsScreen = true;
+        sessionRef.activeBank.store (hardwareBank, std::memory_order_relaxed);
+        sessionRef.mcu.bank.store (hardwareBank, std::memory_order_release);
+    }
+
+    applyBankChange();
+}
+
+void ConsoleView::applyBankChange()
+{
     updateBankVisibility();
     resized();
 
@@ -169,12 +187,23 @@ void ConsoleView::setBank (int bankIndex)
 void ConsoleView::timerCallback()
 {
     // The MCU Bank Left/Right buttons write session.mcu.bank on the audio
-    // thread; mirror it into the visible bank here so the on-screen view +
-    // bank-relative bindings follow the surface. setBank no-ops when the
-    // value already matches, so this doesn't churn.
-    const int mcuBank = sessionRef.mcu.bank.load (std::memory_order_relaxed);
-    if (mcuBank != currentBank)
-        setBank (mcuBank);
+    // thread. Mirror it into the bank-relative binding base and scroll the
+    // screen onto the page holding those tracks. The mcu.bank store is
+    // deliberately NOT echoed back: the surface owns its own position, and the
+    // page it maps onto maps back to a different hardware bank whenever the
+    // stride isn't kBankSize. Binding base follows even when the screen can't
+    // page (window wide enough to show all 24 at once).
+    const int mcuBank = sessionRef.mcu.bank.load (std::memory_order_acquire);
+    if (mcuBank == lastKnownMcuBank) return;
+    lastKnownMcuBank = mcuBank;
+    activeBankFollowsScreen = false;
+    sessionRef.activeBank.store (std::clamp (mcuBank, 0, Session::kNumBanks - 1),
+                                 std::memory_order_relaxed);
+
+    const int screenBank = screenBankForHardwareBank (mcuBank, bankStride(), numBanks());
+    if (screenBank == currentBank) return;
+    currentBank = screenBank;
+    applyBankChange();
 }
 
 void ConsoleView::updateBankVisibility()
@@ -201,24 +230,24 @@ void ConsoleView::resized()
     // master column. Below this we fall back to dynamic banking - bank
     // stride = channelsThatFit().
     showingAllTracks = (area.getWidth() >= fixedWidthFor16Tracks() - 12);
-    // Re-clamp the active bank index against the (possibly changed)
-    // numBanks so a window-shrink doesn't leave us viewing an empty
-    // bank past the end.
-    const int preClampBank = currentBank;
-    currentBank = std::clamp (currentBank, 0, std::max (0, numBanks() - 1));
-    if (currentBank != preClampBank)
-    {
-        // Republish the clamped SCREEN bank so bank-relative MIDI bindings
-        // don't stay pointed past the end. Do NOT clamp mcu.bank here - the
-        // MCU surface owns its own fixed 3-bank range (kNumBanks) independent
-        // of the width-driven screen banking; clamping it to numBanks would
-        // strand the surface on bank 0 whenever the window is wide enough to
-        // show every track at once.
-        sessionRef.activeBank.store (currentBank, std::memory_order_relaxed);
-    }
-    updateBankVisibility();
 
     const int stride = bankStride();
+    const int pages  = numBanks();
+    // Re-clamp the screen page against the (possibly changed) numBanks so a
+    // window-shrink doesn't leave us viewing an empty page past the end.
+    currentBank = std::clamp (currentBank, 0, std::max (0, pages - 1));
+
+    // Both the page index and the stride under it are width-derived, so a
+    // resize moves which hardware bank the page sits in - re-derive, or
+    // bank-relative bindings keep driving whichever strips the OLD width put
+    // under the page. mcu.bank is deliberately untouched: the surface's own
+    // position is width-independent, and with a single page the screen has no
+    // bank opinion to impose in the first place.
+    if (pages > 1 && activeBankFollowsScreen)
+        sessionRef.activeBank.store (hardwareBankForScreenBank (currentBank, stride),
+                                     std::memory_order_relaxed);
+    updateBankVisibility();
+
     int visibleChannels;
     if (showingAllTracks)
     {

--- a/src/ui/ConsoleView.cpp
+++ b/src/ui/ConsoleView.cpp
@@ -234,18 +234,22 @@ void ConsoleView::resized()
     const int stride = bankStride();
     const int pages  = numBanks();
     // Re-clamp the screen page against the (possibly changed) numBanks so a
-    // window-shrink doesn't leave us viewing an empty page past the end.
-    currentBank = std::clamp (currentBank, 0, std::max (0, pages - 1));
+    // width change doesn't leave us viewing an empty page past the end.
+    const auto remappedBanks = screenBankStateAfterResize (currentBank, pages, stride);
+    currentBank = remappedBanks.currentBank;
 
     // Both the page index and the stride under it are width-derived, so a
     // resize moves which hardware bank the page sits in - re-derive, or
     // bank-relative bindings keep driving whichever strips the OLD width put
-    // under the page. mcu.bank is deliberately untouched: the surface's own
-    // position is width-independent, and with a single page the screen has no
-    // bank opinion to impose in the first place.
+    // under the page. When the screen owns the bank, keep the MCU latch, binding
+    // base, and surface bank together; with a single page the screen has no bank
+    // opinion to impose in the first place.
     if (pages > 1 && activeBankFollowsScreen)
-        sessionRef.activeBank.store (hardwareBankForScreenBank (currentBank, stride),
-                                     std::memory_order_relaxed);
+    {
+        lastKnownMcuBank = remappedBanks.lastKnownMcuBank;
+        sessionRef.activeBank.store (remappedBanks.activeBank, std::memory_order_relaxed);
+        sessionRef.mcu.bank.store (remappedBanks.mcuBank, std::memory_order_release);
+    }
     updateBankVisibility();
 
     int visibleChannels;

--- a/src/ui/ConsoleView.h
+++ b/src/ui/ConsoleView.h
@@ -87,6 +87,8 @@ public:
     static std::pair<int, int> rangeForBankAtWidth (int bankIndex,
                                                       int componentWidth) noexcept;
 
+    // Screen page index (0..numBanks()-1), NOT a hardware bank. The matching
+    // hardware bank is derived and published in setBank - see BankMapping.h.
     void setBank (int bankIndex);
     int  getBank() const noexcept { return currentBank; }
 
@@ -131,6 +133,14 @@ private:
     std::unique_ptr<MasterStripComponent> masterStrip;
 
     int currentBank = 0;
+    // Last value of session.mcu.bank this view knows about, whether the surface
+    // moved it or setBank did. Suppresses the echo of our own store.
+    int lastKnownMcuBank = 0;
+    // Whether activeBank was last set from the screen page or from the surface.
+    // Only a screen-derived value depends on the stride, so only that one gets
+    // re-derived on a resize; the surface's own position is width-independent
+    // and must survive one.
+    bool activeBankFollowsScreen = false;
     bool showingAllTracks = false;
 
     // -1 = none. Drives the focus ring + (via stripFocusCb) the A/S/X target.
@@ -139,9 +149,10 @@ private:
     void focusStrip (int track);
 
     void updateBankVisibility();
+    void applyBankChange();
 
     // Polls session.mcu.bank so the MCU surface's Bank Left/Right buttons
-    // (handled on the audio thread) drive the visible bank + bank-relative
+    // (handled on the audio thread) drive the visible page + bank-relative
     // bindings, keeping the surface and the on-screen view on the same 8.
     void timerCallback() override;
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -85,6 +85,7 @@ add_executable(dusk-studio-tests
     session_fader_group.cpp
     transport_state_machine.cpp
     session_mcu_roundtrip.cpp
+    console_bank_mapping.cpp
     mcu_receiver_decode.cpp
     mcu_controller_emit.cpp
     mcu_fader_taper.cpp

--- a/tests/console_bank_mapping.cpp
+++ b/tests/console_bank_mapping.cpp
@@ -1,6 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
 
-#include "session/Session.h"
 #include "ui/BankMapping.h"
 
 using namespace duskstudio;
@@ -57,7 +56,7 @@ TEST_CASE ("Bank mapping: screen page resolves to the bank holding its first tra
 
     SECTION ("stride 24 - no banking, the single page starts at bank 0")
     {
-        REQUIRE (hardwareBankForScreenBank (0, Session::kNumTracks) == 0);
+        REQUIRE (hardwareBankForScreenBank (0, SessionLayout::kNumTracks) == 0);
     }
 }
 
@@ -108,8 +107,8 @@ TEST_CASE ("Bank mapping: hardware bank resolves to the page showing its first t
 
     SECTION ("stride 24 - every bank maps to the single page")
     {
-        for (int hw = 0; hw < Session::kNumBanks; ++hw)
-            REQUIRE (screenBankForHardwareBank (hw, Session::kNumTracks, 1) == 0);
+        for (int hw = 0; hw < SessionLayout::kNumBanks; ++hw)
+            REQUIRE (screenBankForHardwareBank (hw, SessionLayout::kNumTracks, 1) == 0);
     }
 }
 
@@ -118,10 +117,10 @@ TEST_CASE ("Bank mapping: indices past the end of a range clamp into it", "[cons
     SECTION ("a page past the last track can't name a bank past the last bank")
     {
         // First track 24 - one past kNumTracks, so the raw quotient is 3.
-        REQUIRE (hardwareBankForScreenBank (3, 8) == Session::kNumBanks - 1);
-        REQUIRE (hardwareBankForScreenBank (4, 6) == Session::kNumBanks - 1);
+        REQUIRE (hardwareBankForScreenBank (3, 8) == SessionLayout::kNumBanks - 1);
+        REQUIRE (hardwareBankForScreenBank (4, 6) == SessionLayout::kNumBanks - 1);
         // First track 32 - raw quotient 4.
-        REQUIRE (hardwareBankForScreenBank (2, 16) == Session::kNumBanks - 1);
+        REQUIRE (hardwareBankForScreenBank (2, 16) == SessionLayout::kNumBanks - 1);
     }
 
     SECTION ("a bank past the last page clamps to the last page")
@@ -133,7 +132,7 @@ TEST_CASE ("Bank mapping: indices past the end of a range clamp into it", "[cons
 
     SECTION ("a bank past kNumBanks clamps before it is resolved")
     {
-        REQUIRE (screenBankForHardwareBank (Session::kNumBanks, 8, 3) == 2);
+        REQUIRE (screenBankForHardwareBank (SessionLayout::kNumBanks, 8, 3) == 2);
     }
 
     SECTION ("negative and zero inputs")
@@ -159,9 +158,25 @@ TEST_CASE ("Bank mapping: the widest page count the console builds stays in rang
     {
         const int hw = hardwareBankForScreenBank (page, kNarrowestStride);
         REQUIRE (hw >= 0);
-        REQUIRE (hw < Session::kNumBanks);
-        REQUIRE (hw * Session::kBankSize + Session::kBankSize <= Session::kNumTracks);
+        REQUIRE (hw < SessionLayout::kNumBanks);
+        REQUIRE (hw * SessionLayout::kBankSize + SessionLayout::kBankSize
+                 <= SessionLayout::kNumTracks);
     }
 
     REQUIRE (hardwareBankForScreenBank (kMostPages - 1, kNarrowestStride) == 2);
+}
+
+TEST_CASE ("Bank mapping: a resize republishes the clamped page hardware bank",
+           "[console][bank]")
+{
+    // Page 3 at stride 6 begins at track 18 (hardware bank 2). Widening to
+    // stride 12 leaves only two pages, so the screen clamps to page 1 and all
+    // screen-owned hardware-bank state must follow its first track (track 12).
+    REQUIRE (hardwareBankForScreenBank (3, 6) == 2);
+    const auto state = screenBankStateAfterResize (3, 2, 12);
+
+    REQUIRE (state.currentBank == 1);
+    REQUIRE (state.lastKnownMcuBank == 1);
+    REQUIRE (state.activeBank == 1);
+    REQUIRE (state.mcuBank == 1);
 }

--- a/tests/console_bank_mapping.cpp
+++ b/tests/console_bank_mapping.cpp
@@ -1,0 +1,167 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "session/Session.h"
+#include "ui/BankMapping.h"
+
+using namespace duskstudio;
+
+// Screen pages are bankStride()-wide (channelsThatFit(), clamped to [6, 24]);
+// hardware banks are always kBankSize-wide and there are always kNumBanks of
+// them. Each case below names the page's first track, which is what decides
+// the hardware bank it resolves to.
+
+TEST_CASE ("Bank mapping: screen page resolves to the bank holding its first track",
+           "[console][bank]")
+{
+    SECTION ("stride 6 - four pages fold onto three banks")
+    {
+        REQUIRE (hardwareBankForScreenBank (0, 6) == 0);   // first track 0
+        REQUIRE (hardwareBankForScreenBank (1, 6) == 0);   // first track 6
+        REQUIRE (hardwareBankForScreenBank (2, 6) == 1);   // first track 12
+        REQUIRE (hardwareBankForScreenBank (3, 6) == 2);   // first track 18
+    }
+
+    SECTION ("stride 7 - four pages")
+    {
+        REQUIRE (hardwareBankForScreenBank (0, 7) == 0);   // first track 0
+        REQUIRE (hardwareBankForScreenBank (1, 7) == 0);   // first track 7
+        REQUIRE (hardwareBankForScreenBank (2, 7) == 1);   // first track 14
+        REQUIRE (hardwareBankForScreenBank (3, 7) == 2);   // first track 21
+    }
+
+    SECTION ("stride 8 - the one stride where page and bank are the same index")
+    {
+        REQUIRE (hardwareBankForScreenBank (0, 8) == 0);
+        REQUIRE (hardwareBankForScreenBank (1, 8) == 1);
+        REQUIRE (hardwareBankForScreenBank (2, 8) == 2);
+    }
+
+    SECTION ("stride 9 - three pages")
+    {
+        REQUIRE (hardwareBankForScreenBank (0, 9) == 0);   // first track 0
+        REQUIRE (hardwareBankForScreenBank (1, 9) == 1);   // first track 9
+        REQUIRE (hardwareBankForScreenBank (2, 9) == 2);   // first track 18
+    }
+
+    SECTION ("stride 12 - two pages")
+    {
+        REQUIRE (hardwareBankForScreenBank (0, 12) == 0);  // first track 0
+        REQUIRE (hardwareBankForScreenBank (1, 12) == 1);  // first track 12
+    }
+
+    SECTION ("stride 16 - two pages, bank 1 never starts one")
+    {
+        REQUIRE (hardwareBankForScreenBank (0, 16) == 0);  // first track 0
+        REQUIRE (hardwareBankForScreenBank (1, 16) == 2);  // first track 16
+    }
+
+    SECTION ("stride 24 - no banking, the single page starts at bank 0")
+    {
+        REQUIRE (hardwareBankForScreenBank (0, Session::kNumTracks) == 0);
+    }
+}
+
+TEST_CASE ("Bank mapping: hardware bank resolves to the page showing its first track",
+           "[console][bank]")
+{
+    SECTION ("stride 6, four pages")
+    {
+        REQUIRE (screenBankForHardwareBank (0, 6, 4) == 0);   // track 0  -> page 0
+        REQUIRE (screenBankForHardwareBank (1, 6, 4) == 1);   // track 8  -> page 1
+        REQUIRE (screenBankForHardwareBank (2, 6, 4) == 2);   // track 16 -> page 2
+    }
+
+    SECTION ("stride 7, four pages")
+    {
+        REQUIRE (screenBankForHardwareBank (0, 7, 4) == 0);   // track 0  -> page 0
+        REQUIRE (screenBankForHardwareBank (1, 7, 4) == 1);   // track 8  -> page 1
+        REQUIRE (screenBankForHardwareBank (2, 7, 4) == 2);   // track 16 -> page 2
+    }
+
+    SECTION ("stride 8, three pages - identity")
+    {
+        REQUIRE (screenBankForHardwareBank (0, 8, 3) == 0);
+        REQUIRE (screenBankForHardwareBank (1, 8, 3) == 1);
+        REQUIRE (screenBankForHardwareBank (2, 8, 3) == 2);
+    }
+
+    SECTION ("stride 9, three pages - banks 0 and 1 share page 0")
+    {
+        REQUIRE (screenBankForHardwareBank (0, 9, 3) == 0);   // track 0  -> page 0
+        REQUIRE (screenBankForHardwareBank (1, 9, 3) == 0);   // track 8  -> page 0
+        REQUIRE (screenBankForHardwareBank (2, 9, 3) == 1);   // track 16 -> page 1
+    }
+
+    SECTION ("stride 12, two pages")
+    {
+        REQUIRE (screenBankForHardwareBank (0, 12, 2) == 0);  // track 0  -> page 0
+        REQUIRE (screenBankForHardwareBank (1, 12, 2) == 0);  // track 8  -> page 0
+        REQUIRE (screenBankForHardwareBank (2, 12, 2) == 1);  // track 16 -> page 1
+    }
+
+    SECTION ("stride 16, two pages")
+    {
+        REQUIRE (screenBankForHardwareBank (0, 16, 2) == 0);  // track 0  -> page 0
+        REQUIRE (screenBankForHardwareBank (1, 16, 2) == 0);  // track 8  -> page 0
+        REQUIRE (screenBankForHardwareBank (2, 16, 2) == 1);  // track 16 -> page 1
+    }
+
+    SECTION ("stride 24 - every bank maps to the single page")
+    {
+        for (int hw = 0; hw < Session::kNumBanks; ++hw)
+            REQUIRE (screenBankForHardwareBank (hw, Session::kNumTracks, 1) == 0);
+    }
+}
+
+TEST_CASE ("Bank mapping: indices past the end of a range clamp into it", "[console][bank]")
+{
+    SECTION ("a page past the last track can't name a bank past the last bank")
+    {
+        // First track 24 - one past kNumTracks, so the raw quotient is 3.
+        REQUIRE (hardwareBankForScreenBank (3, 8) == Session::kNumBanks - 1);
+        REQUIRE (hardwareBankForScreenBank (4, 6) == Session::kNumBanks - 1);
+        // First track 32 - raw quotient 4.
+        REQUIRE (hardwareBankForScreenBank (2, 16) == Session::kNumBanks - 1);
+    }
+
+    SECTION ("a bank past the last page clamps to the last page")
+    {
+        // Track 16 over a 2-page console: raw quotient 2, one past the last page.
+        REQUIRE (screenBankForHardwareBank (2, 8, 2) == 1);
+        REQUIRE (screenBankForHardwareBank (2, 6, 2) == 1);
+    }
+
+    SECTION ("a bank past kNumBanks clamps before it is resolved")
+    {
+        REQUIRE (screenBankForHardwareBank (Session::kNumBanks, 8, 3) == 2);
+    }
+
+    SECTION ("negative and zero inputs")
+    {
+        REQUIRE (hardwareBankForScreenBank (-1, 8) == 0);
+        REQUIRE (hardwareBankForScreenBank (1, 0) == 0);
+        REQUIRE (screenBankForHardwareBank (-1, 8, 3) == 0);
+        REQUIRE (screenBankForHardwareBank (1, 0, 4) == 0);
+    }
+}
+
+TEST_CASE ("Bank mapping: the widest page count the console builds stays in range",
+           "[console][bank]")
+{
+    // channelsThatFitForWidth floors the stride at ceil(kNumTracks / 4), so the
+    // console can build a 4th page. Stored raw, that page index names a bank
+    // that does not exist: past kNumBanks for the surface, and past kNumTracks
+    // once the audio thread multiplies it by kBankSize.
+    constexpr int kNarrowestStride = 6;
+    constexpr int kMostPages       = 4;
+
+    for (int page = 0; page < kMostPages; ++page)
+    {
+        const int hw = hardwareBankForScreenBank (page, kNarrowestStride);
+        REQUIRE (hw >= 0);
+        REQUIRE (hw < Session::kNumBanks);
+        REQUIRE (hw * Session::kBankSize + Session::kBankSize <= Session::kNumTracks);
+    }
+
+    REQUIRE (hardwareBankForScreenBank (kMostPages - 1, kNarrowestStride) == 2);
+}


### PR DESCRIPTION
## What

- Keep width-dependent console pages separate from fixed 3x8 hardware banks.
- Publish the hardware bank containing the first visible track and mirror MCU bank changes back to the matching screen page.
- Preserve surface-derived banks across resize while recalculating screen-derived banks.
- Add focused mapping and synchronization regression coverage.

## Why

Console page strides range from 6 to 24 channels, while bindings and MCU banks always use groups of 8. Reusing a screen page index as a hardware bank desynchronized visible tracks from controls and could publish an out-of-range MCU bank.

## Validation

- DuskStudio app build
- 537/537 tests passed
- JUCE gate: 179 files / 9257 uses

Fixes #144

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization between visible screen pages and hardware bank selections.
  * Preserved the correct active bank when resizing and prevented unnecessary bank updates.
  * Added boundary handling for invalid or out-of-range bank and page values.

* **Tests**
  * Added coverage for bank mapping across supported layouts, shared banks, identity mappings, and edge cases.
  * Added regression checks to ensure resolved banks remain within valid limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->