### PR TITLE
Close MIDI input callback window (#157)

### DIFF
--- a/src/engine/midi/MidiDevices.cpp
+++ b/src/engine/midi/MidiDevices.cpp
@@ -51,7 +51,12 @@ std::unique_ptr<IMidiOutputBackend> makeOutputBackend()
 // MidiInputClient
 
 MidiInputClient::MidiInputClient()
-    : backend (makeInputBackend())
+    : MidiInputClient (makeInputBackend())
+{
+}
+
+MidiInputClient::MidiInputClient (std::unique_ptr<IMidiInputBackend> backendIn)
+    : backend (std::move (backendIn))
 {
     backend->setReceiver ([this] (const std::string& identifier,
                                   const std::uint8_t* bytes, int numBytes, double timeMs)
@@ -67,6 +72,14 @@ MidiInputClient::~MidiInputClient()
 
 void MidiInputClient::rebuild (double sampleRate)
 {
+    // Dispatch off for the whole rebuild, whoever the caller is: the MIDI thread
+    // demuxes through indexByIdentifier and collectors without synchronisation,
+    // so it must not be live while either is being rebuilt. The backend's stop()
+    // joins that side, and start() at the end re-publishes the finished bank to
+    // it.
+    const bool resumeDispatch = dispatchRunning;
+    if (resumeDispatch) detachCallback();
+
     devices.clear();
     collectors.clear();
     indexByIdentifier.clear();
@@ -88,14 +101,6 @@ void MidiInputClient::rebuild (double sampleRate)
         auto col = std::make_unique<dusk::MidiCollector> (kInputRingBytes);
         col->reset (rate, now);
 
-        // Failure usually = OS denied access (another app exclusively owns the
-        // port). Keep the slot: it stays addressable, it just never fires.
-        if (! backend->enable (d.identifier))
-            std::fprintf (stderr,
-                          "[Dusk Studio/MidiDevices] WARNING: failed to enable MIDI input \"%s\" "
-                          "(id %s). Another application may be holding it open.\n",
-                          d.name.c_str(), d.identifier.c_str());
-
         indexByIdentifier[d.identifier] = (int) collectors.size();
         devices.push_back ({ d.name, d.identifier });
         collectors.push_back (std::move (col));
@@ -111,6 +116,22 @@ void MidiInputClient::rebuild (double sampleRate)
         collectors.push_back (std::move (vkb));
     }
     virtualKeyboardIndex = (int) collectors.size() - 1;
+
+    // Enabling is the last step: a source can deliver the instant it is
+    // subscribed, and every route those bytes can land on exists by now -
+    // whichever thread the backend ends up delivering them on.
+    for (const auto& d : avail)
+    {
+        // Failure usually = OS denied access (another app exclusively owns the
+        // port). Keep the slot: it stays addressable, it just never fires.
+        if (! backend->enable (d.identifier))
+            std::fprintf (stderr,
+                          "[Dusk Studio/MidiDevices] WARNING: failed to enable MIDI input \"%s\" "
+                          "(id %s). Another application may be holding it open.\n",
+                          d.name.c_str(), d.identifier.c_str());
+    }
+
+    if (resumeDispatch) attachCallback();
 }
 
 void MidiInputClient::setDeviceChangeHandler (std::function<void()> h)
@@ -118,9 +139,9 @@ void MidiInputClient::setDeviceChangeHandler (std::function<void()> h)
     backend->setDeviceChangeHandler (std::move (h));
 }
 
-void MidiInputClient::detachCallback()  { backend->stop(); }
+void MidiInputClient::detachCallback()  { backend->stop();  dispatchRunning = false; }
 void MidiInputClient::disableAllDevices() { backend->disableAll(); }
-void MidiInputClient::attachCallback()  { backend->start(); }
+void MidiInputClient::attachCallback()  { backend->start(); dispatchRunning = true; }
 
 void MidiInputClient::resetCollectors (double sampleRate)
 {

--- a/src/engine/midi/MidiDevices.h
+++ b/src/engine/midi/MidiDevices.h
@@ -42,13 +42,27 @@ public:
     static constexpr const char* kVirtualKeyboardIdentifier = "Dusk Studio:virtual-keyboard";
 
     MidiInputClient();
+
+    // Test seam: the same client over a caller-supplied backend, so the
+    // enable-vs-dispatch ordering can be driven without an OS device.
+    explicit MidiInputClient (std::unique_ptr<IMidiInputBackend> backendIn);
+
     ~MidiInputClient();
 
-    // Message thread, input callback DETACHED. Enumerate the hardware inputs,
-    // enable each on the backend, build a per-input collector, then append the
-    // synthetic Virtual-Keyboard slot last (fixed identifier, no OS device).
-    // Mutating the bank with the callback active is UB - see the detach/attach
-    // fence.
+    // Message thread, audio callback DETACHED, disableAllDevices() first.
+    // Enumerate the hardware inputs, build the whole bank (one collector per
+    // input plus the synthetic Virtual-Keyboard slot last, fixed identifier, no
+    // OS device), and only then enable the inputs on the backend: a source can
+    // deliver the instant it is subscribed, so none is subscribed before the
+    // route its bytes need exists.
+    //
+    // Stopping the backend's dispatch for the duration (restored after, if it
+    // was running) is the one part of the fence this owns. The other two stay
+    // with the caller: the audio thread drains these same collectors in
+    // drainBlock while they are cleared and reallocated here, and only
+    // disableAllDevices() clears the backend's source-address -> identifier map,
+    // without which a vanished port's reused address demuxes a new device's
+    // bytes under the dead identifier.
     void rebuild (double sampleRate);
 
     // Message thread, before the first attachCallback. Forwarded to the backend,
@@ -107,6 +121,10 @@ private:
     // Identifier -> collector index for the receiver's demux. Rebuilt only with
     // the backend stopped, so the MIDI thread reads it without synchronisation.
     std::unordered_map<std::string, int> indexByIdentifier;
+
+    // Message thread only. Mirrors whether the backend's dispatch is started, so
+    // rebuild can fence itself against a caller that skipped detachCallback.
+    bool dispatchRunning = false;
 
     int virtualKeyboardIndex = -1;
 };

--- a/tests/midi_device_layer.cpp
+++ b/tests/midi_device_layer.cpp
@@ -1,9 +1,13 @@
 #include <catch2/catch_test_macros.hpp>
 
+#include "engine/midi/MidiBackend.h"
 #include "engine/midi/MidiDevices.h"
 #include "foundation/MidiBuffer.h"
 #include <cstdint>
+#include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
 using duskstudio::midi::MidiInputClient;
 using duskstudio::midi::MidiOutputBank;
@@ -117,3 +121,134 @@ TEST_CASE ("Seam resolves saved identifiers back to bank indices", "[midi][devic
 // What queueRt actually delivers is asserted end to end in alsa_seq_midi.cpp,
 // where a real port receives the bytes; there is no way to observe it here
 // without a device.
+
+namespace
+{
+constexpr std::uint8_t kProbeNote[3] { 0x90, 64, 96 };
+
+// A backend at its most hostile: at the moment the seam subscribes a source it
+// inspects the bank that source's bytes would have to route through, and hands
+// the seam a first byte-run to route right then.
+class ProbeBackend final : public duskstudio::midi::IMidiInputBackend
+{
+public:
+    std::vector<duskstudio::midi::BackendDeviceInfo> enumerate() override
+    {
+        return { { "Probe A", "probe:a" }, { "Probe B", "probe:b" } };
+    }
+
+    void setReceiver (Receiver r) override { receiver = std::move (r); }
+    std::string migrateIdentifier (const std::string&) override { return {}; }
+
+    bool enable (const std::string& identifier) override
+    {
+        ++enableCount;
+        enabledWhileDispatching = enabledWhileDispatching || dispatching;
+
+        if (client != nullptr)
+        {
+            // This source's own route, and the bank as a whole: the synthetic
+            // slot is appended last, so it sitting at the end is what says the
+            // collector vector is finished rather than mid-append.
+            const int idx = client->resolveIndex (identifier);
+            routeReady  = routeReady && idx >= 0 && idx < client->getNumInputs();
+            bankBuilt   = bankBuilt
+                            && client->getVirtualKeyboardIndex() == client->getNumInputs() - 1;
+        }
+
+        if (receiver)
+            receiver (identifier, kProbeNote, 3, duskstudio::midi::backendClockMs());
+        return true;
+    }
+
+    void disableAll() override {}
+    void start() override { dispatching = true; }
+    void stop()  override { dispatching = false; ++stopCount; }
+
+    MidiInputClient* client      = nullptr;
+    Receiver receiver;
+    bool dispatching             = false;
+    bool enabledWhileDispatching = false;
+    bool routeReady              = true;
+    bool bankBuilt               = true;
+    int  enableCount             = 0;
+    int  stopCount               = 0;
+};
+
+int countProbeNotes (const dusk::MidiBuffer& buf)
+{
+    int count = 0;
+    for (const auto meta : buf)
+    {
+        ++count;
+        REQUIRE (meta.numBytes == 3);
+        REQUIRE (meta.data[0] == kProbeNote[0]);
+        REQUIRE (meta.data[1] == kProbeNote[1]);
+        REQUIRE (meta.data[2] == kProbeNote[2]);
+    }
+    return count;
+}
+} // namespace
+
+TEST_CASE ("MidiInputClient wires every route before it enables an input", "[midi][devices]")
+{
+    auto owned = std::make_unique<ProbeBackend>();
+    auto* probe = owned.get();
+
+    MidiInputClient client (std::move (owned));
+    probe->client = &client;
+
+    // 1 Hz, not a real rate: the collectors' retime is relative to the clock
+    // they were seeded with at the top of rebuild, and events below
+    // (elapsed - (numSamples << 5)) samples are dropped at drain time. Scaling
+    // the whole conversion by the sample rate makes that window
+    // (512 << 5) / 1 Hz = over four hours wide, so the delivery assertion below
+    // measures routing rather than how long this process took to reach it.
+    client.rebuild (1.0);
+
+    REQUIRE (probe->enableCount == 2);
+    REQUIRE (probe->routeReady);
+    REQUIRE (probe->bankBuilt);
+
+    dusk::MidiBuffer out;
+    out.reserveBytes (256);
+
+    // Both events were routed from inside enable(), so each landing in its own
+    // collector is what proves the route existed before the enable.
+    for (int i = 0; i < 2; ++i)
+    {
+        client.drainBlock (i, out, 512);
+        REQUIRE (countProbeNotes (out) == 1);
+    }
+
+    // The synthetic slot is bound to no backend source, so nothing routes there.
+    client.drainBlock (client.getVirtualKeyboardIndex(), out, 512);
+    REQUIRE (out.isEmpty());
+}
+
+TEST_CASE ("MidiInputClient rebuild fences the backend's dispatch", "[midi][devices]")
+{
+    auto owned = std::make_unique<ProbeBackend>();
+    auto* probe = owned.get();
+
+    MidiInputClient client (std::move (owned));
+    client.rebuild (48000.0);
+    client.attachCallback();
+    REQUIRE (probe->dispatching);
+
+    const int stopsBefore = probe->stopCount;
+    client.rebuild (48000.0);
+
+    // Stopped for the mutation, restored after it - a caller that skipped the
+    // detach fence still never has the MIDI thread reading a half-built bank.
+    REQUIRE (probe->stopCount == stopsBefore + 1);
+    REQUIRE (probe->dispatching);
+    REQUIRE (! probe->enabledWhileDispatching);
+
+    client.detachCallback();
+    REQUIRE (! probe->dispatching);
+
+    // A rebuild with dispatch already stopped leaves it stopped.
+    client.rebuild (48000.0);
+    REQUIRE (! probe->dispatching);
+}


### PR DESCRIPTION
## What

- build every MIDI input route and the virtual-keyboard slot before enabling any backend input
- stop backend dispatch across a rebuild and restore it only after the finished collector bank is published
- add a hostile test backend that delivers immediately during enable and verifies dispatch fencing

## Why

The reported release/0.12 backtrace was inside JUCE ALSA MIDI input code. That exact Linux path no longer compiles on main because Linux now uses the native ALSA sequencer backend, so this does not claim to repair that removed implementation. It closes the equivalent window in the current Dusk-owned seam: no input is subscribed before its route exists, and no MIDI thread can demultiplex through a half-built bank.

Live MIDI hardware verification remains a manual follow-up because CI has no active input device.

## Validation

- DuskStudio production target builds
- focused MIDI device layer: 53 assertions in 6 test cases
- full Catch2/CTest suite: 550/550 passed
- de-JUCE gate: 179 files / 9,256 uses

Fixes #157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MIDI device initialization and rebuilding for more reliable input handling.
  * Prevented MIDI events from being processed while device routes are being refreshed.
  * Ensured inputs are enabled only after routing is fully configured.
  * Improved event delivery so connected MIDI inputs receive notes correctly without affecting the virtual keyboard slot.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->