### PR TITLE
fix(mcu): make the comp makeup encoder drive the audible parameter

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -718,7 +718,7 @@ The channel compressor has three mutually-exclusive modes. Settings are remember
 
 Left-click the **COMP** header to enable. Right-click the header for the COMP menu — the mode (**Opto**, **FET**, **VCA**), **Reset comp**, and **Open editor…** — and double-click the header to open the editor directly.
 
-All three modes share one set of knobs — **THRESHOLD, RATIO, ATTACK, RELEASE, MAKEUP** — that route to the right underlying parameter for whichever mode is active. Set the **threshold** by dragging the triangle handle on the gain-reduction meter strip (this also engages the compressor); the remaining knobs sit in a 2×2 grid below the header. The **MAKEUP** knob is the shared makeup gain (−12 to +24 dB) and is available in every mode. Knob ranges retune per mode, as listed below.
+All three modes share one set of knobs — **THRESHOLD, RATIO, ATTACK, RELEASE, MAKEUP** — that route to the right underlying parameter for whichever mode is active. Set the **threshold** by dragging the triangle handle on the gain-reduction meter strip (this also engages the compressor); the remaining knobs sit in a 2×2 grid below the header. The **MAKEUP** knob is the shared makeup gain and is available in every mode; its range follows the active mode — −40 to +40 dB in Opto (the optical gain dial's full span), −20 to +20 dB in FET and VCA. Knob ranges retune per mode, as listed below.
 
 ### Opto (optical style)
 
@@ -2345,7 +2345,7 @@ The hardware-insert ping reports its result inline on the editor (not a modal), 
 | VCA      | Release        | 10–5000 ms                    | 100 ms   |
 | VCA      | Soft knee      | Off / On                      | Off      |
 | VCA      | Detector       | Adaptive / Classic            | Adaptive |
-| Comp     | Makeup         | −12 to +24 dB                 | 0 dB     |
+| Comp     | Makeup         | −40 to +40 dB (Opto), −20 to +20 dB (FET / VCA) | 0 dB |
 | Send 1–4 | Level          | −60 to +6 dB (or OFF)         | OFF      |
 | Send 1–4 | Pre/Post       | Pre / Post                    | Post     |
 | Pan      | Position       | −1.0 to +1.0                  | 0        |

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -6,6 +6,7 @@
 #include "McuReceiver.h"
 #include "McuController.h"
 #include "FaderBindingMap.h"
+#include "CompMakeupMap.h"
 #include "../session/RegionEditActions.h"
 #include "DeviceFallbackMessage.h"
 #include "../foundation/MessageThread.h"
@@ -125,12 +126,7 @@ static float currentFracForTarget (Session& session, const MidiBinding& b) noexc
             const auto& s = session.track (b.targetIndex).strip;
             const int mode = std::clamp (s.compMode.load (std::memory_order_relaxed), 0, 2);
             if (b.target == MidiBindingTarget::TrackCompMakeup)
-                switch (mode)
-                {
-                    case 0:  return inv (s.compOptoGain .load (std::memory_order_relaxed),   0.0f, 100.0f);
-                    case 1:  return inv (s.compFetOutput.load (std::memory_order_relaxed), -20.0f,  20.0f);
-                    default: return inv (s.compVcaOutput.load (std::memory_order_relaxed), -20.0f,  20.0f);
-                }
+                return comp::makeupBindingFrac (s);
             switch (mode)
             {
                 case 0:  return inv (s.compOptoPeakRed.load (std::memory_order_relaxed),   0.0f, 100.0f);
@@ -3767,16 +3763,8 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
                             };
                             if (isMakeup)
                             {
-                                switch (mode)
-                                {
-                                    case 0: strip.compOptoGain.store (remap (0.0f, 100.0f), std::memory_order_relaxed); break;
-                                    case 1: strip.compFetOutput.store (remap (-20.0f, 20.0f), std::memory_order_relaxed); break;
-                                    case 2: strip.compVcaOutput.store (remap (-20.0f, 20.0f), std::memory_order_relaxed); break;
-                                }
-                                // Mirror to the unified makeup atom so the
-                                // FET threshold math stays composed (see
-                                // ChannelStripParams::compMakeupDb comment).
-                                strip.compMakeupDb.store (remap (-20.0f, 20.0f), std::memory_order_relaxed);
+                                comp::applyTrackCompMakeupDb (
+                                    strip, comp::makeupBindingFracToDb (strip, frac));
                             }
                             else // threshold
                             {

--- a/src/engine/CompMakeupMap.h
+++ b/src/engine/CompMakeupMap.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include "../session/Session.h"
+
+#include <algorithm>
+#include <atomic>
+
+namespace duskstudio
+{
+namespace comp
+{
+// Channel-strip comp makeup is one user-facing dB control that has to land
+// on whichever per-mode output param the DSP actually reads, and the modes
+// do not share a range. Opto's GAIN is the donor's 0..100 hardware dial -
+// 50 is unity, one unit is 0.8 dB, so the span is +/-40 dB (the donor's
+// OptoGainMapping.h states the same contract UniversalCompressorDSP
+// applies). FET and VCA carry dB straight, over +/-20. A dB figure written
+// into the wrong domain lands wildly off, so both the value and its range
+// come from the active mode.
+//
+// applyTrackCompMakeupDb and trackCompMakeupDb are exact inverses, and the
+// binding frac pair sitting on them is the shape FaderBindingMap.h uses for
+// fader targets: a binding's apply and its soft-takeover read-back must
+// stay inverses or pickup latches at the wrong position.
+//
+// Relative controls (the MCU V-pot) take their base from trackCompMakeupDb
+// rather than any stored dB, so a nudge continues from what the strip is
+// actually playing no matter who wrote it last - UI knob, MIDI binding, a
+// comp-mode switch, or a session saved by an older build.
+//
+// RT-safe: no allocation, no locks, relaxed stores per the param
+// convention. Callable from the audio thread (McuReceiver, the binding
+// apply and read-back) and the message thread alike.
+constexpr float kOptoGainUnityPct = 50.0f;
+constexpr float kOptoGainPctPerDb =  1.25f;   // 1 / 0.8 dB per dial unit
+constexpr float kOptoMakeupMaxDb  = 40.0f;    // Opto dial span
+constexpr float kOutMakeupMaxDb   = 20.0f;    // FET / VCA output params
+
+struct MakeupDomain
+{
+    float minDb;
+    float maxDb;
+};
+
+inline MakeupDomain makeupDomainFor (const ChannelStripParams& strip) noexcept
+{
+    const bool opto = std::clamp (strip.compMode.load (std::memory_order_relaxed), 0, 2) == 0;
+    const float span = opto ? kOptoMakeupMaxDb : kOutMakeupMaxDb;
+    return { -span, span };
+}
+
+inline float makeupDbToOptoGainPct (float db) noexcept
+{
+    return std::clamp (kOptoGainUnityPct + db * kOptoGainPctPerDb, 0.0f, 100.0f);
+}
+
+inline float optoGainPctToMakeupDb (float pct) noexcept
+{
+    return (std::clamp (pct, 0.0f, 100.0f) - kOptoGainUnityPct) / kOptoGainPctPerDb;
+}
+
+inline void applyTrackCompMakeupDb (ChannelStripParams& strip, float db) noexcept
+{
+    const float outDb = std::clamp (db, -kOutMakeupMaxDb, kOutMakeupMaxDb);
+    switch (std::clamp (strip.compMode.load (std::memory_order_relaxed), 0, 2))
+    {
+        case 0:
+            strip.compOptoGain.store (makeupDbToOptoGainPct (db),
+                                      std::memory_order_relaxed);
+            break;
+        case 1:
+            strip.compFetOutput.store (outDb, std::memory_order_relaxed);
+            break;
+        default:
+            strip.compVcaOutput.store (outDb, std::memory_order_relaxed);
+            break;
+    }
+}
+
+inline float trackCompMakeupDb (const ChannelStripParams& strip) noexcept
+{
+    switch (std::clamp (strip.compMode.load (std::memory_order_relaxed), 0, 2))
+    {
+        case 0:
+            return optoGainPctToMakeupDb (
+                strip.compOptoGain.load (std::memory_order_relaxed));
+        case 1:
+            return std::clamp (strip.compFetOutput.load (std::memory_order_relaxed),
+                               -kOutMakeupMaxDb, kOutMakeupMaxDb);
+        default:
+            return std::clamp (strip.compVcaOutput.load (std::memory_order_relaxed),
+                               -kOutMakeupMaxDb, kOutMakeupMaxDb);
+    }
+}
+
+inline float makeupBindingFracToDb (const ChannelStripParams& strip, float frac) noexcept
+{
+    const auto domain = makeupDomainFor (strip);
+    return domain.minDb + frac * (domain.maxDb - domain.minDb);
+}
+
+inline float makeupBindingFrac (const ChannelStripParams& strip) noexcept
+{
+    const auto domain = makeupDomainFor (strip);
+    return std::clamp ((trackCompMakeupDb (strip) - domain.minDb)
+                           / (domain.maxDb - domain.minDb),
+                       0.0f, 1.0f);
+}
+} // namespace comp
+} // namespace duskstudio

--- a/src/engine/McuReceiver.cpp
+++ b/src/engine/McuReceiver.cpp
@@ -1,6 +1,7 @@
 #include "McuReceiver.h"
 #include "McuProtocol.h"
 #include "McuFaderTaper.h"
+#include "CompMakeupMap.h"
 #include "../session/Session.h"
 
 #include <algorithm>
@@ -71,7 +72,7 @@ void McuReceiver::resetVpotTarget (int stripIndex) noexcept
                 case 1: strip.compVcaRatio   .store (4.0f, std::memory_order_relaxed); break;
                 case 2: strip.compVcaAttack  .store (1.0f, std::memory_order_relaxed); break;
                 case 3: strip.compVcaRelease .store (100.0f, std::memory_order_relaxed); break;
-                case 4: strip.compMakeupDb   .store (0.0f, std::memory_order_relaxed); break;
+                case 4: comp::applyTrackCompMakeupDb (strip, 0.0f); break;
                 default: break;
             }
         }
