### PR TITLE
chore(licensing): cover the JUCE-bundled libraries and fix two wrong entries

### DIFF
--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -6,14 +6,18 @@ external component bundled or vendored into the build, the license it
 ships under, and the path where it lives. Update whenever a new
 dependency is added so the legal surface stays auditable.
 
-The full-texts section at the foot of this file reproduces the licenses that
-require a copy of the license text itself to travel with a binary: Apache-2.0,
-and the BSD / IJG / PNG / zlib / Old MIT terms of the codecs and font libraries
-JUCE bundles. That is not yet every text a complete offline notices file would
-carry — the MIT and ISC components listed above ask for their permission notice
-in copies too, and those are named and attributed here rather than reproduced.
-Every entry cites the upstream license file by path, so the missing texts can
-be read at their source until they are folded in.
+The full-texts section at the foot of this file carries the licenses that bind
+a binary distribution: the AGPLv3 covering JUCE, Apache-2.0 covering SheenBidi
+and abseil-cpp, the BSD-3-Clause terms of libFLAC and Ogg/Vorbis (whose
+binary-form clause says to reproduce them in the documentation), the IJG terms
+behind the libjpeg acknowledgement, and HarfBuzz's Old MIT notice. The libpng
+and zlib texts are there for completeness rather than obligation — both bind
+source distribution only, and both make the binary acknowledgement explicitly
+optional. Not every text a complete offline notices file would carry is here
+yet: the remaining MIT and ISC components ask for their permission notice in
+copies too, and those are named and attributed rather than reproduced. Every
+entry cites its upstream license file by path, so the missing texts can be read
+at their source until they are folded in.
 
 PROJECT LICENSE
 ---------------
@@ -28,8 +32,14 @@ JUCE (audio framework)
              4d85afa175a45e0b5da11f9211de3ba88705588e — the JUCE_TAG / JUCE_REV
              pin in .github/workflows/linux-build.yml); 8.0.4 from upstream
              juce-framework/JUCE on the macOS and Windows runners
-  License  : Dual-licensed — AGPLv3 (used here) OR JUCE Commercial
-             (JUCE-wayland/LICENSE.md)
+  License  : Dual-licensed — AGPLv3 (used here) OR JUCE Commercial. JUCE's
+             LICENSE.md states the dual grant but carries no license text of
+             its own, only a link to gnu.org, so the AGPLv3 is reproduced in
+             full at the foot of this file. Dusk Studio's own LICENSE is the
+             GPLv3 text, which is a different document and does not stand in
+             for it: the JUCE part of the binary stays under AGPLv3 and that
+             license, like every GPL-family license, wants a copy to reach
+             whoever receives the work.
   Path     : ../JUCE-wayland (Linux), ../JUCE (macOS/Windows)
   Upstream : https://juce.com/
   Notes    : GPLv3 section 13 grants permission to combine a GPLv3 covered work
@@ -44,10 +54,11 @@ JUCE (audio framework)
              flags that would exclude them (JUCE_USE_FLAC, JUCE_USE_OGGVORBIS,
              JUCE_INCLUDE_PNGLIB_CODE, JUCE_INCLUDE_JPEGLIB_CODE,
              JUCE_INCLUDE_ZLIB_CODE) is set anywhere in the build, so every one
-             stays at its default of enabled. Versions are those vendored in
-             the 8.0.12 Linux pin; upstream 8.0.4 can carry different ones.
-             Licenses marked "reproduced below" require their text to ship
-             with a binary; those texts are at the foot of this file.
+             stays at its default of enabled. The versions on each line are the
+             8.0.12 Linux pin; the macOS / Windows column is recorded further
+             down, and five of these differ there.
+             Licenses marked "reproduced below" have their text at the foot of
+             this file.
                - SheenBidi     2.9.0, Apache-2.0
                                modules/juce_graphics/unicode/sheenbidi/LICENSE
                                (Copyright (C) 2014-2025 Muhammad Tayyab Akram —
@@ -71,12 +82,18 @@ JUCE (audio framework)
                                the work of the Independent JPEG Group.
                - libpng        1.6.37, PNG Reference Library License version 2
                                modules/juce_graphics/image_formats/pnglib/LICENSE;
-                               reproduced below. JUCE's own LICENSE.md labels
-                               this one "zlib", which is wrong — v2 is a
-                               distinct license.
+                               reproduced below for completeness — its
+                               notice-preservation clause binds source
+                               distribution, and it calls the acknowledgement in
+                               product documentation appreciated but not
+                               required. JUCE's own LICENSE.md labels this one
+                               "zlib", which is wrong — v2 is a distinct license.
                - zlib          1.3.1, zlib license
                                modules/juce_core/zip/zlib/LICENSE (Jean-loup
-                               Gailly and Mark Adler); reproduced below.
+                               Gailly and Mark Adler); reproduced below for
+                               completeness, on the same footing as libpng —
+                               clause 3 binds source distribution and clause 1
+                               makes the binary acknowledgement optional.
                - libFLAC       1.4.3, BSD-3-Clause
                                modules/juce_audio_formats/codecs/flac/
                                "Flac Licence.txt" (Josh Coalson 2000-2009,
@@ -91,7 +108,9 @@ JUCE (audio framework)
              JUCE_PLUGINHOST_VST3=1 and JUCE_PLUGINHOST_LV2=1 with no platform
              guard, so JUCE's own copies compile into the macOS and Windows
              binaries too.
-               - VST3 SDK      VST 3.8.0, MIT
+               - VST3 SDK      VST 3.8.0, MIT — on the Linux pin only; see the
+                               platform table below, 8.0.4 vendors 3.7.12 under
+                               Steinberg's older dual grant instead
                                modules/juce_audio_processors_headless/
                                format_types/VST3_SDK/LICENSE.txt (Copyright (c)
                                2025 Steinberg Media Technologies GmbH). This is
@@ -112,6 +131,37 @@ JUCE (audio framework)
                                src/zix file). Versions are the ones JUCE records
                                in format_types/LV2_SDK/juce_lv2_config.h; lv2
                                and sratom carry no version macro there.
