### PR TITLE
docs: correct the bank model, notepad prose and screenshot recipes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ sessions/
 *.flac
 !resources/**/*.wav
 
-# Generated user manual (build via packaging/build-pdf.sh)
+# Generated user manual (build via docs/build-pdf.sh)
 MANUAL.pdf
 
 # Linux release artifacts (built by scripts/package-tarball.sh)

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -24,7 +24,7 @@ This manual covers Dusk Studio (Beta). It is written for musicians and engineers
 
 Dusk Studio includes:
 
-- 24 tracks of audio or MIDI recording, organised as three banks of 8.
+- 24 tracks of audio or MIDI recording, paged on screen to fit the window and addressed by a control surface in three banks of 8.
 - A fixed channel signal chain: phase, insert, HPF, LPF, 4-band EQ, compressor (Opto/FET/VCA), aux sends, pan, fader.
 - Four aux return lanes, each with one plugin or hardware insert slot.
 - Four mix buses, each with a 3-band EQ and console-style bus compressor.
@@ -145,7 +145,7 @@ This chapter is a visual reference. Every numbered callout on the figures below 
 | --- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | 1   | Menu bar          | `File` and `Settings` menus only. No tabs, no hidden submenus.                                                                    |
 | 2   | Stage selector    | Four buttons: **RECORDING**, **MIXING**, **MASTERING**, **AUX** (Cmd/Ctrl+1 to 4). Picks which view fills the console area.            |
-| 3   | Bank selector     | The visible channel bank (e.g. `1-6`, `7-12`, ...), switched with the plain number keys 1 to 4. Only visible when the window is too narrow to show all channel strips at once. |
+| 3   | Bank selector     | The visible page of channel strips (e.g. `1-6`, `7-12`, ...), switched with the plain number keys 1 to 4. Only visible when the window is too narrow to show all 24 at once. |
 | 4   | Transport bar     | Play, record, loop, punch, BPM, time signature, clock, tuner. See the next figure for the inventory.                              |
 | 5   | Tape strip toggle | `▾ TIMELINE` / `▴ TAPE`. Collapses or expands the timeline view below the bar.                                                     |
 | 6   | Console view      | Holds 24 channel strips, 4 buses, and the master strip. Replaced by the aux lane or mastering chain when those stages are active. |
@@ -164,7 +164,7 @@ This chapter is a visual reference. Every numbered callout on the figures below 
 | 6   | Loop             | Toggles loop playback between the loop brackets.                                 |
 | 7   | Punch            | Toggles automatic punch in / punch out using the punch brackets.                 |
 | 8   | Virtual keyboard | Opens the on-screen MIDI keyboard overlay.                                       |
-| 9   | Notepad          | Opens the session notepad for lyrics and notes (markdown, saved with the session). |
+| 9   | Notepad          | Opens the session notepad — lyrics, chords, and session notes, saved with the session. |
 | 10  | Metronome        | Click on / off. Right-click for the click settings.                              |
 | 11  | C/I              | Count-in toggle. One bar of click before record starts.                          |
 | 12  | BPM              | Tempo at the playhead. Double-click to set it directly (in a session with tempo changes, edits the change governing the playhead); or set the tempo from the timeline ruler. **TAP** sets the starting tempo. |
@@ -413,7 +413,7 @@ On first launch Dusk Studio opens a blank session named `Untitled`. The window i
 - A bank selector (only visible when the window is too narrow to show all 24 channel strips at once).
 - The transport bar.
 - The tape strip (the timeline view), collapsed by default.
-- The console view, showing 24 channel strips (in three banks of 8), 4 buses, and the master strip.
+- The console view, showing the 24 channel strips (paged when the window is too narrow for all of them), 4 buses, and the master strip.
 
 Press **RECORDING** to focus the channel strips on input routing and arm controls. Press **MIXING** to focus them on send levels and inserts. Press **MASTERING** to load a finished mix and run it through the mastering chain. Press **AUX** to see the four aux lanes, their inserts, and their send sources.
 
@@ -482,7 +482,7 @@ The window is structured as a stack of horizontal bands.
 ├───────────────────────────────────────────────────────┤
 │  RECORDING   MIXING   MASTERING   AUX                 │  Stage selector
 ├───────────────────────────────────────────────────────┤
-│  1-8   9-16                                           │  Bank selector
+│  1-8   9-16   17-24                                   │  Bank selector
 ├───────────────────────────────────────────────────────┤
 │ ◀◀  ▶  ▶▶  ●  ⟳  ◉   CLK ♩=120 4/4 00:01:23         │  Transport bar
 ├───────────────────────────────────────────────────────┤
