### PR TITLE
Complete the native notepad document editor (#73)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -445,6 +445,8 @@ if(DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD)
 
     add_library(dusk_notepad_ui STATIC
         src/ui/NotepadDocument.cpp
+        src/ui/NotepadEditorCore.cpp
+        src/ui/NotepadEditor.cpp
         src/ui/NativeNotepadWindow.cpp
         "${DUSKSTUDIO_DPF_WIDGETS_SOURCE_DIR}/opengl/DearImGui.cpp")
     target_include_directories(dusk_notepad_ui PRIVATE

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -554,7 +554,11 @@ caret or format a selection; Ctrl+Z undoes and Ctrl+Y or Ctrl+Shift+Z redoes
 both text and formatting. On macOS, Cmd works wherever Ctrl is listed,
 including link activation. Numbered and bulleted lists continue when you press
 Enter, and a second Enter on an empty list item returns to body text.
-Ctrl-click an `http`, `https`, or `mailto` link to open it.
+Ctrl-click an `http`, `https`, or `mailto` link to open it. Selection and
+navigation follow the usual conventions: double-click selects a word,
+triple-click a line, Ctrl+arrow jumps by word, Home, End, and Page Up/Down move
+within the page, Ctrl+A selects everything, and cut, copy, and paste use the
+system clipboard.
 
 The **Markdown** tab exposes the compatible `notepad.md` source for users who
 prefer direct editing. Switching views preserves the selection. The footer

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -561,12 +561,13 @@ within the page, Ctrl+A selects everything, and cut, copy, and paste use the
 system clipboard.
 
 The **Markdown** tab exposes the compatible `notepad.md` source for users who
-prefer direct editing. Switching views preserves the selection. The footer
-distinguishes saved, unsaved, untitled, and failed-save states. Notes are saved
-atomically to `notepad.md` when the notepad closes and on every session save;
-they follow the session on Save As. A failed sidecar write remains dirty and
-blocks a session switch instead of discarding the outgoing notes. Typing in
-either view never triggers transport shortcuts.
+prefer direct editing. Switching views preserves the selection. Click the
+dimmed area outside the notepad to close it. The footer distinguishes saved,
+unsaved, untitled, and failed-save states. Notes are saved atomically to
+`notepad.md` when the notepad closes and on every session save; they follow the
+session on Save As. A failed sidecar write remains dirty and can be retried by
+saving the session again; it blocks a session switch instead of discarding the
+outgoing notes. Typing in either view never triggers transport shortcuts.
 
 \newpage
 

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -5294,7 +5294,7 @@ void MainComponent::toggleNotepad()
         {
             if (auto* self = safeThis.getComponent())
             {
-                self->setEnabled (true);
+                self->notepadDim.reset();
                 if (auto* window = self->getTopLevelComponent())
                     window->toFront (true);
                 // The native notepad held keyboard focus; pull it back so
@@ -5320,18 +5320,34 @@ void MainComponent::toggleNotepad()
             }
         });
 
-    notepadWindow->open (
+    // A JUCE sibling beneath the embedded native child blocks the DAW and
+    // receives clicks outside the notepad. Keep dismissal at this native host
+    // boundary: the DPF/ImGui editor owns document editing only, while close()
+    // preserves the deferred native teardown -> onClosed -> saveNotepadNow()
+    // sequence above.
+    notepadDim = std::make_unique<DimOverlay> (0.80f);
+    notepadDim->setBounds (getLocalBounds());
+    notepadDim->onClick = [safeThis]
+    {
+        if (auto* self = safeThis.getComponent())
+            if (self->notepadWindow != nullptr && self->notepadWindow->isOpen())
+                self->notepadWindow->close();
+    };
+    addAndMakeVisible (notepadDim.get());
+
+    const bool opened = notepadWindow->open (
         reinterpret_cast<std::uintptr_t> (peer->getNativeHandle()),
         notepadGeometryFor (*topLevel),
         notepadText.toStdString(),
         session.getSessionDirectory() != juce::File(),
         notepadDirty);
 
-    if (notepadWindow->isOpen())
-        setEnabled (false); // embedded DPF editor is application-modal to the DAW
-    else
+    if (! opened)
+    {
+        notepadDim.reset();
         statusLabel.setText ("Unable to embed session notepad with the current display backend",
                              juce::dontSendNotification);
+    }
 #endif
 }
 
@@ -5344,11 +5360,11 @@ void MainComponent::dismissNotepad (bool saveChanges)
         notepadWindow->close();
         notepadWindow.reset();
     }
+    notepadDim.reset();
    #endif
 
-    setEnabled (true);
     if (saveChanges)
-        saveNotepadNow();
+        (void) saveNotepadNow();
 }
 
 bool MainComponent::saveNotepadNow()

--- a/src/ui/MainComponent.h
+++ b/src/ui/MainComponent.h
@@ -288,16 +288,18 @@ private:
     void toggleVirtualKeyboard();
 
     // Session notepad (lyrics/notes). The editor is a native DPF/DGL + Dear
-    // ImGui child window embedded in the DAW; this legacy shell only supplies
-    // the native parent/geometry and blocks the DAW while the modal is open.
-    // The live text mirrors the editor callback; notepad.md is written on dismiss and on
-    // every session save. The sidecar is invisible to serialize(), so its own
-    // dirty flag participates explicitly in quit/load protection.
+    // ImGui child window embedded in the DAW. The JUCE shell owns the dimmed,
+    // click-to-dismiss backdrop beneath that native child, so the editor stays
+    // independent of the host's modal/dismissal UI. The live text mirrors the
+    // editor callback; notepad.md is written on dismiss and on every session
+    // save. The sidecar is invisible to serialize(), so its own dirty flag
+    // participates explicitly in quit/load protection.
     void toggleNotepad();
     void dismissNotepad (bool saveChanges);
     bool saveNotepadNow();
    #if DUSKSTUDIO_HAS_NATIVE_NOTEPAD
     std::unique_ptr<NativeNotepadWindow> notepadWindow;
+    std::unique_ptr<class DimOverlay> notepadDim;
    #endif
     juce::String notepadText;
     bool notepadDirty = false;

--- a/src/ui/NativeNotepadWindow.cpp
+++ b/src/ui/NativeNotepadWindow.cpp
@@ -359,11 +359,11 @@ struct NativeNotepadWindow::Impl final : private dusk::Timer
                const std::string& markdown,
                bool sessionExists, bool unsavedChanges)
     {
+        stopTimer();
+        destroyEmbeddedWindow();
         if (nativeParent == 0 || geometry.width < 2 || geometry.height < 2)
             return false;
 
-        stopTimer();
-        destroyEmbeddedWindow();
         document.setMarkdown (markdown);
         markdownMode = false;
         buffer.assign (document.markdown());
@@ -920,9 +920,13 @@ private:
             auto before = currentSnapshot();
             before.selection = selectionBefore;
             buffer.text.resize (std::strlen (buffer.text.c_str()));
+            // Deletions must not join a typing run, or a backspace burst would
+            // undo the text it was correcting along with itself.
+            const auto kind = buffer.text.size() < before.markdown.size()
+                            ? notepad::EditKind::deleting
+                            : notepad::EditKind::typing;
             document.setMarkdown (buffer.text);
-            history.record (notepad::EditKind::typing, std::move (before),
-                            buffer.selection().end);
+            history.record (kind, std::move (before), buffer.selection().end);
             notifyTextChanged();
         }
         else if (selectionBefore.start != buffer.selection().start

--- a/src/ui/NativeNotepadWindow.cpp
+++ b/src/ui/NativeNotepadWindow.cpp
@@ -1,5 +1,7 @@
 #include "NativeNotepadWindow.h"
 #include "NotepadDocument.h"
+#include "NotepadEditor.h"
+#include "NotepadEditorCore.h"
 #include "../foundation/MessageThread.h"
 
 #include <Application.hpp>
@@ -11,8 +13,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cfloat>
-#include <cmath>
 #include <cstring>
 #include <filesystem>
 #include <optional>
@@ -224,16 +224,6 @@ bool sourceSelectionHasWrapper (const std::string& text,
     return (prefixOutside && suffixOutside) || includesMarkers;
 }
 
-std::size_t nextUtf8Offset (const std::string& text, std::size_t offset,
-                            std::size_t limit)
-{
-    offset = std::min (offset + 1, limit);
-    while (offset < limit
-           && (static_cast<unsigned char> (text[offset]) & 0xc0u) == 0x80u)
-        ++offset;
-    return offset;
-}
-
 // The destination is emitted inside "](...)", so a bracket or parenthesis the
 // user typed would close it early and leave raw syntax in the document.
 std::string percentEncodeUrl (const std::string& url)
@@ -287,7 +277,18 @@ struct NativeNotepadWindow::Impl final : private dusk::Timer
         Impl& owner;
     };
 
-    Impl() = default;
+    Impl()
+    {
+        editor.onDocumentChanged = [this] { notifyTextChanged(); };
+        editor.onLinkActivated = [this] (const std::string& target)
+        {
+            if (onLinkOpened)
+                onLinkOpened (target);
+        };
+        editor.onUndoRequested = [this] { restoreHistory (false); };
+        editor.onRedoRequested = [this] { restoreHistory (true); };
+        editor.setDarkPage (darkDocumentPage);
+    }
 
     void buildFontAtlas (float size)
     {
@@ -337,6 +338,7 @@ struct NativeNotepadWindow::Impl final : private dusk::Timer
         if (italicFont == nullptr) italicFont = bodyFont;
         if (boldItalicFont == nullptr) boldItalicFont = boldFont;
         if (monoFont == nullptr) monoFont = bodyFont;
+        editor.setFonts ({ bodyFont, boldFont, italicFont, boldItalicFont, monoFont });
     }
 
     ~Impl()
@@ -353,40 +355,41 @@ struct NativeNotepadWindow::Impl final : private dusk::Timer
         onLinkOpened = std::move (linkOpened);
     }
 
-    void open (std::uintptr_t nativeParent, EmbeddedGeometry geometry,
+    bool open (std::uintptr_t nativeParent, EmbeddedGeometry geometry,
                const std::string& markdown,
                bool sessionExists, bool unsavedChanges)
     {
         if (nativeParent == 0 || geometry.width < 2 || geometry.height < 2)
-            return;
+            return false;
 
+        stopTimer();
         destroyEmbeddedWindow();
         document.setMarkdown (markdown);
         markdownMode = false;
-        buffer.assign (document.documentText());
+        buffer.assign (document.markdown());
         buffer.restoreSelection ({ 0, 0 });
-        selectionAnchor = 0;
-        selectingWithMouse = false;
-        documentScrollY = 0.0f;
+        editor.reset ({ 0, 0 });
+        editor.requestFocus();
         closeRequested = false;
         closeWasPumped = false;
-        focusEditorNextFrame = true;
+        focusEditorNextFrame = false;
         hasSessionFile = sessionExists;
         documentDirty = unsavedChanges;
         saveFailed = false;
         savedMarkdown = unsavedChanges ? std::optional<std::string> {}
                                        : std::optional<std::string> { markdown };
-        typingStyleOverride = false;
-        undoHistory.clear();
-        redoHistory.clear();
+        history.clear();
 
         window = std::make_unique<DGL::Window> (
             app, nativeParent, geometry.width, geometry.height,
             geometry.scaleFactor, false);
-        if (window->getNativeWindowHandle() == 0)
+        // A display without a usable GL configuration leaves Pugl with an
+        // unrealised view: no native handle, and a size hint that never took.
+        if (window->getNativeWindowHandle() == 0
+            || window->getWidth() < 2 || window->getHeight() < 2)
         {
             window.reset();
-            return;
+            return false;
         }
 
         // Dusk Studio owns both native windows, so it also owns the child's
@@ -399,7 +402,7 @@ struct NativeNotepadWindow::Impl final : private dusk::Timer
         if (! window->setEmbeddedOffset (geometry.x, geometry.y))
         {
             window.reset();
-            return;
+            return false;
         }
         {
             DGL::Window::ScopedGraphicsContext context (*window);
@@ -408,6 +411,7 @@ struct NativeNotepadWindow::Impl final : private dusk::Timer
         }
         window->focus();
         startTimer (16);
+        return true;
     }
 
     void close()
@@ -443,47 +447,41 @@ struct NativeNotepadWindow::Impl final : private dusk::Timer
     }
 
 private:
-    struct HistoryState
+    notepad::Snapshot currentSnapshot() const
     {
-        std::string markdown;
-        NotepadDocument::Selection selection;
-        bool selectionIsMarkdown = false;
-    };
-
-    HistoryState historyState (NotepadDocument::Selection selection) const
-    {
-        return { document.markdown(), selection, markdownMode };
+        return { document.markdown(),
+                 markdownMode ? buffer.selection() : editor.selection(),
+                 markdownMode };
     }
 
-    void pushUndo (NotepadDocument::Selection selection)
+    NotepadDocument::Selection selectionForCurrentMode (const notepad::Snapshot& state) const
     {
-        undoHistory.push_back (historyState (selection));
-        if (undoHistory.size() > 256)
-            undoHistory.erase (undoHistory.begin());
-        redoHistory.clear();
-    }
-
-    NotepadDocument::Selection selectionForCurrentMode (const HistoryState& state) const
-    {
-        if (state.selectionIsMarkdown == markdownMode)
+        if (state.selectionIsSource == markdownMode)
             return state.selection;
         return markdownMode ? document.sourceSelection (state.selection)
                             : document.documentSelection (state.selection);
     }
 
-    void restoreHistory (std::vector<HistoryState>& from,
-                         std::vector<HistoryState>& to)
+    void restoreHistory (bool redo)
     {
-        if (from.empty())
+        notepad::Snapshot restored;
+        if (! (redo ? history.redo (currentSnapshot(), restored)
+                    : history.undo (currentSnapshot(), restored)))
             return;
-        to.push_back (historyState (buffer.selection()));
-        const auto state = std::move (from.back());
-        from.pop_back();
-        document.setMarkdown (state.markdown);
-        buffer.assign (markdownMode ? document.markdown() : document.documentText());
-        buffer.restoreSelection (selectionForCurrentMode (state));
-        typingStyleOverride = false;
-        focusEditorNextFrame = true;
+
+        document.setMarkdown (restored.markdown);
+        const auto selection = selectionForCurrentMode (restored);
+        if (markdownMode)
+        {
+            buffer.assign (document.markdown());
+            buffer.restoreSelection (selection);
+            focusEditorNextFrame = true;
+        }
+        else
+        {
+            editor.reset (selection);
+            editor.requestFocus();
+        }
         notifyTextChanged();
     }
 
@@ -525,6 +523,7 @@ private:
         }
         window.reset();
         bodyFont = boldFont = italicFont = boldItalicFont = monoFont = nullptr;
+        editor.setFonts ({});
     }
 
     void notifyTextChanged()
@@ -540,156 +539,106 @@ private:
     {
         if (markdownMode == useMarkdown)
             return;
-        const auto oldSelection = buffer.selection();
+        const auto oldSelection = markdownMode ? buffer.selection() : editor.selection();
         markdownMode = useMarkdown;
-        buffer.assign (markdownMode ? document.markdown() : document.documentText());
-        const auto converted = markdownMode ? document.sourceSelection (oldSelection)
-                                            : document.documentSelection (oldSelection);
-        buffer.restoreSelection (converted);
-        selectionAnchor = converted.start;
-        selectingWithMouse = false;
-        documentScrollY = 0.0f;
-        typingStyleOverride = false;
-        focusEditorNextFrame = true;
-    }
-
-    bool& typingStyleValue (NotepadDocument::InlineStyle style)
-    {
-        switch (style)
+        history.breakRun();
+        if (markdownMode)
         {
-            case NotepadDocument::InlineStyle::bold:   return typingBold;
-            case NotepadDocument::InlineStyle::italic: return typingItalic;
-            case NotepadDocument::InlineStyle::code:   return typingCode;
+            buffer.assign (document.markdown());
+            buffer.restoreSelection (document.sourceSelection (oldSelection));
+            focusEditorNextFrame = true;
         }
-        return typingBold;
-    }
-
-    void initialiseTypingStyle()
-    {
-        if (typingStyleOverride)
-            return;
-        const auto caret = buffer.selection().start;
-        const auto style = document.styleAt (caret);
-        typingBold = style.bold;
-        typingItalic = style.italic;
-        typingCode = style.code;
-        typingStyleOverride = true;
+        else
+        {
+            editor.reset (document.documentSelection (oldSelection));
+            editor.requestFocus();
+        }
     }
 
     void applyInline (NotepadDocument::InlineStyle inlineStyle,
                       const std::string& prefix, const std::string& suffix)
     {
+        if (! markdownMode)
+        {
+            editor.applyInlineStyle (inlineStyle);
+            return;
+        }
+
         const auto selection = buffer.selection();
-        if (markdownMode)
-        {
-            pushUndo (selection);
-            auto source = document.markdown();
-            source.insert (selection.end, suffix);
-            source.insert (selection.start, prefix);
-            document.setMarkdown (std::move (source));
-            buffer.assign (document.markdown());
-            buffer.restoreSelection ({ selection.start + prefix.size(),
-                                       selection.end + prefix.size() });
-        }
-        else if (selection.empty())
-        {
-            initialiseTypingStyle();
-            auto& value = typingStyleValue (inlineStyle);
-            value = ! value;
-        }
-        else
-        {
-            pushUndo (selection);
-            const bool enable = ! document.selectionHasInlineStyle (selection, inlineStyle);
-            document.setDocumentInlineStyle (selection, inlineStyle, enable);
-            buffer.assign (document.documentText());
-            buffer.restoreSelection (selection);
-            notifyTextChanged();
-        }
+        auto before = currentSnapshot();
+        auto source = document.markdown();
+        source.insert (selection.end, suffix);
+        source.insert (selection.start, prefix);
+        document.setMarkdown (std::move (source));
+        buffer.assign (document.markdown());
+        buffer.restoreSelection ({ selection.start + prefix.size(),
+                                   selection.end + prefix.size() });
+        history.record (notepad::EditKind::structural, std::move (before),
+                        selection.end + prefix.size());
         focusEditorNextFrame = true;
-        if (markdownMode)
-            notifyTextChanged();
+        notifyTextChanged();
     }
 
     void applyBlock (NotepadDocument::BlockStyle style)
     {
+        if (! markdownMode)
+        {
+            editor.applyBlockStyle (style);
+            return;
+        }
+
         const auto selection = buffer.selection();
         if (selectedBlockStyle() == style)
             style = NotepadDocument::BlockStyle::body;
-        pushUndo (selection);
-        if (! markdownMode)
+        auto before = currentSnapshot();
+
+        auto source = document.markdown();
+        const auto first = sourceLineStart (source, selection.start);
+        const auto last = sourceLineEnd (source, selection.end);
+        std::vector<std::pair<std::size_t, std::size_t>> lines;
+        for (auto start = first; start <= last;)
         {
-            document.setDocumentBlockStyle (selection, style);
-            buffer.assign (document.documentText());
-            buffer.restoreSelection (selection);
+            const auto end = sourceLineEnd (source, start);
+            lines.emplace_back (start, end);
+            if (end == source.size())
+                break;
+            start = end + 1;
         }
-        else
+        for (std::size_t index = lines.size(); index-- > 0;)
         {
-            auto source = document.markdown();
-            const auto first = sourceLineStart (source, selection.start);
-            const auto last = sourceLineEnd (source, selection.end);
-            std::vector<std::pair<std::size_t, std::size_t>> lines;
-            for (auto start = first; start <= last;)
-            {
-                const auto end = sourceLineEnd (source, start);
-                lines.emplace_back (start, end);
-                if (end == source.size())
-                    break;
-                start = end + 1;
-            }
-            for (std::size_t index = lines.size(); index-- > 0;)
-            {
-                const auto [start, end] = lines[index];
-                source.erase (start, sourceBlockPrefixLength (source, start, end));
-                source.insert (start, blockPrefix (style, index + 1));
-            }
-            document.setMarkdown (std::move (source));
-            buffer.assign (document.markdown());
-            buffer.restoreSelection (selection);
+            const auto [start, end] = lines[index];
+            source.erase (start, sourceBlockPrefixLength (source, start, end));
+            source.insert (start, blockPrefix (style, index + 1));
         }
+        document.setMarkdown (std::move (source));
+        buffer.assign (document.markdown());
+        buffer.restoreSelection (selection);
+        history.record (notepad::EditKind::structural, std::move (before), selection.end);
         focusEditorNextFrame = true;
-        typingStyleOverride = false;
         notifyTextChanged();
     }
 
     void insertLink (const std::string& url)
     {
-        auto selection = buffer.selection();
-        pushUndo (selection);
-        constexpr auto placeholder = "Link text";
-
-        if (markdownMode)
+        if (! markdownMode)
         {
-            auto source = document.markdown();
-            const auto label = selection.empty()
-                             ? std::string (placeholder)
-                             : source.substr (selection.start, selection.end - selection.start);
-            const auto replacement = "[" + label + "](" + url + ")";
-            source.replace (selection.start, selection.end - selection.start, replacement);
-            document.setMarkdown (std::move (source));
-            buffer.assign (document.markdown());
-            buffer.restoreSelection ({ selection.start + 1,
-                                       selection.start + 1 + label.size() });
-        }
-        else
-        {
-            if (selection.empty())
-            {
-                auto text = document.documentText();
-                text.insert (selection.start, placeholder);
-                if (! document.replaceDocumentText (text))
-                {
-                    undoHistory.pop_back();
-                    return;
-                }
-                selection.end = selection.start + std::strlen (placeholder);
-            }
-            document.wrapDocumentSelection (selection, "[", "](" + url + ")");
-            buffer.assign (document.documentText());
-            buffer.restoreSelection (selection);
+            editor.insertLink (url);
+            return;
         }
 
-        typingStyleOverride = false;
+        const auto selection = buffer.selection();
+        auto before = currentSnapshot();
+        auto source = document.markdown();
+        const auto label = selection.empty()
+                         ? std::string ("Link text")
+                         : source.substr (selection.start, selection.end - selection.start);
+        const auto replacement = "[" + label + "](" + url + ")";
+        source.replace (selection.start, selection.end - selection.start, replacement);
+        document.setMarkdown (std::move (source));
+        buffer.assign (document.markdown());
+        buffer.restoreSelection ({ selection.start + 1, selection.start + 1 + label.size() });
+        history.record (notepad::EditKind::structural, std::move (before),
+                        selection.start + 1 + label.size());
         focusEditorNextFrame = true;
         notifyTextChanged();
     }