+             The macOS and Windows runners build against upstream JUCE 8.0.4,
+             an older release that vendors older copies. Read out of the 8.0.4
+             tag's own version headers, the two columns are:
+                                     8.0.12 (Linux)     8.0.4 (macOS/Windows)
+               SheenBidi             2.9.0              no version header
+               HarfBuzz              10.1.0             9.0.0
+               libjpeg               9f, 14-Jan-2024    6b, 27-Mar-1998
+               zlib                  1.3.1              1.2.3
+               VST3 SDK              3.8.0, MIT         3.7.12, dual
+               libpng                1.6.37             1.6.37
+               libFLAC               1.4.3              1.4.3
+               Ogg / Vorbis          1.3.7              1.3.7
+               lilv / serd / sord    0.24.12 / 0.30.10 / 0.16.9, both
+             Three of those differences change what has to be said, not just a
+             number:
+               - libjpeg 6b is copyright (C) 1998 Thomas G. Lane alone, with no
+                 Guido Vollbeding. The IJG acknowledgement below is worded for
+                 both because it names no year, but a macOS or Windows artifact
+                 credits the 1998 copyright, not the 1991-2024 one.
+               - the 8.0.4 VST3 SDK is NOT MIT. Its LICENSE.txt is Steinberg's
+                 older dual grant — proprietary Steinberg VST3 License OR GPLv3
+                 ((c) 2024 Steinberg Media Technologies GmbH) — so macOS and
+                 Windows take it under the GPLv3 arm, exactly as the standalone
+                 external/vst3sdk entry below does. Steinberg relicensed the
+                 interface subset to MIT for 3.8.0.
+               - SheenBidi in 8.0.4 predates SBVersion.h and lays its headers
+                 out flat rather than under Headers/SheenBidi/. Same Apache-2.0
+                 license, so the reproduced text covers it; the version is
+                 simply not recorded in the source and is not guessed here.
+             Everything else matches, including every license identifier apart
+             from VST3's.
 
 Dusk Audio plugins (donor DSP cores)
   License  : GPL-3.0-or-later (matches Dusk Studio)
@@ -312,22 +362,28 @@ libsndfile (all audio file I/O — required on every platform)
              is a configure FATAL_ERROR, and both the app and the test binary
              link the dusk_sndfile interface target.
   Notes    : On Linux and macOS this is a dynamic link against the system
-             libsndfile (libsndfile.so.1), which is LGPL-2.1 section 6(b) —
-             the shared-library mechanism — and needs nothing further.
+             library — libsndfile.so.1 on Linux, libsndfile.1.dylib on macOS —
+             which is LGPL-2.1 section 6(b), the shared-library mechanism, and
+             needs nothing further.
              Windows takes a different route. The workflows run
              `vcpkg install mp3lame:x64-windows-static
              libsndfile:x64-windows-static`, which produces static libraries
              and pulls libsndfile's codec chain — FLAC, Ogg, Opus, mpg123 —
              into the executable alongside it, so no DLL ships and 6(b) is not
-             available. Section 6(a) is, and is already satisfied: Dusk Studio
-             is GPL-3.0-or-later with its complete corresponding source
-             published, and that source includes the exact vcpkg command above,
-             so anyone can rebuild the whole executable and relink it against a
-             modified libsndfile or mpg123. Nothing beyond the published source
-             is owed. Note that vcpkg runs there in classic mode with no
-             manifest, so the codec versions in a given Windows build are the
-             ones that runner's vcpkg baseline supplied rather than a version
-             pinned in this repo.
+             available. That leaves section 6(a), the relink route, and the
+             honest position is that Dusk Studio meets most of it but not all:
+             the application is GPL-3.0-or-later with its complete
+             corresponding source published, and that source carries the exact
+             vcpkg command above, so the build is reproducible in shape. What
+             is missing is a version pin. vcpkg runs there in classic mode with
+             no manifest, so the libsndfile and mpg123 versions baked into any
+             given Windows artifact are whatever that runner's vcpkg baseline
+             supplied on the day, recorded only in the workflow log rather than
+             in this repository. Anyone wanting to relink can obtain those
+             sources from vcpkg upstream, but pinning them here — a vcpkg
+             manifest, or shipping relink materials alongside the artifact —
+             is outstanding work, not something this file should claim is
+             already done.
              libsndfile is LGPL-2.1-or-later and mpg123 LGPL-2.1-only. FLAC and
              Ogg are BSD-3-Clause (texts at the foot of this file, from JUCE's
              vendored copies of the same projects); Opus is BSD-3-Clause
@@ -361,9 +417,9 @@ LAME / libmp3lame (MP3 bounce export — optional)
              /usr/lib64/libmp3lame.so), so LGPL-2.1 section 6(b) applies.
              Windows is the exception: the same vcpkg x64-windows-static
              command described under libsndfile installs mp3lame statically,
-             so a Windows build links it into the executable and discharges
-             section 6 by the same 6(a) route — published complete
-             corresponding source that anyone can rebuild and relink.
+             so a Windows build links it into the executable and falls under
+             the same section 6(a) route, with the same unpinned-version gap
+             noted there.
              Present in a binary only if the build was configured with
              libmp3lame available.
   Upstream : https://lame.sourceforge.io/
@@ -450,29 +506,705 @@ Redistribute the binary: Allowed under GPL-3.0 terms. Include LICENSE,
                           (plus a Debian-policy `copyright` copy), the top
                           level of the Linux tarball, and beside the app in
                           the macOS DMG and the Windows MSI.
