### PR TITLE
fix(session): clamp loaded values to their control ranges

### DIFF
--- a/src/dsp/MasteringDigitalEq.cpp
+++ b/src/dsp/MasteringDigitalEq.cpp
@@ -227,7 +227,11 @@ void MasteringDigitalEq::rebuildIfDirty (int idx) noexcept
 
     const float freq = std::clamp (b.freq.load (std::memory_order_relaxed), 10.0f, (float) (sr * 0.49));
     const float qVal = std::clamp (b.q.load (std::memory_order_relaxed), 0.1f, 10.0f);
-    const float dB   = b.gainDb.load (std::memory_order_relaxed);
+    // computeCoeffs drops a gain whose taps overflow, but one that merely
+    // dwarfs the editor's +/-12 dB (a hand-edited 300) still yields finite
+    // coefficients and a boost that would wreck the mix. Bound it at twice the
+    // editor range: wide enough that no legal setting is reshaped.
+    const float dB   = std::clamp (b.gainDb.load (std::memory_order_relaxed), -24.0f, 24.0f);
 
     // Compute + write in place - no heap allocation on the audio thread.
     const Coeffs c = computeCoeffs (idx, sr, freq, qVal, dB);

--- a/src/foundation/Json.h
+++ b/src/foundation/Json.h
@@ -51,11 +51,6 @@ inline double getDouble (const Json& j, const char* key, double def)
     return v.is_number() ? v.get<double>() : def;
 }
 
-inline float getFloat (const Json& j, const char* key, float def)
-{
-    return (float) getDouble (j, key, (double) def);
-}
-
 inline int getInt (const Json& j, const char* key, int def)
 {
     if (! has (j, key)) return def;
@@ -118,16 +113,20 @@ inline std::string getString (const Json& j, const char* key, const std::string&
 }
 
 // Finite-guarded float: rejects NaN / inf / out-of-float-range doubles from a
-// corrupt file before narrowing (the narrowing cast would be UB). Mirrors the
-// former finiteFloatOr helper.
-inline float getFiniteFloat (const Json& j, const char* key, float fallback)
+// corrupt file before narrowing (the narrowing cast would be UB).
+inline float finiteFloat (const Json& v, float fallback)
 {
-    if (! has (j, key)) return fallback;
-    const auto& v = j[key];
     if (! v.is_number()) return fallback;
     const double d = v.get<double>();
     if (std::isfinite (d) && std::abs (d) <= (double) std::numeric_limits<float>::max())
         return (float) d;
     return fallback;
+}
+
+// Key-addressed sibling of finiteFloat, for reads that resolve off the parent
+// object rather than off an already-extracted value node.
+inline float getFiniteFloat (const Json& j, const char* key, float fallback)
+{
+    return has (j, key) ? finiteFloat (j[key], fallback) : fallback;
 }
 } // namespace dusk::json

--- a/src/session/Session.h
+++ b/src/session/Session.h
@@ -1149,7 +1149,9 @@ struct MasteringParams
     mutable std::atomic<float> meterTruePeakDb      { -100.0f };
 
     // Drives I-LUFS / true-peak cell colour-coding in MasteringView.
-    // 0 = Off (neutral). See kMasteringTargets for the preset table.
+    // 0 = Off (neutral). See kMasteringTargets for the preset table - it
+    // static_asserts against this count, which is what the loader clamps to.
+    static constexpr int kNumTargetPresets = 6;
     std::atomic<int> targetPresetIndex { 0 };
 };
 

--- a/src/session/SessionSerializer.cpp
+++ b/src/session/SessionSerializer.cpp
@@ -155,18 +155,6 @@ inline void migrateTapeStateBlob (const std::string& base64, TapeParams& t)
     }
 }
 
-// Scalar sibling for plain-float fields (region gain, etc.) that aren't atomics.
-inline float finiteFloatOr (const nlohmann::json& src, float fallback) noexcept
-{
-    if (src.is_number())
-    {
-        const double d = src.get<double>();
-        if (std::isfinite (d) && std::abs (d) <= (double) std::numeric_limits<float>::max())
-            return (float) d;
-    }
-    return fallback;
-}
-
 // Finite-guard AND range-clamp in one step, for the mixer parameters that feed
 // DSP directly. Clamping alone is not enough: a non-finite value passes through
 // std::clamp unchanged (NaN compares false against both bounds), and the
@@ -175,7 +163,17 @@ inline void storeFiniteClampedFloat (std::atomic<float>& dst,
                                      const nlohmann::json& src,
                                      float fallback, float minimum, float maximum) noexcept
 {
-    dst.store (std::clamp (finiteFloatOr (src, fallback), minimum, maximum),
+    dst.store (std::clamp (json::finiteFloat (src, fallback), minimum, maximum),
+               std::memory_order_relaxed);
+}
+
+// Same contract addressed by key, for the fields that are written unconditionally
+// (an absent key resets to the fallback rather than retaining the live value).
+inline void storeFiniteClampedFloat (std::atomic<float>& dst,
+                                     const nlohmann::json& parent, const char* key,
+                                     float fallback, float minimum, float maximum) noexcept
+{
+    dst.store (std::clamp (json::getFiniteFloat (parent, key, fallback), minimum, maximum),
                std::memory_order_relaxed);
 }
 
@@ -197,16 +195,13 @@ inline AutomationPoint parseAutomationPoint (const nlohmann::json& pv, double fa
     const double rawT = json::getDouble (pv, "t", 0.0);
     pt.timeSamples   = (std::isfinite (rawT) && rawT > 0.0 && rawT < 9223372036854775808.0)
                            ? (std::int64_t) rawT : (std::int64_t) 0;
-    // NaN slips through jlimit unchanged (NaN compares false both ways), so it
-    // would otherwise poison the lane's binary search / a DSP param. Map it to a
-    // safe default; ±inf is already clamped to the [0,1] range by jlimit.
-    float rawV = json::getFloat (pv, "v", 0.0f);
-    if (std::isnan (rawV)) rawV = 0.0f;
-    pt.value         = jlimit (0.0f, 1.0f, rawV);
-    const float bpm  = json::getFloat (pv, "bpm", safeFallback);
-    // A zero / negative bpm would break tempo-retime math (division by it),
-    // so accept only a finite, strictly-positive value; else fall back.
-    pt.recordedAtBPM = (std::isfinite (bpm) && bpm > 0.0f) ? bpm : safeFallback;
+    // Guarded before the narrowing rather than after it: a NaN would slip
+    // through jlimit unchanged (it compares false both ways) and a double past
+    // float range is UB to cast at all. Both resolve to the fallback.
+    pt.value         = jlimit (0.0f, 1.0f, json::getFiniteFloat (pv, "v", 0.0f));
+    const float bpm  = json::getFiniteFloat (pv, "bpm", safeFallback);
+    // A zero / negative bpm would break tempo-retime math (division by it).
+    pt.recordedAtBPM = bpm > 0.0f ? bpm : safeFallback;
     return pt;
 }
 } // namespace