@@ -698,25 +647,16 @@ private:
                             const std::string& prefix,
                             const std::string& suffix) const
     {
-        if (! markdownMode && buffer.selection().empty() && typingStyleOverride)
-        {
-            switch (style)
-            {
-                case NotepadDocument::InlineStyle::bold:   return typingBold;
-                case NotepadDocument::InlineStyle::italic: return typingItalic;
-                case NotepadDocument::InlineStyle::code:   return typingCode;
-            }
-        }
         return markdownMode
              ? sourceSelectionHasWrapper (document.markdown(), buffer.selection(), prefix, suffix)
-             : document.selectionHasInlineStyle (buffer.selection(), style);
+             : editor.inlineStyleActive (style);
     }
 
     NotepadDocument::BlockStyle selectedBlockStyle() const
     {
         return markdownMode
              ? sourceBlockStyle (document.markdown(), buffer.selection())
-             : document.blockStyleForSelection (buffer.selection());
+             : editor.blockStyle();
     }
 
     bool toolbarButton (const char* label, const char* tooltip, bool active,
@@ -815,10 +755,10 @@ private:
                            ImGuiWindowFlags_NoScrollbar);
 
         if (toolbarButton ("↶", "Undo (Ctrl+Z)", false))
-            restoreHistory (undoHistory, redoHistory);
+            restoreHistory (false);
         ImGui::SameLine (0.0f, 5.0f);
         if (toolbarButton ("↷", "Redo (Ctrl+Y)", false))
-            restoreHistory (redoHistory, undoHistory);
+            restoreHistory (true);
         ImGui::SameLine (0.0f, 10.0f);
 
         static const std::array<const char*, 4> styleNames {
@@ -902,448 +842,6 @@ private:
         ImGui::PopStyleVar (2);
     }
 
-    struct VisualRow
-    {
-        std::size_t start = 0;
-        std::size_t end = 0;
-        std::size_t lineStart = 0;
-        std::size_t lineEnd = 0;
-        NotepadDocument::BlockStyle block = NotepadDocument::BlockStyle::body;
-        NotepadDocument::LineInfo lineInfo;
-        float y = 0.0f;
-        float height = 0.0f;
-        float textIndent = 0.0f;
-        bool firstVisualRow = false;
-    };
-
-    static bool isHeading (NotepadDocument::BlockStyle style) noexcept
-    {
-        return style == NotepadDocument::BlockStyle::heading1
-            || style == NotepadDocument::BlockStyle::heading2
-            || style == NotepadDocument::BlockStyle::heading3;
-    }
-
-    float documentFontSize (NotepadDocument::BlockStyle style, float bodySize) const noexcept
-    {
-        switch (style)
-        {
-            case NotepadDocument::BlockStyle::heading1: return bodySize + 11.0f;
-            case NotepadDocument::BlockStyle::heading2: return bodySize + 7.0f;
-            case NotepadDocument::BlockStyle::heading3: return bodySize + 3.5f;
-            default: return bodySize;
-        }
-    }
-
-    ImFont* fontForStyle (NotepadDocument::TextStyle style,
-                          NotepadDocument::BlockStyle block) const noexcept
-    {
-        if (style.code)
-            return monoFont;
-        const bool bold = style.bold || isHeading (block);
-        if (bold && style.italic)
-            return boldItalicFont;
-        if (bold)
-            return boldFont;
-        if (style.italic)
-            return italicFont;
-        return bodyFont;
-    }
-
-    float documentTextWidth (std::size_t start, std::size_t end, float fontSize,
-                             NotepadDocument::BlockStyle block) const
-    {
-        const auto& text = document.documentText();
-        start = std::min (start, text.size());
-        end = std::min (end, text.size());
-        float width = 0.0f;
-        while (start < end)
-        {
-            const auto style = document.styleAt (start);
-            auto runEnd = nextUtf8Offset (text, start, end);
-            while (runEnd < end && document.styleAt (runEnd) == style)
-                runEnd = nextUtf8Offset (text, runEnd, end);
-            if (auto* const font = fontForStyle (style, block))
-                width += font->CalcTextSizeA (fontSize, FLT_MAX, 0.0f,
-                                              text.data() + start,
-                                              text.data() + runEnd).x;
-            start = runEnd;
-        }
-        return width;
-    }
-
-    NotepadDocument::BlockStyle documentLineStyle (std::size_t lineStart) const
-    {
-        const auto& text = document.documentText();
-        if (lineStart < text.size() && text[lineStart] != '\n')
-            return document.styleAt (lineStart).block;
-        return document.blockStyleForSelection ({ lineStart, lineStart });
-    }
-
-    void buildDocumentLayout (float width, float bodySize)
-    {
-        documentRows.clear();
-        const auto& text = document.documentText();
-        float y = 0.0f;
-        std::size_t lineStart = 0;
-
-        while (lineStart <= text.size())
-        {
-            const auto foundEnd = text.find ('\n', lineStart);
-            const auto lineEnd = foundEnd == std::string::npos ? text.size() : foundEnd;
-            const auto block = documentLineStyle (lineStart);
-            const auto info = document.lineInfoAt (lineStart);
-            const auto fontSize = documentFontSize (block, bodySize);
-            const auto rowHeight = std::ceil (fontSize * (isHeading (block) ? 1.32f : 1.48f));
-            const bool marked = block == NotepadDocument::BlockStyle::bullets
-                             || block == NotepadDocument::BlockStyle::numbers
-                             || block == NotepadDocument::BlockStyle::tasks;
-            const float indent = marked ? 30.0f
-                               : block == NotepadDocument::BlockStyle::quote ? 18.0f : 0.0f;
-            const float wrapWidth = std::max (60.0f, width - indent - 8.0f);
-            if (isHeading (block) && ! documentRows.empty())
-                y += 8.0f;
-
-            auto rowStart = lineStart;
-            bool first = true;
-            if (rowStart == lineEnd)
-            {
-                documentRows.push_back ({ rowStart, rowStart, lineStart, lineEnd,
-                                          block, info, y, rowHeight, indent, true });
-                y += rowHeight;
-            }
-            while (rowStart < lineEnd)
-            {
-                auto offset = rowStart;
-                auto rowEnd = rowStart;
-                auto lastBreak = std::string::npos;
-                float used = 0.0f;
-                while (offset < lineEnd)
-                {
-                    const auto next = nextUtf8Offset (text, offset, lineEnd);
-                    const auto advance = documentTextWidth (offset, next, fontSize, block);
-                    if (used + advance > wrapWidth && offset > rowStart)
-                    {
-                        rowEnd = lastBreak != std::string::npos && lastBreak > rowStart
-                               ? lastBreak : offset;
-                        break;
-                    }
-                    used += advance;
-                    rowEnd = next;
-                    if (text[offset] == ' ' || text[offset] == '\t')
-                        lastBreak = next;
-                    offset = next;
-                }
-                if (rowEnd == rowStart)
-                    rowEnd = nextUtf8Offset (text, rowStart, lineEnd);
-                documentRows.push_back ({ rowStart, rowEnd, lineStart, lineEnd,
-                                          block, info, y, rowHeight, indent, first });
-                y += rowHeight;
-                rowStart = rowEnd;
-                first = false;
-            }
-
-            if (isHeading (block)) y += 4.0f;
-            else if (block == NotepadDocument::BlockStyle::quote) y += 2.0f;
-            if (foundEnd == std::string::npos)
-                break;
-            lineStart = foundEnd + 1;
-        }
-        documentContentHeight = std::max (y, bodySize);
-    }
-
-    std::size_t rowIndexAtY (float localY) const noexcept
-    {
-        if (documentRows.empty())
-            return 0;
-        for (std::size_t i = 0; i < documentRows.size(); ++i)
-            if (localY < documentRows[i].y + documentRows[i].height)
-                return i;
-        return documentRows.size() - 1;
-    }
-
-    std::size_t offsetAtRowX (const VisualRow& row, float localX,
-                              float bodySize) const
-    {
-        const auto& text = document.documentText();
-        const auto fontSize = documentFontSize (row.block, bodySize);
-        float x = 0.0f;
-        for (auto offset = row.start; offset < row.end;)
-        {
-            const auto next = nextUtf8Offset (text, offset, row.end);
-            const auto advance = documentTextWidth (offset, next, fontSize, row.block);
-            if (localX < x + advance * 0.5f)
-                return offset;
-            x += advance;
-            offset = next;
-        }
-        return row.end;
-    }
-
-    std::size_t documentHitTest (ImVec2 mouse, ImVec2 rectMin,
-                                 float bodySize) const
-    {
-        if (documentRows.empty())
-            return 0;
-        const auto rowIndex = rowIndexAtY (std::max (0.0f,
-            mouse.y - rectMin.y + documentScrollY));
-        const auto& row = documentRows[rowIndex];
-        return offsetAtRowX (row, mouse.x - rectMin.x - row.textIndent, bodySize);
-    }
-
-    void handleDocumentMouse (bool hovered, ImVec2 rectMin, ImVec2 rectMax,
-                              float bodySize)
-    {
-        auto& io = ImGui::GetIO();
-        const auto viewportHeight = std::max (1.0f, rectMax.y - rectMin.y);
-        if (hovered && io.MouseWheel != 0.0f)
-            documentScrollY = std::clamp (documentScrollY - io.MouseWheel * 42.0f,
-                                          0.0f,
-                                          std::max (0.0f, documentContentHeight - viewportHeight));
-
-        const auto hit = hovered ? documentHitTest (io.MousePos, rectMin, bodySize) : 0;
-        if (hovered && hit < document.documentText().size()
-            && ! document.linkTargetAt (hit).empty())
-            ImGui::SetMouseCursor (ImGuiMouseCursor_Hand);
-
-        if (hovered && ImGui::IsMouseClicked (ImGuiMouseButton_Left)
-            && io.MouseClickedCount[ImGuiMouseButton_Left] == 1)
-        {
-            const auto rowIndex = rowIndexAtY (std::max (0.0f,
-                io.MousePos.y - rectMin.y + documentScrollY));
-            const auto& row = documentRows[rowIndex];
-
-            if (row.firstVisualRow && row.block == NotepadDocument::BlockStyle::tasks
-                && io.MousePos.x >= rectMin.x + 3.0f
-                && io.MousePos.x <= rectMin.x + row.textIndent - 4.0f)
-            {
-                const auto selection = buffer.selection();
-                pushUndo (selection);
-                document.toggleTaskAt (row.lineStart);
-                buffer.assign (document.documentText());
-                buffer.restoreSelection (selection);
-                notifyTextChanged();
-                return;
-            }
-
-            const auto target = hit < document.documentText().size()
-                              ? document.linkTargetAt (hit)
-                              : std::string {};
-            if ((io.KeyCtrl || io.KeySuper) && ! target.empty())
-            {
-                if (onLinkOpened)
-                    onLinkOpened (target);
-                return;
-            }
-
-            if (io.KeyShift)
-            {
-                if (! selectingWithMouse)
-                    selectionAnchor = buffer.selection().start;
-            }
-            else
-            {
-                selectionAnchor = hit;
-            }
-            buffer.restoreSelection ({ selectionAnchor, hit });
-            typingStyleOverride = false;
-            selectingWithMouse = true;
-        }
-        else if (selectingWithMouse && ImGui::IsMouseDown (ImGuiMouseButton_Left))
-        {
-            const auto dragHit = documentHitTest (io.MousePos, rectMin, bodySize);
-            buffer.restoreSelection ({ selectionAnchor, dragHit });
-        }
-
-        if (ImGui::IsMouseReleased (ImGuiMouseButton_Left))
-            selectingWithMouse = false;
-    }
-
-    void moveDocumentCaretVertically (NotepadDocument::Selection before,
-                                      int direction, bool extend, float bodySize)
-    {
-        if (documentRows.empty())
-            return;
-        std::size_t current = 0;
-        for (std::size_t i = 0; i < documentRows.size(); ++i)
-        {
-            if (before.end >= documentRows[i].start && before.end <= documentRows[i].end)
-            {
-                current = i;
-                break;
-            }
-        }
-        const auto target = static_cast<std::size_t> (std::clamp (
-            static_cast<int> (current) + direction, 0,
-            static_cast<int> (documentRows.size() - 1)));
-        const auto& sourceRow = documentRows[current];
-        const auto& targetRow = documentRows[target];
-        const auto sourceSize = documentFontSize (sourceRow.block, bodySize);
-        const auto x = documentTextWidth (sourceRow.start, before.end,
-                                          sourceSize, sourceRow.block);
-        const auto caret = offsetAtRowX (targetRow, x, bodySize);
-        if (! extend)
-            selectionAnchor = caret;
-        else if (before.empty())
-            selectionAnchor = before.start;
-        buffer.restoreSelection ({ selectionAnchor, caret });
-        typingStyleOverride = false;
-    }
-
-    void keepCaretVisible (ImVec2 rectMin, ImVec2 rectMax)
-    {
-        const auto caret = buffer.selection().end;
-        for (const auto& row : documentRows)
-        {
-            if (caret < row.start || caret > row.end)
-                continue;
-            const auto viewport = rectMax.y - rectMin.y;
-            if (row.y < documentScrollY)
-                documentScrollY = row.y;
-            else if (row.y + row.height > documentScrollY + viewport)
-                documentScrollY = row.y + row.height - viewport;
-            documentScrollY = std::clamp (documentScrollY, 0.0f,
-                                          std::max (0.0f, documentContentHeight - viewport));
-            break;
-        }
-    }
-
-    void drawRichDocument (ImVec2 rectMin, ImVec2 rectMax,
-                           float bodySize, bool editorActive)
-    {
-        const auto& text = document.documentText();
-        auto* const drawList = ImGui::GetWindowDrawList();
-        const auto selection = buffer.selection();
-        const auto textColour = ImGui::GetColorU32 (
-            colour (darkDocumentPage ? 0xe7e8edff : 0x24242aff));
-        const auto mutedColour = ImGui::GetColorU32 (
-            colour (darkDocumentPage ? 0xa9abb5ff : 0x67656dff));
-        const auto linkColour = ImGui::GetColorU32 (
-            colour (darkDocumentPage ? 0x8eb4ffff : 0x315fbdff));
-        const auto codeColour = ImGui::GetColorU32 (
-            colour (darkDocumentPage ? 0xd5a4f0ff : 0x5e367cff));
-        const auto selectionColour = ImGui::GetColorU32 (
-            colour (darkDocumentPage ? 0x516aa6cc : 0xb9c8f0cc));
-        const auto codeBackground = ImGui::GetColorU32 (
-            colour (darkDocumentPage ? 0x34313fff : 0xebe6f1ff));
-        const auto quoteColour = ImGui::GetColorU32 (
-            colour (darkDocumentPage ? 0xb28bd4ff : 0x8061a4ff));
-
-        drawList->PushClipRect (rectMin, rectMax, true);
-        for (const auto& row : documentRows)
-        {
-            const float rowY = rectMin.y + row.y - documentScrollY;
-            if (rowY + row.height < rectMin.y || rowY > rectMax.y)
-                continue;
-            const auto fontSize = documentFontSize (row.block, bodySize);
-            const float textY = rowY + std::max (0.0f, (row.height - fontSize) * 0.38f);
-            const float originX = rectMin.x + row.textIndent;
-
-            const auto selectedStart = std::max (selection.start, row.start);
-            const auto selectedEnd = std::min (selection.end, row.end);
-            if (selectedStart < selectedEnd)
-            {
-                const auto x1 = originX + documentTextWidth (row.start, selectedStart,
-                                                             fontSize, row.block);
-                const auto x2 = originX + documentTextWidth (row.start, selectedEnd,
-                                                             fontSize, row.block);
-                drawList->AddRectFilled (ImVec2 (x1, rowY + 1.0f),
-                                         ImVec2 (std::max (x1 + 2.0f, x2),
-                                                 rowY + row.height - 1.0f),
-                                         selectionColour, 2.0f);
-            }
-
-            if (row.firstVisualRow)
-            {
-                const float markerRight = originX - 9.0f;
-                const float markerY = rowY + row.height * 0.53f;
-                if (row.block == NotepadDocument::BlockStyle::quote)
-                    drawList->AddRectFilled (ImVec2 (rectMin.x + 3.0f, rowY + 1.0f),
-                                             ImVec2 (rectMin.x + 6.0f,
-                                                     rowY + row.height - 1.0f),
-                                             quoteColour, 1.0f);
-                else if (row.block == NotepadDocument::BlockStyle::bullets)
-                    drawList->AddCircleFilled (ImVec2 (markerRight - 4.0f, markerY),
-                                               3.0f, textColour);
-                else if (row.block == NotepadDocument::BlockStyle::numbers
-                         && bodyFont != nullptr)
-                {
-                    const auto marker = std::to_string (row.lineInfo.orderedNumber) + ".";
-                    const auto size = bodyFont->CalcTextSizeA (bodySize, FLT_MAX, 0.0f,
-                                                               marker.c_str()).x;
-                    drawList->AddText (bodyFont, bodySize,
-                                       ImVec2 (markerRight - size, textY), mutedColour,
-                                       marker.c_str());
-                }
-                else if (row.block == NotepadDocument::BlockStyle::tasks)
-                {
-                    const ImVec2 a (markerRight - 14.0f, markerY - 7.0f);
-                    const ImVec2 b (markerRight, markerY + 7.0f);
-                    drawList->AddRect (a, b, mutedColour, 2.0f, 0, 1.5f);
-                    if (row.lineInfo.taskChecked)
-                    {
-                        drawList->AddLine (ImVec2 (a.x + 3.0f, markerY),
-                                           ImVec2 (a.x + 6.0f, b.y - 3.0f),
-                                           quoteColour, 2.0f);
-                        drawList->AddLine (ImVec2 (a.x + 6.0f, b.y - 3.0f),
-                                           ImVec2 (b.x - 2.0f, a.y + 3.0f),
-                                           quoteColour, 2.0f);
-                    }
-                }
-            }
-
-            float x = originX;
-            for (auto runStart = row.start; runStart < row.end;)
-            {
-                const auto runStyle = document.styleAt (runStart);
-                auto runEnd = nextUtf8Offset (text, runStart, row.end);
-                while (runEnd < row.end && document.styleAt (runEnd) == runStyle)
-                    runEnd = nextUtf8Offset (text, runEnd, row.end);
-                auto* const font = fontForStyle (runStyle, row.block);
-                const auto runWidth = documentTextWidth (runStart, runEnd, fontSize, row.block);
-                if (runStyle.code)
-                    drawList->AddRectFilled (ImVec2 (x - 2.0f, rowY + 2.0f),
-                                             ImVec2 (x + runWidth + 2.0f,
-                                                     rowY + row.height - 2.0f),
-                                             codeBackground, 2.0f);
-                const auto colourValue = runStyle.link ? linkColour
-                                       : runStyle.code ? codeColour : textColour;
-                if (font != nullptr)
-                    drawList->AddText (font, fontSize, ImVec2 (x, textY), colourValue,
-                                       text.data() + runStart, text.data() + runEnd);
-                if (runStyle.link)
-                    drawList->AddLine (ImVec2 (x, textY + fontSize + 1.0f),
-                                       ImVec2 (x + runWidth, textY + fontSize + 1.0f),
-                                       linkColour, 1.0f);
-                x += runWidth;
-                runStart = runEnd;
-            }
-
-            if (editorActive && selection.empty()
-                && selection.end >= row.start && selection.end <= row.end)
-            {
-                const auto cursorX = originX + documentTextWidth (
-                    row.start, selection.end, fontSize, row.block);
-                drawList->AddLine (ImVec2 (cursorX, rowY + 2.0f),
-                                   ImVec2 (cursorX, rowY + row.height - 2.0f),
-                                   textColour, 1.2f);
-            }
-        }
-
-        const auto viewport = rectMax.y - rectMin.y;
-        if (documentContentHeight > viewport)
-        {
-            const auto trackX = rectMax.x - 4.0f;
-            const auto thumbHeight = std::max (28.0f, viewport * viewport / documentContentHeight);
-            const auto travel = viewport - thumbHeight;
-            const auto thumbY = rectMin.y + travel * documentScrollY
-                              / std::max (1.0f, documentContentHeight - viewport);
-            drawList->AddRectFilled (ImVec2 (trackX, thumbY),
-                                     ImVec2 (rectMax.x - 1.0f, thumbY + thumbHeight),
-                                     ImGui::GetColorU32 (colour (0xaaa7b0aa)), 2.0f);
-        }
-        drawList->PopClipRect();
-    }
-
     void drawEditor (float height)
     {
         ImGui::PushStyleColor (ImGuiCol_ChildBg, colour (0x111218ff));
@@ -1366,15 +864,24 @@ private:
         ImGui::BeginChild (markdownMode ? "markdown-source" : "document-page",
                            ImVec2 (editorWidth, available.y), true);
 
-        ImGui::PushStyleColor (ImGuiCol_FrameBg,
-                              markdownMode ? colour (0x181922ff)
-                                           : colour (darkDocumentPage
-                                                        ? kDarkDocumentPaperColour
-                                                        : kLightDocumentPaperColour));
-        ImGui::PushStyleColor (ImGuiCol_Text,
-                              markdownMode ? colour (0xd7d9e0ff) : colour (0x00000000));
-        ImGui::PushStyleColor (ImGuiCol_TextSelectedBg,
-                              markdownMode ? colour (0x70599aaa) : colour (0x00000000));
+        if (markdownMode)
+            drawMarkdownSource();
+        else
+            editor.draw (ImGui::GetFontSize());
+
+        ImGui::EndChild();
+        ImGui::PopStyleColor();
+        ImGui::PopStyleVar (2);
+        ImGui::EndChild();
+        ImGui::PopStyleVar();
+        ImGui::PopStyleColor();
+    }
+
+    void drawMarkdownSource()
+    {
+        ImGui::PushStyleColor (ImGuiCol_FrameBg, colour (0x181922ff));
+        ImGui::PushStyleColor (ImGuiCol_Text, colour (0xd7d9e0ff));
+        ImGui::PushStyleColor (ImGuiCol_TextSelectedBg, colour (0x70599aaa));
         ImGui::PushStyleVar (ImGuiStyleVar_FramePadding, ImVec2 (0.0f, 0.0f));
 
         if (focusEditorNextFrame)
@@ -1386,26 +893,17 @@ private:
         const auto flags = ImGuiInputTextFlags_AllowTabInput
                          | ImGuiInputTextFlags_CallbackResize
                          | ImGuiInputTextFlags_CallbackAlways
-                         | ImGuiInputTextFlags_NoUndoRedo
-                         | (markdownMode ? 0 : ImGuiInputTextFlags_NoHorizontalScroll);
-        const auto inputSize = ImGui::GetContentRegionAvail();
-        const auto selectionBeforeInput = buffer.selection();
-        const auto oldDocumentText = document.documentText();
+                         | ImGuiInputTextFlags_NoUndoRedo;
+        const auto selectionBefore = buffer.selection();
         const bool changed = ImGui::InputTextMultiline (
             "##notepad-editor", buffer.text.data(), buffer.text.capacity() + 1,
-            inputSize, flags, EditorBuffer::callback, &buffer);
-        bool acceptedChange = changed;
-        const auto editorRectMin = ImGui::GetItemRectMin();
-        const auto editorRectMax = ImGui::GetItemRectMax();
+            ImGui::GetContentRegionAvail(), flags, EditorBuffer::callback, &buffer);
         const bool editorActive = ImGui::IsItemActive();
