### PR TITLE
fix(console): keep the screen page and the surface bank in step on resize

### DIFF
--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -3427,9 +3427,12 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
                     // 0..kBankSize-1 (or packed pos*N+sub); rewrite into the
                     // matching absolute target + absolute track index by
                     // adding activeBank * kBankSize to the position. The
-                    // load is relaxed because the bank index is owned by
-                    // the message thread (ConsoleView::setBank) and only
-                    // changes on explicit user action.
+                    // load is relaxed because the bank index is written
+                    // only from the message thread - a page press, or the
+                    // console's poll tick mirroring the MCU surface and
+                    // any move a resize queued for it - and a binding
+                    // resolving against the previous bank for one block
+                    // is not worth ordering the whole dispatch for.
                     MidiBinding b = sourceBinding;
                     if (isBankRelativeTarget (b.target))
                     {

--- a/src/ui/BankMapping.h
+++ b/src/ui/BankMapping.h
@@ -32,22 +32,158 @@ inline int screenBankForHardwareBank (int hardwareBank,
     return std::clamp (firstTrack / screenStride, 0, screenBankCount - 1);
 }
 
-struct ScreenBankResizeState
+// What the console must publish to the session atoms after a transition.
+// hardwareBank is only meaningful when one of the publish flags is set.
+struct BankTransition
 {
-    int currentBank;
-    int lastKnownMcuBank;
-    int activeBank;
-    int mcuBank;
+    bool pageMoved            = false;  // the visible page changed; re-lay out
+    bool publishActiveBank    = false;  // store session.activeBank
+    bool publishSurfaceBank   = false;  // store session.mcu.bank unconditionally
+    int  hardwareBank         = 0;
 };
 
-inline ScreenBankResizeState screenBankStateAfterResize (int currentBank,
-                                                          int screenBankCount,
-                                                          int screenStride) noexcept
+// The console's page/bank bookkeeping, kept out of the component so the
+// resize / poll / page-press ordering is testable without a message loop.
+//
+// session.mcu.bank is written on this side by the poll tick or an explicit page
+// press - never a resize. A resize only queues the move it wants in
+// pendingMcuBank: storing it directly would overwrite, and then latch away, a
+// Bank Left/Right press that landed inside the poll window, racing the
+// surface's own read-modify-write of the same atom.
+struct ConsoleBankState
 {
-    const int clampedBank = std::clamp (currentBank,
-                                        0,
-                                        std::max (0, screenBankCount - 1));
-    const int hardwareBank = hardwareBankForScreenBank (clampedBank, screenStride);
-    return { clampedBank, hardwareBank, hardwareBank, hardwareBank };
-}
+    int  screenBank       = 0;   // page on screen, 0..screenBankCount-1
+    int  lastKnownMcuBank = 0;   // last surface bank this side has seen or set
+    bool followsScreen    = false;
+    int  pendingMcuBank   = -1;  // surface move a resize queued, -1 when none
+
+    // The user picked a screen page (or focus walked onto one).
+    BankTransition selectScreenBank (int page, int screenBankCount, int screenStride) noexcept
+    {
+        page = std::clamp (page, 0, std::max (0, screenBankCount - 1));
+        // Must stay a no-op when the page doesn't move: the console names the
+        // page already on screen on every strip click and arrow-key move, and
+        // moving the surface from there would snap it away under the user with
+        // no on-screen feedback, once per click.
+        if (page == screenBank) return {};
+
+        screenBank = page;
+
+        BankTransition t;
+        t.pageMoved = true;
+
+        // A page is stride-wide (6..24); the surface and the bank-relative
+        // bindings are kBankSize-wide, so the page index is never a valid bank
+        // - publish the hardware bank holding the page's first track instead.
+        // With every track on screen there is only one page and it carries no
+        // bank opinion at all, so the surface keeps wherever its own Bank
+        // Left/Right left it.
+        if (screenBankCount > 1)
+        {
+            t.hardwareBank = hardwareBankForScreenBank (page, screenStride);
+            t.publishActiveBank = true;
+            t.publishSurfaceBank = true;
+            // Latch before the caller stores: the poll tick mirrors mcu.bank
+            // back into the screen page, and the hardware bank rarely lines up
+            // with the page. Unlatched, our own store reads back as a surface
+            // move and drags the view off the page the user just picked.
+            lastKnownMcuBank = t.hardwareBank;
+            followsScreen = true;
+            pendingMcuBank = -1;
+        }
+        return t;
+    }
+
+    // The window changed width, so both the page count and the stride are new.
+    // Deliberately publishes nothing.
+    void resize (int screenBankCount, int screenStride) noexcept
+    {
+        // A page index only means anything against the stride that produced it,
+        // so a width too narrow to hold the index destroys the record of what
+        // the user picked. What survives is the hardware bank the console
+        // published for them, which makes the surface authoritative again -
+        // clamping the index instead would drag the surface to whatever the
+        // truncated index resolves to, purely because the window changed size.
+        if (followsScreen
+            && screenBank != std::clamp (screenBank, 0, std::max (0, screenBankCount - 1)))
+            followsScreen = false;
+
+        if (! followsScreen)
+        {
+            // The surface's position is width-independent, so the page moves
+            // back onto the tracks it drives. Clamping alone strands the two
+            // apart: a widen-then-narrow leaves the page at 0 with mcu.bank
+            // untouched, and the poll tick has no change to notice.
+            screenBank = screenBankForHardwareBank (lastKnownMcuBank, screenStride, screenBankCount);
+            pendingMcuBank = -1;
+            return;
+        }
+
+        // The page still names a real position and only the stride under it
+        // moved, which moves which hardware bank the page sits in. Recomputed
+        // every time, so a resize that lands back on the current bank also
+        // retires a request an earlier one queued.
+        const int derived = (screenBankCount > 1)
+                          ? hardwareBankForScreenBank (screenBank, screenStride)
+                          : lastKnownMcuBank;
+        pendingMcuBank = (derived != lastKnownMcuBank) ? derived : -1;
+    }
+
+    // A poll tick carrying the value just read from session.mcu.bank.
+    //
+    // moveSurfaceBank(expected, desired) must move the surface atom from
+    // expected to desired atomically and report whether it won. A press can
+    // land between that read and this write - the audio thread's own
+    // read-modify-write is not atomic against ours either - and the surface's
+    // position outranks a move a resize queued, so losing the exchange drops
+    // the queued move and leaves the latch behind for the next tick to follow.
+    // Only the queued move is conditional: a page press stores unconditionally,
+    // because the user is watching for the surface to follow their click.
+    template <typename MoveSurfaceBank>
+    BankTransition pollTick (int mcuBank, int screenBankCount, int screenStride,
+                             MoveSurfaceBank&& moveSurfaceBank)
+    {
+        BankTransition t;
+
+        if (mcuBank != lastKnownMcuBank)
+        {
+            // The surface moved itself, which outranks anything a resize
+            // queued. Its bank is echoed into the binding base but never back
+            // into mcu.bank: the surface owns its own position, and the page it
+            // maps onto maps back to a different hardware bank whenever the
+            // stride isn't kBankSize.
+            pendingMcuBank = -1;
+            lastKnownMcuBank = mcuBank;
+            followsScreen = false;
+
+            t.publishActiveBank = true;
+            t.hardwareBank = std::clamp (mcuBank, 0, SessionLayout::kNumBanks - 1);
+
+            const int page = screenBankForHardwareBank (mcuBank, screenStride, screenBankCount);
+            if (page != screenBank)
+            {
+                screenBank = page;
+                t.pageMoved = true;
+            }
+            return t;
+        }
+
+        if (pendingMcuBank < 0) return t;
+
+        const int queued = pendingMcuBank;
+        // Stay queued when the exchange loses: the surface moved between the
+        // read and the compare, and if it moves back to the latched bank before
+        // the next tick nothing else would ever repair the page.
+        if (! moveSurfaceBank (lastKnownMcuBank, queued))
+            return t;
+
+        pendingMcuBank = -1;
+
+        t.hardwareBank = queued;
+        t.publishActiveBank = true;
+        lastKnownMcuBank = queued;
+        followsScreen = true;
+        return t;
+    }
+};
 } // namespace duskstudio