-                          That same source-code availability is what
-                          discharges the LGPL section 6 obligation on the
-                          statically linked libsndfile and mpg123 in a
-                          Windows build — no separate object-code drop is
-                          owed. Carrying this file also discharges the
-                          third-party notices the GPL itself does not cover,
-                          such as the IJG acknowledgement and the BSD
-                          copyright notices reproduced below.
+                          Carrying this file also discharges the third-party
+                          notices the GPL itself does not cover, such as the
+                          IJG acknowledgement, the BSD copyright notices and
+                          the AGPLv3 text JUCE's own license points at
+                          without supplying. One thing is NOT settled: the
+                          LGPL section 6 relink route for the statically
+                          linked libsndfile and mpg123 in a Windows build.
+                          See the libsndfile entry — the versions are not
+                          pinned in this repository yet.
 
 
 FULL LICENSE TEXTS
 ------------------
 
-Each license below has a clause that makes its text, or its copyright notice
-and warranty disclaimer, part of any binary distribution. Naming the license is
-not enough for those, so they are set out here: each block is a verbatim copy
-of the file at the path above it, or of the relevant section where the block
-header says so. Paths starting `modules/` are inside the JUCE tree Dusk Studio
-builds against on Linux — dusk-audio/JUCE-wayland tag dusk-wayland-v2, rev
-4d85afa175a45e0b5da11f9211de3ba88705588e, JUCE 8.0.12. The macOS and Windows
-runners build against upstream JUCE 8.0.4, whose vendored copies may carry
-different versions of the same libraries under the same licenses.
+Most of the licenses below have a clause that makes their text, or their
+copyright notice and warranty disclaimer, part of any binary distribution;
+naming them is not enough. The libpng and zlib blocks are the exceptions,
+included for completeness — their terms bind source distribution and make the
+binary acknowledgement optional, as the intro at the top of this file says.
+Each block is a verbatim copy of the file at the path above it, or of the
+relevant section where the block header says so. Paths starting `modules/` are
+inside the JUCE tree Dusk Studio builds against on Linux — the
+dusk-audio/JUCE-wayland tag dusk-wayland-v2, rev
+4d85afa175a45e0b5da11f9211de3ba88705588e, JUCE 8.0.12. The per-platform version
+inventory for those is in the JUCE entry above; upstream 8.0.4 on macOS and
+Windows carries the same licenses apart from the VST3 SDK, which is noted
+there.
 
+
+--------------------------------------------------------------------------------
+JUCE 8.0.12 / 8.0.4 — GNU Affero General Public License v3
+JUCE-wayland/LICENSE.md names this license and links to it, but ships no
+copy. Text below is the canonical FSF document from the address that
+LICENSE.md points at, https://www.gnu.org/licenses/agpl-3.0.txt, verbatim.
+It governs the JUCE part of the binary; Dusk Studio's own code is
+GPL-3.0-or-later and its text is the separate LICENSE file.
+--------------------------------------------------------------------------------
+
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.
 
 --------------------------------------------------------------------------------
 Apache License 2.0 — covers both Apache-2.0 components in the binary:

--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -6,6 +6,15 @@ external component bundled or vendored into the build, the license it
 ships under, and the path where it lives. Update whenever a new
 dependency is added so the legal surface stays auditable.
 
+The full-texts section at the foot of this file reproduces the licenses that
+require a copy of the license text itself to travel with a binary: Apache-2.0,
+and the BSD / IJG / PNG / zlib / Old MIT terms of the codecs and font libraries
+JUCE bundles. That is not yet every text a complete offline notices file would
+carry — the MIT and ISC components listed above ask for their permission notice
+in copies too, and those are named and attributed here rather than reproduced.
+Every entry cites the upstream license file by path, so the missing texts can
+be read at their source until they are folded in.
+
 PROJECT LICENSE
 ---------------
 Dusk Studio source code: GPL-3.0-or-later (./LICENSE)
@@ -15,11 +24,94 @@ VENDORED DEPENDENCIES (compiled into the Dusk Studio binary)
 ------------------------------------------------------
 
 JUCE (audio framework)
-  Version  : 8.x  (Linux pin: dusk-audio/JUCE-wayland tag dusk-wayland-v2;
-                   macOS/Win: upstream juce-framework/JUCE)
-  License  : Dual-licensed — GPL-3.0 (used here) OR JUCE Commercial
+  Version  : 8.0.12 on Linux (dusk-audio/JUCE-wayland tag dusk-wayland-v2, rev
+             4d85afa175a45e0b5da11f9211de3ba88705588e — the JUCE_TAG / JUCE_REV
+             pin in .github/workflows/linux-build.yml); 8.0.4 from upstream
+             juce-framework/JUCE on the macOS and Windows runners
+  License  : Dual-licensed — AGPLv3 (used here) OR JUCE Commercial
+             (JUCE-wayland/LICENSE.md)
   Path     : ../JUCE-wayland (Linux), ../JUCE (macOS/Windows)
   Upstream : https://juce.com/