-        const bool editorHovered = ImGui::IsItemHovered();
         if (auto* const state = ImGui::GetInputTextState (ImGui::GetItemID()))
         {
             // CallbackAlways can observe the selection before the current
             // character edit is committed. The live input state is the
-            // authority after InputTextMultiline returns; keeping this in sync
-            // prevents the next frame from restoring a stale caret and typing
-            // successive formatted characters in reverse order.
+            // authority after InputTextMultiline returns.
             if (state->HasSelection())
             {
                 buffer.selectionStart = state->GetSelectionStart();
@@ -1415,157 +913,37 @@ private:
             {
                 buffer.selectionStart = buffer.selectionEnd = state->GetCursorPos();
             }
-            if (! markdownMode)
-                state->Scroll = {};
         }
+
         if (changed)
         {
-            pushUndo (selectionBeforeInput);
-            const auto editedSelection = buffer.selection();
+            auto before = currentSnapshot();
+            before.selection = selectionBefore;
             buffer.text.resize (std::strlen (buffer.text.c_str()));
-            if (markdownMode)
-            {
-                document.setMarkdown (buffer.text);
-            }
-            else
-            {
-                std::size_t prefix = 0;
-                while (prefix < oldDocumentText.size() && prefix < buffer.text.size()
-                       && oldDocumentText[prefix] == buffer.text[prefix])
-                    ++prefix;
-                std::size_t suffix = 0;
-                while (suffix < oldDocumentText.size() - prefix
-                       && suffix < buffer.text.size() - prefix
-                       && oldDocumentText[oldDocumentText.size() - 1 - suffix]
-                          == buffer.text[buffer.text.size() - 1 - suffix])
-                    ++suffix;
-                const auto insertedEnd = buffer.text.size() - suffix;
-                const auto inserted = buffer.text.substr (prefix, insertedEnd - prefix);
-
-                const auto oldLineStart = selectionBeforeInput.start == 0
-                                        ? std::string::npos
-                                        : oldDocumentText.rfind (
-                                              '\n', selectionBeforeInput.start - 1);
-                const auto lineStart = oldLineStart == std::string::npos ? 0 : oldLineStart + 1;
-                const auto oldLineEnd = oldDocumentText.find ('\n', selectionBeforeInput.start);
-                const auto lineEnd = oldLineEnd == std::string::npos
-                                   ? oldDocumentText.size() : oldLineEnd;
-                const auto oldBlock = document.lineInfoAt (selectionBeforeInput.start).block;
-                const bool listBlock = oldBlock == NotepadDocument::BlockStyle::bullets
-                                    || oldBlock == NotepadDocument::BlockStyle::numbers
-                                    || oldBlock == NotepadDocument::BlockStyle::tasks;
-                const bool exitEmptyList = selectionBeforeInput.empty()
-                                        && inserted == "\n" && lineStart == lineEnd
-                                        && listBlock;
-
-                if (exitEmptyList)
-                {
-                    document.setDocumentBlockStyle (selectionBeforeInput,
-                                                    NotepadDocument::BlockStyle::body);
-                    buffer.assign (document.documentText());
-                    buffer.restoreSelection (selectionBeforeInput);
-                }
-                else if (! document.replaceDocumentText (buffer.text))
-                {
-                    undoHistory.pop_back();
-                    buffer.assign (document.documentText());
-                    buffer.restoreSelection (selectionBeforeInput);
-                    focusEditorNextFrame = true;
-                    acceptedChange = false;
-                }
-                else
-                {
-                    if (typingStyleOverride && insertedEnd > prefix)
-                    {
-                        const NotepadDocument::Selection insertedSelection { prefix, insertedEnd };
-                        document.setDocumentInlineStyle (
-                            insertedSelection, NotepadDocument::InlineStyle::bold, typingBold);
-                        document.setDocumentInlineStyle (
-                            insertedSelection, NotepadDocument::InlineStyle::italic, typingItalic);
-                        document.setDocumentInlineStyle (
-                            insertedSelection, NotepadDocument::InlineStyle::code, typingCode);
-                    }
-
-                    for (std::size_t i = 0; i < inserted.size(); ++i)
-                    {
-                        if (inserted[i] != '\n')
-                            continue;
-                        const auto newLine = prefix + i + 1;
-                        const auto previousOffset = newLine > 1 ? newLine - 2 : 0;
-                        const auto previous = document.lineInfoAt (previousOffset);
-                        if (previous.block == NotepadDocument::BlockStyle::bullets
-                            || previous.block == NotepadDocument::BlockStyle::numbers
-                            || previous.block == NotepadDocument::BlockStyle::tasks)
-                        {
-                            document.setDocumentBlockStyle ({ newLine, newLine }, previous.block);
-                            if (previous.block == NotepadDocument::BlockStyle::numbers)
-                                document.renumberOrderedRunAt (newLine);
-                        }
-                    }
-                    buffer.assign (document.documentText());
-                    buffer.restoreSelection (editedSelection);
-                }
-            }
-            if (acceptedChange)
-                notifyTextChanged();
+            document.setMarkdown (buffer.text);
+            history.record (notepad::EditKind::typing, std::move (before),
+                            buffer.selection().end);
+            notifyTextChanged();
         }
-        else if (selectionBeforeInput.start != buffer.selection().start
-                 || selectionBeforeInput.end != buffer.selection().end)
+        else if (selectionBefore.start != buffer.selection().start
+                 || selectionBefore.end != buffer.selection().end)
         {
-            typingStyleOverride = false;
+            history.breakRun();
         }
 
         const auto& io = ImGui::GetIO();
         const bool shortcut = io.KeyCtrl || io.KeySuper;
         if (editorActive && shortcut && ImGui::IsKeyPressed (ImGuiKey_Z, false))
-        {
-            if (io.KeyShift)
-                restoreHistory (redoHistory, undoHistory);
-            else
-                restoreHistory (undoHistory, redoHistory);
-        }
+            restoreHistory (io.KeyShift);
         else if (editorActive && shortcut && ImGui::IsKeyPressed (ImGuiKey_Y, false))
-        {
-            restoreHistory (redoHistory, undoHistory);
-        }
+            restoreHistory (true);
         else if (editorActive && shortcut && ImGui::IsKeyPressed (ImGuiKey_B, false))
-        {
             applyInline (NotepadDocument::InlineStyle::bold, "**", "**");
-        }
         else if (editorActive && shortcut && ImGui::IsKeyPressed (ImGuiKey_I, false))
-        {
             applyInline (NotepadDocument::InlineStyle::italic, "*", "*");
-        }
-
-        if (! markdownMode)
-        {
-            buildDocumentLayout (editorRectMax.x - editorRectMin.x,
-                                 ImGui::GetFontSize());
-            if (editorActive && ImGui::IsKeyPressed (ImGuiKey_UpArrow, false))
-                moveDocumentCaretVertically (selectionBeforeInput, -1, io.KeyShift,
-                                             ImGui::GetFontSize());
-            else if (editorActive && ImGui::IsKeyPressed (ImGuiKey_DownArrow, false))
-                moveDocumentCaretVertically (selectionBeforeInput, 1, io.KeyShift,
-                                             ImGui::GetFontSize());
-
-            handleDocumentMouse (editorHovered, editorRectMin, editorRectMax,
-                                 ImGui::GetFontSize());
-            if (changed || ImGui::IsKeyPressed (ImGuiKey_UpArrow, false)
-                        || ImGui::IsKeyPressed (ImGuiKey_DownArrow, false))
-                keepCaretVisible (editorRectMin, editorRectMax);
-
-            drawRichDocument (editorRectMin, editorRectMax,
-                              ImGui::GetFontSize(), editorActive);
-        }
 
         ImGui::PopStyleVar();
         ImGui::PopStyleColor (3);
-        ImGui::EndChild();
-        ImGui::PopStyleColor();
-        ImGui::PopStyleVar (2);
-        ImGui::EndChild();
-        ImGui::PopStyleVar();
-        ImGui::PopStyleColor();
     }
 
     void draw (float width, float height)
@@ -1608,7 +986,10 @@ private:
         ImGui::SetCursorPos (ImVec2 (width - 300.0f, 16.0f));
         if (drawGlyphToggle ("##page-theme", darkDocumentPage, "☀", "☾",
                              "Light page / Dark page", 82.0f))
+        {
             darkDocumentPage = ! darkDocumentPage;
+            editor.setDarkPage (darkDocumentPage);
+        }
         ImGui::SameLine (0.0f, 5.0f);
         if (drawGlyphToggle ("##editor-mode", markdownMode, "▤", "M↓",
                              "Document / Markdown", 100.0f))
@@ -1661,6 +1042,8 @@ private:
     std::unique_ptr<DGL::Window> window;
     std::unique_ptr<EditorWidget> editorWidget;
     NotepadDocument document;
+    notepad::UndoStack history;
+    NotepadEditor editor { document, history };
     EditorBuffer buffer;
     TextChangedCallback onTextChanged;
     ClosedCallback onClosed;
@@ -1671,26 +1054,15 @@ private:
     ImFont* boldItalicFont = nullptr;
     ImFont* monoFont = nullptr;
     std::array<char, 384> linkUrl {};
-    std::vector<HistoryState> undoHistory;
-    std::vector<HistoryState> redoHistory;
-    std::vector<VisualRow> documentRows;
     std::optional<std::string> savedMarkdown;
     bool markdownMode = false;
     bool darkDocumentPage = true;
     bool closeRequested = false;
     bool closeWasPumped = false;
     bool focusEditorNextFrame = false;
-    bool selectingWithMouse = false;
-    bool typingStyleOverride = false;
-    bool typingBold = false;
-    bool typingItalic = false;
-    bool typingCode = false;
     bool hasSessionFile = false;
     bool documentDirty = false;
     bool saveFailed = false;
-    std::size_t selectionAnchor = 0;
-    float documentScrollY = 0.0f;
-    float documentContentHeight = 0.0f;
 };
 
 NativeNotepadWindow::NativeNotepadWindow()
@@ -1707,11 +1079,11 @@ void NativeNotepadWindow::setCallbacks (TextChangedCallback textChanged, ClosedC
                         std::move (linkOpened));
 }
 
-void NativeNotepadWindow::open (std::uintptr_t nativeParent, EmbeddedGeometry geometry,
+bool NativeNotepadWindow::open (std::uintptr_t nativeParent, EmbeddedGeometry geometry,
                                 const std::string& markdown,
                                 bool hasSessionFile, bool hasUnsavedChanges)
 {
-    impl->open (nativeParent, geometry, markdown, hasSessionFile, hasUnsavedChanges);
+    return impl->open (nativeParent, geometry, markdown, hasSessionFile, hasUnsavedChanges);
 }
 
 void NativeNotepadWindow::close()

--- a/src/ui/NativeNotepadWindow.cpp
+++ b/src/ui/NativeNotepadWindow.cpp
@@ -163,22 +163,6 @@ std::size_t sourceBlockPrefixLength (const std::string& text,
     return 0;
 }
 
-std::string blockPrefix (NotepadDocument::BlockStyle style, std::size_t number)
-{
-    switch (style)
-    {
-        case NotepadDocument::BlockStyle::heading1: return "# ";
-        case NotepadDocument::BlockStyle::heading2: return "## ";
-        case NotepadDocument::BlockStyle::heading3: return "### ";
-        case NotepadDocument::BlockStyle::quote:    return "> ";
-        case NotepadDocument::BlockStyle::bullets:  return "- ";
-        case NotepadDocument::BlockStyle::numbers:  return std::to_string (number) + ". ";
-        case NotepadDocument::BlockStyle::tasks:    return "- [ ] ";
-        case NotepadDocument::BlockStyle::body:     return {};
-    }
-    return {};
-}
-
 NotepadDocument::BlockStyle sourceBlockStyle (const std::string& text,
                                               NotepadDocument::Selection selection)
 {
@@ -203,25 +187,6 @@ NotepadDocument::BlockStyle sourceBlockStyle (const std::string& text,
     if (text[lineStart] >= '0' && text[lineStart] <= '9')
         return NotepadDocument::BlockStyle::numbers;
     return NotepadDocument::BlockStyle::bullets;
-}
-
-bool sourceSelectionHasWrapper (const std::string& text,
-                                NotepadDocument::Selection selection,
-                                const std::string& prefix,
-                                const std::string& suffix)
-{
-    selection.start = std::min (selection.start, text.size());
-    selection.end = std::min (selection.end, text.size());
-    if (selection.start > selection.end)
-        std::swap (selection.start, selection.end);
-
-    const bool prefixOutside = selection.start >= prefix.size()
-                            && text.compare (selection.start - prefix.size(), prefix.size(), prefix) == 0;
-    const bool suffixOutside = text.compare (selection.end, suffix.size(), suffix) == 0;
-    const bool includesMarkers = selection.end >= selection.start + prefix.size() + suffix.size()
-                              && text.compare (selection.start, prefix.size(), prefix) == 0
-                              && text.compare (selection.end - suffix.size(), suffix.size(), suffix) == 0;
-    return (prefixOutside && suffixOutside) || includesMarkers;
 }
 
 // The destination is emitted inside "](...)", so a bracket or parenthesis the
@@ -488,9 +453,9 @@ private:
     void timerCallback() override
     {
         app.idle();
-        // The Done button is handled inside the ImGui display callback. Wait
-        // until DPF returns from the event pump before destroying its embedded
-        // widget and native child.
+        // Close requests come from the native host boundary. Wait until DPF
+        // returns from the event pump before destroying its embedded widget
+        // and native child.
         if (closeRequested && window != nullptr)
         {
             destroyEmbeddedWindow();
@@ -566,15 +531,13 @@ private:
 
         const auto selection = buffer.selection();
         auto before = currentSnapshot();
-        auto source = document.markdown();
-        source.insert (selection.end, suffix);
-        source.insert (selection.start, prefix);
-        document.setMarkdown (std::move (source));
+        auto transformed = notepad::toggleMarkdownInline (
+            document.markdown(), selection, prefix, suffix);
+        document.setMarkdown (std::move (transformed.markdown));
         buffer.assign (document.markdown());
-        buffer.restoreSelection ({ selection.start + prefix.size(),
-                                   selection.end + prefix.size() });
+        buffer.restoreSelection (transformed.selection);
         history.record (notepad::EditKind::structural, std::move (before),
-                        selection.end + prefix.size());
+                        transformed.selection.end);
         focusEditorNextFrame = true;
         notifyTextChanged();
     }
@@ -591,29 +554,13 @@ private:
         if (selectedBlockStyle() == style)
             style = NotepadDocument::BlockStyle::body;
         auto before = currentSnapshot();
-
-        auto source = document.markdown();
-        const auto first = sourceLineStart (source, selection.start);
-        const auto last = sourceLineEnd (source, selection.end);
-        std::vector<std::pair<std::size_t, std::size_t>> lines;
-        for (auto start = first; start <= last;)
-        {
-            const auto end = sourceLineEnd (source, start);
-            lines.emplace_back (start, end);
-            if (end == source.size())
-                break;
-            start = end + 1;
-        }
-        for (std::size_t index = lines.size(); index-- > 0;)
-        {
-            const auto [start, end] = lines[index];
-            source.erase (start, sourceBlockPrefixLength (source, start, end));
-            source.insert (start, blockPrefix (style, index + 1));
-        }
-        document.setMarkdown (std::move (source));
+        auto transformed = notepad::setMarkdownBlockStyle (
+            document.markdown(), selection, style);
+        document.setMarkdown (std::move (transformed.markdown));
         buffer.assign (document.markdown());
-        buffer.restoreSelection (selection);
-        history.record (notepad::EditKind::structural, std::move (before), selection.end);
+        buffer.restoreSelection (transformed.selection);
+        history.record (notepad::EditKind::structural, std::move (before),
+                        transformed.selection.end);
         focusEditorNextFrame = true;
         notifyTextChanged();
     }
@@ -648,7 +595,8 @@ private:
                             const std::string& suffix) const
     {
         return markdownMode
-             ? sourceSelectionHasWrapper (document.markdown(), buffer.selection(), prefix, suffix)
+             ? notepad::markdownInlineActive (document.markdown(), buffer.selection(),
+                                               prefix, suffix)
              : editor.inlineStyleActive (style);
     }
 
@@ -936,7 +884,8 @@ private:
         }
 
         const auto& io = ImGui::GetIO();
-        const bool shortcut = io.KeyCtrl || io.KeySuper;
+        const bool shortcut = ! notepad::acceptsTextInput (
+            io.KeyCtrl, io.KeyAlt, io.KeySuper);
         if (editorActive && shortcut && ImGui::IsKeyPressed (ImGuiKey_Z, false))
             restoreHistory (io.KeyShift);
         else if (editorActive && shortcut && ImGui::IsKeyPressed (ImGuiKey_Y, false))
@@ -987,7 +936,7 @@ private:
         ImGui::TextUnformatted ("Lyrics and session notes");
         ImGui::PopStyleColor();
 
-        ImGui::SetCursorPos (ImVec2 (width - 300.0f, 16.0f));
+        ImGui::SetCursorPos (ImVec2 (width - 210.0f, 16.0f));
         if (drawGlyphToggle ("##page-theme", darkDocumentPage, "☀", "☾",
                              "Light page / Dark page", 82.0f))
         {
@@ -998,11 +947,6 @@ private:
         if (drawGlyphToggle ("##editor-mode", markdownMode, "▤", "M↓",
                              "Document / Markdown", 100.0f))
             setMode (! markdownMode);
-        ImGui::SameLine (0.0f, 12.0f);
-        ImGui::PushStyleColor (ImGuiCol_Button, colour (0x305a82ff));
-        if (ImGui::Button ("Done", ImVec2 (76.0f, 30.0f)))
-            close();
-        ImGui::PopStyleColor();
 
         ImGui::SetCursorPosY (62.0f);
         drawRibbon();
@@ -1020,7 +964,7 @@ private:
                               saveFailed ? colour (0xe48a8aff) : colour (0x8f909aff));
         const char* saveState = saveFailed ? "Save failed - changes are still unsaved"
                               : documentDirty && hasSessionFile
-                                  ? "Unsaved changes - saved when Done"
+                                  ? "Unsaved changes - saved when closed"
                               : documentDirty
                                   ? "Unsaved changes - save the session to keep them"
                               : hasSessionFile ? "Saved with session  |  notepad.md"

--- a/src/ui/NativeNotepadWindow.cpp
+++ b/src/ui/NativeNotepadWindow.cpp
@@ -189,30 +189,6 @@ NotepadDocument::BlockStyle sourceBlockStyle (const std::string& text,
     return NotepadDocument::BlockStyle::bullets;
 }
 
-// The destination is emitted inside "](...)", so a bracket or parenthesis the
-// user typed would close it early and leave raw syntax in the document.
-std::string percentEncodeUrl (const std::string& url)
-{
-    static constexpr char hexDigits[] = "0123456789ABCDEF";
-    std::string encoded;
-    encoded.reserve (url.size());
-    for (const auto ch : url)
-    {
-        const auto byte = static_cast<unsigned char> (ch);
-        if (byte <= 0x20 || byte == 0x7f || ch == '(' || ch == ')' || ch == '['
-            || ch == ']' || ch == '<' || ch == '>' || ch == '"' || ch == '\\')
-        {
-            encoded.push_back ('%');
-            encoded.push_back (hexDigits[byte >> 4]);
-            encoded.push_back (hexDigits[byte & 0x0f]);
-        }
-        else
-        {
-            encoded.push_back (ch);
-        }
-    }
-    return encoded;
-}
 } // namespace
 
 struct NativeNotepadWindow::Impl final : private dusk::Timer
