### PR TITLE
ci: fold Linux tests into the build job, cache objects with ccache

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -19,10 +19,17 @@ jobs:
         run: tools/juce-gate.sh
 
   build:
-    name: Build Dusk Studio (GCC Release, Ubuntu 22.04, amd64)
+    name: Build + tests (GCC Release, Ubuntu 22.04, amd64)
     # arm64 / Raspberry Pi build-check lives in raspberry-pi-build.yml so each
     # arch only builds once per push.
     runs-on: ubuntu-22.04
+
+    env:
+      # CMakeLists.txt auto-detects ccache and sets the compiler launchers,
+      # so installing it and persisting this directory across runs is the
+      # whole wiring. build-linux and build-tests share the one cache.
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_MAXSIZE: 500M
 
     steps:
       - name: Checkout Dusk Studio
@@ -38,7 +45,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            build-essential cmake ninja-build pkg-config \
+            build-essential cmake ninja-build pkg-config ccache \
             libasound2-dev libjack-jackd2-dev libmp3lame-dev libsndfile1-dev \
             liblilv-dev libsuil-dev lv2-dev \
             ladspa-sdk \
@@ -47,6 +54,14 @@ jobs:
             libxinerama-dev libxrandr-dev libxrender-dev libxss-dev \
             libwebkit2gtk-4.0-dev libgl1-mesa-dev libglu1-mesa-dev xvfb \
             libwayland-dev libxkbcommon-dev libdecor-0-dev
+
+      - name: Cache ccache objects
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-linux-gcc-${{ github.sha }}
+          restore-keys: |
+            ccache-linux-gcc-
 
       - name: Clone JUCE (Dusk-owned Wayland mirror, pinned)
         # CI builds against the SAME Dusk-owned mirror snapshot the release
@@ -134,82 +149,6 @@ jobs:
             env DUSKSTUDIO_RUN_SELFTEST=1 \
             build-linux/DuskStudio_artefacts/Release/DuskStudio
 
