### PR TITLE
Fix MIDI and multisample edge cases (#148)

### DIFF
--- a/src/dsp/ChannelStrip.cpp
+++ b/src/dsp/ChannelStrip.cpp
@@ -1236,10 +1236,10 @@ void ChannelStrip::processAndAccumulate (const float* inL,
 #if DUSKSTUDIO_HAS_NATIVE_CLAP || DUSKSTUDIO_HAS_NATIVE_LV2 || DUSKSTUDIO_HAS_NATIVE_VST3 \
     || DUSKSTUDIO_HAS_NATIVE_AU \
     || DUSKSTUDIO_HAS_MULTISAMPLE
-            // Bridge the block's MIDI into dusk once for whichever native host runs.
-            nativeMidiScratch.clear();
-            for (const auto meta : trackMidi)
-                nativeMidiScratch.addEvent (meta.data, meta.numBytes, meta.samplePosition);
+            // Bridge the block's MIDI into dusk once for whichever native host
+            // runs. This is the last hop before the instrument, so a torn copy
+            // here is a hung note: the bridge is whole-block-or-nothing.
+            dusk::copyEventsWhole (trackMidi, nativeMidiScratch);
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
             if (nativeClapSlot.isLoaded())

--- a/src/engine/PluginSlot.cpp
+++ b/src/engine/PluginSlot.cpp
@@ -1322,9 +1322,7 @@ void PluginSlot::processMonoBlock (float* monoData, int numSamples,
             inPtrs[0] = nullptr;
         }
 
-        oopMidiScratch.clear();
-        for (const auto meta : midiMessages)
-            oopMidiScratch.addEvent (meta.data, meta.numBytes, meta.samplePosition);
+        dusk::copyEventsWhole (midiMessages, oopMidiScratch);
         if (! r->processBlockSync (inPtrs, std::max (rNumIn, 0),
                                        std::max (rNumOut, 0),
                                        numSamples, oopMidiScratch,
@@ -1505,9 +1503,7 @@ void PluginSlot::processStereoBlock (float* L, float* R, int numSamples,
             return;
         }
 
-        oopMidiScratch.clear();
-        for (const auto meta : midiMessages)
-            oopMidiScratch.addEvent (meta.data, meta.numBytes, meta.samplePosition);
+        dusk::copyEventsWhole (midiMessages, oopMidiScratch);
         if (! r->processBlockSync (inPtrs, std::max (rNumIn, 0),
                                        std::max (rNumOut, 0),
                                        numSamples, oopMidiScratch,

--- a/src/engine/midi/MidiDevices.h
+++ b/src/engine/midi/MidiDevices.h
@@ -88,8 +88,10 @@ public:
     // Audio thread. Retime this input's pending events into the dusk boundary
     // buffer. RT-safe: the collector's ring is pre-sized and never grows (an
     // over-capacity burst drops whole records), and `out` was reserveBytes()'d
-    // off the RT path by the caller. Call once per input index per block - the
-    // drain is destructive.
+    // off the RT path by the caller. A block that overruns that cap arrives
+    // empty rather than truncated, matching the out path: a torn tail would let
+    // a note-on through while its note-off was dropped. Call once per input
+    // index per block - the drain is destructive.
     void drainBlock (int inputIndex, dusk::MidiBuffer& out, int numSamples) noexcept;
 
 private:

--- a/src/engine/multisample/DuskMultisampleProcessor.cpp
+++ b/src/engine/multisample/DuskMultisampleProcessor.cpp
@@ -542,8 +542,12 @@ void DuskMultisampleProcessor::processBlock (const hosting::PortBuffers& io) noe
         {
             if ((bits & 1ull) == 0) continue;
             const size_t cc = w * 64 + (size_t) b;
-            sfizz_send_hdcc (impl->synth, 0, (int) cc,
-                             ccCache[cc].load (std::memory_order_relaxed));
+            const float value = ccCache[cc].load (std::memory_order_relaxed);
+            sfizz_send_hdcc (impl->synth, 0, (int) cc, value);
+           #if defined(DUSKSTUDIO_TESTS)
+            if (hdccDispatchObserver != nullptr)
+                hdccDispatchObserver (hdccDispatchObserverContext, (int) cc, value);
+           #endif
         }
     }
 

--- a/src/engine/multisample/DuskMultisampleProcessor.cpp
+++ b/src/engine/multisample/DuskMultisampleProcessor.cpp
@@ -52,15 +52,9 @@ void DuskMultisampleProcessor::setHDCC (int cc, float normValue)
     const float v = std::clamp (normValue, 0.0f, 1.0f);
     ccCache[(size_t) cc].store (v, std::memory_order_relaxed);
 
-    // Queue for the audio thread. If the FIFO is momentarily full
-    // (user spamming a control faster than the audio block rate), drop
-    // the oldest-unread by simply not writing - the cache still holds
-    // the latest value and the next change re-queues it.
-    const auto scope = ccFifo.write (1);
-    if (scope.blockSize1 > 0)
-        ccQueue[(size_t) scope.startIndex1] = { cc, v };
-    else if (scope.blockSize2 > 0)
-        ccQueue[(size_t) scope.startIndex2] = { cc, v };
+    // Release-flag after the store so the audio thread's acquire-exchange
+    // cannot see the bit without the value that set it.
+    ccDirty[(size_t) (cc / 64)].fetch_or (1ull << (cc % 64), std::memory_order_release);
 }
 
 float DuskMultisampleProcessor::getHDCC (int cc) const noexcept
@@ -537,24 +531,19 @@ void DuskMultisampleProcessor::processBlock (const hosting::PortBuffers& io) noe
         }
     }
 
-    // Drain UI-driven CC changes (ARIA custom-UI knobs/faders) queued
-    // by setHDCC on the message thread. sfizz_send_hdcc is the RT-side
-    // entry point; delay 0 applies at block start.
+    // Push UI-driven CC changes (ARIA custom-UI knobs/faders) flagged by
+    // setHDCC on the message thread. sfizz_send_hdcc is the RT-side entry
+    // point; delay 0 applies at block start. Bits left set by a block that
+    // bailed early are picked up by the next one.
+    for (size_t w = 0; w < ccDirty.size(); ++w)
     {
-        const auto ready = ccFifo.getNumReady();
-        if (ready > 0)
+        auto bits = ccDirty[w].exchange (0, std::memory_order_acquire);
+        for (int b = 0; bits != 0; ++b, bits >>= 1)
         {
-            const auto scope = ccFifo.read (ready);
-            for (int i = 0; i < scope.blockSize1; ++i)
-            {
-                const auto& c = ccQueue[(size_t) (scope.startIndex1 + i)];
-                sfizz_send_hdcc (impl->synth, 0, c.cc, c.value);
-            }
-            for (int i = 0; i < scope.blockSize2; ++i)
-            {
-                const auto& c = ccQueue[(size_t) (scope.startIndex2 + i)];
-                sfizz_send_hdcc (impl->synth, 0, c.cc, c.value);
-            }
+            if ((bits & 1ull) == 0) continue;
+            const size_t cc = w * 64 + (size_t) b;
+            sfizz_send_hdcc (impl->synth, 0, (int) cc,
+                             ccCache[cc].load (std::memory_order_relaxed));
         }
     }
 

--- a/src/engine/multisample/DuskMultisampleProcessor.h
+++ b/src/engine/multisample/DuskMultisampleProcessor.h
@@ -157,8 +157,9 @@ public:
 
     // High-definition CC control (drives ARIA custom-UI widgets)
     // setHDCC is called from the message thread (editor widget drag);
-    // it caches the value + queues it lock-free for the audio thread,
-    // which drains the queue at block top and calls sfizz_send_hdcc.
+    // it caches the value and flags the CC lock-free, and the audio thread
+    // pushes the cached value to sfizz_send_hdcc at block top. Repeated sets
+    // between two blocks collapse - sfizz sees only the newest value.
     // cc is 0..kNumHdcc-1 (sfizz's extended CC space). normValue 0..1.
     static constexpr int kNumHdcc = 512;
     void  setHDCC (int cc, float normValue);
@@ -210,14 +211,14 @@ private:
     std::atomic<int>           sf2PresetIndex { 0 };
 
     // CC control plumbing. ccCache holds the last value the UI set per
-    // CC (-1 = unset) for read-back + state save. ccFifo carries
-    // (cc,value) changes from the message thread to the audio thread,
-    // drained at the top of processBlock. SPSC: editor pushes, audio
-    // drains.
-    struct CcChange { int cc; float value; };
-    std::array<std::atomic<float>, kNumHdcc> ccCache;
-    juce::AbstractFifo            ccFifo { 2048 };
-    std::array<CcChange, 2048>    ccQueue;
+    // CC (-1 = unset) for read-back + state save. ccDirty flags which of
+    // those the audio thread has still to hand to sfizz, which reads the
+    // value back out of the cache at drain time: a knob moved faster than
+    // the block rate collapses onto its newest value instead of settling
+    // sfizz on a stale one the cache and the UI disagree with.
+    static constexpr int kCcDirtyWords = (kNumHdcc + 63) / 64;
+    std::array<std::atomic<float>, kNumHdcc>              ccCache;
+    std::array<std::atomic<std::uint64_t>, kCcDirtyWords> ccDirty {};
 
     // Cached "last applied" override values so processBlock only
     // hits sfizz's setter when the user has actually moved a knob.

--- a/src/engine/multisample/DuskMultisampleProcessor.h
+++ b/src/engine/multisample/DuskMultisampleProcessor.h
@@ -167,6 +167,19 @@ public:
     // its own default). Read on the message thread by the editor.
     float getHDCC (int cc) const noexcept;
 
+   #if defined(DUSKSTUDIO_TESTS)
+    // Observes successful sfizz_send_hdcc dispatches at block top. Kept out
+    // of production builds; tests use it to verify the coalescer without
+    // reaching through the sfizz pimpl.
+    using HdccDispatchObserverForTest = void (*) (void*, int, float);
+    void setHdccDispatchObserverForTest (void* context,
+                                         HdccDispatchObserverForTest observer) noexcept
+    {
+        hdccDispatchObserverContext = context;
+        hdccDispatchObserver = observer;
+    }
+   #endif
+
     // Control-block metadata for the stock auto-skin (non-ARIA SFZ that
     // declares `image=` + `label_cc&`). Queried via sfizz's messaging
     // API. Message-thread only.
@@ -219,6 +232,11 @@ private:
     static constexpr int kCcDirtyWords = (kNumHdcc + 63) / 64;
     std::array<std::atomic<float>, kNumHdcc>              ccCache;
     std::array<std::atomic<std::uint64_t>, kCcDirtyWords> ccDirty {};
+
+   #if defined(DUSKSTUDIO_TESTS)
+    void* hdccDispatchObserverContext { nullptr };
+    HdccDispatchObserverForTest hdccDispatchObserver { nullptr };
+   #endif
 
     // Cached "last applied" override values so processBlock only
     // hits sfizz's setter when the user has actually moved a knob.

--- a/src/engine/multisample/Sf2ToSfz.cpp
+++ b/src/engine/multisample/Sf2ToSfz.cpp
@@ -251,7 +251,8 @@ Sf2Conversion convertSf2Preset(const juce::File& sf2,
                 else if (type == 2) pan =  100.0;            // right
             }
 
-            // Loop
+            // Loop. 1 = loop forever, 3 = loop until the key is released and
+            // then play the tail out (SFZ calls that loop_sustain).
             const int sampleModes = genOr(eff, kGenSampleModes, 0);
             const bool loops = (sampleModes == 1 || sampleModes == 3);
 
@@ -319,14 +320,20 @@ Sf2Conversion convertSf2Preset(const juce::File& sf2,
                           + " lokey=" + std::to_string(loKey) + " hikey=" + std::to_string(hiKey)
                           + " lovel=" + std::to_string(loVel) + " hivel=" + std::to_string(hiVel)
                           + " pitch_keycenter=" + std::to_string(rootKey);
-            if (coarse != 0) r += " transpose=" + std::to_string(coarse);
-            if (fine   != 0) r += " tune=" + std::to_string(std::clamp(fine, -100, 100));
+            // The three fine-tune contributions sum to as much as +/-325 cents,
+            // well past the +/-100 SFZ tune allows, so the whole semitones fold
+            // into transpose and only the remainder stays in tune.
+            const int transposeSemis = coarse + fine / 100;
+            const int tuneCents      = fine % 100;
+            if (transposeSemis != 0) r += " transpose=" + std::to_string(transposeSemis);
+            if (tuneCents      != 0) r += " tune=" + std::to_string(tuneCents);
             if (std::abs(volumeDb) > 0.01) r += " volume=" + fmtF(volumeDb, 2);
             if (std::abs(pan) > 0.01)      r += " pan=" + fmtF(pan, 1);
             if (loops && smp.endLoop > smp.startLoop && smp.startLoop >= smp.start
                 && smp.endLoop <= smp.end)
             {
-                r += " loop_mode=loop_continuous";
+                r += sampleModes == 3 ? " loop_mode=loop_sustain"
+                                      : " loop_mode=loop_continuous";
                 r += " loop_start=" + std::to_string((int) (smp.startLoop - smp.start));
                 r += " loop_end="   + std::to_string((int) (smp.endLoop   - smp.start - 1));
             }

--- a/src/foundation/MidiBuffer.h
+++ b/src/foundation/MidiBuffer.h
@@ -59,6 +59,16 @@ public:
     // freely like a plain vector.
     void reserveBytes (std::size_t n) { data.reserve (n); capBytes = n; }
 
+    // Whether a record of this size fits an EMPTY buffer. A failed addEvent
+    // means either "this block has run out of room" or "this record can never
+    // be delivered here at all"; whole-block-or-nothing callers must tell those
+    // apart, because dropping the block over a record no cap could ever hold
+    // silences it forever rather than once.
+    bool fitsWhenEmpty (int numBytes) const noexcept
+    {
+        return numBytes > 0 && kHeader + (std::size_t) numBytes <= capBytes;
+    }
+
     // Returns false when the event was dropped (invalid, or over the reserved
     // cap) so RT callers can keep whole-block semantics instead of splitting
     // paired events at the cap.
@@ -107,4 +117,30 @@ private:
     std::vector<std::uint8_t> data;
     std::size_t capBytes = kUnbounded;
 };
+
+// Refill dest with every event of src (any buffer whose iteration yields
+// .data / .numBytes / .samplePosition), whole-block-or-nothing: if the events
+// cumulatively overrun dest's reserved cap, dest is left empty rather than
+// holding a torn prefix - a note-on delivered without the note-off that fell
+// off the end hangs the note. A single record too big for dest even when empty
+// is undeliverable no matter how the block is cut, so it drops on its own and
+// the rest of the block still gets through (an oversized sysex must not silence
+// the notes around it).
+//
+// Audio-thread safe: dest must have been reserveBytes()'d off the RT path.
+template <typename SourceBuffer>
+inline void copyEventsWhole (const SourceBuffer& src, MidiBuffer& dest)
+{
+    dest.clear();
+    for (const auto meta : src)
+    {
+        if (dest.addEvent (meta.data, meta.numBytes, meta.samplePosition))
+            continue;
+        if (dest.fitsWhenEmpty (meta.numBytes))
+        {
+            dest.clear();
+            return;
+        }
+    }
+}
 } // namespace dusk

--- a/src/foundation/MidiCollector.h
+++ b/src/foundation/MidiCollector.h
@@ -59,6 +59,15 @@ public:
     // Consumer (audio thread), once per block. Retimes the pending events into
     // out with offsets in [0, numSamples-1]. nowMs is the current hi-res ms
     // clock. Drains the ring (destructive) - call exactly once per block.
+    //
+    // out must be EMPTY on entry - an over-cap block is delivered by clearing
+    // it, which discards anything the caller left in there.
+    //
+    // Whole-block-or-nothing: if the block cumulatively overruns out's reserved
+    // cap it is delivered empty, because keeping the head would let a note-on
+    // through while its note-off fell off the tail, hanging the note. A single
+    // record too big for out even when empty is undeliverable at any cut, so it
+    // drops alone and the rest of the block survives.
     void removeNextBlock (dusk::MidiBuffer& out, int numSamples, double nowMs) noexcept
     {
         const double prevLast = lastCallbackTime;
@@ -92,6 +101,7 @@ public:
 
         int numSourceSamples = std::max (1, roundToInt ((nowMs - prevLast) * 0.001 * sampleRate));
         int startSample = 0;
+        bool overCap = false;
 
         if (numSourceSamples > numSamples)
         {
@@ -111,7 +121,9 @@ public:
                 const int s = toSample (timeMs, prevLast);
                 if (s < floorS) return;
                 const int pos = ((s - startSample) * scale) >> 10;
-                out.addEvent (bytes, n, std::clamp (pos, 0, numSamples - 1));
+                if (! out.addEvent (bytes, n, std::clamp (pos, 0, numSamples - 1))
+                      && out.fitsWhenEmpty (n))
+                    overCap = true;
             });
         }
         else
