### PR TITLE
fix(notepad): close out the chord-chart review findings

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -566,21 +566,27 @@ Type the chord name and press Enter to commit it, Esc to cancel, or commit an
 empty name to remove it. The slot shows ranked completions; use Up/Down to
 choose one and Tab to accept it. When the notepad can detect a key, diatonic
 chords come first; otherwise the choices are alphabetical. Ctrl+Shift+K repeats
-the preceding chord at the caret. Click a chord to edit it again. Chords float
-above their syllable and move with the lyric as you edit around them. The
-transpose buttons shift every chord in the notepad by a semitone, spelled with
-the notepad's existing accidental preference so that transposing away and back
-returns your own spelling. Notes are stored as ChordPro brackets in `notepad.md`
-(`[Am]like this`), so the file opens in any chord-sheet app; bracketed text that
-is not a chord name, such as `[Chorus]`, stays literal.
+the preceding chord at the caret. Clicking elsewhere, reaching for a toolbar
+button, and closing the notepad all commit the slot the same way Enter does,
+including the completion it is showing. Click a chord label to edit it again;
+each label answers for the space it occupies, so two chords a syllable apart
+are both reachable. Chords float above their syllable and move with the lyric
+as you edit around them. The transpose buttons shift every chord in the notepad
+by a semitone, spelled with the notepad's existing accidental preference so that
+transposing away and back returns your own spelling. Notes are stored as
+ChordPro brackets in `notepad.md` (`[Am]like this`), so the file opens in any
+chord-sheet app; bracketed text that is not a chord name, such as `[Chorus]`,
+stays literal.
 
 **Sections.** The section button writes a marker such as `[Chorus]` on its own
 line above the caret. Markers are plain text, so typing one by hand is the same
-thing: any bracketed word that is not a chord name stays literal. To remove one,
-put the caret on the marker line, click the **Section** button, and choose
-**Remove current section**, or select and delete the label directly. The chart
-shows only the section label; the compatible `notepad.md` file keeps its
-brackets visible.
+thing: any bracketed word that is not a chord name stays literal. Rename a
+marker by editing its label in the chart. The label has to stay a label, so an
+edit that would put a bracket inside it, or turn it into a chord name, is
+refused and the marker is left as it was. To remove one, put the caret on the
+marker line, click the **Section** button, and choose **Remove current
+section**, or select and delete the label directly. The chart shows only the
+section label; the compatible `notepad.md` file keeps its brackets visible.
 
 The songwriter-focused toolbar keeps chord and section insertion,
 transposition, lyric and title styles, bold, italic, undo and redo, and the

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -74,39 +74,27 @@ juce::Array<juce::File> toFileArray (const std::vector<std::filesystem::path>& p
 }
 
 #if DUSKSTUDIO_HAS_NATIVE_NOTEPAD
-NativeNotepadWindow::EmbeddedGeometry notepadGeometryFor (const juce::Component& topLevel)
+// Where the embedded notepad child sits inside the top-level window, in
+// logical coordinates. The native child's geometry and the dim overlay's
+// click-outside test are the same rectangle in two coordinate spaces.
+juce::Rectangle<int> notepadChildBounds (const juce::Component& topLevel)
 {
-    const auto hostBounds = embedscale::toPhysical (topLevel, topLevel.getLocalBounds());
-    const auto scaleFactor = embedscale::factor (topLevel);
-    const auto margin = std::max (0, juce::roundToInt (16.0 * scaleFactor));
-    const auto width = std::max (
-        2, std::min (hostBounds.getWidth() - margin * 2,
-                     juce::roundToInt (NativeNotepadWindow::kPreferredWidth * scaleFactor)));
-    const auto height = std::max (
-        2, std::min (hostBounds.getHeight() - margin * 2,
-                     juce::roundToInt (NativeNotepadWindow::kPreferredHeight * scaleFactor)));
-    return {
-        hostBounds.getX() + (hostBounds.getWidth() - width) / 2,
-        hostBounds.getY() + (hostBounds.getHeight() - height) / 2,
-        static_cast<std::uint32_t> (width),
-        static_cast<std::uint32_t> (height),
-        scaleFactor
-    };
+    // A window narrower than the margin would otherwise centre a negative
+    // extent, which offsets the origin instead of shrinking the child.
+    return topLevel.getLocalBounds().withSizeKeepingCentre (
+        std::clamp (topLevel.getWidth() - 32, 0, (int) NativeNotepadWindow::kPreferredWidth),
+        std::clamp (topLevel.getHeight() - 32, 0, (int) NativeNotepadWindow::kPreferredHeight));
 }
 
-// notepadGeometryFor's logical twin: where the embedded child lands in
-// target's coordinates, for the dim overlay's click-outside test. One pixel of
-// slack absorbs the rounding between the two.
-auto notepadChildArea (const juce::Component& target, const juce::Component& topLevel)
+NativeNotepadWindow::EmbeddedGeometry notepadGeometryFor (const juce::Component& topLevel)
 {
-    const auto width  = std::min (topLevel.getWidth() - 32,
-                                  (int) NativeNotepadWindow::kPreferredWidth);
-    const auto height = std::min (topLevel.getHeight() - 32,
-                                  (int) NativeNotepadWindow::kPreferredHeight);
-    return target.getLocalArea (&topLevel,
-                                topLevel.getLocalBounds()
-                                    .withSizeKeepingCentre (width, height))
-        .expanded (1);
+    const auto bounds = embedscale::toPhysical (topLevel, notepadChildBounds (topLevel));
+    return {
+        bounds.getX(), bounds.getY(),
+        static_cast<std::uint32_t> (std::max (2, bounds.getWidth())),
+        static_cast<std::uint32_t> (std::max (2, bounds.getHeight())),
+        embedscale::factor (topLevel)
+    };
 }
 #endif
 
@@ -1914,7 +1902,8 @@ void MainComponent::resized()
         {
             notepadWindow->setEmbeddedGeometry (notepadGeometryFor (*topLevel));
             if (notepadDim != nullptr)
-                notepadDim->setNativeChildArea (notepadChildArea (*this, *topLevel));
+                notepadDim->setNativeChildArea (
+                    getLocalArea (topLevel, notepadChildBounds (*topLevel)).expanded (1));
         }
     }
    #endif
@@ -5348,7 +5337,10 @@ void MainComponent::toggleNotepad()
     // sequence above.
     notepadDim = std::make_unique<DimOverlay> (0.80f);
     notepadDim->setBounds (getLocalBounds());
-    notepadDim->setNativeChildArea (notepadChildArea (*this, *topLevel));
+    // One pixel of slack absorbs the rounding between the logical overlay and
+    // the physical child.
+    notepadDim->setNativeChildArea (
+        getLocalArea (topLevel, notepadChildBounds (*topLevel)).expanded (1));
     notepadDim->onClick = [safeThis]
     {
         if (auto* self = safeThis.getComponent())
@@ -5378,8 +5370,10 @@ void MainComponent::dismissNotepad (bool saveChanges)
    #if DUSKSTUDIO_HAS_NATIVE_NOTEPAD
     if (notepadWindow != nullptr)
     {
-        notepadWindow->setCallbacks ({}, {}, {});
+        // close() commits an open chord slot, which reports the new text through
+        // onTextChanged; clearing the callbacks first would drop that final edit.
         notepadWindow->close();
+        notepadWindow->setCallbacks ({}, {}, {});
         notepadWindow.reset();
     }
     notepadDim.reset();

--- a/src/ui/NativeNotepadWindow.cpp
+++ b/src/ui/NativeNotepadWindow.cpp
@@ -24,8 +24,8 @@ namespace duskstudio
 {
 namespace
 {
-// The measure both views share: wide enough for a long lyric line, narrow
-// enough that the eye does not lose the line it is reading.
+// The chart's measure: wide enough for a long lyric line, narrow enough that
+// the eye does not lose the line it is reading.
 constexpr float kContentWidth = 760.0f;
 constexpr float kHeaderHeight = 62.0f;
 constexpr float kRibbonHeight = 62.0f;
@@ -207,7 +207,6 @@ struct NativeNotepadWindow::Impl final : private dusk::Timer
             return false;
 
         document.setMarkdown (markdown);
-        document.setSourceMode (false);
         editor.reset ({ 0, 0 });
         editor.requestFocus();
         closeRequested = false;
@@ -259,6 +258,11 @@ struct NativeNotepadWindow::Impl final : private dusk::Timer
     {
         if (window == nullptr)
             return;
+        // Dismissal can arrive from the DAW side (the dim backdrop) without
+        // ever reaching the editor's own mouse handling, and the sidecar save
+        // follows immediately. Settle an open chord slot here so every route
+        // out of the notepad keeps the chord that was being typed.
+        editor.closeChordEntry();
         closeRequested = true;
         closeWasPumped = false;
     }
@@ -316,13 +320,7 @@ private:
 
     notepad::Snapshot currentSnapshot() const
     {
-        return { document.markdown(), editor.selection(), false };
-    }
-
-    NotepadDocument::Selection selectionForCurrentMode (const notepad::Snapshot& state) const
-    {
-        return state.selectionIsSource ? document.documentSelection (state.selection)
-                                       : state.selection;
+        return { document.markdown(), editor.selection() };
     }
 
     void restoreHistory (bool redo)
@@ -332,9 +330,8 @@ private:
                     : history.undo (currentSnapshot(), restored)))
             return;
 
-        document.setMarkdown (restored.markdown);
-        const auto selection = selectionForCurrentMode (restored);
-        editor.reset (selection);
+        document.restoreMarkdown (restored.markdown);
+        editor.reset (restored.selection);
         editor.requestFocus();
         notifyTextChanged();
     }
@@ -410,8 +407,14 @@ private:
     }
 
     bool toolbarButton (const char* label, const char* tooltip, bool active = false,
-                        float width = 34.0f, ImFont* labelFont = nullptr)
+                        ImFont* labelFont = nullptr)
     {
+        // The atlas is built at the display scale, so a fixed width clips its
+        // own label the moment the font grows. Measure what is about to be
+        // drawn instead - in the label's own font, and past the "##" id tail.
+        constexpr float kLabelPadding = 18.0f;
+        constexpr float kMinButtonWidth = 34.0f;
+
         if (active)
         {
             ImGui::PushStyleColor (ImGuiCol_Button, colour (notepad::kStagePalette.rule));
@@ -420,13 +423,24 @@ private:
         }
         if (labelFont != nullptr)
             ImGui::PushFont (labelFont);
+        const auto width = std::max (kMinButtonWidth,
+                                     ImGui::CalcTextSize (label, nullptr, true).x
+                                         + kLabelPadding);
         const bool clicked = ImGui::Button (label, ImVec2 (width, 32.0f));
         if (labelFont != nullptr)
             ImGui::PopFont();
         if (active)
             ImGui::PopStyleColor (2);
-        if (ImGui::IsItemHovered())
+        // A disabled button is exactly the one whose tooltip explains why it is
+        // disabled, so hovering has to register through BeginDisabled - and the
+        // tooltip has to escape the dimming that BeginDisabled folds into the
+        // global alpha, or the explanation is the hardest thing to read.
+        if (ImGui::IsItemHovered (ImGuiHoveredFlags_AllowWhenDisabled))
+        {
+            ImGui::PushStyleVar (ImGuiStyleVar_Alpha, 1.0f);
             ImGui::SetTooltip ("%s", tooltip);
+            ImGui::PopStyleVar();
+        }
         return clicked;
     }
 
@@ -455,40 +469,38 @@ private:
         // compatible notepad.md file rather than competing with those actions.
         ImGui::SameLine (0.0f, 16.0f);
         if (toolbarButton ("Chord", "Add or edit a chord (Ctrl+K); repeat the previous chord (Ctrl+Shift+K)",
-                           editor.chordEntryActive(), 58.0f))
+                           editor.chordEntryActive()))
         {
             editor.beginChordEntry();
             editor.requestFocus();
         }
         ImGui::SameLine (0.0f, 5.0f);
