### PR TITLE
Fix plugin lifecycle and host edge cases (#147)

### DIFF
--- a/src/engine/PluginSlot.cpp
+++ b/src/engine/PluginSlot.cpp
@@ -372,6 +372,10 @@ void PluginSlot::prepareToPlay (double sampleRate, int blockSize)
         ownedInstance->prepareToPlay (sampleRate, preparedBlockSize);
         cachedLatencySamples.store (ownedInstance->getLatencySamples(),
                                       std::memory_order_relaxed);
+        // Re-publish the live instance last: releaseResources() nulls
+        // currentInstance while keeping ownedInstance, so without this a
+        // release / re-prepare cycle leaves the slot silent until a reload.
+        currentInstance.store (ownedInstance.get(), std::memory_order_release);
         return;
     }
 

--- a/src/engine/PluginSlot.cpp
+++ b/src/engine/PluginSlot.cpp
@@ -499,6 +499,16 @@ void PluginSlot::setTemporarilyInactivePersistenceForTest (
     loadedDescriptor = std::move (descriptor);
     lastKnownStateBase64 = stateBase64;
 }
+
+bool PluginSlot::installInProcessInstanceForTest (
+    PluginInstancePtr instance)
+{
+    PluginDescriptor descriptor;
+    descriptor.name = instance != nullptr ? instance->getName().toStdString()
+                                          : std::string();
+    descriptor.formatName = "Test";
+    return installInProcessInstance (std::move (instance), std::move (descriptor));
+}
 #endif
 
 juce::String PluginSlot::getOfflineName() const

--- a/src/engine/PluginSlot.h
+++ b/src/engine/PluginSlot.h
@@ -33,6 +33,8 @@ class PluginManager;
 // setters from the render context. See timerCallback() + paramFifo.
 class PluginSlot : private dusk::Timer
 {
+    using PluginInstancePtr = std::unique_ptr<juce::AudioPluginInstance>;
+
 public:
     PluginSlot();
     ~PluginSlot() override;
@@ -206,6 +208,11 @@ public:
     // temporarily unpublished (device inactive or OOP child already gone).
     void setTemporarilyInactivePersistenceForTest (
         PluginDescriptor descriptor, const juce::String& stateBase64);
+
+    // Lifecycle seam: installs an in-process test instance through the same
+    // prepare-and-publish path used by descriptor loads.
+    bool installInProcessInstanceForTest (
+        PluginInstancePtr instance);
    #endif
 
    #if JUCE_MAC && DUSKSTUDIO_HAS_OOP_PLUGINS
@@ -248,7 +255,7 @@ private:
     // Message-thread install tail shared by descriptor-based sync and async
     // loads. Primes + atomically swaps in the
     // already-built instance; caller has already rotated the keep-alive ring.
-    bool installInProcessInstance (std::unique_ptr<juce::AudioPluginInstance> fresh,
+    bool installInProcessInstance (PluginInstancePtr fresh,
                                    PluginDescriptor descriptor);
 
     // Liveness token for async-load completions: a completion captures a

--- a/src/engine/clap/ClapHost.h
+++ b/src/engine/clap/ClapHost.h
@@ -42,6 +42,15 @@ public:
     // release on publish, acquire on read.
     void setAudioThread (std::thread::id id) noexcept
         { audioThreadHash.store (std::hash<std::thread::id>{} (id), std::memory_order_release); }
+    // For the message thread temporarily designating itself the audio thread to
+    // satisfy a plugin's thread-check inside an [audio-thread] call. The stamp
+    // MUST be handed back: left in place, the message thread answers true to both
+    // is_audio_thread and is_main_thread for as long as the instance lives.
+    std::size_t exchangeAudioThread (std::thread::id id) noexcept
+        { return audioThreadHash.exchange (std::hash<std::thread::id>{} (id),
+                                           std::memory_order_acq_rel); }
+    void restoreAudioThread (std::size_t previous) noexcept
+        { audioThreadHash.store (previous, std::memory_order_release); }
     void setPlugin (const clap_plugin* p) noexcept    { plugin = p; }
     // The gui request callbacks (request_resize/show/hide) are CLAP [thread-safe] -
     // the plugin may fire them from its own thread while teardown swaps this target on

--- a/src/engine/clap/ClapInstance.cpp
+++ b/src/engine/clap/ClapInstance.cpp
@@ -226,9 +226,13 @@ void ClapInstance::deactivate()
             // stop_processing is [audio-thread], but deactivate runs on the message
             // thread (the engine process gate has quiesced the real audio thread, so
             // exactly one thread is the "audio thread" right now). Re-designate this
-            // thread so the plugin's thread-check inside stop_processing is satisfied.
-            hostObj.setAudioThread (std::this_thread::get_id());
+            // thread so the plugin's thread-check inside stop_processing is satisfied,
+            // then hand the stamp back - process() only re-stamps on its next start,
+            // which a bypassed slot never reaches.
+            const auto previousAudioThread =
+                hostObj.exchangeAudioThread (std::this_thread::get_id());
             plugin->stop_processing (plugin);
+            hostObj.restoreAudioThread (previousAudioThread);
         }
         processing  = false;
         startFailed = false;

--- a/src/engine/vst3/Vst3HostContext.cpp
+++ b/src/engine/vst3/Vst3HostContext.cpp
@@ -149,13 +149,27 @@ public:
             pfds.reserve (fdHandlers.size());
             for (const auto& e : fdHandlers)
             {
-                pfds.push_back ({ e.fd, POLLIN | POLLOUT | POLLERR, 0 });
+                // Read-readiness only: IRunLoop has no direction flags, and a
+                // socket is almost always writable, so requesting POLLOUT makes
+                // revents nonzero every pump and fires onFDIsSet for every fd.
+                // POLLERR/POLLHUP arrive unrequested.
+                pfds.push_back ({ e.fd, POLLIN, 0 });
                 handlers.push_back (e.handler);
             }
             if (::poll (pfds.data(), (nfds_t) pfds.size(), 0) > 0)
                 for (size_t i = 0; i < pfds.size(); ++i)
-                    if (pfds[i].revents != 0 && stillRegistered (handlers[i]))
+                {
+                    const short revents = pfds[i].revents;
+                    if (revents == 0 || ! stillRegistered (handlers[i]))
+                        continue;
+                    // A plugin that closed its fd without unregistering leaves poll
+                    // reporting POLLNVAL immediately on every pump. Drop the handler
+                    // rather than dispatch a dead fd at message-thread rate forever.
+                    if ((revents & POLLNVAL) != 0)
+                        (void) unregisterEventHandler (handlers[i]);
+                    else if ((revents & (POLLIN | POLLHUP | POLLERR)) != 0)
                         handlers[i]->onFDIsSet (pfds[i].fd);
+                }
         }
 
         auto snapshot = timers;

