### PR TITLE
fix(notepad): stop modals and the notepad sharing the window

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -509,7 +509,7 @@ Only one stage is visible at a time, but the same engine drives all four. Switch
 
 Press **Cmd/Ctrl+1 / 2 / 3 / 4** to jump straight to RECORDING / MIXING / MASTERING / AUX. The channel banks have the plain number keys **1 / 2 / 3 / 4**, so a modified digit changes stage and a plain digit changes bank. Hovering any tab or bank button shows its shortcut, and **?** opens a full keyboard-shortcut list (also under **Settings → Keyboard Shortcuts**).
 
-Switching into or out of MASTERING force-stops the transport. The mix engine and the mastering engine cannot run at the same time.
+Switching into or out of MASTERING force-stops the transport. The mix engine and the mastering engine cannot run at the same time. Changing stage also closes the notepad, saving it — the two cannot share the window.
 
 ## The transport bar
 
@@ -595,7 +595,10 @@ undo or redo. The footer shows the current save state, the latest save time when
 available, the `notepad.md` filename, section count, unique chord count, and the
 detected key when enough chords identify one.
 
-Click **Done** or the dimmed area outside the notepad to close it. The header,
+Click **Done** or the dimmed area outside the notepad to close it. The notepad
+also closes itself whenever something else needs the window — an alert, a stage
+switch, or the quit prompt — saving as it goes, except on quit, where the notes
+wait for your Save / Don't Save answer like the rest of the session. The header,
 toolbar, and footer stay fixed; mouse-wheel scrolling moves only the note within
 its writing area. Notes are saved atomically to the compatible `notepad.md` file
 when the notepad closes and on every session save; they follow the session on

--- a/src/ui/EmbeddedModal.h
+++ b/src/ui/EmbeddedModal.h
@@ -4,6 +4,7 @@
 #include "DimOverlay.h"
 #include "../foundation/MessageThread.h"
 #include <functional>
+#include <initializer_list>
 #include <memory>
 #include <vector>
 #include <algorithm>
@@ -59,6 +60,90 @@ struct ModalKeyClaimant
 // modal is up - native editor windows otherwise paint above the modal regardless
 // of JUCE z-order, burying dialogs. Every editor wrapper must carry this tag.
 inline constexpr const char* kPluginEditorTag = "dusk_pluginEditor";
+
+// Hides the plugin editors under a component tree for as long as a covering
+// surface needs the window to itself, then puts them back. Used by
+// EmbeddedModal and by the session notepad's native child - both sit above
+// JUCE's z-order but below the native editor windows, which paint over
+// anything regardless of toFront().
+//
+// Covering surfaces overlap (a combo over an alert over an editor), so each
+// holds one hide token per editor (dusk_modalHideCount) and an editor only
+// returns when the last of them restores - otherwise closing them out of
+// order would re-show an editor still buried under another surface.
+class PluginEditorHider final
+{
+public:
+    ~PluginEditorHider() { restore(); }
+
+    // skip: components belonging to the covering surface itself. A borrowed
+    // plugin-editor body carries the tag and must stay visible.
+    void hideUnder (juce::Component& root,
+                    std::initializer_list<juce::Component*> skip)
+    {
+        restore();   // defensive: idempotent
+        walk (root, skip);
+    }
+
+    void restore()
+    {
+        for (auto& safe : hidden_)
+        {
+            if (auto* c = safe.getComponent())
+            {
+                const int count = (int) c->getProperties()
+                                          .getWithDefault ("dusk_modalHideCount", 0);
+                if (count <= 1)
+                {
+                    c->getProperties().remove ("dusk_modalHideCount");
+                    c->setVisible (true);   // last covering surface gone -> editor returns
+                }
+                else
+                {
+                    c->getProperties().set ("dusk_modalHideCount", count - 1);
+                }
+            }
+        }
+        hidden_.clearQuick();
+    }
+
+private:
+    void walk (juce::Component& c, const std::initializer_list<juce::Component*>& skip)
+    {
+        for (auto* child : c.getChildren())
+        {
+            if (child == nullptr) continue;
+            if (std::find (skip.begin(), skip.end(), child) != skip.end())
+                continue;
+            const bool isPluginEditor =
+                (bool) child->getProperties()
+                            .getWithDefault (kPluginEditorTag, false);
+            if (isPluginEditor)
+            {
+                // Only manage editors that were on-screen when the first
+                // covering surface arrived (count == 0 && visible) or that an
+                // outer surface is already managing (count > 0). A genuinely
+                // app-hidden editor is left alone so we never wrongly re-show it.
+                const int count = (int) child->getProperties()
+                                            .getWithDefault ("dusk_modalHideCount", 0);
+                if (count > 0 || child->isVisible())
+                {
+                    child->getProperties().set ("dusk_modalHideCount", count + 1);
+                    if (count == 0)
+                        child->setVisible (false);
+                    hidden_.add (juce::Component::SafePointer<juce::Component> (child));
+                }
+                // Tagged editor: its whole subtree hides with it, so don't
+                // recurse - a nested tagged editor would collect a redundant
+                // hide token and unbalance the reference count.
+                continue;
+            }
+            walk (*child, skip);
+        }
+    }
+
+    juce::Array<juce::Component::SafePointer<juce::Component>> hidden_;
+};
 
 // Wraps the "DimOverlay + centred panel" pattern used by piano roll,
 // tuner, audio settings, mixdown, bounce, plugin editor.