--- a/src/ui/ConsoleView.cpp
+++ b/src/ui/ConsoleView.cpp
@@ -1,7 +1,5 @@
 #include "ConsoleView.h"
 
-#include "BankMapping.h"
-
 #include <algorithm>
 
 namespace duskstudio
@@ -143,34 +141,17 @@ std::pair<int, int> ConsoleView::rangeForBank (int bankIndex) const noexcept
 
 void ConsoleView::setBank (int bankIndex)
 {
-    const int pages = numBanks();
-    bankIndex = std::clamp (bankIndex, 0, std::max (0, pages - 1));
-    // Must stay a no-op when the page doesn't move: focusStrip calls this on
-    // every strip click and arrow-key move, naming the page already on screen.
-    // Moving the surface from there would snap it away under the user with no
-    // on-screen feedback, once per click.
-    if (bankIndex == currentBank) return;
-    currentBank = bankIndex;
+    applyBankTransition (bankState.selectScreenBank (bankIndex, numBanks(), bankStride()));
+}
 
-    // A page is stride-wide (6..24); the surface and the bank-relative bindings
-    // are kBankSize-wide, so the page index is never a valid bank - publish the
-    // hardware bank holding the page's first track instead. With every track on
-    // screen there is only one page and it carries no bank opinion at all, so
-    // the surface keeps wherever its own Bank Left/Right left it.
-    if (pages > 1)
-    {
-        const int hardwareBank = hardwareBankForScreenBank (currentBank, bankStride());
-        // Latch before the store: timerCallback mirrors mcu.bank back into the
-        // screen page, and the hardware bank rarely lines up with the page.
-        // Without the latch our own store reads back as a surface move and
-        // drags the view off the page the user just picked.
-        lastKnownMcuBank = hardwareBank;
-        activeBankFollowsScreen = true;
-        sessionRef.activeBank.store (hardwareBank, std::memory_order_relaxed);
-        sessionRef.mcu.bank.store (hardwareBank, std::memory_order_release);
-    }
-
-    applyBankChange();
+void ConsoleView::applyBankTransition (const BankTransition& transition)
+{
+    if (transition.publishActiveBank)
+        sessionRef.activeBank.store (transition.hardwareBank, std::memory_order_relaxed);
+    if (transition.publishSurfaceBank)
+        sessionRef.mcu.bank.store (transition.hardwareBank, std::memory_order_release);
+    if (transition.pageMoved)
+        applyBankChange();
 }
 
 void ConsoleView::applyBankChange()