+  Notes    : GPLv3 section 13 grants permission to combine a GPLv3 covered work
+             with an AGPLv3 work and convey the result, which is what Dusk
+             Studio's GPL-3.0-or-later code plus JUCE's AGPLv3 arm is. AGPLv3
+             section 13's own requirement — offer source to users who interact
+             with the program remotely over a network — then attaches to the
+             combination, and is inert here: Dusk Studio is a desktop
+             application with no remote-interaction surface.
+             The libraries below ship vendored inside the JUCE modules Dusk
+             Studio links and ARE compiled into the binary. None of the JUCE
+             flags that would exclude them (JUCE_USE_FLAC, JUCE_USE_OGGVORBIS,
+             JUCE_INCLUDE_PNGLIB_CODE, JUCE_INCLUDE_JPEGLIB_CODE,
+             JUCE_INCLUDE_ZLIB_CODE) is set anywhere in the build, so every one
+             stays at its default of enabled. Versions are those vendored in
+             the 8.0.12 Linux pin; upstream 8.0.4 can carry different ones.
+             Licenses marked "reproduced below" require their text to ship
+             with a binary; those texts are at the foot of this file.
+               - SheenBidi     2.9.0, Apache-2.0
+                               modules/juce_graphics/unicode/sheenbidi/LICENSE
+                               (Copyright (C) 2014-2025 Muhammad Tayyab Akram —
+                               widest range across the vendored sources);
+                               reproduced below, because Apache-2.0 section 4
+                               requires a copy of the license to accompany
+                               every distribution. Upstream ships no NOTICE
+                               file, so section 4(d) adds nothing beyond that.
+               - HarfBuzz      10.1.0, Old MIT
+                               modules/juce_graphics/fonts/harfbuzz/COPYING;
+                               reproduced below with its full copyright-holder
+                               list. That COPYING is the only one in the
+                               vendored subset — no subdirectory overrides it.
+               - libjpeg       9f (14-Jan-2024), Independent JPEG Group license
+                               modules/juce_graphics/image_formats/jpglib/README,
+                               LEGAL ISSUES section (copyright (C) 1991-2024
+                               Thomas G. Lane, Guido Vollbeding); reproduced
+                               below. Condition 2 of that license governs
+                               binary-only distribution and this sentence
+                               discharges it: this software is based in part on
+                               the work of the Independent JPEG Group.
+               - libpng        1.6.37, PNG Reference Library License version 2
+                               modules/juce_graphics/image_formats/pnglib/LICENSE;
+                               reproduced below. JUCE's own LICENSE.md labels
+                               this one "zlib", which is wrong — v2 is a
+                               distinct license.
+               - zlib          1.3.1, zlib license
+                               modules/juce_core/zip/zlib/LICENSE (Jean-loup
+                               Gailly and Mark Adler); reproduced below.
+               - libFLAC       1.4.3, BSD-3-Clause
+                               modules/juce_audio_formats/codecs/flac/
+                               "Flac Licence.txt" (Josh Coalson 2000-2009,
+                               Xiph.Org Foundation 2011-2023); reproduced
+                               below — the binary-form clause requires it.
+               - Ogg / Vorbis  libvorbis 1.3.7, BSD-3-Clause
+                               modules/juce_audio_formats/codecs/oggvorbis/
+                               "Ogg Vorbis Licence.txt" (Xiph.org Foundation
+                               2002-2020); reproduced below, same clause.
+             Two plugin-host SDKs come in the same way, and unlike the native
+             hosts further down they are NOT Linux-only: CMakeLists.txt sets
+             JUCE_PLUGINHOST_VST3=1 and JUCE_PLUGINHOST_LV2=1 with no platform
+             guard, so JUCE's own copies compile into the macOS and Windows
+             binaries too.
+               - VST3 SDK      VST 3.8.0, MIT
+                               modules/juce_audio_processors_headless/
+                               format_types/VST3_SDK/LICENSE.txt (Copyright (c)
+                               2025 Steinberg Media Technologies GmbH). This is
+                               the MIT-licensed interface subset Steinberg
+                               publishes for it, a different thing from the
+                               full SDK in external/vst3sdk below, which is
+                               dual GPLv3 / Steinberg proprietary.
+               - LV2 SDK       ISC, all five components
+                               modules/juce_audio_processors_headless/
+                               format_types/LV2_SDK/<name>/COPYING —
+                               lv2 (Steve Harris, David Robillard 2006-2012,
+                               based on LADSPA by Richard W.E. Furse, Paul
+                               Barton-Davis, Stefan Westerfeld 2000-2002),
+                               lilv 0.24.12, serd 0.30.10, sord 0.16.9 and
+                               sratom (David Robillard). zix rides along inside
+                               lilv and sord under the same ISC terms (David
+                               Robillard 2016-2020, notice at the head of each
+                               src/zix file). Versions are the ones JUCE records
+                               in format_types/LV2_SDK/juce_lv2_config.h; lv2
+                               and sratom carry no version macro there.
 
 Dusk Audio plugins (donor DSP cores)
   License  : GPL-3.0-or-later (matches Dusk Studio)
@@ -41,7 +133,20 @@ sfizz (SFZ / SoundFont sampler engine — powers the multisample instrument)
              compiled in. The sub-components below ship vendored inside sfizz
              and ARE compiled into the Dusk Studio binary; each keeps its own
              permissive license (full text at external/sfizz/**/LICENSE):
-               - abseil-cpp    Apache-2.0   external/sfizz/external/abseil-cpp/
+               - abseil-cpp    LTS 20230125.3 (ABSL_LTS_RELEASE_VERSION and
+                               ABSL_LTS_RELEASE_PATCH_LEVEL in
+                               absl/base/config.h), submodule rev
+                               c2435f8342c2d0ed8101cb43adfd605fdc52dca2,
+                               Apache-2.0
+                               external/sfizz/external/abseil-cpp/LICENSE.
+                               Vendored unconditionally by
+                               sfizz_add_vendor_abseil() in
+                               external/sfizz/cmake/SfizzDeps.cmake, so it is
+                               the second Apache-2.0 component in the binary
+                               after SheenBidi and carries the same section 4
+                               obligation. Covered by the Apache License 2.0
+                               reproduced at the foot of this file; abseil ships
+                               no NOTICE file either.
                - st_audiofile  BSD-2-Clause  external/sfizz/external/st_audiofile/
                - atomic_queue  MIT          external/sfizz/external/atomic_queue/
                - kiss_fft      BSD-3-Clause  external/sfizz/src/external/kiss_fft/
@@ -51,6 +156,31 @@ sfizz (SFZ / SoundFont sampler engine — powers the multisample instrument)
                - cpuid         BSD-3-Clause external/sfizz/src/external/cpuid/  (Steinwurf ApS)
                - hiir          WTFPL        external/sfizz/src/external/hiir/   (Laurent de Soras)
                - simde         MIT / CC0    external/sfizz/external/simde/