--- a/src/engine/vst3/Vst3Instance.cpp
+++ b/src/engine/vst3/Vst3Instance.cpp
@@ -54,7 +54,12 @@ struct Vst3Instance::Impl : public Vst3HostContext::Callbacks
     Vst::HostProcessData     processData;
     Vst::ProcessContext      processContext {};
     Vst::ParameterChanges    inParams, outParams;
-    Vst::EventList           inEvents, outEvents;
+    // The SDK's EventList defaults to 50 and addEvent() silently drops past
+    // that - dense MIDI would strand note-offs. Sized like the CLAP path's
+    // per-block event scratch.
+    static constexpr int32 kMaxEventsPerBlock = 1024;
+    Vst::EventList           inEvents  { kMaxEventsPerBlock },
+                             outEvents { kMaxEventsPerBlock };
     std::vector<float>       silence;                 // shared silent input scratch
     std::vector<float>       sink;                    // shared output sink scratch
     std::vector<float*>      scratchPtrs;             // per-channel pointer scratch
@@ -175,6 +180,7 @@ struct Vst3Instance::Impl : public Vst3HostContext::Callbacks
         if (controller && ! controllerIsComponent)
             controller->terminate();
         controller = nullptr;
+        controllerIsComponent = false;   // create() only ever sets it true
         processor = nullptr;
         if (component)
             component->terminate();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -224,6 +224,7 @@ if(DUSKSTUDIO_NATIVE_CLAP)
         clap_native_slot.cpp
         clap_scanner.cpp
         clap_params.cpp