-        if (toolbarButton ("Section", "Add or remove a song section", false, 64.0f))
+        if (toolbarButton ("Section", "Add or remove a song section"))
             ImGui::OpenPopup ("section-menu");
 
         const bool canTranspose = document.hasChords();
         ImGui::BeginDisabled (! canTranspose);
         ImGui::SameLine (0.0f, 5.0f);
-        if (toolbarButton ("−1", "Transpose every chord down one semitone", false, 38.0f))
+        if (toolbarButton ("−1", "Transpose every chord down one semitone"))
             editor.transposeChords (-1);
         ImGui::SameLine (0.0f, 5.0f);
-        if (toolbarButton ("+1", "Transpose every chord up one semitone", false, 38.0f))
+        if (toolbarButton ("+1", "Transpose every chord up one semitone"))
             editor.transposeChords (1);
         ImGui::EndDisabled();
 
         const auto blockStyle = selectedBlockStyle();
         ImGui::SameLine (0.0f, 16.0f);
         if (toolbarButton ("Lyrics", "Use lyric or note text",
-                           blockStyle == NotepadDocument::BlockStyle::body, 54.0f))
+                           blockStyle == NotepadDocument::BlockStyle::body))
             applyBlock (NotepadDocument::BlockStyle::body);
         ImGui::SameLine (0.0f, 5.0f);
         if (toolbarButton ("Title", "Make this line the song title",
-                           blockStyle == NotepadDocument::BlockStyle::heading1,
-                           48.0f, boldFont))
+                           blockStyle == NotepadDocument::BlockStyle::heading1, boldFont))
             applyBlock (NotepadDocument::BlockStyle::heading1);
 
         ImGui::SameLine (0.0f, 16.0f);
         if (toolbarButton ("B", "Bold the selection (Ctrl+B)",
-                           inlineStyleActive (NotepadDocument::InlineStyle::bold),
-                           34.0f, boldFont))
+                           inlineStyleActive (NotepadDocument::InlineStyle::bold), boldFont))
             applyInline (NotepadDocument::InlineStyle::bold);
         ImGui::SameLine (0.0f, 5.0f);
         if (toolbarButton ("I", "Italicise the selection (Ctrl+I)",
@@ -498,7 +510,7 @@ private:
         const auto spelling = document.spellingMode();
         ImGui::SameLine (0.0f, 16.0f);
         if (toolbarButton ("Auto##spell-auto", "Match the song's existing sharps or flats",
-                           spelling == NotepadDocument::Spelling::followDocument, 46.0f))
+                           spelling == NotepadDocument::Spelling::followDocument))
             document.setSpelling (NotepadDocument::Spelling::followDocument);
         ImGui::SameLine (0.0f, 4.0f);
         if (toolbarButton ("♯##spell-sharps", "Spell chords with sharps",

--- a/src/ui/NotepadChords.cpp
+++ b/src/ui/NotepadChords.cpp
@@ -108,12 +108,21 @@ bool readSuffix (std::string_view token, std::size_t& i) noexcept
     return true;
 }
 
+// A suspension is often infixed - "7sus4", "13sus4" - so the whole suffix is
+// searched rather than only its head.
+bool hasSuspension (std::string_view suffix) noexcept
+{
+    for (std::size_t i = 0; i + 3 <= suffix.size(); ++i)
+        if (matchesWord (suffix, i, "sus"))
+            return true;
+    return false;
+}
+
 struct ParsedChord
 {
     int  root = kInvalidPitch;
     std::string suffix;
     int  bass = kInvalidPitch;
-    std::string bassSuffix;   // empty for a well-formed slash bass
 };
 
 bool parse (std::string_view token, ParsedChord& out)
@@ -183,16 +192,18 @@ enum class Triad { major, minor, diminished, other };
 
 Triad triadFor (const ParsedChord& chord) noexcept
 {
+    // A suspension or an omitted third settles the question before any quality
+    // letter does: neither names a major or a minor triad.
+    if (hasSuspension (chord.suffix)
+        || chord.suffix.compare (0, 3, "aug") == 0
+        || (! chord.suffix.empty() && chord.suffix[0] == '+')
+        || chord.suffix == "5")
+        return Triad::other;
     if (chord.suffix.compare (0, 3, "dim") == 0)
         return Triad::diminished;
     if (! chord.suffix.empty() && chord.suffix[0] == 'm'
         && chord.suffix.compare (0, 3, "maj") != 0)
         return Triad::minor;
-    if (chord.suffix.compare (0, 3, "sus") == 0
-        || chord.suffix.compare (0, 3, "aug") == 0
-        || (! chord.suffix.empty() && chord.suffix[0] == '+')
-        || chord.suffix == "5")
-        return Triad::other;
     return Triad::major;
 }
 
@@ -220,17 +231,28 @@ int diatonicRank (const ParsedChord& candidate, int tonic, bool minor) noexcept
     return 2;
 }
 
+char lower (char c) noexcept
+{
+    return static_cast<char> (std::tolower (static_cast<unsigned char> (c)));
+}
+
 bool alphabeticallyBefore (const std::string& left, const std::string& right) noexcept
 {
     return std::lexicographical_compare (
         left.begin(), left.end(), right.begin(), right.end(),
-        [] (char a, char b)
-        {
-            return std::tolower (static_cast<unsigned char> (a))
-                 < std::tolower (static_cast<unsigned char> (b));
-        });
+        [] (char a, char b) { return lower (a) < lower (b); });
 }
 } // namespace
+
+bool completes (std::string_view candidate, std::string_view draft) noexcept
+{
+    if (draft.empty() || draft.size() > candidate.size())
+        return false;
+    for (std::size_t i = 0; i < draft.size(); ++i)
+        if (lower (draft[i]) != lower (candidate[i]))
+            return false;
+    return true;
+}
 
 std::vector<std::string> rankCandidates (std::vector<std::string> candidates,
                                          std::string_view detectedKey)