-      # Artifact upload intentionally removed: Dusk Studio's binaries are
-      # paid + the source is open. CI proves the build compiles + tests
-      # pass, but doesn't hand out free downloadable binaries. Release
-      # builds happen out of band on a signing-equipped runner.
-
-  tests:
-    name: Catch2 tests (GCC Release, Ubuntu 22.04)
-    runs-on: ubuntu-22.04
-    needs: build
-
-    steps:
-      - name: Checkout Dusk Studio
-        uses: actions/checkout@v7
-        with:
-          # external/sfizz is a submodule; the test binary compiles
-          # DuskMultisampleProcessor.cpp (#include <sfizz.h>), so it must
-          # be present or the build fails with "sfizz.h: No such file".
-          submodules: recursive
-          persist-credentials: false
-
-      - name: Install Linux build deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential cmake ninja-build pkg-config \
-            libasound2-dev libjack-jackd2-dev libmp3lame-dev libsndfile1-dev \
-            liblilv-dev libsuil-dev lv2-dev \
-            libcurl4-openssl-dev libfreetype-dev libfontconfig1-dev \
-            libx11-dev libxcomposite-dev libxcursor-dev libxext-dev \
-            libxinerama-dev libxrandr-dev libxrender-dev libxss-dev \
-            libwebkit2gtk-4.0-dev libgl1-mesa-dev libglu1-mesa-dev \
-            libwayland-dev libxkbcommon-dev libdecor-0-dev
-
-      - name: Clone JUCE (Dusk-owned Wayland mirror, pinned)
-        # Same pinned Dusk-owned mirror snapshot as the build job above; the
-        # snapshot already carries the SIMDNativeOps<long long> alias, so no
-        # patch step. Keep JUCE_TAG / JUCE_REV in lockstep with the build job
-        # and linux-release.yml.
-        env:
-          JUCE_MIRROR: https://github.com/dusk-audio/JUCE-wayland.git
-          JUCE_TAG: dusk-wayland-v2
-          JUCE_REV: 4d85afa175a45e0b5da11f9211de3ba88705588e
-        run: |
-          set -euo pipefail
-          git init -q "${RUNNER_TEMP}/JUCE-wayland"
-          cd "${RUNNER_TEMP}/JUCE-wayland"
-          git remote add origin "${JUCE_MIRROR}"
-          git fetch --depth 1 origin "refs/tags/${JUCE_TAG}"
-          git checkout -q FETCH_HEAD
-          [[ "$(git rev-parse HEAD)" == "${JUCE_REV}" ]] || {
-            echo "ERROR: JUCE checkout $(git rev-parse HEAD) != pinned ${JUCE_REV}" >&2; exit 1; }
-          grep -q "SIMDNativeOps<long long>" \
-            modules/juce_dsp/native/juce_SIMDNativeOps_sse.h || {
-            echo "ERROR: pinned JUCE missing the SIMDNativeOps<long long> alias." >&2; exit 1; }
-
-      - name: Clone Dusk plugins (donor DSP, pinned)
-        # Pinned donor SHA (mirrors linux-release.yml). main consumes source
-        # files the donor's main HEAD has since relocated, so an unpinned
-        # clone breaks configure. Bump every workflow's DONOR_REV together.
-        env:
-          DONOR_REPO: https://github.com/dusk-audio/dusk-audio-plugins.git
-          DONOR_REV: 69f04318e3b7063e382c80ac1cde2388170e668b
-        run: |
-          set -euo pipefail
-          git init -q "${RUNNER_TEMP}/plugins-main"
-          cd "${RUNNER_TEMP}/plugins-main"
-          git remote add origin "${DONOR_REPO}"
-          git fetch --depth 1 origin "${DONOR_REV}"
-          git checkout -q "${DONOR_REV}"
-          [[ "$(git rev-parse HEAD)" == "${DONOR_REV}" ]] || {
-            echo "ERROR: donor checkout $(git rev-parse HEAD) != pinned ${DONOR_REV}" >&2; exit 1; }
-
-      - name: Clone DPF stack (dusk-audio forks, pinned)
-        # Pins + rationale live in .github/actions/clone-dpf-stack.
-        uses: ./.github/actions/clone-dpf-stack
-
       - name: Configure tests
         run: |
           cmake -S . -B build-tests -G Ninja \
@@ -227,3 +166,12 @@ jobs:
 
       - name: Run tests
         run: ctest --test-dir build-tests --output-on-failure
+
+      - name: ccache stats
+        if: always()
+        run: ccache -s
+
+      # Artifact upload intentionally removed: Dusk Studio's binaries are
+      # paid + the source is open. CI proves the build compiles + tests
+      # pass, but doesn't hand out free downloadable binaries. Release
+      # builds happen out of band on a signing-equipped runner.

--- a/.github/workflows/linux-sanitizer.yml
+++ b/.github/workflows/linux-sanitizer.yml
@@ -35,6 +35,13 @@ jobs:
       #   listed JUCE entry points are skipped.
       TSAN_OPTIONS: "second_deadlock_stack=1 halt_on_error=1 exitcode=66 suppressions=${{ github.workspace }}/tools/tsan_suppressions.txt"
 
+      # CMakeLists.txt auto-detects ccache and sets the compiler launchers,
+      # so installing it and persisting this directory across runs is the
+      # whole wiring. Sanitizer objects are not interchangeable with the
+      # Release ones, so this job carries its own cache key.
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_MAXSIZE: 500M
+
     steps:
       - name: Checkout Dusk Studio
         uses: actions/checkout@v7
@@ -45,7 +52,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Linux build deps
-        # Same set as linux-build.yml's tests job. xvfb stays even though
+        # Same set as linux-build.yml's build job. xvfb stays even though
         # the Catch2 binary itself is headless because some narrow-linked
         # units pull in juce_gui_basics for jassert helpers and the
         # initialiser path touches X11. Cheap to keep, prevents flaky
