### PR TITLE
fix(session): resolve unreadable slot names and colours to the default

### DIFF
--- a/src/session/SessionSerializer.cpp
+++ b/src/session/SessionSerializer.cpp
@@ -15,6 +15,7 @@
 #endif
 
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <cstdint>
 #include <map>
@@ -898,9 +899,29 @@ const nlohmann::json& objectAt (const nlohmann::json& arr, int index)
 // resolves to the shared empty object, every setter inside it is skipped, and
 // the live state survives just as an absent key would. The default object
 // replaces it wholesale rather than a scalar standing where a section belongs.
+//
+// A member the default carries as a READABLE STRING - a name, a colour, an EQ
+// type - reaches a setter that keys on the value rather than on the key being
+// present. "name": "" and "name": 42 both read as no string at all there, skip
+// the setter and leave the live value standing exactly as an absent key would,
+// so they resolve to the default as well.
 void fillFromDefaults (nlohmann::json& slot, const nlohmann::json& defaults)
 {
     static const nlohmann::json noDefault = nlohmann::json::object();
+
+    // A colour is scraped for hex digits rather than parsed, so a string that
+    // is not one still yields a colour: "not-a-hex" scrapes down to 0x000000ae,
+    // a fully transparent strip. Only 6 or 8 hex digits read as a colour.
+    auto isReadableString = [] (const std::string& key, const nlohmann::json& v)
+    {
+        if (! v.is_string()) return false;
+        const auto& s = v.get_ref<const nlohmann::json::string_t&>();
+        if (key != "colour")
+            return ! s.empty();
+        return (s.size() == 6 || s.size() == 8)
+            && std::all_of (s.begin(), s.end(),
+                            [] (char c) { return std::isxdigit ((unsigned char) c) != 0; });
+    };
 
     for (auto it = slot.begin(); it != slot.end(); )
     {
@@ -911,8 +932,11 @@ void fillFromDefaults (nlohmann::json& slot, const nlohmann::json& defaults)
         // "there is an object default here" for every key.
         const auto def = defaults.find (it.key());
         const bool defaultIsObject = def != defaults.end() && def->is_object();
+        const bool defaultIsString = def != defaults.end() && isReadableString (it.key(), *def);
 
         if (defaultIsObject && ! it.value().is_object())
+            it.value() = *def;
+        else if (defaultIsString && ! isReadableString (it.key(), it.value()))
             it.value() = *def;
         else if (it.value().is_object())
             fillFromDefaults (it.value(), defaultIsObject ? *def : noDefault);

--- a/tests/session_missing_sections.cpp
+++ b/tests/session_missing_sections.cpp
@@ -230,6 +230,139 @@ TEST_CASE ("a null member in a partial slot resolves to the model default",
     REQUIRE (s.track (0).inputSource.load() == -2);
 }
 
+// The name and colour setters key on the value being a non-empty string rather
+// than on the key being present, so a slot carrying "name": "" or "name": 42
+// skipped them and kept the previously loaded session's name and colour - on
+// every track, bus and aux lane - which the next save then wrote out as the new
+// session's. An unreadable value resolves to the model default like an absent
+// key does.
+TEST_CASE ("an unreadable name or colour resolves to the model default",
+           "[session][serializer]")
+{
+    ScopedTempDir tmp { "dusk-unreadable-name-" };
+    const auto& dir = tmp.dir;
+
+    Session s;
+    s.setSessionDirectory (dir);
+
+    s.track (0).name     = "ghost track";
+    s.track (0).colour   = juce::Colour (0xff102030);
+    s.bus (0).name       = "ghost bus";
+    s.bus (0).colour     = juce::Colour (0xff405060);
+    s.auxLane (0).name   = "ghost aux";
+    s.auxLane (0).colour = juce::Colour (0xff708090);
+
+    const auto target = dir.getChildFile ("session.json");
+
+    SECTION ("empty strings")
+    {
+        target.replaceWithText (
+            R"({"version":3,"tracks":[{"name":"","colour":""}],)"
+            R"("buses":[{"name":"","colour":""}],)"
+            R"("aux_lanes":[{"name":"","colour":""}]})");
+    }
+    SECTION ("values that are not strings")
+    {
+        target.replaceWithText (
+            R"({"version":3,"tracks":[{"name":42,"colour":true}],)"
+            R"("buses":[{"name":42,"colour":true}],)"
+            R"("aux_lanes":[{"name":42,"colour":true}]})");
+    }
+    SECTION ("objects where the names belong")
+    {
+        target.replaceWithText (
+            R"({"version":3,"tracks":[{"name":{},"colour":{}}],)"
+            R"("buses":[{"name":{},"colour":{}}],)"
+            R"("aux_lanes":[{"name":{},"colour":{}}]})");
+    }
+    // A colour is scraped for hex digits rather than parsed, so a string that
+    // is not one loads as a stray-digit colour - here a fully transparent
+    // strip - instead of reading as unspecified.
+    SECTION ("a colour that is not hex")
+    {
+        target.replaceWithText (
+            R"({"version":3,"tracks":[{"name":"","colour":"not-a-hex"}],)"
+            R"("buses":[{"name":"","colour":"not-a-hex"}],)"
+            R"("aux_lanes":[{"name":"","colour":"not-a-hex"}]})");
+    }
+
+    REQUIRE (SessionSerializer::load (s, target));
+
+    const Session defaults;
+    REQUIRE (s.track (0).name     == defaults.track (0).name);
+    REQUIRE (s.track (0).colour   == defaults.track (0).colour);
+    REQUIRE (s.bus (0).name       == defaults.bus (0).name);
+    REQUIRE (s.bus (0).colour     == defaults.bus (0).colour);
+    REQUIRE (s.auxLane (0).name   == defaults.auxLane (0).name);
+    REQUIRE (s.auxLane (0).colour == defaults.auxLane (0).colour);
+}
+
+// The EQ type is the same shape one level down: a string the setter reads for a
+// "black" / "brown" spelling, so an unreadable one left the strip on the
+// previously loaded session's EQ model.
+TEST_CASE ("an unreadable EQ type resolves to the model default",
+           "[session][serializer]")
+{
+    ScopedTempDir tmp { "dusk-unreadable-eq-type-" };
+    const auto& dir = tmp.dir;
+
+    Session s;
+    s.setSessionDirectory (dir);
+    s.track (0).strip.eqBlackMode.store (true);
+
+    const auto target = dir.getChildFile ("session.json");
+
+    SECTION ("empty string")
+    {
+        target.replaceWithText (R"({"version":3,"tracks":[{"eq":{"type":""}}]})");
+    }
+    SECTION ("a value that is not a string")
+    {
+        target.replaceWithText (R"({"version":3,"tracks":[{"eq":{"type":42}}]})");
+    }
+    // An object one level down is the ordering case: the section it sits in is
+    // filled by the same walk that has to replace it.
+    SECTION ("an object where the type belongs")
+    {
+        target.replaceWithText (R"({"version":3,"tracks":[{"eq":{"type":{}}}]})");
+    }
+
+    REQUIRE (SessionSerializer::load (s, target));
+    REQUIRE_FALSE (s.track (0).strip.eqBlackMode.load());
+}
+
+// The other half of the same contract: a value the file does spell out has to
+// reach the session, or resolving the unreadable ones to defaults would just be
+// ignoring the file.
+TEST_CASE ("values the file spells out still apply",
+           "[session][serializer]")
+{
+    ScopedTempDir tmp { "dusk-named-slot-" };
+    const auto& dir = tmp.dir;
+
+    Session s;
+    s.setSessionDirectory (dir);
+    s.track (0).name = "ghost track";
+    s.bus (0).name   = "ghost bus";
+
+    const auto target = dir.getChildFile ("session.json");
+    target.replaceWithText (
+        R"({"version":3,)"
+        R"("tracks":[{"name":"Vocals","colour":"ff112233","eq":{"type":"black"}}],)"
+        R"("buses":[{"name":"Drums","colour":"ff445566"}],)"
+        R"("aux_lanes":[{"name":"Plate","colour":"ff778899"}]})");
+
+    REQUIRE (SessionSerializer::load (s, target));
+
+    REQUIRE (s.track (0).name     == "Vocals");
+    REQUIRE (s.track (0).colour   == juce::Colour (0xff112233));
+    REQUIRE (s.track (0).strip.eqBlackMode.load());
+    REQUIRE (s.bus (0).name       == "Drums");
+    REQUIRE (s.bus (0).colour     == juce::Colour (0xff445566));
+    REQUIRE (s.auxLane (0).name   == "Plate");
+    REQUIRE (s.auxLane (0).colour == juce::Colour (0xff778899));
+}
+
 // A section the file gives as a scalar reaches the restore path as the shared
 // empty object, which passes the section's presence check and then skips every
 // conditional setter inside it - the previously loaded session's routing and


### PR DESCRIPTION
Closes #188.

The #168 defaults machinery filled a partial session slot's absent keys, but name and colour slipped through: their setters gate on the value being non-empty rather than the key being present, so {"name":""} or {"name":42} kept the previous session's names and colours on all 24 tracks, 4 buses, and 4 aux lanes, and the next save persisted them into the new session.

fillFromDefaults now treats an unreadable string the way it treats an absent key: when the model default is a non-empty string and the file offers anything else (empty, wrong type, an object), the default lands. For colour keys, readable additionally means 6 or 8 hex digits, because the old parser scraped stray hex characters out of arbitrary text and produced transparent strips from values like "not-a-hex".

The sweep over every value-gated string in the load path found one more site with the same defect: eq.type, where a bogus value kept the previous session's EQ model. The rest (MIDI identifiers, frozen audio paths, marker colours, mastering source file) key on presence or reset wholesale and are documented as checked in the tests.

Blast radius was verified empirically: a serialized default Session carries exactly seven non-empty string keys (name and colour on the three slot kinds, plus eq.type), so nothing else can be touched by the rule. Regions and other arrays are never recursed.

Tests cover empty, wrong-typed, object-shaped, and non-hex values landing the default; an object where eq.type belongs; and legitimate values still applying. All red without the fix.