+               - cephes        BSD-3-Clause external/sfizz/external/cephes/LICENSE.txt
+                               (Julien Cornebise 2013). Only chbevl.c and i0.c
+                               are vendored. Moshier's original cephes carries
+                               no license of its own; his emailed permission to
+                               redistribute it under BSD is quoted in that
+                               LICENSE.txt.
+             These four arrive one level deeper still, vendored inside
+             st_audiofile. Its CMake links them only when it is not using
+             libsndfile instead (the if(NOT ST_AUDIO_FILE_USE_SNDFILE) branch
+             in external/sfizz/external/st_audiofile/CMakeLists.txt), and Dusk
+             Studio forces SFIZZ_USE_SNDFILE OFF, so the branch that links them
+             is the one every build takes:
+               - dr_libs       public domain / MIT-0 dual, caller's choice
+                               external/sfizz/external/st_audiofile/thirdparty/
+                               dr_libs/LICENSE (David Reid 2020) — dr_wav
+                               0.13.8, dr_flac 0.12.39, dr_mp3 0.6.34
+               - WavPack       5.6.6, BSD-3-Clause
+                               .../thirdparty/wavpack/license.txt
+                               (David Bryant 1998-2022, Conifer Software)
+               - libaiff       MIT
+                               .../thirdparty/libaiff/LICENSE
+                               (Marco Trillo 2005-2008)
+               - stb_vorbis    1.22, MIT / public domain dual, caller's choice
+                               .../thirdparty/stb_vorbis/LICENSE
+                               (Sean Barrett 2017)
 
 nlohmann/json (JSON parser — session + preset serialisation)
   Version  : 3.11.3
@@ -171,19 +301,41 @@ Catch2 (test framework — TEST BUILDS ONLY, not bundled in Dusk Studio)
   Path     : build-tests/_deps/catch2-src/ (FetchContent at configure time)
   Upstream : https://github.com/catchorg/Catch2/
 
-libsndfile (JUCE-free audio file I/O — TEST BUILDS ONLY for now)
+
+SYSTEM DEPENDENCIES (not vendored — resolved at configure time)
+---------------------------------------------------------------
+
+libsndfile (all audio file I/O — required on every platform)
   License  : LGPL-2.1-or-later
-  Path     : not vendored — system shared library found at configure time
-             (libsndfile-dev / libsndfile-devel / brew install libsndfile).
-             The dusk::audio FileReader/Writer unit + its tests compile only
-             when it is present; skipped otherwise. Linked dynamically.
-  Notes    : Will become an app dependency once the JUCE audio-format readers
-             are migrated; currently test-only.
-  Upstream : https://github.com/libsndfile/libsndfile
-
-
-PLATFORM-SPECIFIC OPTIONAL DEPENDENCIES
----------------------------------------
+  Path     : not vendored — found at configure time (libsndfile-dev /
+             libsndfile-devel / brew install libsndfile). A missing libsndfile
+             is a configure FATAL_ERROR, and both the app and the test binary
+             link the dusk_sndfile interface target.
+  Notes    : On Linux and macOS this is a dynamic link against the system
+             libsndfile (libsndfile.so.1), which is LGPL-2.1 section 6(b) —
+             the shared-library mechanism — and needs nothing further.
+             Windows takes a different route. The workflows run
+             `vcpkg install mp3lame:x64-windows-static
+             libsndfile:x64-windows-static`, which produces static libraries
+             and pulls libsndfile's codec chain — FLAC, Ogg, Opus, mpg123 —
+             into the executable alongside it, so no DLL ships and 6(b) is not
+             available. Section 6(a) is, and is already satisfied: Dusk Studio
+             is GPL-3.0-or-later with its complete corresponding source
+             published, and that source includes the exact vcpkg command above,
+             so anyone can rebuild the whole executable and relink it against a
+             modified libsndfile or mpg123. Nothing beyond the published source
+             is owed. Note that vcpkg runs there in classic mode with no
+             manifest, so the codec versions in a given Windows build are the
+             ones that runner's vcpkg baseline supplied rather than a version
+             pinned in this repo.
+             libsndfile is LGPL-2.1-or-later and mpg123 LGPL-2.1-only. FLAC and
+             Ogg are BSD-3-Clause (texts at the foot of this file, from JUCE's
+             vendored copies of the same projects); Opus is BSD-3-Clause
+             (Xiph.Org, Skype, Octasic, Jean-Marc Valin, Timothy B. Terriberry,
+             CSIRO, Gregory Maxwell, Mark Borgerding, Erik de Castro Lopo,
+             Mozilla, Amazon).
+  Upstream : https://github.com/libsndfile/libsndfile ,
+             https://www.mpg123.de/ , https://opus-codec.org/
 
 lilv / suil / lv2 (native LV2 host — Linux builds only)
   License  : ISC (lilv, suil), ISC (lv2 headers)
@@ -192,6 +344,10 @@ lilv / suil / lv2 (native LV2 host — Linux builds only)
              only when all three are present (DUSKSTUDIO_NATIVE_LV2).
   Notes    : Linked against the distro shared objects, never statically. ISC is
              GPL-compatible; no additional obligations beyond the license text.
+             This entry is only about the SYSTEM lilv/suil/lv2 the native host
+             uses. JUCE bundles its own static copies of lv2, lilv, serd, sord
+             and sratom, and those compile into every platform's binary — see
+             the LV2 SDK line under JUCE above.
   Upstream : https://gitlab.com/lv2 (lilv, suil), https://lv2plug.in (lv2)
 
 LAME / libmp3lame (MP3 bounce export — optional)
@@ -199,26 +355,73 @@ LAME / libmp3lame (MP3 bounce export — optional)
   Path     : not vendored — system shared library found at configure time via
              find_library(mp3lame); linked only when present
              (DUSKSTUDIO_HAS_LAME). Builds without it fall back to WAV-only.
