### PR TITLE
docs: point build docs at the real donor layout and document the DPF stack

### DIFF
--- a/BUILDING-LINUX.md
+++ b/BUILDING-LINUX.md
@@ -1,6 +1,6 @@
 # Building Dusk Studio on Linux
 
-Dusk Studio targets Linux as its primary platform. ALSA is the default audio backend; PipeWire's JACK shim works too. JUCE 8 / C++17, no exotic toolchains.
+Dusk Studio targets Linux as its primary platform. It talks to the audio hardware through two backends of its own: a native PipeWire backend, preferred by default, and a native ALSA backend behind it. JUCE 8 / C++17, no exotic toolchains.
 
 This document is aimed at a developer with a Linux machine who has been handed the source tree and wants to compile and run it. Patreon supporters who just want a precompiled binary should grab one from the Patreon post instead.
 
@@ -14,12 +14,14 @@ Verified on Ubuntu 22.04 LTS and Fedora 39. Other distros work with equivalent p
 sudo apt-get update
 sudo apt-get install -y --no-install-recommends \
   build-essential cmake ninja-build pkg-config git \
-  libasound2-dev libjack-jackd2-dev \
+  libasound2-dev libjack-jackd2-dev libpipewire-0.3-dev \
+  libsndfile1-dev libmp3lame-dev \
+  liblilv-dev libsuil-dev lv2-dev \
   ladspa-sdk \
   libcurl4-openssl-dev libfreetype-dev libfontconfig1-dev \
   libx11-dev libxcomposite-dev libxcursor-dev libxext-dev \
   libxinerama-dev libxrandr-dev libxrender-dev libxss-dev \
-  libwebkit2gtk-4.0-dev libglu1-mesa-dev \
+  libwebkit2gtk-4.0-dev libgl1-mesa-dev libglu1-mesa-dev \
   libwayland-dev libxkbcommon-dev libdecor-0-dev
 ```
 
@@ -28,27 +30,33 @@ sudo apt-get install -y --no-install-recommends \
 ```bash
 sudo dnf install -y \
   gcc-c++ cmake ninja-build pkgconf-pkg-config git \
-  alsa-lib-devel jack-audio-connection-kit-devel \
+  alsa-lib-devel jack-audio-connection-kit-devel pipewire-devel \
+  libsndfile-devel lame-devel \
+  lilv-devel suil-devel lv2-devel \
   ladspa-devel \
   libcurl-devel freetype-devel fontconfig-devel \
   libX11-devel libXcomposite-devel libXcursor-devel libXext-devel \
   libXinerama-devel libXrandr-devel libXrender-devel libXScrnSaver-devel \
-  webkit2gtk4.0-devel mesa-libGLU-devel \
+  webkit2gtk4.0-devel mesa-libGL-devel mesa-libGLU-devel \
   wayland-devel libxkbcommon-devel libdecor-devel
 ```
 
+libsndfile is not optional — all audio file I/O goes through it and configure fails without it. The PipeWire, LV2-host and MP3-bounce packages are probed at configure time and drop their feature silently when absent, and the probe result is cached, so install them before the first configure rather than after.
+
 ## Repository layout
 
-Dusk Studio expects two sibling repositories alongside its own checkout:
+Dusk Studio expects four sibling repositories alongside its own checkout:
 
 ```
 ~/projects/
-├── Dusk Studio/             (this repo)
+├── dusk-studio/       (this repo)
 ├── JUCE-wayland/      (plugdata-team fork, branch: wayland-juce8)
-└── plugins-main/      (Dusk Audio plugins, donor DSP — main branch worktree)
+├── plugins/           (Dusk Audio plugins, donor DSP)
+├── DPF/               (DISTRHO Plugin Framework — native notepad UI)
+└── DPF-Widgets/       (Dear ImGui layer for DPF)
 ```
 
-CMake auto-discovers these. Override with `-DJUCE_PATH=...` / `-DDUSK_PLUGINS_PATH=...` if you keep them elsewhere.
+CMake auto-discovers these. Override with `-DJUCE_PATH=...`, `-DDUSK_PLUGINS_PATH=...`, `-DDPF_PATH=...`, `-DDPF_WIDGETS_PATH=...` if you keep them elsewhere.
 
 ### Why the JUCE-wayland fork (Linux-only)
 
@@ -60,19 +68,52 @@ Cross-platform Dusk Studio source compiles against either upstream JUCE or the f
 
 ```bash
 cd ~/projects
-git clone https://github.com/dusk-audio/Dusk Studio.git
+git clone https://github.com/dusk-audio/dusk-studio.git
 git clone --branch wayland-juce8 https://github.com/plugdata-team/JUCE.git JUCE-wayland
-git clone https://github.com/dusk-audio/dusk-audio-plugins.git plugins-main
+git clone https://github.com/dusk-audio/dusk-audio-plugins.git plugins
 ```
 
-If you also have an upstream `JUCE/` and a feature-branch `plugins/` sibling for cross-OS dev, CMake prefers `JUCE-wayland/` and `plugins-main/` first per [CLAUDE.md cross-OS table](CLAUDE.md).
+The explicit `plugins` target on the third clone is mandatory — the repo is named `dusk-audio-plugins` on GitHub, and `../plugins` is the only sibling directory CMake checks ([CMakeLists.txt:358-367](CMakeLists.txt#L358-L367)). Get it wrong and configure prints a warning rather than failing; the build then produces a recorder with no EQ, compressor, or tape.
+
+If you also keep an upstream `JUCE/` sibling for cross-OS dev, CMake prefers `JUCE-wayland/` on Linux and falls back to `JUCE/` only if the fork isn't there.
+
+### The native notepad (DPF + Dear ImGui)
+
+The session notepad is Dusk Studio's first native UI window: DPF/DGL for the OpenGL surface, DPF-Widgets for the Dear ImGui layer. Both come from Dusk-owned forks so an upstream rebase can't break a build.
+
+```bash
+cd ~/projects
+git clone https://github.com/dusk-audio/DPF.git
+git -C DPF checkout f9fbc62af6fa7ce638a6f1e1482896c385a4955e
+git -C DPF submodule update --init
+git clone https://github.com/dusk-audio/DPF-Widgets.git
+git -C DPF-Widgets checkout 730da6397904da66d99667c1cb30fc77fc3d794a
+```
+
+Clone then check out the SHA, rather than cloning a branch: DPF's pin is the tip of `fix/wayland-review-findings`, which was never merged to that fork's `main`. (DPF-Widgets' pin happens to be its `main` tip today, but pin it the same way.) Neither branch may be deleted upstream — a plain clone would stop reaching the commit, and CI fetches the same SHAs. The submodule step is not optional either: DGL pulls its windowing layer from `dgl/src/pugl-upstream`.
+
+The pins live in [.github/actions/clone-dpf-stack/action.yml](.github/actions/clone-dpf-stack/action.yml), which is the single source of truth for every workflow — read them from there if it ever disagrees with the commands above.
+
+Missing either checkout, `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` defaults to **OFF** and configure prints one easily-missed line:
+
+```
+-- Native notepad: DPF / DPF-Widgets not found - disabled
+```
+
+The rest of the app builds and runs normally, but opening the notepad reports *"Notepad unavailable: built without the native notepad UI"*. Passing `-DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=ON` with a checkout missing turns that into a configure error instead of a silent downgrade.
+
+That OFF is sticky, because `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` is a **cached** CMake option. Configure `build-linux/` before cloning DPF and cloning it afterwards changes nothing on the next `cmake -S . -B build-linux` — and the "not found" line stops printing too, so nothing hints that the notepad is still off. Either configure into a fresh build directory or force the cache:
+
+```bash
+cmake -S . -B build-linux -DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=ON
+```
 
 ## Configure + build
 
 From the Dusk Studio directory:
 
 ```bash