@@ -122,9 +134,13 @@ public:
             {
                 const int s = toSample (timeMs, prevLast);
                 if (s < dropBelow) return;
-                out.addEvent (bytes, n, std::clamp (s + startSample, 0, numSamples - 1));
+                if (! out.addEvent (bytes, n, std::clamp (s + startSample, 0, numSamples - 1))
+                      && out.fitsWhenEmpty (n))
+                    overCap = true;
             });
         }
+
+        if (overCap) out.clear();
     }
 
 private:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,6 +95,7 @@ add_executable(dusk-studio-tests
     ${CMAKE_SOURCE_DIR}/src/engine/McuController.cpp
     ${CMAKE_SOURCE_DIR}/src/foundation/MessageThread.cpp
     multisample_state_roundtrip.cpp
+    multisample_hdcc_coalescing.cpp
     bounce_stem_filename.cpp
     bounce_stem_targets.cpp
     dp_importer_parse.cpp

--- a/tests/foundation_midi_buffer.cpp
+++ b/tests/foundation_midi_buffer.cpp
@@ -121,3 +121,71 @@ TEST_CASE ("dusk::MidiBuffer drops past its reserved cap instead of growing",
     for (int i = 0; i < 1000; ++i)
         REQUIRE (unbounded.addEvent (note, 3, i));
 }
+
+// copyEventsWhole is the RT bridge every capped scratch buffer refills through
+// (the native-host bridge in ChannelStrip, the OOP scratch in PluginSlot). Those
+// call sites need the full engine to exercise, so the policy is asserted here on
+// the shared helper instead.
+TEST_CASE ("dusk::copyEventsWhole delivers a block whole or not at all",
+           "[foundation][midi]")
+{
+    const std::uint8_t on[3]  { 0x90, 60, 100 };
+    const std::uint8_t off[3] { 0x80, 60, 0 };
+
+    dusk::MidiBuffer src;
+    src.addEvent (on,  3, 0);
+    src.addEvent (off, 3, 64);
+
+    SECTION ("a block that fits copies through unchanged")
+    {
+        dusk::MidiBuffer dest;
+        dest.reserveBytes (64);
+        dusk::copyEventsWhole (src, dest);
+
+        int n = 0;
+        for (const auto meta : dest)
+        {
+            REQUIRE (meta.numBytes == 3);
+            REQUIRE (meta.data[0] == (n == 0 ? 0x90 : 0x80));
+            ++n;
+        }
+        REQUIRE (n == 2);
+    }
+
+    SECTION ("a block that overruns the cap arrives empty, not truncated")
+    {
+        // Room for the note-on alone: delivering it without the note-off would
+        // hang the note.
+        dusk::MidiBuffer dest;
+        dest.reserveBytes (11);
+        dusk::copyEventsWhole (src, dest);
+        REQUIRE (dest.isEmpty());
+    }
+
+    SECTION ("a record too big for the cap drops alone")
+    {
+        // A bulk sysex no cap could ever hold must not silence the notes around
+        // it - it is undeliverable however the block is cut.
+        std::vector<std::uint8_t> sysex (200, 0x7F);
+        sysex.front() = 0xF0;
+        sysex.back()  = 0xF7;
+
+        dusk::MidiBuffer big;
+        big.addEvent (on, 3, 0);
+        big.addEvent (sysex.data(), (int) sysex.size(), 32);
+        big.addEvent (off, 3, 64);
+
+        dusk::MidiBuffer dest;
+        dest.reserveBytes (64);
+        REQUIRE_FALSE (dest.fitsWhenEmpty ((int) sysex.size()));
+        dusk::copyEventsWhole (big, dest);
+
+        int n = 0;
+        for (const auto meta : dest)
+        {
+            REQUIRE (meta.numBytes == 3);
+            ++n;
+        }
+        REQUIRE (n == 2);
+    }
+}

--- a/tests/midi_collector.cpp
+++ b/tests/midi_collector.cpp
@@ -139,6 +139,92 @@ TEST_CASE ("MidiCollector: monotone input yields non-decreasing offsets", "[midi
     }
 }
 