@@ -1111,8 +1106,8 @@ void restoreTrack (Track& t, int trackIndex, const nlohmann::json& v,
             // and the old fallback turned a corrupt file into a feedback-loud mix.
             // At or below the knob floor collapses to the OFF sentinel, matching
             // what the strip's own fully-CCW position stores.
-            const float loaded = finiteFloatOr (auxLevels[(size_t) i],
-                                                ChannelStripParams::kAuxSendOffDb);
+            const float loaded = json::finiteFloat (auxLevels[(size_t) i],
+                                                    ChannelStripParams::kAuxSendOffDb);
             const float level = loaded <= ChannelStripParams::kAuxSendMinDb + 0.01f
                                   ? ChannelStripParams::kAuxSendOffDb
                                   : std::clamp (loaded,
@@ -1323,7 +1318,7 @@ void restoreTrack (Track& t, int trackIndex, const nlohmann::json& v,
             r.fadeInAuto      = json::getBool (rv, "fade_in_auto", false);
             r.fadeOutAuto     = json::getBool (rv, "fade_out_auto", false);
             r.numChannels     = jlimit (1, 2, json::getInt (rv, "num_channels", 1));
-            r.gainDb          = json::has (rv, "gain_db") ? finiteFloatOr (rv["gain_db"], 0.0f) : 0.0f;
+            r.gainDb          = json::getFiniteFloat (rv, "gain_db", 0.0f);
             r.customColour    = json::has (rv, "custom_colour")
                                  ? juce::Colour::fromString (juce::String (json::getString (rv, "custom_colour")))
                                  : juce::Colour();
@@ -1961,7 +1956,11 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
     double sessionLoadBpm = (double) s.tempoBpm.load (std::memory_order_relaxed);
     if (json::has (transportSection, "tempo_bpm"))
     {
-        const double peeked = json::getDouble (transportSection, "tempo_bpm", 0.0);
+        // Wrong-typed values fall back to the running tempo, matching the block
+        // below: a 0 fallback would anchor the regions at 30 while the block
+        // kept the real tempo, and the two must never disagree.
+        const double peeked = json::getDouble (transportSection, "tempo_bpm",
+                                               (double) s.tempoBpm.load (std::memory_order_relaxed));
         // Clamp to the same 30-300 range the final tempoBpm store uses, so
         // the automation / MIDI fallback tempo stays aligned with the loaded
         // session tempo instead of using a raw out-of-range value. Reject a
@@ -2011,7 +2010,9 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
             if (auto str = json::getString (v, "name");   ! str.empty()) lane.name   = str;
             if (auto str = json::getString (v, "colour"); ! str.empty()) lane.colour = hexToColour (str, lane.colour);
             if (json::has (v, "return_level_db"))
-                lane.params.returnLevelDb.store (jlimit (-100.0f, 12.0f, json::getFloat (v, "return_level_db", 0.0f)));
+                storeFiniteClampedFloat (lane.params.returnLevelDb, v["return_level_db"], 0.0f,
+                                         ChannelStripParams::kFaderMinDb,
+                                         ChannelStripParams::kFaderMaxDb);
             if (json::has (v, "mute"))
                 lane.params.mute.store (json::getBool (v, "mute", false));
             if (json::has (v, "output_pair"))
@@ -2143,7 +2144,9 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
         // session (no pre-load reset), so a conditional store would inherit the
         // previously-loaded session's value. (Audible master state: level /
         // routing / mute.)
-        s.master().faderDb.store    (master.contains ("fader_db")    ? jlimit (-100.0f, 12.0f, json::getFloat (master, "fader_db", 0.0f)) : 0.0f);
+        storeFiniteClampedFloat (s.master().faderDb, master, "fader_db", 0.0f,
+                                 ChannelStripParams::kFaderMinDb,
+                                 ChannelStripParams::kFaderMaxDb);
         s.master().outputPair.store (json::getInt  (master, "output_pair", -1));
         s.master().mute.store       (json::getBool (master, "mute", false));
         // Reset-when-absent too (same rationale as the level/routing/mute lines
@@ -2200,12 +2203,16 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
         // absent here or every field silently inherits.
         static const MasterBusParams kMasterDefaults;
         const bool haveMaster = json::has (root, "master") && root["master"].is_object();
+        // Ranges mirror what the master strip's own controls enforce, so a
+        // hand-edited file can't push the tube EQ / bus comp past any setting
+        // the UI can produce.
         auto loadMasterFloat = [&master, haveMaster] (std::atomic<float>& dst,
                                                       const std::atomic<float>& def,
-                                                      const char* key)
+                                                      const char* key,
+                                                      float minimum, float maximum)
         {
             if (json::has (master, key))
-                dst.store (finiteFloatOr (master[key], def.load()));
+                storeFiniteClampedFloat (dst, master[key], def.load(), minimum, maximum);
             else if (! haveMaster)
                 dst.store (def.load());
         };
@@ -2217,24 +2224,24 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
             else if (! haveMaster)       dst.store (def.load());
         };
         loadMasterBool  (s.master().eqEnabled,           kMasterDefaults.eqEnabled,           "eq_enabled");
-        loadMasterFloat (s.master().eqLfBoost,           kMasterDefaults.eqLfBoost,           "eq_lf_boost");
-        loadMasterFloat (s.master().eqLfAtten,           kMasterDefaults.eqLfAtten,           "eq_lf_atten");
-        loadMasterFloat (s.master().eqLfFreq,            kMasterDefaults.eqLfFreq,            "eq_lf_freq");
-        loadMasterFloat (s.master().eqHfBoost,           kMasterDefaults.eqHfBoost,           "eq_hf_boost");
-        loadMasterFloat (s.master().eqHfBoostFreq,       kMasterDefaults.eqHfBoostFreq,       "eq_hf_boost_freq");
-        loadMasterFloat (s.master().eqHfBoostBandwidth,  kMasterDefaults.eqHfBoostBandwidth,  "eq_hf_boost_bandwidth");
-        loadMasterFloat (s.master().eqHfAtten,           kMasterDefaults.eqHfAtten,           "eq_hf_atten");
-        loadMasterFloat (s.master().eqHfAttenFreq,       kMasterDefaults.eqHfAttenFreq,       "eq_hf_atten_freq");
-        loadMasterFloat (s.master().eqOutputGainDb,      kMasterDefaults.eqOutputGainDb,      "eq_output_gain_db");
+        loadMasterFloat (s.master().eqLfBoost,           kMasterDefaults.eqLfBoost,           "eq_lf_boost",           0.0f, 10.0f);
+        loadMasterFloat (s.master().eqLfAtten,           kMasterDefaults.eqLfAtten,           "eq_lf_atten",           0.0f, 10.0f);
+        loadMasterFloat (s.master().eqLfFreq,            kMasterDefaults.eqLfFreq,            "eq_lf_freq",           20.0f, 100.0f);
+        loadMasterFloat (s.master().eqHfBoost,           kMasterDefaults.eqHfBoost,           "eq_hf_boost",           0.0f, 10.0f);
+        loadMasterFloat (s.master().eqHfBoostFreq,       kMasterDefaults.eqHfBoostFreq,       "eq_hf_boost_freq",   3000.0f, 16000.0f);
+        loadMasterFloat (s.master().eqHfBoostBandwidth,  kMasterDefaults.eqHfBoostBandwidth,  "eq_hf_boost_bandwidth", 0.0f, 10.0f);
+        loadMasterFloat (s.master().eqHfAtten,           kMasterDefaults.eqHfAtten,           "eq_hf_atten",           0.0f, 10.0f);
+        loadMasterFloat (s.master().eqHfAttenFreq,       kMasterDefaults.eqHfAttenFreq,       "eq_hf_atten_freq",   5000.0f, 20000.0f);
+        loadMasterFloat (s.master().eqOutputGainDb,      kMasterDefaults.eqOutputGainDb,      "eq_output_gain_db",   -12.0f, 12.0f);
 
         // Bus comp.
         loadMasterBool  (s.master().compEnabled,      kMasterDefaults.compEnabled,      "comp_enabled");
-        loadMasterFloat (s.master().compThreshDb,     kMasterDefaults.compThreshDb,     "comp_thresh_db");
-        loadMasterFloat (s.master().compRatio,        kMasterDefaults.compRatio,        "comp_ratio");
-        loadMasterFloat (s.master().compAttackMs,     kMasterDefaults.compAttackMs,     "comp_attack_ms");
-        loadMasterFloat (s.master().compReleaseMs,    kMasterDefaults.compReleaseMs,    "comp_release_ms");
+        loadMasterFloat (s.master().compThreshDb,     kMasterDefaults.compThreshDb,     "comp_thresh_db",  -60.0f, 0.0f);
+        loadMasterFloat (s.master().compRatio,        kMasterDefaults.compRatio,        "comp_ratio",        1.0f, 10.0f);
+        loadMasterFloat (s.master().compAttackMs,     kMasterDefaults.compAttackMs,     "comp_attack_ms",    0.1f, 50.0f);
+        loadMasterFloat (s.master().compReleaseMs,    kMasterDefaults.compReleaseMs,    "comp_release_ms",  50.0f, 1000.0f);
         loadMasterBool  (s.master().compReleaseAuto,  kMasterDefaults.compReleaseAuto,  "comp_release_auto");
-        loadMasterFloat (s.master().compMakeupDb,     kMasterDefaults.compMakeupDb,     "comp_makeup_db");
+        loadMasterFloat (s.master().compMakeupDb,     kMasterDefaults.compMakeupDb,     "comp_makeup_db",  -10.0f, 20.0f);
         // Mode publish happens AFTER the lane publishes below - same
         // ordering rationale as the track-load + aux-load blocks, and
         // exactly one publish per lane (empty when absent).
@@ -2284,10 +2291,14 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
             m.sourceFile = resolvePortablePath (json::getString (mast, "source_file"),
                                                 s.getSessionDirectory(),
                                                 s.missingAudioFilesAfterLoad);
+        // Ranges match what the mastering editors enforce. The legacy tube-EQ
+        // atoms and the comp floats have no editor of their own, so they take
+        // the master strip's - the comp floats reach the same donor params.
         auto loadF = [&mast, haveMastering] (const char* k, std::atomic<float>& dst,
-                                             const std::atomic<float>& def)
+                                             const std::atomic<float>& def,
+                                             float minimum, float maximum)
         {
-            if (json::has (mast, k))  dst.store (json::getFiniteFloat (mast, k, def.load()));
+            if (json::has (mast, k))  storeFiniteClampedFloat (dst, mast[k], def.load(), minimum, maximum);
             else if (! haveMastering) dst.store (def.load());
         };
         auto loadB = [&mast, haveMastering] (const char* k, std::atomic<bool>& dst,
@@ -2297,47 +2308,55 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
             else if (! haveMastering) dst.store (def.load());
         };
         loadB ("eq_enabled",        m.eqEnabled,       kMasteringDefaults.eqEnabled);
+        // Per-band sweep limits of the mastering EQ's frequency knobs. The
+        // bands overlap on purpose, so each carries its own pair.
+        static constexpr float kEqBandFreqMin[MasteringParams::kNumEqBands] = {  20.0f,   60.0f,  200.0f,   800.0f,  2000.0f };
+        static constexpr float kEqBandFreqMax[MasteringParams::kNumEqBands] = { 400.0f, 1500.0f, 6000.0f, 12000.0f, 20000.0f };
         for (int b = 0; b < MasteringParams::kNumEqBands; ++b)
         {
             const auto idx = std::string ("eq_band_") + std::to_string (b);
-            loadF ((idx + "_freq").c_str(),    m.eqBandFreq[b],   kMasteringDefaults.eqBandFreq[b]);
-            loadF ((idx + "_gain_db").c_str(), m.eqBandGainDb[b], kMasteringDefaults.eqBandGainDb[b]);
-            loadF ((idx + "_q").c_str(),       m.eqBandQ[b],      kMasteringDefaults.eqBandQ[b]);
+            loadF ((idx + "_freq").c_str(),    m.eqBandFreq[b],   kMasteringDefaults.eqBandFreq[b],
+                   kEqBandFreqMin[b], kEqBandFreqMax[b]);
+            loadF ((idx + "_gain_db").c_str(), m.eqBandGainDb[b], kMasteringDefaults.eqBandGainDb[b], -12.0f, 12.0f);
+            loadF ((idx + "_q").c_str(),       m.eqBandQ[b],      kMasteringDefaults.eqBandQ[b],        0.3f,  6.0f);
         }
-        loadF ("eq_lf_boost",       m.eqLfBoost,       kMasteringDefaults.eqLfBoost);
-        loadF ("eq_hf_boost",       m.eqHfBoost,       kMasteringDefaults.eqHfBoost);
-        loadF ("eq_hf_atten",       m.eqHfAtten,       kMasteringDefaults.eqHfAtten);
-        loadF ("eq_tube_drive",     m.eqTubeDrive,     kMasteringDefaults.eqTubeDrive);
-        loadF ("eq_output_gain_db", m.eqOutputGainDb,  kMasteringDefaults.eqOutputGainDb);
+        loadF ("eq_lf_boost",       m.eqLfBoost,       kMasteringDefaults.eqLfBoost,       0.0f, 10.0f);
+        loadF ("eq_hf_boost",       m.eqHfBoost,       kMasteringDefaults.eqHfBoost,       0.0f, 10.0f);
+        loadF ("eq_hf_atten",       m.eqHfAtten,       kMasteringDefaults.eqHfAtten,       0.0f, 10.0f);
+        loadF ("eq_tube_drive",     m.eqTubeDrive,     kMasteringDefaults.eqTubeDrive,     0.0f, 1.0f);
+        loadF ("eq_output_gain_db", m.eqOutputGainDb,  kMasteringDefaults.eqOutputGainDb, -12.0f, 12.0f);
         loadB ("comp_enabled",      m.compEnabled,     kMasteringDefaults.compEnabled);
-        loadF ("comp_thresh_db",    m.compThreshDb,    kMasteringDefaults.compThreshDb);
-        loadF ("comp_ratio",        m.compRatio,       kMasteringDefaults.compRatio);
-        loadF ("comp_attack_ms",    m.compAttackMs,    kMasteringDefaults.compAttackMs);
-        loadF ("comp_release_ms",   m.compReleaseMs,   kMasteringDefaults.compReleaseMs);
+        loadF ("comp_thresh_db",    m.compThreshDb,    kMasteringDefaults.compThreshDb,  -60.0f, 0.0f);
+        loadF ("comp_ratio",        m.compRatio,       kMasteringDefaults.compRatio,       1.0f, 10.0f);
+        loadF ("comp_attack_ms",    m.compAttackMs,    kMasteringDefaults.compAttackMs,    0.1f, 50.0f);
+        loadF ("comp_release_ms",   m.compReleaseMs,   kMasteringDefaults.compReleaseMs,  50.0f, 1000.0f);
         loadB ("comp_release_auto", m.compReleaseAuto, kMasteringDefaults.compReleaseAuto);
-        loadF ("comp_makeup_db",    m.compMakeupDb,    kMasteringDefaults.compMakeupDb);
+        loadF ("comp_makeup_db",    m.compMakeupDb,    kMasteringDefaults.compMakeupDb,  -10.0f, 20.0f);
         // The limiter is newer than the section around it, so a session saved
         // before it exists still carries "mastering" - these reset on an absent
         // key whether the section is there or not, rather than retaining.
         m.limiterEnabled.store (json::getBool (mast, "limiter_enabled",
                                                kMasteringDefaults.limiterEnabled.load()));
-        m.limiterDriveDb.store (json::getFiniteFloat (mast, "limiter_drive_db",
-                                                      kMasteringDefaults.limiterDriveDb.load()));
-        m.limiterCeilingDb.store (json::getFiniteFloat (mast, "limiter_ceiling_db",
-                                                        kMasteringDefaults.limiterCeilingDb.load()));
-        m.limiterReleaseMs.store (json::getFiniteFloat (mast, "limiter_release_ms",
-                                                        kMasteringDefaults.limiterReleaseMs.load()));
-        // Finite-guarded like the rest: a NaN/inf lookahead would otherwise sit
-        // in the limiter param (and the UI knob) until the next set.
-        m.limiterLookaheadMs.store (json::getFiniteFloat (mast, "limiter_lookahead_ms",
-                                                          kMasteringDefaults.limiterLookaheadMs.load()));
-        m.limiterMode.store (json::getInt (mast, "limiter_mode",
-                                           kMasteringDefaults.limiterMode.load()));
+        storeFiniteClampedFloat (m.limiterDriveDb, mast, "limiter_drive_db",
+                                 kMasteringDefaults.limiterDriveDb.load(), 0.0f, 20.0f);
+        storeFiniteClampedFloat (m.limiterCeilingDb, mast, "limiter_ceiling_db",
+                                 kMasteringDefaults.limiterCeilingDb.load(), -12.0f, 0.0f);
+        storeFiniteClampedFloat (m.limiterReleaseMs, mast, "limiter_release_ms",
+                                 kMasteringDefaults.limiterReleaseMs.load(), 10.0f, 1000.0f);
+        // The limiter's own setter clamps to this range, but the session atom is
+        // what the editor reads back and what the next save writes - left raw, a
+        // corrupt lookahead would never converge and would round-trip forever.
+        storeFiniteClampedFloat (m.limiterLookaheadMs, mast, "limiter_lookahead_ms",
+                                 kMasteringDefaults.limiterLookaheadMs.load(), 0.1f, 10.0f);
+        // 0 Modern, 1 Transparent, 2 Punchy.
+        m.limiterMode.store (std::clamp (json::getInt (mast, "limiter_mode",
+                                                       kMasteringDefaults.limiterMode.load()), 0, 2));
         m.limiterStereoLink.store (json::getBool (mast, "limiter_stereo_link",
                                                   kMasteringDefaults.limiterStereoLink.load()));
         if (json::has (mast, "target_preset"))
-            m.targetPresetIndex.store (json::getInt (mast, "target_preset",
-                                                     kMasteringDefaults.targetPresetIndex.load()));
+            m.targetPresetIndex.store (std::clamp (json::getInt (mast, "target_preset",
+                                                                 kMasteringDefaults.targetPresetIndex.load()),
+                                                   0, MasteringParams::kNumTargetPresets - 1));
         else if (! haveMastering)
             m.targetPresetIndex.store (kMasteringDefaults.targetPresetIndex.load());
     }
