### PR TITLE
fix(hosting): drop native editors when their instance is replaced

### DIFF
--- a/src/engine/clap/ClapEditor.cpp
+++ b/src/engine/clap/ClapEditor.cpp
@@ -11,6 +11,7 @@ ClapEditor::~ClapEditor() { close(); }
 bool ClapEditor::open (const ::clap_plugin* p, ClapHost& host, std::string& errorOut)
 {
     if (p == nullptr) { errorOut = "null plugin"; return false; }
+    if (host.isGuiLeaked()) { errorOut = "gui was leaked on a previous close"; return false; }
 
     gui = static_cast<const clap_plugin_gui_t*> (p->get_extension (p, CLAP_EXT_GUI));
     if (gui == nullptr) { errorOut = "plugin has no gui extension"; return false; }
@@ -146,9 +147,34 @@ void ClapEditor::hide()
 
 void ClapEditor::close()
 {
-    // On shutdown, leak the plugin GUI - u-he's gui->destroy hangs. Otherwise tear
-    // it down normally.
-    if (plugin != nullptr && gui != nullptr && ! leakOnClose)
+    // Leak path: the plugin GUI stays created - u-he's gui->destroy hangs. It is
+    // still drawing into our container window over our display connection, so both
+    // are leaked with it rather than pulled out from under a live GUI. Callbacks go
+    // first: the GUI can fire request_resize from its own thread.
+    if (leakOnClose && created)
+    {
+        if (hostPtr != nullptr)
+        {
+            hostPtr->markGuiLeaked();
+            hostPtr->setCallbacks (nullptr);
+            hostPtr = nullptr;
+        }
+        // Unmap rather than destroy: the GUI keeps the window, but an abandoned
+        // editor must not leave it painting over whatever replaces this view.
+        if (platformContext != nullptr && containerHandle != 0)
+        {
+            XUnmapWindow ((Display*) platformContext, (Window) containerHandle);
+            XFlush ((Display*) platformContext);
+        }
+        platformContext = nullptr;
+        containerHandle = 0;
+        gui = nullptr;
+        plugin = nullptr;
+        created = embedded = mapped = false;
+        return;
+    }
+
+    if (plugin != nullptr && gui != nullptr)
     {
         if (gui->hide != nullptr)    gui->hide (plugin);
         if (gui->destroy != nullptr) gui->destroy (plugin);

--- a/src/engine/clap/ClapEditor.h
+++ b/src/engine/clap/ClapEditor.h
@@ -49,6 +49,17 @@ public:
     // quit. close() then skips gui->hide/gui->destroy; the process is exiting anyway.
     void setLeakOnClose (bool b) noexcept { leakOnClose = b; }
 
+    // The plugin was destroyed out from under this editor. Drop every plugin-side
+    // handle WITHOUT calling through it - the vtables went with the bundle - so
+    // close() only releases the container this host owns.
+    void abandonPlugin() noexcept
+    {
+        plugin  = nullptr;
+        gui     = nullptr;
+        hostPtr = nullptr;
+        created = embedded = false;
+    }
+
     // Message thread, ~60 Hz: apply queued GUI callbacks, pump the plugin's
     // fds/timers, and drain any platform editor events.
     void pump (double elapsedMs);

--- a/src/engine/clap/ClapEditor_Mac.mm
+++ b/src/engine/clap/ClapEditor_Mac.mm
@@ -117,7 +117,30 @@ void ClapEditor::hide()
 
 void ClapEditor::close()
 {
-    if (plugin != nullptr && gui != nullptr && ! leakOnClose)
+    // Leak path: the plugin GUI stays created (it hangs in gui->destroy) and keeps
+    // drawing into our container view, so the view is leaked with it rather than
+    // released out from under a live GUI.
+    if (leakOnClose && created)
+    {
+        if (hostPtr != nullptr)
+        {
+            hostPtr->markGuiLeaked();
+            hostPtr->setCallbacks (nullptr);
+            hostPtr = nullptr;
+        }
+        // Detach without releasing: left as a subview, the peer's dealloc would
+        // release the container out from under the live GUI.
+        if (auto* container = containerView (containerHandle); container != nil)
+            [container removeFromSuperview];
+        platformContext = nullptr;
+        containerHandle = 0;
+        gui = nullptr;
+        plugin = nullptr;
+        created = embedded = mapped = false;
+        return;
+    }
+
+    if (plugin != nullptr && gui != nullptr)
     {
         if (gui->hide != nullptr)    gui->hide (plugin);
         if (gui->destroy != nullptr) gui->destroy (plugin);

--- a/src/engine/clap/ClapHost.cpp
+++ b/src/engine/clap/ClapHost.cpp
@@ -168,16 +168,23 @@ void ClapHost::pumpGui (double elapsedMs)
             if (::poll (pfds.data(), (nfds_t) pfds.size(), 0) > 0)
                 for (const auto& p : pfds)   // iterates the local snapshot - on_fd may (un)register
                 {
-                    clap_posix_fd_flags_t f = 0;
-                    if (p.revents & POLLIN)                          f |= CLAP_POSIX_FD_READ;
-                    if (p.revents & POLLOUT)                         f |= CLAP_POSIX_FD_WRITE;
-                    if (p.revents & (POLLERR | POLLHUP | POLLNVAL))  f |= CLAP_POSIX_FD_ERROR;
-                    if (f == 0) continue;
                     // A prior on_fd() in this loop may have unregistered this fd; skip
                     // it so we don't dispatch a stale descriptor (mirrors the timer path).
                     bool stillRegistered = false;
                     for (const auto& r : fds) if (r.fd == p.fd) { stillRegistered = true; break; }
-                    if (stillRegistered) fdSup->on_fd (plugin, p.fd, f);
+                    if (! stillRegistered) continue;
+
+                    // A plugin that closed its fd without unregistering leaves poll
+                    // reporting POLLNVAL immediately on every pump. Drop the
+                    // registration rather than dispatch an error at message-thread
+                    // rate forever.
+                    if (p.revents & POLLNVAL) { (void) unregisterFd (&host, p.fd); continue; }
+
+                    clap_posix_fd_flags_t f = 0;
+                    if (p.revents & POLLIN)                f |= CLAP_POSIX_FD_READ;
+                    if (p.revents & POLLOUT)               f |= CLAP_POSIX_FD_WRITE;
+                    if (p.revents & (POLLERR | POLLHUP))   f |= CLAP_POSIX_FD_ERROR;
+                    if (f != 0) fdSup->on_fd (plugin, p.fd, f);
                 }
         }
     }

--- a/src/engine/clap/ClapHost.h
+++ b/src/engine/clap/ClapHost.h
@@ -57,6 +57,12 @@ public:
     // the message thread. Publish atomically; the trampolines load-acquire before deref.
     void setCallbacks (Callbacks* c) noexcept         { callbacks.store (c, std::memory_order_release); }
 
+    // An editor that closed on the leak path left the plugin's GUI created. CLAP
+    // allows one GUI per instance, so the next editor over this instance must not
+    // call create() again. Latched for the instance's lifetime - message thread.
+    void markGuiLeaked() noexcept    { guiLeaked = true; }
+    bool isGuiLeaked() const noexcept { return guiLeaked; }
+
     // Message thread: poll the plugin's registered fds (level-triggered) and fire
     // its registered timers, so the embedded GUI processes its X11 events + repaints.
     void pumpGui (double elapsedMs);
@@ -93,6 +99,7 @@ private:
 
     const clap_plugin*       plugin = nullptr;
     std::atomic<Callbacks*>  callbacks { nullptr };
+    bool                     guiLeaked = false;
 
     struct RegFd    { int fd; clap_posix_fd_flags_t flags; };
     struct RegTimer { clap_id id; uint32_t periodMs; double accumMs; };

--- a/src/engine/hosting/NativeInsertSlot.h
+++ b/src/engine/hosting/NativeInsertSlot.h
@@ -6,6 +6,7 @@
 #include "SpscRing.h"
 
 #include <atomic>
+#include <cstdint>
 #include <cstring>
 #include <filesystem>
 #include <memory>
@@ -73,6 +74,7 @@ public:
         adapter.prepare (instance->portLayout(), maxBlock);   // size the fold scratch
         loadedPath     = path.u8string();
         loadedPluginId = pickedId;
+        gen.fetch_add (1, std::memory_order_relaxed);
         ready.store (true, std::memory_order_release);
         return true;
     }
@@ -80,6 +82,7 @@ public:
     void unload()
     {
         ready.store (false, std::memory_order_release);
+        gen.fetch_add (1, std::memory_order_relaxed);
         instance.reset();   // destroy the plugin first - its vtables live in the bundle
         bundle.reset();     // then unload the .so / world backing them
         loadedPath.clear();
@@ -106,6 +109,7 @@ public:
     void leakForShutdown() noexcept
     {
         ready.store (false, std::memory_order_release);
+        gen.fetch_add (1, std::memory_order_relaxed);
         (void) instance.release();
         (void) bundle.release();
         loadedPath.clear();
@@ -193,6 +197,12 @@ public:
     Instance* getInstance() noexcept
         { return ready.load (std::memory_order_acquire) ? instance.get() : nullptr; }
 
+    // Bumped on every load / unload. An attached editor pairs this with the
+    // instance pointer it was built against: a reload can place the successor at
+    // the address the previous instance was freed from, which the pointer alone
+    // cannot tell apart. Identity only - it gates no audio read, so relaxed.
+    std::uint64_t generation() const noexcept { return gen.load (std::memory_order_relaxed); }
+
     // MIDI-binding parameter writes
     // The MIDI apply loop runs on the AUDIO thread, but the instances' param
     // rings are single-producer (message thread: host sets + editor edits), so
@@ -228,8 +238,9 @@ protected:
     // Folds the mixer's stereo insert onto the plugin's negotiated layout. Prepared
     // on load / reactivate; owns its own scratch (no plugin refs, teardown order-free).
     InsertAdapter     adapter;
-    std::atomic<bool> ready    { false };
-    std::atomic<bool> bypassed { false };
+    std::atomic<bool>          ready    { false };
+    std::atomic<bool>          bypassed { false };
+    std::atomic<std::uint64_t> gen      { 0 };
     std::string       loadedPath;
     std::string       loadedPluginId;
 

--- a/src/engine/lv2/Lv2Editor.cpp
+++ b/src/engine/lv2/Lv2Editor.cpp
@@ -79,7 +79,7 @@ struct Lv2Editor::Impl
                            (unsigned) w, (unsigned) h);
             XFlush ((Display*) self->display);
         }
-        if (self->owner->onResize) self->owner->onResize (w, h);
+        if (self->owner != nullptr && self->owner->onResize) self->owner->onResize (w, h);
         return 0;
     }
 };