@@ -774,7 +750,8 @@ private:
             if (ImGui::Button ("Insert", ImVec2 (90.0f, 30.0f)))
             {
                 const auto url = linkUrl[0] == '\0' ? std::string ("https://")
-                                                   : percentEncodeUrl (linkUrl.data());
+                                                   : notepad::encodeMarkdownLinkTarget (
+                                                         linkUrl.data());
                 insertLink (url);
                 linkUrl.fill ('\0');
                 ImGui::CloseCurrentPopup();

--- a/src/ui/NativeNotepadWindow.h
+++ b/src/ui/NativeNotepadWindow.h
@@ -31,7 +31,10 @@ public:
 
     void setCallbacks (TextChangedCallback textChanged, ClosedCallback closed,
                        LinkOpenedCallback linkOpened = {});
-    void open (std::uintptr_t nativeParent, EmbeddedGeometry geometry,
+    // False when the embedded native child could not be created - no usable GL
+    // context, or a display backend that cannot embed a foreign surface. The
+    // window owns nothing afterwards, so isOpen() also reads false.
+    bool open (std::uintptr_t nativeParent, EmbeddedGeometry geometry,
                const std::string& markdown,
                bool hasSessionFile, bool hasUnsavedChanges);
     void setEmbeddedGeometry (EmbeddedGeometry geometry);

--- a/src/ui/NotepadEditor.cpp
+++ b/src/ui/NotepadEditor.cpp
@@ -1,0 +1,933 @@
+#include "NotepadEditor.h"
+
+#include <DearImGui/imgui_internal.h>
+
+#include <algorithm>
+#include <cfloat>
+#include <cmath>
+
+namespace duskstudio
+{
+namespace
+{
+constexpr float kScrollbarWidth = 10.0f;
+constexpr float kWheelStep = 42.0f;
+constexpr char kLinkPlaceholder[] = "Link text";
+
+ImU32 colourOf (unsigned int hex)
+{
+    return ImGui::GetColorU32 (ImVec4 (((hex >> 24) & 0xff) / 255.0f,
+                                       ((hex >> 16) & 0xff) / 255.0f,
+                                       ((hex >> 8) & 0xff) / 255.0f,
+                                       (hex & 0xff) / 255.0f));
+}
+
+float scrollThumbHeight (float viewport, float content)
+{
+    return std::max (28.0f, viewport * viewport / std::max (1.0f, content));
+}
+} // namespace
+
+NotepadEditor::NotepadEditor (NotepadDocument& documentToEdit, notepad::UndoStack& undoHistory)
+    : document (documentToEdit), history (undoHistory)
+{
+    measure = [this] (std::size_t begin, std::size_t end, float fontSize,
+                      NotepadDocument::BlockStyle block)
+    {
+        return measureRange (begin, end, fontSize, block);
+    };
+}
+
+void NotepadEditor::setFonts (const Fonts& value)
+{
+    fonts = value;
+    layoutDirty = true;
+}
+
+void NotepadEditor::reset (NotepadDocument::Selection value)
+{
+    setSelection (value);
+    sticky = {};
+    desiredX = -1.0f;
+    caretAtRowEnd = false;
+    draggingSelection = false;
+    draggingScrollbar = false;
+    layoutDirty = true;
+    scrollToCaret = true;
+    resetBlink();
+}
+
+void NotepadEditor::setSelection (NotepadDocument::Selection value)
+{
+    const auto limit = document.documentText().size();
+    anchor = std::min (value.start, limit);
+    caret = std::min (value.end, limit);
+}
+
+NotepadDocument::Selection NotepadEditor::selection() const noexcept
+{
+    return { std::min (anchor, caret), std::max (anchor, caret) };
+}
+
+ImFont* NotepadEditor::fontForStyle (NotepadDocument::TextStyle style,
+                                     NotepadDocument::BlockStyle block) const noexcept
+{
+    if (style.code)
+        return fonts.mono;
+    const bool bold = style.bold || notepad::isHeading (block);
+    if (bold && style.italic)
+        return fonts.boldItalic;
+    if (bold)
+        return fonts.bold;
+    if (style.italic)
+        return fonts.italic;
+    return fonts.body;
+}
+
+float NotepadEditor::measureRange (std::size_t begin, std::size_t end, float fontSize,
+                                   NotepadDocument::BlockStyle block) const
+{
+    const auto& text = document.documentText();
+    begin = std::min (begin, text.size());
+    end = std::min (end, text.size());
+
+    float width = 0.0f;
+    while (begin < end)
+    {
+        const auto style = document.styleAt (begin);
+        auto runEnd = notepad::nextOffset (text, begin);
+        while (runEnd < end && document.styleAt (runEnd) == style)
+            runEnd = notepad::nextOffset (text, runEnd);
+        runEnd = std::min (runEnd, end);
+        if (auto* const font = fontForStyle (style, block))
+            width += font->CalcTextSizeA (fontSize, FLT_MAX, 0.0f,
+                                          text.data() + begin, text.data() + runEnd).x;
+        begin = runEnd;
+    }
+    return width;
+}
+
+void NotepadEditor::ensureLayout (float width, float bodySize)
+{
+    if (! layoutDirty && std::abs (width - layoutWidth) < 0.5f
+        && std::abs (bodySize - layoutBodySize) < 0.01f)
+        return;
+
+    layout = notepad::buildLayout (document, width, bodySize, measure);
+    layoutWidth = width;
+    layoutBodySize = bodySize;
+    layoutDirty = false;
+}
+
+void NotepadEditor::documentMutated()
+{
+    layoutDirty = true;
+    scrollToCaret = true;
+    resetBlink();
+    const auto limit = document.documentText().size();
+    caret = std::min (caret, limit);
+    anchor = std::min (anchor, limit);
+    if (onDocumentChanged)
+        onDocumentChanged();
+}
+
+notepad::Snapshot NotepadEditor::snapshot() const
+{
+    return { document.markdown(), selection(), false };
+}
+
+void NotepadEditor::resetBlink()
+{
+    if (ImGui::GetCurrentContext() != nullptr)
+        blinkStart = ImGui::GetTime();
+}
+
+void NotepadEditor::moveCaret (std::size_t offset, bool extend, bool preferRowEnd)
+{
+    caret = std::min (offset, document.documentText().size());
+    if (! extend)
+        anchor = caret;
+    caretAtRowEnd = preferRowEnd;
+    desiredX = -1.0f;
+    sticky = {};
+    scrollToCaret = true;
+    resetBlink();
+    history.breakRun();
+}
+
+void NotepadEditor::moveVertical (int direction, bool extend, float bodySize)
+{
+    ensureLayout (layoutWidth, bodySize);
+    if (layout.rows.empty())
+        return;
+
+    const auto rowIndex = layout.rowForOffset (caret, caretAtRowEnd);
+    const auto x = desiredX >= 0.0f
+                 ? desiredX
+                 : notepad::offsetX (document, layout.rows[rowIndex], caret, bodySize, measure);
+
+    if ((direction < 0 && rowIndex == 0)
+        || (direction > 0 && rowIndex + 1 == layout.rows.size()))
+    {
+        moveCaret (direction < 0 ? 0 : document.documentText().size(), extend);
+        return;
+    }
+
+    const auto targetIndex = static_cast<std::size_t> (static_cast<int> (rowIndex) + direction);
+    const auto& row = layout.rows[targetIndex];
+    const auto offset = notepad::offsetAtX (document, row, x, bodySize, measure);
+    moveCaret (offset, extend, offset == row.end && ! row.lastRowOfLine);
+    desiredX = x;
+}
+
+void NotepadEditor::movePage (int direction, bool extend, float viewportHeight, float bodySize)
+{
+    ensureLayout (layoutWidth, bodySize);
+    if (layout.rows.empty())
+        return;
+
+    const auto rowIndex = layout.rowForOffset (caret, caretAtRowEnd);
+    const auto x = desiredX >= 0.0f
+                 ? desiredX
+                 : notepad::offsetX (document, layout.rows[rowIndex], caret, bodySize, measure);
+    const auto targetY = layout.rows[rowIndex].y
+                       + static_cast<float> (direction) * std::max (40.0f, viewportHeight - 24.0f);
+    const auto& row = layout.rows[layout.rowAtY (std::max (0.0f, targetY))];
+    const auto offset = notepad::offsetAtX (document, row, x, bodySize, measure);
+    moveCaret (offset, extend, offset == row.end && ! row.lastRowOfLine);
+    desiredX = x;
+    scrollY += static_cast<float> (direction) * std::max (40.0f, viewportHeight - 24.0f);
+}
+
+void NotepadEditor::selectAll()
+{
+    anchor = 0;
+    caret = document.documentText().size();
+    caretAtRowEnd = false;
+    desiredX = -1.0f;
+    sticky = {};
+    scrollToCaret = true;
+    history.breakRun();
+}
+
+void NotepadEditor::keepCaretVisible (float viewportHeight, float bodySize)
+{
+    ensureLayout (layoutWidth, bodySize);
+    if (layout.rows.empty())
+        return;
+
+    const auto& row = layout.rows[layout.rowForOffset (caret, caretAtRowEnd)];
+    if (row.y < scrollY)
+        scrollY = row.y;
+    else if (row.y + row.height > scrollY + viewportHeight)
+        scrollY = row.y + row.height - viewportHeight;
+}
+
+bool NotepadEditor::replaceRange (std::size_t start, std::size_t end, const std::string& insert,
+                                  notepad::EditKind kind)
+{
+    if (start > end)
+        std::swap (start, end);
+
+    auto text = document.documentText();
+    start = std::min (start, text.size());
+    end = std::min (end, text.size());
+    if (start == end && insert.empty())
+        return false;
+
+    auto before = snapshot();
+    text.replace (start, end - start, insert);
+    if (! document.replaceDocumentText (text))
+    {
+        // The model refused the edit to keep the Markdown intact; the editor
+        // must fall back onto the projection it still holds.
+        reset (selection());
+        return false;
+    }
+
+    const auto caretAfter = start + insert.size();
+    history.record (kind, std::move (before), caretAfter);
+    caret = anchor = std::min (caretAfter, document.documentText().size());
+    caretAtRowEnd = false;
+    desiredX = -1.0f;
+    documentMutated();
+    return true;
+}
+
+void NotepadEditor::insertText (const std::string& value)
+{
+    if (value.empty())
+        return;
+
+    const auto target = selection();
+    if (! replaceRange (target.start, target.end, value, notepad::EditKind::typing))
+        return;
+
+    if (sticky.active)
+        applyStickyStyles ({ target.start, target.start + value.size() });
+}
+
+void NotepadEditor::applyStickyStyles (NotepadDocument::Selection inserted)
+{
+    document.setDocumentInlineStyle (inserted, NotepadDocument::InlineStyle::bold, sticky.bold);
+    document.setDocumentInlineStyle (inserted, NotepadDocument::InlineStyle::italic, sticky.italic);
+    document.setDocumentInlineStyle (inserted, NotepadDocument::InlineStyle::code, sticky.code);
+    layoutDirty = true;
+}
+
+void NotepadEditor::insertNewline()
+{
+    const auto target = selection();
+    const auto& text = document.documentText();
+    const auto info = document.lineInfoAt (target.start);
+    const bool emptyLine = notepad::lineStartOffset (text, target.start)
+                        == notepad::lineEndOffset (text, target.start);
+
+    if (target.empty() && emptyLine && notepad::isList (info.block))
+    {
+        // Enter on an empty list item leaves the list instead of stacking
+        // another marker onto a line the user did not fill in.
+        auto before = snapshot();
+        document.setDocumentBlockStyle (target, NotepadDocument::BlockStyle::body);
+        history.record (notepad::EditKind::structural, std::move (before), target.start);
+        sticky = {};
+        documentMutated();
+        return;
+    }
+
+    if (! replaceRange (target.start, target.end, "\n", notepad::EditKind::structural))
+        return;
+
+    const auto newLine = caret;
+    const auto previous = document.lineInfoAt (newLine > 1 ? newLine - 2 : 0);
+    if (notepad::isList (previous.block))
+    {
+        document.setDocumentBlockStyle ({ newLine, newLine }, previous.block);
+        if (previous.block == NotepadDocument::BlockStyle::numbers)
+            document.renumberOrderedRunAt (newLine);
+        layoutDirty = true;
+    }
+    sticky = {};
+}
+
+void NotepadEditor::deleteBackward (bool wholeWord)
+{
+    const auto target = selection();
+    if (! target.empty())
+    {
+        replaceRange (target.start, target.end, {}, notepad::EditKind::deleting);
+        return;
+    }
+    if (caret == 0)
+        return;
+
+    const auto& text = document.documentText();
+    const auto from = wholeWord ? notepad::wordLeft (text, caret)
+                                : notepad::previousOffset (text, caret);
+    replaceRange (from, caret, {}, notepad::EditKind::deleting);
+}
+
+void NotepadEditor::deleteForward (bool wholeWord)
+{
+    const auto target = selection();
+    if (! target.empty())
+    {
+        replaceRange (target.start, target.end, {}, notepad::EditKind::deleting);
+        return;
+    }
+
+    const auto& text = document.documentText();
+    if (caret >= text.size())
+        return;
+
+    const auto to = wholeWord ? notepad::wordRight (text, caret)
+                              : notepad::nextOffset (text, caret);
+    replaceRange (caret, to, {}, notepad::EditKind::deleting);
+}
+
+void NotepadEditor::toggleTaskLine (std::size_t lineStart)
+{
+    auto before = snapshot();
+    document.toggleTaskAt (lineStart);
+    history.record (notepad::EditKind::structural, std::move (before), caret);
+    documentMutated();
+}
+
+bool& NotepadEditor::stickyValue (NotepadDocument::InlineStyle style) noexcept
+{
+    switch (style)
+    {
+        case NotepadDocument::InlineStyle::italic: return sticky.italic;
+        case NotepadDocument::InlineStyle::code:   return sticky.code;
+        case NotepadDocument::InlineStyle::bold:   break;
+    }
+    return sticky.bold;
+}
+
+void NotepadEditor::toggleSticky (NotepadDocument::InlineStyle style)
+{
+    if (! sticky.active)
+    {
+        const auto current = document.styleAt (caret);
+        sticky = { true, current.bold, current.italic, current.code };
+    }
+    auto& value = stickyValue (style);
+    value = ! value;
+}
+
+void NotepadEditor::applyInlineStyle (NotepadDocument::InlineStyle style)
+{
+    const auto target = selection();
+    if (target.empty())
+    {
+        toggleSticky (style);
+        focusRequested = true;
+        return;
+    }
+
+    auto before = snapshot();
+    const bool enable = ! document.selectionHasInlineStyle (target, style);
+    document.setDocumentInlineStyle (target, style, enable);
+    history.record (notepad::EditKind::structural, std::move (before), target.end);
+    focusRequested = true;
+    documentMutated();
+}
+
+void NotepadEditor::applyBlockStyle (NotepadDocument::BlockStyle style)
+{
+    const auto target = selection();
+    if (blockStyle() == style)
+        style = NotepadDocument::BlockStyle::body;
+
+    auto before = snapshot();
+    document.setDocumentBlockStyle (target, style);
+    if (style == NotepadDocument::BlockStyle::numbers)
+        document.renumberOrderedRunAt (target.start);
+    history.record (notepad::EditKind::structural, std::move (before), target.end);
+    sticky = {};
+    focusRequested = true;
+    documentMutated();
+}
+
+void NotepadEditor::insertLink (const std::string& url)
+{
+    auto target = selection();
+    auto before = snapshot();
+
+    if (target.empty())
+    {
+        auto text = document.documentText();
+        text.insert (target.start, kLinkPlaceholder);
+        if (! document.replaceDocumentText (text))
+        {
+            reset (target);
+            return;
+        }
+        target.end = target.start + sizeof (kLinkPlaceholder) - 1;
+    }
+
+    document.wrapDocumentSelection (target, "[", "](" + url + ")");
+    history.record (notepad::EditKind::structural, std::move (before), target.end);
+    setSelection (target);
+    sticky = {};
+    focusRequested = true;
+    documentMutated();
+}
+
+bool NotepadEditor::inlineStyleActive (NotepadDocument::InlineStyle style) const
+{
+    if (sticky.active && selection().empty())
+    {
+        switch (style)
+        {
+            case NotepadDocument::InlineStyle::bold:   return sticky.bold;
+            case NotepadDocument::InlineStyle::italic: return sticky.italic;
+            case NotepadDocument::InlineStyle::code:   return sticky.code;
+        }
+    }
+    return document.selectionHasInlineStyle (selection(), style);
+}
+
+NotepadDocument::BlockStyle NotepadEditor::blockStyle() const
+{
+    return document.blockStyleForSelection (selection());
+}
+
+std::size_t NotepadEditor::hitTest (ImVec2 position, ImVec2 frameMin, float bodySize) const
+{
+    if (layout.rows.empty())
+        return 0;
+    const auto& row = layout.rows[layout.rowAtY (std::max (0.0f, position.y - frameMin.y + scrollY))];
+    return notepad::offsetAtX (document, row, position.x - frameMin.x - row.indent,
+                               bodySize, measure);
+}
+
+void NotepadEditor::handleMouse (ImVec2 frameMin, ImVec2 frameMax, bool hovered, float bodySize)
+{
+    auto& io = ImGui::GetIO();
+    const auto viewport = std::max (1.0f, frameMax.y - frameMin.y);
+    const auto maxScroll = std::max (0.0f, layout.contentHeight - viewport);
+
+    if (hovered && io.MouseWheel != 0.0f)
+        scrollY = std::clamp (scrollY - io.MouseWheel * kWheelStep, 0.0f, maxScroll);
+
+    if (draggingScrollbar || (hovered && maxScroll > 0.0f
+                              && ImGui::IsMouseClicked (ImGuiMouseButton_Left)
+                              && io.MousePos.x >= frameMax.x - kScrollbarWidth))
+    {
+        if (ImGui::IsMouseDown (ImGuiMouseButton_Left))
+        {
+            draggingScrollbar = true;
+            const auto thumb = scrollThumbHeight (viewport, layout.contentHeight);
+            const auto travel = std::max (1.0f, viewport - thumb);
+            scrollY = std::clamp ((io.MousePos.y - frameMin.y - thumb * 0.5f) / travel * maxScroll,
+                                  0.0f, maxScroll);
+        }
+        else
+        {
+            draggingScrollbar = false;
+        }
+        return;
+    }
+
+    if (layout.rows.empty())
+        return;
+
+    const auto& text = document.documentText();
+    if (hovered)
+    {
+        const auto over = hitTest (io.MousePos, frameMin, bodySize);
+        const bool onLink = over < text.size() && ! document.linkTargetAt (over).empty();
+        ImGui::SetMouseCursor (onLink ? ImGuiMouseCursor_Hand : ImGuiMouseCursor_TextInput);
+    }
+
+    if (hovered && ImGui::IsMouseClicked (ImGuiMouseButton_Left))
+    {
+        const auto clicks = io.MouseClickedCount[ImGuiMouseButton_Left];
+        const auto& row = layout.rows[layout.rowAtY (
+            std::max (0.0f, io.MousePos.y - frameMin.y + scrollY))];
+
+        if (clicks == 1 && row.firstRowOfLine
+            && row.block == NotepadDocument::BlockStyle::tasks
+            && io.MousePos.x >= frameMin.x && io.MousePos.x <= frameMin.x + row.indent - 4.0f)
+        {
+            toggleTaskLine (row.lineStart);
+            return;
+        }
+
+        const auto offset = hitTest (io.MousePos, frameMin, bodySize);
+        if (clicks == 1 && (io.KeyCtrl || io.KeySuper) && offset < text.size())
+        {
+            const auto target = document.linkTargetAt (offset);
+            if (! target.empty())
+            {
+                if (onLinkActivated)
+                    onLinkActivated (target);
+                return;
+            }
+        }
+
+        if (clicks >= 3)
+        {
+            anchor = row.lineStart;
+            moveCaret (row.lineEnd, true, true);
+        }
+        else if (clicks == 2)
+        {
+            const auto word = notepad::wordAt (text, offset);
+            anchor = word.start;
+            moveCaret (word.end, true);
+        }
+        else if (io.KeyShift)
+        {
+            moveCaret (offset, true, offset == row.end && ! row.lastRowOfLine);
+            draggingSelection = true;
+        }
+        else
+        {
+            moveCaret (offset, false, offset == row.end && ! row.lastRowOfLine);
+            draggingSelection = true;
+        }
+    }
+    else if (draggingSelection && ImGui::IsMouseDown (ImGuiMouseButton_Left))
+    {
+        const auto offset = hitTest (io.MousePos, frameMin, bodySize);
+        if (offset != caret)
+            moveCaret (offset, true);
+
+        if (io.MousePos.y < frameMin.y)
+            scrollY = std::max (0.0f, scrollY - kWheelStep * 0.5f);
+        else if (io.MousePos.y > frameMax.y)
+            scrollY = std::min (maxScroll, scrollY + kWheelStep * 0.5f);
+    }
+
+    if (ImGui::IsMouseReleased (ImGuiMouseButton_Left))
+        draggingSelection = false;
+}
+
+void NotepadEditor::handleKeyboard (float viewportHeight, float bodySize)
+{
+    auto& io = ImGui::GetIO();
+    const auto& text = document.documentText();
+    const bool command = io.KeyCtrl || io.KeySuper;
+    const bool shift = io.KeyShift;
+    const bool byWord = io.KeyCtrl || io.KeyAlt;
+
+    if (command && ImGui::IsKeyPressed (ImGuiKey_Z, false))
+    {
+        if (shift)
+        {
+            if (onRedoRequested) onRedoRequested();
+        }
+        else if (onUndoRequested)
+        {
+            onUndoRequested();
+        }
+        return;
+    }
+    if (command && ImGui::IsKeyPressed (ImGuiKey_Y, false))
+    {
+        if (onRedoRequested)
+            onRedoRequested();
+        return;
+    }
+    if (command && ImGui::IsKeyPressed (ImGuiKey_A, false))
+    {
+        selectAll();
+        return;
+    }
+    if (command && ImGui::IsKeyPressed (ImGuiKey_B, false))
+    {
+        applyInlineStyle (NotepadDocument::InlineStyle::bold);
+        return;
+    }
+    if (command && ImGui::IsKeyPressed (ImGuiKey_I, false))
+    {
+        applyInlineStyle (NotepadDocument::InlineStyle::italic);
+        return;
+    }
+    if (command && (ImGui::IsKeyPressed (ImGuiKey_C, false) || ImGui::IsKeyPressed (ImGuiKey_X, false)))
+    {
+        const auto target = selection();
+        if (! target.empty())
+        {
+            ImGui::SetClipboardText (text.substr (target.start, target.end - target.start).c_str());
+            if (ImGui::IsKeyPressed (ImGuiKey_X, false))
+                replaceRange (target.start, target.end, {}, notepad::EditKind::structural);
+        }
+        return;
+    }
+    if (command && ImGui::IsKeyPressed (ImGuiKey_V, false))
+    {
+        if (const auto* const clipboard = ImGui::GetClipboardText())
+        {
+            std::string pasted;
+            for (const auto* character = clipboard; *character != '\0'; ++character)
+                if (*character != '\r')
+                    pasted.push_back (*character);
+            if (! pasted.empty())
+            {
+                const auto target = selection();
+                replaceRange (target.start, target.end, pasted, notepad::EditKind::structural);
+            }
+        }
+        return;
+    }
+
+    if (ImGui::IsKeyPressed (ImGuiKey_LeftArrow))
+    {
+        const auto target = selection();
+        if (! shift && ! target.empty() && ! byWord)
+            moveCaret (target.start, false);
+        else
+            moveCaret (byWord ? notepad::wordLeft (text, caret)
+                              : notepad::previousOffset (text, caret), shift);
+    }
+    else if (ImGui::IsKeyPressed (ImGuiKey_RightArrow))
+    {
+        const auto target = selection();
+        if (! shift && ! target.empty() && ! byWord)
+            moveCaret (target.end, false);
+        else
+            moveCaret (byWord ? notepad::wordRight (text, caret)
+                              : notepad::nextOffset (text, caret), shift);
+    }
+    else if (ImGui::IsKeyPressed (ImGuiKey_UpArrow))
+    {
+        moveVertical (-1, shift, bodySize);
+    }
+    else if (ImGui::IsKeyPressed (ImGuiKey_DownArrow))
+    {
+        moveVertical (1, shift, bodySize);
+    }
+    else if (ImGui::IsKeyPressed (ImGuiKey_PageUp))
+    {
+        movePage (-1, shift, viewportHeight, bodySize);
+    }
+    else if (ImGui::IsKeyPressed (ImGuiKey_PageDown))
+    {
+        movePage (1, shift, viewportHeight, bodySize);
+    }
+    else if (ImGui::IsKeyPressed (ImGuiKey_Home))
+    {
+        ensureLayout (layoutWidth, bodySize);
+        const auto& row = layout.rows[layout.rowForOffset (caret, caretAtRowEnd)];
+        moveCaret (command ? 0 : row.start, shift);
+    }
+    else if (ImGui::IsKeyPressed (ImGuiKey_End))
+    {
+        ensureLayout (layoutWidth, bodySize);
+        const auto& row = layout.rows[layout.rowForOffset (caret, caretAtRowEnd)];
+        moveCaret (command ? text.size() : row.end, shift, true);
+    }
+
+    if (ImGui::IsKeyPressed (ImGuiKey_Backspace))
+        deleteBackward (byWord);
+    if (ImGui::IsKeyPressed (ImGuiKey_Delete))
+        deleteForward (byWord);
+    if (ImGui::IsKeyPressed (ImGuiKey_Enter) || ImGui::IsKeyPressed (ImGuiKey_KeypadEnter))
+        insertNewline();
+
+    if (io.InputQueueCharacters.Size > 0)
+    {
+        std::string typed;
+        if (! command)
+        {
+            for (int i = 0; i < io.InputQueueCharacters.Size; ++i)
+            {
+                const auto character = static_cast<unsigned int> (io.InputQueueCharacters[i]);
+                if (character < 0x20u || character == 0x7fu)
+                    continue;
+                notepad::appendUtf8 (typed, character);
+            }
+        }
+        io.InputQueueCharacters.resize (0);
+        insertText (typed);
+    }
+}
+
+void NotepadEditor::render (ImVec2 frameMin, ImVec2 frameMax, float bodySize, bool active) const
+{
+    auto* const drawList = ImGui::GetWindowDrawList();
+    const auto& text = document.documentText();
+    const auto target = selection();
+
+    const auto textColour = colourOf (darkPage ? 0xe7e8edff : 0x24242aff);
+    const auto mutedColour = colourOf (darkPage ? 0xa9abb5ff : 0x67656dff);
+    const auto linkColour = colourOf (darkPage ? 0x8eb4ffff : 0x315fbdff);
+    const auto codeColour = colourOf (darkPage ? 0xd5a4f0ff : 0x5e367cff);
+    const auto selectionColour = colourOf (darkPage ? 0x516aa6cc : 0xb9c8f0cc);
+    const auto codeBackground = colourOf (darkPage ? 0x34313fff : 0xebe6f1ff);
+    const auto accentColour = colourOf (darkPage ? 0xb28bd4ff : 0x8061a4ff);
+
+    const bool caretVisible = active
+        && std::fmod (ImGui::GetTime() - blinkStart, 1.06) < 0.56;
+    const auto caretRow = layout.rowForOffset (caret, caretAtRowEnd);
+
+    drawList->PushClipRect (frameMin, frameMax, true);
+    for (std::size_t rowIndex = 0; rowIndex < layout.rows.size(); ++rowIndex)
+    {
+        const auto& row = layout.rows[rowIndex];
+        const float rowY = frameMin.y + row.y - scrollY;
+        if (rowY + row.height < frameMin.y || rowY > frameMax.y)
+            continue;
+
+        const auto fontSize = notepad::blockFontSize (row.block, bodySize);
+        const float textY = rowY + std::max (0.0f, (row.height - fontSize) * 0.38f);
+        const float originX = frameMin.x + row.indent;
+
+        const auto selectedStart = std::max (target.start, row.start);
+        const auto selectedEnd = std::min (target.end, row.end);
+        // A selection that runs past a hard line break also covers the newline,
+        // which has no glyph - show it as a stub past the last character.
+        const bool newlineSelected = row.lastRowOfLine && target.start <= row.end
+                                  && target.end > row.end;
+        if (selectedStart < selectedEnd || newlineSelected)
+        {
+            const auto x1 = originX + notepad::offsetX (document, row, selectedStart,
+                                                        bodySize, measure);
+            const auto x2 = originX + notepad::offsetX (document, row, selectedEnd,
+                                                        bodySize, measure)
+                          + (newlineSelected ? 6.0f : 0.0f);
+            drawList->AddRectFilled (ImVec2 (x1, rowY + 1.0f),
+                                     ImVec2 (std::max (x1 + 2.0f, x2), rowY + row.height - 1.0f),
+                                     selectionColour, 2.0f);
+        }
+
+        if (row.firstRowOfLine)
+        {
+            const float markerRight = originX - 9.0f;
+            const float markerY = rowY + row.height * 0.53f;
+            if (row.block == NotepadDocument::BlockStyle::quote)
+                drawList->AddRectFilled (ImVec2 (frameMin.x + 3.0f, rowY + 1.0f),
+                                         ImVec2 (frameMin.x + 6.0f, rowY + row.height - 1.0f),
+                                         accentColour, 1.0f);
+            else if (row.block == NotepadDocument::BlockStyle::bullets)
+                drawList->AddCircleFilled (ImVec2 (markerRight - 4.0f, markerY), 3.0f, textColour);
+            else if (row.block == NotepadDocument::BlockStyle::numbers && fonts.body != nullptr)
+            {
+                const auto marker = std::to_string (row.lineInfo.orderedNumber) + ".";
+                const auto width = fonts.body->CalcTextSizeA (bodySize, FLT_MAX, 0.0f,
+                                                              marker.c_str()).x;
+                drawList->AddText (fonts.body, bodySize,
+                                   ImVec2 (markerRight - width, textY), mutedColour,
+                                   marker.c_str());
+            }
+            else if (row.block == NotepadDocument::BlockStyle::tasks)
+            {
+                const ImVec2 boxMin (markerRight - 14.0f, markerY - 7.0f);
+                const ImVec2 boxMax (markerRight, markerY + 7.0f);
+                drawList->AddRect (boxMin, boxMax, mutedColour, 2.0f, 0, 1.5f);
+                if (row.lineInfo.taskChecked)
+                {
+                    drawList->AddLine (ImVec2 (boxMin.x + 3.0f, markerY),
+                                       ImVec2 (boxMin.x + 6.0f, boxMax.y - 3.0f),
+                                       accentColour, 2.0f);
+                    drawList->AddLine (ImVec2 (boxMin.x + 6.0f, boxMax.y - 3.0f),
+                                       ImVec2 (boxMax.x - 2.0f, boxMin.y + 3.0f),
+                                       accentColour, 2.0f);
+                }
+            }
+        }
+
+        float x = originX;
+        for (auto runStart = row.start; runStart < row.end;)
+        {
+            const auto style = document.styleAt (runStart);
+            auto runEnd = notepad::nextOffset (text, runStart);
+            while (runEnd < row.end && document.styleAt (runEnd) == style)
+                runEnd = notepad::nextOffset (text, runEnd);
+            runEnd = std::min (runEnd, row.end);
+
+            auto* const font = fontForStyle (style, row.block);
+            const auto runWidth = measureRange (runStart, runEnd, fontSize, row.block);
+            if (style.code)
+                drawList->AddRectFilled (ImVec2 (x - 2.0f, rowY + 2.0f),
+                                         ImVec2 (x + runWidth + 2.0f, rowY + row.height - 2.0f),
+                                         codeBackground, 2.0f);
+            if (font != nullptr)
+                drawList->AddText (font, fontSize, ImVec2 (x, textY),
+                                   style.link ? linkColour : style.code ? codeColour : textColour,
+                                   text.data() + runStart, text.data() + runEnd);
+            if (style.link)
+                drawList->AddLine (ImVec2 (x, textY + fontSize + 1.0f),
+                                   ImVec2 (x + runWidth, textY + fontSize + 1.0f),
+                                   linkColour, 1.0f);
+            x += runWidth;
+            runStart = runEnd;
+        }
+
+        if (caretVisible && rowIndex == caretRow)
+        {
+            const auto caretX = originX + notepad::offsetX (document, row, caret, bodySize, measure);
+            drawList->AddLine (ImVec2 (caretX, rowY + 2.0f),
+                               ImVec2 (caretX, rowY + row.height - 2.0f), textColour, 1.4f);
+        }
+    }
+
+    const auto viewport = frameMax.y - frameMin.y;
+    if (layout.contentHeight > viewport)
+    {
+        const auto thumb = scrollThumbHeight (viewport, layout.contentHeight);
+        const auto travel = viewport - thumb;
+        const auto thumbY = frameMin.y + travel * scrollY
+                          / std::max (1.0f, layout.contentHeight - viewport);
+        drawList->AddRectFilled (ImVec2 (frameMax.x - 4.0f, thumbY),
+                                 ImVec2 (frameMax.x - 1.0f, thumbY + thumb),
+                                 colourOf (0xaaa7b0aa), 2.0f);
+    }
+    drawList->PopClipRect();
+}
+
+void NotepadEditor::draw (float bodySize)
+{
+    auto& g = *ImGui::GetCurrentContext();
+    auto* const host = ImGui::GetCurrentWindow();
+    if (host->SkipItems)
+        return;
+
+    const auto origin = ImGui::GetCursorScreenPos();
+    const auto available = ImGui::GetContentRegionAvail();
+    const ImVec2 size (std::max (32.0f, available.x), std::max (32.0f, available.y));
+    const ImVec2 frameMin = origin;
+    const ImVec2 frameMax (origin.x + size.x, origin.y + size.y);
+    const ImRect frame (frameMin, frameMax);
+
+    const auto id = host->GetID ("##notepad-document");
+    ImGui::ItemSize (size);
+    if (! ImGui::ItemAdd (frame, id, &frame, ImGuiItemFlags_Inputable))
+        return;
+
+    const bool hovered = ImGui::IsItemHovered();
+    const bool clicked = ImGui::IsMouseClicked (ImGuiMouseButton_Left);
+
+    // A modal (the link dialog) owns the keyboard while it is up; hand the
+    // focus back only once it has closed and asked for it.
+    if (ImGui::GetTopMostPopupModal() != nullptr)
+    {
+        if (g.ActiveId == id)
+            ImGui::ClearActiveID();
+        ensureLayout (size.x, bodySize);
+        scrollY = std::clamp (scrollY, 0.0f, std::max (0.0f, layout.contentHeight - size.y));
+        render (frameMin, frameMax, bodySize, false);
+        return;
+    }
+
+    // The page is the only text surface in the window, so it takes the caret
+    // back once a toolbar button has finished with the active id - otherwise
+    // every format button would cost the user a click to resume typing.
+    const bool reclaim = keepFocus && g.ActiveId == 0 && ! clicked;
+
+    if (focusRequested || reclaim || (hovered && clicked))
+    {
+        if (g.ActiveId != id)
+        {
+            ImGui::SetActiveID (id, host);
+            ImGui::SetFocusID (id, host);
+            ImGui::FocusWindow (host);
+        }
+        focusRequested = false;
+        keepFocus = true;
+    }
+    else if (g.ActiveId == id && clicked && ! hovered)
+    {
+        ImGui::ClearActiveID();
+        keepFocus = false;
+    }
+
+    const bool active = g.ActiveId == id;
+    if (active)
+    {
+        // Same ownership set as ImGui's own multiline text input: without it
+        // keyboard navigation eats the arrows and Tab moves focus away.
+        static const ImGuiKey ownedKeys[] = {
+            ImGuiKey_LeftArrow, ImGuiKey_RightArrow, ImGuiKey_UpArrow, ImGuiKey_DownArrow,
+            ImGuiKey_Home, ImGuiKey_End, ImGuiKey_PageUp, ImGuiKey_PageDown,
+            ImGuiKey_Enter, ImGuiKey_KeypadEnter, ImGuiKey_Delete, ImGuiKey_Backspace,
+            ImGuiKey_Tab
+        };
+        for (const auto key : ownedKeys)
+            ImGui::SetKeyOwner (key, id);
+        g.ActiveIdUsingNavDirMask |= (1u << ImGuiDir_Left) | (1u << ImGuiDir_Right)
+                                   | (1u << ImGuiDir_Up) | (1u << ImGuiDir_Down);
+        g.WantTextInputNextFrame = 1;
+    }
+    // The page scrolls itself, so the wheel must not also scroll the child.
+    ImGui::SetItemKeyOwner (ImGuiKey_MouseWheelY, ImGuiInputFlags_None);
+
+    ensureLayout (size.x, bodySize);
+    handleMouse (frameMin, frameMax, hovered, bodySize);
+    if (active)
+        handleKeyboard (size.y, bodySize);
+    ensureLayout (size.x, bodySize);
+
+    if (scrollToCaret)
+    {
+        keepCaretVisible (size.y, bodySize);
+        scrollToCaret = false;
+    }
+    scrollY = std::clamp (scrollY, 0.0f, std::max (0.0f, layout.contentHeight - size.y));
+
+    render (frameMin, frameMax, bodySize, active);
+}
+} // namespace duskstudio

--- a/src/ui/NotepadEditor.cpp
+++ b/src/ui/NotepadEditor.cpp
@@ -437,7 +437,8 @@ void NotepadEditor::insertLink (const std::string& url)
         target.end = target.start + sizeof (kLinkPlaceholder) - 1;
     }
 
-    document.wrapDocumentSelection (target, "[", "](" + url + ")");
+    document.wrapDocumentSelection (
+        target, "[", "](" + notepad::encodeMarkdownLinkTarget (url) + ")");
     history.record (notepad::EditKind::structural, std::move (before), target.end);
     setSelection (target);
     sticky = {};
@@ -702,6 +703,10 @@ void NotepadEditor::handleKeyboard (float viewportHeight, float bodySize)
         deleteForward (byWord);
     if (ImGui::IsKeyPressed (ImGuiKey_Enter) || ImGui::IsKeyPressed (ImGuiKey_KeypadEnter))
         insertNewline();
+    // Match Markdown mode's ImGuiInputTextFlags_AllowTabInput semantics.
+    if (! io.KeyCtrl && ! io.KeyAlt && ! io.KeySuper && ! shift
+        && ImGui::IsKeyPressed (ImGuiKey_Tab))
+        insertText ("\t");
 
     if (io.InputQueueCharacters.Size > 0)
     {

--- a/src/ui/NotepadEditor.cpp
+++ b/src/ui/NotepadEditor.cpp
@@ -580,7 +580,8 @@ void NotepadEditor::handleKeyboard (float viewportHeight, float bodySize)
 {
     auto& io = ImGui::GetIO();
     const auto& text = document.documentText();
-    const bool command = io.KeyCtrl || io.KeySuper;
+    const bool acceptsText = notepad::acceptsTextInput (io.KeyCtrl, io.KeyAlt, io.KeySuper);
+    const bool command = ! acceptsText;
     const bool shift = io.KeyShift;
     const bool byWord = io.KeyCtrl || io.KeyAlt;
 
@@ -705,7 +706,7 @@ void NotepadEditor::handleKeyboard (float viewportHeight, float bodySize)
     if (io.InputQueueCharacters.Size > 0)
     {
         std::string typed;
-        if (! command)
+        if (acceptsText)
         {
             for (int i = 0; i < io.InputQueueCharacters.Size; ++i)
             {

--- a/src/ui/NotepadEditor.cpp
+++ b/src/ui/NotepadEditor.cpp
@@ -59,9 +59,12 @@ void NotepadEditor::reset (NotepadDocument::Selection value)
 
 void NotepadEditor::setSelection (NotepadDocument::Selection value)
 {
-    const auto limit = document.documentText().size();
-    anchor = std::min (value.start, limit);
-    caret = std::min (value.end, limit);
+    // A restored selection can carry offsets from a different projection, so it
+    // is snapped: a caret inside a codepoint splits the sequence on the next
+    // edit and truncates a copy.
+    const auto& text = document.documentText();
+    anchor = notepad::snapToBoundary (text, value.start);
+    caret = notepad::snapToBoundary (text, value.end);
 }
 
 NotepadDocument::Selection NotepadEditor::selection() const noexcept
@@ -119,14 +122,17 @@ void NotepadEditor::ensureLayout (float width, float bodySize)
     layoutDirty = false;
 }
 
+// Every mutation path ends here, once, after all of its model operations: the
+// host caches the Markdown this hands out, so a notification that races a
+// follow-up edit (a sticky wrapper, a continued list marker) would strand it.
 void NotepadEditor::documentMutated()
 {
     layoutDirty = true;
     scrollToCaret = true;
     resetBlink();
-    const auto limit = document.documentText().size();
-    caret = std::min (caret, limit);
-    anchor = std::min (anchor, limit);
+    const auto& text = document.documentText();
+    caret = notepad::snapToBoundary (text, caret);
+    anchor = notepad::snapToBoundary (text, anchor);
     if (onDocumentChanged)
         onDocumentChanged();
 }
@@ -250,7 +256,6 @@ bool NotepadEditor::replaceRange (std::size_t start, std::size_t end, const std:
     caret = anchor = std::min (caretAfter, document.documentText().size());
     caretAtRowEnd = false;
     desiredX = -1.0f;
-    documentMutated();
     return true;
 }
 
@@ -265,6 +270,7 @@ void NotepadEditor::insertText (const std::string& value)
 
     if (sticky.active)
         applyStickyStyles ({ target.start, target.start + value.size() });
+    documentMutated();
 }
 
 void NotepadEditor::applyStickyStyles (NotepadDocument::Selection inserted)
@@ -272,7 +278,6 @@ void NotepadEditor::applyStickyStyles (NotepadDocument::Selection inserted)
     document.setDocumentInlineStyle (inserted, NotepadDocument::InlineStyle::bold, sticky.bold);
     document.setDocumentInlineStyle (inserted, NotepadDocument::InlineStyle::italic, sticky.italic);
     document.setDocumentInlineStyle (inserted, NotepadDocument::InlineStyle::code, sticky.code);
-    layoutDirty = true;
 }
 
 void NotepadEditor::insertNewline()
@@ -299,15 +304,17 @@ void NotepadEditor::insertNewline()
         return;
 
     const auto newLine = caret;
-    const auto previous = document.lineInfoAt (newLine > 1 ? newLine - 2 : 0);
+    // The line that the new break ends, not the byte before it: on a blank line
+    // that byte is the terminator of the line above, whose style is not ours.
+    const auto previous = document.lineInfoAt (notepad::lineStartOffset (text, newLine - 1));
     if (notepad::isList (previous.block))
     {
         document.setDocumentBlockStyle ({ newLine, newLine }, previous.block);
         if (previous.block == NotepadDocument::BlockStyle::numbers)
             document.renumberOrderedRunAt (newLine);
-        layoutDirty = true;
     }
     sticky = {};
+    documentMutated();
 }
 
 void NotepadEditor::deleteBackward (bool wholeWord)
@@ -315,7 +322,8 @@ void NotepadEditor::deleteBackward (bool wholeWord)
     const auto target = selection();
     if (! target.empty())
     {
-        replaceRange (target.start, target.end, {}, notepad::EditKind::deleting);
+        if (replaceRange (target.start, target.end, {}, notepad::EditKind::deleting))
+            documentMutated();
         return;
     }
     if (caret == 0)
@@ -324,7 +332,8 @@ void NotepadEditor::deleteBackward (bool wholeWord)
     const auto& text = document.documentText();
     const auto from = wholeWord ? notepad::wordLeft (text, caret)
                                 : notepad::previousOffset (text, caret);
-    replaceRange (from, caret, {}, notepad::EditKind::deleting);
+    if (replaceRange (from, caret, {}, notepad::EditKind::deleting))
+        documentMutated();
 }
 
 void NotepadEditor::deleteForward (bool wholeWord)
@@ -332,7 +341,8 @@ void NotepadEditor::deleteForward (bool wholeWord)
     const auto target = selection();
     if (! target.empty())
     {
-        replaceRange (target.start, target.end, {}, notepad::EditKind::deleting);
+        if (replaceRange (target.start, target.end, {}, notepad::EditKind::deleting))
+            documentMutated();
         return;
     }
 
@@ -342,7 +352,8 @@ void NotepadEditor::deleteForward (bool wholeWord)
 
     const auto to = wholeWord ? notepad::wordRight (text, caret)
                               : notepad::nextOffset (text, caret);
-    replaceRange (caret, to, {}, notepad::EditKind::deleting);
+    if (replaceRange (caret, to, {}, notepad::EditKind::deleting))
+        documentMutated();
 }
 
 void NotepadEditor::toggleTaskLine (std::size_t lineStart)