@@ -53,7 +60,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            build-essential cmake ninja-build pkg-config \
+            build-essential cmake ninja-build pkg-config ccache \
             llvm \
             libasound2-dev libjack-jackd2-dev libmp3lame-dev libsndfile1-dev \
             liblilv-dev libsuil-dev lv2-dev \
@@ -63,6 +70,14 @@ jobs:
             libxinerama-dev libxrandr-dev libxrender-dev libxss-dev \
             libwebkit2gtk-4.0-dev libgl1-mesa-dev libglu1-mesa-dev xvfb \
             libwayland-dev libxkbcommon-dev libdecor-0-dev
+
+      - name: Cache ccache objects
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-linux-tsan-${{ github.sha }}
+          restore-keys: |
+            ccache-linux-tsan-
 
       - name: Clone JUCE (Dusk-owned Wayland mirror, pinned)
         # Same pinned Dusk-owned mirror snapshot as linux-build.yml; the
@@ -138,3 +153,7 @@ jobs:
         run: |
           ctest --test-dir build-tsan --output-on-failure \
                 -E "VCA detector mode toggle is a no-op|FET has no GR-driven sub-bass HPF"
+
+      - name: ccache stats
+        if: always()
+        run: ccache -s

--- a/.github/workflows/raspberry-pi-build.yml
+++ b/.github/workflows/raspberry-pi-build.yml
@@ -2,9 +2,10 @@ name: Raspberry Pi build (arm64)
 
 # Build-check for Raspberry Pi 4 / 5 (64-bit) and other aarch64 Linux. Runs on
 # GitHub's native ARM64 runner — no cross-compile, no QEMU. Compiles Dusk
-# Studio, then smoke-launches the binary and drives the headless self-test so a
-# link/startup regression specific to arm64 is caught early. No artifact is
-# published (binaries are paid; the source is open).
+# Studio, smoke-launches the binary, drives the headless self-test so a
+# link/startup regression specific to arm64 is caught early, then runs the
+# Catch2 suite for arm coverage of the DSP paths. No artifact is published
+# (binaries are paid; the source is open).
 
 on:
   push:
@@ -15,8 +16,15 @@ on:
 
 jobs:
   build:
-    name: Build Dusk Studio (GCC Release, Ubuntu 22.04, arm64)
+    name: Build + tests (GCC Release, Ubuntu 22.04, arm64)
     runs-on: ubuntu-22.04-arm
+
+    env:
+      # CMakeLists.txt auto-detects ccache and sets the compiler launchers,
+      # so installing it and persisting this directory across runs is the
+      # whole wiring. build-linux and build-tests share the one cache.
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_MAXSIZE: 500M
 
     steps:
       - name: Checkout Dusk Studio
@@ -39,7 +47,7 @@ jobs:
           ok=0
           for i in 1 2 3; do
             sudo apt-get update && sudo apt-get install -y --no-install-recommends \
-              build-essential cmake ninja-build pkg-config \
+              build-essential cmake ninja-build pkg-config ccache \
               libasound2-dev libjack-jackd2-dev libmp3lame-dev libsndfile1-dev \
               liblilv-dev libsuil-dev lv2-dev \
               ladspa-sdk \
@@ -51,6 +59,14 @@ jobs:
             echo "apt attempt $i failed; retrying in 20s"; sleep 20
           done
           [ "$ok" = 1 ] || { echo "apt failed after 3 attempts"; exit 1; }
+
+      - name: Cache ccache objects
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-linux-arm64-${{ github.sha }}
+          restore-keys: |
+            ccache-linux-arm64-
 
       - name: Clone JUCE (Dusk-owned Wayland mirror, pinned)
         # Same pinned Dusk-owned mirror snapshot as linux-build.yml. The