@@ -163,10 +164,8 @@ void McuReceiver::applyVpotDelta (int stripIndex, int delta) noexcept
                                                                     ChannelStripParams::kCompReleaseMax,
                                                                     strip.compVcaRelease.load() + d * 10.0f),
                                                       std::memory_order_relaxed); break;
-                case 4: strip.compMakeupDb.store (jlimit (ChannelStripParams::kCompMakeupMin,
-                                                                  ChannelStripParams::kCompMakeupMax,
-                                                                  strip.compMakeupDb.load() + d * 0.3f),
-                                                    std::memory_order_relaxed); break;
+                case 4: comp::applyTrackCompMakeupDb (
+                            strip, comp::trackCompMakeupDb (strip) + d * 0.3f); break;
                 default: break;
             }
         }

--- a/src/session/Session.h
+++ b/src/session/Session.h
@@ -267,12 +267,6 @@ struct ChannelStripParams
     // Audio thread does NOT read directly; see ChannelStrip::updateCompParameters.
     std::atomic<float> compThresholdDb { 0.0f };
 
-    // FET threshold reads this back when recomputing compFetOutput so
-    // threshold + makeup compose (without it, threshold's chain
-    // compensation overwrites makeup). VCA / Opto write here for
-    // consistency / save state.
-    std::atomic<float> compMakeupDb    { 0.0f };
-
     // Engine writes liveFaderDb at the top of every block: Off mode
     // mirrors faderDb; Read mode carries lane value. ChannelStrip
     // reads liveFaderDb, not faderDb, so Off/Read hand-off lives in

