### PR TITLE
docs: record the pre-tag fixes in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,11 @@ application framework and became Dusk Studio's own.
 - **License texts ship with the packages.** The tarball, the deb and rpm,
   the DMG and the MSI now carry `LICENSE` and `LICENSES.txt`, and the
   attribution list credits the notepad's UI stack (DPF, Dear ImGui, pugl and
-  the components they embed) along with the CLAP headers.
+  the components they embed) along with the CLAP headers. A completeness pass
+  then covered the framework's bundled text-shaping, image and codec
+  libraries, reproduced every license text that must accompany a binary - the
+  AGPLv3 included - recorded per-platform version inventories, corrected the
+  framework's license terms and libsndfile's real scope.
 
 ### Fixed
 
@@ -147,6 +151,21 @@ application framework and became Dusk Studio's own.
   left unscanned and the scan completed immediately with a
   sandbox-host-unavailable warning. The Windows packaging script now validates
   the staged install contains both executables before creating the MSI.
+- **Package contents.** The deb, rpm, DMG and MSI included the application
+  framework's entire source tree, its build tool and its CMake config -
+  roughly 65 MB and three thousand files nothing at runtime reads, claiming
+  paths a real framework package would own. The install set is now the
+  application payload alone.
+- **Manual.** The control-surface chapter still described the pre-0.13 bank
+  behaviour; it now explains the two axes - screen pages sized by window
+  width, the surface's fixed banks of eight - and how they stay in step. The
+  notepad chapter matches the shipping editor, the keyboard reference gains
+  the notepad shortcuts including the word-motion keys macOS actually uses,
+  and the PDF renders the sharp and flat signs instead of dropping them.
+- **Build docs.** The source-build instructions referenced a donor checkout
+  layout that no longer exists, omitted the submodules and the notepad's UI
+  dependencies, and marked packages optional that configure requires; a
+  source build now follows them as written.
 
 ## [0.12.6] - 2026-07-25
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(APPLE AND NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
 endif()
 
 # Version is sourced from the top-level VERSION file so packaging
-# scripts (AppImage, deb/rpm, MSI, DMG) and AppStream metadata see the
+# scripts (tarball, deb/rpm, MSI, DMG) and AppStream metadata see the
 # same value as the binary. scripts/bump-version.sh writes both
 # VERSION and the AppStream <release> entry; do NOT edit the project()
 # version literal here.
@@ -262,8 +262,9 @@ endif()
 
 # EXCLUDE_FROM_ALL keeps JUCE's own install rules out of our install set;
 # without it every cpack package carries juceaide, the whole module source
-# tree and JUCE's CMake package config. The default build is unaffected: the
-# modules are INTERFACE libraries and juceaide is an imported executable.
+# tree and JUCE's CMake package config. The build is unaffected: the modules
+# are INTERFACE libraries and juceaide is an imported executable, so nothing
+# in that directory was in the default build to lose.
 add_subdirectory(${DUSKSTUDIO_JUCE_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/JUCE EXCLUDE_FROM_ALL)
 
 # App icon. JUCE bakes the PNG into platform-specific resources at
@@ -1395,9 +1396,8 @@ endif()
 
 # Packaging via CPack. Generators are selected by scripts/package-*.{sh,ps1}
 # at cpack invocation time (-G DEB / -G RPM / -G WIX / -G DragNDrop);
-# this block just supplies the metadata each generator reads. The
-# AppImage path is NOT a CPack generator - linuxdeploy + appimagetool
-# stage AppDir from the same install() rules below.
+# this block just supplies the metadata each generator reads. The Linux
+# tarball is not CPack: scripts/package-tarball.sh stages artefacts directly.
 install(TARGETS DuskStudio
         RUNTIME DESTINATION bin
         BUNDLE  DESTINATION .)


### PR DESCRIPTION
Records the four pre-tag fixes (#221, #222, #223, #224) in the 0.13.0 section, following the pattern #217 set: the license bullet gains the completeness pass, and Fixed gains package contents, manual, and build docs entries.

Also carries the two packaging-comment corrections that missed #222's merge: the exclusion rationale states why the default build loses nothing, and the two stale AppImage references are gone (the tarball replaced it).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded package-license documentation to include embedded libraries, complete license texts, platform versions, and corrected framework coverage.
  * Documented reduced package contents, updated control-surface and notepad manuals, corrected PDF glyph rendering, and revised source-build requirements.
  * Clarified tarball packaging and JUCE source-tree handling in build documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->