@@ -187,23 +168,20 @@ void ConsoleView::applyBankChange()
 void ConsoleView::timerCallback()
 {
     // The MCU Bank Left/Right buttons write session.mcu.bank on the audio
-    // thread. Mirror it into the bank-relative binding base and scroll the
-    // screen onto the page holding those tracks. The mcu.bank store is
-    // deliberately NOT echoed back: the surface owns its own position, and the
-    // page it maps onto maps back to a different hardware bank whenever the
-    // stride isn't kBankSize. Binding base follows even when the screen can't
-    // page (window wide enough to show all 24 at once).
+    // thread. This tick is the only place that reads it, and - together with an
+    // explicit page press - the only place that writes it, so a surface press
+    // always gets seen before any screen-derived move goes out. A press landing
+    // between the load and the exchange wins it: the exchange fails, the
+    // surface keeps its position, and the next tick follows it.
     const int mcuBank = sessionRef.mcu.bank.load (std::memory_order_acquire);
-    if (mcuBank == lastKnownMcuBank) return;
-    lastKnownMcuBank = mcuBank;
-    activeBankFollowsScreen = false;
-    sessionRef.activeBank.store (std::clamp (mcuBank, 0, Session::kNumBanks - 1),
-                                 std::memory_order_relaxed);
-
-    const int screenBank = screenBankForHardwareBank (mcuBank, bankStride(), numBanks());
-    if (screenBank == currentBank) return;
-    currentBank = screenBank;
-    applyBankChange();
+    applyBankTransition (bankState.pollTick (
+        mcuBank, numBanks(), bankStride(),
+        [this] (int expected, int desired)
+        {
+            return sessionRef.mcu.bank.compare_exchange_strong (expected, desired,
+                                                                std::memory_order_release,
+                                                                std::memory_order_relaxed);
+        }));
 }
 
 void ConsoleView::updateBankVisibility()
@@ -212,7 +190,7 @@ void ConsoleView::updateBankVisibility()
     for (int i = 0; i < Session::kNumTracks; ++i)
     {
         const int bank = (stride > 0) ? (i / stride) : 0;
-        strips[(size_t) i]->setVisible (showingAllTracks || bank == currentBank);
+        strips[(size_t) i]->setVisible (showingAllTracks || bank == bankState.screenBank);
     }
 }
 