-  Notes    : Linked against the system SHARED library (e.g. libmp3lame.so),
-             never statically — find_library resolves the distro / Homebrew
-             shared object at configure time (verified: release Linux build
-             links /usr/lib64/libmp3lame.so). The LGPL-2.1 §6 relink obligation
-             is met by that dynamic-link boundary. Present in a binary only if
-             the build was configured with libmp3lame available.
+  Notes    : On Linux and macOS, linked against the system SHARED library —
+             find_library resolves the distro / Homebrew shared object at
+             configure time (verified: release Linux build links
+             /usr/lib64/libmp3lame.so), so LGPL-2.1 section 6(b) applies.
+             Windows is the exception: the same vcpkg x64-windows-static
+             command described under libsndfile installs mp3lame statically,
+             so a Windows build links it into the executable and discharges
+             section 6 by the same 6(a) route — published complete
+             corresponding source that anyone can rebuild and relink.
+             Present in a binary only if the build was configured with
+             libmp3lame available.
   Upstream : https://lame.sourceforge.io/
 
 System shared libraries (Linux builds — linked dynamically, never bundled)
-  License  : PipeWire MIT; ALSA / libasound LGPL-2.1-or-later; libX11 MIT;
-             libGL supplied by the system OpenGL driver (Mesa: MIT)
+  License  : PipeWire MIT; ALSA / libasound LGPL-2.1-or-later; libX11 and the
+             X extension libraries it comes with (Xcursor, Xext, Xrandr) MIT;
+             libGL supplied by the system OpenGL driver (Mesa: MIT);
+             libdbus-1 dual-licensed AFL-2.1 OR GPL-2.0-or-later;
+             libfreetype FreeType License (FTL);
+             libfontconfig MIT-style permission grant (Keith Packard, Red Hat
+             and others — /usr/share/licenses/fontconfig/COPYING on a
+             typical install)
   Path     : not vendored — pkg-config libpipewire-0.3, find_package(OpenGL),
              and a plain link by name for asound / X11. PipeWire is the primary
              audio backend, ALSA the fallback backend and the MIDI transport,
              X11 the plugin-editor embedding host, and GL the renderer the
-             native notepad UI draws through.
+             native notepad UI draws through. Three more arrive indirectly:
+             DPF's dgl-system-libs adds libdbus-1 when pkg-config finds it, and
+             JUCE's juce_graphics module declares freetype2 and fontconfig as
+             Linux packages, so both land on the link line without either name
+             appearing in this repo's CMakeLists.txt.
   Notes    : Dusk Studio redistributes none of these — they come from the
-             user's distribution. Listed so the link surface is complete.
+             user's distribution, and the whole set is dynamically linked.
+             Listed so the non-toolchain link surface is complete; the
+             toolchain runtimes are the entry below.
+             FreeType's license asks any binary distribution carrying its code
+             to state that the software is based in part on the work of the
+             FreeType Team. Dusk Studio links the FreeType the user's
+             distribution supplies rather than shipping one, so the clause does
+             not bite, but the acknowledgement is made here anyway.
+             D-Bus is taken under its GPL-2.0-or-later arm, which upgrades to
+             GPLv3 and so combines with Dusk Studio's own license. The AFL-2.1
+             arm is the alternative D-Bus offers, but the FSF reads AFL-2.1 as
+             GPL-incompatible, so it is not the one relied on here.
   Upstream : https://pipewire.org/ , https://www.alsa-project.org/ ,