--- a/src/ui/ChannelCompEditor.cpp
+++ b/src/ui/ChannelCompEditor.cpp
@@ -1,5 +1,6 @@
 #include "ChannelCompEditor.h"
 #include "DuskStudioLookAndFeel.h"
+#include "../engine/CompMakeupMap.h"
 
 #include <algorithm>
 
@@ -260,6 +261,16 @@ void ChannelCompEditor::refreshLabelsForMode()
     // incoming value against whichever range is currently active.
     applyTimingRanges (attackKnob, releaseKnob, m);
 
+    // Opto's dial spans +/-40 dB, FET / VCA +/-20, so a fixed knob range
+    // would leave one end unreachable and snap the gain on first touch.
+    // Slider::setRange notifies when it clamps the current value, which
+    // would write that clamped value back into the strip - park the
+    // callback across the change and let syncKnobsFromMode restore it.
+    const auto makeupDomain = comp::makeupDomainFor (track.strip);
+    makeupKnob.onValueChange = nullptr;
+    makeupKnob.setRange (makeupDomain.minDb, makeupDomain.maxDb, 0.01);
+    makeupKnob.onValueChange = [this] { writeMakeupToMode(); };
+
     // OverEasy + detector-mode toggles: VCA only.
     const bool vcaMode = (m == 2);
     vcaOverEasyBtn.setVisible (vcaMode);
@@ -299,9 +310,7 @@ void ChannelCompEditor::refreshLabelsForMode()
 //   VCA:  threshDb -> compVcaThreshDb  (clamped to that param's -38..12)
 //   Opto: threshDb -> compOptoPeakRed  (lower threshold = more reduction;
 //                                       linear remap of -60..0 to 100..0 %)
-//   FET:  threshDb -> chain compFetInput up and compFetOutput down by the
-//                     same amount so net level holds while compression
-//                     increases (the user's stated intent).
+//   FET:  threshDb -> compFetThresholdDb (clamped to that param's -60..0)
 //
 // Similar logic for the other four knobs - Opto's release/attack/ratio are
 // fixed by the optical model so those knobs are no-ops in Opto mode.
@@ -410,34 +419,7 @@ void ChannelCompEditor::writeReleaseToMode()
 
 void ChannelCompEditor::writeMakeupToMode()
 {
-    const float dB = (float) makeupKnob.getValue();
-    // Always store the user's intent in the unified `compMakeupDb` field.
-    // FET reads this back when the threshold knob changes so the two
-    // controls compose without overwriting each other (otherwise lowering
-    // threshold would wipe whatever makeup the user had dialled in).
-    track.strip.compMakeupDb.store (dB, std::memory_order_relaxed);
-
-    const int mode = jlimit (0, 2, track.strip.compMode.load (std::memory_order_relaxed));
-    switch (mode)
-    {
-        case 0: // Opto: 0..100 % gain, 50 % = unity
-        {
-            const float pct = jlimit (0.0f, 100.0f, 50.0f + dB * 2.5f);
-            track.strip.compOptoGain.store (pct, std::memory_order_relaxed);
-            break;
-        }
-        case 1: // FET: independent OUTPUT knob, no chain coupling.
-        {
-            track.strip.compFetOutput.store (jlimit (-20.0f, 20.0f, dB),
-                                              std::memory_order_relaxed);
-            break;
-        }
-        case 2:
-        default:
-            track.strip.compVcaOutput.store (jlimit (-20.0f, 20.0f, dB),
-                                              std::memory_order_relaxed);
-            break;
-    }
+    comp::applyTrackCompMakeupDb (track.strip, (float) makeupKnob.getValue());
 }
 
 // Read back per-mode params and update the knob displays (called when the