@@ -612,8 +623,9 @@ void NotepadEditor::handleKeyboard (float viewportHeight, float bodySize)
         if (! target.empty())
         {
             ImGui::SetClipboardText (text.substr (target.start, target.end - target.start).c_str());
-            if (ImGui::IsKeyPressed (ImGuiKey_X, false))
-                replaceRange (target.start, target.end, {}, notepad::EditKind::structural);
+            if (ImGui::IsKeyPressed (ImGuiKey_X, false)
+                && replaceRange (target.start, target.end, {}, notepad::EditKind::structural))
+                documentMutated();
         }
         return;
     }
@@ -628,7 +640,9 @@ void NotepadEditor::handleKeyboard (float viewportHeight, float bodySize)
             if (! pasted.empty())
             {
                 const auto target = selection();
-                replaceRange (target.start, target.end, pasted, notepad::EditKind::structural);
+                if (replaceRange (target.start, target.end, pasted,
+                                  notepad::EditKind::structural))
+                    documentMutated();
             }
         }
         return;

--- a/src/ui/NotepadEditor.h
+++ b/src/ui/NotepadEditor.h
@@ -26,6 +26,8 @@ public:
     };
 
     NotepadEditor (NotepadDocument& documentToEdit, notepad::UndoStack& undoHistory);