@@ -2370,7 +2389,7 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
         s.midiEditorSnap  = json::has (tport, "midi_editor_snap")
                               ? json::getBool (tport, "midi_editor_snap", true)   : true;
         if (json::has (tport, "piano_roll_key_snap"))
-            s.pianoRollKeySnap = json::getBool (tport, "piano_roll_key_snap", false);
+            s.pianoRollKeySnap = json::getBool (tport, "piano_roll_key_snap", true);
         if (json::has (tport, "snap_resolution"))
         {
             const int i = json::getInt (tport, "snap_resolution", 0);
@@ -2385,8 +2404,10 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
             // Guard the value before narrowing to float: a value past float range
             // (e.g. a hand-edited 1e40) would be UB to cast and would otherwise
             // clamp to 300, silently overwriting the session's real tempo. Reject
-            // it and keep the existing tempo instead.
-            const double bpm = json::getDouble (tport, "tempo_bpm", 0.0);
+            // it and keep the existing tempo instead - which is also why the
+            // wrong-type fallback is that tempo and not 0 (which would clamp to 30).
+            const double bpm = json::getDouble (tport, "tempo_bpm",
+                                                (double) s.tempoBpm.load (std::memory_order_relaxed));
             if (std::isfinite (bpm) && std::abs (bpm) <= (double) std::numeric_limits<float>::max())
                 s.tempoBpm.store (jlimit (30.0f, 300.0f, (float) bpm));
         }
