### PR TITLE
docs: record the fixes that landed after the changelog was written

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@ application framework and became Dusk Studio's own.
   math utilities are now Dusk Studio's own code rather than the application
   framework's. Behaviour is unchanged by design; this is the groundwork for
   the interface rewrite.
+- **License texts ship with the packages.** The tarball, the deb and rpm,
+  the DMG and the MSI now carry `LICENSE` and `LICENSES.txt`, and the
+  attribution list credits the notepad's UI stack (DPF, Dear ImGui, pugl and
+  the components they embed) along with the CLAP headers.
 
 ### Fixed
 
@@ -89,7 +93,15 @@ application framework and became Dusk Studio's own.
   reopened. They round-trip now, and fall back to the model default when the
   keys are absent.
 - **Console bank switching.** Changing bank left MIDI bank bindings and the
-  Mackie surface pointing at the previous eight strips.
+  Mackie surface pointing at the previous eight strips. Resizing the window no
+  longer strands the visible page away from the bank the surface is driving,
+  and a bank press made during a window drag is no longer swallowed.
+- **Compressor makeup on the control surface.** The makeup encoder wrote a
+  parameter no processing read, so turning it did nothing and pushing it to
+  reset did nothing either. It now drives the active compressor mode's gain,
+  the same one a MIDI binding drives. The optical mode's makeup was also
+  labelled at half its real value everywhere it appeared, so a reading of
+  +12 dB was delivering +24 dB; the numbers now match the gain.
 - **Joining regions.** A join could land on the wrong slot, cut the merged
   region short, or drop the last region's fade-out; the merge now sizes from
   the latest end across the selection and carries that region's fade. Editing
@@ -107,7 +119,9 @@ application framework and became Dusk Studio's own.
   belongs to. A plugin slot also re-publishes reliably after a reload.
 - **MIDI and soundfonts.** Hung notes no longer lose their tail, CC values no
   longer diverge from what was sent, and several SF2-to-SFZ translation faults
-  are corrected.
+  are corrected. A dense burst that filled the input ring but overflowed a
+  smaller downstream buffer used to be dropped whole, note-offs included; every
+  buffer along the path now matches the ring.
 - **Interface.** Modals opened over the notepad are visible and no longer leak
   keystrokes to the transport; the on-screen keyboard's note keys no longer
   double as transport shortcuts; modal teardown, plugin editor embedding and


### PR DESCRIPTION
Part of #178.

The 0.13.0 section was written before the last four PRs merged, so it does not mention them:

- The console-bank bullet gains the resize half of #186: a resize could strand the visible page away from the bank the surface was driving, and a bank press made during a window drag could be swallowed.
- The compressor makeup encoder (#189) gets its own entry. It is a control-surface fix, but the second half of it affects everyone: the optical mode's makeup was labelled at half its real value everywhere it appeared, so a knob reading +12 dB was delivering +24 dB. That is worth a user seeing before they wonder why their mixes changed.
- The MIDI bullet gains the drain sizing from #187: a dense burst that filled the input ring but overflowed a smaller downstream buffer was dropped whole, note-offs included.
- A Changed entry for #179, since the packages now carry LICENSE and LICENSES.txt and the attribution list covers the notepad's UI stack.

Changelog only. The bump script's `## [0.13.0]` gate still passes and the section stays ASCII.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed console bank switching and window resizing behavior.
  - Corrected compressor makeup control behavior and optical-mode gain labeling.
  - Improved MIDI buffer handling to preserve dense note bursts and note-off messages.

- **Documentation**
  - Added packaged license texts and expanded attribution credits for version 0.13.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->