+// The engine's per-input block buffer is reserveBytes()-capped, so a burst can
+// outrun it. Delivering the head of the block and dropping the tail would let a
+// note-on through while its note-off was lost, hanging the note - the whole
+// block goes instead, the same policy the MIDI out path applies.
+TEST_CASE ("MidiCollector drops the whole block when the destination is capped",
+           "[midi][collector]")
+{
+    const std::uint8_t on[]  = { 0x90, 0x40, 0x7F };
+    const std::uint8_t off[] = { 0x80, 0x40, 0x00 };
+
+    // Header (2 ints) + 3 payload bytes = 11 bytes per event, so this cap holds
+    // exactly one of the pair.
+    dusk::MidiBuffer out;
+    out.reserveBytes (11);
+
+    MidiCollector c;
+    c.reset (48000.0, 0.0);
+    REQUIRE (c.addMessage (on,  3, 1.0));
+    REQUIRE (c.addMessage (off, 3, 2.0));
+    c.removeNextBlock (out, 512, 3.0);
+    REQUIRE (out.isEmpty());
+
+    // The ring was still drained, so the next block starts clean and a pair
+    // that fits is delivered in full.
+    REQUIRE (c.addMessage (on, 3, 4.0));
+    c.removeNextBlock (out, 512, 5.0);
+    REQUIRE (offsets (out).size() == 1u);
+}
+
+// The squeeze path (backlog longer than the block) adds events through its own
+// branch, so the cap has to be honoured there too.
+TEST_CASE ("MidiCollector drops a squeezed block whole when the cap is hit",
+           "[midi][collector]")
+{
+    dusk::MidiBuffer out;
+    out.reserveBytes (22);   // two 3-byte events
+
+    MidiCollector c;
+    c.reset (48000.0, 0.0);
+    const std::uint8_t note[] = { 0x90, 0x40, 0x7F };
+    REQUIRE (c.addMessage (note, 3, 0.0));
+    REQUIRE (c.addMessage (note, 3, 10.0));
+    REQUIRE (c.addMessage (note, 3, 20.0));
+
+    // numSourceSamples 960 > 512 - the squeeze branch, as in the offsets test
+    // above. The third event overruns the cap and takes the block with it.
+    c.removeNextBlock (out, 512, 20.0);
+    REQUIRE (out.isEmpty());
+}
+
+// A record no cap could ever hold is undeliverable however the block is cut, so
+// failing the block over it would silence that input for as long as the device
+// keeps sending them. A DX7-class bulk dump is well inside the ring's capacity
+// and well past the destination's, which is exactly the case that has to drop
+// on its own.
+TEST_CASE ("MidiCollector drops an oversized record alone", "[midi][collector]")
+{
+    std::vector<std::uint8_t> sysex (4104, 0x7F);
+    sysex.front() = 0xF0;
+    sysex.back()  = 0xF7;
+
+    const std::uint8_t on[]  = { 0x90, 0x40, 0x7F };
+    const std::uint8_t off[] = { 0x80, 0x40, 0x00 };
+
+    dusk::MidiBuffer out;
+    out.reserveBytes (4096);
+
+    MidiCollector c (16384);
+    c.reset (48000.0, 0.0);
+    REQUIRE (c.addMessage (on, 3, 1.0));
+    REQUIRE (c.addMessage (sysex.data(), (int) sysex.size(), 1.5));
+    REQUIRE (c.addMessage (off, 3, 2.0));
+
+    c.removeNextBlock (out, 512, 3.0);
+
+    // The note pair survives intact; only the dump is gone.
+    int n = 0;
+    for (const auto meta : out)
+    {
+        REQUIRE (meta.numBytes == 3);
+        REQUIRE (meta.data[0] == (n == 0 ? 0x90 : 0x80));
+        ++n;
+    }
+    REQUIRE (n == 2);
+}
+
 TEST_CASE ("MidiCollector: full ring drops the overflowing message", "[midi][collector]")
 {
     // Tiny ring: one 3-byte record is 15 bytes, so a 16-byte ring holds exactly

--- a/tests/multisample_hdcc_coalescing.cpp
+++ b/tests/multisample_hdcc_coalescing.cpp
@@ -1,0 +1,89 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "engine/multisample/DuskMultisampleProcessor.h"
+
+#include <array>
+#include <utility>
+
+using Catch::Matchers::WithinAbs;
+
+namespace
+{
+using Dispatch = std::pair<int, float>;
+
+struct DispatchLog
+{
+    std::array<Dispatch, 4> values {};
+    std::size_t size { 0 };
+};
+
+void recordDispatch (void* context, int cc, float value)
+{
+    auto& log = *static_cast<DispatchLog*> (context);
+    if (log.size < log.values.size())
+        log.values[log.size++] = { cc, value };
+}
+
+void processOneBlock (duskstudio::DuskMultisampleProcessor& processor)
+{
+    constexpr int blockSize = 16;
+    float left[blockSize] {};
+    float right[blockSize] {};
+    float* outputs[] { left, right };
+
+    duskstudio::hosting::PortBuffers io;
+    io.mainOut = outputs;
+    io.mainOutChannels = 2;
+    io.numFrames = blockSize;
+    processor.processBlock (io);
+}
+
+void activate (duskstudio::DuskMultisampleProcessor& processor)
+{
+    std::string error;
+    REQUIRE (processor.activate (48000.0, 16, error));
+}
+} // namespace
+
+TEST_CASE ("Multisample HDCC coalescing dispatches only the latest value",
+           "[multisample][hdcc]")
+{
+    duskstudio::DuskMultisampleProcessor processor;
+    activate (processor);
+
+    DispatchLog dispatches;
+    processor.setHdccDispatchObserverForTest (&dispatches, recordDispatch);
+
+    processor.setHDCC (17, 0.1f);
+    processor.setHDCC (17, 0.4f);
+    processor.setHDCC (17, 0.9f);
+    processOneBlock (processor);
+
+    REQUIRE (dispatches.size == 1);
+    CHECK (dispatches.values[0].first == 17);
+    CHECK_THAT (dispatches.values[0].second, WithinAbs (0.9f, 1.0e-6f));
+
+    processOneBlock (processor);
+    CHECK (dispatches.size == 1);
+}
+
+TEST_CASE ("Multisample HDCC coalescing dispatches different controllers independently",
+           "[multisample][hdcc]")
+{
+    duskstudio::DuskMultisampleProcessor processor;
+    activate (processor);
+
+    DispatchLog dispatches;
+    processor.setHdccDispatchObserverForTest (&dispatches, recordDispatch);
+
+    processor.setHDCC (3, 0.25f);
+    processor.setHDCC (300, 0.75f);
+    processOneBlock (processor);
+
+    REQUIRE (dispatches.size == 2);
+    CHECK (dispatches.values[0].first == 3);
+    CHECK_THAT (dispatches.values[0].second, WithinAbs (0.25f, 1.0e-6f));
+    CHECK (dispatches.values[1].first == 300);
+    CHECK_THAT (dispatches.values[1].second, WithinAbs (0.75f, 1.0e-6f));
+}

--- a/tests/sf2_to_sfz_convert.cpp
+++ b/tests/sf2_to_sfz_convert.cpp
@@ -5,6 +5,13 @@
 
 #include <juce_core/juce_core.h>
 
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
 namespace
 {
 const juce::File kFluidR3 { "/Users/marckorte/Downloads/FluidR3_GM_GS.sf2" };
@@ -18,6 +25,104 @@ juce::File freshTempDir()
     d.createDirectory();
     return d;
 }
+
+// Little-endian SF2 assembly, same shape as the builder in
+// sf2_reader_parse.cpp, parameterised on the tuning / loop generators the
+// converter has to translate. Kept local so the two test TUs stay independent.
+struct Sf2Buf
+{
+    std::vector<std::uint8_t> b;
+    void u8   (std::uint8_t v)  { b.push_back(v); }
+    void u16  (std::uint16_t v) { u8((std::uint8_t) (v & 0xFF)); u8((std::uint8_t) (v >> 8)); }
+    void s16  (int v)           { u16((std::uint16_t) (std::int16_t) v); }
+    void u32  (std::uint32_t v) { for (int i = 0; i < 4; ++i) u8((std::uint8_t) (v >> (8 * i))); }
+    void id   (const char* s)   { for (int i = 0; i < 4; ++i) u8((std::uint8_t) s[i]); }
+    void name (const char* s)   { char n[20] {}; std::strncpy(n, s, 20); for (int i = 0; i < 20; ++i) u8((std::uint8_t) n[i]); }
+    void raw  (const std::vector<std::uint8_t>& x) { b.insert(b.end(), x.begin(), x.end()); }
+};
+
+void sf2Chunk (Sf2Buf& out, const char* cid, const std::vector<std::uint8_t>& body)
+{
+    out.id(cid);
+    out.u32((std::uint32_t) body.size());
+    out.raw(body);
+    if (body.size() & 1) out.u8(0);
+}
+
+struct TuningOpts
+{
+    int coarseTune      { 0 };   // igen 51, semitones
+    int fineTune        { 0 };   // igen 52, cents
+    int sampleModes     { 0 };   // igen 54
+    int pitchCorrection { 0 };   // shdr, cents
+};
+
+// One preset -> one instrument zone -> one 100-frame sample looping 10..90.
+std::vector<std::uint8_t> tunedSf2 (const TuningOpts& o)
+{
+    Sf2Buf phdr;
+    phdr.name("pre0"); phdr.u16(0); phdr.u16(0); phdr.u16(0); phdr.u32(0); phdr.u32(0); phdr.u32(0);
+    phdr.name("EOP");  phdr.u16(0); phdr.u16(0); phdr.u16(1); phdr.u32(0); phdr.u32(0); phdr.u32(0);
+
+    Sf2Buf pbag; pbag.u16(0); pbag.u16(0); pbag.u16(1); pbag.u16(0);
+    Sf2Buf pgen; pgen.u16(41); pgen.u16(0);   // 41 = instrument
+
+    Sf2Buf inst;
+    inst.name("inst0"); inst.u16(0);
+    inst.name("EOI");   inst.u16(1);
+
+    Sf2Buf ibag; ibag.u16(0); ibag.u16(0); ibag.u16(5); ibag.u16(0);
+    Sf2Buf igen;
+    igen.u16(43); igen.u16(0x7F00);        // keyRange 0..127
+    igen.u16(51); igen.s16(o.coarseTune);
+    igen.u16(52); igen.s16(o.fineTune);
+    igen.u16(54); igen.s16(o.sampleModes);
+    igen.u16(53); igen.u16(0);              // sampleID -> sample 0 (terminal)
+
+    Sf2Buf shdr;
+    shdr.name("samp0"); shdr.u32(0); shdr.u32(100); shdr.u32(10); shdr.u32(90);
+    shdr.u32(44100); shdr.u8(60); shdr.u8((std::uint8_t) (std::int8_t) o.pitchCorrection);
+    shdr.u16(0); shdr.u16(1);
+    shdr.name("EOS");  shdr.u32(0); shdr.u32(0); shdr.u32(0); shdr.u32(0);
+    shdr.u32(0);     shdr.u8(0);  shdr.u8(0); shdr.u16(0); shdr.u16(0);
+
+    Sf2Buf pdta; pdta.id("pdta");
+    sf2Chunk(pdta, "phdr", phdr.b); sf2Chunk(pdta, "pbag", pbag.b); sf2Chunk(pdta, "pgen", pgen.b);
+    sf2Chunk(pdta, "inst", inst.b); sf2Chunk(pdta, "ibag", ibag.b); sf2Chunk(pdta, "igen", igen.b);
+    sf2Chunk(pdta, "shdr", shdr.b);
+
+    Sf2Buf sdta; sdta.id("sdta");
+    sf2Chunk(sdta, "smpl", std::vector<std::uint8_t> (200, 0));   // 100 16-bit frames
+
+    Sf2Buf content; content.id("sfbk");
+    sf2Chunk(content, "LIST", sdta.b);
+    sf2Chunk(content, "LIST", pdta.b);
+
+    Sf2Buf file; file.id("RIFF"); file.u32((std::uint32_t) content.b.size()); file.raw(content.b);
+    return file.b;
+}
+
+// Convert a synthesised SF2 and hand back just the SFZ text, cleaning up the
+// temp file + extracted WAVs.
+std::string convertTuned (const TuningOpts& o)
+{
+    const auto bytes = tunedSf2(o);
+    auto sf2 = juce::File::createTempFile(".sf2");
+    {
+        std::ofstream os (std::filesystem::u8path(sf2.getFullPathName().toStdString()),
+                          std::ios::binary);
+        os.write(reinterpret_cast<const char*>(bytes.data()), (std::streamsize) bytes.size());
+    }
+
+    auto dir  = freshTempDir();
+    auto conv = duskstudio::convertSf2Preset(sf2, 0, dir);
+    sf2.deleteFile();
+    dir.deleteRecursively();
+
+    REQUIRE(conv.ok);
+    REQUIRE(dusk::text::contains(conv.sfzText, "<region>"));
+    return conv.sfzText;
+}
 }
 
 TEST_CASE("Sf2ToSfz: missing file fails cleanly", "[sf2conv]")