@@ -493,6 +493,8 @@ The window is structured as a stack of horizontal bands.
 │                                                       │
 └───────────────────────────────────────────────────────┘
 ```
+
+The bank selector appears only when the window is too narrow for all 24 strips, and it pages the console by whatever does fit — as few as six strips on the narrowest window, never more than four pages. A control surface's bank is a separate, fixed axis: eight strips at a time, tracks 1–8, 9–16, or 17–24. The two stay in step. Picking a page moves the surface to the bank holding that page's first track, and **Bank Left** / **Bank Right** on the surface moves the page to the one holding that bank's first track. When every strip fits on screen there is no page to pick, so the surface — and the bank-relative MIDI bindings that follow it — stays where you left it.
 
 Modal dialogs (audio settings, plugin picker, region editor, piano roll, import target picker) appear centered with a dimmed backdrop behind them. Press **Esc** or click outside the modal to dismiss.
 
@@ -507,7 +509,7 @@ Only one stage is visible at a time, but the same engine drives all four. Switch
 - **MASTERING** swaps the console view for the mastering chain, including a file picker for loading a finished mix.
 - **AUX** swaps the console view for the four aux return lanes, with a full-width view of each lane's plugin chain.
 
-Press **Cmd/Ctrl+1 / 2 / 3 / 4** to jump straight to RECORDING / MIXING / MASTERING / AUX. The channel banks have the plain number keys **1 / 2 / 3 / 4**, so a modified digit changes stage and a plain digit changes bank. Hovering any tab or bank button shows its shortcut, and **?** opens a full keyboard-shortcut list (also under **Settings → Keyboard Shortcuts**).
+Press **Cmd/Ctrl+1 / 2 / 3 / 4** to jump straight to RECORDING / MIXING / MASTERING / AUX. The bank selector has the plain number keys **1 / 2 / 3 / 4**, so a modified digit changes stage and a plain digit changes the visible page of strips. Hovering any tab or bank button shows its shortcut, and **?** opens a full keyboard-shortcut list (also under **Settings → Keyboard Shortcuts**).
 
 Switching into or out of MASTERING force-stops the transport. The mix engine and the mastering engine cannot run at the same time. Changing stage also closes the notepad, saving it — the two cannot share the window.
 
@@ -522,7 +524,7 @@ From left to right:
 - **Record** (●). Toggles record. Requires at least one track armed.
 - **Loop** (⟳). Toggles loop playback.
 - **Punch** (◉). Toggles punch recording. Right-click to enable/disable pre-roll and post-roll and set their seconds.
-- **Virtual keyboard** (⌨). Opens an on-screen MIDI keyboard.
+- **Virtual keyboard** (⌨). Opens an on-screen MIDI keyboard — see below.
 - **Notepad**. Opens the session notepad — see below.
 - **Metronome** (♩). Toggles the click. Right-click for click settings.
 - **C/I**. Toggles count-in (one bar of click before record starts).
@@ -541,19 +543,26 @@ When the timeline is expanded, a toolbar row sits directly above the tape strip:
 
 In compact mode (window narrower than 1850 pixels), `TIMELINE` becomes `▾` and the time-format toggle hides; right-click the clock display to flip format instead.
 
+## The virtual keyboard
+
+The ⌨ button (or **K**) opens an on-screen MIDI keyboard. It belongs to the transport bar, not to any one view: it opens in any stage, with or without the piano roll. It appears as a MIDI source called **Virtual Keyboard (Dusk Studio)** in each track's MIDI input picker, and loading an instrument onto a track with no input bound selects it automatically so the instrument is playable straight away.
+
+While it is open, every letter and digit in its layout belongs to the keyboard rather than to the shortcuts — **P** and **R** play their notes instead of toggling punch and record, at any octave (shift the octave high enough that a key runs past the top of the MIDI range and it simply does nothing). Keys outside the layout still work as usual, so **Space**, **.**, **L**, **[** / **]** keep driving the transport, and **K** or **Esc** closes the keyboard.
+
 ## The notepad
 
 ![Session notepad.](docs/images/np-12-notepad.png)
 
 A document editor for lyrics and session notes, opened from the transport bar.
-It is a wrapped, page-style editor: formatting is
+There is one view, the **chart**, and you type straight onto it: formatting is
 shown in place, headings use document typography, links are underlined, and
 bullets, numbering, quotes, and clickable task boxes render as real document
 elements. Use the toolbar or Ctrl+B / Ctrl+I to set the typing style at the
 caret or format a selection; Ctrl+Z undoes and Ctrl+Y or Ctrl+Shift+Z redoes
-both text and formatting. On macOS, Cmd works wherever Ctrl is listed,
-including link activation. Numbered and bulleted lists continue when you press
-Enter, and a second Enter on an empty list item returns to body text.
+both text and formatting. On macOS, Cmd works wherever Ctrl is listed for a
+command, link activation included; word motion and word delete are the
+exception and stay on Ctrl or Option. Numbered and bulleted lists continue when
+you press Enter, and a second Enter on an empty list item returns to body text.
 Ctrl-click an `http`, `https`, or `mailto` link to open it. Selection and
 navigation follow the usual conventions: double-click selects a word,
 triple-click a line, Ctrl+arrow jumps by word, Home, End, and Page Up/Down move
@@ -578,22 +587,29 @@ ChordPro brackets in `notepad.md` (`[Am]like this`), so the file opens in any
 chord-sheet app; bracketed text that is not a chord name, such as `[Chorus]`,
 stays literal.
 
-**Sections.** The section button writes a marker such as `[Chorus]` on its own
-line above the caret. Markers are plain text, so typing one by hand is the same
-thing: any bracketed word that is not a chord name stays literal. Rename a
-marker by editing its label in the chart. The label has to stay a label, so an
-edit that would put a bracket inside it, or turn it into a chord name, is
-refused and the marker is left as it was. To remove one, put the caret on the
-marker line, click the **Section** button, and choose **Remove current
-section**, or select and delete the label directly. The chart shows only the
-section label; the compatible `notepad.md` file keeps its brackets visible.
+**Sections.** The **Section** button opens a short list — Intro, Verse,
+Pre-chorus, Chorus, Bridge, Solo, Outro — and the label you pick is written as a
+marker such as `[Chorus]` on its own line above the caret. The list is a
+shortcut, not a vocabulary: markers are plain text, so typing one by hand is the
+same thing, and any bracketed word that is not a chord name stays literal.
+Rename a marker by editing its label in the chart. The label has to stay a
+label, so an edit that would put a bracket inside it, or turn it into a chord
+name, is refused and the marker is left as it was. To remove one, put the caret
+on the marker line, click **Section**, and choose **Remove current section** —
+it only appears when the caret is on a marker — or select and delete the label
+directly. The chart shows only the section label; the compatible `notepad.md`
+file keeps its brackets visible.
 
 The songwriter-focused toolbar keeps chord and section insertion,
 transposition, lyric and title styles, bold, italic, undo and redo, and the
-chord-spelling preference visible. Undo and redo dim when there is nothing to
-undo or redo. The footer shows the current save state, the latest save time when
-available, the `notepad.md` filename, section count, unique chord count, and the
-detected key when enough chords identify one.
+chord-spelling preference visible. Spelling is three buttons — **Auto**, **♯**,
+**♭**. Auto follows the accidentals already written in the song; the other two
+force sharps or flats. Whichever is lit is what transposition and the chord
+completions spell with. Undo and redo dim when there is nothing to undo or redo,
+and the transpose buttons dim until the notepad holds a chord. The footer shows
+the current save state, the latest save time when available, the `notepad.md`
+filename, section count, unique chord count, and the detected key when enough
+chords identify one.
 
 Click **Done** or the dimmed area outside the notepad to close it. The notepad
 also closes itself whenever something else needs the window — an alert, a stage
@@ -1375,9 +1391,9 @@ The note-creation grid is set from the toolbar dropdown; there is no keyboard sh
 
 ## Step record
 
-Open the virtual keyboard from the transport bar (the keyboard icon, or **K**). Each note you press in the keyboard is entered at the current edit cursor. When all keys are released, the cursor advances by one snap step. This is the fastest way to enter a chord progression without playing in real time.
+With the piano roll open, each note you press on the virtual keyboard is entered at the current edit cursor. When all keys are released, the cursor advances by one snap step. This is the fastest way to enter a chord progression without playing in real time.
 
-While the keyboard is open, every letter and digit in its layout belongs to the keyboard, not to the shortcuts — **P** and **R** play their notes instead of toggling punch and record, at any octave (shift the octave high enough that a key runs past the top of the MIDI range and it simply does nothing). Keys outside the layout still work as usual, so **Space**, **.**, **L**, **[** / **]** keep driving the transport, and **K** or **Esc** closes the keyboard.
+The keyboard is a transport-bar tool rather than part of the piano roll: it opens from the ⌨ button (or **K**) in any stage, and it takes over the letter and digit keys in its layout for as long as it is open. See *The virtual keyboard* for the details.
 
 ## Navigation
 
@@ -1672,6 +1688,7 @@ Once connected:
 - **Motorised faders** mirror Dusk Studio's channel and master faders.
 - The **eight strip faders** drive the active bank (tracks 1–8, 9–16, or 17–24).
 - **Bank Left** / **Bank Right** step the bank by 8.
+- The surface's bank and the console's visible page of strips are separate axes, kept in step: a bank step moves the page to the one holding that bank's first track, and picking a page moves the surface the other way. With all 24 strips on screen there is no page to pick, and the surface keeps whichever bank you left it on.
 - **Channel Left** / **Channel Right** step the selected channel by 1.
 - **Mute / Solo / Arm / Select** buttons mirror and drive the on-screen buttons. LEDs reflect state.
 - **V-pot** rotaries drive pan, sends, EQ band gain, or compressor depending on the **assign mode**. Press **Pan**, **Send** (repeated presses cycle sends 1–4), **EQ**, or the **Track** button (mapped to the compressor in Dusk Studio) to switch. The surface's **Plugin** and **Inst** assign buttons are not mapped.
@@ -1738,7 +1755,7 @@ Right-click the binding in the MIDI Bindings panel to change its mode.
 - **Per-aux**: Fader, Mute.
 - **Master**: Fader, EQ low boost, EQ high boost, compressor threshold, compressor makeup, compressor ratio.
 - **Per-track aux send**: send level for each of the four aux destinations.
-- **Bank-relative variants**: every "Per-track ..." target above has a `(banked)` counterpart that drives the active bank's 8 strips by position rather than absolute track number. One 8-fader controller can therefore drive whichever 8 of the 24 tracks are in the visible bank.
+- **Bank-relative variants**: every "Per-track ..." target above has a `(banked)` counterpart addressed by position 1–8 within the active bank rather than by absolute track number, so one 8-fader controller reaches all 24 tracks. The active bank is the surface's fixed bank of 8 — tracks 1–8, 9–16, or 17–24 — not the console's visible page, which is as wide as the window allows. **Bank Left** / **Bank Right** moves it, and so does picking a page in the bank selector, which jumps the surface to the bank holding that page's first track. With all 24 strips on screen there is no page to pick and the bindings follow the surface alone.
 
 ## The MIDI Bindings panel
 
@@ -1930,7 +1947,7 @@ Shortcuts use **Cmd** on macOS and **Ctrl** on Linux and Windows unless noted.
 | Shortcut             | Action                                  |
 | -------------------- | --------------------------------------- |
 | **Cmd+1 … Cmd+4**    | Recording / Mixing / Mastering / Aux    |
-| **1 … 4**            | Select channel bank 1 to 4              |
+| **1 … 4**            | Select strip page 1 to 4 (bank selector) |
 
 ## Timeline
 
@@ -1976,6 +1993,42 @@ The piano roll modal captures its own keypresses first (see `PianoRollComponent:
 | **Cmd+]** / **Cmd+[**             | Next / previous MIDI region                                  |
 | **Esc**                           | Close modal                                                  |
 
+## Notepad
+
+The notepad takes every keypress while it is open, so no transport shortcut
+fires as you type.
+
+| Shortcut                             | Action                                               |
+| ------------------------------------ | ---------------------------------------------------- |
+| **Cmd+B**                            | Bold the selection, or the typing style at the caret |
+| **Cmd+I**                            | Italicise the selection, or the typing style         |
+| **Cmd+K**                            | Open a chord slot above the word at the caret        |
+| **Cmd+Shift+K**                      | Repeat the preceding chord at the caret              |
+| **Cmd+Z**                            | Undo                                                 |
+| **Cmd+Y** / **Cmd+Shift+Z**          | Redo                                                 |
+| **Cmd+A**                            | Select all                                           |
+| **Cmd+C** / **Cmd+X** / **Cmd+V**    | Copy / cut / paste                                   |
+| **Cmd+click**                        | Open an `http`, `https`, or `mailto` link            |
+| **Ctrl+←** / **Ctrl+→**              | Move by word                                         |
+| **Ctrl+Backspace** / **Ctrl+Delete** | Delete the word before / after the caret             |
+| **Home** / **End**                   | Start / end of the wrapped row                       |
+| **Cmd+Home** / **Cmd+End**           | Start / end of the note                              |
+| **Page Up** / **Page Down**          | Move a page up / down                                |
+| **Tab**                              | Insert a tab — the page owns the key, so it never moves focus |
+
+The two word rows are the exception to the chapter's Cmd/Ctrl convention: word
+motion and word delete are **Ctrl** or **Option** on every platform, macOS
+included. Cmd moves and deletes one character there.
+
+An open chord slot takes the keys instead:
+
+| Shortcut      | Action                                          |
+| ------------- | ----------------------------------------------- |
+| **Enter**     | Commit the chord, or the highlighted completion |
+| **Esc**       | Cancel the slot                                 |
+| **↑** / **↓** | Move through the completions                    |
+| **Tab**       | Accept the highlighted completion               |
+
 ## Window
 
 | Shortcut       | Action                          |
@@ -1988,7 +2041,7 @@ The piano roll modal captures its own keypresses first (see `PianoRollComponent:
 
 - Shortcuts that would conflict with a focused text field always defer to the text field. You can edit a track label or type into the BPM spinner without accidentally arming a track or starting playback.
 - **M** drops a marker at the playhead, not mute; per-track mute is **X** to avoid the clash with the marker action.
-- Plain **B** is unused; **Cmd+B** triggers Bounce (Logic convention).
+- Plain **B** taps tempo; **Cmd+B** triggers Bounce (Logic convention).
 
 \newpage
 
@@ -2128,7 +2181,7 @@ Dusk Studio targets functional accessibility for screen reader users. The 24-cha
 
 ## What's still rough
 
-- In the **Recording** and **Mixing** stages, **Left / Right arrows** move a gold focus ring across the 24 channel strips, automatically flipping the visible bank as you cross a boundary. The focused strip is the target for the **A / S / X** (arm / solo / mute) shortcuts, so you can walk the mixer and toggle states without the mouse. (Clicking a strip moves the ring too.)
+- In the **Recording** and **Mixing** stages, **Left / Right arrows** move a gold focus ring across the 24 channel strips, automatically flipping the visible page as you cross a boundary. The focused strip is the target for the **A / S / X** (arm / solo / mute) shortcuts, so you can walk the mixer and toggle states without the mouse. (Clicking a strip moves the ring too.)
 - Region drag-and-drop on the timeline relies on mouse gestures. Region edit actions (split, trim, fade, gain) are all available via the keyboard reference; the drag-to-move case is the gap.
 - Plugin editors are out of Dusk Studio's accessibility control surface. JUCE forwards screen-reader requests to each plugin; vendor accessibility varies.
 
@@ -2448,7 +2501,7 @@ The hardware-insert ping reports its result inline on the editor (not a modal), 
 
 **Aux lane.** A return path that receives sends from any number of channels, processes them through one plugin or hardware insert, and feeds the result into the master. Four aux lanes total.
 
-**Bank.** A group of 8 channels mapped to a Mackie Control surface's eight strips. Three banks cover the full 24 channels.
+**Bank.** A group of 8 channels — tracks 1–8, 9–16, or 17–24 — addressed by a Mackie Control surface's eight strips and by bank-relative MIDI bindings. Three banks cover the full 24 channels. Distinct from a console page, though the two move together.
 
 **Bounce.** Offline rendering of the project to a stereo audio file.
 
@@ -2469,6 +2522,8 @@ The hardware-insert ping reports its result inline on the editor (not a modal), 
 **OOP plugin sandbox.** Out-of-process plugin hosting. Each loaded plugin runs in a child process so a crash does not take the DAW with it.
 
 **Opto compressor.** A compressor whose gain reduction is performed by a photo-resistor, in the classic optical tradition.
+
+**Page (console).** The set of channel strips on screen at once, chosen by the bank selector. As narrow as six strips, never more than four pages; a window wide enough for all 24 has a single page and no selector. Independent of the fixed bank of 8.
 
 **Program EQ.** A passive program-EQ topology with separately controllable boost and cut at the same frequency.
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -482,7 +482,7 @@ The window is structured as a stack of horizontal bands.
 ├───────────────────────────────────────────────────────┤
 │  RECORDING   MIXING   MASTERING   AUX                 │  Stage selector
 ├───────────────────────────────────────────────────────┤
-│  1-8   9-16   17-24                                   │  Bank selector
+│  1-6   7-12   13-18   19-24                           │  Bank selector
 ├───────────────────────────────────────────────────────┤
 │ ◀◀  ▶  ▶▶  ●  ⟳  ◉   CLK ♩=120 4/4 00:01:23         │  Transport bar
 ├───────────────────────────────────────────────────────┤
@@ -494,7 +494,7 @@ The window is structured as a stack of horizontal bands.
 └───────────────────────────────────────────────────────┘
 ```
 
-The bank selector appears only when the window is too narrow for all 24 strips, and it pages the console by whatever does fit — as few as six strips on the narrowest window, never more than four pages. A control surface's bank is a separate, fixed axis: eight strips at a time, tracks 1–8, 9–16, or 17–24. The two stay in step. Picking a page moves the surface to the bank holding that page's first track, and **Bank Left** / **Bank Right** on the surface moves the page to the one holding that bank's first track. When every strip fits on screen there is no page to pick, so the surface — and the bank-relative MIDI bindings that follow it — stays where you left it.
+The bank selector appears only when the window is too narrow for all 24 strips, and it pages the console by whatever does fit — as few as six strips on the narrowest window, never more than four pages. Each button names its range: in the compact transport layout drawn above (window under 1850 pixels) the label is the bare range, `1-6`; at full size it reads `BANK 1  (1-6)`. The range widens with the window. A control surface's bank is a separate, fixed axis: eight strips at a time, tracks 1–8, 9–16, or 17–24. The two stay in step. Picking a page moves the surface to the bank holding that page's first track, and **Bank Left** / **Bank Right** on the surface moves the page to the one holding that bank's first track. When every strip fits on screen there is no page to pick, so the surface — and the bank-relative MIDI bindings that follow it — stays where you left it.
 
 Modal dialogs (audio settings, plugin picker, region editor, piano roll, import target picker) appear centered with a dimmed backdrop behind them. Press **Esc** or click outside the modal to dismiss.
 
@@ -550,8 +550,6 @@ The ⌨ button (or **K**) opens an on-screen MIDI keyboard. It belongs to the tr
 While it is open, every letter and digit in its layout belongs to the keyboard rather than to the shortcuts — **P** and **R** play their notes instead of toggling punch and record, at any octave (shift the octave high enough that a key runs past the top of the MIDI range and it simply does nothing). Keys outside the layout still work as usual, so **Space**, **.**, **L**, **[** / **]** keep driving the transport, and **K** or **Esc** closes the keyboard.
 
 ## The notepad
-
-![Session notepad.](docs/images/np-12-notepad.png)
 
 A document editor for lyrics and session notes, opened from the transport bar.
 There is one view, the **chart**, and you type straight onto it: formatting is
@@ -2012,9 +2010,9 @@ fires as you type.
 | **Ctrl+←** / **Ctrl+→**              | Move by word                                         |
 | **Ctrl+Backspace** / **Ctrl+Delete** | Delete the word before / after the caret             |
 | **Home** / **End**                   | Start / end of the wrapped row                       |
-| **Cmd+Home** / **Cmd+End**           | Start / end of the note                              |
+| **Cmd+Home** / **Cmd+End**           | Start / end of the chart                             |
 | **Page Up** / **Page Down**          | Move a page up / down                                |
-| **Tab**                              | Insert a tab — the page owns the key, so it never moves focus |
+| **Tab**                              | Insert a tab — the chart owns the key, so it never moves focus |
 
 The two word rows are the exception to the chapter's Cmd/Ctrl convention: word
 motion and word delete are **Ctrl** or **Option** on every platform, macOS

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ src/
 tests/         # 622 Catch2 unit tests (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
-MANUAL.md      # end-user manual (Pandoc-buildable to PDF via packaging/build-pdf.sh)
+MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)
 ```
 
 ## Builds & contributing

--- a/docs/build-pdf.sh
+++ b/docs/build-pdf.sh
@@ -45,10 +45,12 @@ trap 'rm -rf "${PROCESSED_DIR}"' EXIT
 perl -CSD -pe 's/[ \t]*\x{2014}[ \t]*/ - /g' "${SRC}" > "${PROCESSED}"
 
 # The body font (Latin Modern, pandoc's xelatex default) lacks the handful of
-# symbol glyphs the manual uses - musical note, geometric triangles/discs,
-# transport arrows, >=, keyboard, refresh. Map each to a DejaVu Sans fallback
-# (ships via fonts-dejavu and covers all of them) so they render instead of
-# dropping out. Only these codepoints fall back; the rest stays Latin Modern.
+# symbol glyphs the manual uses - musical note, sharp, flat, geometric
+# triangles/discs, transport arrows, >=, keyboard, refresh. Map each to a
+# DejaVu Sans fallback (ships via fonts-dejavu and covers all of them) so they
+# render instead of dropping out. A codepoint missing from this list renders as
+# nothing at all, silently apart from a xelatex "Missing character" warning.
+# Only these codepoints fall back; the rest stays Latin Modern.
 HEADER="${PROCESSED_DIR}/glyph-fallback.tex"
 cat > "${HEADER}" <<'TEX'
 \usepackage{newunicodechar}
@@ -63,6 +65,8 @@ cat > "${HEADER}" <<'TEX'
 \newunicodechar{◉}{{\glyphfallback ◉}}
 \newunicodechar{●}{{\glyphfallback ●}}
 \newunicodechar{♩}{{\glyphfallback ♩}}
+\newunicodechar{♭}{{\glyphfallback ♭}}
+\newunicodechar{♯}{{\glyphfallback ♯}}
 \newunicodechar{⟳}{{\glyphfallback ⟳}}
 \newunicodechar{⚠}{{\glyphfallback ⚠}}
 

--- a/docs/capture-screenshots.sh
+++ b/docs/capture-screenshots.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Drive Dusk Studio's built-in capture harness to (re)generate manual figures.
 #
-# Produces the ✅ rows in docs/screenshot-list.md into docs/images/. The
-# remaining rows (MTC dropdown, OS file browser, offline-plugin slot) are
+# Produces the ✅ rows in docs/screenshot-list.md into docs/images/. The one
+# remaining row, the notepad, is a native window this cannot reach and is
 # captured by hand — see that file.
 #
 # Runs the app on an ISOLATED Xvfb display (X11 backend), NOT your live
@@ -32,13 +32,15 @@ if [[ ! -x "${BIN}" ]]; then
 fi
 
 mkdir -p "${OUT}"
+LOG=""
 
 # ── Start an isolated virtual display ───────────────────────────────────
 echo "Starting Xvfb on ${DISPLAY_NUM} (${SCREEN}) ..." >&2
 Xvfb "${DISPLAY_NUM}" -screen 0 "${SCREEN}" -nolisten tcp >/dev/null 2>&1 &
 XVFB_PID=$!
-cleanup() { kill "${XVFB_PID}" >/dev/null 2>&1 || true; }
+cleanup() { kill "${XVFB_PID}" >/dev/null 2>&1 || true; rm -f "${LOG}"; }
 trap cleanup EXIT
+LOG="$(mktemp)"
 sleep 1   # let the server come up
 
 echo "Capturing into ${OUT} ..." >&2
@@ -48,8 +50,18 @@ env -u WAYLAND_DISPLAY \
     DISPLAY="${DISPLAY_NUM}" \
     DUSKSTUDIO_SKIP_STARTUP_DIALOG=1 \
     DUSKSTUDIO_CAPTURE_DIR="${OUT}" \
-    timeout 180 "${BIN}" || true   # harness quits itself; ignore teardown status
+    timeout 180 "${BIN}" 2>&1 | tee "${LOG}" >&2 || true
 
 rm -rf "${OUT}/_demo"
+
+# The harness quits the app itself and Linux teardown still returns nonzero, so
+# the exit status says nothing. Its own "done" line is the only signal that
+# every figure was written; without it the run died part-way and docs/images
+# still holds the PNGs from last time.
+if ! grep -q '\[Dusk Studio/capture\] done' "${LOG}"; then
+  echo "error: the capture harness did not finish - the PNGs in ${OUT} are stale." >&2
+  exit 1
+fi
+
 echo "Done. PNGs in ${OUT}:" >&2
 ls -1 "${OUT}"/*.png 2>/dev/null | sed "s#${OUT}/#  #" >&2 || echo "  (none — check stderr above)" >&2

--- a/docs/capture-screenshots.sh
+++ b/docs/capture-screenshots.sh
@@ -56,10 +56,10 @@ rm -rf "${OUT}/_demo"
 
 # The harness quits the app itself and Linux teardown still returns nonzero, so
 # the exit status says nothing. Its own "done" line is the only signal that
-# every figure was written; without it the run died part-way and docs/images
-# still holds the PNGs from last time.
+# every figure was written; without it the run died part-way, leaving the
+# figures it never reached at whatever an earlier run wrote.
 if ! grep -q '\[Dusk Studio/capture\] done' "${LOG}"; then
-  echo "error: the capture harness did not finish - the PNGs in ${OUT} are stale." >&2
+  echo "error: the capture harness did not finish — some PNGs in ${OUT} may be left over from an earlier run." >&2
   exit 1
 fi
 

--- a/docs/screenshot-list.md
+++ b/docs/screenshot-list.md
@@ -1,8 +1,9 @@
 # Dusk Studio — Manual Screenshot List
 
-The 32 unique PNGs referenced by `MANUAL.md` (33 refs — `np-09-tape-strip.png`
-is used twice). Capture target: `docs/images/<name>.png`. Filenames must match
-the markers embedded in `MANUAL.md` exactly.
+The 31 unique PNGs referenced by `MANUAL.md` (32 refs — `np-09-tape-strip.png`
+is used twice), plus `np-12-notepad.png`, whose embed is pulled until it is
+reshot. Capture target: `docs/images/<name>.png`. Filenames must match the
+markers embedded in `MANUAL.md` exactly.
 
 Most of these are produced automatically by the capture harness — run:
 
@@ -48,28 +49,28 @@ notes below.
 | `np-06-master-strip.png`            | L235   | ✅   | Master strip top-to-bottom.                                 |
 | `np-07-aux-view.png`                | L250   | ✅   | One aux lane shown full-width.                              |
 | `np-08-mastering-view.png`          | L263   | ✅   | Mastering chain.                                            |
-| `np-09-tape-strip.png`              | L278, L1149 | ✅ | Tape strip with regions, a marker, and a loop bracket. (Reused at both lines.) |
+| `np-09-tape-strip.png`              | L278, L1147 | ✅ | Tape strip with regions, a marker, and a loop bracket. (Reused at both lines.) |
 | `np-10-region-editor.png`           | L293   | ✅   | Audio region editor modal.                                  |
 | `np-11-piano-roll.png`              | L305   | ✅   | Piano roll modal.                                           |
-| `np-12-notepad.png`                 | L554   | ❌   | Notepad chart: title, section markers, chords over syllables. |
+| `np-12-notepad.png`                 | pulled | ❌   | Notepad chart: title, section markers, chords over syllables. |
 
 ## Chapter figures
 
 | Filename                        | Manual | Auto | What to capture                                            |
 | ------------------------------- | ------ | ---- | --------------------------------------------------------- |
-| `rec-01-arm-multiple.png`       | L1044  | ✅   | Eight tracks armed simultaneously, RECORDING stage.       |
-| `ed-04-region-editor-modal.png` | L1266  | ✅   | Region editor modal over a region with fade-in/out.       |
-| `ed-05-piano-roll-full.png`     | L1318  | ✅   | Piano roll with notes, a CC ramp, scale highlight.        |
-| `fx-01-eq.png`                  | L709   | ✅   | Channel EQ editor — HPF/LPF + 4 bands, curve shaped.      |
-| `fx-02-comp.png`                | L731   | ✅   | Channel compressor editor (VCA mode).                     |
-| `fx-03-tape.png`                | L886   | ✅   | Master tape-machine editor (native panel).                |
-| `mm-01-automation-modes.png`    | L1406  | ✅   | A fader's automation-mode label (READ / WRITE / TOUCH).   |
-| `mm-02-mastering-chain.png`     | L967   | ✅   | Mastering chain with EQ, comp, and limiter engaged.       |
-| `pl-01-plugin-picker.png`       | L1480  | ✅   | Plugin picker panel populated.                            |
-| `pl-04-hw-insert.png`           | L1599  | ✅   | Hardware insert editor with I/O pickers and Ping button.  |
-| `sync-01-mcu-bindings.png`      | L1714  | ✅   | MIDI Bindings panel populated with a few learned bindings.|
-| `bnc-01-bounce-dialog.png`      | L1841  | ✅   | Bounce dialog (file picker + progress). (No format options — see note.) |
-| `ts-02-plugin-offline.png`      | L2097  | ✅   | A plugin slot in the `⚠ (offline)` state (the harness stages a synthetic one). |
+| `rec-01-arm-multiple.png`       | L1042  | ✅   | Eight tracks armed simultaneously, RECORDING stage.       |
+| `ed-04-region-editor-modal.png` | L1264  | ✅   | Region editor modal over a region with fade-in/out.       |
+| `ed-05-piano-roll-full.png`     | L1316  | ✅   | Piano roll with notes, a CC ramp, scale highlight.        |
+| `fx-01-eq.png`                  | L707   | ✅   | Channel EQ editor — HPF/LPF + 4 bands, curve-shaped.      |
+| `fx-02-comp.png`                | L729   | ✅   | Channel compressor editor (VCA mode).                     |
+| `fx-03-tape.png`                | L884   | ✅   | Master tape-machine editor (native panel).                |
+| `mm-01-automation-modes.png`    | L1404  | ✅   | A fader's automation-mode label (READ / WRITE / TOUCH).   |
+| `mm-02-mastering-chain.png`     | L965   | ✅   | Mastering chain with EQ, comp, and limiter engaged.       |
+| `pl-01-plugin-picker.png`       | L1478  | ✅   | Plugin picker panel populated.                            |
+| `pl-04-hw-insert.png`           | L1597  | ✅   | Hardware insert editor with I/O pickers and Ping button.  |
+| `sync-01-mcu-bindings.png`      | L1712  | ✅   | MIDI Bindings panel populated with a few learned bindings.|
+| `bnc-01-bounce-dialog.png`      | L1839  | ✅   | Bounce dialog (file picker + progress). (No format options — see note.) |
+| `ts-02-plugin-offline.png`      | L2095  | ✅   | A plugin slot in the `⚠ (offline)` state (the harness stages a synthetic one). |
 
 ## Compact-mode strips (captured, not yet referenced by `MANUAL.md`)
 
@@ -142,7 +143,10 @@ exist.)
 
 The checked-in `np-12-notepad.png` still shows the pre-0.13 prototype notepad —
 raw Markdown textarea, old toolbar, a Close button — none of which exists any
-more. It is stale until someone reshoots it per the recipe above.
+more. Rather than ship a figure that contradicts the prose beside it, the embed
+is pulled from `MANUAL.md` for 0.13: the PNG and this recipe stay put, and the
+figure goes back under `## The notepad` as a one-line
+`![Session notepad.](docs/images/np-12-notepad.png)` once it is reshot.
 
 ---
 

--- a/docs/screenshot-list.md
+++ b/docs/screenshot-list.md
@@ -11,8 +11,9 @@ docs/capture-screenshots.sh         # builds (if needed), drives the app, writes
 ```
 
 The harness drives the real app via `DUSKSTUDIO_CAPTURE_DIR` (see
-`src/ui/ScreenshotCapture.*`). The **Auto** column marks what it produces; the
-rest are manual (transient states, popup menus, OS dialogs) with notes below.
+`src/ui/ScreenshotCapture.*`). The **Auto** column marks what it produces. Only
+the notepad is manual — it is a native window the harness cannot reach — with
+notes below.
 
 **Capture conventions (manual shots)**
 
@@ -27,50 +28,48 @@ rest are manual (transient states, popup menus, OS dialogs) with notes below.
 
 | Filename                   | Manual | Auto | What to capture                                                     |
 | -------------------------- | ------ | ---- | ------------------------------------------------------------------ |
-| `qg-01-startup.png`        | L62    | ✅   | First-launch window, Startup dialog visible, audio device unset.   |
-| `qg-02-audio-settings.png` | L70    | ✅   | `Settings → Audio` panel, a real interface selected.               |
-| `qg-03-arm-track.png`      | L82    | ✅   | Channel strip 1 armed (ARM lit), input picked, IN on. RECORDING.   |
-| `qg-04-record-rolling.png` | L90    | ✅   | Mid-record: meters lit, a region drawing into the tape strip.      |
-| `qg-05-overdub.png`        | L98    | ✅   | Track 1 has a region; track 2 mid-record.                          |
-| `qg-06-mixing-stage.png`   | L114   | ✅   | MIXING stage on strip 1 — send knobs replace the input block.      |
-| `qg-07-bounce-dialog.png`  | L124   | ✅   | Bounce **file picker** at the session folder, then progress bar. (No format options — see note.) |
+| `qg-01-startup.png`        | L66    | ✅   | First-launch window, Startup dialog visible, audio device unset.   |
+| `qg-02-audio-settings.png` | L74    | ✅   | `Settings → Audio` panel, a real interface selected.               |
+| `qg-03-arm-track.png`      | L86    | ✅   | Channel strip 1 armed (ARM lit), input picked, IN on. RECORDING.   |
+| `qg-04-record-rolling.png` | L94    | ✅   | Mid-record: meters lit, a region drawing into the tape strip.      |
+| `qg-05-overdub.png`        | L102   | ✅   | Track 1 has a region; track 2 mid-record.                          |
+| `qg-06-mixing-stage.png`   | L118   | ✅   | MIXING stage on strip 1 — send knobs replace the input block.      |
+| `qg-07-bounce-dialog.png`  | L128   | ✅   | Bounce **file picker** at the session folder, then progress bar. (No format options — see note.) |
 
 ## Names and Functions of Parts (annotated — add callouts after capture)
 
 | Filename                            | Manual | Auto | What to capture                                              |
 | ----------------------------------- | ------ | ---- | ----------------------------------------------------------- |
-| `np-01-main-window.png`             | L138   | ✅   | Full window, six horizontal bands.                          |
-| `np-02-transport-bar.png`           | L151   | ✅   | Transport bar, full width.                                  |
-| `np-03-channel-strip-mixing.png`    | L178   | ✅   | One full channel strip, MIXING stage (sends visible).       |
-| `np-04-channel-strip-recording.png` | L205   | ✅   | Same strip, RECORDING stage (input block + ARM/IN/PRINT).   |
-| `np-05-bus-strip.png`               | L216   | ✅   | One bus strip top-to-bottom.                                |
-| `np-06-master-strip.png`            | L231   | ✅   | Master strip top-to-bottom.                                 |
-| `np-07-aux-view.png`                | L246   | ✅   | One aux lane shown full-width.                              |
-| `np-08-mastering-view.png`          | L259   | ✅   | Mastering chain.                                            |
-| `np-09-tape-strip.png`              | L274, L1000 | ✅ | Tape strip with regions, a marker, and a loop bracket. (Reused at both lines.) |
-| `np-10-region-editor.png`           | L288   | ✅   | Audio region editor modal.                                  |
-| `np-11-piano-roll.png`              | L300   | ✅   | Piano roll modal.                                           |
-| `np-12-notepad.png`                 | L544   | ❌   | Native Document view with styled sample lyrics and lists.   |
+| `np-01-main-window.png`             | L142   | ✅   | Full window, six horizontal bands.                          |
+| `np-02-transport-bar.png`           | L155   | ✅   | Transport bar, full width.                                  |
+| `np-03-channel-strip-mixing.png`    | L182   | ✅   | One full channel strip, MIXING stage (sends visible).       |
+| `np-04-channel-strip-recording.png` | L209   | ✅   | Same strip, RECORDING stage (input block + ARM/IN/PRINT).   |
+| `np-05-bus-strip.png`               | L220   | ✅   | One bus strip top-to-bottom.                                |
+| `np-06-master-strip.png`            | L235   | ✅   | Master strip top-to-bottom.                                 |
+| `np-07-aux-view.png`                | L250   | ✅   | One aux lane shown full-width.                              |
+| `np-08-mastering-view.png`          | L263   | ✅   | Mastering chain.                                            |
+| `np-09-tape-strip.png`              | L278, L1149 | ✅ | Tape strip with regions, a marker, and a loop bracket. (Reused at both lines.) |
+| `np-10-region-editor.png`           | L293   | ✅   | Audio region editor modal.                                  |
+| `np-11-piano-roll.png`              | L305   | ✅   | Piano roll modal.                                           |
+| `np-12-notepad.png`                 | L554   | ❌   | Notepad chart: title, section markers, chords over syllables. |
 
 ## Chapter figures
 
 | Filename                        | Manual | Auto | What to capture                                            |
 | ------------------------------- | ------ | ---- | --------------------------------------------------------- |
-| `rec-01-arm-multiple.png`       | L903   | ✅   | Eight tracks armed simultaneously, RECORDING stage.       |
-| `ed-04-region-editor-modal.png` | L1102  | ✅   | Region editor modal over a region with fade-in/out.       |
-| `ed-05-piano-roll-full.png`     | L1152  | ✅   | Piano roll with notes, a CC ramp, scale highlight.        |
-| `fx-01-eq.png`                  | EQ §   | ✅   | Channel EQ editor — HPF/LPF + 4 bands, curve shaped.      |
-| `fx-02-comp.png`                | Comp § | ✅   | Channel compressor editor (VCA mode).                     |
-| `fx-03-tape.png`                | Tape § | ✅   | Master tape-machine editor (native panel).                |
-| `mm-01-automation-modes.png`    | L1238  | ✅   | A fader's automation-mode label (READ / WRITE / TOUCH).   |
-| `mm-02-mastering-chain.png`     | L835   | ✅   | Mastering chain with EQ, comp, and limiter engaged.       |
-| `pl-01-plugin-picker.png`       | L1296  | ✅   | Plugin picker panel populated.                            |
-| `pl-04-hw-insert.png`           | L1392  | ✅   | Hardware insert editor with I/O pickers and Ping button.  |
-| `sync-01-mcu-bindings.png`      | L1492  | ✅   | MIDI Bindings panel populated with a few learned bindings.|
-| `sync-02-mtc-rates.png`         | L1430  | ⚠️   | MTC frame-rate dropdown **open** showing all four rates.  |
-| `ses-02-session-folder.png`     | L1556  | ❌   | OS file browser showing the session folder contents.      |
-| `bnc-01-bounce-dialog.png`      | L1617  | ✅   | Bounce dialog (file picker + progress). (No format options — see note.) |
-| `ts-02-plugin-offline.png`      | L1815  | ⚠️   | A plugin slot showing the `⚠ (offline)` state.            |
+| `rec-01-arm-multiple.png`       | L1044  | ✅   | Eight tracks armed simultaneously, RECORDING stage.       |
+| `ed-04-region-editor-modal.png` | L1266  | ✅   | Region editor modal over a region with fade-in/out.       |
+| `ed-05-piano-roll-full.png`     | L1318  | ✅   | Piano roll with notes, a CC ramp, scale highlight.        |
+| `fx-01-eq.png`                  | L709   | ✅   | Channel EQ editor — HPF/LPF + 4 bands, curve shaped.      |
+| `fx-02-comp.png`                | L731   | ✅   | Channel compressor editor (VCA mode).                     |
+| `fx-03-tape.png`                | L886   | ✅   | Master tape-machine editor (native panel).                |
+| `mm-01-automation-modes.png`    | L1406  | ✅   | A fader's automation-mode label (READ / WRITE / TOUCH).   |
+| `mm-02-mastering-chain.png`     | L967   | ✅   | Mastering chain with EQ, comp, and limiter engaged.       |
+| `pl-01-plugin-picker.png`       | L1480  | ✅   | Plugin picker panel populated.                            |
+| `pl-04-hw-insert.png`           | L1599  | ✅   | Hardware insert editor with I/O pickers and Ping button.  |
+| `sync-01-mcu-bindings.png`      | L1714  | ✅   | MIDI Bindings panel populated with a few learned bindings.|
+| `bnc-01-bounce-dialog.png`      | L1841  | ✅   | Bounce dialog (file picker + progress). (No format options — see note.) |
+| `ts-02-plugin-offline.png`      | L2097  | ✅   | A plugin slot in the `⚠ (offline)` state (the harness stages a synthetic one). |
 
 ## Compact-mode strips (captured, not yet referenced by `MANUAL.md`)
 
@@ -101,37 +100,37 @@ The harness renders the track I/O config popup in all three modes. No
 ## Manual-only shots (notes)
 
 - **`np-12-notepad.png`**: the notepad is a separate DPF/DGL native window, so
-  JUCE's `createComponentSnapshot` cannot capture it. Open the notepad, use the
-  Markdown tab to paste the sample below, switch back to Document, and capture
-  the native window.
+  JUCE's `createComponentSnapshot` cannot capture it — and DGL will not open
+  under Xvfb, so this one has to be shot on a live desktop session rather than
+  through `capture-screenshots.sh`.
+
+  There is a single view, the chart; the ChordPro source is the session's
+  `notepad.md` sidecar and there is no source tab in the window. The quickest
+  way to stage the sample is to write it into `<session>/notepad.md` with the
+  session closed, reopen the session, then open the notepad from the transport
+  bar. Building it in the chart works too — **Section** for the markers,
+  **Ctrl+K** for the chords.
 
   ```markdown
-  # Little Angel — verse 1
+  # Little Angel
 
-  Sang this one **too fast** at the *first* session; keep the pocket lazy and
-  let the last word of every line trail off before the downbeat, otherwise the
-  chorus lands early and the whole take rushes.
+  [Verse]
+  [Am]Sang this one too [F]fast at the [C]first session,
+  [Am]keep the pocket [F]lazy and the [G]last word [C]late.
+
+  [Chorus]
+  [F]Little angel, [C]don't come [G]down for me [Am]yet.
 
   Reference: [rough mix](https://example.com/little-angel-rough)
 
-  - warm up the tape echo before take 1
-  - double the hook an octave down
-
-  1. tune down a half step
-  2. print the vocal dry
-
-  - [x] comp the verse
-  - [ ] re-cut the bridge harmony
+  Warm the tape echo up before take 1, and double the hook an octave
+  **down** on the *second* chorus.
   ```
-- **`sync-02-mtc-rates.png`** (⚠️): the frame-rate list is a native popup menu;
-  `createComponentSnapshot` can't grab it. Open `Settings → MIDI sync`, click the
-  MTC rate dropdown, capture the window with `gnome-screenshot -w` while the menu
-  is open.
-- **`ses-02-session-folder.png`** (❌): this is the OS file manager, not a Dusk
-  Studio window. Open the session folder in Files/Nautilus and screenshot it.
-- **`ts-02-plugin-offline.png`** (⚠️): needs a session referencing a plugin that
-  isn't installed on this box. Either load such a session and grab the strip, or
-  let the harness stage a synthetic offline slot (best-effort).
+
+  Capture with the caret in a lyric line. The shot should show the chord labels
+  floating over their syllables, `[Verse]` and `[Chorus]` rendered as section
+  labels rather than brackets, the Markdown link left intact beside them, and a
+  footer reading two sections, four chords, and the detected key.
 
 ## Stale-caption fix log
 
@@ -141,12 +140,16 @@ at the device rate, fixed 5 s tail). The capture for `qg-07` / `bnc-01` is the
 versions of this list said "sample rate 48k, bit depth 24" — that UI does not
 exist.)
 
+The checked-in `np-12-notepad.png` still shows the pre-0.13 prototype notepad —
+raw Markdown textarea, old toolbar, a Close button — none of which exists any
+more. It is stale until someone reshoots it per the recipe above.
+
 ---
 
 ## Production checklist
 
 - [ ] `docs/capture-screenshots.sh` produces every ✅ row into `docs/images/`.
-- [ ] Manual rows (⚠️ / ❌) captured by hand.
+- [ ] `np-12-notepad.png` captured by hand on a live desktop session.
 - [ ] Annotated `np-*` shots have callouts overlaid (number + leader line).
 - [ ] PNGs shrunk (`oxipng -o4` or `pngquant`).
 - [ ] `MANUAL.pdf` rebuilds clean via `docs/build-pdf.sh` with all images present.


### PR DESCRIPTION
Fixes #192.

MANUAL.md, docs/screenshot-list.md, docs/capture-screenshots.sh, .gitignore, plus a one-word path fix in README.

- Bank model rewritten at all ten sites: screen paging is width-derived (up to four pages, stride 6 to 24) and the hardware bank of 8 is a separate axis; (banked) MIDI targets follow the surface bank. Verified against BankMapping.h, ConsoleView.cpp and the AudioEngine binding resolution.
- Notepad prose matches the shipping window: Section button opens a picker of seven labels, chord spelling is a three way Auto/sharp/flat control, and there is no separate source or markdown view. The issue's chart/source naming did not survive verification; the two things needing names are the chart and the notepad.md sidecar.
- New notepad shortcut reference. Every row verified in NotepadEditor.cpp, including the platform exception: word motion and word delete are Ctrl (or Option) everywhere, because the editor's word flag never reads Cmd on macOS.
- Virtual keyboard gets its own section instead of sitting under step record.
- Screenshot list: np-12 recipe rewritten for the chart notepad with ChordPro sample content that exercises key detection; stale rows removed; ts-02 marked harness-emitted; line-number column refreshed.
- capture-screenshots.sh now fails on a mid-run harness crash: success requires the harness's own done sentinel, not just process exit status.

Not in this PR: the np-12 PNG itself still shows the deleted prototype. Recapture is manual (DGL will not open under Xvfb) and is tracked in the screenshot list's stale log.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the user manual with clearer guidance on responsive pages, fixed control-surface banks, synchronized navigation, virtual-keyboard MIDI input, and step recording.
  * Added documentation for notepad chart editing, section markers, chord spelling, platform shortcuts, and expanded keyboard controls.
  * Clarified that the **B** key taps tempo and standardized bank/page terminology.
  * Updated manual-building and screenshot-capture instructions, including improved validation and notepad screenshot requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->