### PR TITLE
fix(packaging): exclude JUCE's install rules from the package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,7 +260,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     unset(_duskstudio_juce_wayland_dir)
 endif()
 
-add_subdirectory(${DUSKSTUDIO_JUCE_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/JUCE)
+# EXCLUDE_FROM_ALL keeps JUCE's own install rules out of our install set;
+# without it every cpack package carries juceaide, the whole module source
+# tree and JUCE's CMake package config. The default build is unaffected: the
+# modules are INTERFACE libraries and juceaide is an imported executable.
+add_subdirectory(${DUSKSTUDIO_JUCE_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/JUCE EXCLUDE_FROM_ALL)
 
 # App icon. JUCE bakes the PNG into platform-specific resources at
 # build time (.ico on Windows, .icns on macOS, embedded data block on


### PR DESCRIPTION
Fixes #215.

One functional line: JUCE's add_subdirectory gains EXCLUDE_FROM_ALL, which stops CMake emitting the subdirectory's install script. cmake --install drops from 3089 files / 101 MiB to 9 files / 37 MiB; the 9 survivors are the Dusk payload and match the previous install byte for byte apart from relink build ids. No juceaide, no include/JUCE-8.0.12, no lib/cmake/JUCE-8.0.12 in any package.

Safe because JUCE's directory contributes only INTERFACE libraries and an imported juceaide, so nothing we build leaves the default build. Verified from scratch: clean configure + build (warning count identical), cpack TGZ payload is exactly the 9 files, 632/632 tests, juce-gate green. sfizz and DPF already carried EXCLUDE_FROM_ALL; the generated install script now includes nothing.

Packaging surfaces audited: package-tarball.sh hand-stages and never runs cmake --install; package-windows.ps1's install gate asserts only files from our own rules; macOS DragNDrop and DEB/RPM sit on the same scoped install set.

Merge order: land #214 first. The JUCE source tree this removes was the accidental carrier of third-party license texts in the DMG and MSI; #214 makes LICENSES.txt the deliberate carrier.

Follow-up regression guards (assert the install set stays scoped) are #218.