### PR TITLE
fix(packaging): ship plugin-host in Windows MSI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to Dusk Studio. Format loosely follows
 back-filled from `git log`; once tags exist this file is the
 canonical source.
 
+## [0.13.0] - Unreleased
+
+### Fixed
+
+- **Windows plug-in scanning.** The MSI now includes
+  `dusk-studio-plugin-host.exe` beside the main application. The helper was
+  built but omitted from CMake's install set, so every third-party plug-in was
+  deliberately left unscanned and the scan completed immediately with a
+  sandbox-host-unavailable warning. The Windows packaging script now validates
+  the staged install contains both executables before creating the MSI.
+  (Ported from the 0.12.7 fix on `release/0.12`.)
+
 ## [0.12.6] - 2026-07-25
 
 Beta patch on the 0.12 line: manual recording latency compensation for

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1393,6 +1393,16 @@ endif()
 install(TARGETS DuskStudio
         RUNTIME DESTINATION bin
         BUNDLE  DESTINATION .)
+# On Linux/Windows the plugin host is a separate executable that the main app
+# resolves beside itself.  Building it as a dependency is not enough: CPack
+# only packages targets with install rules, so omitting this target left the
+# Windows MSI without the sandbox scanner (issue #116).  The macOS helper is
+# already inside DuskStudio.app/Contents/MacOS because its runtime output is
+# directed beside the app executable, and installing the bundle carries it.
+if(TARGET dusk-studio-plugin-host AND NOT APPLE)
+    install(TARGETS dusk-studio-plugin-host
+            RUNTIME DESTINATION bin)
+endif()
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/packaging/audio.dusk.studio.desktop"
         DESTINATION share/applications)
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/packaging/DuskStudio.appdata.xml"

--- a/scripts/package-windows.ps1
+++ b/scripts/package-windows.ps1
@@ -29,6 +29,28 @@ if (-not (Get-Command "candle.exe" -ErrorAction SilentlyContinue)) {
     Write-Error "WIX Toolset not on PATH — install from https://wixtoolset.org/"
 }
 
+# CPack consumes CMake's install rules. Validate that layout before building
+# the MSI so a compiled-but-uninstalled helper cannot silently ship again.
+$InstallCheckDir = Join-Path ([System.IO.Path]::GetTempPath()) `
+    ("dusk-studio-install-check-" + [guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $InstallCheckDir | Out-Null
+try {
+    & cmake --install $BuildDir --config Release --prefix $InstallCheckDir
+    if ($LASTEXITCODE -ne 0) {
+        throw "cmake --install validation failed with exit $LASTEXITCODE"
+    }
+
+    foreach ($RequiredExe in @("DuskStudio.exe", "dusk-studio-plugin-host.exe")) {
+        $InstalledExe = Join-Path (Join-Path $InstallCheckDir "bin") $RequiredExe
+        if (-not (Test-Path -PathType Leaf $InstalledExe)) {
+            throw "install layout missing required executable: $InstalledExe"
+        }
+    }
+    Write-Host "Validated install layout: app + plugin scan host"
+} finally {
+    Remove-Item -Recurse -Force $InstallCheckDir -ErrorAction SilentlyContinue
+}
+
 Push-Location $BuildDir
 try {
     & cpack -G WIX -C Release

--- a/tests/multisample_state_roundtrip.cpp
+++ b/tests/multisample_state_roundtrip.cpp
@@ -11,6 +11,27 @@
 
 using Catch::Matchers::WithinAbs;
 
+TEST_CASE ("DuskMultisampleProcessor loads an SFZ file path with spaces", "[multisample][sfz]")
+{
+    const auto sfz = juce::File::getSpecialLocation (juce::File::tempDirectory)
+                         .getNonexistentChildFile ("Dusk SFZ load test", ".sfz", false);
+    struct ScopedFileCleanup
+    {
+        juce::File file;
+        ~ScopedFileCleanup() { file.deleteFile(); }
+    } cleanup { sfz };
+
+    REQUIRE (sfz.replaceWithText ("<region> key=60 sample=*sine\n"));
+
+    duskstudio::DuskMultisampleProcessor processor;
+    juce::String error;
+    REQUIRE (processor.loadSfzFile (sfz, error));
+    REQUIRE (error.isEmpty());
+    REQUIRE (processor.hasLoadedFile());
+    REQUIRE (processor.getLoadedFilePath() == sfz.getFullPathName());
+    REQUIRE (processor.getNumRegions() == 1);
+}
+
 namespace
 {
 // Hand-build a valid two-preset SF2 (both presets share one instrument zone +


### PR DESCRIPTION
Port the 0.12.7 fix from release/0.12 (#117): install dusk-studio-plugin-host beside DuskStudio so CPack stages it, and validate the staged layout in package-windows.ps1 before cpack runs. Without it, 0.13.0 cut from main re-ships #116  every plug-in left unscanned with a sandbox-host-unavailable warning. Also ports the SFZ path-with-spaces regression test bundled in #117.

Closes #180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows plug-in scanning by ensuring the required sandbox helper is included and available during installation.
  * Improved reliability when loading SFZ files from paths containing spaces.

* **Tests**
  * Added regression coverage for SFZ files with space-containing paths.

* **Changelog**
  * Documented the Windows plug-in scanning fix in the upcoming 0.13.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->