@@ -2411,7 +2432,7 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
         if (json::has (tport, "sync_source_input"))
             s.syncSourceInputIdentifier = json::getString (tport, "sync_source_input");
         if (json::has (tport, "sync_follow_tempo"))
-            s.externalSyncFollowsTempo.store (json::getBool (tport, "sync_follow_tempo", false));
+            s.externalSyncFollowsTempo.store (json::getBool (tport, "sync_follow_tempo", true));
         if (json::has (tport, "sync_chase_transport"))
             s.externalSyncChasesTransport.store (json::getBool (tport, "sync_chase_transport", false));
         if (json::has (tport, "sync_output"))
@@ -2438,9 +2459,10 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
         if (json::has (tport, "beats_per_bar"))     s.beatsPerBar.store      (jlimit (1, 32, json::getInt (tport, "beats_per_bar", 4)));
         if (json::has (tport, "beat_unit"))         s.beatUnit.store         (jlimit (1, 32, json::getInt (tport, "beat_unit", 4)));
         if (json::has (tport, "metronome_enabled")) s.metronomeEnabled.store (json::getBool (tport, "metronome_enabled", false));
-        if (json::has (tport, "metronome_vol_db"))  s.metronomeVolDb.store   (jlimit (-60.0f, 12.0f, json::getFloat (tport, "metronome_vol_db", 0.0f)));
+        if (json::has (tport, "metronome_vol_db"))
+            storeFiniteClampedFloat (s.metronomeVolDb, tport["metronome_vol_db"], -12.0f, -60.0f, 12.0f);
         if (json::has (tport, "metronome_click_recording"))