@@ -233,23 +211,10 @@ void ConsoleView::resized()
 
     const int stride = bankStride();
     const int pages  = numBanks();
-    // Re-clamp the screen page against the (possibly changed) numBanks so a
-    // width change doesn't leave us viewing an empty page past the end.
-    const auto remappedBanks = screenBankStateAfterResize (currentBank, pages, stride);
-    currentBank = remappedBanks.currentBank;
-
-    // Both the page index and the stride under it are width-derived, so a
-    // resize moves which hardware bank the page sits in - re-derive, or
-    // bank-relative bindings keep driving whichever strips the OLD width put
-    // under the page. When the screen owns the bank, keep the MCU latch, binding
-    // base, and surface bank together; with a single page the screen has no bank
-    // opinion to impose in the first place.
-    if (pages > 1 && activeBankFollowsScreen)
-    {
-        lastKnownMcuBank = remappedBanks.lastKnownMcuBank;
-        sessionRef.activeBank.store (remappedBanks.activeBank, std::memory_order_relaxed);
-        sessionRef.mcu.bank.store (remappedBanks.mcuBank, std::memory_order_release);
-    }
+    // Re-derives the page against the new width and queues any surface move it
+    // implies for the poll tick. Publishes nothing itself - a drag-resize
+    // storing mcu.bank here would swallow a Bank Left/Right press.
+    bankState.resize (pages, stride);
     updateBankVisibility();
 
     int visibleChannels;
@@ -261,7 +226,7 @@ void ConsoleView::resized()
     {
         // Sparse last bank gets only the remainder; non-final banks get
         // the full stride.
-        const int firstIdx = currentBank * stride;
+        const int firstIdx = bankState.screenBank * stride;
         visibleChannels = std::min (stride, Session::kNumTracks - firstIdx);
     }
 
@@ -374,7 +339,7 @@ void ConsoleView::resized()
     {
         const int trackIdx = showingAllTracks
                               ? i
-                              : (currentBank * stride + i);
+                              : (bankState.screenBank * stride + i);
         if (trackIdx >= Session::kNumTracks) break;
         strips[(size_t) trackIdx]->setBounds (x, y, channelW, h);
         x += channelW + (i + 1 < visibleChannels ? kStripGap : 0);

--- a/src/ui/ConsoleView.h
+++ b/src/ui/ConsoleView.h
@@ -5,6 +5,7 @@
 #include <array>
 #include <functional>
 #include <memory>
+#include "BankMapping.h"
 #include "BusComponent.h"
 #include "ChannelStripComponent.h"
 #include "MasterStripComponent.h"
@@ -88,9 +89,9 @@ public:
                                                       int componentWidth) noexcept;
 
     // Screen page index (0..numBanks()-1), NOT a hardware bank. The matching
-    // hardware bank is derived and published in setBank - see BankMapping.h.
+    // hardware bank is derived by ConsoleBankState - see BankMapping.h.
     void setBank (int bankIndex);
-    int  getBank() const noexcept { return currentBank; }
+    int  getBank() const noexcept { return bankState.screenBank; }
 
     // Component accessors for the screenshot-capture harness. Return the
     // realised strip components so the capture pass can snapshot one strip
@@ -132,15 +133,7 @@ private:
     std::array<std::unique_ptr<BusComponent>,       Session::kNumBuses> busStrips;
     std::unique_ptr<MasterStripComponent> masterStrip;
 
-    int currentBank = 0;
-    // Last value of session.mcu.bank this view knows about, whether the surface
-    // moved it or setBank did. Suppresses the echo of our own store.
-    int lastKnownMcuBank = 0;
-    // Whether activeBank was last set from the screen page or from the surface.
-    // Only a screen-derived value depends on the stride, so only that one gets
-    // re-derived on a resize; the surface's own position is width-independent
-    // and must survive one.
-    bool activeBankFollowsScreen = false;
+    ConsoleBankState bankState;
     bool showingAllTracks = false;
 
     // -1 = none. Drives the focus ring + (via stripFocusCb) the A/S/X target.
@@ -150,10 +143,12 @@ private:
 
     void updateBankVisibility();
     void applyBankChange();