-cd ~/projects/Dusk Studio
+cd ~/projects/dusk-studio
 cmake -S . -B build-linux -G Ninja -DCMAKE_BUILD_TYPE=Release
 cmake --build build-linux -j$(nproc)
 ```
@@ -103,7 +144,9 @@ cmake --build build-linux-debug -j$(nproc)
 ```bash
 cmake -S . -B build-linux \
   -DJUCE_PATH=/some/other/JUCE \
-  -DDUSK_PLUGINS_PATH=/some/other/plugins
+  -DDUSK_PLUGINS_PATH=/some/other/plugins \
+  -DDPF_PATH=/some/other/DPF \
+  -DDPF_WIDGETS_PATH=/some/other/DPF-Widgets
 ```
 
 ## Tests
@@ -140,12 +183,14 @@ Useful for confirming the audio engine wires up correctly without needing to dri
 
 ## Audio backend selection
 
-Dusk Studio ships its own ALSA backend ([src/engine/alsa/](src/engine/alsa/)) plus the stock JUCE backends (JACK / ALSA-via-JUCE). Pick from the **Audio Device** panel inside Dusk Studio.
+Dusk Studio ships two backends of its own, both speaking to the system directly rather than through JUCE. Pick from the **Audio Device** panel inside Dusk Studio, where they appear as **PipeWire** and **ALSA**.
 
-- **ALSA (Dusk Studio native)** — direct hardware access, lowest latency, no graph hops. Default.
-- **JACK** — works against PipeWire's JACK shim or a real JACK server. Use if your interface is owned by PipeWire's graph and you want to route through there.
+- **PipeWire** ([src/engine/pipewire/](src/engine/pipewire/)) — a single `pw_filter` node on the graph; every Sink / Source node is listed as its own device. Correct graph latency and a client that shows up as "Dusk Studio" instead of a generic JACK name. Preferred by default: it is registered first, and the panel opens on the first backend that enumerates any device ([src/engine/device/DeviceManager.cpp:204-218](src/engine/device/DeviceManager.cpp#L204-L218)).
+- **ALSA** ([src/engine/alsa/](src/engine/alsa/)) — direct hardware access, no graph hops. What you get when PipeWire isn't running, and what to pick when you want the interface to yourself.
 
-The Dusk Studio-native ALSA backend handles USB hot-unplug by surfacing the device error to the engine, which finalises any in-flight take. Details in [docs/USER_GUIDE.md](docs/USER_GUIDE.md#troubleshooting).
+There is no JACK backend. Dusk Studio used to reach PipeWire through JUCE's JACK path over the pipewire-jack shim; the native backend replaced it, and on Linux the JUCE device layer isn't compiled at all ([CMakeLists.txt:596-607](CMakeLists.txt#L596-L607)). To feed other applications, patch Dusk Studio inside PipeWire's graph with qpwgraph or Helvum.
+
+The Dusk Studio-native ALSA backend handles USB hot-unplug by surfacing the device error to the engine, which finalises any in-flight take. Details in [MANUAL.md](MANUAL.md#audio-device-disconnected-mid-session).
 
 ## Out-of-process plugin host (opt-in, all platforms)
 
@@ -163,7 +208,7 @@ See [packaging/README.md](packaging/README.md). Run `scripts/package-tarball.sh`
 
 - **JUCE-wayland fork is required at runtime.** The fork has five local commits (XEmbed mapping, X11-on-Wayland fix, peer-creation latch, XEmbed bg fix) on top of plugdata-team's `wayland-juce8` branch. Vanilla upstream JUCE will compile (the `addDefaultFormats` shim in [src/engine/JuceCompat.h](src/engine/JuceCompat.h) abstracts the API split) but will hit the mutter crash on plugin-editor close under GNOME/Wayland. See [CLAUDE.md](CLAUDE.md) for context.
 - **Plugin destructors are intentionally leaked at shutdown.** [src/DuskStudioApp.cpp](src/DuskStudioApp.cpp) `leakAllPluginInstancesForShutdown` is a Linux-only workaround for Diva's `__cxa_pure_virtual` abort in `~AM_VST3_ViewInterface`. The OS reclaims memory on process exit.
-- **PipeWire native backend is not implemented.** Dusk Studio uses ALSA directly or via JUCE's JACK backend (which speaks to PipeWire's JACK shim). A native PipeWire-graph integration would be a future addition, not blocking.
+- **No PipeWire backend without its dev package.** The backend compiles only when pkg-config finds `libpipewire-0.3` at configure time ([CMakeLists.txt:758-764](CMakeLists.txt#L758-L764)), and a configure without it says nothing — you get an ALSA-only binary and notice when the **Audio Device** panel offers one backend instead of two. Install `libpipewire-0.3-dev` first, then configure into a fresh build directory.
 - **Compiler warnings.** The vendored Dusk DSP `.cpp` files compiled into Dusk Studio emit shadow/sign-conversion warnings. `DUSKSTUDIO_STRICT_WARNINGS=ON` (`-Werror`) is opt-in but not yet enabled in CI until those are cleaned upstream or wrapped with per-source overrides.
 
 ## Reporting build issues

--- a/BUILDING-LINUX.md
+++ b/BUILDING-LINUX.md
@@ -30,7 +30,7 @@ sudo apt-get install -y --no-install-recommends \
 ```bash
 sudo dnf install -y \
   gcc-c++ cmake ninja-build pkgconf-pkg-config git \
-  alsa-lib-devel jack-audio-connection-kit-devel pipewire-devel \
+  alsa-lib-devel pipewire-jack-audio-connection-kit-devel pipewire-devel \
   libsndfile-devel lame-devel \
   lilv-devel suil-devel lv2-devel \
   ladspa-devel \
