### PR TITLE
fix(midi): size every whole-block drain destination to the ring

### DIFF
--- a/src/dsp/ChannelStrip.cpp
+++ b/src/dsp/ChannelStrip.cpp
@@ -74,14 +74,13 @@ void ChannelStrip::prepare (double sampleRate, int blockSize, int oversamplingFa
     pdcDelayR.reset();
     pdcSilentRun = (std::int64_t) kMaxPdcSamples;
 
-    // Pre-size the MIDI scratch buffers so the audio thread's addEvent /
-    // processBlock calls never grow them. 4 KB covers ~400-800 typical
-    // channel-voice messages per block; far above any sane density even
-    // for instrument plugins generating dense controller streams.
+    // Headroom for what the hosted plugin emits. Only a hint - a plugin whose
+    // MIDI output runs past it still grows the buffer on the audio thread.
     pluginMidiScratch.ensureSize (4096);
-    // Same headroom for the native-host bridge; reserveBytes caps it so the
-    // per-block juce->dusk refill drops any overflow instead of allocating.
-    nativeMidiScratch.reserveBytes (4096);
+    // The native bridge is a hard cap instead, and the refill through it is
+    // whole-block-or-nothing, so it takes the shared MIDI ceiling: below that, a
+    // burst the input ring delivered whole would arrive here as nothing at all.
+    nativeMidiScratch.reserveBytes (dusk::kMidiBlockBytes);
 
     // Plugin slot - prepared at the same SR/BS so the audio thread never
     // sees an unprepared instance. If the slot has no plugin loaded, this

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -1144,8 +1144,10 @@ void AudioEngine::rebuildMidiBanks()
 
     // One drained-block buffer per input, reserved off the RT path so the
     // per-block drain + test-inject merge never allocate on the audio thread.
+    // Sized to the collector ring: anything smaller turns a backlog that fits
+    // the ring into an empty block under the drain's whole-block contract.
     perInputMidi.assign ((size_t) midiIn.getNumInputs(), dusk::MidiBuffer{});
-    for (auto& m : perInputMidi) m.reserveBytes (4096);
+    for (auto& m : perInputMidi) m.reserveBytes (dusk::kMidiBlockBytes);
 
     // Re-resolve the session's sync + MCU wiring against the fresh banks so a
     // hot-plug doesn't strand an index at a stale slot (STAYS in the engine -
@@ -2635,9 +2637,13 @@ void AudioEngine::prepareForSelfTest (double sr, int bs)
     for (auto& v : auxLaneR)  v.assign ((size_t) bs, 0.0f);
     for (auto& v : playbackScratch)  v.assign ((size_t) bs, 0.0f);
     for (auto& v : playbackScratchR) v.assign ((size_t) bs, 0.0f);
-    for (auto& m : perTrackMidiScratch) m.ensureSize (4096);
-    midiClockOutScratch.reserveBytes (4096);
-    midiOutTrackScratch.reserveBytes (4096);
+    // Growth hint only, but it has to track the dusk ceiling: this buffer is
+    // refilled from perInputMidi every block, and a juce event costs 6 bytes of
+    // header against dusk's 8, so a hint at the shared size means one drained
+    // block never reallocs here on the audio thread.
+    for (auto& m : perTrackMidiScratch) m.ensureSize (dusk::kMidiBlockBytes);
+    midiClockOutScratch.reserveBytes (dusk::kMidiBlockBytes);
+    midiOutTrackScratch.reserveBytes (dusk::kMidiBlockBytes);
     silentInputScratch.assign ((size_t) bs, 0.0f);
 
     for (auto& a : laneAccum)
@@ -4744,16 +4750,11 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
             {
                 // Bridge the juce per-track buffer into the dusk out-scratch
                 // (pre-reserved) for queueRt's dusk boundary. Whole-block or
-                // nothing: a partial copy on cap overflow could split paired
-                // events (note on/off), so mirror the pre-flip whole-block
-                // drop semantics.
-                midiOutTrackScratch.clear();
-                bool fits = true;
-                for (const auto meta : perTrackMidiScratch[(size_t) t])
-                    if (! midiOutTrackScratch.addEvent (meta.data, meta.numBytes,
-                                                        meta.samplePosition))
-                    { fits = false; break; }
-                if (fits)
+                // nothing, since a partial copy on cap overflow could split
+                // paired events (note on/off); empty means the block was
+                // dropped and there is nothing to send.
+                dusk::copyEventsWhole (perTrackMidiScratch[(size_t) t], midiOutTrackScratch);
+                if (! midiOutTrackScratch.isEmpty())
                     midiOut.queueRt (outIdx, midiOutTrackScratch,
                                      currentSampleRate.load (std::memory_order_relaxed));
             }

--- a/src/engine/PluginSlot.cpp
+++ b/src/engine/PluginSlot.cpp
@@ -349,6 +349,11 @@ void PluginSlot::prepareToPlay (double sampleRate, int blockSize)
     stereoScratch.setSize (2, preparedBlockSize, false, false, true);
 
    #if DUSKSTUDIO_HAS_OOP_PLUGINS
+    // The wire format sets this one, not the shared ceiling - but it must not
+    // fall under it, or the OOP path alone would start emptying blocks the rest
+    // of the MIDI path delivers.
+    static_assert (duskstudio::ipc::kMidiBytes >= dusk::kMidiBlockBytes,
+                   "IPC MIDI cap must not sit below the shared MIDI ceiling");
     oopMidiScratch.reserveBytes (duskstudio::ipc::kMidiBytes);
    #endif
 

--- a/src/engine/midi/MidiDevices.cpp
+++ b/src/engine/midi/MidiDevices.cpp
@@ -13,11 +13,6 @@ namespace duskstudio::midi
 {
 namespace
 {
-// Per-input ring capacity. Sized well past a dense controller burst plus a
-// 1 kB-class sysex so the drop-whole-record policy only fires when the audio
-// thread has genuinely stopped draining.
-constexpr std::size_t kInputRingBytes = 16384;
-
 // Stand-in rate for a collector built before the audio device reports one.
 constexpr double kFallbackSampleRate = 48000.0;
 
@@ -98,7 +93,7 @@ void MidiInputClient::rebuild (double sampleRate)
     const double rate = sampleRate > 0.0 ? sampleRate : kFallbackSampleRate;
     for (const auto& d : avail)
     {
-        auto col = std::make_unique<dusk::MidiCollector> (kInputRingBytes);
+        auto col = std::make_unique<dusk::MidiCollector> (dusk::kMidiBlockBytes);
         col->reset (rate, now);
 
         indexByIdentifier[d.identifier] = (int) collectors.size();
@@ -111,7 +106,7 @@ void MidiInputClient::rebuild (double sampleRate)
     // collector directly; the audio thread drains it like any other input.
     devices.push_back ({ "Virtual Keyboard (Dusk Studio)", kVirtualKeyboardIdentifier });
     {
-        auto vkb = std::make_unique<dusk::MidiCollector> (kInputRingBytes);
+        auto vkb = std::make_unique<dusk::MidiCollector> (dusk::kMidiBlockBytes);
         vkb->reset (rate, now);
         collectors.push_back (std::move (vkb));
     }
@@ -192,9 +187,10 @@ MidiOutputBank::MidiOutputBank()
 {
     // Pre-size every slot buffer so the audio-thread copy in queueRt never
     // allocates - reserveBytes also caps it, so an over-cap block is dropped by
-    // addEvent rather than reallocated.
+    // addEvent rather than reallocated. Sized from the shared ceiling so a burst
+    // that survived the input ring is not thrown away at the last hop out.
     for (auto& slot : queue)
-        slot.events.reserveBytes (kSlotBytes);
+        slot.events.reserveBytes (dusk::kMidiBlockBytes);
 }
 
 MidiOutputBank::~MidiOutputBank()
@@ -327,20 +323,13 @@ void MidiOutputBank::queueRt (int port, const dusk::MidiBuffer& events, double s
         return;   // pump stalled - drop the block
 
     auto& slot = queue[(size_t) (w % (std::uint32_t) kQueueDepth)];
-    slot.events.clear();   // keeps the pre-sized capacity
 
-    // A block past the pre-sized cap is dropped whole (same policy as
-    // queue-full) rather than split: addEvent refuses to grow, so a partial copy
-    // would tear paired events apart. The reserved slot is simply left
-    // uncommitted.
-    for (const auto meta : events)
-    {
-        if (! slot.events.addEvent (meta.data, meta.numBytes, meta.samplePosition))
-        {
-            slot.events.clear();
-            return;
-        }
-    }
+    // Whole-block or nothing: a partial copy would tear paired events apart, so
+    // an over-cap block leaves the reserved slot uncommitted, same as when the
+    // queue is full. The copy clears first and keeps the reserved capacity, so
+    // nothing allocates here.
+    dusk::copyEventsWhole (events, slot.events);
+    if (slot.events.isEmpty()) return;
 
     slot.port       = port;
     slot.timeMs     = backendClockMs();

--- a/src/engine/midi/MidiDevices.h
+++ b/src/engine/midi/MidiDevices.h
@@ -206,7 +206,6 @@ private:
     // it only touches the queue's writer side.
     std::mutex bankMutex;
 
-    static constexpr int kSlotBytes  = 4096;
     struct QueuedMidiOut
     {
         int              port       = -1;

--- a/src/foundation/MidiBuffer.h
+++ b/src/foundation/MidiBuffer.h
@@ -13,6 +13,24 @@
 // the decoders read raw bytes directly.
 namespace dusk
 {
+// One ceiling for the whole MIDI path: the capacity of the input ring AND the
+// reserve of every buffer a whole-block drain lands in. Both come from here
+// because a destination smaller than the ring is a silent bug - a backlog that
+// fits the ring but not the destination arrives as an EMPTY block under
+// whole-block-or-nothing, losing note-offs for notes already sounding.
+//
+// On the ring -> MidiBuffer hop equal sizes make that impossible: a MidiBuffer
+// record carries 8 bytes of header against the ring's 12, so any record set the
+// ring accepted fits a destination of the same size. The later juce -> dusk hops
+// have no such margin - a juce record is 6 bytes of header, and a per-track
+// buffer accumulates from several sources under no cap at all - so they lean on
+// the matched sizing here plus the whole-block escape to stay safe rather than
+// on arithmetic.
+//
+// 16 KB clears a dense controller burst plus a 1 kB-class sysex, so a drop means
+// the audio thread has genuinely stopped draining.
+constexpr std::size_t kMidiBlockBytes = 16 * 1024;
+
 // Non-owning view of one message's raw bytes (valid while its MidiBuffer lives).
 class MidiMessage
 {

--- a/src/foundation/MidiCollector.h
+++ b/src/foundation/MidiCollector.h
@@ -33,7 +33,7 @@ namespace dusk
 class MidiCollector
 {
 public:
-    explicit MidiCollector (std::size_t ringCapacityBytes = 8192)
+    explicit MidiCollector (std::size_t ringCapacityBytes = kMidiBlockBytes)
         : ring (ringCapacityBytes) {}
 
     // Off-RT only. Resize the backing ring.
@@ -67,7 +67,8 @@ public:
     // cap it is delivered empty, because keeping the head would let a note-on
     // through while its note-off fell off the tail, hanging the note. A single
     // record too big for out even when empty is undeliverable at any cut, so it
-    // drops alone and the rest of the block survives.
+    // drops alone and the rest of the block survives. Reserve out at the ring's
+    // capacity (kMidiBlockBytes) and the cumulative case cannot arise at all.
     void removeNextBlock (dusk::MidiBuffer& out, int numSamples, double nowMs) noexcept
     {
         const double prevLast = lastCallbackTime;

--- a/tests/alsa_seq_midi.cpp
+++ b/tests/alsa_seq_midi.cpp
@@ -285,12 +285,18 @@ TEST_CASE ("MidiOutputBank RT queue delivers through the pump, bounded by its de
     REQUIRE (bank.isOpen (dst));
 
     // Past the slot cap: dropped whole rather than truncated, and likewise takes
-    // no slot.
+    // no slot. Filled to exactly what a slot holds and then one event beyond,
+    // keyed off the shared ceiling so raising that cannot quietly turn this into
+    // a block that fits.
     dusk::MidiBuffer big;
-    big.reserveBytes (1 << 16);
+    big.reserveBytes (dusk::kMidiBlockBytes * 2);
+    dusk::MidiBuffer slotSized;
+    slotSized.reserveBytes (dusk::kMidiBlockBytes);
     const std::uint8_t filler[3] { 0x90, 0x7f, 100 };
-    for (int i = 0; i < 4096; ++i)
-        REQUIRE (big.addEvent (filler, 3, i));
+    int n = 0;
+    for (; slotSized.addEvent (filler, 3, n); ++n)
+        REQUIRE (big.addEvent (filler, 3, n));
+    REQUIRE (big.addEvent (filler, 3, n));
     bank.queueRt (dst, big, 48000.0);
 
     // The pump is not running, so only kQueueDepth blocks can commit; the rest

--- a/tests/midi_collector.cpp
+++ b/tests/midi_collector.cpp
@@ -3,6 +3,7 @@
 #include "foundation/MidiBuffer.h"
 #include "foundation/MidiCollector.h"
 
+#include <array>
 #include <cstdint>
 #include <vector>
 
@@ -239,4 +240,55 @@ TEST_CASE ("MidiCollector: full ring drops the overflowing message", "[midi][col
     dusk::MidiBuffer out;
     c.removeNextBlock (out, 512, 2.0);
     REQUIRE (offsets (out).size() == 1u);   // only the accepted message survives
+}
+
+// Whole-block-or-nothing only holds the hung-note line if the destination can
+// take everything the ring can. A destination smaller than the ring turns a
+// mid-size backlog into an EMPTY block - every note-off in it lost, for notes
+// whose note-ons went out in an earlier block. Both sides come from
+// kMidiBlockBytes so the drop can only mean "the ring itself overflowed".
+TEST_CASE ("MidiCollector delivers a ring-full backlog into a matching destination",
+           "[midi][collector]")
+{
+    MidiCollector c (dusk::kMidiBlockBytes);
+    c.reset (48000.0, 0.0);
+
+    // Measure how many 3-byte messages the ring really holds rather than
+    // deriving it from the record header sizes, so this still fills the ring if
+    // either header changes. Kept on a pair boundary so the backlog ends on a
+    // note-off; 372 is what the old 4 KB destination could take.
+    int ringMessages = 0;
+    {
+        MidiCollector probe (dusk::kMidiBlockBytes);
+        const std::uint8_t filler[3] { 0x90, 0x40, 0x7F };
+        while (probe.addMessage (filler, 3, 1.0)) ++ringMessages;
+    }
+    const int numMessages = ringMessages & ~1;
+    REQUIRE (numMessages > 372);
+
+    std::vector<std::array<std::uint8_t, 3>> pushed;
+    for (int i = 0; i < numMessages; ++i)
+    {
+        const bool noteOn = (i % 2) == 0;
+        const std::array<std::uint8_t, 3> msg { (std::uint8_t) (noteOn ? 0x90 : 0x80),
+                                                (std::uint8_t) (36 + (i / 2) % 60),
+                                                (std::uint8_t) (noteOn ? 0x7F : 0x00) };
+        REQUIRE (c.addMessage (msg.data(), 3, 1.0 + 0.0005 * i));
+        pushed.push_back (msg);
+    }
+
+    dusk::MidiBuffer out;
+    out.reserveBytes (dusk::kMidiBlockBytes);
+    c.removeNextBlock (out, 512, 2.0);
+
+    std::vector<std::array<std::uint8_t, 3>> got;
+    for (const auto meta : out)
+    {
+        REQUIRE (meta.numBytes == 3);
+        got.push_back ({ meta.data[0], meta.data[1], meta.data[2] });
+    }
+
+    REQUIRE (got.size() == pushed.size());
+    REQUIRE (got == pushed);            // every message, in order
+    REQUIRE (got.back()[0] == 0x80);    // including the release at the tail
 }


### PR DESCRIPTION
Closes #187.

The MIDI input ring held 16 KB but the drain destinations held 4 KB, and the whole-block-or-nothing contract from #148 means a backlog that fits the ring but not the destination delivers nothing at all: a 400-1100 message burst dropped every event including the note-offs, relocating the hung-note bug instead of fixing it.

One shared constant now sizes the chain: dusk::kMidiBlockBytes (16 KB) is the ring capacity and the reserve for every whole-block destination, so the sizes cannot drift apart again. Five destinations were under-sized, three of them beyond the two the issue found: the MIDI-thru path (input, per-track scratch, output queue slots) would have dropped bursts at the output hop even with the input fixed. The per-track JUCE scratch buffer also tracks the ceiling; leaving it at 4 KB would have turned the burst into a malloc on the audio thread, since JUCE's ensureSize is a growth hint rather than a cap.

For the ring-to-buffer hop the fix is arithmetic: a ring record costs 12 bytes of header against the buffer's 8, so any backlog the ring accepted always fits the destination. The later JUCE-to-dusk hops have no such margin and lean on the matched sizing plus the whole-block escape: the two remaining hand-rolled copy loops now use dusk::copyEventsWhole, which skips a record that could never fit even into an empty destination instead of silencing the block around it (an oversized sysex drops alone, the notes keep flowing). A static_assert ties the IPC wire ceiling to the shared constant so the OOP path cannot silently fall behind.

Memory cost is about 1.3 MB more of prepare-time reserve, nothing on the audio thread.

Regression test fills the ring to capacity (1092 messages, probed from the real record cost) and asserts every event arrives; at the old 4 KB destination geometry it delivers zero. The ALSA queue test now builds its over-cap block relative to the constant so raising the ceiling cannot invert its meaning.