+        clap_host_thread_check.cpp
         ${CMAKE_SOURCE_DIR}/src/engine/clap/ClapBundle.cpp
         ${CMAKE_SOURCE_DIR}/src/engine/clap/ClapHost.cpp
         ${CMAKE_SOURCE_DIR}/src/engine/clap/ClapInstance.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(dusk-studio-tests
     ${CMAKE_SOURCE_DIR}/src/engine/PluginDescriptor.cpp
     plugin_manager_descriptor.cpp
     plugin_slot_persistence.cpp
+    plugin_slot_lifecycle.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/PluginManager.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/PluginSlot.cpp
     native_plugin_cache.cpp

--- a/tests/clap_host_thread_check.cpp
+++ b/tests/clap_host_thread_check.cpp
@@ -1,0 +1,60 @@
+// The host's thread-check extension: a message thread that temporarily
+// designates itself the audio thread (deactivate() calling [audio-thread]
+// stop_processing) must hand the stamp back, or it answers true to both
+// is_audio_thread and is_main_thread for the rest of the instance's life.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/clap/ClapHost.h"
+
+#include <thread>
+
+using duskstudio::clap::ClapHost;
+
+TEST_CASE ("CLAP host thread-check stamps and un-stamps the audio thread", "[clap][host]")
+{
+    ClapHost host;
+    const auto* h = host.get();
+    const auto* check = static_cast<const clap_host_thread_check_t*> (
+        h->get_extension (h, CLAP_EXT_THREAD_CHECK));
+    REQUIRE (check != nullptr);
+
+    SECTION ("a fresh host treats the constructing thread as main, not audio")
+    {
+        REQUIRE (check->is_main_thread (h));
+        REQUIRE_FALSE (check->is_audio_thread (h));
+    }
+
+    SECTION ("the process() stamp designates the calling thread")
+    {
+        host.setAudioThread (std::this_thread::get_id());
+        REQUIRE (check->is_audio_thread (h));
+    }
+
+    SECTION ("a borrowed stamp is handed back")
+    {
+        // deactivate()'s shape on a slot the audio thread never started.
+        const auto borrowed = host.exchangeAudioThread (std::this_thread::get_id());
+        REQUIRE (check->is_audio_thread (h));
+
+        host.restoreAudioThread (borrowed);
+        REQUIRE_FALSE (check->is_audio_thread (h));
+        REQUIRE (check->is_main_thread (h));
+    }
+
+    SECTION ("restore returns the previous owner's stamp, not a cleared one")
+    {
+        // This thread stands in for the prior owner, so the stamp being handed
+        // back is provably non-zero - restoring a fresh host's 0 would pass the
+        // section above either way. std::thread::id {} is the borrower here;
+        // the direction doesn't matter, only that the exact hash comes back.
+        host.setAudioThread (std::this_thread::get_id());
+
+        const auto borrowed = host.exchangeAudioThread (std::thread::id {});
+        REQUIRE_FALSE (check->is_audio_thread (h));
+
+        host.restoreAudioThread (borrowed);
+        REQUIRE (check->is_audio_thread (h));
+        REQUIRE (host.exchangeAudioThread (std::thread::id {}) == borrowed);
+    }
+}

--- a/tests/plugin_slot_lifecycle.cpp
+++ b/tests/plugin_slot_lifecycle.cpp
@@ -1,0 +1,83 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/PluginManager.h"
+#include "engine/PluginSlot.h"
+
+using namespace duskstudio;
+
+namespace
+{
+class LifecyclePluginInstance final : public juce::AudioPluginInstance
+{
+public:
+    using juce::AudioPluginInstance::processBlock;
+
+    LifecyclePluginInstance()
+        : AudioPluginInstance (BusesProperties()
+            .withInput  ("Input",  juce::AudioChannelSet::stereo(), true)
+            .withOutput ("Output", juce::AudioChannelSet::stereo(), true))
+    {
+    }
+
+    const juce::String getName() const override { return "Lifecycle test"; }
+
+    void prepareToPlay (double, int) override { ++prepareCalls; }
+    void releaseResources() override          { ++releaseCalls; }
+
+    void processBlock (juce::AudioBuffer<float>&,
+                       juce::MidiBuffer&) override
+    {
+        ++processCalls;
+    }
+
+    juce::AudioProcessorEditor* createEditor() override { return nullptr; }
+    bool hasEditor() const override                      { return false; }
+    bool acceptsMidi() const override                    { return false; }
+    bool producesMidi() const override                   { return false; }
+    double getTailLengthSeconds() const override         { return 0.0; }
+
+    int getNumPrograms() override                        { return 1; }
+    int getCurrentProgram() override                     { return 0; }
+    void setCurrentProgram (int) override                {}
+    const juce::String getProgramName (int) override     { return {}; }
+    void changeProgramName (int, const juce::String&) override {}
+
+    void getStateInformation (juce::MemoryBlock&) override {}
+    void setStateInformation (const void*, int) override    {}
+
+    void fillInPluginDescription (juce::PluginDescription& description) const override
+    {
+        description.name = getName();
+        description.pluginFormatName = "Test";
+        description.fileOrIdentifier = "lifecycle-test";
+    }
+
+    int prepareCalls = 0;
+    int releaseCalls = 0;
+    int processCalls = 0;
+};
+} // namespace
+
+TEST_CASE ("PluginSlot republishes an in-process instance after release and prepare")
+{
+    PluginManager manager;
+    PluginSlot slot;
+    slot.setManager (manager);
+    slot.prepareToPlay (48000.0, 64);
+
+    auto instance = std::make_unique<LifecyclePluginInstance>();
+    auto* lifecycle = instance.get();
+    REQUIRE (slot.installInProcessInstanceForTest (std::move (instance)));
+
+    slot.releaseResources();
+    slot.prepareToPlay (48000.0, 64);
+
+    float left[64] {};
+    float right[64] {};
+    juce::MidiBuffer midi;
+    slot.processStereoBlock (left, right, 64, midi);
+
+    CHECK (lifecycle->releaseCalls == 2);
+    CHECK (lifecycle->prepareCalls == 2);
+    CHECK (lifecycle->processCalls == 1);
+}

--- a/tests/vst3_hostcontext_runloop.cpp
+++ b/tests/vst3_hostcontext_runloop.cpp
@@ -80,6 +80,44 @@ TEST_CASE ("Vst3HostContext run loop dispatches fds and timers", "[vst3][hostcon
         ::close (fds[1]);
     }
 
+    SECTION ("a writable-but-not-readable fd is never dispatched")
+    {
+        // The write end of an empty pipe is POLLOUT-ready on every pump and
+        // never readable: polling for anything but read-readiness would fire
+        // onFDIsSet at pump rate for the life of the editor.
+        int fds[2] {};
+        REQUIRE (::pipe (fds) == 0);
+
+        FdHandler handler;
+        REQUIRE (runLoop->registerEventHandler (&handler, fds[1]) == kResultOk);
+
+        for (int i = 0; i < 5; ++i) ctx.pump (16.0);
+        REQUIRE (handler.fires == 0);
+
+        REQUIRE (runLoop->unregisterEventHandler (&handler) == kResultOk);
+        ::close (fds[0]);
+        ::close (fds[1]);
+    }
+
+    SECTION ("an fd closed behind our back is dropped, not dispatched forever")
+    {
+        int fds[2] {};
+        REQUIRE (::pipe (fds) == 0);
+
+        FdHandler handler;
+        REQUIRE (runLoop->registerEventHandler (&handler, fds[0]) == kResultOk);
+        ::close (fds[0]);   // plugin dropped the fd without unregistering
+
+        ctx.pump (16.0);
+        REQUIRE (handler.fires == 0);
+        REQUIRE (ctx.numEventHandlers() == 0);   // POLLNVAL latches - handler must go
+
+        ctx.pump (16.0);
+        REQUIRE (handler.fires == 0);
+
+        ::close (fds[1]);
+    }
+
     SECTION ("timer fires on cadence, not per pump")
     {
         TimerHandler timer;


### PR DESCRIPTION
## What

- Republish in-process plugin instances after release and prepare cycles.
- Restore CLAP audio-thread stamping after stop processing.
- Reset reused VST3 controller state and raise MIDI event-list capacity to 1024.
- Poll VST3 run-loop descriptors only for readable/error states and retire invalid descriptors.
- Add focused CLAP thread-check and VST3 run-loop regressions.

## Why

Lifecycle transitions could silently leave slots unpublished, CLAP could permanently classify the message thread as audio, reused VST3 controllers could skip termination, dense MIDI could exceed the default event capacity, and writable descriptors could be dispatched continuously.

## Validation

- DuskStudio app build
- 539/539 tests passed
- JUCE gate: 179 files / 9257 uses

Fixes #147

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented audio plugins from becoming silent after reconfiguration or preparation.
  - Improved CLAP plugin deactivation and audio-thread handling for more reliable processing.
  - Improved VST3 event handling, including safer recovery from closed or invalid event sources.
  - Increased the supported number of VST3 input and output events per audio block.
  - Improved plugin lifecycle cleanup and state reset behavior.

- **Tests**
  - Added coverage for CLAP thread handling and VST3 event-loop edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->