-            s.metronomeClickWhileRecording.store (json::getBool (tport, "metronome_click_recording", false));
+            s.metronomeClickWhileRecording.store (json::getBool (tport, "metronome_click_recording", true));
         if (json::has (tport, "metronome_click_playing"))
             s.metronomeClickWhilePlaying  .store (json::getBool (tport, "metronome_click_playing", false));
         if (json::has (tport, "metronome_only_countin"))
@@ -2455,8 +2477,10 @@ bool SessionSerializer::load (Session& s, const juce::File& source)
         // silently ignore the legacy field on load so older session.json
         // files still parse cleanly.
         if (json::has (tport, "last_record_point")) s.lastRecordPointSamples.store (json::getInt64 (tport, "last_record_point", 0));
-        if (json::has (tport, "pre_roll_seconds"))  s.preRollSeconds.store   (jlimit (0.0f, 300.0f, json::getFloat (tport, "pre_roll_seconds", 0.0f)));
-        if (json::has (tport, "post_roll_seconds")) s.postRollSeconds.store  (jlimit (0.0f, 300.0f, json::getFloat (tport, "post_roll_seconds", 0.0f)));
+        if (json::has (tport, "pre_roll_seconds"))
+            storeFiniteClampedFloat (s.preRollSeconds, tport["pre_roll_seconds"], 0.0f, 0.0f, 300.0f);
+        if (json::has (tport, "post_roll_seconds"))
+            storeFiniteClampedFloat (s.postRollSeconds, tport["post_roll_seconds"], 0.0f, 0.0f, 300.0f);
         // Default true when absent (Session.h) so an older file lacking the key
         // doesn't inherit a disabled flag from a previously-loaded session.
         s.preRollEnabled.store  (json::getBool (tport, "pre_roll_enabled", true));