+    NotepadEditor (const NotepadEditor&) = delete;
+    NotepadEditor& operator= (const NotepadEditor&) = delete;
 
     std::function<void()> onDocumentChanged;
     std::function<void (const std::string&)> onLinkActivated;

--- a/src/ui/NotepadEditor.h
+++ b/src/ui/NotepadEditor.h
@@ -65,6 +65,8 @@ private:
                         NotepadDocument::BlockStyle block) const;
 
     void ensureLayout (float width, float bodySize);
+    // Closes a mutation: exactly one call per edit, after every model operation
+    // that edit performs.
     void documentMutated();
     notepad::Snapshot snapshot() const;
 
@@ -74,6 +76,8 @@ private:
     void selectAll();
     void keepCaretVisible (float viewportHeight, float bodySize);
 
+    // Applies the edit and records it; the caller owns the closing
+    // documentMutated() so post-edit model work joins the same notification.
     bool replaceRange (std::size_t start, std::size_t end, const std::string& insert,
                        notepad::EditKind kind);
     void insertText (const std::string& value);

--- a/src/ui/NotepadEditor.h
+++ b/src/ui/NotepadEditor.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include "NotepadDocument.h"
+#include "NotepadEditorCore.h"
+
+#include <DearImGui.hpp>
+
+#include <functional>
+#include <string>
+
+namespace duskstudio
+{
+// Rich-text editor for the notepad's Document mode. It owns wrapping, caret,
+// selection, input and painting; every text mutation goes through
+// NotepadDocument's projection so the Markdown source stays authoritative.
+class NotepadEditor final
+{
+public:
+    struct Fonts
+    {
+        ImFont* body = nullptr;
+        ImFont* bold = nullptr;
+        ImFont* italic = nullptr;
+        ImFont* boldItalic = nullptr;
+        ImFont* mono = nullptr;
+    };
+
+    NotepadEditor (NotepadDocument& documentToEdit, notepad::UndoStack& undoHistory);
+
+    std::function<void()> onDocumentChanged;
+    std::function<void (const std::string&)> onLinkActivated;
+    std::function<void()> onUndoRequested;
+    std::function<void()> onRedoRequested;
+
+    void setFonts (const Fonts& value);
+    void setDarkPage (bool dark) noexcept { darkPage = dark; }
+
+    // Adopts the document as it stands now - used on open, mode switch and
+    // history restore, and whenever an edit was refused by the model.
+    void reset (NotepadDocument::Selection value);
+    void setSelection (NotepadDocument::Selection value);
+    NotepadDocument::Selection selection() const noexcept;
+    void requestFocus() noexcept { focusRequested = true; }
+
+    void draw (float bodySize);
+
+    void applyInlineStyle (NotepadDocument::InlineStyle style);
+    void applyBlockStyle (NotepadDocument::BlockStyle style);
+    void insertLink (const std::string& url);
+    bool inlineStyleActive (NotepadDocument::InlineStyle style) const;
+    NotepadDocument::BlockStyle blockStyle() const;
+
+private:
+    struct StickyStyle
+    {
+        bool active = false;
+        bool bold = false;
+        bool italic = false;
+        bool code = false;
+    };
+
+    ImFont* fontForStyle (NotepadDocument::TextStyle style,
+                          NotepadDocument::BlockStyle block) const noexcept;
+    float measureRange (std::size_t begin, std::size_t end, float fontSize,
+                        NotepadDocument::BlockStyle block) const;
+
+    void ensureLayout (float width, float bodySize);
+    void documentMutated();
+    notepad::Snapshot snapshot() const;
+
+    void moveCaret (std::size_t offset, bool extend, bool preferRowEnd = false);
+    void moveVertical (int direction, bool extend, float bodySize);
+    void movePage (int direction, bool extend, float viewportHeight, float bodySize);
+    void selectAll();
+    void keepCaretVisible (float viewportHeight, float bodySize);
+
+    bool replaceRange (std::size_t start, std::size_t end, const std::string& insert,
+                       notepad::EditKind kind);
+    void insertText (const std::string& value);
+    void insertNewline();
+    void deleteBackward (bool wholeWord);
+    void deleteForward (bool wholeWord);
+    void toggleTaskLine (std::size_t lineStart);
+    void toggleSticky (NotepadDocument::InlineStyle style);
+    void applyStickyStyles (NotepadDocument::Selection inserted);
+    bool& stickyValue (NotepadDocument::InlineStyle style) noexcept;
+
+    void handleMouse (ImVec2 frameMin, ImVec2 frameMax, bool hovered, float bodySize);
+    void handleKeyboard (float viewportHeight, float bodySize);
+    void render (ImVec2 frameMin, ImVec2 frameMax, float bodySize, bool active) const;
+
+    std::size_t hitTest (ImVec2 position, ImVec2 frameMin, float bodySize) const;
+    void resetBlink();
+
+    NotepadDocument& document;
+    notepad::UndoStack& history;
+    notepad::MeasureFn measure;
+    notepad::Layout layout;
+    Fonts fonts;
+    StickyStyle sticky;
+
+    std::size_t caret = 0;
+    std::size_t anchor = 0;
+    float desiredX = -1.0f;
+    float scrollY = 0.0f;
+    float layoutWidth = -1.0f;
+    float layoutBodySize = -1.0f;
+    double blinkStart = 0.0;
+    bool layoutDirty = true;
+    bool caretAtRowEnd = false;
+    bool scrollToCaret = false;
+    bool focusRequested = false;
+    bool keepFocus = false;
+    bool draggingSelection = false;
+    bool draggingScrollbar = false;
+    bool darkPage = true;
+};
+} // namespace duskstudio

--- a/src/ui/NotepadEditorCore.cpp
+++ b/src/ui/NotepadEditorCore.cpp
@@ -57,6 +57,14 @@ std::size_t previousOffset (const std::string& text, std::size_t offset) noexcep
     return offset;
 }
 
+std::size_t snapToBoundary (const std::string& text, std::size_t offset) noexcept
+{
+    offset = std::min (offset, text.size());
+    while (offset > 0 && offset < text.size() && isContinuation (text, offset))
+        --offset;
+    return offset;
+}
+
 std::size_t lineStartOffset (const std::string& text, std::size_t offset) noexcept
 {
     offset = std::min (offset, text.size());

--- a/src/ui/NotepadEditorCore.cpp
+++ b/src/ui/NotepadEditorCore.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 
 namespace duskstudio
 {
@@ -33,6 +34,57 @@ CharClass classify (const std::string& text, std::size_t offset) noexcept
         || (byte >= 'a' && byte <= 'z') || (byte >= 'A' && byte <= 'Z'))
         return CharClass::word;
     return CharClass::punctuation;
+}
+
+NotepadDocument::Selection normaliseSelection (
+    const std::string& text, NotepadDocument::Selection selection) noexcept
+{
+    selection.start = std::min (selection.start, text.size());
+    selection.end = std::min (selection.end, text.size());
+    if (selection.start > selection.end)
+        std::swap (selection.start, selection.end);
+    return selection;
+}
+
+std::size_t markdownBlockPrefixLength (const std::string& text,
+                                       std::size_t start,
+                                       std::size_t end)
+{
+    auto i = start;
+    while (i < end && text[i] == '#' && i - start < 6)
+        ++i;
+    if (i > start && i < end && text[i] == ' ')
+        return i + 1 - start;
+
+    i = start;
+    while (i < end && text[i] >= '0' && text[i] <= '9')
+        ++i;
+    if (i > start && i + 1 < end && text[i] == '.' && text[i + 1] == ' ')
+        return i + 2 - start;
+
+    if (text.compare (start, std::min<std::size_t> (6, end - start), "- [ ] ") == 0
+        || text.compare (start, std::min<std::size_t> (6, end - start), "- [x] ") == 0)
+        return 6;
+    if (end - start >= 2 && text[start + 1] == ' '
+        && (text[start] == '-' || text[start] == '*' || text[start] == '+' || text[start] == '>'))
+        return 2;
+    return 0;
+}
+
+std::string markdownBlockPrefix (NotepadDocument::BlockStyle style, std::size_t number)
+{
+    switch (style)
+    {
+        case NotepadDocument::BlockStyle::heading1: return "# ";
+        case NotepadDocument::BlockStyle::heading2: return "## ";
+        case NotepadDocument::BlockStyle::heading3: return "### ";
+        case NotepadDocument::BlockStyle::quote:    return "> ";
+        case NotepadDocument::BlockStyle::bullets:  return "- ";
+        case NotepadDocument::BlockStyle::numbers:  return std::to_string (number) + ". ";
+        case NotepadDocument::BlockStyle::tasks:    return "- [ ] ";
+        case NotepadDocument::BlockStyle::body:     return {};
+    }
+    return {};
 }
 } // namespace
 
@@ -175,6 +227,136 @@ void appendUtf8 (std::string& text, unsigned int codepoint)
         text.push_back (static_cast<char> (0x80u | ((codepoint >> 6) & 0x3fu)));
         text.push_back (static_cast<char> (0x80u | (codepoint & 0x3fu)));
     }
+}
+
+bool acceptsTextInput (bool control, bool alt, bool super) noexcept
+{
+    return ! super && (! control || alt);
+}
+
+bool markdownInlineActive (const std::string& markdown,
+                           NotepadDocument::Selection selection,
+                           const std::string& prefix,
+                           const std::string& suffix)
+{
+    if (prefix.empty() && suffix.empty())
+        return false;
+
+    selection = normaliseSelection (markdown, selection);
+    const bool prefixOutside = selection.start >= prefix.size()
+                            && markdown.compare (selection.start - prefix.size(),
+                                                 prefix.size(), prefix) == 0;
+    const bool suffixOutside = markdown.compare (selection.end, suffix.size(), suffix) == 0;
+    const bool includesMarkers = selection.end >= selection.start + prefix.size() + suffix.size()
+                              && markdown.compare (selection.start, prefix.size(), prefix) == 0
+                              && markdown.compare (selection.end - suffix.size(),
+                                                   suffix.size(), suffix) == 0;
+    return (prefixOutside && suffixOutside) || includesMarkers;
+}
+
+MarkdownTransform toggleMarkdownInline (const std::string& markdown,
+                                        NotepadDocument::Selection selection,
+                                        const std::string& prefix,
+                                        const std::string& suffix)
+{
+    selection = normaliseSelection (markdown, selection);
+    MarkdownTransform result { markdown, selection };
+    if (prefix.empty() && suffix.empty())
+        return result;
+
+    const bool wrappersOutside = selection.start >= prefix.size()
+                              && markdown.compare (selection.start - prefix.size(),
+                                                   prefix.size(), prefix) == 0
+                              && markdown.compare (selection.end, suffix.size(), suffix) == 0;
+    const bool markersIncluded = selection.end >= selection.start + prefix.size() + suffix.size()
+                              && markdown.compare (selection.start, prefix.size(), prefix) == 0
+                              && markdown.compare (selection.end - suffix.size(),
+                                                   suffix.size(), suffix) == 0;
+
+    if (wrappersOutside)
+    {
+        result.markdown.erase (selection.end, suffix.size());
+        result.markdown.erase (selection.start - prefix.size(), prefix.size());
+        result.selection = { selection.start - prefix.size(),
+                             selection.end - prefix.size() };
+    }
+    else if (markersIncluded)
+    {
+        result.markdown.erase (selection.end - suffix.size(), suffix.size());
+        result.markdown.erase (selection.start, prefix.size());
+        result.selection = { selection.start,
+                             selection.end - prefix.size() - suffix.size() };
+    }
+    else
+    {
+        result.markdown.insert (selection.end, suffix);
+        result.markdown.insert (selection.start, prefix);
+        result.selection = { selection.start + prefix.size(),
+                             selection.end + prefix.size() };
+    }
+    return result;
+}
+
+MarkdownTransform setMarkdownBlockStyle (const std::string& markdown,
+                                         NotepadDocument::Selection selection,
+                                         NotepadDocument::BlockStyle style)
+{
+    selection = normaliseSelection (markdown, selection);
+
+    struct PrefixEdit
+    {
+        std::size_t start = 0;
+        std::size_t oldLength = 0;
+        std::string replacement;
+    };
+
+    std::vector<PrefixEdit> edits;
+    const auto firstLine = lineStartOffset (markdown, selection.start);
+    const auto finalProbe = selection.end > selection.start ? selection.end - 1
+                                                            : selection.end;
+    const auto lastLine = lineStartOffset (markdown, finalProbe);
+    for (auto start = firstLine, number = std::size_t { 1 };; ++number)
+    {
+        const auto end = lineEndOffset (markdown, start);
+        edits.push_back ({ start, markdownBlockPrefixLength (markdown, start, end),
+                           markdownBlockPrefix (style, number) });
+        if (start == lastLine || end == markdown.size())
+            break;
+        start = end + 1;
+    }
+
+    const auto mapOffset = [&edits] (std::size_t offset)
+    {
+        std::ptrdiff_t delta = 0;
+        for (const auto& edit : edits)
+        {
+            if (offset < edit.start)
+                break;
+
+            const auto oldEnd = edit.start + edit.oldLength;
+            const auto replacementLength = edit.replacement.size();
+            if (edit.oldLength == 0 && offset == edit.start)
+                return static_cast<std::size_t> (
+                    static_cast<std::ptrdiff_t> (edit.start + replacementLength) + delta);
+            if (offset <= oldEnd)
+            {
+                const auto within = offset == oldEnd
+                                  ? replacementLength
+                                  : std::min (offset - edit.start, replacementLength);
+                return static_cast<std::size_t> (
+                    static_cast<std::ptrdiff_t> (edit.start + within) + delta);
+            }
+            delta += static_cast<std::ptrdiff_t> (replacementLength)
+                   - static_cast<std::ptrdiff_t> (edit.oldLength);
+        }
+        return static_cast<std::size_t> (static_cast<std::ptrdiff_t> (offset) + delta);
+    };
+
+    MarkdownTransform result { markdown,
+                               { mapOffset (selection.start), mapOffset (selection.end) } };
+    for (auto edit = edits.rbegin(); edit != edits.rend(); ++edit)
+        result.markdown.replace (edit->start, edit->oldLength, edit->replacement);
+    return result;
 }
 
 bool isHeading (NotepadDocument::BlockStyle block) noexcept

