### PR TITLE
fix(session): reset mastering and transport on a missing section

### DIFF
--- a/src/session/SessionSerializer.cpp
+++ b/src/session/SessionSerializer.cpp
@@ -1922,25 +1922,6 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
                                   ? sr : 0.0;
     }
 
-    // Peek at transport.tempo_bpm BEFORE the track loop so legacy sessions
-    // (no recorded_at_bpm field on MidiRegion) get anchored to their own
-    // saved tempo rather than the struct default of 120. The transport
-    // block is parsed in full further down; this is a read-only peek.
-    double sessionLoadBpm = (double) s.tempoBpm.load (std::memory_order_relaxed);
-    {
-        const auto& tportPeek = json::child (root, "transport");
-        if (json::has (tportPeek, "tempo_bpm"))
-        {
-            const double peeked = json::getDouble (tportPeek, "tempo_bpm", 0.0);
-            // Clamp to the same 30-300 range the final tempoBpm store uses, so
-            // the automation / MIDI fallback tempo stays aligned with the loaded
-            // session tempo instead of using a raw out-of-range value. Reject a
-            // value past float range before it narrows (UB) - keep the seeded tempo.
-            if (std::isfinite (peeked) && std::abs (peeked) <= (double) std::numeric_limits<float>::max())
-                sessionLoadBpm = jlimit (30.0, 300.0, peeked);
-        }
-    }
-
     // A truncated / hand-edited file may lack whole section keys, or list
     // fewer buses / aux lanes than this build has. Every slot must still be
     // driven through restore - skipping any leaves the PREVIOUS session's
@@ -1964,6 +1945,30 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
                       "[Dusk Studio/SessionSerializer] the default-session template failed "
                       "to parse; keys this file does not describe keep the previously "
                       "loaded session's state\n");