@@ -280,7 +302,7 @@ const char* keyName (int tonic, bool minor) noexcept
 // anything about mode.
 bool carriesThird (const std::string& suffix) noexcept
 {
-    if (suffix.compare (0, 3, "sus") == 0)
+    if (hasSuspension (suffix))
         return false;
     for (const auto ch : suffix)
         if (ch != '5' && ch != '(' && ch != ')')

--- a/src/ui/NotepadChords.h
+++ b/src/ui/NotepadChords.h
@@ -24,6 +24,11 @@ std::string transpose (std::string_view token, int semitones, bool preferFlats);
 std::vector<std::string> rankCandidates (std::vector<std::string> candidates,
                                          std::string_view detectedKey);
 
+// True when a partly typed name completes to this candidate. Case-insensitive,
+// because chord charts are typed in a hurry and "am" means Am. An empty draft
+// completes nothing: a slot with nothing in it suggests nothing.
+bool completes (std::string_view candidate, std::string_view draft) noexcept;
+
 // Best-fitting key for a set of chord names, or empty when the evidence does
 // not support a claim. The rule, which is not to be tuned against a sample
 // document:

--- a/src/ui/NotepadDocument.cpp
+++ b/src/ui/NotepadDocument.cpp
@@ -87,7 +87,7 @@ void projectInline (ProjectionBuilder& out, std::size_t start, std::size_t end,
         // CommonMark's compact combined form must be recognized before the
         // two-star bold delimiter. Otherwise ***Heading*** is consumed as a
         // bold run containing a literal leading star, leaving the final star
-        // visible in Document mode.
+        // visible in the projection.
         if (i + 2 < end && source.compare (i, 3, "***") == 0)
         {
             const auto close = findUnescaped (source, "***", i + 3, end);
@@ -367,10 +367,15 @@ ProjectionBuilder buildProjection (const std::string& markdown)
 
 void NotepadDocument::setMarkdown (std::string text)
 {
-    markdownText = std::move (text);
     // A new document brings its own notation: the spelling only stays sticky
     // across edits to the document that established it.
     flatSpelling = false;
+    restoreMarkdown (std::move (text));
+}
+
+void NotepadDocument::restoreMarkdown (std::string text)
+{
+    markdownText = std::move (text);
     rebuildProjection();
 }
 
@@ -386,14 +391,25 @@ bool NotepadDocument::replaceDocumentText (const std::string& text)
            && projectedText[projectedText.size() - 1 - suffix] == text[text.size() - 1 - suffix])
         ++suffix;
 
-    const auto escapeAt = [this] (std::size_t sourceOffset, const std::string& value)
+    // A section label is projected without its brackets, so the boundary after
+    // its last character maps past the hidden ']' just as a bold run's does.
+    // An edit that stays inside the label has to land inside the brackets too,
+    // or the line stops being a marker and the integrity check below drops the
+    // keystroke. A range that already swallows the '[' is removing the whole
+    // marker and keeps its outward reach.
+    const auto keepInsideSectionLabel = [this] (Selection range)
     {
-        // Source mode edits the Markdown directly, so its syntax characters are
-        // the point: escaping them there would turn a typed '*' into '\\*'.
-        if (sourceMode)
-            return value;
-        return escapeDocumentInsertion (
-            value, sourceOffset == 0 || markdownText[sourceOffset - 1] == '\n');
+        if (range.end == 0 || markdownText[range.end - 1] != ']')
+            return range;
+        const auto lineStart = lineStartAt (markdownText, range.end);
+        if (lineEndAt (markdownText, lineStart) != range.end)
+            return range;
+        const auto contentStart = lineStart
+                                + blockPrefixLength (markdownText, lineStart, range.end);
+        if (range.start > contentStart
+            && isSectionLine (markdownText, contentStart, range.end))
+            --range.end;
+        return range;
     };
 
     const auto oldEnd = projectedText.size() - suffix;
@@ -403,36 +419,36 @@ bool NotepadDocument::replaceDocumentText (const std::string& text)
     // marker or the edit would create invalid Markdown and flatten the run.
     auto source = sourceSelection ({ prefix, oldEnd });
 
-    // A section label is projected without its brackets. Deleting the entire
-    // visible label therefore needs to include the hidden source prefix (and
-    // any block prefix on a hand-authored marker); otherwise "[Verse]" would
-    // become "[" and the projection-integrity check below would reject the
-    // edit. Keep the newline so ordinary text deletion leaves an empty line.
+    // Deleting the entire visible label needs to include the hidden source
+    // prefix (and any block prefix on a hand-authored marker); otherwise
+    // "[Verse]" would become "[". Keep the newline so ordinary text deletion
+    // leaves an empty line.
     const auto insertedLength = text.size() - prefix - suffix;
-    if (! sourceMode && insertedLength == 0 && prefix < oldEnd)
-    {
-        const auto projectedLineStart = lineStartAt (projectedText, prefix);
-        const auto projectedLineEnd = lineEndAt (projectedText, prefix);
-        if (prefix == projectedLineStart && oldEnd >= projectedLineEnd
-            && lineInfoAt (prefix).section)
-            source.start = lineStartAt (markdownText, source.start);
-    }
+    const bool wholeLabel = insertedLength == 0 && prefix < oldEnd
+                         && prefix == lineStartAt (projectedText, prefix)
+                         && oldEnd >= lineEndAt (projectedText, prefix)
+                         && lineInfoAt (prefix).section;
+    if (wholeLabel)
+        source.start = lineStartAt (markdownText, source.start);
+    else if (prefix < oldEnd)
+        source = keepInsideSectionLabel (source);
+
     if (prefix == oldEnd && prefix > 0)
     {
         // At the right edge of a styled run the projected boundary sits after
         // its hidden closing marker. Insert just inside that marker first; the
         // caller can then retain or clear the run's style without producing a
         // chain of adjacent wrappers for character-by-character typing.
-        const auto previousCharacter = sourceSelection ({ prefix - 1, prefix });
+        const auto previousCharacter = keepInsideSectionLabel (
+            sourceSelection ({ prefix - 1, prefix }));
         source.start = source.end = previousCharacter.end;
     }
-    const auto sourceStart = source.start;
-    const auto sourceEnd = source.end;
-
+    const auto atLineStart = source.start == 0 || markdownText[source.start - 1] == '\n';
     auto previousMarkdown = markdownText;
-    markdownText.replace (sourceStart, sourceEnd - sourceStart,
-                          escapeAt (sourceStart,
-                                    text.substr (prefix, text.size() - prefix - suffix)));
+    markdownText.replace (
+        source.start, source.end - source.start,
+        escapeDocumentInsertion (text.substr (prefix, text.size() - prefix - suffix),
+                                 atLineStart));
     rebuildProjection();
     if (projectedText == text)
         return true;
@@ -476,50 +492,6 @@ NotepadDocument::Selection NotepadDocument::sourceSelection (Selection selection
     }
 
     return { sourceStart, sourceEnd };
-}
-
-NotepadDocument::Selection NotepadDocument::documentSelection (Selection selection) const noexcept
-{
-    selection.start = std::min (selection.start, markdownText.size());
-    selection.end = std::min (selection.end, markdownText.size());
-    if (selection.start > selection.end)
-        std::swap (selection.start, selection.end);
-
-    const auto boundaryFor = [this] (std::size_t sourceOffset)
-    {
-        const auto found = std::lower_bound (documentBoundaryToSource.begin(),
-                                             documentBoundaryToSource.end(),
-                                             sourceOffset);
-        return static_cast<std::size_t> (std::distance (documentBoundaryToSource.begin(),
-                                                       found));
-    };
-    return { std::min (boundaryFor (selection.start), projectedText.size()),
-             std::min (boundaryFor (selection.end), projectedText.size()) };
-}
-
-void NotepadDocument::wrapDocumentSelection (Selection selection,
-                                             const std::string& prefix,
-                                             const std::string& suffix)
-{
-    const auto source = sourceSelection (selection);
-    const bool hasPrefix = source.start >= prefix.size()
-                        && markdownText.compare (source.start - prefix.size(), prefix.size(), prefix) == 0;
-    const bool hasSuffixBeforeEnd = source.end >= suffix.size()
-                                 && markdownText.compare (source.end - suffix.size(), suffix.size(), suffix) == 0;
-    const bool hasSuffixAfterEnd = markdownText.compare (source.end, suffix.size(), suffix) == 0;
-
-    if (hasPrefix && (hasSuffixBeforeEnd || hasSuffixAfterEnd))
-    {
-        const auto suffixStart = hasSuffixBeforeEnd ? source.end - suffix.size() : source.end;
-        markdownText.erase (suffixStart, suffix.size());
-        markdownText.erase (source.start - prefix.size(), prefix.size());
-    }
-    else
-    {
-        markdownText.insert (source.end, suffix);
-        markdownText.insert (source.start, prefix);
-    }
-    rebuildProjection();
 }
 
 void NotepadDocument::setDocumentInlineStyle (Selection selection,
@@ -658,12 +630,6 @@ void NotepadDocument::setDocumentBlockStyle (Selection selection, BlockStyle sty
 
 NotepadDocument::LineInfo NotepadDocument::lineInfoAt (std::size_t documentOffset) const noexcept
 {
-    // Source mode shows the syntax rather than acting on it, so every line is
-    // body text: a heading keeps its metrics between the two views and the
-    // toggle moves nothing.
-    if (sourceMode)
-        return {};
-
     documentOffset = std::min (documentOffset, projectedText.size());
     const auto sourceOffset = documentBoundaryToSource[documentOffset];
     const auto start = lineStartAt (markdownText, sourceOffset);
@@ -758,16 +724,8 @@ const NotepadDocument::ChordToken*
     NotepadDocument::chordTokenAt (std::size_t documentOffset) const noexcept
 {
     for (const auto& token : chordTokens)
-    {
-        // Source mode edits the bracket itself, so the caret only has to be
-        // somewhere inside the token; the rendered view anchors chords on a
-        // character, and there the offset is the anchor.
-        const bool hit = sourceMode
-                       ? documentOffset >= token.start && documentOffset < token.end
-                       : documentOffset == token.documentOffset;
-        if (hit)
+        if (documentOffset == token.documentOffset)
             return &token;
-    }
     return nullptr;
 }
 
@@ -784,6 +742,11 @@ bool NotepadDocument::setChordAt (std::size_t documentOffset, const std::string&
 
     if (const auto* const token = chordTokenAt (documentOffset); token != nullptr)
     {
+        // Rewriting a chord as itself leaves the Markdown byte-identical.
+        // Saying so is what keeps a re-commit of an unchanged slot out of the
+        // undo history, where it would also discard the redo stack.
+        if (token->name == name)
+            return false;
         markdownText.replace (token->start, token->end - token->start,
                               name.empty() ? std::string() : "[" + name + "]");
         rebuildProjection();
@@ -801,10 +764,8 @@ bool NotepadDocument::setChordAt (std::size_t documentOffset, const std::string&
 
 bool NotepadDocument::repeatPreviousChordAt (std::size_t documentOffset)
 {
-    const auto sourceOffset = sourceMode
-                            ? std::min (documentOffset, markdownText.size())
-                            : documentBoundaryToSource[std::min (
-                                  documentOffset, documentBoundaryToSource.size() - 1)];
+    const auto sourceOffset = documentBoundaryToSource[std::min (
+        documentOffset, documentBoundaryToSource.size() - 1)];
     const ChordToken* previous = nullptr;
     for (const auto& token : chordTokens)
     {
@@ -929,14 +890,9 @@ NotepadDocument::BlockStyle NotepadDocument::blockStyleForSelection (Selection s
     return initial;
 }
 
-const std::string& NotepadDocument::renderedText() const
-{
-    return renderedTextCache.has_value() ? *renderedTextCache : projectedText;
-}
-
 std::size_t NotepadDocument::wordCount() const noexcept
 {
-    const auto& text = renderedText();
+    const auto& text = projectedText;   // the lyric, never the syntax behind it
     std::size_t count = 0;
     std::size_t start = 0;
     while (start < text.size())
@@ -960,7 +916,7 @@ std::size_t NotepadDocument::characterCount() const noexcept
     // The editor navigates by codepoint, so the count has to agree with it:
     // an accent or an emoji is one character, not the two to four bytes it
     // occupies.
-    const auto& text = renderedText();
+    const auto& text = projectedText;
     std::size_t count = 0;
     for (std::size_t offset = 0; offset < text.size();
          offset = notepad::nextOffset (text, offset))
@@ -995,21 +951,11 @@ std::vector<std::string> NotepadDocument::uniqueChordNames() const
     return names;
 }
 
-void NotepadDocument::setSourceMode (bool showSource)
-{
-    if (sourceMode == showSource)
-        return;
-    sourceMode = showSource;
-    rebuildProjection();
-}
-
 void NotepadDocument::rebuildProjection()
 {
-    renderedTextCache.reset();
-
-    // One traversal feeds both lanes, so the tokens the chord commands rewrite
-    // are exactly the chords the projection renders: an escaped bracket, a code
-    // span and a link destination stay literal text in both.
+    // One traversal feeds the text and the chord lane, so the tokens the chord
+    // commands rewrite are exactly the chords the projection renders: an
+    // escaped bracket, a code span and a link destination stay literal in both.
     auto out = buildProjection (markdownText);
 
     chordTokens.clear();
@@ -1027,21 +973,6 @@ void NotepadDocument::rebuildProjection()
     }
     if (flats != 0 || sharps != 0)
         flatSpelling = flats > sharps;
-
-    if (sourceMode)
-    {
-        // The counts describe the lyric in both modes, so they measure the
-        // rendered text this walk just produced rather than the syntax.
-        renderedTextCache = std::move (out.text);
-        projectedText = markdownText;
-        documentBoundaryToSource.resize (markdownText.size() + 1);
-        for (std::size_t i = 0; i <= markdownText.size(); ++i)
-            documentBoundaryToSource[i] = i;
-        projectedStyles.assign (markdownText.size(), TextStyle {});
-        projectedLinkTargets.assign (markdownText.size(), std::string {});
-        projectedChords.clear();
-        return;
-    }
 
     projectedText = std::move (out.text);
     documentBoundaryToSource = std::move (out.boundaries);

--- a/src/ui/NotepadDocument.h
+++ b/src/ui/NotepadDocument.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstddef>
-#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -76,11 +75,10 @@ public:
     };
 
     void setMarkdown (std::string text);
-    // Source mode projects the Markdown 1:1, with no hidden syntax, styles or
-    // chords, so the same editor drives both views: one set of layout metrics,
-    // one caret, one undo stack.
-    void setSourceMode (bool showSource);
-    bool isSourceMode() const noexcept { return sourceMode; }
+    // Puts an earlier state of the same document back. Unlike setMarkdown this
+    // keeps the accidental preference, which belongs to the document rather
+    // than to any one of its states.
+    void restoreMarkdown (std::string text);
     // False when the edit could not be mapped back onto the Markdown source and
     // was dropped to keep it intact - the caller must resync its editor buffer
     // from documentText().
@@ -98,10 +96,6 @@ public:
     void renumberOrderedRunAt (std::size_t documentOffset);
 
     Selection sourceSelection (Selection documentSelection) const noexcept;
-    Selection documentSelection (Selection sourceSelection) const noexcept;
-    void wrapDocumentSelection (Selection selection,
-                                const std::string& prefix,
-                                const std::string& suffix);
     void setDocumentInlineStyle (Selection selection, InlineStyle style, bool enabled);
     void setDocumentBlockStyle (Selection selection, BlockStyle style);
 
@@ -122,11 +116,12 @@ public:
     std::string chordAt (std::size_t documentOffset) const;
     // Inserts, replaces, or (empty name) removes the chord anchored at the
     // offset. Names that don't parse as a chord are rejected, so a stray
-    // bracket can never be minted from the document view.
+    // bracket can never be minted from the document view. False also means
+    // "nothing to do" - rewriting a chord as itself, or removing one that is
+    // not there - so a caller can tell an edit from a no-op before recording
+    // an undo step.
     bool setChordAt (std::size_t documentOffset, const std::string& name);
     // Copies the last chord before documentOffset into a slot at that offset.
-    // Source mode resolves both offsets against the visible Markdown, while the
-    // rendered mode uses lyric anchors.
     bool repeatPreviousChordAt (std::size_t documentOffset);
     void transposeChords (int semitones, bool preferFlats);
     // Writes "[Label]" on its own line above documentOffset's line, straight
@@ -156,14 +151,11 @@ private:
         std::size_t start = 0;   // the '[' in markdownText
         std::size_t end = 0;     // one past the ']'
         std::string name;
-        // Where the rendered projection anchors it; meaningless in source mode,
-        // which resolves a chord by the caret's position inside the token.
-        std::size_t documentOffset = 0;
+        std::size_t documentOffset = 0;   // where the projection anchors it
     };
 
     void rebuildProjection();
     const ChordToken* chordTokenAt (std::size_t documentOffset) const noexcept;
-    const std::string& renderedText() const;
 
     std::string markdownText;
     std::string projectedText;
@@ -173,16 +165,10 @@ private:
     std::vector<std::size_t> documentBoundaryToSource { 0 };
     std::vector<TextStyle> projectedStyles;
     std::vector<std::string> projectedLinkTargets;
-    bool sourceMode = false;
     std::vector<Chord> projectedChords;
-    // The source span of every chord the projection renders, kept in both modes:
-    // chord commands act on the source, so they keep working while the source
-    // view is up and projectedChords is empty.
+    // The source span of every chord the projection renders: chord commands act
+    // on the Markdown, the projection only shows where they landed.
     std::vector<ChordToken> chordTokens;
-    // Word and character counts describe the lyric, so they are measured on the
-    // rendered projection in both modes: never the syntax the source shows.
-    // Only source mode fills this; the rendered view counts projectedText.
-    std::optional<std::string> renderedTextCache;
     // Sticky, because a transpose can land every chord on a natural and erase
     // the evidence: re-deriving it there would spell the way back in sharps
     // and hand a flat writer a document they did not write.

--- a/src/ui/NotepadEditor.cpp
+++ b/src/ui/NotepadEditor.cpp
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <array>
 #include <cfloat>
-#include <cctype>
 #include <cmath>
 
 namespace duskstudio
@@ -32,18 +31,6 @@ float scrollThumbHeight (float viewport, float content)
 {
     return std::max (28.0f, viewport * viewport / std::max (1.0f, content));
 }
-
-bool hasPrefixIgnoringCase (const std::string& text, const std::string& prefix) noexcept
-{
-    if (prefix.size() > text.size())
-        return false;
-    return std::equal (prefix.begin(), prefix.end(), text.begin(),
-                       [] (char a, char b)
-                       {
-                           return std::tolower (static_cast<unsigned char> (a))
-                                == std::tolower (static_cast<unsigned char> (b));
-                       });
-}
 } // namespace
 
 NotepadEditor::NotepadEditor (NotepadDocument& documentToEdit, notepad::UndoStack& undoHistory)
@@ -64,6 +51,7 @@ void NotepadEditor::setFonts (const Fonts& value)
 
 void NotepadEditor::reset (NotepadDocument::Selection value)
 {
+    clearChordSlot();
     setSelection (value);
     sticky = {};
     desiredX = -1.0f;
@@ -158,7 +146,7 @@ void NotepadEditor::documentMutated()
 
 notepad::Snapshot NotepadEditor::snapshot() const
 {
-    return { document.markdown(), selection(), false };
+    return { document.markdown(), selection() };
 }
 
 void NotepadEditor::resetBlink()
@@ -233,19 +221,6 @@ void NotepadEditor::selectAll()
     sticky = {};
     scrollToCaret = true;
     history.breakRun();
-}
-
-float NotepadEditor::caretViewportOffset() const noexcept
-{
-    if (layout.rows.empty())
-        return 0.0f;
-    return layout.rows[layout.rowForOffset (caret, caretAtRowEnd)].y - scrollY;
-}
-
-void NotepadEditor::keepCaretAtViewportOffset (float offset) noexcept
-{
-    pendingCaretViewport = offset;
-    caretViewportPending = true;
 }
 
 void NotepadEditor::keepCaretVisible (float viewportHeight, float bodySize)
@@ -420,6 +395,7 @@ void NotepadEditor::toggleSticky (NotepadDocument::InlineStyle style)
 
 void NotepadEditor::applyInlineStyle (NotepadDocument::InlineStyle style)
 {
+    closeChordEntry();
     const auto target = selection();
     if (target.empty())
     {
@@ -438,6 +414,7 @@ void NotepadEditor::applyInlineStyle (NotepadDocument::InlineStyle style)
 
 void NotepadEditor::applyBlockStyle (NotepadDocument::BlockStyle style)
 {
+    closeChordEntry();
     const auto target = selection();
     if (blockStyle() == style)
         style = NotepadDocument::BlockStyle::body;
@@ -483,14 +460,30 @@ std::size_t NotepadEditor::hitTest (ImVec2 position, ImVec2 frameMin, float body
 void NotepadEditor::handleMouse (ImVec2 frameMin, ImVec2 frameMax, bool hovered, float bodySize)
 {
     auto& io = ImGui::GetIO();
+    const bool clicked = ImGui::IsMouseClicked (ImGuiMouseButton_Left);
+
+    // Settling the slot can add or drop a chord band, which moves every row
+    // below it, so what the click landed on is read off the layout that was on
+    // screen when the button went down - not the one the commit produces.
+    const auto row = layout.rows.empty()
+                   ? notepad::Row {}
+                   : layout.rows[layout.rowAtY (
+                         std::max (0.0f, io.MousePos.y - frameMin.y + scrollY))];
+    const auto rowTop = frameMin.y + row.y - scrollY;
+
+    if (chordEditing && clicked)
+    {
+        closeChordEntry();
+        ensureLayout (layoutWidth, bodySize);
+    }
+
     const auto viewport = std::max (1.0f, frameMax.y - frameMin.y);
     const auto maxScroll = std::max (0.0f, layout.contentHeight - viewport);
 
     if (hovered && io.MouseWheel != 0.0f)
         scrollY = std::clamp (scrollY - io.MouseWheel * kWheelStep, 0.0f, maxScroll);
 
-    if (draggingScrollbar || (hovered && maxScroll > 0.0f
-                              && ImGui::IsMouseClicked (ImGuiMouseButton_Left)
+    if (draggingScrollbar || (hovered && maxScroll > 0.0f && clicked
                               && io.MousePos.x >= frameMax.x - kScrollbarWidth))
     {
         if (ImGui::IsMouseDown (ImGuiMouseButton_Left))
@@ -519,11 +512,9 @@ void NotepadEditor::handleMouse (ImVec2 frameMin, ImVec2 frameMax, bool hovered,
         ImGui::SetMouseCursor (onLink ? ImGuiMouseCursor_Hand : ImGuiMouseCursor_TextInput);
     }
 
-    if (hovered && ImGui::IsMouseClicked (ImGuiMouseButton_Left))
+    if (hovered && clicked)
     {
         const auto clicks = io.MouseClickedCount[ImGuiMouseButton_Left];
-        const auto& row = layout.rows[layout.rowAtY (
-            std::max (0.0f, io.MousePos.y - frameMin.y + scrollY))];
 
         if (clicks == 1 && row.firstRowOfLine
             && row.block == NotepadDocument::BlockStyle::tasks
@@ -533,31 +524,29 @@ void NotepadEditor::handleMouse (ImVec2 frameMin, ImVec2 frameMax, bool hovered,
             return;
         }
 
-        // A click in the chord band edits the chord it landed on instead of
-        // moving the caret into the lyric underneath.
-        const auto rowTop = frameMin.y + row.y - scrollY;
+        // A click in the chord band edits the label it landed on instead of
+        // moving the caret into the lyric underneath. The bands are the drawn
+        // label spans, so what looks clickable is what is.
         if (clicks == 1 && row.chordTop > 0.0f && io.MousePos.y < rowTop + row.chordTop)
         {
-            const auto over = notepad::offsetAtX (document, row,
-                                                  io.MousePos.x - frameMin.x - row.indent,
-                                                  bodySize, measure);
-            for (const auto& chord : document.chords())
+            const auto chordSize = notepad::chordFontSize (bodySize);
+            const auto placements = notepad::rowChordPlacements (document, row, bodySize,
+                                                                 measure,
+                                                                 chordLabelWidth (chordSize));
+            const auto index = notepad::chordAtX (placements,
+                                                  io.MousePos.x - frameMin.x - row.indent);
+            if (index != std::string::npos)
             {
-                if (chord.documentOffset < row.start
-                    || chord.documentOffset > row.end
-                    || (chord.documentOffset == row.end && ! row.lastRowOfLine))
-                    continue;
-                const auto reach = chord.documentOffset + chord.name.size();
-                if (over >= chord.documentOffset && over <= reach)
-                {
-                    moveCaret (chord.documentOffset, false);
-                    beginChordEntry();
-                    return;
-                }
+                const auto anchorOffset = document.chords()[index].documentOffset;
+                moveCaret (anchorOffset, false);
+                beginChordEntry (anchorOffset);
+                return;
             }
         }
 
-        const auto offset = hitTest (io.MousePos, frameMin, bodySize);
+        const auto offset = notepad::offsetAtX (document, row,
+                                                io.MousePos.x - frameMin.x - row.indent,
+                                                bodySize, measure);
         if (clicks == 1 && (io.KeyCtrl || io.KeySuper) && offset < text.size())
         {
             const auto target = document.linkTargetAt (offset);
@@ -746,7 +735,7 @@ void NotepadEditor::handleKeyboard (float viewportHeight, float bodySize)
         deleteForward (byWord);
     if (ImGui::IsKeyPressed (ImGuiKey_Enter) || ImGui::IsKeyPressed (ImGuiKey_KeypadEnter))
         insertNewline();
-    // Match Markdown mode's ImGuiInputTextFlags_AllowTabInput semantics.
+    // Tab indents the lyric rather than moving focus; the page owns the key.
     if (! io.KeyCtrl && ! io.KeyAlt && ! io.KeySuper && ! shift
         && ImGui::IsKeyPressed (ImGuiKey_Tab))
         insertText ("\t");
@@ -769,12 +758,10 @@ void NotepadEditor::handleKeyboard (float viewportHeight, float bodySize)
     }
 }
 
-void NotepadEditor::beginChordEntry()
+void NotepadEditor::beginChordEntry (std::optional<std::size_t> anchor)
 {
-    // Chords land on syllables, so the slot anchors on the word under the
-    // caret rather than the caret itself: click anywhere in "morning" and the
-    // chord sits over its first letter.
-    chordAnchor = chordAnchorAtCaret();
+    closeChordEntry();
+    chordAnchor = anchor.value_or (chordAnchorAtCaret());
     chordDraft = document.chordAt (chordAnchor);
     refreshChordCandidates();
     chordCandidateIndex = 0;
@@ -789,6 +776,16 @@ std::size_t NotepadEditor::chordAnchorAtCaret() const
     const auto& text = document.documentText();
     const auto word = notepad::wordAt (text, caret);
     return word.start < word.end ? word.start : caret;
+}
+
+notepad::LabelWidthFn NotepadEditor::chordLabelWidth (float chordSize) const
+{
+    return [this, chordSize] (const std::string& name)
+    {
+        return fonts.bold != nullptr
+             ? fonts.bold->CalcTextSizeA (chordSize, FLT_MAX, 0.0f, name.c_str()).x
+             : 0.0f;
+    };
 }
 
 void NotepadEditor::refreshChordCandidates()
@@ -814,11 +811,8 @@ void NotepadEditor::refreshChordCandidates()
 std::vector<const std::string*> NotepadEditor::matchingChordCandidates() const
 {
     std::vector<const std::string*> matches;
-    if (chordDraft.empty())
-        return matches;
-
     for (const auto& candidate : chordCandidates)
-        if (hasPrefixIgnoringCase (candidate, chordDraft))
+        if (notepad::chords::completes (candidate, chordDraft))
             matches.push_back (&candidate);
     return matches;
 }
@@ -858,12 +852,15 @@ bool NotepadEditor::acceptChordCandidate()
 
 void NotepadEditor::insertSectionMarker (const std::string& label)
 {
+    closeChordEntry();
     auto before = snapshot();
     if (! document.insertSectionMarker (selection().start, label))
         return;
 
-    const auto caretShift = label.size() + (document.isSourceMode() ? 3u : 1u);
-    caret = anchor = std::min (caret + caretShift, document.documentText().size());
+    // The marker takes a line of its own above the caret: the label plus the
+    // newline that follows it, with the brackets hidden by the projection.
+    caret = anchor = std::min (caret + label.size() + 1u,
+                               document.documentText().size());
     history.breakRun();
     history.record (notepad::EditKind::structural, std::move (before), caret);
     focusRequested = true;
@@ -872,6 +869,7 @@ void NotepadEditor::insertSectionMarker (const std::string& label)
 
 void NotepadEditor::removeSectionMarker()
 {
+    closeChordEntry();
     const auto target = selection().start;
     const auto lineStart = notepad::lineStartOffset (document.documentText(), target);
     auto before = snapshot();
@@ -887,23 +885,51 @@ void NotepadEditor::removeSectionMarker()
 
 void NotepadEditor::commitChordEntry()
 {
-    const auto before = snapshot();
-    const bool documentChanged = document.setChordAt (chordAnchor, chordDraft);
-    if (! documentChanged && ! chordDraft.empty())
-        return;
+    if (! chordDraft.empty() && ! notepad::chords::isChord (chordDraft))
+    {
+        // A half-typed name commits as the completion the slot is showing, so
+        // every route out places what the user can see. With no completion to
+        // fall back on, hold the slot open for a correction rather than
+        // dropping what was typed.
+        const auto* const candidate = selectedChordCandidate();
+        if (candidate == nullptr)
+            return;
+        chordDraft = *candidate;
+    }
 
-    if (documentChanged)
+    auto before = snapshot();
+    if (document.setChordAt (chordAnchor, chordDraft))
     {
         history.breakRun();
-        history.record (notepad::EditKind::structural, before, caret);
+        history.record (notepad::EditKind::structural, std::move (before), caret);
         documentMutated();
     }
+    clearChordSlot();
+}
+
+void NotepadEditor::clearChordSlot()
+{
+    if (! chordEditing)
+        return;
     chordEditing = false;
     chordDraft.clear();
     chordCandidates.clear();
     chordCandidateIndex = 0;
     chordSuggestionAccepted = false;
     layoutDirty = true;
+}
+
+void NotepadEditor::closeChordEntry()
+{
+    // With no slot open chordAnchor is stale and chordDraft is empty, which
+    // together would read as "remove the chord at that anchor".
+    if (! chordEditing)
+        return;
+    commitChordEntry();
+    // The commit settles and clears every draft it can place; it holds the slot
+    // open only for one that resolves to no chord at all, and a mouse action or
+    // a closing window cannot wait for the correction.
+    clearChordSlot();
 }
 
 void NotepadEditor::repeatPreviousChord()
@@ -926,12 +952,7 @@ bool NotepadEditor::handleChordEntry()
     auto& io = ImGui::GetIO();
     if (ImGui::IsKeyPressed (ImGuiKey_Escape))
     {
-        chordEditing = false;
-        chordDraft.clear();
-        chordCandidates.clear();
-        chordCandidateIndex = 0;
-        chordSuggestionAccepted = false;
-        layoutDirty = true;
+        clearChordSlot();
         io.InputQueueCharacters.resize (0);
         return true;
     }
@@ -954,9 +975,6 @@ bool NotepadEditor::handleChordEntry()
     }
     if (ImGui::IsKeyPressed (ImGuiKey_Enter) || ImGui::IsKeyPressed (ImGuiKey_KeypadEnter))
     {
-        if (! chordDraft.empty() && ! matches.empty()
-            && ! notepad::chords::isChord (chordDraft))
-            chordDraft = *matches[chordCandidateIndex % matches.size()];
         commitChordEntry();
         io.InputQueueCharacters.resize (0);
         return true;
@@ -993,6 +1011,7 @@ bool NotepadEditor::handleChordEntry()
 
 void NotepadEditor::transposeChords (int semitones)
 {
+    closeChordEntry();
     if (! document.hasChords() || semitones == 0)
         return;
 
@@ -1041,8 +1060,7 @@ void NotepadEditor::render (ImVec2 frameMin, ImVec2 frameMax, float bodySize, bo
         const float textHeight = row.height - row.chordTop;
         // Inset from the row top by a share of the glyph size, not of the row:
         // centring inside the row makes a heading's baseline depend on its row
-        // height, so the title jumped when the source view drew the same line
-        // at body metrics.
+        // height, so a chord band above the title would shift the title itself.
         const float textY = textTop + fontSize * 0.17f;
         const float originX = frameMin.x + row.indent;
 
@@ -1134,8 +1152,7 @@ void NotepadEditor::render (ImVec2 frameMin, ImVec2 frameMax, float bodySize, bo
                                     || (chordAnchor == row.end && row.lastRowOfLine));
         if ((row.chordTop > 0.0f || slotOnThisRow) && fonts.bold != nullptr)
         {
-            const auto chordSize = std::max (10.0f, bodySize
-                * (notepad::kTypeScale.chord / notepad::kTypeScale.lyric));
+            const auto chordSize = notepad::chordFontSize (bodySize);
             const float bandTop = rowY + std::max (row.chordTop,
                                                    notepad::chordBandHeight (bodySize))
                                 - chordSize - 1.0f;
@@ -1199,21 +1216,20 @@ void NotepadEditor::render (ImVec2 frameMin, ImVec2 frameMax, float bodySize, bo
                                        ImVec2 (caretX, bandTop + chordSize), chordColour, 1.2f);
                 }
             }
-            for (const auto& chord : document.chords())
+            for (const auto& placement : notepad::rowChordPlacements (
+                     document, row, bodySize, measure, chordLabelWidth (chordSize)))
             {
+                const auto& chord = document.chords()[placement.chordIndex];
                 if (chordEditing && chord.documentOffset == chordAnchor)
                     continue;
-                if (chord.documentOffset < row.start
-                    || (chord.documentOffset > row.end
-                        || (chord.documentOffset == row.end && ! row.lastRowOfLine)))
-                    continue;
 
-                const auto anchorX = originX
-                    + notepad::offsetX (document, row,
-                                        std::min (chord.documentOffset, row.end),
-                                        bodySize, measure);
+                const auto anchorX = originX + placement.x;
+                // Clipped to the span the click test uses, so two chords a
+                // syllable apart cannot print over each other.
+                const ImVec4 clip (anchorX, bandTop - 2.0f,
+                                   anchorX + placement.width, bandTop + chordSize + 2.0f);
                 drawList->AddText (fonts.bold, chordSize, ImVec2 (anchorX, bandTop),
-                                   chordColour, chord.name.c_str());
+                                   chordColour, chord.name.c_str(), nullptr, 0.0f, &clip);
             }
         }
 
@@ -1260,18 +1276,6 @@ void NotepadEditor::draw (float bodySize)
 
     const bool hovered = ImGui::IsItemHovered();
     const bool clicked = ImGui::IsMouseClicked (ImGuiMouseButton_Left);
-
-    // A modal (the link dialog) owns the keyboard while it is up; hand the
-    // focus back only once it has closed and asked for it.
-    if (ImGui::GetTopMostPopupModal() != nullptr)
-    {
-        if (g.ActiveId == id)
-            ImGui::ClearActiveID();
-        ensureLayout (size.x, bodySize);
-        scrollY = std::clamp (scrollY, 0.0f, std::max (0.0f, layout.contentHeight - size.y));
-        render (frameMin, frameMax, bodySize, false);
-        return;
-    }
 
     // The page is the only text surface in the window, so it takes the caret
     // back once a toolbar button has finished with the active id - otherwise
@@ -1331,14 +1335,6 @@ void NotepadEditor::draw (float bodySize)
         handleKeyboard (size.y, bodySize);
     ensureLayout (size.x, bodySize);
 
-    if (caretViewportPending)
-    {
-        if (! layout.rows.empty())
-            scrollY = layout.rows[layout.rowForOffset (caret, caretAtRowEnd)].y
-                    - pendingCaretViewport;
-        caretViewportPending = false;
-        scrollToCaret = false;
-    }
     if (scrollToCaret)
     {
         keepCaretVisible (size.y, bodySize);

--- a/src/ui/NotepadEditor.h
+++ b/src/ui/NotepadEditor.h
@@ -6,15 +6,15 @@
 #include <DearImGui.hpp>
 
 #include <functional>
+#include <optional>
 #include <string>
 #include <vector>
 
 namespace duskstudio
 {
-// The notepad's editor, driving both views: the document projection and the
-// Markdown source, which differ only in what NotepadDocument projects. It owns
-// wrapping, caret, selection, input and painting; every text mutation goes
-// through the projection so the Markdown source stays authoritative.
+// The notepad's editor: wrapping, caret, selection, input and painting over the
+// document projection. Every text mutation goes through that projection, so the
+// Markdown source stays authoritative.
 class NotepadEditor final
 {
 public:
@@ -38,29 +38,29 @@ public:
 
     void setFonts (const Fonts& value);
 
-    // Adopts the document as it stands now - used on open, mode switch and
-    // history restore, and whenever an edit was refused by the model.
+    // Adopts the document as it stands now - used on open and history restore,
+    // and whenever an edit was refused by the model. Any open chord slot is
+    // discarded: its anchor belongs to the projection being replaced.
     void reset (NotepadDocument::Selection value);
     void setSelection (NotepadDocument::Selection value);
     NotepadDocument::Selection selection() const noexcept;
     void requestFocus() noexcept { focusRequested = true; }
-
-    // Distance from the top of the viewport to the caret's row. Captured
-    // before a mode switch and handed back after it, so the line under the
-    // reader's eye stays where it was even though the two projections wrap at
-    // different offsets.
-    float caretViewportOffset() const noexcept;
-    void keepCaretAtViewportOffset (float offset) noexcept;
 
     void draw (float bodySize);
 
     void applyInlineStyle (NotepadDocument::InlineStyle style);
     void applyBlockStyle (NotepadDocument::BlockStyle style);
 
-    // Opens the chord slot over the word at the caret, seeded with the chord
-    // already anchored there. Enter commits, Esc cancels, an empty name
-    // removes the chord.
-    void beginChordEntry();
+    // Opens the chord slot, seeded with the chord already anchored there.
+    // Without an anchor the slot lands on the word at the caret, so a chord
+    // sits over the first letter of the syllable it names. Enter commits, Esc
+    // cancels, an empty name removes the chord.
+    void beginChordEntry (std::optional<std::size_t> anchor = {});
+    // Settles an open slot the way Enter would, discarding a draft that
+    // resolves to no chord. Every entry point that mutates the document calls
+    // this first: chordAnchor points into the projection the slot was opened
+    // against, and an edit under it would land the chord somewhere else.
+    void closeChordEntry();
     void insertSectionMarker (const std::string& label);
     void removeSectionMarker();
     bool chordEntryActive() const noexcept { return chordEditing; }
@@ -116,11 +116,13 @@ private:
     // closed, so the same frame's remaining keys reach the text editor.
     bool handleChordEntry();
     void commitChordEntry();
+    void clearChordSlot();
     void repeatPreviousChord();
     std::size_t chordAnchorAtCaret() const;
     void refreshChordCandidates();
     std::vector<const std::string*> matchingChordCandidates() const;
     const std::string* selectedChordCandidate() const;
+    notepad::LabelWidthFn chordLabelWidth (float chordSize) const;
     void render (ImVec2 frameMin, ImVec2 frameMax, float bodySize, bool active) const;
 
     std::size_t hitTest (ImVec2 position, ImVec2 frameMin, float bodySize) const;
@@ -143,8 +145,6 @@ private:
     bool chordEditing = false;
     float desiredX = -1.0f;
     float scrollY = 0.0f;
-    float pendingCaretViewport = 0.0f;
-    bool caretViewportPending = false;
     float layoutWidth = -1.0f;
     float layoutBodySize = -1.0f;
     double blinkStart = 0.0;

--- a/src/ui/NotepadEditorCore.cpp
+++ b/src/ui/NotepadEditorCore.cpp
@@ -1,4 +1,5 @@
 #include "NotepadEditorCore.h"
+#include "NotepadTheme.h"
 
 #include <algorithm>
 #include <cmath>
@@ -234,29 +235,6 @@ bool acceptsTextInput (bool control, bool alt, bool super) noexcept
     return ! super && (! control || alt);
 }
 
-std::string encodeMarkdownLinkTarget (const std::string& target)
-{
-    static constexpr char hexDigits[] = "0123456789ABCDEF";
-    std::string encoded;
-    encoded.reserve (target.size());
-    for (const auto ch : target)
-    {
-        const auto byte = static_cast<unsigned char> (ch);
-        if (byte <= 0x20 || byte == 0x7f || ch == '(' || ch == ')' || ch == '['
-            || ch == ']' || ch == '<' || ch == '>' || ch == '"' || ch == '\\')
-        {
-            encoded.push_back ('%');
-            encoded.push_back (hexDigits[byte >> 4]);
-            encoded.push_back (hexDigits[byte & 0x0f]);
-        }
-        else
-        {
-            encoded.push_back (ch);
-        }
-    }
-    return encoded;
-}
-
 bool markdownInlineActive (const std::string& markdown,
                            NotepadDocument::Selection selection,
                            const std::string& prefix,
@@ -423,6 +401,11 @@ float blockIndent (NotepadDocument::BlockStyle block) noexcept
 float chordBandHeight (float bodySize) noexcept
 {
     return std::max (12.0f, bodySize * 1.05f);
+}
+
+float chordFontSize (float bodySize) noexcept
+{
+    return std::max (10.0f, bodySize * (kTypeScale.chord / kTypeScale.lyric));
 }
 
 namespace
@@ -617,6 +600,46 @@ std::size_t offsetAtX (const NotepadDocument& document, const Row& row, float lo
     return row.end;
 }
 
+std::vector<ChordPlacement> rowChordPlacements (const NotepadDocument& document, const Row& row,
+                                                float bodySize, const MeasureFn& measure,
+                                                const LabelWidthFn& labelWidth)
+{
+    // A one-letter chord is narrower than a comfortable target, so a lone label
+    // reaches a little past its glyphs. The clamp below still keeps it short of
+    // its neighbour.
+    constexpr float kMinLabelReach = 16.0f;
+
+    std::vector<ChordPlacement> placements;
+    const auto& chords = document.chords();
+    for (std::size_t i = 0; i < chords.size(); ++i)
+    {
+        if (! inRow (chords[i].documentOffset, row.start, row.end, row.lastRowOfLine))
+            continue;
+        auto x = offsetX (document, row, chords[i].documentOffset, bodySize, measure);
+        // Two chords written onto the same character share an anchor and have
+        // no syllable to tell them apart. Set the second beside the first
+        // rather than on top of it, or one of them is invisible and no click
+        // can ever reach it.
+        if (! placements.empty() && x <= placements.back().x)
+            x = placements.back().x + placements.back().width;
+        placements.push_back ({ i, x, std::max (kMinLabelReach,
+                                                labelWidth (chords[i].name)) });
+    }
+
+    for (std::size_t i = 0; i + 1 < placements.size(); ++i)
+        placements[i].width = std::min (placements[i].width,
+                                        placements[i + 1].x - placements[i].x);
+    return placements;
+}
+
+std::size_t chordAtX (const std::vector<ChordPlacement>& placements, float localX) noexcept
+{
+    for (const auto& placement : placements)
+        if (localX >= placement.x && localX < placement.x + placement.width)
+            return placement.chordIndex;
+    return std::string::npos;
+}
+
 void UndoStack::clear() noexcept
 {
     undoEntries.clear();
@@ -637,7 +660,6 @@ void UndoStack::record (EditKind kind, Snapshot before, std::size_t caretAfter)
                        && kind != EditKind::structural
                        && ! undoEntries.empty()
                        && undoEntries.back().kind == kind
-                       && undoEntries.back().state.selectionIsSource == before.selectionIsSource
                        && undoEntries.back().caretAfter == before.selection.start
                        && before.selection.empty();
     runBroken = kind == EditKind::structural;

--- a/src/ui/NotepadEditorCore.h
+++ b/src/ui/NotepadEditorCore.h
@@ -34,11 +34,6 @@ void appendUtf8 (std::string& text, unsigned int codepoint);
 // for editor commands.
 bool acceptsTextInput (bool control, bool alt, bool super) noexcept;
 
-// Produces a target safe for this editor's Markdown link parser. Percent
-// encoding avoids both early ')' termination and backslashes leaking into the
-// URL returned by NotepadDocument::linkTargetAt().
-std::string encodeMarkdownLinkTarget (const std::string& target);
-
 struct MarkdownTransform
 {
     std::string markdown;
@@ -64,6 +59,8 @@ float blockRowHeight (NotepadDocument::BlockStyle block, float bodySize) noexcep
 float blockIndent (NotepadDocument::BlockStyle block) noexcept;
 // Height of the chord band drawn above a row that carries chords.
 float chordBandHeight (float bodySize) noexcept;
+// Point size the chord lane is drawn at above lyrics of the given size.
+float chordFontSize (float bodySize) noexcept;
 
 // Vertical bands of the panel. The chrome keeps its stated heights and the
 // chart absorbs whatever is left, so a band can never be handed a fraction of
@@ -129,6 +126,28 @@ float offsetX (const NotepadDocument& document, const Row& row, std::size_t offs
 std::size_t offsetAtX (const NotepadDocument& document, const Row& row, float localX,
                        float bodySize, const MeasureFn& measure);
 
+// Width of a chord label drawn in the chord lane. Supplied by the renderer for
+// the same reason MeasureFn is: the geometry stays free of any toolkit.
+using LabelWidthFn = std::function<float (const std::string&)>;
+
+struct ChordPlacement
+{
+    std::size_t chordIndex = 0;   // into NotepadDocument::chords()
+    float x = 0.0f;               // from the row's indent
+    float width = 0.0f;
+};
+
+// The chords anchored on a row, left to right, each with the span its label
+// occupies. A label is truncated where the next chord's anchor starts, and two
+// chords sharing an anchor are set side by side, so the spans never overlap and
+// every label is both visible and reachable by exactly one click.
+std::vector<ChordPlacement> rowChordPlacements (const NotepadDocument& document, const Row& row,
+                                                float bodySize, const MeasureFn& measure,
+                                                const LabelWidthFn& labelWidth);
+// Index into NotepadDocument::chords() for the label covering localX, or npos
+// when the click landed on bare band.
+std::size_t chordAtX (const std::vector<ChordPlacement>& placements, float localX) noexcept;
+
 enum class EditKind
 {
     typing,
@@ -140,9 +159,6 @@ struct Snapshot
 {
     std::string markdown;
     NotepadDocument::Selection selection;
-    // Selections are recorded in the coordinate space of the mode that made the
-    // edit; the restoring side maps them when the mode has changed since.
-    bool selectionIsSource = false;
 };
 
 class UndoStack final

--- a/src/ui/NotepadTheme.h
+++ b/src/ui/NotepadTheme.h
@@ -28,28 +28,16 @@ inline constexpr std::uint32_t withAlpha (std::uint32_t rgba, std::uint8_t alpha
     return (rgba & 0xffffff00u) | alpha;
 }
 
-// A 1.25 scale. Sizes are logical pixels before the display scale factor.
+// Sizes are logical pixels before the display scale factor. The window builds
+// its font atlas at the lyric size and derives the chord lane from the ratio,
+// so the two lanes keep their proportion at any display scale.
 struct TypeScale
 {
-    float ui = 12.0f;        // toolbar, tooltips, status bar
-    float section = 12.0f;   // section labels, tracked and uppercased
-    float chord = 15.0f;     // the chord lane
-    float lyric = 17.0f;     // lyrics, and the Markdown source
-    float title = 26.0f;     // the song title, once
+    float chord = 15.0f;
+    float lyric = 17.0f;
 };
 
 inline constexpr TypeScale kTypeScale {};
-
-// Reading mode steps the lyric and chord sizes together so the two lanes keep
-// their proportion at arm's length. Step 0 is the writing size.
-inline constexpr int kMinReadingStep = -1;
-inline constexpr int kMaxReadingStep = 4;
-
-inline float readingScale (int step) noexcept
-{
-    const auto clamped = std::clamp (step, kMinReadingStep, kMaxReadingStep);
-    return 1.0f + 0.15f * static_cast<float> (clamped);
-}
 
 // WCAG relative luminance and contrast ratio, so the palette's legibility is
 // asserted by a test rather than eyeballed against a screenshot.

--- a/tests/notepad_chords.cpp
+++ b/tests/notepad_chords.cpp
@@ -77,6 +77,31 @@ TEST_CASE ("Chord entry candidates use a claimed key and otherwise sort alphabet
         CHECK (chords::rankCandidates (candidates, "not a key") == alphabetical);
         CHECK (chords::rankCandidates (candidates, "D7") == alphabetical);
     }
+
+    SECTION ("an infixed suspension is not the degree's major triad")
+    {
+        // F is the fourth of C and F7sus4 sits on it, but a suspension names no
+        // triad, so the plain fifth leads even though it sorts later.
+        CHECK (chords::rankCandidates ({ "F7sus4", "G" }, "C")
+               == std::vector<std::string> { "G", "F7sus4" });
+    }
+}
+
+TEST_CASE ("A partly typed chord name completes case-insensitively")
+{
+    // What the slot shows is what committing it places, so the match that
+    // drives the completion has to accept the casing a hurried writer types.
+    CHECK (chords::completes ("Am", "am"));
+    CHECK (chords::completes ("Am", "A"));
+    CHECK (chords::completes ("Cmaj7", "cM"));
+    CHECK (chords::completes ("Am", "Am"));
+
+    CHECK_FALSE (chords::completes ("Am", "Amj"));
+    CHECK_FALSE (chords::completes ("Am", "m"));
+    CHECK_FALSE (chords::completes ("A", "Am"));
+    // Nothing typed suggests nothing: an empty slot must not adopt the first
+    // ranked candidate when it closes.
+    CHECK_FALSE (chords::completes ("Am", ""));
 }
 
 TEST_CASE ("chord brackets are hidden from the document projection")
@@ -204,6 +229,16 @@ TEST_CASE ("setChordAt inserts, replaces and removes")
         CHECK (document.markdown() == "one two");
     }
 
+    SECTION ("rewriting a chord as itself reports that nothing changed")
+    {
+        // Closing a chord slot without editing it must not look like an edit:
+        // the caller records an undo step on true, and recording one would
+        // both add a phantom step and throw away the redo stack.
+        REQUIRE (document.setChordAt (4, "G"));
+        CHECK_FALSE (document.setChordAt (4, "G"));
+        CHECK (document.markdown() == "one [G]two");
+    }
+
     SECTION ("removing where no chord is anchored is a no-op")
     {
         CHECK_FALSE (document.setChordAt (2, ""));
@@ -220,13 +255,6 @@ TEST_CASE ("repeatPreviousChordAt copies the preceding chord in either view")
     {
         REQUIRE (document.repeatPreviousChordAt (8));
         CHECK (document.markdown() == "[Am]one [F]two [F]three");
-    }
-
-    SECTION ("the Markdown source uses the preceding visible token")
-    {
-        document.setSourceMode (true);
-        REQUIRE (document.repeatPreviousChordAt (document.documentText().size()));
-        CHECK (document.markdown() == "[Am]one [F]two three[F]");
     }
 
     SECTION ("there is nothing to repeat before the first chord")
@@ -304,44 +332,43 @@ TEST_CASE ("Transpose keeps the notation the document already uses")
         flats.setMarkdown ("[Eb]one");
         CHECK (flats.prefersFlats());
     }
+
+    SECTION ("stepping back through history keeps the document's own reading")
+    {
+        // Undo and redo put earlier states of the same document back. The state
+        // they restore can be all naturals, and re-deriving there would hand a
+        // flat writer a document spelled in sharps.
+        NotepadDocument flats;
+        flats.setMarkdown ("[Db]x");
+        REQUIRE (flats.prefersFlats());
+
+        flats.transposeChords (-1, flats.prefersFlats());
+        REQUIRE (flats.markdown() == "[C]x");
+
+        flats.restoreMarkdown ("[Db]x");
+        flats.restoreMarkdown ("[C]x");
+        CHECK (flats.prefersFlats());
+    }
 }
 
-TEST_CASE ("Chord commands and counts survive the source view")
+TEST_CASE ("Chord commands reach the source behind the hidden syntax")
 {
     NotepadDocument document;
     document.setMarkdown ("# Title\n\n[Am]one two");
-    const auto renderedWords = document.wordCount();
-    const auto renderedCharacters = document.characterCount();
+    // The counts describe the lyric, never the syntax the projection hides.
+    CHECK (document.wordCount() == 3);
+    CHECK (document.characterCount() == std::string ("Title\n\none two").size());
 
-    document.setSourceMode (true);
-    CHECK (document.hasChords());
-    CHECK (document.wordCount() == renderedWords);
-    CHECK (document.characterCount() == renderedCharacters);
-
-    SECTION ("transpose still rewrites the source")
+    SECTION ("transpose rewrites the source")
     {
         document.transposeChords (2, document.prefersFlats());
         CHECK (document.markdown() == "# Title\n\n[Bm]one two");
     }
 
-    SECTION ("a chord can be inserted at a source offset")
+    SECTION ("a chord can be appended past the last lyric character")
     {
-        REQUIRE (document.setChordAt (document.markdown().size(), "G"));
+        REQUIRE (document.setChordAt (document.documentText().size(), "G"));
         CHECK (document.markdown() == "# Title\n\n[Am]one two[G]");
-    }
-
-    SECTION ("a caret inside a token edits that chord instead of nesting one")
-    {
-        // The token runs [9, 13); the caret sits on its 'm'.
-        REQUIRE (document.markdown().compare (9, 4, "[Am]") == 0);
-        CHECK (document.chordAt (11) == "Am");
-
-        REQUIRE (document.setChordAt (11, "C"));
-        CHECK (document.markdown() == "# Title\n\n[C]one two");
-
-        REQUIRE (document.setChordAt (10, ""));
-        CHECK (document.markdown() == "# Title\n\none two");
-        CHECK_FALSE (document.hasChords());
     }
 }
 
@@ -364,6 +391,26 @@ TEST_CASE ("Key detection only claims a key the evidence supports")
         // its neighbours establish.
         CHECK (chords::detectKey ({ "Am", "Gb5" }).empty());
         CHECK (chords::detectKey ({ "Am", "F", "C", "E5" }) == "Am");
+    }
+
+    SECTION ("a suspension behind a figure is still a suspension")
+    {
+        // "7sus4" and friends put the figure first; the third is replaced all
+        // the same, so they may not vote as major triads.
+        CHECK (chords::detectKey ({ "A7sus4", "D9sus2", "E13sus4" }).empty());
+        CHECK (chords::detectKey ({ "C", "F", "G7sus4" }).empty());
+    }
+
+    SECTION ("a tie the opening triad cannot break stays blank")
+    {
+        // Every key that fits C-Bb-F-G is a tie, and C major is not among them
+        // - the opening triad claims a tonic the evidence rules out, so no key
+        // is named rather than one of the ties being picked arbitrarily.
+        CHECK (chords::detectKey ({ "C", "Bb", "F", "G" }).empty());
+
+        // The same shape with an opening triad that is one of the ties resolves
+        // to it.
+        CHECK (chords::detectKey ({ "Bb", "C", "F", "G" }) == "Bb");
     }
 
     SECTION ("two chords are not evidence")

--- a/tests/notepad_document.cpp
+++ b/tests/notepad_document.cpp
@@ -39,7 +39,7 @@ TEST_CASE ("Notepad document formatting mutates Markdown and remains selectable"
     const auto boldStart = document.documentText().find ("this bold");
     REQUIRE (boldStart != std::string::npos);
     const NotepadDocument::Selection boldSelection { boldStart, boldStart + 9 };
-    document.wrapDocumentSelection (boldSelection, "**", "**");
+    document.setDocumentInlineStyle (boldSelection, NotepadDocument::InlineStyle::bold, true);
     CHECK (document.markdown().find ("**this bold**") != std::string::npos);
     CHECK (document.selectionHasInlineStyle (
         boldSelection, NotepadDocument::InlineStyle::bold));
@@ -56,7 +56,7 @@ TEST_CASE ("Notepad document formatting mutates Markdown and remains selectable"
     CHECK (document.selectionHasInlineStyle (
         editedBold, NotepadDocument::InlineStyle::bold));
 
-    document.wrapDocumentSelection (editedBold, "**", "**");
+    document.setDocumentInlineStyle (editedBold, NotepadDocument::InlineStyle::bold, false);
     CHECK (document.markdown().find ("**still bold**") == std::string::npos);
 
     const auto headingStart = document.documentText().find ("Promote this line");
@@ -259,18 +259,18 @@ TEST_CASE ("Notepad document exposes list, task, and link presentation metadata"
     CHECK (document.lineInfoAt (numbered).orderedNumber == 1);
 }
 
-TEST_CASE ("Notepad source and document selections round-trip across hidden syntax",
+TEST_CASE ("Notepad projected selections map onto the text they show",
            "[notepad][document]")
 {
     NotepadDocument document;
     document.setMarkdown ("# A **bold** [link](https://example.com)");
     const auto start = document.documentText().find ("bold");
     REQUIRE (start != std::string::npos);
-    const NotepadDocument::Selection projected { start, start + 4 };
-    const auto source = document.sourceSelection (projected);
-    const auto roundTrip = document.documentSelection (source);
-    CHECK (roundTrip.start == projected.start);
-    CHECK (roundTrip.end == projected.end);
+
+    // The mapping lands on the label itself, inside every hidden marker: the
+    // heading prefix and the opening "**" ahead of it, the closing "**" after.
+    const auto source = document.sourceSelection ({ start, start + 4 });
+    CHECK (document.markdown().substr (source.start, source.end - source.start) == "bold");
 }
 
 // orderedPrefixLength accepts any run of digits, so the ordered-number
@@ -299,64 +299,10 @@ TEST_CASE ("Notepad counts characters the way the editor navigates them",
     CHECK (document.characterCount() == 6);
     CHECK (document.wordCount() == 2);
 
-    SECTION ("hidden syntax is not counted in either mode")
+    SECTION ("hidden syntax is not counted")
     {
         document.setMarkdown ("**caf\xc3\xa9**");
         CHECK (document.characterCount() == 4);
-        document.setSourceMode (true);
-        CHECK (document.characterCount() == 4);
-    }
-}
-
-TEST_CASE ("Notepad source mode projects the Markdown one to one",
-           "[notepad][document][source]")
-{
-    NotepadDocument document;
-    document.setMarkdown ("# Title\n\nline [Am]one\n");
-    REQUIRE (document.chords().size() == 1);
-
-    document.setSourceMode (true);
-    CHECK (document.isSourceMode());
-    CHECK (document.documentText() == document.markdown());
-    CHECK (document.chords().empty());
-
-    // Every line is body text in source mode, so a heading keeps its metrics
-    // across the toggle and the reader's line does not move.
-    CHECK (document.lineInfoAt (0).block == NotepadDocument::BlockStyle::body);
-    CHECK (document.styleAt (0).block == NotepadDocument::BlockStyle::body);
-    CHECK_FALSE (document.styleAt (0).bold);
-
-    SECTION ("offsets map through unchanged")
-    {
-        const NotepadDocument::Selection selection { 2, 7 };
-        CHECK (document.sourceSelection (selection).start == selection.start);
-        CHECK (document.sourceSelection (selection).end == selection.end);
-        CHECK (document.documentSelection (selection).start == selection.start);
-        CHECK (document.documentSelection (selection).end == selection.end);
-    }
-
-    SECTION ("chord commands still reach the source")
-    {
-        CHECK (document.hasChords());
-        document.transposeChords (2, document.prefersFlats());
-        CHECK (document.markdown() == "# Title\n\nline [Bm]one\n");
-    }
-
-    SECTION ("typed Markdown syntax round-trips unescaped")
-    {
-        auto edited = document.documentText();
-        edited.insert (edited.size(), "*star* [Am]bracket");
-        REQUIRE (document.replaceDocumentText (edited));
-        CHECK (document.markdown() == edited);
-        CHECK (document.documentText() == edited);
-    }
-
-    SECTION ("switching back restores the rendered projection")
-    {
-        document.setSourceMode (false);
-        CHECK (document.documentText() == "Title\n\nline one\n");
-        CHECK (document.chords().size() == 1);
-        CHECK (document.lineInfoAt (0).block == NotepadDocument::BlockStyle::heading1);
     }
 }
 
@@ -378,6 +324,56 @@ TEST_CASE ("Section markers project as their label", "[notepad][document][sectio
         REQUIRE (document.replaceDocumentText (edited));
         CHECK (document.markdown() == "\nline one\n");
         CHECK (document.documentText() == "\nline one\n");
+        CHECK (document.sectionCount() == 0);
+    }
+
+    SECTION ("backspace at the label's last character stays inside the brackets")
+    {
+        auto edited = document.documentText();
+        edited.erase (5, 1);   // Backspace over the 's' of "Chorus".
+        REQUIRE (document.replaceDocumentText (edited));
+        CHECK (document.markdown() == "[Choru]\nline one\n");
+        CHECK (document.documentText() == "Choru\nline one\n");
+        CHECK (document.lineInfoAt (0).section);
+    }
+
+    SECTION ("typing at the end of the label extends it")
+    {
+        auto edited = document.documentText();
+        edited.insert (6, "es");
+        REQUIRE (document.replaceDocumentText (edited));
+        CHECK (document.markdown() == "[Choruses]\nline one\n");
+        CHECK (document.documentText() == "Choruses\nline one\n");
+        CHECK (document.lineInfoAt (0).section);
+    }
+
+    SECTION ("replacing the label's tail keeps the marker intact")
+    {
+        auto edited = document.documentText();
+        edited.replace (3, 3, "ir");   // "Chorus" -> "Choir"
+        REQUIRE (document.replaceDocumentText (edited));
+        CHECK (document.markdown() == "[Choir]\nline one\n");
+        CHECK (document.sectionCount() == 1);
+    }
+
+    SECTION ("a hand-authored marker behind a block prefix edits the same way")
+    {
+        document.setMarkdown ("- [Chorus]\nline one\n");
+        auto edited = document.documentText();
+        edited.insert (6, "!");
+        REQUIRE (document.replaceDocumentText (edited));
+        CHECK (document.markdown() == "- [Chorus!]\nline one\n");
+        CHECK (document.lineInfoAt (0).section);
+    }
+
+    SECTION ("a deletion reaching into the label from outside still clears it")
+    {
+        document.setMarkdown ("line one\n[Chorus]\n");
+        auto edited = document.documentText();
+        // From mid-lyric through the whole label: the marker goes with it.
+        edited.erase (5, document.documentText().size() - 6);
+        REQUIRE (document.replaceDocumentText (edited));
+        CHECK (document.markdown() == "line \n");
         CHECK (document.sectionCount() == 0);
     }
 

--- a/tests/notepad_editor_core.cpp
+++ b/tests/notepad_editor_core.cpp
@@ -86,20 +86,6 @@ TEST_CASE ("Notepad editor accepts AltGr text without turning command chords int
     CHECK (notepad::acceptsTextInput (false, false, false));
 }
 
-TEST_CASE ("Notepad Markdown link targets encode parser delimiters and controls",
-           "[notepad][editor][markdown]")
-{
-    const auto encoded = notepad::encodeMarkdownLinkTarget (
-        "https://example.test/a b)\n[x]\\tail");
-    CHECK (encoded == "https://example.test/a%20b%29%0A%5Bx%5D%5Ctail");
-    CHECK (notepad::encodeMarkdownLinkTarget (encoded) == encoded);
-
-    NotepadDocument document;
-    document.setMarkdown ("[label](" + encoded + ")");
-    CHECK (document.documentText() == "label");
-    CHECK (document.linkTargetAt (0) == encoded);
-}
-
 TEST_CASE ("Notepad Markdown inline commands toggle matching wrappers",
            "[notepad][editor][markdown]")
 {
@@ -338,6 +324,86 @@ TEST_CASE ("Notepad editor hit testing round-trips against caret positions",
     CHECK (notepad::offsetAtX (document, row, 1000.0f, 10.0f, measure) == row.end);
 }
 
+TEST_CASE ("Notepad chord labels claim the span they are drawn in",
+           "[notepad][editor][layout][chords]")
+{
+    // "on " is three characters wide, so the second chord's anchor lands inside
+    // the reach of the first chord's much longer name.
+    NotepadDocument document;
+    document.setMarkdown ("[Cmaj7]on [G]two");
+    REQUIRE (document.documentText() == "on two");
+    REQUIRE (document.chords().size() == 2);
+    REQUIRE (document.chords()[1].documentOffset == 3);
+
+    const auto measure = fixedAdvance (10.0f, 10.0f);
+    const auto layout = notepad::buildLayout (document, 400.0f, 10.0f, measure);
+    REQUIRE (layout.rows.size() == 1);
+
+    const notepad::LabelWidthFn labelWidth = [] (const std::string& name)
+    {
+        return static_cast<float> (name.size()) * 8.0f;
+    };
+    const auto placements = notepad::rowChordPlacements (document, layout.rows[0], 10.0f,
+                                                          measure, labelWidth);
+    REQUIRE (placements.size() == 2);
+    CHECK (placements[0].x == 0.0f);
+    CHECK (placements[1].x == 30.0f);
+    // "Cmaj7" would draw 40 units wide; it stops where the next anchor starts.
+    CHECK (placements[0].width == 30.0f);
+
+    // Each chord answers for its own span, and the one behind a long name is
+    // still reachable.
+    CHECK (notepad::chordAtX (placements, 0.0f) == 0);
+    CHECK (notepad::chordAtX (placements, 29.0f) == 0);
+    CHECK (notepad::chordAtX (placements, 30.0f) == 1);
+    CHECK (notepad::chordAtX (placements, 44.0f) == 1);
+
+    SECTION ("bare band belongs to no chord")
+    {
+        CHECK (notepad::chordAtX (placements, -4.0f) == std::string::npos);
+        CHECK (notepad::chordAtX (placements, 200.0f) == std::string::npos);
+    }
+
+    SECTION ("a one-letter label still offers a usable target")
+    {
+        NotepadDocument lone;
+        lone.setMarkdown ("[C]one");
+        const auto row = notepad::buildLayout (lone, 400.0f, 10.0f, measure).rows[0];
+        const auto single = notepad::rowChordPlacements (lone, row, 10.0f, measure,
+                                                          labelWidth);
+        REQUIRE (single.size() == 1);
+        CHECK (single[0].width > labelWidth ("C"));
+    }
+
+    SECTION ("two chords on one character sit side by side")
+    {
+        // They share an anchor, so neither owns the syllable. Stacking them
+        // would draw one over the other and leave it unreachable by click.
+        NotepadDocument stacked;
+        stacked.setMarkdown ("[Am][C]one");
+        const auto row = notepad::buildLayout (stacked, 400.0f, 10.0f, measure).rows[0];
+        const auto both = notepad::rowChordPlacements (stacked, row, 10.0f, measure,
+                                                        labelWidth);
+        REQUIRE (both.size() == 2);
+        CHECK (both[0].x == 0.0f);
+        CHECK (both[1].x == both[0].x + both[0].width);
+        CHECK (notepad::chordAtX (both, both[0].x) == 0);
+        CHECK (notepad::chordAtX (both, both[1].x) == 1);
+    }
+
+    SECTION ("chords on other rows are not offered")
+    {
+        NotepadDocument wrapped;
+        wrapped.setMarkdown ("[Am]aaaa bbbb cccc dddd eeee ffff gggg hhhh iiii [C]jjjj");
+        const auto rows = notepad::buildLayout (wrapped, 400.0f, 10.0f, measure).rows;
+        REQUIRE (rows.size() == 2);
+        CHECK (notepad::rowChordPlacements (wrapped, rows[0], 10.0f, measure,
+                                            labelWidth).size() == 1);
+        CHECK (notepad::rowChordPlacements (wrapped, rows[1], 10.0f, measure,
+                                            labelWidth).size() == 1);
+    }
+}
+
 TEST_CASE ("Notepad editor layout walks multi-byte text by codepoint",
            "[notepad][editor][layout]")
 {
@@ -399,7 +465,7 @@ TEST_CASE ("Notepad editor undo coalesces a typing run into one step",
 
     const auto typed = [&history] (const std::string& before, std::size_t caret)
     {
-        history.record (notepad::EditKind::typing, { before, { caret, caret }, false },
+        history.record (notepad::EditKind::typing, { before, { caret, caret } },
                         caret + 1);
     };
 
@@ -409,14 +475,14 @@ TEST_CASE ("Notepad editor undo coalesces a typing run into one step",
     CHECK (history.undoDepth() == 1);
 
     notepad::Snapshot restored;
-    REQUIRE (history.undo ({ "abc", { 3, 3 }, false }, restored));
+    REQUIRE (history.undo ({ "abc", { 3, 3 } }, restored));
     CHECK (restored.markdown.empty());
     CHECK (restored.selection.start == 0);
     CHECK (history.undoDepth() == 0);
     CHECK (history.canRedo());
 
     notepad::Snapshot redone;
-    REQUIRE (history.redo ({ "", { 0, 0 }, false }, redone));
+    REQUIRE (history.redo ({ "", { 0, 0 } }, redone));
     CHECK (redone.markdown == "abc");
 }
 
@@ -425,46 +491,31 @@ TEST_CASE ("Notepad editor undo breaks runs on caret moves and structural edits"
 {
     notepad::UndoStack history;
 
-    history.record (notepad::EditKind::typing, { "", { 0, 0 }, false }, 1);
-    history.record (notepad::EditKind::typing, { "a", { 1, 1 }, false }, 2);
+    history.record (notepad::EditKind::typing, { "", { 0, 0 } }, 1);
+    history.record (notepad::EditKind::typing, { "a", { 1, 1 } }, 2);
     CHECK (history.undoDepth() == 1);
 
     // A caret move between keystrokes starts a new step even though the kind
     // and the offsets still line up.
     history.breakRun();
-    history.record (notepad::EditKind::typing, { "ab", { 2, 2 }, false }, 3);
+    history.record (notepad::EditKind::typing, { "ab", { 2, 2 } }, 3);
     CHECK (history.undoDepth() == 2);
 
     // Deletions never join a typing run, and every toolbar edit stands alone.
-    history.record (notepad::EditKind::deleting, { "abc", { 3, 3 }, false }, 2);
+    history.record (notepad::EditKind::deleting, { "abc", { 3, 3 } }, 2);
     CHECK (history.undoDepth() == 3);
-    history.record (notepad::EditKind::structural, { "ab", { 2, 2 }, false }, 2);
-    history.record (notepad::EditKind::structural, { "**ab**", { 2, 2 }, false }, 2);
+    history.record (notepad::EditKind::structural, { "ab", { 2, 2 } }, 2);
+    history.record (notepad::EditKind::structural, { "**ab**", { 2, 2 } }, 2);
     CHECK (history.undoDepth() == 5);
 
     // Typing after an undo starts a fresh step rather than extending the one
     // that was just restored.
     notepad::Snapshot restored;
-    REQUIRE (history.undo ({ "***ab***", { 2, 2 }, false }, restored));
+    REQUIRE (history.undo ({ "***ab***", { 2, 2 } }, restored));
     const auto depthAfterUndo = history.undoDepth();
-    history.record (notepad::EditKind::typing, { "**ab**", { 2, 2 }, false }, 3);
+    history.record (notepad::EditKind::typing, { "**ab**", { 2, 2 } }, 3);
     CHECK (history.undoDepth() == depthAfterUndo + 1);
     CHECK_FALSE (history.canRedo());
-}
-
-TEST_CASE ("Notepad editor undo never coalesces across editing modes",
-           "[notepad][editor][undo]")
-{
-    notepad::UndoStack history;
-
-    // Document mode records projected offsets, Markdown mode source offsets.
-    // They can meet at the same number and still mean different places.
-    history.record (notepad::EditKind::typing, { "a", { 1, 1 }, false }, 2);
-    history.record (notepad::EditKind::typing, { "ab", { 2, 2 }, true }, 3);
-    CHECK (history.undoDepth() == 2);
-
-    history.record (notepad::EditKind::typing, { "abc", { 3, 3 }, true }, 4);
-    CHECK (history.undoDepth() == 2);
 }
 
 TEST_CASE ("Notepad editor undo replacing a selection is its own step",
@@ -472,10 +523,10 @@ TEST_CASE ("Notepad editor undo replacing a selection is its own step",
 {
     notepad::UndoStack history;
 
-    history.record (notepad::EditKind::typing, { "", { 0, 0 }, false }, 1);
+    history.record (notepad::EditKind::typing, { "", { 0, 0 } }, 1);
     // Typing over a selection starts at the same offset the previous run ended
     // at, but it must not be folded into it.
-    history.record (notepad::EditKind::typing, { "a", { 1, 4 }, false }, 2);
+    history.record (notepad::EditKind::typing, { "a", { 1, 4 } }, 2);
     CHECK (history.undoDepth() == 2);
 }
 
@@ -485,12 +536,12 @@ TEST_CASE ("Notepad editor undo history is bounded", "[notepad][editor][undo]")
 
     for (std::size_t i = 0; i < notepad::UndoStack::kMaxEntries + 20; ++i)
         history.record (notepad::EditKind::structural,
-                        { std::string (i, 'x'), { i, i }, false }, i);
+                        { std::string (i, 'x'), { i, i } }, i);
 
     CHECK (history.undoDepth() == notepad::UndoStack::kMaxEntries);
 
     notepad::Snapshot restored;
-    REQUIRE (history.undo ({ "current", { 0, 0 }, false }, restored));
+    REQUIRE (history.undo ({ "current", { 0, 0 } }, restored));
     CHECK (restored.markdown.size() == notepad::UndoStack::kMaxEntries + 19);
 }
 

--- a/tests/notepad_theme.cpp
+++ b/tests/notepad_theme.cpp
@@ -1,5 +1,4 @@
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include "ui/NotepadTheme.h"
 
@@ -38,19 +37,4 @@ TEST_CASE ("Notepad palette keeps the chrome and writing surface distinguishable
     CHECK (separation > 1.05);
     CHECK (separation < 2.0);
     CHECK (notepad::contrastRatio (p.rule, p.stage) < 2.0);
-}
-
-TEST_CASE ("Notepad reading steps scale monotonically around the writing size",
-           "[notepad][theme]")
-{
-    CHECK (notepad::readingScale (0) == 1.0f);
-    CHECK (notepad::readingScale (notepad::kMinReadingStep) < 1.0f);
-    CHECK (notepad::readingScale (notepad::kMaxReadingStep) > 1.5f);
-
-    for (int step = notepad::kMinReadingStep; step < notepad::kMaxReadingStep; ++step)
-        CHECK (notepad::readingScale (step) < notepad::readingScale (step + 1));
-
-    // Out-of-range steps clamp rather than running the type off the page.
-    CHECK (notepad::readingScale (-9) == notepad::readingScale (notepad::kMinReadingStep));
-    CHECK (notepad::readingScale (99) == notepad::readingScale (notepad::kMaxReadingStep));
 }

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -117,7 +117,7 @@ src/ui/ImportTargetPicker.cpp	97
 src/ui/ImportTargetPicker.h	11
 src/ui/Lv2PluginEditorComponent.cpp	3
 src/ui/Lv2PluginEditorComponent.h	4
-src/ui/MainComponent.cpp	474
+src/ui/MainComponent.cpp	471
 src/ui/MainComponent.h	57
 src/ui/MasterStripComponent.cpp	402
 src/ui/MasterStripComponent.h	59


### PR DESCRIPTION
Chord-band clicks resolve against the label geometry the chart draws instead of mixing the chord name's byte length into document-offset space, and the draw side clips to the same spans so adjacent labels neither overlap nor swallow each other's click. Two chords sharing an anchor are set side by side rather than stacked. The resolved anchor is handed to beginChordEntry rather than re-derived from the caret word.

An open chord slot is settled before anything moves the document out from under its anchor: a mouse click in the page, a ribbon action, a history restore, or the window closing from the DAW side. Every route runs the same commit, so the completion the slot is showing is placed whichever way the user leaves it, and the click is measured against the layout that was on screen rather than the one the commit produces. Rewriting a chord as itself reports that nothing changed, keeping an untouched slot out of the undo history and off the redo stack.

Editing the trailing edge of a section label was silently reverted: the projected boundary after the label mapped past the hidden bracket, so backspace and typing there produced a line that was not a marker any more and the projection check dropped the keystroke.

Also: the accidental preference survives undo and redo; 7sus4 and its relatives read as suspensions rather than major triads; disabled toolbar buttons show their tooltip at full opacity; ribbon buttons size from the text they draw so labels stop clipping at HiDPI; the duplicated notepad geometry in MainComponent is one function that clamps before centring; and the source-view model path, the link-dialog remnants, the reading-scale helpers and the unused type-scale fields are deleted.