@@ -27,6 +132,66 @@ TEST_CASE("Sf2ToSfz: missing file fails cleanly", "[sf2conv]")
     REQUIRE_FALSE(conv.ok);
     REQUIRE_FALSE(conv.error.empty());
     dir.deleteRecursively();
+}
+
+// SFZ tune is +/-100 cents, but sample pitchCorrection + instrument fine tune +
+// preset fine tune sum to as much as +/-325, so the whole semitones have to
+// reach the region through transpose or the excess is silently lost.
+TEST_CASE("Sf2ToSfz: folds whole semitones out of the combined fine tune", "[sf2conv]")
+{
+    SECTION("positive correction past a semitone")
+    {
+        // 1 semitone coarse + (190 + 60) cents = transpose 3, tune 50.
+        const auto sfz = convertTuned({ /*coarse*/ 1, /*fine*/ 190, /*modes*/ 0,
+                                        /*pitchCorrection*/ 60 });
+        REQUIRE(dusk::text::contains(sfz, "transpose=3 tune=50"));
+    }
+
+    SECTION("negative correction past a semitone")
+    {
+        const auto sfz = convertTuned({ 0, -190, 0, -60 });
+        REQUIRE(dusk::text::contains(sfz, "transpose=-2 tune=-50"));
+    }
+
+    SECTION("sub-semitone correction stays in tune alone")
+    {
+        const auto sfz = convertTuned({ 0, 30, 0, 12 });
+        REQUIRE(dusk::text::contains(sfz, "tune=42"));
+        REQUIRE_FALSE(dusk::text::contains(sfz, "transpose="));
+    }
+
+    SECTION("exact semitones leave no tune opcode")
+    {
+        const auto sfz = convertTuned({ 0, 200, 0, 0 });
+        REQUIRE(dusk::text::contains(sfz, "transpose=2"));
+        REQUIRE_FALSE(dusk::text::contains(sfz, "tune="));
+    }
+}
+
+// sampleModes 3 is "loop until release, then play the tail"; loop_continuous
+// would leave those release tails looping forever.
+TEST_CASE("Sf2ToSfz: maps the SF2 loop modes onto their SFZ equivalents", "[sf2conv]")
+{
+    SECTION("sampleModes 1 loops forever")
+    {
+        const auto sfz = convertTuned({ 0, 0, 1, 0 });
+        REQUIRE(dusk::text::contains(sfz, "loop_mode=loop_continuous"));
+        REQUIRE(dusk::text::contains(sfz, "loop_start=10"));
+        REQUIRE(dusk::text::contains(sfz, "loop_end=89"));
+    }
+
+    SECTION("sampleModes 3 loops until release")
+    {
+        const auto sfz = convertTuned({ 0, 0, 3, 0 });
+        REQUIRE(dusk::text::contains(sfz, "loop_mode=loop_sustain"));
+        REQUIRE_FALSE(dusk::text::contains(sfz, "loop_continuous"));
+    }
+
+    SECTION("sampleModes 0 does not loop")
+    {
+        const auto sfz = convertTuned({ 0, 0, 0, 0 });
+        REQUIRE_FALSE(dusk::text::contains(sfz, "loop_mode="));
+    }
 }
 
 TEST_CASE("Sf2ToSfz: converts FluidR3 preset 0 to SFZ + WAVs", "[sf2conv][.fixture]")

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -42,7 +42,7 @@ src/engine/multisample/AriaBank.h	9
 src/engine/multisample/AriaGui.cpp	23
 src/engine/multisample/AriaGui.h	18
 src/engine/multisample/DuskMultisampleProcessor.cpp	70