@@ -41,7 +41,7 @@ sudo dnf install -y \
   wayland-devel libxkbcommon-devel libdecor-devel
 ```
 
-libsndfile is not optional — all audio file I/O goes through it and configure fails without it. The PipeWire, LV2-host and MP3-bounce packages are probed at configure time and drop their feature silently when absent, and the probe result is cached, so install them before the first configure rather than after.
+libsndfile is not optional — all audio file I/O goes through it and configure fails without it. The PipeWire, LV2-host and MP3-bounce packages are probed at configure time and quietly drop their feature when absent; each miss costs you one easy-to-miss line in the configure log, so read it. On Fedora, take the `pipewire-jack-*` JACK headers rather than `jack-audio-connection-kit-devel`: the two conflict, and dnf will refuse the transaction on a PipeWire box.
 
 ## Repository layout
 
@@ -64,13 +64,21 @@ Stock JUCE on Linux uses X11 for top-level windows, which under GNOME / Wayland 
 
 Cross-platform Dusk Studio source compiles against either upstream JUCE or the fork; the wayland fork is required at runtime on Linux desktops. Mac dev uses upstream JUCE.
 
+`wayland-juce8` is a third-party branch head that moves under you, so the clone below is a dev convenience, not a reproducible input. CI and every release build the Dusk-owned mirror at an immutable tag instead — `dusk-audio/JUCE-wayland`, tag `dusk-wayland-v2`, rev `4d85afa175a45e0b5da11f9211de3ba88705588e` ([linux-release.yml:131-133](.github/workflows/linux-release.yml#L131-L133)). Match a release exactly by cloning that tag rather than the branch.
+
 ### Clone everything
 
 ```bash
 cd ~/projects
-git clone https://github.com/dusk-audio/dusk-studio.git
+git clone --recurse-submodules https://github.com/dusk-audio/dusk-studio.git
 git clone --branch wayland-juce8 https://github.com/plugdata-team/JUCE.git JUCE-wayland
 git clone https://github.com/dusk-audio/dusk-audio-plugins.git plugins
+```
+
+`--recurse-submodules` is required, not tidiness. Dusk Studio carries three: `external/clap`, `external/sfizz`, and `external/vst3sdk`. A clone without them fails configure outright on the CLAP headers (the native CLAP host defaults ON here, [CMakeLists.txt:27-33](CMakeLists.txt#L27-L33), and [CMakeLists.txt:1051-1056](CMakeLists.txt#L1051-L1056) stops the build), and a missing `external/sfizz` costs you the SF2 / multisample instrument with no diagnostic at all ([CMakeLists.txt:1138](CMakeLists.txt#L1138) simply gates on the header being there). Already cloned without them:
+
+```bash
+git submodule update --init --recursive
 ```
 
 The explicit `plugins` target on the third clone is mandatory — the repo is named `dusk-audio-plugins` on GitHub, and `../plugins` is the only sibling directory CMake checks ([CMakeLists.txt:358-367](CMakeLists.txt#L358-L367)). Get it wrong and configure prints a warning rather than failing; the build then produces a recorder with no EQ, compressor, or tape.
@@ -90,11 +98,11 @@ git clone https://github.com/dusk-audio/DPF-Widgets.git
 git -C DPF-Widgets checkout 730da6397904da66d99667c1cb30fc77fc3d794a
 ```
 