@@ -445,14 +427,13 @@ void ChannelCompEditor::writeMakeupToMode()
 void ChannelCompEditor::syncKnobsFromMode()
 {
     const int mode = jlimit (0, 2, track.strip.compMode.load (std::memory_order_relaxed));
+    makeupKnob.setValue (comp::trackCompMakeupDb (track.strip), juce::dontSendNotification);
     switch (mode)
     {
         case 0: // Opto
         {
             const float peakRed = track.strip.compOptoPeakRed.load (std::memory_order_relaxed);
             threshKnob.setValue (-peakRed * (60.0f / 100.0f), juce::dontSendNotification);
-            const float gain = track.strip.compOptoGain.load (std::memory_order_relaxed);
-            makeupKnob.setValue ((gain - 50.0f) / 2.5f, juce::dontSendNotification);
             // ratio/attack/release: leave at displayed values; they don't apply
             break;
         }
@@ -471,7 +452,6 @@ void ChannelCompEditor::syncKnobsFromMode()
             ratioKnob.setValue   (kFetRatioDisplay[ratioIdx], juce::dontSendNotification);
             attackKnob.setValue  (track.strip.compFetAttack.load  (std::memory_order_relaxed), juce::dontSendNotification);
             releaseKnob.setValue (track.strip.compFetRelease.load (std::memory_order_relaxed), juce::dontSendNotification);
-            makeupKnob.setValue  (track.strip.compFetOutput.load  (std::memory_order_relaxed), juce::dontSendNotification);
             break;
         }
         case 2: // VCA
@@ -480,7 +460,6 @@ void ChannelCompEditor::syncKnobsFromMode()
             ratioKnob.setValue   (track.strip.compVcaRatio.load    (std::memory_order_relaxed), juce::dontSendNotification);
             attackKnob.setValue  (track.strip.compVcaAttack.load   (std::memory_order_relaxed), juce::dontSendNotification);
             releaseKnob.setValue (track.strip.compVcaRelease.load  (std::memory_order_relaxed), juce::dontSendNotification);
-            makeupKnob.setValue  (track.strip.compVcaOutput.load   (std::memory_order_relaxed), juce::dontSendNotification);
             break;
     }
 }

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -9,6 +9,7 @@
 #include "EmbeddedModal.h"
 #include "HardwareInsertEditor.h"
 #include "PluginPickerHelpers.h"
+#include "../engine/CompMakeupMap.h"
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
   #include "ClapPluginEditorComponent.h"   // Linux-only native CLAP editor
 #endif
@@ -350,13 +351,12 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
     setupCompKnob (optoGainKnob, optoGainLabel, "MAK",
                    0.0, 100.0, 50.0, 0.0, "Output gain (50 % = unity = 0 dB)",
                    track.strip.compOptoGain, "", 0);