--- a/src/ui/NotepadEditorCore.cpp
+++ b/src/ui/NotepadEditorCore.cpp
@@ -1,0 +1,419 @@
+#include "NotepadEditorCore.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace duskstudio
+{
+namespace notepad
+{
+namespace
+{
+bool isContinuation (const std::string& text, std::size_t offset) noexcept
+{
+    return (static_cast<unsigned char> (text[offset]) & 0xc0u) == 0x80u;
+}
+
+enum class CharClass
+{
+    word,
+    space,
+    punctuation,
+    newline
+};
+
+CharClass classify (const std::string& text, std::size_t offset) noexcept
+{
+    const auto byte = static_cast<unsigned char> (text[offset]);
+    if (byte == '\n' || byte == '\r')
+        return CharClass::newline;
+    if (byte == ' ' || byte == '\t')
+        return CharClass::space;
+    if (byte >= 0x80 || byte == '_' || (byte >= '0' && byte <= '9')
+        || (byte >= 'a' && byte <= 'z') || (byte >= 'A' && byte <= 'Z'))
+        return CharClass::word;
+    return CharClass::punctuation;
+}
+} // namespace
+
+std::size_t nextOffset (const std::string& text, std::size_t offset) noexcept
+{
+    if (offset >= text.size())
+        return text.size();
+    ++offset;
+    while (offset < text.size() && isContinuation (text, offset))
+        ++offset;
+    return offset;
+}
+
+std::size_t previousOffset (const std::string& text, std::size_t offset) noexcept
+{
+    offset = std::min (offset, text.size());
+    if (offset == 0)
+        return 0;
+    --offset;
+    while (offset > 0 && isContinuation (text, offset))
+        --offset;
+    return offset;
+}
+
+std::size_t lineStartOffset (const std::string& text, std::size_t offset) noexcept
+{
+    offset = std::min (offset, text.size());
+    const auto found = offset == 0 ? std::string::npos : text.rfind ('\n', offset - 1);
+    return found == std::string::npos ? 0 : found + 1;
+}
+
+std::size_t lineEndOffset (const std::string& text, std::size_t offset) noexcept
+{
+    const auto found = text.find ('\n', std::min (offset, text.size()));
+    return found == std::string::npos ? text.size() : found;
+}
+
+std::size_t wordLeft (const std::string& text, std::size_t offset) noexcept
+{
+    offset = std::min (offset, text.size());
+    while (offset > 0)
+    {
+        const auto previous = previousOffset (text, offset);
+        const auto category = classify (text, previous);
+        if (category != CharClass::space && category != CharClass::newline)
+            break;
+        offset = previous;
+        if (category == CharClass::newline)
+            return offset;
+    }
+    if (offset == 0)
+        return 0;
+    const auto category = classify (text, previousOffset (text, offset));
+    while (offset > 0)
+    {
+        const auto previous = previousOffset (text, offset);
+        if (classify (text, previous) != category)
+            break;
+        offset = previous;
+    }
+    return offset;
+}
+
+std::size_t wordRight (const std::string& text, std::size_t offset) noexcept
+{
+    offset = std::min (offset, text.size());
+    if (offset < text.size() && classify (text, offset) == CharClass::newline)
+        return nextOffset (text, offset);
+
+    const auto category = offset < text.size() ? classify (text, offset) : CharClass::space;
+    while (offset < text.size() && classify (text, offset) == category
+           && category != CharClass::space)
+        offset = nextOffset (text, offset);
+    while (offset < text.size() && classify (text, offset) == CharClass::space)
+        offset = nextOffset (text, offset);
+    return offset;
+}
+
+Range wordAt (const std::string& text, std::size_t offset) noexcept
+{
+    offset = std::min (offset, text.size());
+    if (text.empty())
+        return { 0, 0 };
+
+    auto probe = offset;
+    if (probe == text.size() || classify (text, probe) == CharClass::newline)
+    {
+        if (probe == 0)
+            return { probe, probe };
+        const auto previous = previousOffset (text, probe);
+        if (classify (text, previous) == CharClass::newline)
+            return { probe, probe };
+        probe = previous;
+    }
+
+    const auto category = classify (text, probe);
+    auto start = probe;
+    while (start > 0)
+    {
+        const auto previous = previousOffset (text, start);
+        if (classify (text, previous) != category)
+            break;
+        start = previous;
+    }
+    auto end = probe;
+    while (end < text.size() && classify (text, end) == category)
+        end = nextOffset (text, end);
+    return { start, end };
+}
+
+void appendUtf8 (std::string& text, unsigned int codepoint)
+{
+    if (codepoint < 0x80u)
+    {
+        text.push_back (static_cast<char> (codepoint));
+    }
+    else if (codepoint < 0x800u)
+    {
+        text.push_back (static_cast<char> (0xc0u | (codepoint >> 6)));
+        text.push_back (static_cast<char> (0x80u | (codepoint & 0x3fu)));
+    }
+    else if (codepoint < 0x10000u)
+    {
+        text.push_back (static_cast<char> (0xe0u | (codepoint >> 12)));
+        text.push_back (static_cast<char> (0x80u | ((codepoint >> 6) & 0x3fu)));
+        text.push_back (static_cast<char> (0x80u | (codepoint & 0x3fu)));
+    }
+    else if (codepoint <= 0x10ffffu)
+    {
+        text.push_back (static_cast<char> (0xf0u | (codepoint >> 18)));
+        text.push_back (static_cast<char> (0x80u | ((codepoint >> 12) & 0x3fu)));
+        text.push_back (static_cast<char> (0x80u | ((codepoint >> 6) & 0x3fu)));
+        text.push_back (static_cast<char> (0x80u | (codepoint & 0x3fu)));
+    }
+}
+
+bool isHeading (NotepadDocument::BlockStyle block) noexcept
+{
+    return block == NotepadDocument::BlockStyle::heading1
+        || block == NotepadDocument::BlockStyle::heading2
+        || block == NotepadDocument::BlockStyle::heading3;
+}
+
+bool isList (NotepadDocument::BlockStyle block) noexcept
+{
+    return block == NotepadDocument::BlockStyle::bullets
+        || block == NotepadDocument::BlockStyle::numbers
+        || block == NotepadDocument::BlockStyle::tasks;
+}
+
+float blockFontSize (NotepadDocument::BlockStyle block, float bodySize) noexcept
+{
+    switch (block)
+    {
+        case NotepadDocument::BlockStyle::heading1: return bodySize + 11.0f;
+        case NotepadDocument::BlockStyle::heading2: return bodySize + 7.0f;
+        case NotepadDocument::BlockStyle::heading3: return bodySize + 3.5f;
+        default: return bodySize;
+    }
+}
+
+float blockRowHeight (NotepadDocument::BlockStyle block, float bodySize) noexcept
+{
+    const auto fontSize = blockFontSize (block, bodySize);
+    return std::ceil (fontSize * (isHeading (block) ? 1.32f : 1.48f));
+}
+
+float blockIndent (NotepadDocument::BlockStyle block) noexcept
+{
+    if (isList (block))
+        return 30.0f;
+    return block == NotepadDocument::BlockStyle::quote ? 18.0f : 0.0f;
+}
+
+Layout buildLayout (const NotepadDocument& document, float width, float bodySize,
+                    const MeasureFn& measure)
+{
+    Layout layout;
+    const auto& text = document.documentText();
+    float y = 0.0f;
+    std::size_t lineStart = 0;
+
+    while (lineStart <= text.size())
+    {
+        const auto found = text.find ('\n', lineStart);
+        const auto lineEnd = found == std::string::npos ? text.size() : found;
+        const auto info = document.lineInfoAt (lineStart);
+        const auto fontSize = blockFontSize (info.block, bodySize);
+        const auto rowHeight = blockRowHeight (info.block, bodySize);
+        const auto indent = blockIndent (info.block);
+        const auto wrapWidth = std::max (60.0f, width - indent - 8.0f);
+
+        if (isHeading (info.block) && ! layout.rows.empty())
+            y += 8.0f;
+
+        const auto firstRowIndex = layout.rows.size();
+        auto rowStart = lineStart;
+        if (rowStart == lineEnd)
+        {
+            layout.rows.push_back ({ rowStart, rowStart, lineStart, lineEnd, info.block,
+                                     info, y, rowHeight, indent, true, true });
+            y += rowHeight;
+        }
+        while (rowStart < lineEnd)
+        {
+            auto offset = rowStart;
+            auto rowEnd = rowStart;
+            auto lastBreak = std::string::npos;
+            float used = 0.0f;
+            while (offset < lineEnd)
+            {
+                const auto next = nextOffset (text, offset);
+                const auto advance = measure (offset, std::min (next, lineEnd), fontSize,
+                                              info.block);
+                if (used + advance > wrapWidth && offset > rowStart)
+                {
+                    rowEnd = lastBreak != std::string::npos && lastBreak > rowStart
+                           ? lastBreak : offset;
+                    break;
+                }
+                used += advance;
+                rowEnd = std::min (next, lineEnd);
+                if (text[offset] == ' ' || text[offset] == '\t')
+                    lastBreak = rowEnd;
+                offset = rowEnd;
+            }
+            if (rowEnd == rowStart)
+                rowEnd = std::min (nextOffset (text, rowStart), lineEnd);
+            layout.rows.push_back ({ rowStart, rowEnd, lineStart, lineEnd, info.block, info,
+                                     y, rowHeight, indent,
+                                     layout.rows.size() == firstRowIndex, rowEnd == lineEnd });
+            y += rowHeight;
+            rowStart = rowEnd;
+        }
+
+        if (isHeading (info.block))
+            y += 4.0f;
+        else if (info.block == NotepadDocument::BlockStyle::quote)
+            y += 2.0f;
+
+        if (found == std::string::npos)
+            break;
+        lineStart = found + 1;
+    }
+
+    layout.contentHeight = std::max (y, bodySize);
+    return layout;
+}
+
+std::size_t Layout::rowForOffset (std::size_t offset, bool preferRowEnd) const noexcept
+{
+    if (rows.empty())
+        return 0;
+
+    std::size_t match = 0;
+    bool found = false;
+    for (std::size_t i = 0; i < rows.size(); ++i)
+    {
+        if (rows[i].start > offset)
+            break;
+        if (offset > rows[i].end)
+            continue;
+        match = i;
+        found = true;
+        if (offset < rows[i].end || preferRowEnd)
+            break;
+    }
+    return found ? match : rows.size() - 1;
+}
+
+std::size_t Layout::rowAtY (float y) const noexcept
+{
+    if (rows.empty())
+        return 0;
+    for (std::size_t i = 0; i < rows.size(); ++i)
+        if (y < rows[i].y + rows[i].height)
+            return i;
+    return rows.size() - 1;
+}
+
+float offsetX (const NotepadDocument& document, const Row& row, std::size_t offset,
+               float bodySize, const MeasureFn& measure)
+{
+    const auto& text = document.documentText();
+    const auto fontSize = blockFontSize (row.block, bodySize);
+    offset = std::clamp (offset, row.start, std::min (row.end, text.size()));
+
+    float x = 0.0f;
+    for (auto runStart = row.start; runStart < offset;)
+    {
+        const auto style = document.styleAt (runStart);
+        auto runEnd = nextOffset (text, runStart);
+        while (runEnd < offset && document.styleAt (runEnd) == style)
+            runEnd = nextOffset (text, runEnd);
+        runEnd = std::min (runEnd, offset);
+        x += measure (runStart, runEnd, fontSize, row.block);
+        runStart = runEnd;
+    }
+    return x;
+}
+
+std::size_t offsetAtX (const NotepadDocument& document, const Row& row, float localX,
+                       float bodySize, const MeasureFn& measure)
+{
+    const auto& text = document.documentText();
+    const auto fontSize = blockFontSize (row.block, bodySize);
+    float x = 0.0f;
+    for (auto offset = row.start; offset < row.end;)
+    {
+        const auto next = std::min (nextOffset (text, offset), row.end);
+        const auto advance = measure (offset, next, fontSize, row.block);
+        if (localX < x + advance * 0.5f)
+            return offset;
+        x += advance;
+        offset = next;
+    }
+    return row.end;
+}
+
+void UndoStack::clear() noexcept
+{
+    undoEntries.clear();
+    redoEntries.clear();
+    runBroken = true;
+}
+
+void UndoStack::breakRun() noexcept
+{
+    runBroken = true;
+}
+
+void UndoStack::record (EditKind kind, Snapshot before, std::size_t caretAfter)
+{
+    redoEntries.clear();
+
+    const bool coalesce = ! runBroken
+                       && kind != EditKind::structural
+                       && ! undoEntries.empty()
+                       && undoEntries.back().kind == kind
+                       && undoEntries.back().state.selectionIsSource == before.selectionIsSource
+                       && undoEntries.back().caretAfter == before.selection.start
+                       && before.selection.empty();
+    runBroken = kind == EditKind::structural;
+
+    if (coalesce)
+    {
+        undoEntries.back().caretAfter = caretAfter;
+        return;
+    }
+
+    undoEntries.push_back ({ kind, std::move (before), caretAfter });
+    if (undoEntries.size() > kMaxEntries)
+        undoEntries.erase (undoEntries.begin());
+}
+
+bool UndoStack::undo (const Snapshot& current, Snapshot& restored)
+{
+    if (undoEntries.empty())
+        return false;
+
+    redoEntries.push_back ({ EditKind::structural, current, current.selection.end });
+    if (redoEntries.size() > kMaxEntries)
+        redoEntries.erase (redoEntries.begin());
+    restored = std::move (undoEntries.back().state);
+    undoEntries.pop_back();
+    runBroken = true;
+    return true;
+}
+
+bool UndoStack::redo (const Snapshot& current, Snapshot& restored)
+{
+    if (redoEntries.empty())
+        return false;
+
+    undoEntries.push_back ({ EditKind::structural, current, current.selection.end });
+    if (undoEntries.size() > kMaxEntries)
+        undoEntries.erase (undoEntries.begin());
+    restored = std::move (redoEntries.back().state);
+    redoEntries.pop_back();
+    runBroken = true;
+    return true;
+}
+} // namespace notepad
+} // namespace duskstudio

--- a/src/ui/NotepadEditorCore.cpp
+++ b/src/ui/NotepadEditorCore.cpp
@@ -234,6 +234,29 @@ bool acceptsTextInput (bool control, bool alt, bool super) noexcept
     return ! super && (! control || alt);
 }
 