@@ -88,6 +88,7 @@ Lv2Editor::Lv2Editor() : impl (std::make_unique<Impl>()) { impl->owner = this; }
 Lv2Editor::~Lv2Editor() { close(); }
 
 void Lv2Editor::setLeakOnClose (bool b) noexcept { impl->leakOnClose = b; }
+void Lv2Editor::abandonPlugin() noexcept { impl->instance = nullptr; }
 int  Lv2Editor::preferredWidth()  const noexcept { return impl->prefW; }
 int  Lv2Editor::preferredHeight() const noexcept { return impl->prefH; }
 bool Lv2Editor::isOpen()     const noexcept { return impl->discovered; }
@@ -295,6 +296,31 @@ void Lv2Editor::hide()
 
 void Lv2Editor::close()
 {
+    if (impl->leakOnClose && impl->suilInstance != nullptr)
+    {
+        // Shutdown path: the suil instance is deliberately leaked because a
+        // foreign-toolkit UI can hang in its own teardown. That leaked UI still
+        // holds this Impl as its suil controller and ui:resize handle, and draws
+        // into the host window over the Impl's display connection, so the whole
+        // Impl is leaked with it - a UI ticking its own timer would otherwise
+        // write ports through freed memory. The DSP instance is NOT leaked (the
+        // slot may unload it right after), so the pointer to it goes first.
+        impl->owner    = nullptr;
+        impl->instance = nullptr;
+        // Unmap rather than destroy: the UI keeps the window, but an abandoned
+        // editor must not leave it painting over whatever replaces this view.
+        if (impl->display != nullptr && impl->hostWindow != 0)
+        {
+            XUnmapWindow ((Display*) impl->display, (Window) impl->hostWindow);
+            XFlush ((Display*) impl->display);
+        }
+        static auto* leakedAtShutdown = new std::vector<std::unique_ptr<Impl>>;
+        leakedAtShutdown->push_back (std::move (impl));
+        impl = std::make_unique<Impl>();
+        impl->owner = this;
+        return;
+    }
+
     if (! impl->leakOnClose)
     {
         if (impl->suilInstance != nullptr) suil_instance_free (impl->suilInstance);

--- a/src/engine/lv2/Lv2Editor.h
+++ b/src/engine/lv2/Lv2Editor.h
@@ -57,6 +57,11 @@ public:
     // can hang on the way out (same rationale as the CLAP editor leak path).
     void setLeakOnClose (bool b) noexcept;
 
+    // The DSP instance was destroyed out from under this editor. Drops the
+    // reference the suil callbacks dereference, so close() can still free the UI
+    // without writing ports into a freed plugin.
+    void abandonPlugin() noexcept;
+
     // Message thread, ~60 Hz: drive ui:idleInterface and platform event work.
     void pump();
 

--- a/src/engine/lv2/Lv2Editor_Mac.mm
+++ b/src/engine/lv2/Lv2Editor_Mac.mm
@@ -86,6 +86,7 @@ Lv2Editor::Lv2Editor() : impl (std::make_unique<Impl>()) { impl->owner = this; }
 Lv2Editor::~Lv2Editor() { close(); }
 
 void Lv2Editor::setLeakOnClose (bool b) noexcept { impl->leakOnClose = b; }
+void Lv2Editor::abandonPlugin() noexcept { impl->instance = nullptr; }
 int  Lv2Editor::preferredWidth()  const noexcept { return impl->prefW; }
 int  Lv2Editor::preferredHeight() const noexcept { return impl->prefH; }
 bool Lv2Editor::isOpen()     const noexcept { return impl->discovered; }
@@ -277,8 +278,11 @@ void Lv2Editor::close()
         // foreign-toolkit UI can hang in its own teardown. That leaked UI still
         // holds this Impl as its suil controller and ui:resize handle, so the
         // Impl has to outlive us too - a UI ticking its own NSTimer would
-        // otherwise write ports through freed memory.
-        impl->owner = nullptr;
+        // otherwise write ports through freed memory. The DSP instance is NOT
+        // leaked (the slot may unload it right after), so the pointer to it
+        // goes first.
+        impl->owner    = nullptr;
+        impl->instance = nullptr;
         static auto* leakedAtShutdown = new std::vector<std::unique_ptr<Impl>>;
         if (impl->container != nil)
             [impl->container removeFromSuperview];

--- a/src/engine/vst3/Vst3Editor.cpp
+++ b/src/engine/vst3/Vst3Editor.cpp
@@ -211,6 +211,14 @@ void Vst3Editor::hide()
     impl->mapped = false;
 }
 
+void Vst3Editor::abandonPlugin() noexcept
+{
+    (void) impl->view.take();
+    impl->instance = nullptr;
+    impl->host     = nullptr;
+    impl->embedded = false;
+}
+
 void Vst3Editor::close()
 {
     if (impl->view)

--- a/src/engine/vst3/Vst3Editor.h
+++ b/src/engine/vst3/Vst3Editor.h
@@ -47,6 +47,12 @@ public:
     void hide();
     void close();
 
+    // The instance was destroyed out from under this editor. Drops the view
+    // without releasing it and without the removed()/setFrame() teardown - the
+    // module those calls live in was unloaded with the instance. close() then
+    // only releases the host container.
+    void abandonPlugin() noexcept;
+
     // Linux geometry diagnostics. macOS uses logical component bounds directly,
     // so these return false there.
     bool getRootRelativePosition (std::uintptr_t referenceHandle,

--- a/src/engine/vst3/Vst3Editor_Mac.mm
+++ b/src/engine/vst3/Vst3Editor_Mac.mm
@@ -172,6 +172,14 @@ void Vst3Editor::hide()
     impl->visible = false;
 }
 
+void Vst3Editor::abandonPlugin() noexcept
+{
+    (void) impl->view.take();
+    impl->instance = nullptr;
+    impl->host     = nullptr;
+    impl->embedded = false;
+}
+
 void Vst3Editor::close()
 {
     if (impl->view)

--- a/src/ui/AuxLaneComponent.cpp
+++ b/src/ui/AuxLaneComponent.cpp
@@ -437,7 +437,12 @@ void AuxLaneComponent::timerCallback()
         nameLabel.setText (lane.name, juce::dontSendNotification);
 
     for (int i = 0; i < AuxLaneParams::kMaxLanePlugins; ++i)
+    {
+        // rebuildSlots only runs on lane edits, so without this the lane would
+        // hold an abandoned editor until the next one.
+        syncNativeEditorOwnersForSlot (i);
         refreshSlotControls (i);
+    }
     if (stripMeter != nullptr) stripMeter->repaint();
     if (sendPanel  != nullptr) sendPanel->repaint();
 
@@ -1319,27 +1324,55 @@ void AuxLaneComponent::detachAuEditorForSlot (int slotIdx)
 #endif
 }
 
-void AuxLaneComponent::dropAllNativeEditors()
+void AuxLaneComponent::syncNativeEditorOwnersForSlot (int slotIdx)
+{
+    [[maybe_unused]] auto& ui = slots[(size_t) slotIdx];
+    [[maybe_unused]] auto detach = [this] (auto& body) { removeChildComponent (&body); };
+#if DUSKSTUDIO_HAS_NATIVE_CLAP
+    syncNativeEditorOwner (ui.clapEditor, detach);
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    syncNativeEditorOwner (ui.lv2Editor, detach);
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_VST3
+    syncNativeEditorOwner (ui.vst3Editor, detach);
+#endif
+}
+
+void AuxLaneComponent::dropAllNativeEditors (NativeEditorTeardown teardown)
 {
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
     for (int i = 0; i < AuxLaneParams::kMaxLanePlugins; ++i)
     {
-        if (slots[(size_t) i].clapEditor != nullptr)
-            slots[(size_t) i].clapEditor->leakForShutdown();   // u-he hangs in gui->destroy
+        if (auto& ed = slots[(size_t) i].clapEditor; ed != nullptr)
+        {
+            // Only an exiting process leaks the GUI (u-he hangs in gui->destroy).
+            if (teardown == NativeEditorTeardown::LeakForExit)          ed->leakForShutdown();
+            else if (teardown == NativeEditorTeardown::AbandonInstance) ed->abandonInstance();
+        }
         detachClapEditorForSlot (i);
     }
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_LV2
     for (int i = 0; i < AuxLaneParams::kMaxLanePlugins; ++i)
     {
-        if (slots[(size_t) i].lv2Editor != nullptr)
-            slots[(size_t) i].lv2Editor->leakForShutdown();
+        if (auto& ed = slots[(size_t) i].lv2Editor; ed != nullptr)
+        {
+            if (teardown == NativeEditorTeardown::LeakForExit)          ed->leakForShutdown();
+            else if (teardown == NativeEditorTeardown::AbandonInstance) ed->abandonInstance();
+        }
         detachLv2EditorForSlot (i);
     }
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_VST3
     for (int i = 0; i < AuxLaneParams::kMaxLanePlugins; ++i)
-        detachVst3EditorForSlot (i);   // in-process C++ teardown - no leak path needed
+    {
+        // In-process C++ teardown - no leak path needed.
+        if (auto& ed = slots[(size_t) i].vst3Editor;
+            ed != nullptr && teardown == NativeEditorTeardown::AbandonInstance)
+            ed->abandonInstance();
+        detachVst3EditorForSlot (i);
+    }
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_AU
     for (int i = 0; i < AuxLaneParams::kMaxLanePlugins; ++i)
@@ -1480,6 +1513,10 @@ void AuxLaneComponent::rebuildSlots()
 {
     for (int i = 0; i < AuxLaneParams::kMaxLanePlugins; ++i)
     {
+        // Reap editors that abandoned their instance on their own pump tick, so
+        // the pass below rebuilds against whatever the slot holds now.
+        syncNativeEditorOwnersForSlot (i);
+
         auto& ui = slots[(size_t) i];
         const int mode = strip.insertMode[(size_t) i].load (std::memory_order_relaxed);
 
@@ -1510,6 +1547,7 @@ void AuxLaneComponent::rebuildSlots()
                     if (ed->attach (*clapInst, err))
                     {
                         ui.clapEditor = std::move (ed);
+                        ui.clapEditor->bindOwner (strip.getNativeClapSlot (i));
                         addAndMakeVisible (*ui.clapEditor);
                         layoutEditorForSlot (i);
                     }
@@ -1536,6 +1574,7 @@ void AuxLaneComponent::rebuildSlots()
                     if (ed->attach (*lv2Inst, err))
                     {
                         ui.lv2Editor = std::move (ed);
+                        ui.lv2Editor->bindOwner (strip.getNativeLv2Slot (i));
                         addAndMakeVisible (*ui.lv2Editor);
                         layoutEditorForSlot (i);
                     }
@@ -1562,6 +1601,7 @@ void AuxLaneComponent::rebuildSlots()
                     if (ed->attach (*vst3Inst, err))
                     {
                         ui.vst3Editor = std::move (ed);
+                        ui.vst3Editor->bindOwner (strip.getNativeVst3Slot (i));
                         addAndMakeVisible (*ui.vst3Editor);
                         layoutEditorForSlot (i);
                     }

--- a/src/ui/AuxLaneComponent.h
+++ b/src/ui/AuxLaneComponent.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include "../session/Session.h"
 #include "DuskComboBox.h"
+#include "NativeEditorOwner.h"
 #include "../engine/device/ChannelSet.h"
 
 namespace duskstudio
@@ -38,7 +39,7 @@ public:
     // foreign toolkit's destructor can hang on the way out) and every kind closes
     // its own X11 Display, which hangs if deferred to the destructor cascade. See
     // MainComponent::beginSafeShutdown phase 4.
-    void dropAllNativeEditors();
+    void dropAllNativeEditors (NativeEditorTeardown teardown);
 
     void childBoundsChanged (juce::Component* child) override;
     void mouseDown (const juce::MouseEvent&) override;
@@ -90,6 +91,9 @@ private:
     void detachLv2EditorForSlot (int slotIdx);
     void detachVst3EditorForSlot (int slotIdx);
     void detachAuEditorForSlot (int slotIdx);
+    // Reap any native editor on this slot that already abandoned its instance on
+    // its own pump tick. Polled from timerCallback and rebuildSlots.
+    void syncNativeEditorOwnersForSlot (int slotIdx);
     void hideEditorsKeepingAlive();
     void layoutEditorForSlot (int slotIdx);
     void scheduleEditorRefits (int slotIdx);

--- a/src/ui/AuxView.cpp
+++ b/src/ui/AuxView.cpp
@@ -241,11 +241,11 @@ void AuxView::setActiveLane (int index)
     resized();
 }
 
-void AuxView::dropAllNativeEditors()
+void AuxView::dropAllNativeEditors (NativeEditorTeardown teardown)
 {
     for (auto& lane : lanes)
         if (lane != nullptr)
-            lane->dropAllNativeEditors();
+            lane->dropAllNativeEditors (teardown);
 }
 
 void AuxView::visibilityChanged()

--- a/src/ui/AuxView.h
+++ b/src/ui/AuxView.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include "../session/Session.h"
 #include "EmbeddedModal.h"
+#include "NativeEditorOwner.h"
 
 namespace duskstudio
 {
@@ -41,7 +42,7 @@ public:
     // Shutdown: close every lane's native editors (CLAP, LV2, VST3 - each owns an
     // X11 Display + host window) while the main peer + message loop are still
     // alive. See MainComponent::beginSafeShutdown phase 4.
-    void dropAllNativeEditors();
+    void dropAllNativeEditors (NativeEditorTeardown teardown);
 
 private:
     void timerCallback() override;

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -1474,7 +1474,7 @@ ChannelStripComponent::~ChannelStripComponent()
     // Drop the cached editor BEFORE the strip's PluginSlot destructs,
     // since the editor's destructor calls editorBeingDeleted on its
     // owning AudioProcessor. dropPluginEditor() also closes the modal.
-    dropPluginEditor();
+    dropPluginEditor (NativeEditorTeardown::Destroy);
 }
 
 void ChannelStripComponent::rebuildMidiInputDropdown()
@@ -2125,10 +2125,11 @@ bool ChannelStripComponent::insertSlotOccupied() const
 
 void ChannelStripComponent::refreshPluginSlotButton()
 {
-#if DUSKSTUDIO_HAS_MULTISAMPLE
     // Before any of the per-rung early-returns below: a clone / undo replay can
-    // destroy or replace the multisample instance without going through the UI,
-    // and the editor holds a reference to it on a live timer.
+    // destroy or replace an instance without going through the UI, and the editors
+    // hold a reference to it on a live timer.
+    syncNativeEditorOwners();
+#if DUSKSTUDIO_HAS_MULTISAMPLE
     syncMultisampleEditorOwner();
 #endif
     // Native CLAP insert - name from the loaded .clap bundle. The JUCE pluginSlot is
@@ -2271,14 +2272,14 @@ void ChannelStripComponent::refreshPluginSlotButton()
     // now-being-destructed AudioProcessor. Drop it before that processor
     // disappears so we don't leave a dangling pointer in pluginEditor.
     if (name.isEmpty())
-        dropPluginEditor();
+        dropPluginEditor (NativeEditorTeardown::Destroy);
     else if (pluginEditor != nullptr
              && pluginEditorOwner != pluginSlot.getInstance())
     {
         // Plugin was Replaced - the cached editor belongs to the prior
         // instance. Drop it so the next Open Editor builds a fresh one
         // for the new instance.
-        dropPluginEditor();
+        dropPluginEditor (NativeEditorTeardown::Destroy);
     }
 }
 
@@ -2324,6 +2325,7 @@ void ChannelStripComponent::openPluginEditor()
             clapEditor = std::make_unique<ClapPluginEditorComponent>();
             juce::String err;
             if (! clapEditor->attach (*inst, err)) { clapEditor.reset(); return; }
+            clapEditor->bindOwner (engine.getChannelStrip (trackIndex).getNativeClapSlot());
         }
         pluginEditorModal.showBorrowed (*parent, *clapEditor, onClose);
         return;
@@ -2344,6 +2346,7 @@ void ChannelStripComponent::openPluginEditor()
                 lv2Editor.reset();
                 return;
             }
+            lv2Editor->bindOwner (engine.getChannelStrip (trackIndex).getNativeLv2Slot());
         }
         pluginEditorModal.showBorrowed (*parent, *lv2Editor, onClose);
         return;
@@ -2364,6 +2367,7 @@ void ChannelStripComponent::openPluginEditor()
                 vst3Editor.reset();
                 return;
             }