-             https://www.x.org/ , https://mesa3d.org/
+             https://www.x.org/ , https://mesa3d.org/ ,
+             https://www.freedesktop.org/wiki/Software/dbus/ ,
+             https://freetype.org/ ,
+             https://www.freedesktop.org/wiki/Software/fontconfig/
+
+Toolchain runtimes (the compiler's own libraries — linked dynamically)
+  License  : libstdc++, libgcc_s and libatomic are GPL-3.0-or-later WITH
+             GCC-exception-3.1 (the GCC Runtime Library Exception); glibc
+             (libc, libm) is LGPL-2.1-or-later, with parts GPL-2.0-or-later and
+             LGPL-2.1-or-later WITH GCC-exception-2.0
+  Path     : not vendored — supplied by the compiler and C library the build
+             machine uses. On the release Linux binary these are the remaining
+             DT_NEEDED entries: libstdc++.so.6, libgcc_s.so.1, libatomic.so.1,
+             libc.so.6, libm.so.6.
+  Notes    : The GCC Runtime Library Exception is what lets a program link
+             these without the runtime's own GPL reaching the program, and the
+             glibc exception plays the same role for the C library. Dusk Studio
+             would satisfy both anyway, being GPLv3, and ships none of them.
+             Version and license strings above are as the build machine's
+             distribution records them (GCC 15.3.0, glibc 2.40 here); another
+             distribution will differ in version but not in license.
+  Upstream : https://gcc.gnu.org/ , https://www.gnu.org/software/libc/
 
 
 Steinberg ASIO SDK (Windows only, optional)
@@ -247,3 +450,543 @@ Redistribute the binary: Allowed under GPL-3.0 terms. Include LICENSE,
                           (plus a Debian-policy `copyright` copy), the top
                           level of the Linux tarball, and beside the app in
                           the macOS DMG and the Windows MSI.
+                          That same source-code availability is what
+                          discharges the LGPL section 6 obligation on the
+                          statically linked libsndfile and mpg123 in a
+                          Windows build — no separate object-code drop is
+                          owed. Carrying this file also discharges the
+                          third-party notices the GPL itself does not cover,
+                          such as the IJG acknowledgement and the BSD
+                          copyright notices reproduced below.
+
+
+FULL LICENSE TEXTS
+------------------
+
+Each license below has a clause that makes its text, or its copyright notice
+and warranty disclaimer, part of any binary distribution. Naming the license is
+not enough for those, so they are set out here: each block is a verbatim copy
+of the file at the path above it, or of the relevant section where the block
+header says so. Paths starting `modules/` are inside the JUCE tree Dusk Studio
+builds against on Linux — dusk-audio/JUCE-wayland tag dusk-wayland-v2, rev
+4d85afa175a45e0b5da11f9211de3ba88705588e, JUCE 8.0.12. The macOS and Windows
+runners build against upstream JUCE 8.0.4, whose vendored copies may carry
+different versions of the same libraries under the same licenses.
+
+
+--------------------------------------------------------------------------------
+Apache License 2.0 — covers both Apache-2.0 components in the binary:
+  SheenBidi 2.9.0, Copyright (C) 2014-2025 Muhammad Tayyab Akram
+  abseil-cpp LTS 20230125.3, Copyright The Abseil Authors (Google Inc.
+  per external/sfizz/external/abseil-cpp/AUTHORS)
+Text below is modules/juce_graphics/unicode/sheenbidi/LICENSE verbatim,
+including the blank line it opens with. abseil ships the same license at
+external/sfizz/external/abseil-cpp/LICENSE; the only differences there are that
+it spells the two apache.org URLs https rather than http and that it ends with
+a trailing blank line instead of opening with one. Neither project ships a
+NOTICE file, so Apache-2.0 section 4(d) adds nothing to the section 4(a) copy
+provided here.
+--------------------------------------------------------------------------------
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+--------------------------------------------------------------------------------
+HarfBuzz 10.1.0 — Old MIT
+modules/juce_graphics/fonts/harfbuzz/COPYING
+--------------------------------------------------------------------------------
+
+HarfBuzz is licensed under the so-called "Old MIT" license.  Details follow.
+For parts of HarfBuzz that are licensed under different licenses see individual
+files names COPYING in subdirectories where applicable.
+
+Copyright © 2010-2022  Google, Inc.
+Copyright © 2015-2020  Ebrahim Byagowi
+Copyright © 2019,2020  Facebook, Inc.
+Copyright © 2012,2015  Mozilla Foundation
+Copyright © 2011  Codethink Limited
+Copyright © 2008,2010  Nokia Corporation and/or its subsidiary(-ies)
+Copyright © 2009  Keith Stribley
+Copyright © 2011  Martin Hosken and SIL International
+Copyright © 2007  Chris Wilson
+Copyright © 2005,2006,2020,2021,2022,2023  Behdad Esfahbod
+Copyright © 2004,2007,2008,2009,2010,2013,2021,2022,2023  Red Hat, Inc.
+Copyright © 1998-2005  David Turner and Werner Lemberg
+Copyright © 2016  Igalia S.L.
+Copyright © 2022  Matthias Clasen
+Copyright © 2018,2021  Khaled Hosny
+Copyright © 2018,2019,2020  Adobe, Inc
+Copyright © 2013-2015  Alexei Podtelezhnikov
+
+For full copyright notices consult the individual files in the package.
+
+
+Permission is hereby granted, without written agreement and without
+license or royalty fees, to use, copy, modify, and distribute this
+software and its documentation for any purpose, provided that the
+above copyright notice and the following two paragraphs appear in
+all copies of this software.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
+--------------------------------------------------------------------------------
+libjpeg 9f — Independent JPEG Group license
+modules/juce_graphics/image_formats/jpglib/README, the whole LEGAL ISSUES
+section (lines 100-154; the rest of that README is build and usage notes)
+--------------------------------------------------------------------------------
+
+LEGAL ISSUES
+============
+
+In plain English:
+
+1. We don't promise that this software works.  (But if you find any bugs,
+   please let us know!)
+2. You can use this software for whatever you want.  You don't have to pay us.
+3. You may not pretend that you wrote this software.  If you use it in a
+   program, you must acknowledge somewhere in your documentation that
+   you've used the IJG code.
+
+In legalese:
+
+The authors make NO WARRANTY or representation, either express or implied,
+with respect to this software, its quality, accuracy, merchantability, or
+fitness for a particular purpose.  This software is provided "AS IS", and you,
+its user, assume the entire risk as to its quality and accuracy.
+
+This software is copyright (C) 1991-2024, Thomas G. Lane, Guido Vollbeding.
+All Rights Reserved except as specified below.
+
+Permission is hereby granted to use, copy, modify, and distribute this
+software (or portions thereof) for any purpose, without fee, subject to these
+conditions:
+(1) If any part of the source code for this software is distributed, then this
+README file must be included, with this copyright and no-warranty notice
+unaltered; and any additions, deletions, or changes to the original files
+must be clearly indicated in accompanying documentation.
+(2) If only executable code is distributed, then the accompanying
+documentation must state that "this software is based in part on the work of
+the Independent JPEG Group".
+(3) Permission for use of this software is granted only if the user accepts
+full responsibility for any undesirable consequences; the authors accept
+NO LIABILITY for damages of any kind.
+
+These conditions apply to any software derived from or based on the IJG code,
+not just to the unmodified library.  If you use our work, you ought to
+acknowledge us.
+
+Permission is NOT granted for the use of any IJG author's name or company name
+in advertising or publicity relating to this software or products derived from
+it.  This software may be referred to only as "the Independent JPEG Group's
+software".
+
+We specifically permit and encourage the use of this software as the basis of
+commercial products, provided that all warranty or liability claims are
+assumed by the product vendor.
+
+
+The Unix configuration script "configure" was produced with GNU Autoconf.
+It is copyright by the Free Software Foundation but is freely distributable.
+The same holds for its supporting scripts (config.guess, config.sub,
+ltmain.sh).  Another support script, install-sh, is copyright by X Consortium
+but is also freely distributable.
+
+--------------------------------------------------------------------------------
+libpng 1.6.37 — PNG Reference Library License version 2
+modules/juce_graphics/image_formats/pnglib/LICENSE
+(the version-1 history that follows in that file governs libpng 0.5
+through 1.6.35 and is not reproduced)
+--------------------------------------------------------------------------------
+
+COPYRIGHT NOTICE, DISCLAIMER, and LICENSE
+=========================================
+
+PNG Reference Library License version 2
+---------------------------------------
+
+ * Copyright (c) 1995-2019 The PNG Reference Library Authors.
+ * Copyright (c) 2018-2019 Cosmin Truta.
+ * Copyright (c) 2000-2002, 2004, 2006-2018 Glenn Randers-Pehrson.
+ * Copyright (c) 1996-1997 Andreas Dilger.
+ * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+
+The software is supplied "as is", without warranty of any kind,
+express or implied, including, without limitation, the warranties
+of merchantability, fitness for a particular purpose, title, and
+non-infringement.  In no event shall the Copyright owners, or
+anyone distributing the software, be liable for any damages or
+other liability, whether in contract, tort or otherwise, arising
+from, out of, or in connection with the software, or the use or
+other dealings in the software, even if advised of the possibility
+of such damage.
+
+Permission is hereby granted to use, copy, modify, and distribute
+this software, or portions hereof, for any purpose, without fee,
+subject to the following restrictions:
+
+ 1. The origin of this software must not be misrepresented; you
+    must not claim that you wrote the original software.  If you
+    use this software in a product, an acknowledgment in the product
+    documentation would be appreciated, but is not required.
+
+ 2. Altered source versions must be plainly marked as such, and must
+    not be misrepresented as being the original software.
+
+ 3. This Copyright notice may not be removed or altered from any
+    source or altered source distribution.
+
+--------------------------------------------------------------------------------
+zlib 1.3.1 — zlib license
+modules/juce_core/zip/zlib/LICENSE
+--------------------------------------------------------------------------------
+
+The following notice was included with the original zlib distribution.
+It applies to all files within this directory.
+
+Minor modifications to some source files have been made, as described in the
+accompanying JUCE_CHANGES.txt.
+
+================================================================================
+
+Copyright notice:
+
+ (C) 1995-2022 Jean-loup Gailly and Mark Adler
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Jean-loup Gailly        Mark Adler
+  jloup@gzip.org          madler@alumni.caltech.edu
+
+--------------------------------------------------------------------------------
+libFLAC 1.4.3 — BSD-3-Clause
+modules/juce_audio_formats/codecs/flac/Flac Licence.txt
+--------------------------------------------------------------------------------
+
+=====================================================================
+
+I've incorporated FLAC directly into the JUCE codebase because it makes
+things much easier than having to make all your builds link correctly to
+the appropriate libraries on every different platform.
+
+I've made minimal changes to the FLAC code - just tweaked a few include paths
+to make it build smoothly, added some headers to allow you to turn off FLAC
+compilation, and commented-out a couple of unused bits of code.
+
+=====================================================================
+
+
+The following license is the BSD-style license that comes with the
+Flac distribution, and which applies just to the files I've
+included in this directory. For more info, and to get the rest of the
+distribution, visit the Flac homepage: https://xiph.org/flac/
+
+=====================================================================
+
+libFLAC - Free Lossless Audio Codec library
+Copyright (C) 2000-2009  Josh Coalson
+Copyright (C) 2011-2023  Xiph.Org Foundation
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+- Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+- Neither the name of the Xiph.Org Foundation nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
+Ogg / Vorbis (libvorbis 1.3.7) — BSD-3-Clause
+modules/juce_audio_formats/codecs/oggvorbis/Ogg Vorbis Licence.txt
+--------------------------------------------------------------------------------
+
+=====================================================================
+
+Ogg-Vorbis is incorporated directly into the JUCE codebase because it makes
+things much easier than having to make all your builds link correctly to
+the appropriate libraries on every different platform.
+
+There are minimal changes to the Ogg-Vorbis code - a few include paths have
+been changed to make it build smoothly, and some headers have been added to
+allow you to exclude it from the build. Any significant code modifications
+are marked clearly by "JUCE CHANGE STARTS HERE" and "JUCE CHANGE ENDS HERE"
+comments.
+
+=====================================================================
+
+The following license is the BSD-style license that comes with the Ogg-Vorbis
+distribution, and which applies just to the header files included in this
+directory. For more info, and to get the rest of the distribution, visit the
+Ogg-Vorbis homepage: https://xiph.org/vorbis
+
+=====================================================================
+
+Copyright (c) 2002-2020 Xiph.org Foundation
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+- Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+- Neither the name of the Xiph.org Foundation nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Fixes #214.