-src/engine/multisample/DuskMultisampleProcessor.h	25
+src/engine/multisample/DuskMultisampleProcessor.h	24
 src/engine/multisample/Sf2ToSfz.cpp	9
 src/engine/multisample/Sf2ToSfz.h	4
 src/foundation/MessageThread.cpp	4


### PR DESCRIPTION
## What
- make capped MIDI handoffs whole-block-or-nothing while dropping individually undeliverable oversized records
- coalesce multisample CC updates through the latest cached value
- fold SF2 fine tune into transpose and map loop-until-release to loop_sustain
- add focused MIDI buffer, collector, and SF2 conversion regressions

## Why
Truncated MIDI blocks could retain note-ons while dropping their note-offs, a saturated CC queue could leave sfizz behind the UI state, and two SF2 translation paths produced incorrect pitch or release behavior.

## Validation
- DuskStudio app target built successfully
- 546/546 Catch2 tests passed
- tools/juce-gate.sh: 179 files / 9256 uses, down one use and allowlist count 25 to 24
- git diff --check clean

Fixes #148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MIDI block handling to prevent partial delivery when capacity is exceeded.
  * Oversized individual MIDI events are safely skipped without affecting neighboring events.
  * High-definition controller updates now consistently deliver the latest value.
  * Improved SF2-to-SFZ tuning conversion and sustain-loop mapping.

* **Enhancements**
  * MIDI event transfers are now handled atomically for more reliable instrument and plugin processing.

* **Tests**
  * Added coverage for MIDI capacity handling, controller delivery, tuning conversion, and sample loop modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->