+            vst3Editor->bindOwner (engine.getChannelStrip (trackIndex).getNativeVst3Slot());
         }
         pluginEditorModal.showBorrowed (*parent, *vst3Editor, onClose);
         return;
@@ -2553,7 +2557,7 @@ void ChannelStripComponent::openPluginEditor()
     if (instance == nullptr) return;
 
     if (pluginEditor != nullptr && pluginEditorOwner != instance)
-        dropPluginEditor();
+        dropPluginEditor (NativeEditorTeardown::Destroy);
 
     if (pluginEditor == nullptr)
     {
@@ -2618,29 +2622,35 @@ void ChannelStripComponent::closePluginEditor()
    #endif
 }
 
-void ChannelStripComponent::dropPluginEditor()
+void ChannelStripComponent::dropPluginEditor (NativeEditorTeardown teardown)
 {
     closePluginEditor();
 
-    // Native CLAP editor: leak rather than destroy - u-he plugins hang in
-    // gui->destroy on shutdown (same class as the JUCE leak-on-shutdown). The
-    // shared instance is leaked separately by the engine's shutdown loop. Linux-only.
+    // Only an exiting process leaks the plugin GUI (u-he hangs in gui->destroy);
+    // the instance is leaked to match by the engine's shutdown loop. Linux-only.
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
     if (clapEditor != nullptr)
     {
-        clapEditor->leakForShutdown();
+        if (teardown == NativeEditorTeardown::LeakForExit)          clapEditor->leakForShutdown();
+        else if (teardown == NativeEditorTeardown::AbandonInstance) clapEditor->abandonInstance();
         clapEditor.reset();
     }
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_LV2
     if (lv2Editor != nullptr)
     {
-        lv2Editor->leakForShutdown();
+        if (teardown == NativeEditorTeardown::LeakForExit)          lv2Editor->leakForShutdown();
+        else if (teardown == NativeEditorTeardown::AbandonInstance) lv2Editor->abandonInstance();
         lv2Editor.reset();
     }
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_VST3
-    vst3Editor.reset();   // in-process C++ teardown - no leak path needed
+    if (vst3Editor != nullptr)
+    {
+        // In-process C++ teardown - no leak path needed.
+        if (teardown == NativeEditorTeardown::AbandonInstance) vst3Editor->abandonInstance();
+        vst3Editor.reset();
+    }
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_AU
     auEditor.reset();
@@ -3026,6 +3036,26 @@ void ChannelStripComponent::loadNativeAuForChannel (const juce::String& componen
     openPluginEditor();
 }
 #endif // DUSKSTUDIO_HAS_NATIVE_AU
+
+void ChannelStripComponent::syncNativeEditorOwners()
+{
+    // Dismiss the modal FIRST - it borrows the body by raw pointer, so leaving it
+    // showing (or re-showable) past the reset is a second use-after-free.
+    [[maybe_unused]] auto dismiss = [this] (auto& body)
+    {
+        if (pluginEditorModal.getBody() == &body)
+            pluginEditorModal.close();
+    };
+#if DUSKSTUDIO_HAS_NATIVE_CLAP
+    syncNativeEditorOwner (clapEditor, dismiss);
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    syncNativeEditorOwner (lv2Editor, dismiss);
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_VST3
+    syncNativeEditorOwner (vst3Editor, dismiss);
+#endif
+}
 
 #if DUSKSTUDIO_HAS_MULTISAMPLE
 void ChannelStripComponent::syncMultisampleEditorOwner()

--- a/src/ui/ChannelStripComponent.h
+++ b/src/ui/ChannelStripComponent.h
@@ -9,6 +9,7 @@
 #include "CompHeaderButton.h"
 #include "EmbeddedModal.h"
 #include "DuskComboBox.h"
+#include "NativeEditorOwner.h"
 #include "SectionPillButton.h"
 #include "../session/Session.h"
 #include "../foundation/MessageThread.h"
@@ -358,6 +359,9 @@ private:
     std::unique_ptr<class Vst3PluginEditorComponent> vst3Editor;
     void loadNativeVst3ForChannel (const juce::File& vst3File, const juce::String& pluginId = {});
 #endif
+    // Reap any native editor that already abandoned its instance on its own pump
+    // tick. Polled from refreshPluginSlotButton; the tick is what closes the UAF.
+    void syncNativeEditorOwners();
 #if DUSKSTUDIO_HAS_NATIVE_AU
     std::unique_ptr<class AuPluginEditorComponent> auEditor;
     void loadNativeAuForChannel (const juce::String& componentId);
@@ -401,7 +405,7 @@ public:
     // editors on shutdown BEFORE the chain destructs. Tearing down a
     // plugin's native X11 window during Mutter's cascade-shutdown of
     // the main window race-crashes the compositor on Linux/Wayland.
-    void dropPluginEditor();
+    void dropPluginEditor (NativeEditorTeardown teardown);
 
 private:
 

--- a/src/ui/ClapPluginEditorComponent.cpp
+++ b/src/ui/ClapPluginEditorComponent.cpp
@@ -19,6 +19,9 @@ ClapPluginEditorComponent::ClapPluginEditorComponent()
 ClapPluginEditorComponent::~ClapPluginEditorComponent()
 {
     stopTimer();
+    // Every reset path lands here, and gui->destroy would call into the bundle
+    // that was unloaded with the instance.
+    if (ownerIsStale()) editor.abandonPlugin();
     editor.close();
     if (ownsInstance) instance.deactivate();   // attach() mode: the slot owns it
 }
@@ -104,6 +107,10 @@ int ClapPluginEditorComponent::componentExtentFromEditor (int extent) const
 
 void ClapPluginEditorComponent::tryEmbed()
 {
+    // Layout / hierarchy events reach here in the same message-loop turn as an
+    // undo-triggered unload, so this is a plugin-code entry point like the pump.
+    if (ownerIsStale()) { abandonInstance(); return; }
+
     // Embed ONLY when actually on-screen. Some plugins (u-he Satin) abort() if asked
     // to set_parent/show into a parent that isn't viewable yet - so no pre-warm: build
     // + map when shown, exactly like the JUCE editor path. The kept-alive remap on a
@@ -148,6 +155,7 @@ void ClapPluginEditorComponent::tryEmbed()
 
 void ClapPluginEditorComponent::pushBounds()
 {
+    if (ownerIsStale()) return;   // setBounds drives gui->set_size on the plugin
     if (! embedded) return;
     // Borrowed bodies get setBounds'd by EmbeddedModal BEFORE being re-added
     // to a parent - getTopLevelComponent() is then `this` and the area
@@ -180,7 +188,20 @@ void ClapPluginEditorComponent::visibilityChanged()
 void ClapPluginEditorComponent::leakForShutdown()
 {
     stopTimer();
+    // The engine leaks its slots first, which bumps the generation - unbind so
+    // that cannot read as stale and divert the destructor into a destroy.
+    ownerSlot = nullptr;
     editor.setLeakOnClose (true);
+}
+
+void ClapPluginEditorComponent::abandonInstance()
+{
+    stopTimer();
+    editor.abandonPlugin();
+    editor.close();   // plugin handles are gone; this releases only what we own
+    ownerSlot = nullptr;
+    abandoned = true;
+    loaded = embedded = embedding = false;
 }
 
 #if defined(__linux__)
@@ -230,6 +251,8 @@ void ClapPluginEditorComponent::verifyGeometry()
 
 void ClapPluginEditorComponent::timerCallback()
 {
+    if (ownerIsStale()) { abandonInstance(); return; }
+
     // Keep the native child container's visible state in sync with our real on-screen
     // visibility. visibilityChanged() does NOT fire for ancestor (aux-tab / stage)
     // changes, so without this poll the container stays visible over whatever view

--- a/src/ui/ClapPluginEditorComponent.h
+++ b/src/ui/ClapPluginEditorComponent.h
@@ -5,7 +5,9 @@
 #include "../engine/clap/ClapBundle.h"
 #include "../engine/clap/ClapInstance.h"
 #include "../engine/clap/ClapEditor.h"
+#include "../engine/clap/NativeClapSlot.h"
 #include "../foundation/MessageThread.h"
+#include "NativeEditorOwner.h"
 
 namespace duskstudio
 {
@@ -34,8 +36,24 @@ public:
 
     bool isLoaded() const noexcept { return loaded; }
 
+    // Bind to the slot that owns the attached instance, so the pump tick notices
+    // it being destroyed or replaced. See NativeEditorOwner.h.
+    void bindOwner (clap::NativeClapSlot& slot) noexcept
+    { owner.stamp (slot); ownerSlot = &slot; }
+
+    bool ownerIsStale() const noexcept
+    { return ownerSlot != nullptr && owner.isStale (*ownerSlot); }
+
+    // Set once this editor tore itself down on one of its own guards - the reap
+    // needs it because abandoning unbinds the slot.
+    bool wasAbandoned() const noexcept { return abandoned; }
+
     // App shutdown: stop pumping + leak the plugin GUI (u-he hangs in gui->destroy).
     void leakForShutdown();
+
+    // The instance is gone: stop pumping, drop the plugin-side handles, and
+    // release what this host owns. See NativeEditorOwner.h.
+    void abandonInstance();
 
     void resized() override;
     void parentHierarchyChanged() override;
@@ -60,6 +78,9 @@ private:
     clap::ClapBundle   bundle;
     clap::ClapInstance instance;
     clap::ClapEditor   editor;
+    NativeEditorOwner      owner;
+    clap::NativeClapSlot*  ownerSlot = nullptr;
+    bool abandoned = false;
     bool ownsInstance = false;
     bool loaded    = false;
     bool embedded  = false;

--- a/src/ui/ConsoleView.cpp
+++ b/src/ui/ConsoleView.cpp
@@ -6,11 +6,11 @@
 
 namespace duskstudio
 {
-void ConsoleView::dropAllPluginEditors()
+void ConsoleView::dropAllPluginEditors (NativeEditorTeardown teardown)
 {
     for (auto& strip : strips)
         if (strip != nullptr)
-            strip->dropPluginEditor();
+            strip->dropPluginEditor (teardown);
 }
 
 ConsoleView::ConsoleView (Session& session, AudioEngine& engine) : sessionRef (session)

--- a/src/ui/ConsoleView.h
+++ b/src/ui/ConsoleView.h
@@ -104,7 +104,7 @@ public:
     // Called from MainComponent::requestQuit before systemRequestedQuit
     // so editor windows (real top-level DocumentWindows on Linux) die
     // in a quiet window rather than racing Mutter's teardown.
-    void dropAllPluginEditors();
+    void dropAllPluginEditors (NativeEditorTeardown teardown);
 
 private:
     Session& sessionRef;

--- a/src/ui/Lv2PluginEditorComponent.cpp
+++ b/src/ui/Lv2PluginEditorComponent.cpp
@@ -21,6 +21,9 @@ Lv2PluginEditorComponent::Lv2PluginEditorComponent()
 Lv2PluginEditorComponent::~Lv2PluginEditorComponent()
 {
     stopTimer();
+    // Every reset path lands here, and the suil callbacks still hold the
+    // instance that went.
+    if (ownerIsStale()) editor.abandonPlugin();
     editor.close();
 }
 
@@ -87,6 +90,10 @@ int Lv2PluginEditorComponent::componentExtentFromEditor (int extent) const
 
 void Lv2PluginEditorComponent::tryEmbed()
 {
+    // Layout / hierarchy events reach here in the same message-loop turn as an
+    // undo-triggered unload, so this is a plugin-code entry point like the pump.
+    if (ownerIsStale()) { abandonInstance(); return; }
+
     // Embed ONLY when actually on-screen: the UI instantiates directly into our
     // host window, and toolkit wrappers can abort realising into a non-viewable
     // parent (same rule as the CLAP editor).
@@ -130,6 +137,7 @@ void Lv2PluginEditorComponent::tryEmbed()
 
 void Lv2PluginEditorComponent::pushBounds()
 {
+    if (ownerIsStale()) return;   // setBounds resizes the UI's own widget window
     if (! embedded) return;
     // Borrowed bodies get setBounds'd by EmbeddedModal BEFORE being re-added
     // to a parent - getTopLevelComponent() is then `this` and the area
@@ -162,7 +170,21 @@ void Lv2PluginEditorComponent::visibilityChanged()
 void Lv2PluginEditorComponent::leakForShutdown()
 {
     stopTimer();
+    // The engine leaks its slots first, which bumps the generation - unbind so
+    // that cannot read as stale and divert the destructor into a destroy.
+    ownerSlot = nullptr;
     editor.setLeakOnClose (true);
+}
+
+void Lv2PluginEditorComponent::abandonInstance()
+{
+    stopTimer();
+    editor.abandonPlugin();
+    editor.close();   // plugin handles are gone; this releases only what we own
+    ownerSlot = nullptr;
+    abandoned = true;
+    attachedInstance = nullptr;
+    loaded = embedded = embedding = false;
 }
 
 #if defined(__linux__)
@@ -212,6 +234,9 @@ void Lv2PluginEditorComponent::verifyGeometry()
 
 void Lv2PluginEditorComponent::timerCallback()
 {
+    // Ahead of the epoch read below, which dereferences the instance.
+    if (ownerIsStale()) { abandonInstance(); return; }
+
     // reactivate() (device rate/block change) frees and rebuilds the
     // LilvInstance this UI captured via instance-access at embed time. Tear
     // the UI down BEFORE the pump below can drive its idle interface against

--- a/src/ui/Lv2PluginEditorComponent.h
+++ b/src/ui/Lv2PluginEditorComponent.h
@@ -3,7 +3,9 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 
 #include "../engine/lv2/Lv2Editor.h"
+#include "../engine/lv2/NativeLv2Slot.h"
 #include "../foundation/MessageThread.h"
+#include "NativeEditorOwner.h"
 
 #include <cstdint>
 
@@ -30,8 +32,24 @@ public:
 
     bool isLoaded() const noexcept { return loaded; }
 
+    // Bind to the slot that owns the attached instance, so the pump tick notices
+    // it being destroyed or replaced. See NativeEditorOwner.h.
+    void bindOwner (lv2::NativeLv2Slot& slot) noexcept
+    { owner.stamp (slot); ownerSlot = &slot; }
+
+    bool ownerIsStale() const noexcept
+    { return ownerSlot != nullptr && owner.isStale (*ownerSlot); }
+
+    // Set once this editor tore itself down on one of its own guards - the reap
+    // needs it because abandoning unbinds the slot.
+    bool wasAbandoned() const noexcept { return abandoned; }
+
     // App shutdown: stop pumping + leak the UI (foreign-toolkit destructors hang).
     void leakForShutdown();
+
+    // The instance is gone: stop pumping, drop the plugin-side handles, and
+    // release what this host owns. See NativeEditorOwner.h.
+    void abandonInstance();
 
     void resized() override;
     void parentHierarchyChanged() override;
@@ -50,6 +68,9 @@ private:
     int componentExtentFromEditor (int extent) const;
 
     lv2::Lv2Editor editor;
+    NativeEditorOwner    owner;
+    lv2::NativeLv2Slot*  ownerSlot = nullptr;
+    bool abandoned = false;
     lv2::Lv2Instance* attachedInstance = nullptr;
     std::uint64_t embeddedEpoch = 0;
     bool loaded    = false;

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -1004,14 +1004,14 @@ MainComponent::~MainComponent()
     // requestQuit's onSave / onDontSave handlers above (e.g. SIGTERM,
     // window-manager-initiated kill).
     if (consoleView != nullptr)
-        consoleView->dropAllPluginEditors();
+        consoleView->dropAllPluginEditors (NativeEditorTeardown::LeakForExit);
 
     // Aux native editors (CLAP, LV2, VST3) need the same early teardown while the
     // main peer + message loop are still alive. beginSafeShutdown() does this, but
     // a quit path that skips it (SIGTERM / WM kill) must still tear them down here
     // rather than leave them for the late ~AuxView cascade.
     if (auxView != nullptr)
-        auxView->dropAllNativeEditors();
+        auxView->dropAllNativeEditors (NativeEditorTeardown::LeakForExit);
 
     // Sidecar flush for abnormal quit paths that bypass requestQuit's combined
     // session/notepad dirty prompt. Normal Save and Don't Save paths have
@@ -2877,7 +2877,7 @@ void MainComponent::beginSafeShutdown()
 
     markPhase ("phase 4: drop plugin editor windows");
     if (consoleView != nullptr)
-        consoleView->dropAllPluginEditors();
+        consoleView->dropAllPluginEditors (NativeEditorTeardown::LeakForExit);
     // JUCE AUX plugin editors tear down fine with the normal ~MainWindow -> ~AuxView
     // cascade. NATIVE editors (CLAP, LV2, VST3) do NOT: each opens its own X11
     // Display + a host window parented into the main peer, and its close (plugin-UI
@@ -2885,7 +2885,7 @@ void MainComponent::beginSafeShutdown()
     // peer is gone - CLAP/LV2 additionally leak their plugin UIs there. Tear them
     // down here - main peer + message loop alive, audio callback detached (phase 3).
     if (auxView != nullptr)
-        auxView->dropAllNativeEditors();
+        auxView->dropAllNativeEditors (NativeEditorTeardown::LeakForExit);
 
     markPhase ("phase 5: flush window operations");
     duskstudio::platform::flushWindowOperations();
@@ -3214,15 +3214,15 @@ bool MainComponent::finishLoadingSessionFrom (const juce::File& sourceJson,
     engine.getUndoManager().clearUndoHistory();
 
     // Native plugin editors (CLAP/LV2/VST3) reference the instances the
-    // reload below evicts - a suil/plugin UI whose pump timer ticks after
-    // the instance is gone crashes inside the plugin's own event loop.
-    // Tear every editor down NOW, while the instances are still alive
-    // (same order the strip loaders use). The console is rebuilt after
-    // the load anyway; aux lanes lazily re-embed on next show.
+    // reload below evicts. Tear every editor down NOW, while the instances
+    // are still alive (same order the strip loaders use). The console is
+    // rebuilt after the load anyway; aux lanes lazily re-embed on next show.
+    // AbandonInstance, not the exit path: the app runs on, so leaking each
+    // editor's private display connection would cost an X client slot per load.
     if (consoleView != nullptr)
-        consoleView->dropAllPluginEditors();
+        consoleView->dropAllPluginEditors (NativeEditorTeardown::AbandonInstance);
     if (auxView != nullptr)
-        auxView->dropAllNativeEditors();
+        auxView->dropAllNativeEditors (NativeEditorTeardown::AbandonInstance);
 
     engine.consumePluginStateAfterLoad();
     // Surface any plugin restore failures as a single summary dialog so

--- a/src/ui/NativeEditorOwner.h
+++ b/src/ui/NativeEditorOwner.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+namespace duskstudio
+{
+// Identity of the native plugin instance an editor component was built against.
+// Undo replay (RegionEditActions), session restore (AudioEngine) and
+// one-host-per-insert eviction (ChannelStrip) all destroy an instance without
+// going through the UI, and that teardown unloads the module the editor's
+// handles point into. The slot's load generation rides along with the pointer
+// because a reload can place the successor at the address the previous instance
+// was freed from.
+//
+// The editor component holds the stamp and re-checks it on every path that
+// reaches plugin code: the pump tick, the embed, and the bounds push. Layout
+// and hierarchy events fire in the same message-loop turn as the unload that
+// retires an instance, so a guard on the pump alone leaves the other two open.
+struct NativeEditorOwner
+{
+    template <typename Slot>
+    void stamp (Slot& slot) noexcept
+    {
+        instance   = static_cast<const void*> (slot.getInstance());
+        generation = slot.generation();
+    }
+
+    template <typename Slot>
+    bool isStale (Slot& slot) const noexcept
+    {
+        return instance != static_cast<const void*> (slot.getInstance())
+            || generation != slot.generation();
+    }
+
+    const void*   instance   = nullptr;
+    std::uint64_t generation = 0;
+};
+
+// How a cached native editor is torn down when its owner drops it.
+enum class NativeEditorTeardown
+{
+    // The app runs on and the instance stays loaded: full teardown including the
+    // plugin's own gui->destroy, so a later re-open creates a fresh GUI.
+    Destroy,
+    // The caller destroys the instance immediately afterwards (session restore).
+    // Drop our plugin-side handles rather than run the plugin's teardown - a
+    // foreign-toolkit GUI can hang there, and the plugin releases it along with
+    // itself - but still close the container + display this host owns.
+    AbandonInstance,
+    // The process is exiting: leak the GUI (it hangs in its own destructor)
+    // together with the container + display it is still drawing into.
+    LeakForExit,
+};
+
+// Drop `editor` once its instance is no longer the slot's live one, or once it
+// has already abandoned itself on one of its own guards - abandoning unbinds the
+// slot, so staleness alone stops reporting and the component would sit there as
+// a dead rectangle. Order is load-bearing: the editor abandons its plugin-side
+// handles first, then `detach` does the owner's own bookkeeping - dismissing a
+// modal that borrows the component, removing it as a child - while it is still
+// alive.
+template <typename EditorComponent, typename Detach>
+void syncNativeEditorOwner (std::unique_ptr<EditorComponent>& editor, Detach&& detach)
+{
+    if (editor == nullptr) return;
+    if (! editor->ownerIsStale() && ! editor->wasAbandoned()) return;
+    editor->abandonInstance();
+    detach (*editor);
+    editor.reset();
+}
+} // namespace duskstudio

--- a/src/ui/Vst3PluginEditorComponent.cpp
+++ b/src/ui/Vst3PluginEditorComponent.cpp
@@ -28,6 +28,9 @@ Vst3PluginEditorComponent::Vst3PluginEditorComponent()
 Vst3PluginEditorComponent::~Vst3PluginEditorComponent()
 {
     stopTimer();
+    // Every reset path lands here, and releasing the view calls into the module
+    // that was unloaded with the instance.
+    if (ownerIsStale()) editor.abandonPlugin();
     editor.close();
 }
 
@@ -84,6 +87,10 @@ int Vst3PluginEditorComponent::componentExtentFromEditor (int extent) const
 
 void Vst3PluginEditorComponent::tryEmbed()
 {
+    // Layout / hierarchy events reach here in the same message-loop turn as an
+    // undo-triggered unload, so this is a plugin-code entry point like the pump.
+    if (ownerIsStale()) { abandonInstance(); return; }
+
     // Embed ONLY when actually on-screen (toolkit-backed editors can abort
     // realising into a non-viewable parent). `embedding` breaks the re-entry
     // cycle: attached() can fire resizeView synchronously -> onResize -> setSize
@@ -128,6 +135,7 @@ void Vst3PluginEditorComponent::tryEmbed()
 
 void Vst3PluginEditorComponent::pushBounds()
 {
+    if (ownerIsStale()) return;   // setBounds drives IPlugView::onSize
     if (! embedded) return;
     // Borrowed bodies get setBounds'd by EmbeddedModal BEFORE being re-added
     // to a parent - getTopLevelComponent() is then `this` and the area
@@ -155,6 +163,16 @@ void Vst3PluginEditorComponent::visibilityChanged()
     {
         editor.hide();
     }
+}
+
+void Vst3PluginEditorComponent::abandonInstance()
+{
+    stopTimer();
+    editor.abandonPlugin();
+    editor.close();   // plugin handles are gone; this releases only what we own
+    ownerSlot = nullptr;
+    abandoned = true;
+    loaded = embedded = embedding = false;
 }
 
 #if defined(__linux__)
@@ -204,6 +222,8 @@ void Vst3PluginEditorComponent::verifyGeometry()
 
 void Vst3PluginEditorComponent::timerCallback()
 {
+    if (ownerIsStale()) { abandonInstance(); return; }
+
     // Ancestor visibility changes (tab switches) don't fire visibilityChanged -
     // poll like the CLAP/LV2 editors so the native window can't float over
     // another view. The un-embedded poll covers the mirror case: a component

--- a/src/ui/Vst3PluginEditorComponent.h
+++ b/src/ui/Vst3PluginEditorComponent.h
@@ -3,10 +3,14 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 
 #include "../engine/vst3/Vst3Editor.h"
+#if DUSKSTUDIO_HAS_NATIVE_VST3
+#include "../engine/vst3/NativeVst3Slot.h"
+#endif
 #if DUSKSTUDIO_HAS_NATIVE_AU
 #include "../engine/au/AuEditor.h"
 #endif
 #include "../foundation/MessageThread.h"
+#include "NativeEditorOwner.h"
 
 namespace duskstudio
 {
@@ -31,6 +35,22 @@ public:
 
     bool isLoaded() const noexcept { return loaded; }
 
+    // Bind to the slot that owns the attached instance, so the pump tick notices
+    // it being destroyed or replaced. See NativeEditorOwner.h.
+    void bindOwner (vst3::NativeVst3Slot& slot) noexcept
+    { owner.stamp (slot); ownerSlot = &slot; }
+
+    bool ownerIsStale() const noexcept
+    { return ownerSlot != nullptr && owner.isStale (*ownerSlot); }
+
+    // Set once this editor tore itself down on one of its own guards - the reap
+    // needs it because abandoning unbinds the slot.
+    bool wasAbandoned() const noexcept { return abandoned; }
+
+    // The instance is gone: stop pumping, drop the plugin-side handles, and
+    // release what this host owns. See NativeEditorOwner.h.
+    void abandonInstance();
+
     void resized() override;
     void parentHierarchyChanged() override;
     void visibilityChanged() override;
@@ -48,6 +68,9 @@ private:
     int componentExtentFromEditor (int extent) const;
 
     vst3::Vst3Editor editor;
+    NativeEditorOwner      owner;
+    vst3::NativeVst3Slot*  ownerSlot = nullptr;
+    bool abandoned = false;
     double lastPumpMs = 0.0;
     bool loaded    = false;
     bool embedded  = false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(dusk-studio-tests
     rt_priority.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/AudioWorkerPool.cpp
     embedded_modal_close_safety.cpp
+    native_editor_owner.cpp
     x11_anti_pattern_guard.cpp
     snap_helpers.cpp
     fade_shapes.cpp

--- a/tests/native_editor_owner.cpp
+++ b/tests/native_editor_owner.cpp
@@ -1,0 +1,172 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "../src/engine/hosting/NativeInsertSlot.h"
+#include "../src/ui/NativeEditorOwner.h"
+
+#include <memory>
+
+using duskstudio::NativeEditorOwner;
+
+namespace
+{
+struct FakeInstance { int id = 0; };
+
+// Stands in for a real slot: the editor-side contract is getInstance() plus
+// generation().
+struct FakeSlot
+{
+    FakeInstance* getInstance() noexcept { return live; }
+    std::uint64_t generation() const noexcept { return gen; }
+
+    FakeInstance* live = nullptr;
+    std::uint64_t gen  = 0;
+};
+
+struct FakeEditor
+{
+    explicit FakeEditor (int& counter) : abandonCount (counter) {}
+
+    // Mirrors the real components: abandoning unbinds the slot, so staleness
+    // stops reporting from here on and only `abandoned` still marks the editor
+    // as reapable.
+    void abandonInstance() { ++abandonCount; stale = false; abandoned = true; }
+    bool ownerIsStale() const noexcept { return stale; }
+    bool wasAbandoned() const noexcept { return abandoned; }
+
+    int& abandonCount;
+    bool stale     = false;
+    bool abandoned = false;
+};
+
+// Minimal traits for a real NativeInsertSlot instantiation - enough to reach
+// load() / unload() / leakForShutdown() with no plugin format behind it.
+struct FakeBundle
+{
+    bool load (const std::string&, std::string&) { return true; }
+};
+
+struct FakeSlotInstance
+{
+    bool create (FakeBundle&, const std::string&, std::string&) { return true; }
+    bool activate (double, int, std::string&) { active = true; return true; }
+    bool isActive() const noexcept { return active; }
+    const duskstudio::hosting::PortLayout& portLayout() const noexcept { return layout; }
+
+    duskstudio::hosting::PortLayout layout;
+    bool active = false;
+};
+
+struct FakeTraits
+{
+    using Bundle   = FakeBundle;
+    using Instance = FakeSlotInstance;
+    static constexpr const char* bundleNoun = "bundle";
+    static bool pickPlugin (const Bundle&, const std::string&,
+                            std::string& idOut, std::string&)
+    { idOut = "fake"; return true; }
+};
+} // namespace
+
+TEST_CASE ("NativeEditorOwner tracks the slot it was stamped against")
+{
+    FakeInstance inst;
+    FakeSlot slot { &inst, 1 };
+
+    NativeEditorOwner owner;
+    owner.stamp (slot);
+    REQUIRE_FALSE (owner.isStale (slot));
+
+    SECTION ("an unloaded slot is stale")
+    {
+        slot.live = nullptr;
+        slot.gen  = 2;
+        REQUIRE (owner.isStale (slot));
+    }
+
+    SECTION ("a different instance is stale")
+    {
+        FakeInstance other;
+        slot.live = &other;
+        slot.gen  = 2;
+        REQUIRE (owner.isStale (slot));
+    }
+
+    SECTION ("a reload landing on the same address is stale")
+    {
+        // The pointer alone cannot tell the successor apart from the instance
+        // that was freed from that address - the generation is what catches it.
+        slot.gen = 2;
+        REQUIRE (owner.isStale (slot));
+    }
+}
+
+TEST_CASE ("NativeInsertSlot bumps its generation on every identity change")
+{
+    duskstudio::hosting::NativeInsertSlot<FakeTraits> slot;
+    const auto atRest = slot.generation();
+
+    std::string err;
+    REQUIRE (slot.load ("fake.bundle", 48000.0, 512, err));
+    const auto afterLoad = slot.generation();
+    REQUIRE (afterLoad != atRest);
+
+    NativeEditorOwner owner;
+    owner.stamp (slot);
+    REQUIRE_FALSE (owner.isStale (slot));
+
+    slot.unload();
+    REQUIRE (slot.generation() != afterLoad);
+    REQUIRE (owner.isStale (slot));
+
+    REQUIRE (slot.load ("fake.bundle", 48000.0, 512, err));
+    const auto afterReload = slot.generation();
+    owner.stamp (slot);
+    slot.leakForShutdown();
+    REQUIRE (slot.generation() != afterReload);
+    REQUIRE (owner.isStale (slot));
+}
+
+TEST_CASE ("syncNativeEditorOwner drops a stale editor and keeps a live one")
+{
+    int abandoned = 0;
+    auto editor = std::make_unique<FakeEditor> (abandoned);
+
+    int detached = 0;
+    auto detach = [&detached] (auto&) { ++detached; };
+
+    duskstudio::syncNativeEditorOwner (editor, detach);
+    REQUIRE (editor != nullptr);
+    REQUIRE (abandoned == 0);
+    REQUIRE (detached == 0);
+
+    editor->stale = true;
+    duskstudio::syncNativeEditorOwner (editor, detach);
+    REQUIRE (editor == nullptr);
+    // The plugin-side handles must be dropped before the component destructs,
+    // and the owner's own bookkeeping run while it is still alive.
+    REQUIRE (abandoned == 1);
+    REQUIRE (detached == 1);
+
+    // Nothing left to reap.
+    duskstudio::syncNativeEditorOwner (editor, detach);
+    REQUIRE (detached == 1);
+}
+
+TEST_CASE ("syncNativeEditorOwner reaps an editor that abandoned itself")
+{
+    // The guards on the component's own pump / embed paths tear it down first
+    // and unbind the slot, so by the time the owner polls there is no staleness
+    // left to see - only the abandoned mark. Missing that leaves a dead
+    // rectangle on screen until something else disturbs the lane.
+    int abandoned = 0;
+    auto editor = std::make_unique<FakeEditor> (abandoned);
+    editor->abandonInstance();
+    REQUIRE_FALSE (editor->ownerIsStale());
+
+    int detached = 0;
+    auto detach = [&detached] (auto&) { ++detached; };
+
+    duskstudio::syncNativeEditorOwner (editor, detach);
+    REQUIRE (editor == nullptr);
+    REQUIRE (detached == 1);
+}


### PR DESCRIPTION
CLAP/LV2/VST3 editor components cached raw instance pointers with no owner check while undo replay, session restore and one-host-per-insert eviction destroy instances from outside the UI, leaving the editors driving retired plugins.

Each editor now carries the slot's instance pointer plus a load generation (a reload can land the successor on the freed address) and checks it on every path that reaches plugin code: the pump tick, the embed, and the bounds push. Layout and hierarchy events fire in the same message-loop turn as the unload that retires an instance, so guarding the pump alone would leave the embed and resize paths open. A stale editor abandons its plugin-side handles at whichever guard sees it first: gui->destroy, IPlugView::removed and the suil controller all reach into a module that is already gone. Abandoning unbinds the slot, so the strip and lane polls reap on that mark rather than on staleness.

Also fixes the teardown paths this exposed: the LV2 shutdown leak now covers the whole reachable graph rather than the two suil handles, neither editor tears down (nor leaves mapped) a container or display under a live leaked GUI, a leaked CLAP GUI blocks a second gui->create on the same instance, and POLLNVAL unregisters the fd handler instead of dispatching an error every pump. Dropping an editor now takes the teardown its caller needs - destroy, abandon, or leak - so only an exiting process leaks, and a session load no longer burns an X client slot per open editor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin editor shutdown and recovery when plugin instances are replaced or closed unexpectedly.
  * Prevented stale editor windows from accessing unloaded plugin instances.
  * Improved GUI event handling and cleanup for more reliable operation.

* **Tests**
  * Added coverage for editor ownership, stale instance detection, cleanup, and reload scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->