@@ -118,6 +203,19 @@ public:
         return *stack;
     }
 
+    // Invoked at the top of every show() / showBorrowed(), before any modal
+    // component exists. MainComponent registers a hook that closes the session
+    // notepad: it is an embedded native child window, so a modal centred over
+    // it lands INSIDE the child - invisible, unclickable, holding X11 focus,
+    // and the forwarder below still feeds transport keys to the arrangement
+    // behind it. Cleared in ~MainComponent. Call sites copy it before
+    // invoking - a hook is allowed to clear its own slot while it runs.
+    static std::function<void()>& beforeModalShown()
+    {
+        static std::function<void()> hook;
+        return hook;
+    }
+
     EmbeddedModal()  = default;
     ~EmbeddedModal() override { close(); }
 
@@ -155,6 +253,7 @@ public:
                bool forwardShortcuts = true,
                std::function<void()> onDismissOutside = {})
     {
+        if (auto hook = beforeModalShown()) hook();
         close();
         ++modalGeneration();
         host = &parent;
@@ -196,11 +295,11 @@ public:
         }
 
         const auto bounds = parent.getLocalBounds();
-        const int w = juce::jmax (1, body_->getWidth());
-        const int h = juce::jmax (1, body_->getHeight());
+        const int w = std::max (1, body_->getWidth());
+        const int h = std::max (1, body_->getHeight());
         const auto bodyBounds = bounds.withSizeKeepingCentre (
-            juce::jmin (w, bounds.getWidth()  - 16),
-            juce::jmin (h, bounds.getHeight() - 16));
+            std::min (w, bounds.getWidth()  - 16),
+            std::min (h, bounds.getHeight() - 16));
 
         // Slightly larger than body so rounded corners frame the panel.
         // Added BEFORE body so body paints on top.
@@ -222,7 +321,8 @@ public:
         body_->addKeyListener (this);
 
         if (hidePluginEditors)
-            hidePluginEditorsUnder (parent);
+            editorHider_.hideUnder (parent, { dim_.get(), backdrop_.get(),
+                                              body_.get(), borrowedBody_ });
 
         activeModalStack().push_back (this);
     }
@@ -236,6 +336,7 @@ public:
                        juce::Component& body,
                        std::function<void()> onDismiss = {})
     {
+        if (auto hook = beforeModalShown()) hook();
         close();
         ++modalGeneration();
         host = &parent;
@@ -264,11 +365,11 @@ public:
         parent.addAndMakeVisible (dim_.get());
 
         const auto bounds = parent.getLocalBounds();
-        const int w = juce::jmax (1, body.getWidth());
-        const int h = juce::jmax (1, body.getHeight());
+        const int w = std::max (1, body.getWidth());
+        const int h = std::max (1, body.getHeight());
         const auto bodyBounds = bounds.withSizeKeepingCentre (
-            juce::jmin (w, bounds.getWidth()  - 16),
-            juce::jmin (h, bounds.getHeight() - 16));
+            std::min (w, bounds.getWidth()  - 16),
+            std::min (h, bounds.getHeight() - 16));
 
         backdrop_ = std::make_unique<Backdrop>();
         backdrop_->setBounds (bodyBounds.expanded (kBackdropMargin));