@@ -139,3 +155,25 @@ jobs:
           timeout 60 xvfb-run --auto-servernum \
             env DUSKSTUDIO_RUN_SELFTEST=1 \
             build-linux/DuskStudio_artefacts/Release/DuskStudio
+
+      - name: Configure tests
+        run: |
+          cmake -S . -B build-tests -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DDUSKSTUDIO_BUILD_TESTS=ON \
+            -DDUSKSTUDIO_SKIP_FORK_CHECK=ON \
+            -DDUSKSTUDIO_REQUIRE_NATIVE_LV2=ON \
+            -DJUCE_PATH="${RUNNER_TEMP}/JUCE-wayland" \
+            -DDUSK_PLUGINS_PATH="${RUNNER_TEMP}/plugins-main" \
+            -DDPF_PATH="${RUNNER_TEMP}/DPF" \
+            -DDPF_WIDGETS_PATH="${RUNNER_TEMP}/DPF-Widgets"
+
+      - name: Build tests
+        run: cmake --build build-tests --target dusk-studio-tests -j
+
+      - name: Run tests
+        run: ctest --test-dir build-tests --output-on-failure
+
+      - name: ccache stats
+        if: always()
+        run: ccache -s


### PR DESCRIPTION
Closes #205.

The Linux side of a PR took about 21 minutes of pipeline time and, in the sample run I measured, 51 minutes of wall clock: the Catch2 job waited on `needs: build`, then queued for a second runner (24 minutes in that run), then cold-built the entire tree again - same OS, same toolchain, same JUCE/sfizz/donor objects as the build job it was waiting for.

Three changes:

- The Catch2 job folds into the Linux build job, the shape macOS already uses. One runner checks out, installs deps and clones the pinned JUCE/donor/DPF once, builds the app, runs the headless self-test, then configures and runs the test suite. The De-JUCE ratchet job is untouched. The test configure flags are carried over unchanged, including `-DDUSKSTUDIO_REQUIRE_NATIVE_LV2=ON`.
- ccache with actions/cache on the three Linux jobs (merged build+tests, TSan, arm64), each with its own cache key since sanitizer and arm64 objects are not interchangeable. No compiler-launcher flags are passed: CMakeLists.txt already finds ccache and sets `CMAKE_C/CXX_COMPILER_LAUNCHER` unconditionally at top level, which both build directories inherit. `ccache -s` runs at the end of each job so the hit rate is visible.
- The arm64 job now runs the test suite too. It builds on a native runner, so there was never a technical reason to skip it; this is the first arm coverage the suite has had.

Expected Linux verdict: about 12 minutes cold, 4 to 6 warm, with the second-runner queue gone entirely.

Branch protection needs an edit at merge time, and it has to happen BEFORE the merge or this PR is unmergeable: ruleset "main protection" currently requires `Catch2 tests (GCC Release, Ubuntu 22.04)` (job no longer exists) and `Build Dusk Studio (GCC Release, Ubuntu 22.04, amd64)` (renamed). Both come out; `Build + tests (GCC Release, Ubuntu 22.04, amd64)` goes in. The arm64 job's rename needs nothing - it is not a required check.

Two knobs left deliberately unturned: `MainComponent.cpp` uses `__DATE__`/`__TIME__`, so ccache will not cache that one translation unit without `CCACHE_SLOPPINESS: time_macros`, which trades a stale build stamp for the saving; and if a hit rate disappoints, the TSan job's 500M cache is the one to raise first, since instrumented objects are much larger.

Note the suite has never run on aarch64 before. If a float-tolerance assertion fails there it is a real finding rather than a workflow bug, and that job is not a required check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Raspberry Pi arm64 builds now run the Catch2 test suite and report test results.
  * Linux and sanitizer workflows consistently report compiler-cache statistics, including after failures.

* **Performance**
  * Added compiler caching to Linux, sanitizer, and Raspberry Pi build workflows to reduce repeated build times.

* **CI Improvements**
  * Updated workflow naming and build configuration for clearer coverage of builds and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->