+    void applyBankTransition (const BankTransition& transition);
 
     // Polls session.mcu.bank so the MCU surface's Bank Left/Right buttons
     // (handled on the audio thread) drive the visible page + bank-relative
     // bindings, keeping the surface and the on-screen view on the same 8.
+    // Also the only place a move queued by a resize reaches the surface.
     void timerCallback() override;
 };
 } // namespace duskstudio

--- a/tests/console_bank_mapping.cpp
+++ b/tests/console_bank_mapping.cpp
@@ -166,17 +166,294 @@ TEST_CASE ("Bank mapping: the widest page count the console builds stays in rang
     REQUIRE (hardwareBankForScreenBank (kMostPages - 1, kNarrowestStride) == 2);
 }
 
-TEST_CASE ("Bank mapping: a resize republishes the clamped page hardware bank",
+// The remaining cases drive ConsoleBankState the way the console does: a page
+// press or poll tick hands back a BankTransition the caller stores into the
+// session atoms, while a resize stores nothing. Console holds the two atoms so
+// a sequence can assert what actually reached the surface.
+namespace
+{
+struct Console
+{
+    ConsoleBankState state;
+    int activeBankAtom = 0;
+    int mcuBankAtom    = 0;   // also written by the surface, on the audio thread
+    int pages          = 3;
+    int stride         = SessionLayout::kBankSize;
+    // Runs a press between the tick's read of mcuBankAtom and its exchange,
+    // which is the window the exchange exists to close.
+    bool pressDuringExchange = false;
+
+    void apply (const BankTransition& t)
+    {
+        if (t.publishActiveBank)  activeBankAtom = t.hardwareBank;
+        if (t.publishSurfaceBank) mcuBankAtom    = t.hardwareBank;
+        if (t.pageMoved)          state.resize (pages, stride);   // console relayout
+    }
+
+    void pressPage (int page)     { apply (state.selectScreenBank (page, pages, stride)); }
+    void resizeTo (int p, int s)  { pages = p; stride = s; state.resize (pages, stride); }
+
+    void poll()
+    {
+        apply (state.pollTick (mcuBankAtom, pages, stride,
+                               [this] (int expected, int desired)
+                               {
+                                   if (pressDuringExchange) surfaceBankRight();
+                                   if (mcuBankAtom != expected) return false;
+                                   mcuBankAtom = desired;
+                                   return true;
+                               }));
+    }
+
+    // Bank Right on the surface, handled on the audio thread.
+    void surfaceBankRight()
+    {
+        if (mcuBankAtom < SessionLayout::kNumBanks - 1) ++mcuBankAtom;
+    }
+};
+} // namespace
+
+TEST_CASE ("Console bank state: a resize that only relocates the page queues the move",
            "[console][bank]")
 {
-    // Page 3 at stride 6 begins at track 18 (hardware bank 2). Widening to
-    // stride 12 leaves only two pages, so the screen clamps to page 1 and all
-    // screen-owned hardware-bank state must follow its first track (track 12).
-    REQUIRE (hardwareBankForScreenBank (3, 6) == 2);
-    const auto state = screenBankStateAfterResize (3, 2, 12);
+    // The page index still names a real position, so the screen keeps the bank
+    // and the surface follows the tracks that moved under the page: page 2
+    // begins at track 16 at stride 8, and at track 12 once the stride is 6.
+    Console c;
+    c.pages = 3;
+    c.stride = SessionLayout::kBankSize;
+    c.pressPage (2);
+    REQUIRE (c.mcuBankAtom == 2);
+    REQUIRE (c.state.followsScreen);
 
-    REQUIRE (state.currentBank == 1);
-    REQUIRE (state.lastKnownMcuBank == 1);
-    REQUIRE (state.activeBank == 1);
-    REQUIRE (state.mcuBank == 1);
+    c.resizeTo (4, 6);
+    REQUIRE (c.state.screenBank == 2);
+    // Queued, not stored: the poll tick owns the write.
+    REQUIRE (c.state.pendingMcuBank == 1);
+    REQUIRE (c.mcuBankAtom == 2);
+
+    c.poll();
+    REQUIRE (c.mcuBankAtom == 1);
+    REQUIRE (c.activeBankAtom == 1);
+    REQUIRE (c.state.lastKnownMcuBank == 1);
+    REQUIRE (c.state.pendingMcuBank == -1);
+}
+
+TEST_CASE ("Console bank state: a widen that destroys the page hands the bank to the surface",
+           "[console][bank]")
+{
+    // Page 3 at stride 6 begins at track 18 (hardware bank 2). One page cannot
+    // hold that index, so the record of what the user picked is gone and the
+    // published hardware bank is what survives. Clamping the index instead
+    // would drag the surface off bank 2 on the way back down.
+    REQUIRE (hardwareBankForScreenBank (3, 6) == 2);
+
+    Console c;
+    c.pages = 4;
+    c.stride = 6;
+    c.pressPage (3);
+    REQUIRE (c.mcuBankAtom == 2);
+    REQUIRE (c.state.followsScreen);
+
+    c.resizeTo (1, SessionLayout::kNumTracks);
+    REQUIRE_FALSE (c.state.followsScreen);
+    REQUIRE (c.state.screenBank == 0);
+    REQUIRE (c.state.pendingMcuBank == -1);
+    REQUIRE (c.mcuBankAtom == 2);
+
+    c.resizeTo (3, SessionLayout::kBankSize);
+    REQUIRE (c.state.screenBank == 2);
+    REQUIRE (c.state.pendingMcuBank == -1);
+    REQUIRE (c.mcuBankAtom == 2);
+
+    c.poll();
+    REQUIRE (c.state.screenBank == 2);
+    REQUIRE (c.mcuBankAtom == 2);
+}
+
+TEST_CASE ("Console bank state: a press landing inside the exchange keeps the surface",
+           "[console][bank]")
+{
+    // The queued move reads mcu.bank on the tick and writes it a few
+    // instructions later. A press in between must win the atom, and must not be
+    // latched away - the latch is what the next tick compares against.
+    Console c;
+    c.pages = 3;
+    c.stride = SessionLayout::kBankSize;
+    c.pressPage (1);                 // track 8 -> bank 1
+    REQUIRE (c.mcuBankAtom == 1);
+
+    c.resizeTo (4, 6);               // page 1 -> track 6 -> bank 0
+    REQUIRE (c.state.pendingMcuBank == 0);
+
+    c.pressDuringExchange = true;
+    c.poll();
+    REQUIRE (c.mcuBankAtom == 2);
+    REQUIRE (c.state.lastKnownMcuBank == 1);
+    // The move stays queued: were the surface to come back to bank 1 before the
+    // next tick, dropping it here would strand the page with nothing to repair it.
+    REQUIRE (c.state.pendingMcuBank == 0);
+    REQUIRE (c.state.followsScreen);
+
+    c.pressDuringExchange = false;
+    c.poll();
+    REQUIRE_FALSE (c.state.followsScreen);
+    REQUIRE (c.state.lastKnownMcuBank == 2);
+    REQUIRE (c.activeBankAtom == 2);
+    REQUIRE (c.mcuBankAtom == 2);
+    REQUIRE (c.state.screenBank == screenBankForHardwareBank (2, 6, 4));
+}
+
+TEST_CASE ("Console bank state: a widen-then-narrow re-derives the page from the surface bank",
+           "[console][bank]")
+{
+    // The surface owns the bank here, so its position is width-independent and
+    // the screen page is what has to move. Clamping alone leaves the screen on
+    // tracks 1-8 while the surface drives 17-24, and the poll tick cannot
+    // repair it: mcu.bank never changed, so there is nothing for it to notice.
+    Console c;
+    c.pages = 3;
+    c.stride = SessionLayout::kBankSize;
+    c.mcuBankAtom = 2;
+    c.poll();
+
+    REQUIRE_FALSE (c.state.followsScreen);
+    REQUIRE (c.state.screenBank == 2);
+    REQUIRE (c.activeBankAtom == 2);
+
+    c.resizeTo (1, SessionLayout::kNumTracks);   // widen: every track on one page
+    REQUIRE (c.state.screenBank == 0);
+
+    c.resizeTo (3, SessionLayout::kBankSize);    // narrow back
+    REQUIRE (c.state.screenBank == 2);
+    REQUIRE (c.state.pendingMcuBank == -1);
+    REQUIRE (c.mcuBankAtom == 2);
+
+    // A poll tick after the resize must stay a no-op - nothing moved.
+    c.poll();
+    REQUIRE (c.state.screenBank == 2);
+    REQUIRE (c.mcuBankAtom == 2);
+}
+
+TEST_CASE ("Console bank state: a narrower stride re-derives the page for the same surface bank",
+           "[console][bank]")
+{
+    Console c;
+    c.pages = 3;
+    c.stride = SessionLayout::kBankSize;
+    c.mcuBankAtom = 1;
+    c.poll();
+    REQUIRE (c.state.screenBank == 1);
+
+    // Bank 1 starts at track 8, which at stride 6 sits on page 1 (tracks 6-11).
+    c.resizeTo (4, 6);
+    REQUIRE (c.state.screenBank == screenBankForHardwareBank (1, 6, 4));
+    REQUIRE (c.mcuBankAtom == 1);
+}
+
+TEST_CASE ("Console bank state: a resize inside the poll window cannot swallow a bank press",
+           "[console][bank]")
+{
+    // The surface writes mcu.bank on the audio thread and the console only
+    // notices on its 50 ms tick. A drag-resize firing in that window must not
+    // store over the press, nor latch it away by advancing lastKnownMcuBank.
+    Console c;
+    c.pages = 2;
+    c.stride = 12;
+    c.pressPage (1);                 // page 1 at stride 12 -> track 12 -> bank 1
+    REQUIRE (c.mcuBankAtom == 1);
+    REQUIRE (c.state.lastKnownMcuBank == 1);
+
+    c.surfaceBankRight();            // audio thread: bank 1 -> 2
+    c.resizeTo (4, 6);               // page 1 at stride 6 -> track 6 -> bank 0
+
+    REQUIRE (c.mcuBankAtom == 2);              // the press survives the resize
+    REQUIRE (c.state.lastKnownMcuBank == 1);   // still unseen, so the tick will see it
+    REQUIRE (c.state.pendingMcuBank == 0);     // the resize only queued its move
+
+    c.poll();
+    REQUIRE (c.mcuBankAtom == 2);              // surface outranks the queued move
+    REQUIRE (c.activeBankAtom == 2);
+    REQUIRE (c.state.lastKnownMcuBank == 2);
+    REQUIRE (c.state.pendingMcuBank == -1);
+    REQUIRE_FALSE (c.state.followsScreen);
+    REQUIRE (c.state.screenBank == screenBankForHardwareBank (2, 6, 4));
+}
+
+TEST_CASE ("Console bank state: a page press latches its own store", "[console][bank]")
+{
+    // Page 1 at stride 12 resolves to hardware bank 1, which maps back to page
+    // 0. Unlatched, the next tick would read our own store as a surface move
+    // and drag the view off the page the user just picked.
+    Console c;
+    c.pages = 2;
+    c.stride = 12;
+    c.pressPage (1);
+
+    REQUIRE (c.state.screenBank == 1);
+    REQUIRE (c.state.lastKnownMcuBank == 1);
+    REQUIRE (screenBankForHardwareBank (1, 12, 2) == 0);
+
+    c.poll();
+    REQUIRE (c.state.screenBank == 1);
+}
+
+TEST_CASE ("Console bank state: a page press retires a move an earlier resize queued",
+           "[console][bank]")
+{
+    Console c;
+    c.pages = 3;
+    c.stride = SessionLayout::kBankSize;
+    c.pressPage (2);                 // track 16 -> bank 2
+    c.resizeTo (4, 6);               // page 2 -> track 12 -> bank 1
+    REQUIRE (c.state.pendingMcuBank == 1);
+
+    c.pressPage (0);                 // user picks page 0 before the tick
+    REQUIRE (c.mcuBankAtom == 0);
+    REQUIRE (c.state.pendingMcuBank == -1);
+
+    c.poll();
+    REQUIRE (c.mcuBankAtom == 0);
+}
+
+TEST_CASE ("Console bank state: a resize back onto the current bank queues nothing",
+           "[console][bank]")
+{
+    Console c;
+    c.pages = 3;
+    c.stride = SessionLayout::kBankSize;
+    c.pressPage (1);                 // track 8 -> bank 1
+    REQUIRE (c.mcuBankAtom == 1);
+
+    c.resizeTo (2, 12);              // page 1 -> track 12 -> still bank 1
+    REQUIRE (c.state.pendingMcuBank == -1);
+
+    c.poll();
+    REQUIRE (c.mcuBankAtom == 1);
+    REQUIRE (c.activeBankAtom == 1);
+}
+
+TEST_CASE ("Console bank state: one page carries no bank opinion", "[console][bank]")
+{
+    // Every track on screen: the screen has no page to impose, so the surface
+    // keeps wherever its own Bank Left/Right left it.
+    Console c;
+    c.pages = 1;
+    c.stride = SessionLayout::kNumTracks;
+    c.mcuBankAtom = 2;
+    c.poll();
+    REQUIRE (c.activeBankAtom == 2);
+    REQUIRE (c.state.screenBank == 0);
+
+    c.state.screenBank = 1;          // stale page left by a narrower width
+    c.pressPage (0);
+    REQUIRE (c.state.screenBank == 0);
+    REQUIRE (c.mcuBankAtom == 2);
+    REQUIRE_FALSE (c.state.followsScreen);
+
+    c.resizeTo (1, SessionLayout::kNumTracks);
+    REQUIRE (c.state.pendingMcuBank == -1);
+
+    c.poll();
+    REQUIRE (c.mcuBankAtom == 2);
 }


### PR DESCRIPTION
Closes #186.

Two follow-ups to #144's screen-pages / hardware-banks split, both in the console resize path.

**The screen could strand away from the surface.** A resize only clamped the screen page, and a clamp does nothing when the index already fits, so widening until all 24 strips showed and narrowing back left the screen on tracks 1-8 while the surface drove 17-24, with the poll tick unable to repair it. A resize now re-derives the page from the bank the surface is on.

The mirror of that bug was live on the other branch of the same condition: when the screen owned the bank, a width that could not represent the page index destroyed the record of the user's choice and the narrow-back dragged the surface to bank 0. A page index only means something against the stride that produced it, so when the index cannot survive, the bank axis goes back to the surface and the page re-derives from it. That path no longer clamps at all: the index is either representable, or ownership has flipped.

**A resize could swallow a bank press.** #144 made resize a second writer of the shared bank atom, so a drag-resize inside the 50 ms poll window overwrote a surface press and latched the overwrite as if the surface had asked for it. Resize is now a reader: it records the bank its new page implies, and the poll tick performs the move only after checking whether the surface moved itself, through a compare-exchange against the bank the console last saw. A press that lands inside that window wins the atom and the queued move stays queued for the next tick rather than being dropped, so there is no interleaving where the two axes end up disagreeing with nothing left to repair them. An explicit page press still publishes immediately: the user is watching for the faders to follow their click.

The four pieces of bank state moved into a ConsoleBankState in BankMapping.h with the three transitions as methods, each returning what the component should publish. `resize()` returns void, which is the guarantee that a resize publishes nothing.

Verification: 617 tests pass (14 bank cases, up from 5), each defect proven red by reintroducing it, and the state machine was additionally driven through exhaustive stride sweeps and 200,000 randomized interleavings of resize / page press / poll / surface press with no invariant violation. Build clean, gate unchanged, allowlist untouched.

Bench steps, since the timing is not unit-testable:

1. Narrow the window until the bank selector shows 3-4 pages.
2. Press Bank Right twice on the surface (screen follows to 17-24). Widen until all 24 strips show, narrow back: the screen must land on the surface's 8, not tracks 1-8.
3. Narrow to a `1-6 / 7-12 / 13-18 / 19-24` width, click page `19-24`. Widen to all 24, narrow back to a `1-8 / 9-16 / 17-24` width: the surface must still be on 17-24 and the screen must show it.
4. Click a screen page so the screen owns the bank, then slow drag-resize the window edge while pressing Bank Right mid-drag: the press must stand and the screen must follow it.
5. Repeat 4 tapping Bank Right repeatedly during a continuous drag: no tap lost or bounced.
6. Click through the page buttons: faders follow each click immediately. Walk the focus ring across a bank boundary: no surface jitter.
7. Confirm bank-relative MIDI bindings drive the same 8 the faders do after each of the above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved console bank navigation during screen resizing and page changes.
  * Preserved pending surface moves when concurrent hardware and surface updates occur.
  * Improved synchronization between screen selection, hardware bank changes, and visible layouts.
  * Prevented unnecessary bank updates when the selected bank remains unchanged.

* **Tests**
  * Added comprehensive coverage for resizing, page restoration, bank ownership, concurrent updates, and single-page consoles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->