@@ -293,7 +394,8 @@ public:
         // popups (DuskContextMenu / DuskComboBox) that must NOT recentre.
         parent.addComponentListener (this);
 
-        hidePluginEditorsUnder (parent);
+        editorHider_.hideUnder (parent, { dim_.get(), backdrop_.get(),
+                                          body_.get(), borrowedBody_ });
 
         activeModalStack().push_back (this);
     }
@@ -333,7 +435,7 @@ public:
         // Restore any plugin editors we hid in show() before tearing
         // down the modal body. Done first so their setVisible(true)
         // doesn't fight with the message-loop teardown path below.
-        restoreHiddenPluginEditors();
+        editorHider_.restore();
 
         if (host == nullptr)
         {
@@ -455,7 +557,7 @@ public:
     {
         removeFromModalStack();
         stopListeningForOutsideClicks();
-        restoreHiddenPluginEditors();
+        editorHider_.restore();
 
         // A borrowed body outlives this modal (the strip owns the plugin editor),
         // so its listeners must come off even when the host SafePointer nulled -
@@ -515,8 +617,8 @@ public:
         if (body == nullptr || host == nullptr) return;
         const auto bounds = host->getLocalBounds();
         const auto bodyBounds = bounds.withSizeKeepingCentre (
-            juce::jmin (juce::jmax (1, body->getWidth()),  bounds.getWidth()  - 16),
-            juce::jmin (juce::jmax (1, body->getHeight()), bounds.getHeight() - 16));
+            std::min (std::max (1, body->getWidth()),  bounds.getWidth()  - 16),
+            std::min (std::max (1, body->getHeight()), bounds.getHeight() - 16));
         body->setTopLeftPosition (bodyBounds.getTopLeft());
         // Re-fit the backdrop to the body's REAL bounds (not the clamped
         // rect) - a body that outgrew its open-time size otherwise keeps
@@ -666,85 +768,10 @@ private:
     bool forwardShortcuts_ = true;
     bool listeningForOutsideClicks = false;
 
-    // Components hidden by hidePluginEditorsUnder() in show(); restored
-    // by restoreHiddenPluginEditors() in close(). Plugin editors (in
-    // particular OOP / XEmbed / GL-rendering hosts) can paint above
-    // JUCE's modal in the native window's z-order regardless of
-    // toFront() - toggling their visibility forces them out of view
-    // for the modal's lifetime.
-    juce::Array<juce::Component::SafePointer<juce::Component>> hiddenForModal_;
-
-    void hidePluginEditorsUnder (juce::Component& root)
-    {
-        restoreHiddenPluginEditors();   // defensive: idempotent show
-        walkHidePluginEditors (root);
-    }
-
-    void walkHidePluginEditors (juce::Component& c)
-    {
-        for (auto* child : c.getChildren())
-        {
-            if (child == nullptr) continue;
-            // Skip the modal's own backdrop / body / dim so we don't
-            // hide the modal itself.
-            if (child == dim_.get() || child == backdrop_.get()
-                || child == body_.get() || child == borrowedBody_)
-                continue;
-            const bool isPluginEditor =
-                (bool) child->getProperties()
-                            .getWithDefault (kPluginEditorTag, false);
-            if (isPluginEditor)
-            {
-                // Per-editor hide token (dusk_modalHideCount). Each stacked
-                // modal that covers the editor holds one; the editor stays
-                // hidden until the LAST of them restores. A plain
-                // setVisible(true) on close would re-show an editor still
-                // covered by another modal when modals close out of order.
-                //
-                // Only manage editors that were on-screen when the first
-                // covering modal opened (count == 0 && visible) or that an
-                // outer modal is already managing (count > 0). A genuinely
-                // app-hidden editor (count 0, invisible) is left alone so we
-                // never wrongly re-show it.
-                const int count = (int) child->getProperties()
-                                            .getWithDefault ("dusk_modalHideCount", 0);
-                if (count > 0 || child->isVisible())
-                {
-                    child->getProperties().set ("dusk_modalHideCount", count + 1);
-                    if (count == 0)
-                        child->setVisible (false);
-                    hiddenForModal_.add (juce::Component::SafePointer<juce::Component> (child));
-                }
-                // Tagged editor: its whole subtree hides with it, so don't
-                // recurse - a nested tagged editor would collect a redundant
-                // hide token and unbalance the reference count.
-                continue;
-            }
-            walkHidePluginEditors (*child);
-        }
-    }
-
-    void restoreHiddenPluginEditors()
-    {
-        for (auto& safe : hiddenForModal_)
-        {
-            if (auto* c = safe.getComponent())
-            {
-                const int count = (int) c->getProperties()
-                                          .getWithDefault ("dusk_modalHideCount", 0);
-                if (count <= 1)
-                {
-                    c->getProperties().remove ("dusk_modalHideCount");
-                    c->setVisible (true);   // last covering modal gone -> editor returns
-                }
-                else
-                {
-                    c->getProperties().set ("dusk_modalHideCount", count - 1);
-                }
-            }
-        }
-        hiddenForModal_.clearQuick();
-    }
+    // Plugin editors (OOP / XEmbed / GL-rendering hosts especially) paint
+    // above the modal in the native window's z-order regardless of toFront(),
+    // so they are hidden for the modal's lifetime.
+    PluginEditorHider editorHider_;
 };
 
 // Global KeyListener that forwards transport / navigation hotkeys (Space, R,

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -871,6 +871,12 @@ MainComponent::MainComponent()
         showDuskAlert (*this, "Audio device disconnected", msg);
     });
 