-    // Display the OPTO gain in dB (matches the popup editor's GAIN knob).
-    // Storage stays in percent (0..100, 50 = unity) per the donor's
-    // opto_gain parameter contract: dB = (pct - 50) / 2.5.
+    // Display the OPTO gain in dB. Storage stays in percent (0..100,
+    // 50 = unity) - the dial-to-dB conversion is the donor's, and the
+    // popup editor's MAKEUP knob reads the same helper.
     optoGainKnob.textFromValueFunction = [] (double pct) -> juce::String
     {
-        const double db = (pct - 50.0) / 2.5;
-        return juce::String (db, 1) + " dB";
+        return juce::String (comp::optoGainPctToMakeupDb ((float) pct), 1) + " dB";
     };
     optoGainKnob.updateText();
     // Comp threshold + makeup right-click hooks. Each per-mode "threshold-

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -91,6 +91,7 @@ add_executable(dusk-studio-tests
     mcu_receiver_decode.cpp
     mcu_controller_emit.cpp
     mcu_fader_taper.cpp
+    comp_makeup_fanout.cpp
     foundation_message_thread.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/McuReceiver.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/McuController.cpp

--- a/tests/comp_makeup_fanout.cpp
+++ b/tests/comp_makeup_fanout.cpp
@@ -1,0 +1,193 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "engine/CompMakeupMap.h"
+#include "session/Session.h"
+
+using Catch::Matchers::WithinAbs;
+using namespace duskstudio;
+
+TEST_CASE ("comp makeup fans out to the active mode's audible param",
+           "[comp][makeup]")
+{
+    Session s;
+    auto& strip = s.track (0).strip;
+
+    SECTION ("Opto: dB rides the donor's 0..100 dial at 0.8 dB per unit")
+    {
+        strip.compMode.store (0, std::memory_order_relaxed);
+        comp::applyTrackCompMakeupDb (strip, 6.0f);
+        REQUIRE_THAT (strip.compOptoGain.load (std::memory_order_relaxed),
+                      WithinAbs (57.5f, 1e-4f));
+    }
+
+    SECTION ("FET: dB lands on the OUTPUT param")
+    {
+        strip.compMode.store (1, std::memory_order_relaxed);
+        comp::applyTrackCompMakeupDb (strip, -3.5f);
+        REQUIRE_THAT (strip.compFetOutput.load (std::memory_order_relaxed),
+                      WithinAbs (-3.5f, 1e-4f));
+    }
+
+    SECTION ("VCA: dB lands on the OUTPUT param")
+    {
+        strip.compMode.store (2, std::memory_order_relaxed);
+        comp::applyTrackCompMakeupDb (strip, 9.25f);
+        REQUIRE_THAT (strip.compVcaOutput.load (std::memory_order_relaxed),
+                      WithinAbs (9.25f, 1e-4f));
+    }
+
+    SECTION ("only the active mode's param moves")
+    {
+        strip.compMode.store (1, std::memory_order_relaxed);
+        comp::applyTrackCompMakeupDb (strip, 8.0f);
+        REQUIRE_THAT (strip.compVcaOutput.load (std::memory_order_relaxed),
+                      WithinAbs (0.0f, 1e-4f));
+        REQUIRE_THAT (strip.compOptoGain.load (std::memory_order_relaxed),
+                      WithinAbs (50.0f, 1e-4f));
+    }
+}
+
+// Unity has to be unity in every mode: Opto's dial centre is 50, the two
+// output params sit at 0 dB.
+TEST_CASE ("comp makeup 0 dB is unity in every mode", "[comp][makeup]")
+{
+    Session s;
+    auto& strip = s.track (0).strip;
+
+    strip.compMode.store (0, std::memory_order_relaxed);
+    strip.compOptoGain.store (80.0f, std::memory_order_relaxed);
+    comp::applyTrackCompMakeupDb (strip, 0.0f);
+    REQUIRE_THAT (strip.compOptoGain.load (std::memory_order_relaxed),
+                  WithinAbs (50.0f, 1e-4f));
+
+    strip.compMode.store (1, std::memory_order_relaxed);
+    strip.compFetOutput.store (12.0f, std::memory_order_relaxed);
+    comp::applyTrackCompMakeupDb (strip, 0.0f);
+    REQUIRE_THAT (strip.compFetOutput.load (std::memory_order_relaxed),
+                  WithinAbs (0.0f, 1e-4f));
+}
+
+TEST_CASE ("comp makeup read-back is the exact inverse of the fan-out",
+           "[comp][makeup]")
+{
+    Session s;
+    auto& strip = s.track (0).strip;
+
+    for (int mode = 0; mode <= 2; ++mode)
+    {
+        strip.compMode.store (mode, std::memory_order_relaxed);
+        const auto domain = comp::makeupDomainFor (strip);
+        for (float db : { domain.minDb, -0.5f, 0.0f, 3.0f, domain.maxDb })
+        {
+            comp::applyTrackCompMakeupDb (strip, db);
+            REQUIRE_THAT (comp::trackCompMakeupDb (strip), WithinAbs (db, 1e-3f));
+        }
+    }
+}
+
+// Each mode's dial has its own reach: Opto spans +/-40 dB, the FET and VCA
+// output params +/-20. Past the edge the fan-out saturates instead of
+// wrapping or writing an out-of-range value the donor would clamp anyway,
+// and the read-back reports the saturated value so a relative control
+// nudged past the edge steps straight back down.
+TEST_CASE ("comp makeup saturates at each mode's domain edge", "[comp][makeup]")
+{
+    Session s;
+    auto& strip = s.track (0).strip;
+
+    strip.compMode.store (0, std::memory_order_relaxed);
+    REQUIRE_THAT (comp::makeupDomainFor (strip).maxDb, WithinAbs (40.0f, 1e-6f));
+    comp::applyTrackCompMakeupDb (strip, 48.0f);
+    REQUIRE_THAT (strip.compOptoGain.load (std::memory_order_relaxed),
+                  WithinAbs (100.0f, 1e-4f));
+    REQUIRE_THAT (comp::trackCompMakeupDb (strip), WithinAbs (40.0f, 1e-4f));
+    comp::applyTrackCompMakeupDb (strip, -48.0f);
+    REQUIRE_THAT (strip.compOptoGain.load (std::memory_order_relaxed),
+                  WithinAbs (0.0f, 1e-4f));
+    REQUIRE_THAT (comp::trackCompMakeupDb (strip), WithinAbs (-40.0f, 1e-4f));
+
+    strip.compMode.store (1, std::memory_order_relaxed);
+    REQUIRE_THAT (comp::makeupDomainFor (strip).maxDb, WithinAbs (20.0f, 1e-6f));
+    comp::applyTrackCompMakeupDb (strip, 24.0f);
+    REQUIRE_THAT (strip.compFetOutput.load (std::memory_order_relaxed),
+                  WithinAbs (20.0f, 1e-4f));
+
+    strip.compMode.store (2, std::memory_order_relaxed);
+    comp::applyTrackCompMakeupDb (strip, -40.0f);
+    REQUIRE_THAT (strip.compVcaOutput.load (std::memory_order_relaxed),
+                  WithinAbs (-20.0f, 1e-4f));
+}
+
+// A param carrying a value from outside its documented range (a hand-edited
+// session, a donor default that moved) must not hand a relative control a
+// base it can never write back.
+TEST_CASE ("comp makeup read-back clamps an out-of-range param",
+           "[comp][makeup]")
+{
+    Session s;
+    auto& strip = s.track (0).strip;
+
+    strip.compMode.store (1, std::memory_order_relaxed);
+    strip.compFetOutput.store (35.0f, std::memory_order_relaxed);
+    REQUIRE_THAT (comp::trackCompMakeupDb (strip), WithinAbs (20.0f, 1e-4f));
+
+    strip.compMode.store (0, std::memory_order_relaxed);
+    strip.compOptoGain.store (140.0f, std::memory_order_relaxed);
+    REQUIRE_THAT (comp::trackCompMakeupDb (strip), WithinAbs (40.0f, 1e-4f));
+}
+
+// The binding pair is what MidiBindingTarget::TrackCompMakeup drives: apply
+// maps the CC fraction through the active mode's domain, the soft-takeover
+// read-back inverts it. Both directions are pinned against the per-mode
+// ranges the binding has always used - Opto is a straight 0..100 % sweep of
+// the fraction, FET / VCA a -20..+20 dB sweep - because a bound CC that
+// moved would be a regression on the path this control already had right.
+TEST_CASE ("comp makeup binding pair matches the per-mode CC ranges",
+           "[comp][makeup][binding]")
+{
+    Session s;
+    auto& strip = s.track (0).strip;
+
+    for (float frac : { 0.0f, 0.25f, 0.5f, 0.75f, 1.0f })
+    {
+        strip.compMode.store (0, std::memory_order_relaxed);
+        comp::applyTrackCompMakeupDb (strip, comp::makeupBindingFracToDb (strip, frac));
+        REQUIRE_THAT (strip.compOptoGain.load (std::memory_order_relaxed),
+                      WithinAbs (frac * 100.0f, 1e-4f));
+        REQUIRE_THAT (comp::makeupBindingFrac (strip), WithinAbs (frac, 1e-4f));
+
+        strip.compMode.store (1, std::memory_order_relaxed);
+        comp::applyTrackCompMakeupDb (strip, comp::makeupBindingFracToDb (strip, frac));
+        REQUIRE_THAT (strip.compFetOutput.load (std::memory_order_relaxed),
+                      WithinAbs (-20.0f + frac * 40.0f, 1e-4f));
+        REQUIRE_THAT (comp::makeupBindingFrac (strip), WithinAbs (frac, 1e-4f));
+
+        strip.compMode.store (2, std::memory_order_relaxed);
+        comp::applyTrackCompMakeupDb (strip, comp::makeupBindingFracToDb (strip, frac));
+        REQUIRE_THAT (strip.compVcaOutput.load (std::memory_order_relaxed),
+                      WithinAbs (-20.0f + frac * 40.0f, 1e-4f));
+        REQUIRE_THAT (comp::makeupBindingFrac (strip), WithinAbs (frac, 1e-4f));
+    }
+}
+
+// Read-back from a param the binding did not write (UI knob, MCU, session
+// load) still has to report the position pickup expects.
+TEST_CASE ("comp makeup binding read-back reports the param's position",
+           "[comp][makeup][binding]")
+{
+    Session s;
+    auto& strip = s.track (0).strip;
+
+    strip.compMode.store (0, std::memory_order_relaxed);
+    strip.compOptoGain.store (80.0f, std::memory_order_relaxed);
+    REQUIRE_THAT (comp::makeupBindingFrac (strip), WithinAbs (0.8f, 1e-4f));
+
+    strip.compMode.store (1, std::memory_order_relaxed);
+    strip.compFetOutput.store (10.0f, std::memory_order_relaxed);
+    REQUIRE_THAT (comp::makeupBindingFrac (strip), WithinAbs (0.75f, 1e-4f));
+
+    strip.compMode.store (2, std::memory_order_relaxed);
+    strip.compVcaOutput.store (-20.0f, std::memory_order_relaxed);
+    REQUIRE_THAT (comp::makeupBindingFrac (strip), WithinAbs (0.0f, 1e-4f));
+}

--- a/tests/mcu_receiver_decode.cpp
+++ b/tests/mcu_receiver_decode.cpp
@@ -4,6 +4,7 @@
 #include "engine/McuProtocol.h"
 #include "engine/McuReceiver.h"
 #include "session/Session.h"
+#include "session/SessionSerializer.h"
 #include "support/DuskMidiTestBridge.h"
 
 #include <juce_audio_basics/juce_audio_basics.h>
@@ -190,6 +191,141 @@ TEST_CASE ("McuReceiver: V-pot push (PAN mode) resets pan to 0", "[mcu][receiver
     r.process (makeNoteOn (mcu::btn::VPotPushBase + 3, 0x7F), 0);
     REQUIRE_THAT (s.track (3).strip.pan.load (std::memory_order_relaxed),
                   WithinAbs (0.0f, 1e-4f));
+}
+
+TEST_CASE ("McuReceiver: V-pot rotate (COMP mode) makeup moves the audible param",
+           "[mcu][receiver]")
+{
+    Session s;
+    McuReceiver r (s);
+    s.mcu.assignMode.store (6, std::memory_order_relaxed);       // COMP
+    s.mcu.selectedChannel.store (2, std::memory_order_relaxed);
+    auto& strip = s.track (2).strip;
+
+    // Encoder 5 (index 4) is MAKEUP, 0.3 dB per tick. The value the DSP
+    // reads is the active mode's output param, and a tick is worth the
+    // same real dB in every mode.
+    strip.compMode.store (2, std::memory_order_relaxed);         // VCA
+    r.process (makeCc (mcu::cc::VPotRotateBase + 4, 0x05), 0);   // +5 ticks
+    REQUIRE_THAT (strip.compVcaOutput.load (std::memory_order_relaxed),
+                  WithinAbs (1.5f, 1e-4f));
+
+    // Opto's makeup is the donor's 0..100 dial at 0.8 dB per unit, so the
+    // same +1.5 dB from unity is 51.875, not a raw +1.5 on the dial.
+    strip.compMode.store (0, std::memory_order_relaxed);
+    r.process (makeCc (mcu::cc::VPotRotateBase + 4, 0x05), 0);
+    REQUIRE_THAT (strip.compOptoGain.load (std::memory_order_relaxed),
+                  WithinAbs (51.875f, 1e-3f));
+
+    // Left turn: bit 6 set = negative. 2 ticks = -0.6 dB, so +0.9 dB total.
+    r.process (makeCc (mcu::cc::VPotRotateBase + 4, 0x40 | 0x02), 0);
+    REQUIRE_THAT (strip.compOptoGain.load (std::memory_order_relaxed),
+                  WithinAbs (51.125f, 1e-3f));
+}
+
+// A strip parked at the bottom of its makeup range - a CC binding driven to
+// zero, or a session that stored the floor - must step by one tick from
+// there. Clamping the base into some other range first would fling the
+// strip several dB on the very first tick.
+TEST_CASE ("McuReceiver: makeup nudge steps from the mode's floor",
+           "[mcu][receiver]")
+{
+    Session s;
+    McuReceiver r (s);
+    s.mcu.assignMode.store (6, std::memory_order_relaxed);
+    auto& strip = s.track (0).strip;
+    strip.compMode.store (1, std::memory_order_relaxed);          // FET
+    strip.compFetOutput.store (-20.0f, std::memory_order_relaxed);
+
+    r.process (makeCc (mcu::cc::VPotRotateBase + 4, 0x01), 0);
+    REQUIRE_THAT (strip.compFetOutput.load (std::memory_order_relaxed),
+                  WithinAbs (-19.7f, 1e-4f));
+
+    // Down from the floor holds at the floor rather than drifting below it.
+    r.process (makeCc (mcu::cc::VPotRotateBase + 4, 0x40 | 0x0A), 0);
+    REQUIRE_THAT (strip.compFetOutput.load (std::memory_order_relaxed),
+                  WithinAbs (-20.0f, 1e-4f));
+}
+
+TEST_CASE ("McuReceiver: V-pot push (COMP mode) returns makeup to unity",
+           "[mcu][receiver]")
+{
+    Session s;
+    McuReceiver r (s);
+    s.mcu.assignMode.store (6, std::memory_order_relaxed);
+    s.mcu.selectedChannel.store (1, std::memory_order_relaxed);
+    auto& strip = s.track (1).strip;
+    strip.compMode.store (1, std::memory_order_relaxed);         // FET
+    strip.compFetOutput.store (7.5f, std::memory_order_relaxed);
+
+    r.process (makeNoteOn (mcu::btn::VPotPushBase + 4, 0x7F), 0);
+    REQUIRE_THAT (strip.compFetOutput.load (std::memory_order_relaxed),
+                  WithinAbs (0.0f, 1e-4f));
+
+    strip.compMode.store (0, std::memory_order_relaxed);         // Opto
+    strip.compOptoGain.store (80.0f, std::memory_order_relaxed);
+    r.process (makeNoteOn (mcu::btn::VPotPushBase + 4, 0x7F), 0);
+    REQUIRE_THAT (strip.compOptoGain.load (std::memory_order_relaxed),
+                  WithinAbs (50.0f, 1e-4f));  // unity, not silence
+}
+
+// The makeup encoder is relative, so the value it nudges from has to still
+// be there after a reload: one tick on a freshly-loaded session continues
+// from the saved makeup instead of restarting near unity.
+TEST_CASE ("McuReceiver: makeup nudge base survives a session reload",
+           "[mcu][receiver]")
+{
+    const auto dir = juce::File::getSpecialLocation (juce::File::tempDirectory)
+                        .getChildFile ("dusk-studio-mcu-makeup-"
+                                          + juce::String (juce::Random::getSystemRandom().nextInt()));
+    dir.createDirectory();
+    const auto target = dir.getChildFile ("session.json");
+
+    Session a;
+    McuReceiver ra (a);
+    a.mcu.assignMode.store (6, std::memory_order_relaxed);
+
+    SECTION ("VCA")
+    {
+        a.track (0).strip.compMode.store (2, std::memory_order_relaxed);
+        ra.process (makeCc (mcu::cc::VPotRotateBase + 4, 0x14), 0);   // +20 ticks = +6 dB
+        REQUIRE_THAT (a.track (0).strip.compVcaOutput.load (std::memory_order_relaxed),
+                      WithinAbs (6.0f, 1e-4f));
+        REQUIRE (SessionSerializer::save (a, target));
+
+        Session b;
+        REQUIRE (SessionSerializer::load (b, target));
+        REQUIRE (b.mcu.assignMode.load (std::memory_order_relaxed) == 6);
+        REQUIRE_THAT (b.track (0).strip.compVcaOutput.load (std::memory_order_relaxed),
+                      WithinAbs (6.0f, 1e-4f));
+
+        McuReceiver rb (b);
+        rb.process (makeCc (mcu::cc::VPotRotateBase + 4, 0x01), 0);
+        REQUIRE_THAT (b.track (0).strip.compVcaOutput.load (std::memory_order_relaxed),
+                      WithinAbs (6.3f, 1e-4f));
+    }
+
+    SECTION ("Opto")
+    {
+        // +6 dB on the dial is 57.5; one more tick is +6.3 dB = 57.875.
+        a.track (0).strip.compMode.store (0, std::memory_order_relaxed);
+        ra.process (makeCc (mcu::cc::VPotRotateBase + 4, 0x14), 0);
+        REQUIRE_THAT (a.track (0).strip.compOptoGain.load (std::memory_order_relaxed),
+                      WithinAbs (57.5f, 1e-3f));
+        REQUIRE (SessionSerializer::save (a, target));
+
+        Session b;
+        REQUIRE (SessionSerializer::load (b, target));
+        REQUIRE_THAT (b.track (0).strip.compOptoGain.load (std::memory_order_relaxed),
+                      WithinAbs (57.5f, 1e-3f));
+
+        McuReceiver rb (b);
+        rb.process (makeCc (mcu::cc::VPotRotateBase + 4, 0x01), 0);
+        REQUIRE_THAT (b.track (0).strip.compOptoGain.load (std::memory_order_relaxed),
+                      WithinAbs (57.875f, 1e-3f));
+    }
+
+    dir.deleteRecursively();
 }
 
 TEST_CASE ("McuReceiver: PLAY / STOP / RECORD buttons enqueue pendingTransportAction",


### PR DESCRIPTION
Closes #189.

The MCU channel-comp makeup encoder (V-pot 5 in COMP assign) nudged `compMakeupDb`, a track parameter no DSP reads, so the encoder was inaudible; the MIDI-binding path fanned out to the mode's real parameter correctly. Both paths, plus the comp editor, now share one mapping in `src/engine/CompMakeupMap.h`: apply writes the active mode's audible parameter (the optical gain dial, FET output, or VCA output), derive is its exact inverse, and the MCU nudge takes its base from derive rather than from a stale mirror. V-pot push-to-reset had the same defect and is fixed with it.

Deriving rather than serializing was the choice because the mirror goes stale in more ways than a reload: a comp-mode switch, an undo restore, and the inline strip's per-mode knobs all move the audible parameter without touching it. `ChannelStripParams::compMakeupDb` had no reader left after this and is deleted; the aux, master and mastering structs keep their own same-named parameters, which do drive DSP and are serialized. No session key changed, so old and new sessions load identically.

**The mapping was wrong, and not only for the surface.** The dB-to-dial constant used throughout was 2.5 % per dB; the donor's optical dial is 0.8 dB per unit (`UniversalCompressorDSP.cpp`, `OptoGainMapping.h`), i.e. 1.25 % per dB with a ±40 dB span. Every Opto makeup write in the app was therefore twice as hot as its label, and the editor knob's fixed −12 to +24 dB range matched no mode: in Opto it left the top and bottom of the dial out of reach, in FET and VCA the last 4 dB were dead. The mapping is now per-mode (Opto ±40, FET and VCA ±20), the editor knob retunes with the mode, and the inline strip's dB readout goes through the same helper instead of carrying its own copy of the old constant. The binding path's values are unchanged in every mode: a bound CC sweeps the same range and soft-takeover picks up at the same position as before.

**What you will see on an existing session:** an Opto strip whose stored dial sits at 80 now reads +24 dB instead of +12 dB. The audio is identical and nothing is rewritten on disk; the label was wrong before and is right now. MANUAL's makeup range lines are corrected to match.

Tests: 619 pass. New coverage for the fan-out to each mode, the derive/apply inverse including domain edges and saturation, per-mode unity, the binding pair's parity with the values the old code produced, the nudge stepping from a mode floor without the clamp-up jump this change would otherwise have introduced, and reload continuity. Reverting the corrected constant alone reddens eight of them.

The knob-range wiring is not headlessly testable (the test binary deliberately does not link juce_gui_basics), so it needs a bench check: open the comp popup on an Opto strip whose dial is at 100, confirm MAKEUP reads +40 dB and that touching it does not snap the gain; repeat at dial 0 for −40; switch the popup to FET and back and confirm the value survives the round-trip.

Other bench steps: 5 clockwise ticks on V-pot 5 in Opto should move the dial to 51.875 (+1.5 dB) and be audible; push resets to unity (dial 50, not 0); after save and reload one tick continues from the saved value rather than restarting at 0.3 dB; and a CC bound to track comp makeup should produce the same audible result with soft-takeover pickup at the knob's current position in all three modes.