+
+    // Resolved once, here, and consumed twice: by the tempo peek below and by
+    // the transport block far further down. A section the file doesn't describe
+    // (absent, or not an object) reads from the serialized defaults, so the
+    // anchor tempo and the tempo the session ends up running at cannot disagree.
+    const auto& transportSection = json::has (root, "transport") && root["transport"].is_object()
+                                       ? json::child (root, "transport")
+                                       : json::child (sectionDefaults, "transport");
+
+    // Peek at transport.tempo_bpm BEFORE the track loop so legacy sessions
+    // (no recorded_at_bpm field on MidiRegion) get anchored to their own
+    // saved tempo rather than the struct default of 120. The transport
+    // block is parsed in full further down; this is a read-only peek.
+    double sessionLoadBpm = (double) s.tempoBpm.load (std::memory_order_relaxed);
+    if (json::has (transportSection, "tempo_bpm"))
+    {
+        const double peeked = json::getDouble (transportSection, "tempo_bpm", 0.0);
+        // Clamp to the same 30-300 range the final tempoBpm store uses, so
+        // the automation / MIDI fallback tempo stays aligned with the loaded
+        // session tempo instead of using a raw out-of-range value. Reject a
+        // value past float range before it narrows (UB) - keep the seeded tempo.
+        if (std::isfinite (peeked) && std::abs (peeked) <= (double) std::numeric_limits<float>::max())
+            sessionLoadBpm = jlimit (30.0, 300.0, peeked);
+    }
 
     {
         const auto& tracks = ! json::array (root, "tracks").empty()
@@ -2263,67 +2268,88 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
     // Always reset: a session without a saved mastering source must not
     // inherit the previously loaded session's file.
     s.mastering().sourceFile = juce::File();
-    if (json::has (root, "mastering"))
     {
+        // Mastering diverges from the per-track fill exactly like the master
+        // strip above: with the section present, a key it omits keeps the
+        // in-memory value; only a wholly absent section resets every field, so
+        // nothing inherits the previously loaded session's chain. A non-object
+        // counts as absent - json::child resolves it to the shared empty
+        // object, which would otherwise read as present-but-empty and retain
+        // everything.
+        static const MasteringParams kMasteringDefaults;
+        const bool haveMastering = json::has (root, "mastering") && root["mastering"].is_object();
         const auto& mast = json::child (root, "mastering");
         auto& m = s.mastering();
         if (json::has (mast, "source_file"))
             m.sourceFile = resolvePortablePath (json::getString (mast, "source_file"),
                                                 s.getSessionDirectory(),
                                                 s.missingAudioFilesAfterLoad);
-        auto loadF = [&] (const char* k, std::atomic<float>& dst)
-            { if (json::has (mast, k)) dst.store (json::getFloat (mast, k, 0.0f)); };
-        auto loadB = [&] (const char* k, std::atomic<bool>& dst)
-            { if (json::has (mast, k)) dst.store (json::getBool (mast, k, false)); };
-        loadB ("eq_enabled",        m.eqEnabled);
+        auto loadF = [&mast, haveMastering] (const char* k, std::atomic<float>& dst,
+                                             const std::atomic<float>& def)
+        {
+            if (json::has (mast, k))  dst.store (json::getFiniteFloat (mast, k, def.load()));
+            else if (! haveMastering) dst.store (def.load());
+        };
+        auto loadB = [&mast, haveMastering] (const char* k, std::atomic<bool>& dst,
+                                             const std::atomic<bool>& def)
+        {
+            if (json::has (mast, k))  dst.store (json::getBool (mast, k, def.load()));
+            else if (! haveMastering) dst.store (def.load());
+        };
+        loadB ("eq_enabled",        m.eqEnabled,       kMasteringDefaults.eqEnabled);
         for (int b = 0; b < MasteringParams::kNumEqBands; ++b)
         {
             const auto idx = std::string ("eq_band_") + std::to_string (b);
-            loadF ((idx + "_freq").c_str(),    m.eqBandFreq[b]);
-            loadF ((idx + "_gain_db").c_str(), m.eqBandGainDb[b]);
-            loadF ((idx + "_q").c_str(),       m.eqBandQ[b]);
+            loadF ((idx + "_freq").c_str(),    m.eqBandFreq[b],   kMasteringDefaults.eqBandFreq[b]);
+            loadF ((idx + "_gain_db").c_str(), m.eqBandGainDb[b], kMasteringDefaults.eqBandGainDb[b]);
+            loadF ((idx + "_q").c_str(),       m.eqBandQ[b],      kMasteringDefaults.eqBandQ[b]);
         }
-        loadF ("eq_lf_boost",       m.eqLfBoost);
-        loadF ("eq_hf_boost",       m.eqHfBoost);
-        loadF ("eq_hf_atten",       m.eqHfAtten);
-        loadF ("eq_tube_drive",     m.eqTubeDrive);
-        loadF ("eq_output_gain_db", m.eqOutputGainDb);
-        loadB ("comp_enabled",      m.compEnabled);
-        loadF ("comp_thresh_db",    m.compThreshDb);
-        loadF ("comp_ratio",        m.compRatio);
-        loadF ("comp_attack_ms",    m.compAttackMs);
-        loadF ("comp_release_ms",   m.compReleaseMs);
-        loadB ("comp_release_auto", m.compReleaseAuto);
-        loadF ("comp_makeup_db",    m.compMakeupDb);
-        // Limiter fields are newly persisted, so old sessions lack them - reset
-        // to the struct defaults when absent instead of inheriting the prior
-        // session's limiter state (loadB/loadF conditional-store, no reset).
-        m.limiterEnabled.store    (json::getBool  (mast, "limiter_enabled", true));
-        m.limiterDriveDb.store    (json::getFloat (mast, "limiter_drive_db", 0.0f));
-        m.limiterCeilingDb.store  (json::getFloat (mast, "limiter_ceiling_db", -0.3f));
-        m.limiterReleaseMs.store  (json::getFloat (mast, "limiter_release_ms", 100.0f));
-        {
-            // Validate before storing: a NaN/±inf here would otherwise sit in the
-            // limiter param (and the UI knob) until the next set; fall back to the
-            // default so a corrupt session can't strand non-finite lookahead.
-            const float la = json::getFloat (mast, "limiter_lookahead_ms", 2.0f);
-            m.limiterLookaheadMs.store (std::isfinite (la) ? la : 2.0f);
-        }
-        m.limiterMode.store       (json::getInt  (mast, "limiter_mode", 0));
-        m.limiterStereoLink.store (json::getBool (mast, "limiter_stereo_link", true));
+        loadF ("eq_lf_boost",       m.eqLfBoost,       kMasteringDefaults.eqLfBoost);
+        loadF ("eq_hf_boost",       m.eqHfBoost,       kMasteringDefaults.eqHfBoost);
+        loadF ("eq_hf_atten",       m.eqHfAtten,       kMasteringDefaults.eqHfAtten);
+        loadF ("eq_tube_drive",     m.eqTubeDrive,     kMasteringDefaults.eqTubeDrive);
+        loadF ("eq_output_gain_db", m.eqOutputGainDb,  kMasteringDefaults.eqOutputGainDb);
+        loadB ("comp_enabled",      m.compEnabled,     kMasteringDefaults.compEnabled);
+        loadF ("comp_thresh_db",    m.compThreshDb,    kMasteringDefaults.compThreshDb);
+        loadF ("comp_ratio",        m.compRatio,       kMasteringDefaults.compRatio);
+        loadF ("comp_attack_ms",    m.compAttackMs,    kMasteringDefaults.compAttackMs);
+        loadF ("comp_release_ms",   m.compReleaseMs,   kMasteringDefaults.compReleaseMs);
+        loadB ("comp_release_auto", m.compReleaseAuto, kMasteringDefaults.compReleaseAuto);
+        loadF ("comp_makeup_db",    m.compMakeupDb,    kMasteringDefaults.compMakeupDb);
+        // The limiter is newer than the section around it, so a session saved
+        // before it exists still carries "mastering" - these reset on an absent
+        // key whether the section is there or not, rather than retaining.
+        m.limiterEnabled.store (json::getBool (mast, "limiter_enabled",
+                                               kMasteringDefaults.limiterEnabled.load()));
+        m.limiterDriveDb.store (json::getFiniteFloat (mast, "limiter_drive_db",
+                                                      kMasteringDefaults.limiterDriveDb.load()));
+        m.limiterCeilingDb.store (json::getFiniteFloat (mast, "limiter_ceiling_db",
+                                                        kMasteringDefaults.limiterCeilingDb.load()));
+        m.limiterReleaseMs.store (json::getFiniteFloat (mast, "limiter_release_ms",
+                                                        kMasteringDefaults.limiterReleaseMs.load()));
+        // Finite-guarded like the rest: a NaN/inf lookahead would otherwise sit
+        // in the limiter param (and the UI knob) until the next set.
+        m.limiterLookaheadMs.store (json::getFiniteFloat (mast, "limiter_lookahead_ms",
+                                                          kMasteringDefaults.limiterLookaheadMs.load()));
+        m.limiterMode.store (json::getInt (mast, "limiter_mode",
+                                           kMasteringDefaults.limiterMode.load()));
+        m.limiterStereoLink.store (json::getBool (mast, "limiter_stereo_link",
+                                                  kMasteringDefaults.limiterStereoLink.load()));
         if (json::has (mast, "target_preset"))
-            m.targetPresetIndex.store (json::getInt (mast, "target_preset", 0));
+            m.targetPresetIndex.store (json::getInt (mast, "target_preset",
+                                                     kMasteringDefaults.targetPresetIndex.load()));
+        else if (! haveMastering)
+            m.targetPresetIndex.store (kMasteringDefaults.targetPresetIndex.load());
     }
-    // Reset-when-absent: these are newer than most sessions on disk, and the
-    // load reuses the live Session, so a conditional store would leave the
-    // previously loaded session's MTC settings in place.
-    s.externalTimeCodeChasesTransport.store (false, std::memory_order_relaxed);
-    s.syncOutputEmitTimeCode.store (false, std::memory_order_relaxed);
-    s.syncOutputTimeCodeFrameRate.store (3, std::memory_order_relaxed);
 
-    if (json::has (root, "transport"))
     {
-        const auto& tport = json::child (root, "transport");
+        // The section resolved up with the tempo peek. Present, it keeps the
+        // same per-key retention as master and mastering above; absent or not
+        // an object, it reads from the serialized defaults rather than being
+        // skipped, so the previously loaded session's loop and punch ranges,
+        // tempo map, sync / MCU identifiers and MIDI bindings don't stay live
+        // under the new session. Either way every field below is written once.
+        const auto& tport = transportSection;
         if (json::has (tport, "loop_enabled"))  s.savedLoopEnabled  = json::getBool  (tport, "loop_enabled", false);
         if (json::has (tport, "loop_start"))    s.savedLoopStart    = json::getInt64 (tport, "loop_start", 0);
         if (json::has (tport, "loop_end"))      s.savedLoopEnd      = json::getInt64 (tport, "loop_end", 0);

--- a/tests/session_clamp_corrupt_values.cpp
+++ b/tests/session_clamp_corrupt_values.cpp
@@ -59,11 +59,10 @@ TEST_CASE ("SessionSerializer::load clamps corrupt automation + EQ values",
     )JSON");
 
     Session s;
-    // Seed an explicit, non-default session tempo so the per-point bpm fallback is
-    // tested against a known value rather than coupling the assertion to whatever the
-    // Session default tempo happens to be. The fixture JSON sets no transport tempo,
-    // so this seeded value survives the load and is what the corrupt (+inf) point
-    // falls back to.
+    // Seed a non-default tempo the load has to overwrite: the fixture carries no
+    // transport section, so the tempo AND the anchor the corrupt (+inf) point
+    // falls back to both come from the model default (120), not from whatever the
+    // previously loaded session was running at.
     s.tempoBpm.store (100.0f);
     REQUIRE (SessionSerializer::load (s, target));
 
@@ -81,9 +80,10 @@ TEST_CASE ("SessionSerializer::load clamps corrupt automation + EQ values",
     REQUIRE_THAT (pts[0].value, WithinAbs (1.0f, 1e-6f));
     REQUIRE_THAT (pts[1].value, WithinAbs (0.25f, 1e-6f));
 
-    // Non-finite bpm rejected — falls back to the seeded session tempo (100).
+    // Non-finite bpm rejected - falls back to the loaded session tempo (120).
     REQUIRE (std::isfinite (pts[0].recordedAtBPM));
-    REQUIRE_THAT (pts[0].recordedAtBPM, WithinAbs (100.0f, 1e-3f));
+    REQUIRE_THAT (pts[0].recordedAtBPM, WithinAbs (120.0f, 1e-3f));
+    REQUIRE_THAT (s.tempoBpm.load(), WithinAbs (120.0f, 1e-3f));
 
     // Non-finite EQ gain rejected — the in-memory default (0 dB) is kept.
     const float lmGain = s.track (0).strip.lmGainDb.load();
@@ -197,6 +197,47 @@ TEST_CASE ("SessionSerializer::load defaults present invalid master bools",
     REQUIRE (s.master().eqEnabled.load() == false);
     REQUIRE (s.master().compEnabled.load() == true);
     REQUIRE (s.master().compReleaseAuto.load() == true);
+
+    target.getParentDirectory().deleteRecursively();
+}
+
+// The mastering chain reads its values the same way the master strip does, so
+// a value of the wrong type resolves to the model default rather than to a
+// blanket zero / false. comp_ratio 0 would divide into the compressor's ratio
+// math, and auto-release defaults ON, so neither can be the silent fallback.
+TEST_CASE ("SessionSerializer::load defaults present invalid mastering values",
+           "[session][serializer][corruption]")
+{
+    const auto target = writeSession (R"JSON(
+    {
+      "version": 3,
+      "mastering": {
+        "comp_ratio": "x",
+        "comp_attack_ms": 12.0,
+        "comp_thresh_db": 1e40,
+        "comp_release_auto": "maybe",
+        "eq_enabled": true
+      }
+    }
+    )JSON");
+
+    Session s;
+    s.mastering().compRatio.store (8.0f);
+    s.mastering().compAttackMs.store (99.0f);
+    s.mastering().compThreshDb.store (-24.0f);
+    s.mastering().compReleaseAuto.store (false);
+    s.mastering().eqEnabled.store (false);
+    s.mastering().compMakeupDb.store (6.0f);
+
+    REQUIRE (SessionSerializer::load (s, target));
+    const duskstudio::MasteringParams def;
+    REQUIRE_THAT (s.mastering().compRatio.load(), WithinAbs (def.compRatio.load(), 1e-6f));
+    REQUIRE_THAT (s.mastering().compAttackMs.load(), WithinAbs (12.0f, 1e-6f));
+    REQUIRE_THAT (s.mastering().compThreshDb.load(), WithinAbs (def.compThreshDb.load(), 1e-6f));
+    REQUIRE (s.mastering().compReleaseAuto.load() == def.compReleaseAuto.load());
+    REQUIRE (s.mastering().eqEnabled.load() == true);
+    // A missing key in a present mastering section retains the live value.
+    REQUIRE_THAT (s.mastering().compMakeupDb.load(), WithinAbs (6.0f, 1e-6f));
 
     target.getParentDirectory().deleteRecursively();
 }

--- a/tests/session_missing_sections.cpp
+++ b/tests/session_missing_sections.cpp
@@ -376,3 +376,290 @@ TEST_CASE ("a pathologically nested track slot falls back to the default",
     REQUIRE (s.track (0).name == defaults.track (0).name);
     REQUIRE_THAT (s.track (0).strip.faderDb.load(), WithinAbs (0.0f, 1e-6f));
 }
+
+// The mastering chain was restored entirely inside a "mastering" presence
+// check, so a file without the key left every field holding the previous
+// session's chain - and the Mastering stage then processed the newly loaded
+// mix through it.
+TEST_CASE ("loading a session without a mastering section resets the chain",
+           "[session][serializer]")
+{
+    ScopedTempDir tmp { "dusk-missing-mastering-" };
+    const auto& dir = tmp.dir;
+
+    Session s;
+    s.setSessionDirectory (dir);
+
+    auto& m = s.mastering();
+    m.sourceFile = dir.getChildFile ("ghost-mix.wav");
+    m.eqEnabled.store (true);
+    for (int b = 0; b < MasteringParams::kNumEqBands; ++b)
+    {
+        m.eqBandFreq[b]  .store (777.0f + (float) b);
+        m.eqBandGainDb[b].store (6.0f + (float) b);
+        m.eqBandQ[b]     .store (3.5f + (float) b);
+    }
+    m.eqLfBoost      .store (5.0f);
+    m.eqHfBoost      .store (4.0f);
+    m.eqHfAtten      .store (3.0f);
+    m.eqTubeDrive    .store (0.9f);
+    m.eqOutputGainDb .store (2.0f);
+    m.compEnabled    .store (true);
+    m.compThreshDb   .store (-18.0f);
+    m.compRatio      .store (8.0f);
+    m.compAttackMs   .store (1.0f);
+    m.compReleaseMs  .store (500.0f);
+    m.compReleaseAuto.store (false);
+    m.compMakeupDb   .store (6.0f);
+    m.limiterEnabled   .store (false);
+    m.limiterDriveDb   .store (9.0f);
+    m.limiterCeilingDb .store (-6.0f);
+    m.limiterReleaseMs .store (400.0f);
+    m.limiterMode      .store (2);
+    m.limiterStereoLink.store (false);
+    m.limiterLookaheadMs.store (8.0f);
+    m.targetPresetIndex.store (3);
+
+    const auto target = dir.getChildFile ("session.json");
+
+    SECTION ("mastering key absent")
+    {
+        target.replaceWithText (R"({"version":3})");
+    }
+    SECTION ("mastering key present but not an object")
+    {
+        target.replaceWithText (R"({"version":3,"mastering":42})");
+    }
+
+    REQUIRE (SessionSerializer::load (s, target));
+
+    const MasteringParams def;
+    REQUIRE (m.sourceFile == juce::File());
+    REQUIRE (m.eqEnabled.load() == def.eqEnabled.load());
+    for (int b = 0; b < MasteringParams::kNumEqBands; ++b)
+    {
+        REQUIRE_THAT (m.eqBandFreq[b]  .load(), WithinAbs (def.eqBandFreq[b]  .load(), 1e-6f));
+        REQUIRE_THAT (m.eqBandGainDb[b].load(), WithinAbs (def.eqBandGainDb[b].load(), 1e-6f));
+        REQUIRE_THAT (m.eqBandQ[b]     .load(), WithinAbs (def.eqBandQ[b]     .load(), 1e-6f));
+    }
+    REQUIRE_THAT (m.eqLfBoost     .load(), WithinAbs (def.eqLfBoost     .load(), 1e-6f));
+    REQUIRE_THAT (m.eqHfBoost     .load(), WithinAbs (def.eqHfBoost     .load(), 1e-6f));
+    REQUIRE_THAT (m.eqHfAtten     .load(), WithinAbs (def.eqHfAtten     .load(), 1e-6f));
+    REQUIRE_THAT (m.eqTubeDrive   .load(), WithinAbs (def.eqTubeDrive   .load(), 1e-6f));
+    REQUIRE_THAT (m.eqOutputGainDb.load(), WithinAbs (def.eqOutputGainDb.load(), 1e-6f));
+    REQUIRE (m.compEnabled.load() == def.compEnabled.load());
+    REQUIRE_THAT (m.compThreshDb  .load(), WithinAbs (def.compThreshDb  .load(), 1e-6f));
+    REQUIRE_THAT (m.compRatio     .load(), WithinAbs (def.compRatio     .load(), 1e-6f));
+    REQUIRE_THAT (m.compAttackMs  .load(), WithinAbs (def.compAttackMs  .load(), 1e-6f));
+    REQUIRE_THAT (m.compReleaseMs .load(), WithinAbs (def.compReleaseMs .load(), 1e-6f));
+    REQUIRE (m.compReleaseAuto.load() == def.compReleaseAuto.load());
+    REQUIRE_THAT (m.compMakeupDb  .load(), WithinAbs (def.compMakeupDb  .load(), 1e-6f));
+    REQUIRE (m.limiterEnabled.load() == def.limiterEnabled.load());
+    REQUIRE_THAT (m.limiterDriveDb    .load(), WithinAbs (def.limiterDriveDb    .load(), 1e-6f));
+    REQUIRE_THAT (m.limiterCeilingDb  .load(), WithinAbs (def.limiterCeilingDb  .load(), 1e-6f));
+    REQUIRE_THAT (m.limiterReleaseMs  .load(), WithinAbs (def.limiterReleaseMs  .load(), 1e-6f));
+    REQUIRE_THAT (m.limiterLookaheadMs.load(), WithinAbs (def.limiterLookaheadMs.load(), 1e-6f));
+    REQUIRE (m.limiterMode.load()       == def.limiterMode.load());
+    REQUIRE (m.limiterStereoLink.load() == def.limiterStereoLink.load());
+    REQUIRE (m.targetPresetIndex.load() == def.targetPresetIndex.load());
+}
+
+// Mastering follows the master strip rather than the per-track fill: a section
+// that IS there describes the chain, and a key it omits keeps the live value.
+// The limiter is the exception - it postdates the section, so a file written
+// before it must not inherit one.
+TEST_CASE ("a partial mastering section retains the keys it omits",
+           "[session][serializer]")
+{
+    ScopedTempDir tmp { "dusk-partial-mastering-" };
+    const auto& dir = tmp.dir;
+
+    Session s;
+    s.setSessionDirectory (dir);
+
+    auto& m = s.mastering();
+    m.eqEnabled       .store (true);
+    m.eqLfBoost       .store (5.0f);
+    m.eqOutputGainDb  .store (2.0f);
+    m.compRatio       .store (8.0f);
+    m.limiterCeilingDb.store (-6.0f);
+
+    const auto target = dir.getChildFile ("session.json");
+    target.replaceWithText (
+        R"({"version":3,"mastering":{"comp_ratio":6.0,"eq_output_gain_db":1e40}})");
+
+    REQUIRE (SessionSerializer::load (s, target));
+
+    const MasteringParams def;
+    REQUIRE_THAT (m.compRatio.load(), WithinAbs (6.0f, 1e-6f));
+    // Past float range: unusable, so the model default rather than the file's
+    // value or the live one.
+    REQUIRE_THAT (m.eqOutputGainDb.load(), WithinAbs (def.eqOutputGainDb.load(), 1e-6f));
+    REQUIRE (m.eqEnabled.load());
+    REQUIRE_THAT (m.eqLfBoost.load(), WithinAbs (5.0f, 1e-6f));
+    REQUIRE_THAT (m.limiterCeilingDb.load(), WithinAbs (def.limiterCeilingDb.load(), 1e-6f));
+}
+
+// Transport had the same presence check around it, with a wider blast radius:
+// loop and punch ranges, tempo and the whole tempo map, sync / MCU identifiers
+// and the MIDI bindings the audio thread reads all survived a file that never
+// described them.
+TEST_CASE ("loading a session without a transport section resets transport state",
+           "[session][serializer]")
+{
+    ScopedTempDir tmp { "dusk-missing-transport-" };
+    const auto& dir = tmp.dir;
+
+    Session s;
+    s.setSessionDirectory (dir);
+
+    s.savedLoopEnabled  = true;
+    s.savedLoopStart    = 48000;
+    s.savedLoopEnd      = 96000;
+    s.savedPunchEnabled = true;
+    s.savedPunchIn      = 24000;
+    s.savedPunchOut     = 72000;
+    s.snapToGrid        = true;
+    s.audioEditorSnap   = true;
+    s.midiEditorSnap    = false;
+    s.pianoRollKeySnap  = false;
+    s.snapResolution    = SnapResolution::CDFrames;
+    s.tempoBpm.store (90.0f);
+    s.tempoMap.setPoints ({ { 0, 100.0f }, { 48000, 140.0f } });
+    s.uiStage.store (2);
+    s.syncSourceInputIdentifier = "ghost-in";
+    s.externalSyncFollowsTempo   .store (false);
+    s.externalSyncChasesTransport.store (true);
+    s.syncOutputIdentifier = "ghost-out";
+    s.syncOutputEmitClock.store (true);
+    s.externalTimeCodeChasesTransport.store (true,  std::memory_order_relaxed);
+    s.syncOutputEmitTimeCode         .store (true,  std::memory_order_relaxed);
+    s.syncOutputTimeCodeFrameRate    .store (0,     std::memory_order_relaxed);
+    s.mcu.inputIdentifier  = "ghost-mcu-in";
+    s.mcu.outputIdentifier = "ghost-mcu-out";
+    s.mcu.assignMode.store (5, std::memory_order_relaxed);
+    s.beatsPerBar.store (7);
+    s.beatUnit   .store (8);
+    s.metronomeEnabled           .store (true);
+    s.metronomeVolDb             .store (6.0f);
+    s.metronomeClickWhileRecording.store (false);
+    s.metronomeClickWhilePlaying .store (true);
+    s.metronomeOnlyDuringCountIn .store (true);
+    s.metronomePolyphonic        .store (true);
+    s.countInEnabled  .store (true);
+    s.timeDisplayMode .store (1);
+    s.lastRecordPointSamples.store (123456);
+    s.preRollSeconds .store (4.0f);
+    s.postRollSeconds.store (5.0f);
+    s.preRollEnabled .store (false);
+    s.postRollEnabled.store (false);
+    s.oversamplingFactor.store (4, std::memory_order_relaxed);
+    {
+        MidiBinding b;
+        b.channel     = 1;
+        b.dataNumber  = 7;
+        b.trigger     = MidiBindingTrigger::CC;
+        b.target      = MidiBindingTarget::TransportPlay;
+        auto ghost = std::make_unique<std::vector<MidiBinding>>();
+        ghost->push_back (b);
+        s.midiBindings.publish (std::move (ghost));
+    }
+
+    // The track carries a legacy MIDI region (no recorded_at_bpm), whose anchor
+    // is stamped from the tempo peeked off the transport section.
+    const auto target = dir.getChildFile ("session.json");
+    const juce::String legacyMidiTrack =
+        R"(,"tracks":[{"midi_regions":[{"timeline_start":0,"length_samples":48000,"length_ticks":1920}]}])";
+
+    SECTION ("transport key absent")
+    {
+        target.replaceWithText (R"({"version":3)" + legacyMidiTrack + "}");
+    }
+    SECTION ("transport key present but not an object")
+    {
+        target.replaceWithText (R"({"version":3,"transport":42)" + legacyMidiTrack + "}");
+    }
+
+    REQUIRE (SessionSerializer::load (s, target));
+
+    const Session def;
+    REQUIRE (s.savedLoopEnabled  == def.savedLoopEnabled);
+    REQUIRE (s.savedLoopStart    == def.savedLoopStart);
+    REQUIRE (s.savedLoopEnd      == def.savedLoopEnd);
+    REQUIRE (s.savedPunchEnabled == def.savedPunchEnabled);
+    REQUIRE (s.savedPunchIn      == def.savedPunchIn);
+    REQUIRE (s.savedPunchOut     == def.savedPunchOut);
+    REQUIRE (s.snapToGrid       == def.snapToGrid);
+    REQUIRE (s.audioEditorSnap  == def.audioEditorSnap);
+    REQUIRE (s.midiEditorSnap   == def.midiEditorSnap);
+    REQUIRE (s.pianoRollKeySnap == def.pianoRollKeySnap);
+    REQUIRE (s.snapResolution   == def.snapResolution);
+    REQUIRE_THAT (s.tempoBpm.load(), WithinAbs (def.tempoBpm.load(), 1e-6f));
+    REQUIRE (s.tempoMap.empty());
+    REQUIRE (s.uiStage.load() == def.uiStage.load());
+    REQUIRE (s.syncSourceInputIdentifier.isEmpty());
+    REQUIRE (s.externalSyncFollowsTempo.load()    == def.externalSyncFollowsTempo.load());
+    REQUIRE (s.externalSyncChasesTransport.load() == def.externalSyncChasesTransport.load());
+    REQUIRE (s.syncOutputIdentifier.isEmpty());
+    REQUIRE (s.syncOutputEmitClock.load() == def.syncOutputEmitClock.load());
+    REQUIRE (s.externalTimeCodeChasesTransport.load (std::memory_order_relaxed)
+               == def.externalTimeCodeChasesTransport.load (std::memory_order_relaxed));
+    REQUIRE (s.syncOutputEmitTimeCode.load (std::memory_order_relaxed)
+               == def.syncOutputEmitTimeCode.load (std::memory_order_relaxed));
+    REQUIRE (s.syncOutputTimeCodeFrameRate.load (std::memory_order_relaxed)
+               == def.syncOutputTimeCodeFrameRate.load (std::memory_order_relaxed));
+    REQUIRE (s.mcu.inputIdentifier.isEmpty());
+    REQUIRE (s.mcu.outputIdentifier.isEmpty());
+    REQUIRE (s.mcu.assignMode.load (std::memory_order_relaxed)
+               == def.mcu.assignMode.load (std::memory_order_relaxed));
+    REQUIRE (s.beatsPerBar.load() == def.beatsPerBar.load());
+    REQUIRE (s.beatUnit   .load() == def.beatUnit   .load());
+    REQUIRE (s.metronomeEnabled.load() == def.metronomeEnabled.load());
+    REQUIRE_THAT (s.metronomeVolDb.load(), WithinAbs (def.metronomeVolDb.load(), 1e-6f));
+    REQUIRE (s.metronomeClickWhileRecording.load() == def.metronomeClickWhileRecording.load());
+    REQUIRE (s.metronomeClickWhilePlaying  .load() == def.metronomeClickWhilePlaying  .load());
+    REQUIRE (s.metronomeOnlyDuringCountIn  .load() == def.metronomeOnlyDuringCountIn  .load());
+    REQUIRE (s.metronomePolyphonic         .load() == def.metronomePolyphonic         .load());
+    REQUIRE (s.countInEnabled .load() == def.countInEnabled .load());
+    REQUIRE (s.timeDisplayMode.load() == def.timeDisplayMode.load());
+    REQUIRE (s.lastRecordPointSamples.load() == def.lastRecordPointSamples.load());
+    REQUIRE_THAT (s.preRollSeconds .load(), WithinAbs (def.preRollSeconds .load(), 1e-6f));
+    REQUIRE_THAT (s.postRollSeconds.load(), WithinAbs (def.postRollSeconds.load(), 1e-6f));
+    REQUIRE (s.preRollEnabled .load() == def.preRollEnabled .load());
+    REQUIRE (s.postRollEnabled.load() == def.postRollEnabled.load());
+    REQUIRE (s.midiBindings.current().empty());
+    REQUIRE (s.oversamplingFactor.load (std::memory_order_relaxed)
+               == def.oversamplingFactor.load (std::memory_order_relaxed));
+
+    // The anchor the legacy region was stamped with has to be the tempo the
+    // session actually ends up at. Anchoring it to the seeded 90 while the
+    // transport resets to 120 mis-retimes the region on the first tempo change.
+    const auto& midi = s.track (0).midiRegions.current();
+    REQUIRE (midi.size() == 1);
+    REQUIRE_THAT (midi[0].recordedAtBPM, WithinAbs ((double) def.tempoBpm.load(), 1e-6));
+}
+
+// The other half of the transport contract: a section that IS there is the
+// session's description of its transport, and a key it leaves out keeps the
+// live value rather than snapping to the model default.
+TEST_CASE ("a partial transport section retains the keys it omits",
+           "[session][serializer]")
+{
+    ScopedTempDir tmp { "dusk-partial-transport-" };
+    const auto& dir = tmp.dir;
+
+    Session s;
+    s.setSessionDirectory (dir);
+    s.beatsPerBar.store (7);
+    s.uiStage.store (2);
+    s.savedLoopEnabled = true;
+
+    const auto target = dir.getChildFile ("session.json");
+    target.replaceWithText (R"({"version":3,"transport":{"beats_per_bar":3}})");
+
+    REQUIRE (SessionSerializer::load (s, target));
+
+    REQUIRE (s.beatsPerBar.load() == 3);
+    REQUIRE (s.uiStage.load() == 2);
+    REQUIRE (s.savedLoopEnabled);
+}


### PR DESCRIPTION
load() reuses the live Session, and both sections were restored inside a presence check with no else. A file lacking the key left the previously loaded session's mastering chain processing the new mix, and its loop and punch ranges, tempo, tempo map, sync / MCU identifiers and MIDI bindings live under the new session's name.

Mastering now follows the master strip: a present section retains the value for a key it omits, a wholly absent (or non-object) one resets every field to the model default, and a present-but-unusable value falls to the default too. Transport keeps the same per-key retention when the section is there, and is driven from the serialized default session when it is not, so each field it restores still runs exactly once.

The tempo peek that anchors legacy MIDI regions and automation points resolves the transport section the same way, so a file without one can't anchor them to the previous session's tempo while the transport itself resets. That leaves the three MTC stores ahead of the block as dead writes - the block always runs now and overwrites all three - so they go.

Fixes #182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Session loading now reliably resets missing or invalid transport settings to defaults, including tempo, synchronization, metronome, MIDI, display, and loop state.
  - Mastering settings now restore valid values consistently, reset corrupt fields safely, and preserve valid partial settings.
  - Legacy MIDI sessions use the correct default tempo when transport data is unavailable.
- **Tests**
  - Added coverage for missing, partial, malformed, and corrupt session settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->