+    // The notepad and an embedded modal must never share the window (see
+    // beforeModalShown). The notepad saves whenever it closes, so the alerts
+    // that can fire over it - sample-rate mismatch, device lost - take it back
+    // rather than open where nobody can see or click them.
+    EmbeddedModal::beforeModalShown() = [this] { yieldNotepadWindow(); };
+
     // Startup: if the saved audio device was in use (held by PipeWire / JACK /
     // another DAW), the engine ctor already tried to fall back to a working one.
     // Tell the user what happened - switched to another device, or left with
@@ -991,7 +997,12 @@ MainComponent::MainComponent()
 
 MainComponent::~MainComponent()
 {
+    tearingDown = true;
     stopTimer();   // halt autosave before tearing down engine / session
+
+    // Drop the modal hook before anything else: its closure holds a raw this,
+    // and the teardown below can still raise an alert.
+    EmbeddedModal::beforeModalShown() = nullptr;
 
     // The notepad owns its own DGL application and embedded native child. Drop it
     // while the main peer and message loop are still alive, and suppress its
@@ -2040,6 +2051,10 @@ void MainComponent::switchToStage (AudioEngine::Stage s)
 {
     if (engine.getStage() == s) return;
 
+    // A stage swap under the notepad re-adds a fullscreen view above the dim
+    // and leaves the native child hovering over a screen the user can't reach.
+    yieldNotepadWindow();
+
     std::fprintf (stderr, "[MainComponent] switchToStage(%d) enter\n", (int) s);
     std::fflush (stderr);
     engine.setStage (s);
@@ -2784,6 +2799,13 @@ bool MainComponent::currentSessionDirty()
 
 void MainComponent::requestQuit()
 {
+    // Take the window back before the dirty check, and WITHOUT saving: the
+    // titlebar X reaches here past both the dim and the native child, and the
+    // sidecar write has to wait for the user's answer or Don't Save and Cancel
+    // would each commit the notepad behind their backs. notepadDirty survives
+    // into the check below, and the modal hook then finds nothing left to close.
+    yieldNotepadWindow (/*saveChanges*/ false);
+
     // Industry-standard dirty-only prompt. Compare the live serialized
     // session JSON against the snapshot we took at the last successful
     // save (or session load) - any single-knob / fader / region edit
@@ -5402,13 +5424,8 @@ void MainComponent::toggleNotepad()
             if (auto* self = safeThis.getComponent())
             {
                 self->notepadDim.reset();
-                if (auto* window = self->getTopLevelComponent())
-                    window->toFront (true);
-                // The native notepad held keyboard focus; pull it back so
-                // transport / edit shortcuts work without a stray click first
-                // (same reason as dismissStartupDialog).
-                if (self->isShowing())
-                    self->grabKeyboardFocus();
+                self->notepadEditorHider.restore();
+                self->reclaimFocusFromNotepad();
                 self->saveNotepadNow();
             }
         },
@@ -5444,6 +5461,10 @@ void MainComponent::toggleNotepad()
                 self->notepadWindow->close();
     };
     addAndMakeVisible (notepadDim.get());
+    // The dim only covers JUCE's z-order. A native plugin editor keeps painting
+    // over both it and the notepad's own child, so it hides for the notepad's
+    // lifetime exactly as it does under an embedded modal.
+    notepadEditorHider.hideUnder (*this, { notepadDim.get() });
 
     const bool opened = notepadWindow->open (
         reinterpret_cast<std::uintptr_t> (peer->getNativeHandle()),
@@ -5455,6 +5476,7 @@ void MainComponent::toggleNotepad()
     if (! opened)
     {
         notepadDim.reset();
+        notepadEditorHider.restore();
         setStatusText ("Unable to embed session notepad with the current display backend");
     }
 #endif
@@ -5463,6 +5485,7 @@ void MainComponent::toggleNotepad()
 void MainComponent::dismissNotepad (bool saveChanges)
 {
    #if DUSKSTUDIO_HAS_NATIVE_NOTEPAD
+    const bool wasOpen = notepadDim != nullptr;
     if (notepadWindow != nullptr)
     {
         // close() commits an open chord slot, which reports the new text through
@@ -5472,10 +5495,44 @@ void MainComponent::dismissNotepad (bool saveChanges)
         notepadWindow.reset();
     }
     notepadDim.reset();
+    notepadEditorHider.restore();
+    // wasOpen: only a dismissal that actually tore down a live notepad needs
+    // the focus handed back; the deferred closed callback that normally does
+    // it never runs on this route.
+    if (wasOpen)
+        reclaimFocusFromNotepad();
    #endif
 
     if (saveChanges)
         (void) saveNotepadNow();
+}
+
+void MainComponent::reclaimFocusFromNotepad()
+{
+    // Quit paths that bypass requestQuit (SIGTERM, logout) reach this from the
+    // destructor cascade, where a WM round-trip would poke a half-destroyed
+    // top-level window.
+    if (tearingDown)
+        return;
+    // The native child held keyboard focus at the X11 level; pull it back so
+    // transport / edit shortcuts work without a stray click first (same reason
+    // as dismissStartupDialog).
+    if (auto* window = getTopLevelComponent())
+        window->toFront (true);
+    if (isShowing())
+        grabKeyboardFocus();
+}
+
+void MainComponent::yieldNotepadWindow (bool saveChanges)
+{
+   #if DUSKSTUDIO_HAS_NATIVE_NOTEPAD
+    // The dim exists for exactly as long as the notepad does, including the
+    // deferred native teardown between close() and its closed callback.
+    if (notepadDim != nullptr)
+        dismissNotepad (saveChanges);
+   #else
+    (void) saveChanges;
+   #endif
 }
 
 bool MainComponent::saveNotepadNow()

--- a/src/ui/MainComponent.h
+++ b/src/ui/MainComponent.h
@@ -305,9 +305,16 @@ private:
     void toggleNotepad();
     void dismissNotepad (bool saveChanges);
     bool saveNotepadNow();
+    // Close the notepad when something else needs the window: an embedded
+    // modal (which would otherwise centre inside the native child), a stage
+    // switch, or the quit prompt. No-op when the notepad isn't open.
+    // saveChanges=false leaves the sidecar for a decision still pending.
+    void yieldNotepadWindow (bool saveChanges = true);
+    void reclaimFocusFromNotepad();
    #if DUSKSTUDIO_HAS_NATIVE_NOTEPAD
     std::unique_ptr<NativeNotepadWindow> notepadWindow;
     std::unique_ptr<class DimOverlay> notepadDim;
+    PluginEditorHider notepadEditorHider;
    #endif
     juce::String notepadText;
     bool notepadDirty = false;
@@ -316,6 +323,7 @@ private:
     // detach idempotent and signals publishPluginStateForSave that the
     // atomic-park sleeps can be skipped.
     bool engineDetached = false;
+    bool tearingDown = false;
 
     // One-shot latch so the session-vs-device sample-rate warning fires once
     // per mismatch, not on every autosave tick. Reset on load and when the

--- a/src/ui/NativeNotepadWindow.cpp
+++ b/src/ui/NativeNotepadWindow.cpp
@@ -267,7 +267,7 @@ struct NativeNotepadWindow::Impl final : private dusk::Timer
         closeWasPumped = false;
     }
 
-    bool isOpen() const noexcept { return window != nullptr; }
+    bool isOpen() const noexcept { return window != nullptr || closeRequested; }
 
     void setEmbeddedGeometry (EmbeddedGeometry geometry)
     {

--- a/src/ui/NativeNotepadWindow.h
+++ b/src/ui/NativeNotepadWindow.h
@@ -38,7 +38,11 @@ public:
                const std::string& markdown,
                bool hasSessionFile, bool hasUnsavedChanges);
     void setEmbeddedGeometry (EmbeddedGeometry geometry);
+    // Teardown is deferred over two event-pump ticks; close() only asks for it.
     void close();
+    // True from a successful open() until the closed callback has run, so a
+    // toggle during that deferred teardown cannot restart the window
+    // underneath the pending close - and its save.
     bool isOpen() const noexcept;
     void markSaved();
     void markSaveFailed();

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -107,7 +107,7 @@ src/ui/EditCursors.cpp	58
 src/ui/EditCursors.h	7
 src/ui/EditModeToolbar.cpp	48
 src/ui/EditModeToolbar.h	10
-src/ui/EmbeddedModal.h	68
+src/ui/EmbeddedModal.h	58
 src/ui/FadeCurve.h	10
 src/ui/FreezeDialog.cpp	36
 src/ui/FreezeDialog.h	9


### PR DESCRIPTION
Closes #185.

The notepad and embedded modals no longer fight over the window. A static hook on EmbeddedModal runs before any modal shows and closes the notepad first, saving as it goes. That covers every present and future modal with one seam: the sample-rate nag, device-lost alerts, record-failure alerts, pickers, and stage switches (Cmd+1..4 close it the same way). Before this, an alert raised over the open notepad centred inside the native child: invisible, unclickable, and its shortcut forwarding let Space or R reach the transport while you thought you were typing.

One deliberate exception: quit. requestQuit closes the notepad without saving before it computes the dirty state, so your notes participate in the Save / Don't Save / Cancel prompt like the rest of the session instead of being committed to disk before you answer. Don't Save genuinely does not write them; Cancel leaves the file untouched with the notes still dirty in memory.

Also in here:

- The plugin-editor hide machinery moved out of EmbeddedModal into a shared PluginEditorHider; the notepad now hides native plugin editors under itself the way modals always did. This matters on the Aux stage, where editors embed inline with no dim.
- Closing the notepad from a stage switch now hands keyboard focus back (it used to strand X11 focus on the destroyed native child until you clicked), with a teardown guard so quit paths that bypass requestQuit (SIGTERM, logout) never poke a half-destroyed window.
- isOpen() now reads true across the two-tick close handshake, so a toggle racing the close can no longer swallow the pending save.
- MANUAL updated: the notepad-closes-first behavior, the quit exception, and the stage-switch note.

No notepad UI surface added; the songwriter toolbar is untouched. The JUCE gate went down: EmbeddedModal.h 68 to 58.

Manual checks:

1. Notepad open with edits, click the titlebar X. The notepad closes, the prompt is fully visible. Don't Save: notepad.md must not carry the edits. Cancel: file untouched, next Ctrl+S writes them. Save: file carries them.
2. Notepad open, disconnect the interface. Notepad closes and saves, the alert is visible and clickable, Space/R no longer leak to the transport.
3. Notepad open, drive a stage change from an MCU/MIDI binding. After the close, Space works immediately with no click first.
4. Aux stage with a native plugin editor showing, switch to Recording, open the notepad: no editor pixels over it; the editor is back when you return to Aux.
5. Click the dim and immediately press the Notepad button: closes and saves, no reopen that swallows the save.
6. Combo popups, context menus, and plugin-editor modals still hide and restore plugin editors as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coordination between the native notepad, modal dialogs, stage changes, alerts, and quit prompts.
  * Prevented notepad reopening during pending close and save operations.
  * Preserved plugin editor visibility when the notepad or modal dialogs open and close.
  * Improved focus handling and cleanup during window transitions.

* **Documentation**
  * Clarified notepad behavior when switching stages, responding to alerts, and quitting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->