+std::string encodeMarkdownLinkTarget (const std::string& target)
+{
+    static constexpr char hexDigits[] = "0123456789ABCDEF";
+    std::string encoded;
+    encoded.reserve (target.size());
+    for (const auto ch : target)
+    {
+        const auto byte = static_cast<unsigned char> (ch);
+        if (byte <= 0x20 || byte == 0x7f || ch == '(' || ch == ')' || ch == '['
+            || ch == ']' || ch == '<' || ch == '>' || ch == '"' || ch == '\\')
+        {
+            encoded.push_back ('%');
+            encoded.push_back (hexDigits[byte >> 4]);
+            encoded.push_back (hexDigits[byte & 0x0f]);
+        }
+        else
+        {
+            encoded.push_back (ch);
+        }
+    }
+    return encoded;
+}
+
 bool markdownInlineActive (const std::string& markdown,
                            NotepadDocument::Selection selection,
                            const std::string& prefix,

--- a/src/ui/NotepadEditorCore.h
+++ b/src/ui/NotepadEditorCore.h
@@ -29,6 +29,29 @@ struct Range
 Range wordAt (const std::string& text, std::size_t offset) noexcept;
 void appendUtf8 (std::string& text, unsigned int codepoint);
 
+// AltGr is reported by ImGui as Ctrl+Alt on platforms that use it. Treat that
+// pair as text input while keeping Ctrl-only and Super combinations available
+// for editor commands.
+bool acceptsTextInput (bool control, bool alt, bool super) noexcept;
+
+struct MarkdownTransform
+{
+    std::string markdown;
+    NotepadDocument::Selection selection;
+};
+
+bool markdownInlineActive (const std::string& markdown,
+                           NotepadDocument::Selection selection,
+                           const std::string& prefix,
+                           const std::string& suffix);
+MarkdownTransform toggleMarkdownInline (const std::string& markdown,
+                                        NotepadDocument::Selection selection,
+                                        const std::string& prefix,
+                                        const std::string& suffix);
+MarkdownTransform setMarkdownBlockStyle (const std::string& markdown,
+                                         NotepadDocument::Selection selection,
+                                         NotepadDocument::BlockStyle style);
+
 bool isHeading (NotepadDocument::BlockStyle block) noexcept;
 bool isList (NotepadDocument::BlockStyle block) noexcept;
 float blockFontSize (NotepadDocument::BlockStyle block, float bodySize) noexcept;

--- a/src/ui/NotepadEditorCore.h
+++ b/src/ui/NotepadEditorCore.h
@@ -34,6 +34,11 @@ void appendUtf8 (std::string& text, unsigned int codepoint);
 // for editor commands.
 bool acceptsTextInput (bool control, bool alt, bool super) noexcept;
 
+// Produces a target safe for this editor's Markdown link parser. Percent
+// encoding avoids both early ')' termination and backslashes leaking into the
+// URL returned by NotepadDocument::linkTargetAt().
+std::string encodeMarkdownLinkTarget (const std::string& target);
+
 struct MarkdownTransform
 {
     std::string markdown;

--- a/src/ui/NotepadEditorCore.h
+++ b/src/ui/NotepadEditorCore.h
@@ -13,6 +13,8 @@ namespace notepad
 {
 std::size_t nextOffset (const std::string& text, std::size_t offset) noexcept;
 std::size_t previousOffset (const std::string& text, std::size_t offset) noexcept;
+// Rounds an offset down onto the start of the codepoint that contains it.
+std::size_t snapToBoundary (const std::string& text, std::size_t offset) noexcept;
 std::size_t lineStartOffset (const std::string& text, std::size_t offset) noexcept;
 std::size_t lineEndOffset (const std::string& text, std::size_t offset) noexcept;
 std::size_t wordLeft (const std::string& text, std::size_t offset) noexcept;

--- a/src/ui/NotepadEditorCore.h
+++ b/src/ui/NotepadEditorCore.h
@@ -1,0 +1,124 @@
+#pragma once
+
+#include "NotepadDocument.h"
+
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace duskstudio
+{
+namespace notepad
+{
+std::size_t nextOffset (const std::string& text, std::size_t offset) noexcept;
+std::size_t previousOffset (const std::string& text, std::size_t offset) noexcept;
+std::size_t lineStartOffset (const std::string& text, std::size_t offset) noexcept;
+std::size_t lineEndOffset (const std::string& text, std::size_t offset) noexcept;
+std::size_t wordLeft (const std::string& text, std::size_t offset) noexcept;
+std::size_t wordRight (const std::string& text, std::size_t offset) noexcept;
+
+struct Range
+{
+    std::size_t start = 0;
+    std::size_t end = 0;
+};
+
+Range wordAt (const std::string& text, std::size_t offset) noexcept;
+void appendUtf8 (std::string& text, unsigned int codepoint);
+
+bool isHeading (NotepadDocument::BlockStyle block) noexcept;
+bool isList (NotepadDocument::BlockStyle block) noexcept;
+float blockFontSize (NotepadDocument::BlockStyle block, float bodySize) noexcept;
+float blockRowHeight (NotepadDocument::BlockStyle block, float bodySize) noexcept;
+float blockIndent (NotepadDocument::BlockStyle block) noexcept;
+
+// Width of documentText()[begin, end) drawn at fontSize inside a block of the
+// given style. The renderer supplies the font metrics; the layout math stays
+// free of any toolkit so it can be unit tested against a synthetic advance.
+using MeasureFn = std::function<float (std::size_t begin, std::size_t end, float fontSize,
+                                       NotepadDocument::BlockStyle block)>;
+
+struct Row
+{
+    std::size_t start = 0;
+    std::size_t end = 0;
+    std::size_t lineStart = 0;
+    std::size_t lineEnd = 0;
+    NotepadDocument::BlockStyle block = NotepadDocument::BlockStyle::body;
+    NotepadDocument::LineInfo lineInfo;
+    float y = 0.0f;
+    float height = 0.0f;
+    float indent = 0.0f;
+    bool firstRowOfLine = false;
+    bool lastRowOfLine = false;
+};
+
+struct Layout
+{
+    std::vector<Row> rows;
+    float contentHeight = 0.0f;
+
+    // A caret at a soft-wrap boundary belongs to two rows. preferRowEnd picks
+    // the row that ends there (End, or a click past the last glyph); otherwise
+    // the caret rides the following row, which is where typing continues.
+    std::size_t rowForOffset (std::size_t offset, bool preferRowEnd) const noexcept;
+    std::size_t rowAtY (float y) const noexcept;
+};
+
+Layout buildLayout (const NotepadDocument& document, float width, float bodySize,
+                    const MeasureFn& measure);
+float offsetX (const NotepadDocument& document, const Row& row, std::size_t offset,
+               float bodySize, const MeasureFn& measure);
+std::size_t offsetAtX (const NotepadDocument& document, const Row& row, float localX,
+                       float bodySize, const MeasureFn& measure);
+
+enum class EditKind
+{
+    typing,
+    deleting,
+    structural
+};
+
+struct Snapshot
+{
+    std::string markdown;
+    NotepadDocument::Selection selection;
+    // Selections are recorded in the coordinate space of the mode that made the
+    // edit; the restoring side maps them when the mode has changed since.
+    bool selectionIsSource = false;
+};
+
+class UndoStack final
+{
+public:
+    static constexpr std::size_t kMaxEntries = 256;
+
+    void clear() noexcept;
+    // Ends the current coalescing run, so the next edit starts a fresh step.
+    void breakRun() noexcept;
+
+    void record (EditKind kind, Snapshot before, std::size_t caretAfter);
+
+    bool canUndo() const noexcept { return ! undoEntries.empty(); }
+    bool canRedo() const noexcept { return ! redoEntries.empty(); }
+    bool undo (const Snapshot& current, Snapshot& restored);
+    bool redo (const Snapshot& current, Snapshot& restored);
+
+    std::size_t undoDepth() const noexcept { return undoEntries.size(); }
+    std::size_t redoDepth() const noexcept { return redoEntries.size(); }
+
+private:
+    struct Entry
+    {
+        EditKind kind = EditKind::structural;
+        Snapshot state;
+        std::size_t caretAfter = 0;
+    };
+
+    std::vector<Entry> undoEntries;
+    std::vector<Entry> redoEntries;
+    bool runBroken = true;
+};
+} // namespace notepad
+} // namespace duskstudio

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -127,7 +127,9 @@ add_executable(dusk-studio-tests
     session_automation_load_publish.cpp
     session_notepad_sidecar.cpp
     notepad_document.cpp
+    notepad_editor_core.cpp
     ${CMAKE_SOURCE_DIR}/src/ui/NotepadDocument.cpp
+    ${CMAKE_SOURCE_DIR}/src/ui/NotepadEditorCore.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/MidiTimeCodeReceiver.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/MidiTimeCodeEmitter.cpp
     ${CMAKE_SOURCE_DIR}/src/session/Session.cpp

--- a/tests/notepad_document.cpp
+++ b/tests/notepad_document.cpp
@@ -96,6 +96,17 @@ TEST_CASE ("Notepad document edits preserve wrappers at formatting boundaries",
                                              NotepadDocument::InlineStyle::italic));
 }
 
+TEST_CASE ("Notepad document projection preserves a typed indentation tab",
+           "[notepad][document][input]")
+{
+    NotepadDocument document;
+    document.setMarkdown ("ab");
+
+    REQUIRE (document.replaceDocumentText ("a\tb"));
+    CHECK (document.markdown() == "a\tb");
+    CHECK (document.documentText() == "a\tb");
+}
+
 TEST_CASE ("Notepad inline commands split and rejoin styled runs safely",
            "[notepad][document]")
 {

--- a/tests/notepad_editor_core.cpp
+++ b/tests/notepad_editor_core.cpp
@@ -76,6 +76,102 @@ TEST_CASE ("Notepad editor word jumps stop at word and line boundaries",
     CHECK (atLineEnd.end == 10);
 }
 
+TEST_CASE ("Notepad editor accepts AltGr text without turning command chords into text",
+           "[notepad][editor][input]")
+{
+    CHECK_FALSE (notepad::acceptsTextInput (true, false, false));  // Ctrl
+    CHECK_FALSE (notepad::acceptsTextInput (false, false, true));  // Super / Cmd
+    CHECK (notepad::acceptsTextInput (true, true, false));         // Ctrl+Alt / AltGr
+    CHECK (notepad::acceptsTextInput (false, true, false));        // Alt
+    CHECK (notepad::acceptsTextInput (false, false, false));
+}
+
+TEST_CASE ("Notepad Markdown inline commands toggle matching wrappers",
+           "[notepad][editor][markdown]")
+{
+    SECTION ("selection inside wrappers removes them and keeps the label selected")
+    {
+        const auto result = notepad::toggleMarkdownInline ("**bold**", { 2, 6 }, "**", "**");
+        CHECK (result.markdown == "bold");
+        CHECK (result.selection.start == 0);
+        CHECK (result.selection.end == 4);
+    }
+
+    SECTION ("marker-inclusive selection removes markers and selects the label")
+    {
+        const auto result = notepad::toggleMarkdownInline ("**bold**", { 0, 8 }, "**", "**");
+        CHECK (result.markdown == "bold");
+        CHECK (result.selection.start == 0);
+        CHECK (result.selection.end == 4);
+    }
+
+    SECTION ("unformatted selection gains wrappers and keeps the label selected")
+    {
+        const auto result = notepad::toggleMarkdownInline ("bold", { 0, 4 }, "**", "**");
+        CHECK (result.markdown == "**bold**");
+        CHECK (result.selection.start == 2);
+        CHECK (result.selection.end == 6);
+        CHECK (notepad::markdownInlineActive (result.markdown, result.selection,
+                                              "**", "**"));
+    }
+
+    SECTION ("collapsed caret lands between a new empty wrapper pair")
+    {
+        const auto result = notepad::toggleMarkdownInline ("ab", { 1, 1 }, "**", "**");
+        CHECK (result.markdown == "a****b");
+        CHECK (result.selection.start == 3);
+        CHECK (result.selection.end == 3);
+    }
+}
+
+TEST_CASE ("Notepad Markdown block commands preserve source selections",
+           "[notepad][editor][markdown]")
+{
+    using Block = NotepadDocument::BlockStyle;
+
+    SECTION ("single-line add moves the selection with its original text")
+    {
+        const auto result = notepad::setMarkdownBlockStyle ("alpha", { 0, 5 },
+                                                            Block::heading1);
+        CHECK (result.markdown == "# alpha");
+        CHECK (result.selection.start == 2);
+        CHECK (result.selection.end == 7);
+        CHECK (result.markdown.substr (result.selection.start,
+                                      result.selection.end - result.selection.start)
+               == "alpha");
+    }
+
+    SECTION ("single-line remove keeps the content selected")
+    {
+        const auto result = notepad::setMarkdownBlockStyle ("# alpha", { 2, 7 },
+                                                            Block::body);
+        CHECK (result.markdown == "alpha");
+        CHECK (result.selection.start == 0);
+        CHECK (result.selection.end == 5);
+    }
+
+    SECTION ("single-line change tracks a differently-sized prefix")
+    {
+        const auto result = notepad::setMarkdownBlockStyle ("# alpha", { 2, 7 },
+                                                            Block::heading3);
+        CHECK (result.markdown == "### alpha");
+        CHECK (result.selection.start == 4);
+        CHECK (result.selection.end == 9);
+    }
+
+    SECTION ("multi-line edit keeps the first and last selected text boundaries")
+    {
+        const auto result = notepad::setMarkdownBlockStyle (
+            "one\n## two\nthree", { 0, 10 }, Block::bullets);
+        CHECK (result.markdown == "- one\n- two\nthree");
+        CHECK (result.selection.start == 2);
+        CHECK (result.selection.end == 11);
+        CHECK (result.markdown.substr (result.selection.start,
+                                      result.selection.end - result.selection.start)
+               == "one\n- two");
+    }
+}
+
 TEST_CASE ("Notepad editor resolves the line a new break ends",
            "[notepad][editor]")
 {

--- a/tests/notepad_editor_core.cpp
+++ b/tests/notepad_editor_core.cpp
@@ -43,6 +43,14 @@ TEST_CASE ("Notepad editor UTF-8 caret movement steps whole codepoints",
     CHECK (notepad::previousOffset (text, 3) == 1);
     CHECK (notepad::previousOffset (text, 1) == 0);
     CHECK (notepad::previousOffset (text, 0) == 0);
+
+    // A caret restored from an older projection can land mid-sequence; snapping
+    // is what keeps the next edit from splitting the codepoint.
+    CHECK (notepad::snapToBoundary (text, 2) == 1);
+    CHECK (notepad::snapToBoundary (text, 4) == 3);
+    CHECK (notepad::snapToBoundary (text, 5) == 3);
+    CHECK (notepad::snapToBoundary (text, 6) == 6);
+    CHECK (notepad::snapToBoundary (text, 99) == text.size());
 }
 
 TEST_CASE ("Notepad editor word jumps stop at word and line boundaries",
@@ -66,6 +74,19 @@ TEST_CASE ("Notepad editor word jumps stop at word and line boundaries",
     const auto atLineEnd = notepad::wordAt (text, 10);
     CHECK (atLineEnd.start == 6);
     CHECK (atLineEnd.end == 10);
+}
+
+TEST_CASE ("Notepad editor resolves the line a new break ends",
+           "[notepad][editor]")
+{
+    // List continuation probes the line the inserted break terminates. On a
+    // blank line that is the blank line itself, not the line above it, or
+    // Enter would revive a marker the user just dismissed.
+    const std::string text = "one\n\n";
+
+    CHECK (notepad::lineStartOffset (text, 4) == 4);
+    CHECK (notepad::lineStartOffset (text, 3) == 0);
+    CHECK (notepad::lineEndOffset (text, 4) == 4);
 }
 
 TEST_CASE ("Notepad editor layout wraps body text at the content width",
@@ -152,6 +173,41 @@ TEST_CASE ("Notepad editor hit testing round-trips against caret positions",
     CHECK (notepad::offsetAtX (document, row, 1000.0f, 10.0f, measure) == row.end);
 }
 
+TEST_CASE ("Notepad editor layout walks multi-byte text by codepoint",
+           "[notepad][editor][layout]")
+{
+    NotepadDocument document;
+    document.setMarkdown ("héllo wörld – ünïcode");
+
+    const auto& text = document.documentText();
+    const auto measure = fixedAdvance (10.0f, 10.0f);
+    const auto layout = notepad::buildLayout (document, 108.0f, 10.0f, measure);
+
+    REQUIRE (layout.rows.size() > 1);
+    for (const auto& row : layout.rows)
+    {
+        // No row may start or end inside a UTF-8 sequence.
+        CHECK (notepad::snapToBoundary (text, row.start) == row.start);
+        CHECK (notepad::snapToBoundary (text, row.end) == row.end);
+    }
+
+    const auto& row = layout.rows.front();
+    for (auto offset = row.start; offset <= row.end;
+         offset = notepad::nextOffset (text, offset))
+    {
+        const auto x = notepad::offsetX (document, row, offset, 10.0f, measure);
+        CHECK (notepad::offsetAtX (document, row, x, 10.0f, measure) == offset);
+        if (offset == row.end)
+            break;
+    }
+
+    // Rejoining the rows reproduces the line, so no byte was dropped or split.
+    std::string rebuilt;
+    for (const auto& r : layout.rows)
+        rebuilt += rowText (document, r);
+    CHECK (rebuilt == text);
+}
+
 TEST_CASE ("Notepad editor rows resolve caret rows at wrap boundaries",
            "[notepad][editor][layout]")
 {
@@ -229,6 +285,21 @@ TEST_CASE ("Notepad editor undo breaks runs on caret moves and structural edits"
     history.record (notepad::EditKind::typing, { "**ab**", { 2, 2 }, false }, 3);
     CHECK (history.undoDepth() == depthAfterUndo + 1);
     CHECK_FALSE (history.canRedo());
+}
+
+TEST_CASE ("Notepad editor undo never coalesces across editing modes",
+           "[notepad][editor][undo]")
+{
+    notepad::UndoStack history;
+
+    // Document mode records projected offsets, Markdown mode source offsets.
+    // They can meet at the same number and still mean different places.
+    history.record (notepad::EditKind::typing, { "a", { 1, 1 }, false }, 2);
+    history.record (notepad::EditKind::typing, { "ab", { 2, 2 }, true }, 3);
+    CHECK (history.undoDepth() == 2);
+
+    history.record (notepad::EditKind::typing, { "abc", { 3, 3 }, true }, 4);
+    CHECK (history.undoDepth() == 2);
 }
 
 TEST_CASE ("Notepad editor undo replacing a selection is its own step",

--- a/tests/notepad_editor_core.cpp
+++ b/tests/notepad_editor_core.cpp
@@ -1,0 +1,259 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "ui/NotepadEditorCore.h"
+
+#include <string>
+
+using duskstudio::NotepadDocument;
+namespace notepad = duskstudio::notepad;
+
+namespace
+{
+// One unit of width per byte, scaled by the block's font size, so wrap points
+// are exact multiples of the content width in the assertions below.
+notepad::MeasureFn fixedAdvance (float perByteAtBodySize, float bodySize)
+{
+    return [perByteAtBodySize, bodySize] (std::size_t begin, std::size_t end, float fontSize,
+                                          NotepadDocument::BlockStyle)
+    {
+        return static_cast<float> (end - begin) * perByteAtBodySize * (fontSize / bodySize);
+    };
+}
+
+std::string rowText (const NotepadDocument& document, const notepad::Row& row)
+{
+    return document.documentText().substr (row.start, row.end - row.start);
+}
+} // namespace
+
+TEST_CASE ("Notepad editor UTF-8 caret movement steps whole codepoints",
+           "[notepad][editor]")
+{
+    const std::string text = "aé漢z";
+
+    CHECK (notepad::nextOffset (text, 0) == 1);
+    CHECK (notepad::nextOffset (text, 1) == 3);
+    CHECK (notepad::nextOffset (text, 3) == 6);
+    CHECK (notepad::nextOffset (text, 6) == 7);
+    CHECK (notepad::nextOffset (text, 7) == 7);
+
+    CHECK (notepad::previousOffset (text, 7) == 6);
+    CHECK (notepad::previousOffset (text, 6) == 3);
+    CHECK (notepad::previousOffset (text, 3) == 1);
+    CHECK (notepad::previousOffset (text, 1) == 0);
+    CHECK (notepad::previousOffset (text, 0) == 0);
+}
+
+TEST_CASE ("Notepad editor word jumps stop at word and line boundaries",
+           "[notepad][editor]")
+{
+    const std::string text = "alpha beta\ngamma";
+
+    CHECK (notepad::wordRight (text, 0) == 6);
+    CHECK (notepad::wordRight (text, 6) == 10);
+    // The line break is a stop of its own so a word jump never skips a line.
+    CHECK (notepad::wordRight (text, 10) == 11);
+
+    CHECK (notepad::wordLeft (text, 10) == 6);
+    CHECK (notepad::wordLeft (text, 6) == 0);
+    CHECK (notepad::wordLeft (text, 11) == 10);
+
+    const auto word = notepad::wordAt (text, 8);
+    CHECK (word.start == 6);
+    CHECK (word.end == 10);
+
+    const auto atLineEnd = notepad::wordAt (text, 10);
+    CHECK (atLineEnd.start == 6);
+    CHECK (atLineEnd.end == 10);
+}
+
+TEST_CASE ("Notepad editor layout wraps body text at the content width",
+           "[notepad][editor][layout]")
+{
+    NotepadDocument document;
+    document.setMarkdown ("alpha beta gamma delta");
+
+    // 10 units per byte, 68 units of content: 6 bytes fit per row after the
+    // layout's 8 unit right gutter.
+    const auto layout = notepad::buildLayout (document, 68.0f, 10.0f,
+                                              fixedAdvance (10.0f, 10.0f));
+
+    REQUIRE (layout.rows.size() == 4);
+    CHECK (rowText (document, layout.rows[0]) == "alpha ");
+    CHECK (rowText (document, layout.rows[1]) == "beta ");
+    CHECK (rowText (document, layout.rows[2]) == "gamma ");
+    CHECK (rowText (document, layout.rows[3]) == "delta");
+    CHECK (layout.rows[0].firstRowOfLine);
+    CHECK_FALSE (layout.rows[1].firstRowOfLine);
+    CHECK (layout.rows[3].lastRowOfLine);
+    CHECK (layout.contentHeight > 0.0f);
+
+    // Rows tile the line without gaps or overlap.
+    for (std::size_t i = 1; i < layout.rows.size(); ++i)
+        CHECK (layout.rows[i].start == layout.rows[i - 1].end);
+}
+
+TEST_CASE ("Notepad editor layout gives headings their own metrics",
+           "[notepad][editor][layout]")
+{
+    NotepadDocument document;
+    document.setMarkdown ("# Heading here\nbody");
+
+    const auto layout = notepad::buildLayout (document, 400.0f, 10.0f,
+                                              fixedAdvance (2.0f, 10.0f));
+
+    REQUIRE (layout.rows.size() >= 2);
+    CHECK (layout.rows.front().block == NotepadDocument::BlockStyle::heading1);
+    // The projection hides "# ", so the row text is the heading content only.
+    CHECK (rowText (document, layout.rows.front()) == "Heading here");
+    CHECK (layout.rows.front().height > layout.rows.back().height);
+    CHECK (layout.rows.back().block == NotepadDocument::BlockStyle::body);
+}
+
+TEST_CASE ("Notepad editor layout indents list lines and keeps marker data",
+           "[notepad][editor][layout]")
+{
+    NotepadDocument document;
+    document.setMarkdown ("- first\n- second\n\n1. one\n2. two\n- [x] done");
+
+    const auto layout = notepad::buildLayout (document, 400.0f, 10.0f,
+                                              fixedAdvance (2.0f, 10.0f));
+
+    REQUIRE (layout.rows.size() == 6);
+    CHECK (rowText (document, layout.rows[0]) == "first");
+    CHECK (layout.rows[0].indent > 0.0f);
+    CHECK (layout.rows[2].start == layout.rows[2].end); // the blank line
+    CHECK (layout.rows[3].block == NotepadDocument::BlockStyle::numbers);
+    CHECK (layout.rows[3].lineInfo.orderedNumber == 1);
+    CHECK (layout.rows[4].lineInfo.orderedNumber == 2);
+    CHECK (layout.rows[5].block == NotepadDocument::BlockStyle::tasks);
+    CHECK (layout.rows[5].lineInfo.taskChecked);
+    CHECK (rowText (document, layout.rows[5]) == "done");
+}
+
+TEST_CASE ("Notepad editor hit testing round-trips against caret positions",
+           "[notepad][editor][layout]")
+{
+    NotepadDocument document;
+    document.setMarkdown ("alpha beta gamma delta");
+
+    const auto measure = fixedAdvance (10.0f, 10.0f);
+    const auto layout = notepad::buildLayout (document, 68.0f, 10.0f, measure);
+    REQUIRE (layout.rows.size() == 4);
+
+    const auto& row = layout.rows[1];
+    for (auto offset = row.start; offset <= row.end; ++offset)
+    {
+        const auto x = notepad::offsetX (document, row, offset, 10.0f, measure);
+        CHECK (notepad::offsetAtX (document, row, x, 10.0f, measure) == offset);
+    }
+    // Past the end of a row the caret lands on the row's last boundary.
+    CHECK (notepad::offsetAtX (document, row, 1000.0f, 10.0f, measure) == row.end);
+}
+
+TEST_CASE ("Notepad editor rows resolve caret rows at wrap boundaries",
+           "[notepad][editor][layout]")
+{
+    NotepadDocument document;
+    document.setMarkdown ("alpha beta gamma delta");
+
+    const auto layout = notepad::buildLayout (document, 68.0f, 10.0f,
+                                              fixedAdvance (10.0f, 10.0f));
+    REQUIRE (layout.rows.size() == 4);
+    const auto boundary = layout.rows[0].end;
+    REQUIRE (boundary == layout.rows[1].start);
+
+    CHECK (layout.rowForOffset (boundary, false) == 1);
+    CHECK (layout.rowForOffset (boundary, true) == 0);
+    CHECK (layout.rowForOffset (0, false) == 0);
+    CHECK (layout.rowForOffset (document.documentText().size(), false)
+           == layout.rows.size() - 1);
+}
+
+TEST_CASE ("Notepad editor undo coalesces a typing run into one step",
+           "[notepad][editor][undo]")
+{
+    notepad::UndoStack history;
+
+    const auto typed = [&history] (const std::string& before, std::size_t caret)
+    {
+        history.record (notepad::EditKind::typing, { before, { caret, caret }, false },
+                        caret + 1);
+    };
+
+    typed ("", 0);
+    typed ("a", 1);
+    typed ("ab", 2);
+    CHECK (history.undoDepth() == 1);
+
+    notepad::Snapshot restored;
+    REQUIRE (history.undo ({ "abc", { 3, 3 }, false }, restored));
+    CHECK (restored.markdown.empty());
+    CHECK (restored.selection.start == 0);
+    CHECK (history.undoDepth() == 0);
+    CHECK (history.canRedo());
+
+    notepad::Snapshot redone;
+    REQUIRE (history.redo ({ "", { 0, 0 }, false }, redone));
+    CHECK (redone.markdown == "abc");
+}
+
+TEST_CASE ("Notepad editor undo breaks runs on caret moves and structural edits",
+           "[notepad][editor][undo]")
+{
+    notepad::UndoStack history;
+
+    history.record (notepad::EditKind::typing, { "", { 0, 0 }, false }, 1);
+    history.record (notepad::EditKind::typing, { "a", { 1, 1 }, false }, 2);
+    CHECK (history.undoDepth() == 1);
+
+    // A caret move between keystrokes starts a new step even though the kind
+    // and the offsets still line up.
+    history.breakRun();
+    history.record (notepad::EditKind::typing, { "ab", { 2, 2 }, false }, 3);
+    CHECK (history.undoDepth() == 2);
+
+    // Deletions never join a typing run, and every toolbar edit stands alone.
+    history.record (notepad::EditKind::deleting, { "abc", { 3, 3 }, false }, 2);
+    CHECK (history.undoDepth() == 3);
+    history.record (notepad::EditKind::structural, { "ab", { 2, 2 }, false }, 2);
+    history.record (notepad::EditKind::structural, { "**ab**", { 2, 2 }, false }, 2);
+    CHECK (history.undoDepth() == 5);
+
+    // Typing after an undo starts a fresh step rather than extending the one
+    // that was just restored.
+    notepad::Snapshot restored;
+    REQUIRE (history.undo ({ "***ab***", { 2, 2 }, false }, restored));
+    const auto depthAfterUndo = history.undoDepth();
+    history.record (notepad::EditKind::typing, { "**ab**", { 2, 2 }, false }, 3);
+    CHECK (history.undoDepth() == depthAfterUndo + 1);
+    CHECK_FALSE (history.canRedo());
+}
+
+TEST_CASE ("Notepad editor undo replacing a selection is its own step",
+           "[notepad][editor][undo]")
+{
+    notepad::UndoStack history;
+
+    history.record (notepad::EditKind::typing, { "", { 0, 0 }, false }, 1);
+    // Typing over a selection starts at the same offset the previous run ended
+    // at, but it must not be folded into it.
+    history.record (notepad::EditKind::typing, { "a", { 1, 4 }, false }, 2);
+    CHECK (history.undoDepth() == 2);
+}
+
+TEST_CASE ("Notepad editor undo history is bounded", "[notepad][editor][undo]")
+{
+    notepad::UndoStack history;
+
+    for (std::size_t i = 0; i < notepad::UndoStack::kMaxEntries + 20; ++i)
+        history.record (notepad::EditKind::structural,
+                        { std::string (i, 'x'), { i, i }, false }, i);
+
+    CHECK (history.undoDepth() == notepad::UndoStack::kMaxEntries);
+
+    notepad::Snapshot restored;
+    REQUIRE (history.undo ({ "current", { 0, 0 }, false }, restored));
+    CHECK (restored.markdown.size() == notepad::UndoStack::kMaxEntries + 19);
+}

--- a/tests/notepad_editor_core.cpp
+++ b/tests/notepad_editor_core.cpp
@@ -86,6 +86,20 @@ TEST_CASE ("Notepad editor accepts AltGr text without turning command chords int
     CHECK (notepad::acceptsTextInput (false, false, false));
 }
 
+TEST_CASE ("Notepad Markdown link targets encode parser delimiters and controls",
+           "[notepad][editor][markdown]")
+{
+    const auto encoded = notepad::encodeMarkdownLinkTarget (
+        "https://example.test/a b)\n[x]\\tail");
+    CHECK (encoded == "https://example.test/a%20b%29%0A%5Bx%5D%5Ctail");
+    CHECK (notepad::encodeMarkdownLinkTarget (encoded) == encoded);
+
+    NotepadDocument document;
+    document.setMarkdown ("[label](" + encoded + ")");
+    CHECK (document.documentText() == "label");
+    CHECK (document.linkTargetAt (0) == encoded);
+}
+
 TEST_CASE ("Notepad Markdown inline commands toggle matching wrappers",
            "[notepad][editor][markdown]")
 {
@@ -169,6 +183,18 @@ TEST_CASE ("Notepad Markdown block commands preserve source selections",
         CHECK (result.markdown.substr (result.selection.start,
                                       result.selection.end - result.selection.start)
                == "one\n- two");
+    }
+
+    SECTION ("numbered lines receive sequential markers and preserve outer text bounds")
+    {
+        const auto result = notepad::setMarkdownBlockStyle (
+            "alpha\nbeta", { 0, 10 }, Block::numbers);
+        CHECK (result.markdown == "1. alpha\n2. beta");
+        CHECK (result.selection.start == 3);
+        CHECK (result.selection.end == 16);
+        CHECK (result.markdown.substr (result.selection.start,
+                                      result.selection.end - result.selection.start)
+               == "alpha\n2. beta");
     }
 }
 


### PR DESCRIPTION
## What

- replace the session notepad text area with a custom DGL/ImGui document editor with wrapped layout, selection, formatting, Markdown/source mode, and coherent undo
- let the host own the native child dimming and click-away dismissal, then restore focus and save on close without a Done control
- keep failed saves dirty for retry and close the AltGr, Markdown toggle, and block-selection invariants found during adversarial review
- add toolkit-free regression coverage for input acceptance and Markdown transformations

## Why

The embedded document editor needs editor-grade interaction and a close flow that belongs to the host window rather than to content inside the native child. The final invariants also prevent text loss or surprising selection movement around international input and Markdown formatting.

## Validation

- production DuskStudio target builds
- focused notepad suite: 28 cases / 241 assertions
- full CTest suite: 567/567 passed
- JUCE gate: 179 coupled source files / 9,256 uses (no increase)
- `git diff --check` clean

Live native-child stacking, click-away edges, resize/HiDPI behavior, focus restoration, an actual unwritable-directory retry, and the np-12 screenshot remain manual checks on a usable Wayland/GLX session; the private validation display here cannot create the required DGL context.

Refs #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a richer notepad editor with text selection, navigation, Markdown formatting, links, task lists, clipboard actions, and undo/redo.
  - Improved scrolling, caret movement, layout, themes, and keyboard shortcuts.
  - Added clearer visual blocking while the notepad is open.

- **Bug Fixes**
  - Improved handling of failed note saves and embedding failures.
  - Preserved focus and interaction behavior when opening or closing the editor.

- **Documentation**
  - Expanded notepad guidance for editing, shortcuts, links, clipboard operations, and retrying failed saves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->