LICENSES.txt only. Adds entries for everything the shipped binary links that had no credit, and reproduces the license texts whose terms require them to accompany the binary.

- JUCE-bundled: SheenBidi 2.9.0 (Apache-2.0), HarfBuzz 10.1.0, libjpeg 9f, libpng 1.6.37, zlib 1.3.1, libFLAC 1.4.3, libvorbis 1.3.7. Every text read from the vendored source in JUCE-wayland at the CI pin (dusk-wayland-v2) and byte-verified. SheenBidi ships no NOTICE file upstream, so the license copy alone discharges Apache 2.0 section 4; it is reproduced in full.
- abseil-cpp (Apache-2.0 via sfizz, LTS 20230125.3) entry expanded and covered by the reproduced Apache text.
- JUCE's own vendored VST3 SDK (MIT, verified against format_types/VST3_SDK/LICENSE.txt) and LV2 SDK (ISC set incl. zix) added; both compile in on every platform via the unconditional pluginhost flags.
- JUCE entry corrected to AGPLv3 (JUCE 8 open-source arm) with the GPLv3 section 13 bridge stated.
- libsndfile de-listed from vendored, moved to system deps; the test-builds-only claim was wrong, it is an unconditional runtime dep. Windows static-triplet caveat recorded with the actual LGPL section 6 discharge route (published corresponding source; there is no vcpkg manifest, versions come from the runner baseline).
- Dynamic deps (libdbus-1, freetype, fontconfig), sfizz sub-bundles, and toolchain runtimes recorded.

Merge order: this must land before or with #215. The packaging fix stops shipping JUCE's source tree, which was the accidental carrier of these texts in the DMG and MSI; after #215 this file is the sole carrier.

Follow-up for full offline notice completeness is #219.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded licensing and attribution documentation for bundled and system dependencies.
  - Added version, revision, provenance, license location, and build inclusion details.
  - Documented platform-specific linking, redistribution requirements, and LGPL compliance guidance.
  - Included full license texts for additional open-source components, including Apache-2.0, HarfBuzz, libjpeg, libpng, zlib, FLAC, and Ogg/Vorbis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->