### PR TITLE
Fix app shell and build edge cases (#150)

### DIFF
--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -10,9 +10,9 @@ name: Windows tests
 
 on:
   push:
-    branches: [main, develop, 'release/**']
+    branches: [main, 'release/**']
   pull_request:
-    branches: [main, develop, 'release/**']
+    branches: [main, 'release/**']
   workflow_dispatch:
 
 permissions:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,6 +507,7 @@ target_sources(DuskStudio PRIVATE
     src/session/SessionSerializer.cpp
     src/session/SessionTemplates.cpp
     src/util/CrashHandler.cpp
+    src/util/SingleInstance.cpp
     src/ui/AnalogVuMeter.cpp
     src/ui/AppConfig.cpp
     src/ui/AudioRegionEditor.cpp
@@ -1332,9 +1333,10 @@ endif()
 # AddressSanitizer + UBSan. Off by default; opt-in via
 # -DDUSKSTUDIO_ENABLE_ASAN=ON. Applied build-wide (directory-level options)
 # because sanitizer-instrumented code can't link against
-# non-instrumented code without symbol-resolution drama. CI runs the
-# test binary under ASAN to catch heap corruption / use-after-free /
-# undefined-behaviour from a long-running session's worth of edits.
+# non-instrumented code without symbol-resolution drama. Local-only: the
+# sanitizer workflow in CI runs TSan, so an ASAN pass over the test binary
+# (heap corruption / use-after-free / undefined behaviour) is something you
+# run by hand before a release.
 # Not for production builds — overhead is ~2× CPU and ~3× memory.
 option(DUSKSTUDIO_ENABLE_ASAN "Enable AddressSanitizer + UBSan" OFF)
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -146,7 +146,7 @@ echo
 echo "Next steps:"
 echo "  1) Refresh patrons:   scripts/update-patrons.py   (commit in the plugins repo)"
 echo "  2) Review the diff:   git diff VERSION $APPDATA"
-echo "  3) Rebuild + smoke:   cmake --build build -j && build/.../DuskStudio --selftest"
+echo "  3) Rebuild + smoke:   cmake --build build -j && DUSKSTUDIO_RUN_SELFTEST=1 build/.../DuskStudio"
 echo "  4) Commit:            git commit -am \"Release v$NEW_VERSION\""
 echo "  5) Tag:               git tag -a v$NEW_VERSION -m \"Dusk Studio $NEW_VERSION\""
 echo "  6) Package:           scripts/package-{tarball,macos}.sh, scripts/package-windows.ps1"

--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -28,6 +28,7 @@
 #include "foundation/MessageThread.h"
 #include "session/SessionSerializer.h"
 #include "util/CrashHandler.h"
+#include "util/SingleInstance.h"
 #if JUCE_LINUX
  #include "engine/ipc/IpcSelfTest.h"
 #endif
@@ -1225,9 +1226,10 @@ struct DuskStudioApp::BounceTest : private dusk::Timer
 
     ~BounceTest() override { stopTimer(); }
 
-    // Synchronous setup on the message thread. Returns false if setup failed
-    // (return value + [FAIL] already emitted); the caller then quits immediately.
-    bool begin()
+    // Synchronous setup on the message thread. A setup failure ends the run
+    // through finish() like any other terminal state, so the log always closes
+    // with the RESULT line a scraper looks for.
+    void begin()
     {
         std::fprintf (stdout, "=== Dusk Studio Headless Bounce Test ===\n");
         std::fprintf (stdout, "Plugin: %s\nSR=%.0f BS=%d\n\n", pluginPath.toRawUTF8(), sr, bs);
@@ -1256,14 +1258,16 @@ struct DuskStudioApp::BounceTest : private dusk::Timer
         if (! synthesiseContent())
         {
             exitCode = 1;
-            return false;
+            finish();
+            return;
         }
 
         if (! loadPluginByExtension())
         {
             // loadPluginByExtension already printed the [FAIL] line.
             exitCode = 1;
-            return false;
+            finish();
+            return;
         }
 
         std::fprintf (stdout, "[INFO] loaded %s insert on track 0: %s\n\n",
@@ -1287,13 +1291,13 @@ struct DuskStudioApp::BounceTest : private dusk::Timer
             std::fprintf (stdout, "[FAIL] MasterMix bounce start() returned false: %s\n",
                           bounce->getLastError().c_str());
             exitCode = 1;
-            return false;
+            finish();
+            return;
         }
 
         phase = Phase::WaitMaster;
         phaseStartMs = juce::Time::getMillisecondCounter();
         startTimer (25);
-        return true;
     }
 
 private:
@@ -1857,11 +1861,7 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
     if (const char* path = std::getenv ("DUSKSTUDIO_BOUNCE_TEST"); path != nullptr && *path)
     {
         bounceTest = std::make_unique<BounceTest> (*this, juce::String (path));
-        if (! bounceTest->begin())
-        {
-            setApplicationReturnValue (1);
-            quit();
-        }
+        bounceTest->begin();
         return;
     }
 
@@ -1886,6 +1886,7 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
         if (! comp->load (juce::File (juce::String (path)), err))
         {
             std::fprintf (stderr, "[clap editor test] load failed: %s\n", err.toRawUTF8());
+            setApplicationReturnValue (1);
             quit();
             return;
         }
@@ -1926,6 +1927,7 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
         if (! lv2EditorTest->slot.load (std::filesystem::u8path (path), 48000.0, 1024, err))
         {
             std::fprintf (stderr, "[lv2 editor test] load failed: %s\n", err.c_str());
+            setApplicationReturnValue (1);
             quit();
             return;
         }
@@ -1935,6 +1937,7 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
         if (inst == nullptr || ! comp->attach (*inst, jerr))
         {
             std::fprintf (stderr, "[lv2 editor test] attach failed: %s\n", jerr.toRawUTF8());
+            setApplicationReturnValue (1);
             quit();
             return;
         }
@@ -1970,6 +1973,7 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
         if (! vst3EditorTest->bundle.load (path, err))
         {
             std::fprintf (stderr, "[vst3 editor test] load failed: %s\n", err.c_str());
+            setApplicationReturnValue (1);
             quit();
             return;
         }
@@ -1982,6 +1986,7 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
         {
             std::fprintf (stderr, "[vst3 editor test] create failed: %s\n",
                           classId.empty() ? "no effect class in module" : err.c_str());
+            setApplicationReturnValue (1);
             quit();
             return;
         }
@@ -1990,6 +1995,7 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
         if (! comp->attach (vst3EditorTest->instance, jerr))
         {
             std::fprintf (stderr, "[vst3 editor test] attach failed: %s\n", jerr.toRawUTF8());
+            setApplicationReturnValue (1);
             quit();
             return;
         }
@@ -2250,6 +2256,29 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
         return;
     }
 
+    // One instance per user + display. The .desktop entry and the session
+    // MIME handler both pass %f, so opening a session from a file manager
+    // launches the binary again; without this it would be a second engine
+    // contending for the device and a second autosave loop writing the same
+    // session directory. A launch that finds an instance already running
+    // hands the session over (-> anotherInstanceStarted) and exits. Placed
+    // after every headless env-gate above so self-test / bounce / perf runs
+    // never take part in the handshake.
+    //
+    // What travels is the resolved path, quoted, not the raw tokens: the
+    // running instance would resolve a relative one against its own working
+    // directory rather than the launching shell's, so `cd ~/Sessions &&
+    // DuskStudio mysong/session.json` would quietly open nothing.
+    const auto handoffPath = sessionPathFromCommandLine (commandLine).getFullPathName();
+    const auto handoff = handoffPath.isNotEmpty() ? handoffPath.quoted().toStdString()
+                                                  : std::string();
+    if (! single_instance::acquire (handoff,
+                                    [this] (std::string cl) { anotherInstanceStarted (cl); }))
+    {
+        quit();
+        return;
+    }
+
     // Install crash handler + FileLogger AFTER every selftest env-gate
     // above has had its chance to quit. Self-test paths don't want
     // stray daily log files littering the user's data dir (or CI
@@ -2285,6 +2314,10 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
 
 void DuskStudioApp::shutdown()
 {
+    // Stop the single-instance listener first: a handoff arriving mid-teardown
+    // would target a window that is about to go away.
+    single_instance::release();
+
     // Persist window geometry before tearing down the window. Reading
     // getWindowStateAsString() AFTER mainWindow.reset() would crash; doing
     // it here captures the user's last visible position/size/fullscreen.

--- a/src/DuskStudioApp.h
+++ b/src/DuskStudioApp.h
@@ -12,6 +12,14 @@ public:
 
     const juce::String getApplicationName() override       { return JUCE_APPLICATION_NAME_STRING; }
     const juce::String getApplicationVersion() override    { return JUCE_APPLICATION_VERSION_STRING; }
+    // Stays open on every platform. The framework's own gate runs before
+    // initialise(), so it would swallow the headless env-gated runs
+    // (DUSKSTUDIO_RUN_SELFTEST, BOUNCE_TEST, the editor tests) whenever a GUI
+    // instance happens to be open - and on Linux it could not deliver the
+    // handoff anyway, its cross-process broadcast having no implementation
+    // there. Single-instance behaviour is Linux's own handshake in
+    // initialise() (single_instance::acquire), which sits after those env
+    // gates and dispatches into anotherInstanceStarted.
     bool moreThanOneInstanceAllowed() override             { return true; }
 
     void initialise (const juce::String& commandLine) override;

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -22,11 +22,14 @@ struct ForceXWaylandByDefault
     ForceXWaylandByDefault()
     {
         // Truthy per the DUSKSTUDIO_* env-flag convention (envFlagSet): a
-        // non-zero integer or "true". Unset, "0" or junk keep the XWayland
-        // default - setting the flag to 0 must not enable the native path.
+        // non-zero integer, "true" or "yes". Unset, "0" or junk keep the
+        // XWayland default - setting the flag to 0 must not enable the
+        // native path.
         const char* v = std::getenv ("DUSKSTUDIO_NATIVE_WAYLAND");
         const bool nativeWayland = v != nullptr
-                                    && (std::atoi (v) != 0 || strcasecmp (v, "true") == 0);
+                                    && (std::atoi (v) != 0
+                                        || strcasecmp (v, "true") == 0
+                                        || strcasecmp (v, "yes") == 0);
         if (! nativeWayland)
             setenv ("JUCE_XWAYLAND", "1", 0);
     }

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -1,6 +1,7 @@
 #include "DuskStudioApp.h"
 
 #if defined (__linux__)
+#include <cerrno>
 #include <cstdlib>
 #include <strings.h>
 
@@ -17,6 +18,18 @@
 // framework's entry-point macro.
 namespace
 {
+bool nativeWaylandRequested (const char* value) noexcept
+{
+    if (value == nullptr) return false;
+    if (strcasecmp (value, "true") == 0 || strcasecmp (value, "yes") == 0)
+        return true;
+
+    char* end = nullptr;
+    errno = 0;
+    const long parsed = std::strtol (value, &end, 10);
+    return errno != ERANGE && end != value && *end == '\0' && parsed != 0;
+}
+
 struct ForceXWaylandByDefault
 {
     ForceXWaylandByDefault()
@@ -26,10 +39,7 @@ struct ForceXWaylandByDefault
         // XWayland default - setting the flag to 0 must not enable the
         // native path.
         const char* v = std::getenv ("DUSKSTUDIO_NATIVE_WAYLAND");
-        const bool nativeWayland = v != nullptr
-                                    && (std::atoi (v) != 0
-                                        || strcasecmp (v, "true") == 0
-                                        || strcasecmp (v, "yes") == 0);
+        const bool nativeWayland = nativeWaylandRequested (v);
         if (! nativeWayland)
             setenv ("JUCE_XWAYLAND", "1", 0);
     }

--- a/src/util/SingleInstance.cpp
+++ b/src/util/SingleInstance.cpp
@@ -2,6 +2,7 @@
 
 #include "../foundation/MessageThread.h"
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstddef>
@@ -30,6 +31,8 @@ namespace
 {
 constexpr std::size_t kMaxPayloadBytes = 64 * 1024;
 constexpr int kReadBudgetMs = 2000;
+constexpr int kDeliveryBudgetMs = 2000;
+using Deadline = std::chrono::steady_clock::time_point;
 
 struct Listener
 {
@@ -121,14 +124,39 @@ bool peerIsThisUser (int fd)
     return len == sizeof cred && cred.uid == ::getuid();
 }
 
-bool writeAll (int fd, const std::string& payload)
+int pollUntil (int fd, short events, const Deadline deadline)
+{
+    for (;;)
+    {
+        const auto now = std::chrono::steady_clock::now();
+        if (now >= deadline) return 0;
+        const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds> (
+            deadline - now);
+
+        pollfd p {};
+        p.fd = fd;
+        p.events = events;
+        const int ready = ::poll (&p, 1, std::max (1, (int) remaining.count()));
+        if (ready > 0) return p.revents;
+        if (ready == 0) return 0;
+        if (errno != EINTR) return 0;
+    }
+}
+
+bool writeAll (int fd, const std::string& payload, const Deadline deadline)
 {
     std::size_t sent = 0;
     while (sent < payload.size())
     {
+        if (std::chrono::steady_clock::now() >= deadline) return false;
         const ssize_t n = ::send (fd, payload.data() + sent, payload.size() - sent, MSG_NOSIGNAL);
         if (n > 0) { sent += (std::size_t) n; continue; }
         if (n < 0 && errno == EINTR) continue;
+        if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+        {
+            const int revents = pollUntil (fd, POLLOUT, deadline);
+            if ((revents & POLLOUT) != 0) continue;
+        }
         return false;
     }
     return true;
@@ -137,11 +165,10 @@ bool writeAll (int fd, const std::string& payload)
 // One deadline for the whole exchange, not per read: a peer dribbling a byte
 // at a time under a per-read timeout would hold the listener open forever, and
 // release() waits on this thread.
-std::string readPayload (int fd)
+bool readPayload (int fd, int wakeFd, std::string& payload)
 {
     const auto deadline = std::chrono::steady_clock::now()
                             + std::chrono::milliseconds (kReadBudgetMs);
-    std::string payload;
     char buf[1024];
 
     while (payload.size() < kMaxPayloadBytes)
@@ -150,23 +177,27 @@ std::string readPayload (int fd)
         if (now >= deadline) break;
         const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds> (deadline - now);
 
-        pollfd p {};
-        p.fd = fd;
-        p.events = POLLIN;
-        const int ready = ::poll (&p, 1, (int) remaining.count());
+        pollfd fds[2] {};
+        fds[0].fd = fd;
+        fds[0].events = POLLIN;
+        fds[1].fd = wakeFd;
+        fds[1].events = POLLIN;
+        const int ready = ::poll (fds, 2, std::max (1, (int) remaining.count()));
         if (ready < 0)
         {
             if (errno == EINTR) continue;
             break;
         }
         if (ready == 0) break;
+        if (fds[1].revents != 0) return false;
+        if (fds[0].revents == 0) continue;
 
         const ssize_t got = ::read (fd, buf, sizeof buf);
         if (got > 0) { payload.append (buf, (std::size_t) got); continue; }
         if (got < 0 && (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)) continue;
         break;
     }
-    return payload;
+    return true;
 }
 
 void listenLoop (Listener* l)
@@ -209,8 +240,10 @@ void listenLoop (Listener* l)
 
         if (peerIsThisUser (peer))
         {
-            const auto payload = readPayload (peer);
+            std::string payload;
+            const bool completed = readPayload (peer, l->wakeFds[0], payload);
             ::close (peer);
+            if (! completed) return;
             auto fn = l->onCommandLine;
             dusk::callAsync ([fn, payload] { fn (payload); });
         }
@@ -246,17 +279,44 @@ bool handOver (const sockaddr_un& addr, socklen_t len, const std::string& payloa
 {
     for (int attempt = 0; attempt < 2; ++attempt)
     {
-        const int fd = ::socket (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+        const int fd = ::socket (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0);
         if (fd < 0) return false;
 
+        const auto deadline = std::chrono::steady_clock::now()
+                                + std::chrono::milliseconds (kDeliveryBudgetMs);
+        bool connected = false;
+        int connectErr = 0;
         if (::connect (fd, (const sockaddr*) &addr, len) == 0)
         {
-            const bool sent = writeAll (fd, payload);
+            connected = true;
+        }
+        else
+        {
+            connectErr = errno;
+            if (connectErr == EINPROGRESS || connectErr == EALREADY
+                || connectErr == EINTR || connectErr == EAGAIN
+                || connectErr == EWOULDBLOCK)
+            {
+                const int revents = pollUntil (fd, POLLOUT, deadline);
+                if ((revents & POLLNVAL) == 0 && revents != 0)
+                {
+                    socklen_t errorLen = sizeof connectErr;
+                    if (::getsockopt (fd, SOL_SOCKET, SO_ERROR,
+                                      &connectErr, &errorLen) == 0)
+                        connected = connectErr == 0;
+                    else
+                        connectErr = errno;
+                }
+            }
+        }
+
+        if (connected)
+        {
+            const bool sent = writeAll (fd, payload, deadline);
             if (sent) ::shutdown (fd, SHUT_WR);
             ::close (fd);
             return sent;
         }
-        const int connectErr = errno;
         ::close (fd);
         if (connectErr != ECONNREFUSED) return false;
 

--- a/src/util/SingleInstance.cpp
+++ b/src/util/SingleInstance.cpp
@@ -1,0 +1,334 @@
+#include "SingleInstance.h"
+
+#include "../foundation/MessageThread.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <utility>
+
+#if defined (__linux__)
+ #include <cerrno>
+ #include <fcntl.h>
+ #include <poll.h>
+ #include <sys/socket.h>
+ #include <sys/stat.h>
+ #include <sys/un.h>
+ #include <unistd.h>
+#endif
+
+namespace duskstudio::single_instance
+{
+#if defined (__linux__)
+namespace
+{
+constexpr std::size_t kMaxPayloadBytes = 64 * 1024;
+constexpr int kReadBudgetMs = 2000;
+
+struct Listener
+{
+    std::thread thread;
+    std::atomic<int> listenFd { -1 };
+    std::atomic<bool> unlinked { false };
+    int wakeFds[2] = { -1, -1 };
+    std::string socketPath;
+    std::function<void (std::string)> onCommandLine;
+};
+
+// Raw, never owned by a static destructor: a plugin that calls exit() on a
+// license failure skips shutdown(), and destroying a still-joinable thread at
+// static teardown is std::terminate. release() is the only path that frees it;
+// an abnormal exit leaks it, which the process exit cleans up anyway.
+Listener* listener = nullptr;
+
+std::uint64_t hashOf (const char* s) noexcept
+{
+    std::uint64_t h = 1469598103934665603ull;
+    for (; *s != '\0'; ++s)
+    {
+        h ^= (std::uint64_t) (unsigned char) *s;
+        h *= 1099511628211ull;
+    }
+    return h;
+}
+
+// $XDG_RUNTIME_DIR/dusk-studio/instance-<display hash>.sock. The runtime dir is
+// per-user and 0700, which is the permission bit an abstract-namespace socket
+// does not have: without it any local process of any uid could bind the name
+// first (every real launch then hands off to nobody and quits) or connect and
+// feed the running instance a session of its choosing, whose plugin references
+// get loaded. The display is hashed rather than embedded because it can be an
+// absolute path, and a name long enough to truncate would collapse two
+// displays onto one slot.
+bool makeSocketPath (std::string& out)
+{
+    const char* runtimeDir = std::getenv ("XDG_RUNTIME_DIR");
+    if (runtimeDir == nullptr || *runtimeDir != '/') return false;
+
+    const std::string dir = std::string (runtimeDir) + "/dusk-studio";
+    if (::mkdir (dir.c_str(), 0700) != 0 && errno != EEXIST) return false;
+
+    struct stat st {};
+    if (::lstat (dir.c_str(), &st) != 0) return false;
+    if (! S_ISDIR (st.st_mode)
+        || st.st_uid != ::getuid()
+        || (st.st_mode & (S_IRWXG | S_IRWXO)) != 0)
+        return false;
+
+    const char* display = std::getenv ("WAYLAND_DISPLAY");
+    if (display == nullptr || *display == '\0') display = std::getenv ("DISPLAY");
+    if (display == nullptr) display = "";
+
+    char name[40] = {};
+    std::snprintf (name, sizeof name, "/instance-%016llx.sock",
+                   (unsigned long long) hashOf (display));
+    out = dir + name;
+    return out.size() < sizeof (sockaddr_un::sun_path);
+}
+
+void makeAddress (const std::string& path, sockaddr_un& addr, socklen_t& len)
+{
+    std::memset (&addr, 0, sizeof addr);
+    addr.sun_family = AF_UNIX;
+    std::memcpy (addr.sun_path, path.c_str(), path.size());
+    len = (socklen_t) (offsetof (sockaddr_un, sun_path) + path.size() + 1);
+}
+
+// Closing the listening fd is what makes a later launch fall back to acting as
+// primary; leaving it bound but unserviced would strand every launch after it.
+// Both exchanges keep this safe to call from the listener thread and from
+// release() without double-closing or unlinking a socket file that a newer
+// primary has since created at the same path.
+void teardown (Listener& l)
+{
+    const int fd = l.listenFd.exchange (-1);
+    if (fd >= 0) ::close (fd);
+    if (! l.unlinked.exchange (true) && ! l.socketPath.empty())
+        ::unlink (l.socketPath.c_str());
+}
+
+bool peerIsThisUser (int fd)
+{
+    ucred cred {};
+    socklen_t len = sizeof cred;
+    if (::getsockopt (fd, SOL_SOCKET, SO_PEERCRED, &cred, &len) != 0) return false;
+    return len == sizeof cred && cred.uid == ::getuid();
+}
+
+bool writeAll (int fd, const std::string& payload)
+{
+    std::size_t sent = 0;
+    while (sent < payload.size())
+    {
+        const ssize_t n = ::send (fd, payload.data() + sent, payload.size() - sent, MSG_NOSIGNAL);
+        if (n > 0) { sent += (std::size_t) n; continue; }
+        if (n < 0 && errno == EINTR) continue;
+        return false;
+    }
+    return true;
+}
+
+// One deadline for the whole exchange, not per read: a peer dribbling a byte
+// at a time under a per-read timeout would hold the listener open forever, and
+// release() waits on this thread.
+std::string readPayload (int fd)
+{
+    const auto deadline = std::chrono::steady_clock::now()
+                            + std::chrono::milliseconds (kReadBudgetMs);
+    std::string payload;
+    char buf[1024];
+
+    while (payload.size() < kMaxPayloadBytes)
+    {
+        const auto now = std::chrono::steady_clock::now();
+        if (now >= deadline) break;
+        const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds> (deadline - now);
+
+        pollfd p {};
+        p.fd = fd;
+        p.events = POLLIN;
+        const int ready = ::poll (&p, 1, (int) remaining.count());
+        if (ready < 0)
+        {
+            if (errno == EINTR) continue;
+            break;
+        }
+        if (ready == 0) break;
+
+        const ssize_t got = ::read (fd, buf, sizeof buf);
+        if (got > 0) { payload.append (buf, (std::size_t) got); continue; }
+        if (got < 0 && (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)) continue;
+        break;
+    }
+    return payload;
+}
+
+void listenLoop (Listener* l)
+{
+    for (;;)
+    {
+        const int fd = l->listenFd.load();
+        if (fd < 0) return;
+
+        pollfd fds[2] {};
+        fds[0].fd = fd;
+        fds[0].events = POLLIN;
+        fds[1].fd = l->wakeFds[0];
+        fds[1].events = POLLIN;
+
+        if (::poll (fds, 2, -1) < 0)
+        {
+            if (errno == EINTR) continue;
+            teardown (*l);
+            return;
+        }
+        if (fds[1].revents != 0) return;                        // release() woke us
+        if ((fds[0].revents & (POLLERR | POLLHUP | POLLNVAL)) != 0)
+        {
+            teardown (*l);
+            return;
+        }
+        if ((fds[0].revents & POLLIN) == 0) continue;
+
+        const int peer = ::accept4 (fd, nullptr, nullptr, SOCK_CLOEXEC | SOCK_NONBLOCK);
+        if (peer < 0)
+        {
+            if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK || errno == ECONNABORTED)
+                continue;
+            // Out of descriptors and the like: the fd stays readable, so
+            // continuing here would spin the thread at 100% CPU.
+            teardown (*l);
+            return;
+        }
+
+        if (peerIsThisUser (peer))
+        {
+            const auto payload = readPayload (peer);
+            ::close (peer);
+            auto fn = l->onCommandLine;
+            dusk::callAsync ([fn, payload] { fn (payload); });
+        }
+        else
+        {
+            ::close (peer);
+        }
+    }
+}
+
+bool startListener (int fd, const std::string& path,
+                    std::function<void (std::string)> onCommandLine)
+{
+    if (::listen (fd, 8) != 0) return false;
+
+    auto* l = new Listener();
+    if (::pipe2 (l->wakeFds, O_CLOEXEC) != 0)
+    {
+        delete l;
+        return false;
+    }
+    l->listenFd.store (fd);
+    l->socketPath = path;
+    l->onCommandLine = std::move (onCommandLine);
+    listener = l;
+    l->thread = std::thread (listenLoop, l);
+    return true;
+}
+
+// A fresh socket per attempt: a connect that failed leaves the fd unusable for
+// a second try.
+bool handOver (const sockaddr_un& addr, socklen_t len, const std::string& payload)
+{
+    for (int attempt = 0; attempt < 2; ++attempt)
+    {
+        const int fd = ::socket (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+        if (fd < 0) return false;
+
+        if (::connect (fd, (const sockaddr*) &addr, len) == 0)
+        {
+            const bool sent = writeAll (fd, payload);
+            if (sent) ::shutdown (fd, SHUT_WR);
+            ::close (fd);
+            return sent;
+        }
+        const int connectErr = errno;
+        ::close (fd);
+        if (connectErr != ECONNREFUSED) return false;
+
+        // A primary that has bound but not yet called listen() refuses
+        // connections for a moment. Retry once before reading the refusal as
+        // "the file outlived the process that made it".
+        if (attempt == 0)
+            std::this_thread::sleep_for (std::chrono::milliseconds (50));
+    }
+    return false;
+}
+} // namespace
+
+bool acquire (const std::string& payload, std::function<void (std::string)> onCommandLine)
+{
+    std::string path;
+    if (! makeSocketPath (path)) return true;
+
+    sockaddr_un addr {};
+    socklen_t len = 0;
+    makeAddress (path, addr, len);
+
+    for (int attempt = 0; attempt < 2; ++attempt)
+    {
+        const int fd = ::socket (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+        if (fd < 0) return true;
+
+        if (::bind (fd, (const sockaddr*) &addr, len) == 0)
+        {
+            if (! startListener (fd, path, std::move (onCommandLine)))
+            {
+                ::close (fd);
+                ::unlink (path.c_str());
+            }
+            return true;
+        }
+        const int bindErr = errno;
+        ::close (fd);
+        if (bindErr != EADDRINUSE) return true;
+
+        if (handOver (addr, len, payload)) return false;
+
+        // Nothing is listening: a primary died without cleaning up. Drop the
+        // file and take the slot on the next pass.
+        if (::unlink (path.c_str()) != 0 && errno != ENOENT) return true;
+    }
+    return true;
+}
+
+void release()
+{
+    Listener* l = listener;
+    if (l == nullptr) return;
+    listener = nullptr;
+
+    if (l->wakeFds[1] >= 0)
+    {
+        const char wake = 0;
+        while (::write (l->wakeFds[1], &wake, 1) < 0 && errno == EINTR) {}
+    }
+    if (l->thread.joinable()) l->thread.join();
+
+    teardown (*l);
+    if (l->wakeFds[0] >= 0) ::close (l->wakeFds[0]);
+    if (l->wakeFds[1] >= 0) ::close (l->wakeFds[1]);
+    delete l;
+}
+
+#else
+
+bool acquire (const std::string&, std::function<void (std::string)>) { return true; }
+void release() {}
+
+#endif
+} // namespace duskstudio::single_instance

--- a/src/util/SingleInstance.h
+++ b/src/util/SingleInstance.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <functional>
+#include <string>
+
+namespace duskstudio::single_instance
+{
+// Claim the single-instance slot for this user + desktop session.
+//
+// Returns true if this process is the primary; onCommandLine then fires on the
+// message thread for every later launch, carrying that launch's payload -
+// which may be empty, meaning "raise the window". A launch that finds the slot
+// taken hands its payload over and gets false back, so it can quit before
+// opening a device or starting an autosave loop the primary already owns.
+// Paths in the payload must already be absolute: the primary resolves relative
+// ones against its own working directory, not the launching shell's.
+//
+// A failed handshake reports "primary" rather than blocking the launch: a
+// broken socket must not stop the app from starting. Linux only - the slot
+// lives under XDG_RUNTIME_DIR, whose per-user ownership is half of what keeps
+// a hostile local process out of the handoff, and the .desktop %f double
+// launch it guards against is a Linux problem. Elsewhere this is a no-op that
+// always returns true.
+bool acquire (const std::string& payload,
+              std::function<void (std::string)> onCommandLine);
+
+// Drop the slot and join the listener. Idempotent; safe if acquire() was
+// never called or returned false.
+void release();
+} // namespace duskstudio::single_instance

--- a/tests/x11_anti_pattern_guard.cpp
+++ b/tests/x11_anti_pattern_guard.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <fstream>
+#include <optional>
 #include <sstream>
 #include <string>
 
@@ -27,7 +28,10 @@
 
 namespace
 {
-std::string readEntireFile (const std::string& path)
+// Nullopt on failure so the caller can tell "audited file is gone /
+// unreadable" apart from "audited file is clean" - the guard has to fail on
+// the former, or renaming an audited path silently retires it.
+std::optional<std::string> readEntireFile (const std::string& path)
 {
     std::ifstream in (path);
     if (! in.is_open()) return {};
@@ -43,10 +47,8 @@ std::string readEntireFile (const std::string& path)
  #define DUSKSTUDIO_SOURCE_DIR "."
 #endif
 
-bool fileContainsXOpenDisplayNull (const std::string& relativePath)
+bool containsXOpenDisplayNull (const std::string& contents)
 {
-    const auto contents = readEntireFile (
-        std::string (DUSKSTUDIO_SOURCE_DIR) + "/" + relativePath);
     // Match `XOpenDisplay(nullptr)` and `XOpenDisplay (nullptr)`.
     // We don't try to be clever about comments — a literal in a
     // doc comment would also flag, which is fine: the comment
@@ -72,6 +74,9 @@ TEST_CASE ("XOpenDisplay(nullptr) is confined to PlatformWindowing impls",
     for (const auto* path : shouldBeClean)
     {
         INFO ("file under audit: " << path);
-        REQUIRE_FALSE (fileContainsXOpenDisplayNull (path));
+        const auto contents = readEntireFile (std::string (DUSKSTUDIO_SOURCE_DIR) + "/" + path);
+        REQUIRE (contents.has_value());
+        REQUIRE_FALSE (contents->empty());
+        REQUIRE_FALSE (containsXOpenDisplayNull (*contents));
     }
 }

--- a/tests/x11_anti_pattern_guard.cpp
+++ b/tests/x11_anti_pattern_guard.cpp
@@ -2,7 +2,6 @@
 
 #include <fstream>
 #include <optional>
-#include <sstream>
 #include <string>
 
 // Regression guard: outside the per-platform PlatformWindowing
@@ -35,9 +34,19 @@ std::optional<std::string> readEntireFile (const std::string& path)
 {
     std::ifstream in (path);
     if (! in.is_open()) return {};
-    std::ostringstream ss;
-    ss << in.rdbuf();
-    return ss.str();
+
+    std::string contents;
+    char buffer[4096];
+    for (;;)
+    {
+        in.read (buffer, sizeof buffer);
+        const auto count = in.gcount();
+        if (count > 0) contents.append (buffer, (std::size_t) count);
+
+        if (in.bad()) return {};
+        if (in.eof()) return contents;
+        if (in.fail()) return {};
+    }
 }
 
 // DUSKSTUDIO_SOURCE_DIR is defined by the test target's CMake so the


### PR DESCRIPTION
## What
- add a Linux-only per-user/display single-instance handshake after all headless gates, forwarding resolved session paths to the running app
- make bounce/editor-test failures use complete and consistent exit paths
- accept yes for native Wayland, fail the X11 guard on missing inputs, correct the ASAN and self-test guidance, and drop the nonexistent Windows develop trigger

## Why
The framework gate runs before initialise and would swallow headless jobs; its Linux broadcast path also cannot deliver the requested session. A post-gate Unix-socket handoff prevents competing engines/autosaves while deliberately leaving macOS and Windows multi-instance. The remaining changes remove silent or misleading app/build behavior.

The donor pins and VST3 InsertAdapter link gate are already fixed on main. CPACK_PACKAGE_CONTACT still requires a real project address and is tracked as a manual release follow-up rather than guessing one here.

## Validation
- DuskStudio app target built successfully
- 548/548 Catch2 tests passed
- tools/juce-gate.sh: 179 files / 9256 uses, unchanged
- git diff --check clean

Fixes #150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added single-instance behavior on Linux, forwarding subsequent launches to the existing application.
  * Improved handling of session paths when launching another instance.
  * Expanded native Wayland configuration to accept numeric, `true`, and `yes` values.

* **Bug Fixes**
  * Improved startup and shutdown handling for single-instance coordination.
  * Native editor test failures now correctly report unsuccessful application exits.
  * Windows test coverage now runs for `main` and `release/**` branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->