--- a/src/ui/MasteringView.cpp
+++ b/src/ui/MasteringView.cpp
@@ -161,6 +161,10 @@ constexpr MasteringTarget kMasteringTargets[] =
     { "Broadcast (EBU R128)", -23.0f,  -1.0f },
 };
 constexpr int kNumMasteringTargets = (int) (sizeof (kMasteringTargets) / sizeof (kMasteringTargets[0]));
+// The session loader clamps the saved index without seeing this table; adding a
+// preset here without widening the clamp would silently drop it on reload.
+static_assert (kNumMasteringTargets == MasteringParams::kNumTargetPresets,
+               "kMasteringTargets and MasteringParams::kNumTargetPresets must agree");
 } // namespace
 
 MasteringView::MasteringView (Session& s, AudioEngine& e)

--- a/tests/foundation_json.cpp
+++ b/tests/foundation_json.cpp
@@ -23,7 +23,7 @@ TEST_CASE ("dusk::json accessors coerce-or-default like juce::var", "[foundation
         REQUIRE (json::getBool  (j, "bnum", false) == true);   // number coerces to bool
         REQUIRE (json::getString(j, "s")       == "hi");
         REQUIRE (json::getInt   (j, "neg", 0)  == -7);
-        REQUIRE_THAT (json::getFloat (j, "f", 0.0f), WithinAbs (0.25f, 1e-12));
+        REQUIRE_THAT (json::getFiniteFloat (j, "f", 0.0f), WithinAbs (0.25f, 1e-12));
     }
 
     SECTION ("missing keys return defaults")

--- a/tests/mastering_digital_eq.cpp
+++ b/tests/mastering_digital_eq.cpp
@@ -11,6 +11,7 @@
 #include <dsp/DuskFilters.hpp>
 #include <juce_dsp/juce_dsp.h>
 
+#include <algorithm>
 #include <cmath>
 #include <random>
 #include <vector>
@@ -198,4 +199,38 @@ TEST_CASE ("MasteringDigitalEq per-block param re-push is inert", "[mastering][e
         if (! identical) break;
     }
     REQUIRE (identical);
+}
+
+TEST_CASE ("MasteringDigitalEq bounds an absurd band gain", "[mastering][eq]")
+{
+    // computeCoeffs falls back to passthrough only when the taps actually
+    // overflow. A gain that merely dwarfs the editor's range (a hand-edited
+    // 300 dB) stays finite all the way to the filter and multiplies the mix by
+    // billions. The rebuild's clamp keeps the band a filter instead.
+    MasteringDigitalEq eq;
+    eq.prepare (kSr, 256);
+    eq.setEnabled (true);
+    eq.setBandFreq (2, 1000.0f);
+    eq.setBandQ (2, 1.0f);
+    eq.setBandGainDb (2, 300.0f);
+
+    const float w = juce::MathConstants<float>::twoPi * 1000.0f / (float) kSr;
+    float peak = 0.0f;
+    bool finite = true;
+    for (int blk = 0; blk < 16; ++blk)
+    {
+        std::vector<float> l (256), r (256);
+        for (int i = 0; i < 256; ++i)
+            l[(size_t) i] = r[(size_t) i] = 0.25f * std::sin (w * (float) (blk * 256 + i));
+        eq.processInPlace (l.data(), r.data(), 256);
+
+        for (int i = 0; i < 256; ++i)
+        {
+            finite = finite && std::isfinite (l[(size_t) i]) && std::isfinite (r[(size_t) i]);
+            peak = std::max (peak, std::max (std::abs (l[(size_t) i]), std::abs (r[(size_t) i])));
+        }
+    }
+    REQUIRE (finite);
+    // +24 dB on a 0.25 input settles near 4; unclamped it reaches ~2e9.
+    REQUIRE (peak < 100.0f);
 }

--- a/tests/session_clamp_corrupt_values.cpp
+++ b/tests/session_clamp_corrupt_values.cpp
@@ -331,3 +331,191 @@ TEST_CASE ("SessionSerializer::load clamps corrupt strip and hardware values",
 
     target.getParentDirectory().deleteRecursively();
 }