-Clone then check out the SHA, rather than cloning a branch: DPF's pin is the tip of `fix/wayland-review-findings`, which was never merged to that fork's `main`. (DPF-Widgets' pin happens to be its `main` tip today, but pin it the same way.) Neither branch may be deleted upstream — a plain clone would stop reaching the commit, and CI fetches the same SHAs. The submodule step is not optional either: DGL pulls its windowing layer from `dgl/src/pugl-upstream`.
+Clone then check out the SHA, rather than cloning a branch: DPF's pin is the tip of `fix/wayland-review-findings`, which was never merged to that fork's `main`. (DPF-Widgets' pin happens to be its `main` tip today, but pin it the same way.) Neither branch may be deleted upstream — a plain clone would stop reaching the commit, and CI fetches the same SHAs. Both checkouts end up on a detached HEAD, which is what you want here. The submodule step is not optional either: DGL pulls its windowing layer from `dgl/src/pugl-upstream`.
 
 The pins live in [.github/actions/clone-dpf-stack/action.yml](.github/actions/clone-dpf-stack/action.yml), which is the single source of truth for every workflow — read them from there if it ever disagrees with the commands above.
 
-Missing either checkout, `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` defaults to **OFF** and configure prints one easily-missed line:
+Missing either checkout, `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` defaults to **OFF** and configure says so once, quietly:
 
 ```
 -- Native notepad: DPF / DPF-Widgets not found - disabled
@@ -102,10 +110,11 @@ Missing either checkout, `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` defaults to **OFF** 
 
 The rest of the app builds and runs normally, but opening the notepad reports *"Notepad unavailable: built without the native notepad UI"*. Passing `-DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=ON` with a checkout missing turns that into a configure error instead of a silent downgrade.
 
-That OFF is sticky, because `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` is a **cached** CMake option. Configure `build-linux/` before cloning DPF and cloning it afterwards changes nothing on the next `cmake -S . -B build-linux` — and the "not found" line stops printing too, so nothing hints that the notepad is still off. Either configure into a fresh build directory or force the cache:
+That OFF is sticky, because `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` is a **cached** CMake option — the one dependency here that a later reconfigure won't pick up on its own. Configure `build-linux/` before cloning DPF and cloning it afterwards changes nothing on the next configure, and the "not found" line stops printing too, so nothing hints that the notepad is still off. Either configure into a fresh build directory or force the cache, keeping the rest of the flags from [Configure + build](#configure--build) below:
 
 ```bash
-cmake -S . -B build-linux -DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=ON
+cmake -S . -B build-linux -G Ninja -DCMAKE_BUILD_TYPE=Release \
+  -DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=ON
 ```
 
 ## Configure + build
@@ -185,10 +194,12 @@ Useful for confirming the audio engine wires up correctly without needing to dri
 
 Dusk Studio ships two backends of its own, both speaking to the system directly rather than through JUCE. Pick from the **Audio Device** panel inside Dusk Studio, where they appear as **PipeWire** and **ALSA**.
 
-- **PipeWire** ([src/engine/pipewire/](src/engine/pipewire/)) — a single `pw_filter` node on the graph; every Sink / Source node is listed as its own device. Correct graph latency and a client that shows up as "Dusk Studio" instead of a generic JACK name. Preferred by default: it is registered first, and the panel opens on the first backend that enumerates any device ([src/engine/device/DeviceManager.cpp:204-218](src/engine/device/DeviceManager.cpp#L204-L218)).
+- **PipeWire** ([src/engine/pipewire/](src/engine/pipewire/)) — a single `pw_filter` node on the graph; every Sink / Source node is listed as its own device. Correct graph latency and a client that shows up as "Dusk Studio" instead of a generic JACK name. Registered first ([src/engine/device/DeviceManager.cpp:204-218](src/engine/device/DeviceManager.cpp#L204-L218)), so it wins the first-run pick.
 - **ALSA** ([src/engine/alsa/](src/engine/alsa/)) — direct hardware access, no graph hops. What you get when PipeWire isn't running, and what to pick when you want the interface to yourself.
 
-There is no JACK backend. Dusk Studio used to reach PipeWire through JUCE's JACK path over the pipewire-jack shim; the native backend replaced it, and on Linux the JUCE device layer isn't compiled at all ([CMakeLists.txt:596-607](CMakeLists.txt#L596-L607)). To feed other applications, patch Dusk Studio inside PipeWire's graph with qpwgraph or Helvum.
+On a machine with no saved settings the first backend that enumerates any device is selected ([DeviceManager.cpp:227-236](src/engine/device/DeviceManager.cpp#L227-L236)), which is PipeWire when it's built in and the graph is up. After that your saved choice wins: the stored device blob names its backend and that lookup runs first ([DeviceManager.cpp:426-430](src/engine/device/DeviceManager.cpp#L426-L430)).
+
+There is no JACK backend to pick — no JACK device type is registered, so nothing JACK-shaped appears in the panel. Dusk Studio used to reach PipeWire through JUCE's JACK path over the pipewire-jack shim, and the native backend replaced it; `juce_audio_devices` still compiles (pulled in transitively by `juce_audio_utils`, [CMakeLists.txt:1291-1295](CMakeLists.txt#L1291-L1295)) with `JUCE_JACK=1`, which is why the JACK development headers stay a build dependency. To feed other applications while the PipeWire backend is active, patch Dusk Studio inside the graph with qpwgraph or Helvum; on the ALSA backend there is no graph to patch.
 
 The Dusk Studio-native ALSA backend handles USB hot-unplug by surfacing the device error to the engine, which finalises any in-flight take. Details in [MANUAL.md](MANUAL.md#audio-device-disconnected-mid-session).
 
@@ -208,7 +219,7 @@ See [packaging/README.md](packaging/README.md). Run `scripts/package-tarball.sh`
 
 - **JUCE-wayland fork is required at runtime.** The fork has five local commits (XEmbed mapping, X11-on-Wayland fix, peer-creation latch, XEmbed bg fix) on top of plugdata-team's `wayland-juce8` branch. Vanilla upstream JUCE will compile (the `addDefaultFormats` shim in [src/engine/JuceCompat.h](src/engine/JuceCompat.h) abstracts the API split) but will hit the mutter crash on plugin-editor close under GNOME/Wayland. See [CLAUDE.md](CLAUDE.md) for context.
 - **Plugin destructors are intentionally leaked at shutdown.** [src/DuskStudioApp.cpp](src/DuskStudioApp.cpp) `leakAllPluginInstancesForShutdown` is a Linux-only workaround for Diva's `__cxa_pure_virtual` abort in `~AM_VST3_ViewInterface`. The OS reclaims memory on process exit.
-- **No PipeWire backend without its dev package.** The backend compiles only when pkg-config finds `libpipewire-0.3` at configure time ([CMakeLists.txt:758-764](CMakeLists.txt#L758-L764)), and a configure without it says nothing — you get an ALSA-only binary and notice when the **Audio Device** panel offers one backend instead of two. Install `libpipewire-0.3-dev` first, then configure into a fresh build directory.
+- **No PipeWire backend without its dev package.** The backend compiles only when pkg-config finds `libpipewire-0.3` at configure time ([CMakeLists.txt:758-764](CMakeLists.txt#L758-L764)). The miss is easy to scroll past — `--   No package 'libpipewire-0.3' found` in the configure log — and the symptom is an ALSA-only **Audio Device** panel. Install `libpipewire-0.3-dev` and configure again; the probe re-runs every time, so the same build directory is fine.
 - **Compiler warnings.** The vendored Dusk DSP `.cpp` files compiled into Dusk Studio emit shadow/sign-conversion warnings. `DUSKSTUDIO_STRICT_WARNINGS=ON` (`-Werror`) is opt-in but not yet enabled in CI until those are cleaned upstream or wrapped with per-source overrides.
 
 ## Reporting build issues

--- a/BUILDING-WINDOWS.md
+++ b/BUILDING-WINDOWS.md
@@ -14,20 +14,22 @@ This document is aimed at a developer with a Windows machine who has been handed
 
 ## Repository layout
 
-Dusk Studio expects two sibling repositories to be present alongside its own checkout:
+Dusk Studio expects four sibling repositories to be present alongside its own checkout:
 
 ```
 C:\dev\
 ├── dusk-studio\       (this repo)
-├── JUCE\            (JUCE 8.0.x, the framework)
-└── plugins\         (Dusk Audio plugins, donor DSP)
+├── JUCE\              (JUCE 8.0.x, the framework)
+├── plugins\           (Dusk Audio plugins, donor DSP)
+├── DPF\               (DISTRHO Plugin Framework — native notepad UI)
+└── DPF-Widgets\       (Dear ImGui layer for DPF)
 ```
 
-CMake auto-discovers these. If you put them elsewhere, pass `-DJUCE_PATH=...` and `-DDUSK_PLUGINS_PATH=...` at configure time.
+CMake auto-discovers these. If you put them elsewhere, pass `-DJUCE_PATH=...`, `-DDUSK_PLUGINS_PATH=...`, `-DDPF_PATH=...`, and `-DDPF_WIDGETS_PATH=...` at configure time.
 
 ### Clone everything
 
-Open a terminal (PowerShell, cmd, or Git Bash). Both Dusk Studio repos are public, no auth needed.
+Open a terminal (PowerShell, cmd, or Git Bash). All of these repos are public, no auth needed.
 
 ```cmd
 cd C:\dev
@@ -36,9 +38,36 @@ git clone --branch 8.0.4 https://github.com/juce-framework/JUCE.git
 git clone https://github.com/dusk-audio/dusk-audio-plugins.git plugins
 ```
 
-The explicit `plugins` target on the third clone is mandatory: CMake auto-discovery looks for a sibling directory named `plugins\` or `plugins-main\` ([CMakeLists.txt:160-168](CMakeLists.txt#L160-L168)). The repo itself is named `dusk-audio-plugins` on GitHub, so without the explicit target you'd get a directory CMake can't find.
+The explicit `plugins` target on the third clone is mandatory: CMake auto-discovery looks for a sibling directory named `plugins\` and nothing else ([CMakeLists.txt:358-367](CMakeLists.txt#L358-L367)). The repo itself is named `dusk-audio-plugins` on GitHub, so without the explicit target you'd get a directory CMake can't find — and it warns rather than failing, leaving you with a recorder that has no EQ, compressor, or tape.
 
-The Dusk Studio repo's own directory name (`dusk-studio\`) doesn't matter to the build, but feel free to `git clone <url> Dusk Studio` if you prefer.
+The Dusk Studio repo's own directory name (`dusk-studio\`) doesn't matter to the build, so rename it if you prefer.
+
+### The native notepad (DPF + Dear ImGui)
+
+The session notepad is a native window built on DPF/DGL plus the Dear ImGui layer from DPF-Widgets, rather than a JUCE component. Both come from Dusk-owned forks pinned to the revisions CI builds:
+
+```cmd
+cd C:\dev
+git clone https://github.com/dusk-audio/DPF.git
+git -C DPF checkout f9fbc62af6fa7ce638a6f1e1482896c385a4955e
+git -C DPF submodule update --init
+git clone https://github.com/dusk-audio/DPF-Widgets.git
+git -C DPF-Widgets checkout 730da6397904da66d99667c1cb30fc77fc3d794a
+```
+
+Clone then check out the SHA, rather than cloning a branch: DPF's pin is the tip of `fix/wayland-review-findings`, which was never merged to that fork's `main`. (DPF-Widgets' pin happens to be its `main` tip today, but pin it the same way.) Neither branch may be deleted upstream — a plain clone would stop reaching the commit, and CI fetches the same SHAs. The submodule step is not optional either: DGL pulls its windowing layer from `dgl/src/pugl-upstream`. The pins live in [.github/actions/clone-dpf-stack/action.yml](.github/actions/clone-dpf-stack/action.yml), the single source of truth for every workflow.
+
+Missing either checkout, `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` defaults to **OFF** and configure prints one easily-missed line:
+
+```
+-- Native notepad: DPF / DPF-Widgets not found - disabled
+```
+
+Everything else builds and runs, but opening the notepad reports *"Notepad unavailable: built without the native notepad UI"*. Passing `-DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=ON` with a checkout missing makes it a configure error instead.
+
+That OFF is sticky, because `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` is a **cached** CMake option. Configure `build\` before cloning DPF and cloning it afterwards changes nothing on the next configure — and the "not found" line stops printing too. Either configure into a fresh build directory or force the cache with `-DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=ON`.
+
+If you override the paths explicitly, give DPF **forward slashes** — `-DDPF_PATH=C:/dev/DPF`. DPF's own CMake re-parses the value, and backslashes come through as invalid escapes.
 
 ## Configure + build
 
@@ -71,10 +100,10 @@ Debug binary appears under `build\DuskStudio_artefacts\Debug\`.
 ### Opening in Visual Studio
 
 ```cmd
-start build\Dusk Studio.sln
+start build\DuskStudio.sln
 ```
 
-In VS, right-click the **Dusk Studio** project → **Set as Startup Project** → F5 to debug.
+In VS, right-click the **DuskStudio** project → **Set as Startup Project** → F5 to debug.
 
 ## Overriding paths (if not using the sibling layout)
 
@@ -82,6 +111,8 @@ In VS, right-click the **Dusk Studio** project → **Set as Startup Project** �
 cmake -S . -B build ^
   -DJUCE_PATH=C:/some/other/JUCE ^
   -DDUSK_PLUGINS_PATH=C:/some/other/plugins ^
+  -DDPF_PATH=C:/some/other/DPF ^
+  -DDPF_WIDGETS_PATH=C:/some/other/DPF-Widgets ^
   -G "Visual Studio 17 2022" -A x64
 ```
 
@@ -110,9 +141,9 @@ Useful for confirming the audio engine wires up correctly without needing to dri
 
 ## Known caveats on Windows
 
-- **PlatformWindowing_Windows.cpp is a stub.** Most things work; the file exists as the place to land Windows-specific window-management fixes if/when XEmbed-equivalent bugs surface. The Linux-only `JUCE_XEmbedComponent` source isn't compiled on Windows ([CMakeLists.txt:57](CMakeLists.txt#L57)).
+- **PlatformWindowing_Windows.cpp is a stub.** Most things work; the file exists as the place to land Windows-specific window-management fixes if/when XEmbed-equivalent bugs surface. CMake picks the per-platform implementation at [CMakeLists.txt:615-621](CMakeLists.txt#L615-L621).
 - **No ASIO without the SDK.** WASAPI is the default; ASIO requires the SDK download above. Most users will be fine on WASAPI.
-- **The ALSA backend is not compiled.** [CMakeLists.txt:263](CMakeLists.txt#L263) gates Dusk Studio's custom ALSA `AudioIODeviceType` behind `UNIX AND NOT APPLE`. Windows falls through to JUCE's stock WASAPI/ASIO types.
+- **The ALSA backend is not compiled.** [CMakeLists.txt:728](CMakeLists.txt#L728) gates Dusk Studio's custom ALSA `AudioIODeviceType` behind `UNIX AND NOT APPLE`. Windows falls through to JUCE's stock WASAPI/ASIO types.
 - **Compiler warnings.** Project is primarily developed on Clang/GCC. MSVC may emit warnings; none are fatal. `/WX` (warnings-as-errors) is not enabled.
 - **MinGW/MSYS2 not tested.** Stick to MSVC via Visual Studio 2022.
 

--- a/BUILDING-WINDOWS.md
+++ b/BUILDING-WINDOWS.md
@@ -10,7 +10,14 @@ This document is aimed at a developer with a Windows machine who has been handed
    - During install, check the **"Desktop development with C++"** workload.
    - This brings MSVC, the Windows 10/11 SDK, and CMake. No separate CMake install needed.
 2. **Git for Windows**: https://git-scm.com/download/win
-3. *(optional)* **Steinberg ASIO SDK**, only if you want ASIO driver support in the audio device picker. Download from https://www.steinberg.net/asiosdk, accept the EULA, unzip somewhere stable, then pass `-DJUCE_ASIO_SDK_PATH=C:/path/to/asiosdk` at CMake configure time. Skip this for a first build; WASAPI works fine.
+3. **vcpkg**, for libsndfile and LAME. libsndfile is not optional on any platform — all audio file I/O goes through it and configure hard-fails without it ([CMakeLists.txt:574-582](CMakeLists.txt#L574-L582)). LAME is what enables MP3 bounce. Install the same static triplet CI uses, then hand CMake the prefix:
+
+   ```cmd
+   vcpkg install libsndfile:x64-windows-static mp3lame:x64-windows-static
+   ```
+
+   and add `-DCMAKE_PREFIX_PATH=<vcpkg-root>/installed/x64-windows-static` to the configure line, forward slashes as with the DPF paths below. `%VCPKG_INSTALLATION_ROOT%` holds that root on the CI images; on a hand-installed vcpkg, substitute wherever you cloned it.
+4. **Steinberg ASIO SDK** — effectively required for the Visual Studio flow in this document, despite reading like an extra. A multi-config generator with Release among its configurations fails the configure without it ([CMakeLists.txt:668-675](CMakeLists.txt#L668-L675) and [:703-709](CMakeLists.txt#L703-L709)), which is exactly what `-G "Visual Studio 17 2022"` gives you: a shipping Windows binary must not silently come out WASAPI-only. Download from https://www.steinberg.net/asiosdk, accept the EULA, unzip somewhere stable, then pass `-DASIOSDK_PATH=C:/path/to/asiosdk` (its `common/` must contain `iasiodrv.h`). To skip the download on a first dev build, pass `-DDUSKSTUDIO_REQUIRE_ASIO=OFF` instead and accept WASAPI only.
 
 ## Repository layout
 
@@ -33,10 +40,12 @@ Open a terminal (PowerShell, cmd, or Git Bash). All of these repos are public, n
 
 ```cmd
 cd C:\dev
-git clone https://github.com/dusk-audio/dusk-studio.git
+git clone --recurse-submodules https://github.com/dusk-audio/dusk-studio.git
 git clone --branch 8.0.4 https://github.com/juce-framework/JUCE.git
 git clone https://github.com/dusk-audio/dusk-audio-plugins.git plugins
 ```
+
+`--recurse-submodules` matters: `external/sfizz` carries the SF2 / multisample instrument engine, and CMake gates it purely on the header being present ([CMakeLists.txt:1138](CMakeLists.txt#L1138)) — clone without it and the feature is gone with no diagnostic. If you already cloned flat, run `git submodule update --init --recursive`.
 
 The explicit `plugins` target on the third clone is mandatory: CMake auto-discovery looks for a sibling directory named `plugins\` and nothing else ([CMakeLists.txt:358-367](CMakeLists.txt#L358-L367)). The repo itself is named `dusk-audio-plugins` on GitHub, so without the explicit target you'd get a directory CMake can't find — and it warns rather than failing, leaving you with a recorder that has no EQ, compressor, or tape.
 
@@ -57,15 +66,15 @@ git -C DPF-Widgets checkout 730da6397904da66d99667c1cb30fc77fc3d794a
 
 Clone then check out the SHA, rather than cloning a branch: DPF's pin is the tip of `fix/wayland-review-findings`, which was never merged to that fork's `main`. (DPF-Widgets' pin happens to be its `main` tip today, but pin it the same way.) Neither branch may be deleted upstream — a plain clone would stop reaching the commit, and CI fetches the same SHAs. The submodule step is not optional either: DGL pulls its windowing layer from `dgl/src/pugl-upstream`. The pins live in [.github/actions/clone-dpf-stack/action.yml](.github/actions/clone-dpf-stack/action.yml), the single source of truth for every workflow.
 
-Missing either checkout, `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` defaults to **OFF** and configure prints one easily-missed line:
+Missing either checkout, `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` defaults to **OFF** and configure says so once, quietly:
 
 ```
 -- Native notepad: DPF / DPF-Widgets not found - disabled
 ```
 
-Everything else builds and runs, but opening the notepad reports *"Notepad unavailable: built without the native notepad UI"*. Passing `-DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=ON` with a checkout missing makes it a configure error instead.
+The build otherwise completes as normal, but opening the notepad reports *"Notepad unavailable: built without the native notepad UI"*. Passing `-DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=ON` with a checkout missing makes it a configure error instead.
 
-That OFF is sticky, because `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` is a **cached** CMake option. Configure `build\` before cloning DPF and cloning it afterwards changes nothing on the next configure — and the "not found" line stops printing too. Either configure into a fresh build directory or force the cache with `-DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=ON`.
+That OFF is sticky, because `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` is a **cached** CMake option — the one dependency here a later reconfigure won't pick up on its own. Configure `build\` before cloning DPF and cloning it afterwards changes nothing on the next configure, and the "not found" line stops printing too. Either configure into a fresh build directory or add `-DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=ON` to the configure command below.
 
 If you override the paths explicitly, give DPF **forward slashes** — `-DDPF_PATH=C:/dev/DPF`. DPF's own CMake re-parses the value, and backslashes come through as invalid escapes.
 
@@ -75,11 +84,13 @@ From the Dusk Studio directory:
 
 ```cmd
 cd C:\dev\dusk-studio
-cmake -S . -B build -G "Visual Studio 17 2022" -A x64
+cmake -S . -B build -G "Visual Studio 17 2022" -A x64 ^
+  -DCMAKE_PREFIX_PATH=%VCPKG_INSTALLATION_ROOT%/installed/x64-windows-static ^
+  -DASIOSDK_PATH=C:/dev/asiosdk
 cmake --build build --config Release -j
 ```
 
-The first configure pulls in JUCE's CMake helpers and may take a minute. Subsequent configures are fast.
+Swap `-DASIOSDK_PATH=...` for `-DDUSKSTUDIO_REQUIRE_ASIO=OFF` if you skipped the SDK download. The first configure pulls in JUCE's CMake helpers and may take a minute. Subsequent configures are fast.
 
 The built binary lands at:
 

--- a/README.md
+++ b/README.md
@@ -117,11 +117,11 @@ Precompiled (unsigned) binaries delivered via Patreon — Linux tarball + Window
 |----------|-----|
 | Linux | [BUILDING-LINUX.md](BUILDING-LINUX.md) |
 | Windows | [BUILDING-WINDOWS.md](BUILDING-WINDOWS.md) |
-| macOS | Mirror of Linux flow; upstream JUCE 8.0.4 + sibling `plugins`. Smoke-built per push on `macos-14` (Apple Silicon Sonoma) — see [.github/workflows/macos-build.yml](.github/workflows/macos-build.yml). |
+| macOS | Mirror of Linux flow; upstream JUCE 8.0.4, sibling `plugins`, and the same pinned DPF stack. Smoke-built per push on `macos-14` (Apple Silicon Sonoma) — see [.github/workflows/macos-build.yml](.github/workflows/macos-build.yml). |
 | Linux tarball packaging | [packaging/README.md](packaging/README.md) |
 | End-user manual / troubleshooting | [MANUAL.md](MANUAL.md) |
 
-After a build, sanity check with `Dusk Studio --version` — prints app + JUCE + platform string and exits 0. Useful as a paste-target for Patreon support DMs.
+After a build, sanity check with `DuskStudio --version` — prints app + JUCE + platform string and exits 0. Useful as a paste-target for Patreon support DMs.
 
 CI runs on every push to `main` against Linux (Ubuntu 22.04 GCC), macOS (14 Apple Silicon, Ninja + ccache), and Windows (Server 2022 MSVC). Windows tests (`windows-tests.yml`) exercise the Catch2 suite on every push + PR. Linux ThreadSanitizer (`linux-sanitizer.yml`) runs the Catch2 suite under TSan on every PR + push. Tagged releases (`v*`) trigger the Windows MSI, macOS DMG, and Linux tarball workflows — each builds an unsigned binary and publishes it to the private releases repo (one shared release per tag, distinct asset names).
 

--- a/docs/MAINTAINER-GUIDE.md
+++ b/docs/MAINTAINER-GUIDE.md
@@ -293,13 +293,17 @@ ctest --test-dir build-tests --output-on-failure
 
 ### Dependency discovery (the thing most likely to bite you)
 
-CMake auto-detects four external repos at configure time. **Read the configure output** — it prints which paths it picked.
+CMake auto-detects four external repos at configure time, on top of three git submodules. **Read the configure output** — it prints which paths it picked.
+
+- **Submodules** (`external/clap`, `external/sfizz`, `external/vst3sdk`): clone with `--recurse-submodules`, or run `git submodule update --init --recursive`. They fail in three different ways, which is worth knowing before you debug the wrong one. Missing `external/clap` is fatal — the native CLAP host defaults ON on Linux and macOS, and the configure stops with a "CLAP headers missing" error. Missing `external/vst3sdk` is loud but survivable: a STATUS line, native VST3 disabled, unless you explicitly asked for `-DDUSKSTUDIO_NATIVE_VST3=ON`, which turns it fatal. Missing `external/sfizz` says **nothing at all** — the block is wrapped in a bare `EXISTS` test, so SF2 / multisample support simply isn't in the binary.
 
 - **JUCE:** `-DJUCE_PATH=…` wins; else on Linux it prefers `../JUCE-wayland` (a plugdata-team fork with ~5 local commits Dusk Studio depends on — XEmbed, X11-on-Wayland fix, peer-creation latch), falling back to `../JUCE`; on macOS it uses `../JUCE` (upstream). The upstream-vs-fork API difference (`addDefaultFormatsToManager`) is hidden behind [src/engine/JuceCompat.h](../src/engine/JuceCompat.h) — call `duskstudio::juce_compat::addDefaultFormats(fm)` and never sprinkle `#ifdef __linux__` at call sites.
 - **Dusk plugins:** `-DDUSK_PLUGINS_PATH=…` wins; else `../plugins`, and that is the whole list — one checkout, resting on `main` (the stable donor API). Build while it sits on a feature branch and you build against that branch. Missing entirely, configure only *warns*: you get a recorder with no EQ, comp, or tape rather than a failed build, so read the configure output.
-- **DPF + DPF-Widgets** (the native notepad UI): `-DDPF_PATH=…` / `-DDPF_WIDGETS_PATH=…` win; else `../DPF` and `../DPF-Widgets`, else the `external/` fallbacks, which are placeholders for the eventual release pinning and are not populated today. The two checks are ANDed, so missing *either* one silently defaults `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` to OFF (one STATUS line: `Native notepad: DPF / DPF-Widgets not found - disabled`) and the notepad reports *"Notepad unavailable: built without the native notepad UI"* at runtime. Forcing `-DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=ON` without them is a configure error rather than a silent downgrade. Clone the Dusk-owned forks at the revisions CI pins — [.github/actions/clone-dpf-stack/action.yml](../.github/actions/clone-dpf-stack/action.yml) is the single source of truth for those pins:
+- **DPF + DPF-Widgets** (the native notepad UI): `-DDPF_PATH=…` / `-DDPF_WIDGETS_PATH=…` win; else `../DPF` and `../DPF-Widgets`, else the `external/` fallbacks, which are placeholders for the eventual release pinning and are not populated today. The two checks are ANDed, so missing *either* one quietly defaults `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` to OFF, announced by one easy-to-miss STATUS line (`Native notepad: DPF / DPF-Widgets not found - disabled`); at runtime the notepad then reports *"Notepad unavailable: built without the native notepad UI"*. Forcing `-DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=ON` without them is a configure error rather than a silent downgrade. Clone the Dusk-owned forks at the revisions CI pins — [.github/actions/clone-dpf-stack/action.yml](../.github/actions/clone-dpf-stack/action.yml) is the single source of truth for those pins:
 
 ```bash
+cd /path/to/dusk-studio
+
 git clone https://github.com/dusk-audio/DPF.git ../DPF
 git -C ../DPF checkout f9fbc62af6fa7ce638a6f1e1482896c385a4955e
 git -C ../DPF submodule update --init     # dgl/src/pugl-upstream

--- a/docs/MAINTAINER-GUIDE.md
+++ b/docs/MAINTAINER-GUIDE.md
@@ -44,7 +44,7 @@ cmake --build build -j$(nproc)
 ./build/DuskStudio_artefacts/Release/DuskStudio
 ```
 
-JUCE and the Dusk plugins repo are auto-discovered from sibling directories (`../JUCE` / `../JUCE-wayland`, `../plugins` / `../plugins-main`). See Part 5 for what happens when discovery fails — it will, eventually, and the error messages are not always obvious.
+JUCE, the Dusk plugins repo, and the DPF stack behind the native notepad are auto-discovered from sibling directories (`../JUCE` / `../JUCE-wayland`, `../plugins`, `../DPF`, `../DPF-Widgets`). See Part 5 for what happens when discovery fails — it will, eventually, and the error messages are not always obvious.
 
 **Checkpoint:** the app launches, you can create a track, arm it, and play a click.
 
@@ -246,7 +246,7 @@ Per channel: **HPF → 4-band EQ → compressor (Opto/FET/VCA) → sends → pan
 
 ### Where the actual EQ/comp/tape code lives (vendored DSP)
 
-This is a gotcha that will confuse you the first time: **the EQ, compressor, and tape DSP are not in this repo.** They are header-only "cores" shared with the Dusk Audio plugins, pulled in from a sibling repo resolved at configure time (`-DDUSK_PLUGINS_PATH`, or `../plugins-main`, or `../plugins`). Classes like `UniversalCompressor`, `BritishEQProcessor`, `TubeEQProcessor`, and the TapeMachine processor come from there.
+This is a gotcha that will confuse you the first time: **the EQ, compressor, and tape DSP are not in this repo.** They are header-only "cores" shared with the Dusk Audio plugins, pulled in from a sibling repo resolved at configure time (`-DDUSK_PLUGINS_PATH`, else `../plugins`). Classes like `UniversalCompressor`, `BritishEQProcessor`, `TubeEQProcessor`, and the TapeMachine processor come from there.
 
 If `DUSK_PLUGINS_PATH` isn't found, the build defines `DUSKSTUDIO_HAS_DUSK_DSP=0` and you get a recorder with basic internal EQ and no comp/tape. So "where did the compressor go?" almost always means "the plugins repo wasn't discovered." Check the CMake configure output.
 
@@ -293,17 +293,31 @@ ctest --test-dir build-tests --output-on-failure
 
 ### Dependency discovery (the thing most likely to bite you)
 
-CMake auto-detects two external repos at configure time. **Read the configure output** — it prints which paths it picked.
+CMake auto-detects four external repos at configure time. **Read the configure output** — it prints which paths it picked.
 
 - **JUCE:** `-DJUCE_PATH=…` wins; else on Linux it prefers `../JUCE-wayland` (a plugdata-team fork with ~5 local commits Dusk Studio depends on — XEmbed, X11-on-Wayland fix, peer-creation latch), falling back to `../JUCE`; on macOS it uses `../JUCE` (upstream). The upstream-vs-fork API difference (`addDefaultFormatsToManager`) is hidden behind [src/engine/JuceCompat.h](../src/engine/JuceCompat.h) — call `duskstudio::juce_compat::addDefaultFormats(fm)` and never sprinkle `#ifdef __linux__` at call sites.
-- **Dusk plugins:** `-DDUSK_PLUGINS_PATH=…` wins; else prefers `../plugins-main` (a git worktree pinned to the plugins repo's `main` so feature-branch work doesn't break the donor API), falling back to `../plugins`. Set it up once on Linux: `cd ../plugins && git worktree add ../plugins-main main`.
+- **Dusk plugins:** `-DDUSK_PLUGINS_PATH=…` wins; else `../plugins`, and that is the whole list — one checkout, resting on `main` (the stable donor API). Build while it sits on a feature branch and you build against that branch. Missing entirely, configure only *warns*: you get a recorder with no EQ, comp, or tape rather than a failed build, so read the configure output.
+- **DPF + DPF-Widgets** (the native notepad UI): `-DDPF_PATH=…` / `-DDPF_WIDGETS_PATH=…` win; else `../DPF` and `../DPF-Widgets`, else the `external/` fallbacks, which are placeholders for the eventual release pinning and are not populated today. The two checks are ANDed, so missing *either* one silently defaults `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` to OFF (one STATUS line: `Native notepad: DPF / DPF-Widgets not found - disabled`) and the notepad reports *"Notepad unavailable: built without the native notepad UI"* at runtime. Forcing `-DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=ON` without them is a configure error rather than a silent downgrade. Clone the Dusk-owned forks at the revisions CI pins — [.github/actions/clone-dpf-stack/action.yml](../.github/actions/clone-dpf-stack/action.yml) is the single source of truth for those pins:
+
+```bash
+git clone https://github.com/dusk-audio/DPF.git ../DPF
+git -C ../DPF checkout f9fbc62af6fa7ce638a6f1e1482896c385a4955e
+git -C ../DPF submodule update --init     # dgl/src/pugl-upstream
+
+git clone https://github.com/dusk-audio/DPF-Widgets.git ../DPF-Widgets
+git -C ../DPF-Widgets checkout 730da6397904da66d99667c1cb30fc77fc3d794a
+```
+
+Clone then check out the SHA rather than cloning a branch: DPF's pin is the tip of `fix/wayland-review-findings`, never merged to that fork's `main` (DPF-Widgets' pin is its `main` tip today, but treat it the same). Neither branch may be deleted upstream, or both these commands and CI's fetch-by-SHA stop resolving.
+
+`DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` is a cached `option()`, which makes the OFF sticky in a nasty way: configure a build dir before the checkouts exist, add them later, and re-running CMake in that same dir leaves the notepad off — and the STATUS line above no longer prints, because its guard also requires the deps to be missing. Use a fresh build dir after cloning, or pass `-DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=ON` to overwrite the cache entry.
 
 The cross-OS layout (development happens on macOS, Linux testing on a separate machine — both use the same build-dir names so switching machines never needs a reconfigure):
 
 | OS | App | Tests | JUCE | Plugins |
 |---|---|---|---|---|
 | macOS | `build/` | `build-tests/` | `../JUCE` (upstream) | `../plugins` |
-| Linux | `build/` | `build-tests/` | `../JUCE-wayland` (fork) | `../plugins-main` (worktree) |
+| Linux | `build/` | `build-tests/` | `../JUCE-wayland` (fork) | `../plugins` |
 
 ### When to add a test
 

--- a/docs/native-clap-host-plan.md
+++ b/docs/native-clap-host-plan.md
@@ -52,7 +52,7 @@ JUCE off-screen-embed guesswork (which failed 3×).
 ## DuskVerb as CLAP
 
 Build the Dusk plugins (convolution-reverb = **DuskVerb**, etc.) as **CLAP** targets in
-`plugins-main` (clap entry or clap-wrapper). You own these, so the whole aux path —
+`../plugins` (clap entry or clap-wrapper). You own these, so the whole aux path —
 load, process, editor — can be native CLAP end-to-end. 3rd-party VST3/LV2 stay on JUCE
 until native VST3/LV2 land.
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -21,6 +21,13 @@ Dusk Studio registers with GNOME Software / KDE Discover and double-clicking
 
 - A Release build in `build-linux/` with both the `DuskStudio` and
   `dusk-studio-plugin-host` artefacts present.
+- The DPF stack discoverable at configure time — sibling `../DPF` and
+  `../DPF-Widgets` checkouts, or `-DDPF_PATH=` / `-DDPF_WIDGETS_PATH=`. Miss
+  either and the native notepad is compiled out of the binary you are about to
+  ship, announced by nothing louder than a
+  `Native notepad: DPF / DPF-Widgets not found - disabled` line in the
+  configure log. Clone instructions and the pinned revisions are in
+  `BUILDING-LINUX.md` under "The native notepad".
 - ImageMagick (`magick` or `convert`) on `$PATH` — used to scale the brand
   icon to the 256×256 PNG the desktop entry references.
 - The brand icon at `assets/ds-icon.png`.
@@ -39,6 +46,10 @@ cmake --build build-linux -j
 # 2. Pack the tarball.
 scripts/package-tarball.sh
 ```
+
+Configure into a fresh `build-linux/`. `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` is a
+cached option: a directory first configured without the DPF checkouts keeps the
+notepad off after you clone them, and drops the warning line too.
 
 Output: `dusk-studio-<version>-Linux-<arch>.tar.xz` in the repo root, ready to
 upload to Patreon. Its structure:

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -36,7 +36,12 @@ Dusk Studio registers with GNOME Software / KDE Discover and double-clicking
 
 Done outside CMake by `scripts/package-tarball.sh`, which stages the program
 directory, copies the integration assets, generates the icon, and packs
-everything with `tar`. Run from a clean Ubuntu 22.04 build:
+everything with `tar`. Run from a clean Ubuntu 22.04 build.
+
+Configure into a fresh `build-linux/`. `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` is a
+cached option: a directory first configured without the DPF checkouts keeps the
+notepad off after you clone them, and drops its STATUS line too, so a release
+built in a reused directory can ship without the notepad and without saying so.
 
 ```bash
 # 1. Build Dusk Studio as usual.
@@ -46,10 +51,6 @@ cmake --build build-linux -j
 # 2. Pack the tarball.
 scripts/package-tarball.sh
 ```
-
-Configure into a fresh `build-linux/`. `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` is a
-cached option: a directory first configured without the DPF checkouts keeps the
-notepad off after you clone them, and drops the warning line too.
 
 Output: `dusk-studio-<version>-Linux-<arch>.tar.xz` in the repo root, ready to
 upload to Patreon. Its structure:


### PR DESCRIPTION
Fixes #191.

BUILDING-LINUX.md, BUILDING-WINDOWS.md, docs/MAINTAINER-GUIDE.md, packaging/README.md, README.md, docs/native-clap-host-plan.md.

- Every plugins-main site rewritten to the real resolution rule: -DDUSK_PLUGINS_PATH or sibling ../plugins. The failure mode is documented as it actually is: a configure warning and a build with no DSP cores, not a fatal error.
- The native notepad's DPF stack is documented in all build docs and the tarball recipe: pinned clone commands (the pins live in .github/actions/clone-dpf-stack/action.yml; DPF's pin is the tip of an unmerged branch, so checkout by SHA), the mandatory pugl submodule, and the cached option() trap where a re-configure in the same build dir keeps the notepad silently off.
- BUILDING-LINUX's audio backend section matched the pre-native-backend era. It now describes what ships: a native PipeWire backend preferred by default, a native ALSA backend behind it, no JACK path on Linux at all (the JUCE device layer is not compiled there). The old text claimed the PipeWire backend was not implemented.
- Prerequisites fixed: libsndfile was missing despite configure hard-failing without it; PipeWire, LV2 host and MP3 bounce packages added with a note that their probes drop features silently and cache the result.
- Rename collateral in the same files: broken clone URL, DuskStudio.sln, binary name in README.

Found while verifying the backend claims and filed separately: CI never installs the PipeWire dev package, so released Linux builds are ALSA-only (#220).