+
+// 1e30 survives the finite guard - it is a perfectly good float - but no
+// mastering control can dial it, and it still reaches DSP: band gains become
+// biquad coefficients, and the comp / limiter values go straight into the
+// donor's parameter atoms. Each has to land on its control's edge instead.
+TEST_CASE ("SessionSerializer::load clamps out-of-range mastering values",
+           "[session][serializer][corruption]")
+{
+    const auto target = writeSession (R"JSON(
+    {
+      "version": 3,
+      "mastering": {
+        "eq_band_0_freq": -1e30,
+        "eq_band_2_freq": 1e30,
+        "eq_band_2_gain_db": 1e30,
+        "eq_band_2_q": -1e30,
+        "eq_tube_drive": 1e30,
+        "comp_thresh_db": -1e30,
+        "comp_ratio": 1e30,
+        "comp_makeup_db": 1e30,
+        "limiter_drive_db": 1e30,
+        "limiter_ceiling_db": 1e30,
+        "limiter_release_ms": -1e30,
+        "limiter_lookahead_ms": 1e30,
+        "limiter_mode": 99,
+        "target_preset": 99
+      }
+    }
+    )JSON");
+
+    Session s;
+    REQUIRE (SessionSerializer::load (s, target));
+    const auto& m = s.mastering();
+
+    // Per-band sweep limits of the editor's frequency knobs.
+    REQUIRE_THAT (m.eqBandFreq[0].load(), WithinAbs (20.0f, 1e-3f));
+    REQUIRE_THAT (m.eqBandFreq[2].load(), WithinAbs (6000.0f, 1e-3f));
+    REQUIRE_THAT (m.eqBandGainDb[2].load(), WithinAbs (12.0f, 1e-6f));
+    REQUIRE_THAT (m.eqBandQ[2].load(), WithinAbs (0.3f, 1e-6f));
+    REQUIRE_THAT (m.eqTubeDrive.load(), WithinAbs (1.0f, 1e-6f));
+
+    REQUIRE_THAT (m.compThreshDb.load(), WithinAbs (-60.0f, 1e-6f));
+    REQUIRE_THAT (m.compRatio.load(), WithinAbs (10.0f, 1e-6f));
+    REQUIRE_THAT (m.compMakeupDb.load(), WithinAbs (20.0f, 1e-6f));
+
+    REQUIRE_THAT (m.limiterDriveDb.load(), WithinAbs (20.0f, 1e-6f));
+    REQUIRE_THAT (m.limiterCeilingDb.load(), WithinAbs (0.0f, 1e-6f));
+    REQUIRE_THAT (m.limiterReleaseMs.load(), WithinAbs (10.0f, 1e-6f));
+    // Clamped at load as well as in the limiter's setter: this atom is what the
+    // editor reads back and what the next save writes.
+    REQUIRE_THAT (m.limiterLookaheadMs.load(), WithinAbs (10.0f, 1e-6f));
+    REQUIRE (m.limiterMode.load() == 2);
+    REQUIRE (m.targetPresetIndex.load() == duskstudio::MasteringParams::kNumTargetPresets - 1);
+
+    target.getParentDirectory().deleteRecursively();
+}
+
+// Same contract on the master strip: every track and bus equivalent clamps, so
+// the master must not be the one path where a hand-edited value reaches the
+// tube EQ and bus comp untouched.
+TEST_CASE ("SessionSerializer::load clamps out-of-range master values",
+           "[session][serializer][corruption]")
+{
+    const auto target = writeSession (R"JSON(
+    {
+      "version": 3,
+      "master": {
+        "fader_db": 1e30,
+        "eq_lf_boost": 1e30,
+        "eq_hf_atten_freq": -1e30,
+        "eq_output_gain_db": 1e30,
+        "comp_ratio": 1e30,
+        "comp_attack_ms": -1e30
+      }
+    }
+    )JSON");
+
+    Session s;
+    REQUIRE (SessionSerializer::load (s, target));
+    const auto& mb = s.master();
+
+    REQUIRE_THAT (mb.faderDb.load(), WithinAbs (12.0f, 1e-6f));
+    REQUIRE_THAT (mb.eqLfBoost.load(), WithinAbs (10.0f, 1e-6f));
+    REQUIRE_THAT (mb.eqHfAttenFreq.load(), WithinAbs (5000.0f, 1e-3f));
+    REQUIRE_THAT (mb.eqOutputGainDb.load(), WithinAbs (12.0f, 1e-6f));
+    REQUIRE_THAT (mb.compRatio.load(), WithinAbs (10.0f, 1e-6f));
+    REQUIRE_THAT (mb.compAttackMs.load(), WithinAbs (0.1f, 1e-6f));
+
+    target.getParentDirectory().deleteRecursively();
+}
+
+// 1e40 overflows to inf when narrowed to float, and a clamp alone would pin it
+// at the ceiling - loading a corrupt file at maximum aux return / metronome
+// level with a 5-minute pre-roll. The model default is the only safe landing.
+// The wrong-type fallbacks in the same block are pinned here too: a fallback of
+// false where the model says true silently flips the feature off.
+TEST_CASE ("SessionSerializer::load rejects non-finite transport and aux values",
+           "[session][serializer][corruption]")
+{
+    const auto target = writeSession (R"JSON(
+    {
+      "version": 3,
+      "aux_lanes": [ { "return_level_db": 1e40 } ],
+      "tracks": [
+        { "automation": { "fader_db": [ { "t": 0, "v": 0.5 } ] } }
+      ],
+      "transport": {
+        "metronome_vol_db": 1e40,
+        "pre_roll_seconds": 1e40,
+        "post_roll_seconds": -1e40,
+        "piano_roll_key_snap": "maybe",
+        "sync_follow_tempo": "maybe",
+        "metronome_click_recording": "maybe",
+        "tempo_bpm": "fast"
+      }
+    }
+    )JSON");
+
+    Session s;
+    s.auxLane (0).params.returnLevelDb.store (-20.0f);
+    s.metronomeVolDb.store (3.0f);
+    s.preRollSeconds.store (5.0f);
+    s.postRollSeconds.store (5.0f);
+    s.tempoBpm.store (90.0f);
+
+    REQUIRE (SessionSerializer::load (s, target));
+
+    REQUIRE_THAT (s.auxLane (0).params.returnLevelDb.load(), WithinAbs (0.0f, 1e-6f));
+    REQUIRE_THAT (s.metronomeVolDb.load(), WithinAbs (-12.0f, 1e-6f));
+    REQUIRE_THAT (s.preRollSeconds.load(), WithinAbs (0.0f, 1e-6f));
+    REQUIRE_THAT (s.postRollSeconds.load(), WithinAbs (0.0f, 1e-6f));
+
+    REQUIRE (s.pianoRollKeySnap == true);
+    REQUIRE (s.externalSyncFollowsTempo.load() == true);
+    REQUIRE (s.metronomeClickWhileRecording.load() == true);
+    // A non-numeric tempo keeps the running one rather than collapsing to the
+    // 30 BPM floor a zero fallback would clamp to - and the pre-track peek that
+    // anchors automation / region tempo has to reach the same conclusion. The
+    // two are read from the same key by separate code paths, so pin them
+    // together: a peek that disagreed would anchor the points at 30.
+    REQUIRE_THAT (s.tempoBpm.load(), WithinAbs (90.0f, 1e-3f));
+    const auto& pts = s.track (0).automationLanes[(size_t) AutomationParam::FaderDb].pointsConst();
+    REQUIRE (pts.size() == 1);
+    REQUIRE_THAT (pts[0].recordedAtBPM, WithinAbs (90.0f, 1e-3f));
+
+    target.getParentDirectory().deleteRecursively();
+}
+
+// The pre-track tempo peek and the transport block read the same key through
+// separate code paths, and the anchor they hand to automation / region tempo
+// must never disagree with the tempo the session ends up running at. The
+// absent, out-of-float-range and non-numeric shapes are pinned by the cases
+// above; this covers the numeric ones, in range and past it.
+TEST_CASE ("SessionSerializer::load agrees on tempo between the peek and the block",
+           "[session][serializer][corruption]")
+{
+    auto loadWithTempo = [] (const char* literal, float& sessionBpm, float& anchorBpm)
+    {
+        const auto target = writeSession (juce::String (R"JSON(
+        {
+          "version": 3,
+          "tracks": [
+            { "automation": { "fader_db": [ { "t": 0, "v": 0.5 } ] } }
+          ],
+          "transport": { "tempo_bpm": )JSON") + literal + " }\n}");
+
+        Session s;
+        s.tempoBpm.store (90.0f);
+        REQUIRE (SessionSerializer::load (s, target));
+
+        const auto& pts = s.track (0).automationLanes[(size_t) AutomationParam::FaderDb].pointsConst();
+        REQUIRE (pts.size() == 1);
+        sessionBpm = s.tempoBpm.load();
+        anchorBpm  = pts[0].recordedAtBPM;
+        target.getParentDirectory().deleteRecursively();
+    };
+
+    float sessionBpm = 0.0f, anchorBpm = 0.0f;
+
+    loadWithTempo ("145.0", sessionBpm, anchorBpm);
+    REQUIRE_THAT (sessionBpm, WithinAbs (145.0f, 1e-3f));
+    REQUIRE_THAT (anchorBpm, WithinAbs (145.0f, 1e-3f));
+
+    // Past the 30-300 range both sides clamp, and they clamp to the same value.
+    loadWithTempo ("5000.0", sessionBpm, anchorBpm);
+    REQUIRE_THAT (sessionBpm, WithinAbs (300.0f, 1e-3f));
+    REQUIRE_THAT (anchorBpm, WithinAbs (300.0f, 1e-3f));
+}


### PR DESCRIPTION
Closes #183.

PR #198 added the finite guards, so a corrupt session value already falls back to the model default instead of narrowing through UB. This adds the other half: every mastering and master float now clamps to the range its UI control enforces, taken from the control sources themselves (per-band EQ frequency windows from MasteringEqEditor's kBandRanges, gain and Q from the editor bounds, limiter drive/ceiling/release/mode from MasteringLimiterEditor, master Pultec and comp ranges from MasterStripComponent, aux return and master fader from the shared fader constants). The remaining clamped-but-unguarded sites (aux return, master fader, metronome volume, pre/post-roll) were converted to the same finite-plus-clamp convention.

Also in here:

- The wrong-type tempo fallback now keeps the load-time BPM peek and the transport restore in agreement on every value shape (absent, numeric, past range, past float range, non-numeric). Each shape is pinned with both the session tempo and a region anchor assertion.
- json::getFloat is deleted. It had no callers left and an unguarded getFloat sitting next to getFiniteFloat is exactly the footgun that produced this issue.
- target_preset clamps through a new MasteringParams::kNumTargetPresets, with a static_assert in MasteringView binding it to the preset table so adding a preset without bumping the constant fails the build.
- MasteringDigitalEq clamps band gain to +-24 dB at the rebuild site. Coefficient infinities already fell back to passthrough; the real hazard was a finite but absurd gain (a 300 dB value produced a measured 2.1e9 linear peak).

One deliberate behavior change: an out-of-float-range automation point value (for example 1e40) previously narrowed to inf and clamped to full scale, reading as a full-scale fader move. It now takes the 0.0 fallback and reads as silence.

Verification: app build with zero new warnings, 605/605 tests (four new cases, each proven red without its fix), juce-gate at baseline with the allowlist untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Stabilized mastering EQ behavior by limiting extreme band-gain values.
  - Improved session loading with validation and safe bounds for mixer, tempo, mastering, transport, automation, metronome, and MIDI settings.
  - Invalid or corrupted session values now fall back safely while preserving valid settings.
  - Corrected defaults for piano-roll snapping, external sync tempo, and recording metronome clicks.

- **Tests**
  - Added coverage for extreme EQ gains and corrupted session data.
  - Added validation for bounded parameters, non-finite values, and tempo consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->