### PR TITLE
fix(packaging): stage the committed icon instead of deriving it at package time

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -104,7 +104,7 @@ jobs:
             libxinerama-dev libxrandr-dev libxrender-dev libxss-dev \
             libwebkit2gtk-4.0-dev libgl1-mesa-dev libglu1-mesa-dev \
             libwayland-dev libxkbcommon-dev libdecor-0-dev \
-            imagemagick xz-utils
+            xz-utils
 
       - name: Clone JUCE (Dusk-owned Wayland mirror, pinned)
         # Linux ships against the Wayland fork, NOT upstream: it carries the
@@ -253,7 +253,7 @@ jobs:
         # at the repo root (arch from uname -m, so the arm runner produces the
         # aarch64 tarball): a portable program directory (run ./DuskStudio/DuskStudio
         # in place) plus install.sh for optional menu / PATH / session-file-type
-        # integration. Needs ImageMagick (icon downscale).
+        # integration.
         run: BUILD_DIR=build-linux scripts/package-tarball.sh
 
       - name: Checksums

--- a/BUILDING-LINUX.md
+++ b/BUILDING-LINUX.md
@@ -213,7 +213,7 @@ Routes new plugin loads through the `dusk-studio-plugin-host` child process so a
 
 ## Packaging the Linux tarball
 
-See [packaging/README.md](packaging/README.md). Run `scripts/package-tarball.sh` after a Release build in `build-linux/`; it emits `dusk-studio-<version>-Linux-<arch>.tar.xz` (a portable program dir + `install.sh`). Requires ImageMagick and `assets/ds-icon.png`.
+See [packaging/README.md](packaging/README.md). Run `scripts/package-tarball.sh` after a Release build in `build-linux/`; it emits `dusk-studio-<version>-Linux-<arch>.tar.xz` (a portable program dir + `install.sh`).
 
 ## Known caveats on Linux
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1460,6 +1460,8 @@ endif()
 # than derived at build time so cpack DEB/RPM cannot emit an iconless package;
 # regenerate from the master asset with
 # `magick assets/ds-icon.png -resize 256x256 -strip packaging/DuskStudio.png`.
+# Nothing verifies the two stay in sync, so regenerating after editing
+# assets/ds-icon.png is on whoever edits it.
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/packaging/DuskStudio.png"
         DESTINATION share/icons/hicolor/256x256/apps)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1459,7 +1459,8 @@ endif()
 # The hicolor size the .desktop Icon=DuskStudio key resolves. Committed rather
 # than derived at build time so cpack DEB/RPM cannot emit an iconless package;
 # regenerate from the master asset with
-# `magick assets/ds-icon.png -resize 256x256 -strip packaging/DuskStudio.png`.
+# `magick assets/ds-icon.png -resize 256x256 -strip packaging/DuskStudio.png`
+# (ImageMagick 6 spells the command `convert`).
 # Nothing verifies the two stay in sync, so regenerating after editing
 # assets/ds-icon.png is on whoever edits it.
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/packaging/DuskStudio.png"

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -32,7 +32,8 @@ Dusk Studio registers with GNOME Software / KDE Discover and double-clicking
 - The committed 256×256 icon at `packaging/DuskStudio.png` — the size the
   desktop entry's `Icon=DuskStudio` key resolves. Edit the master
   `assets/ds-icon.png` and you must regenerate it by hand with
-  `magick assets/ds-icon.png -resize 256x256 -strip packaging/DuskStudio.png`;
+  `magick assets/ds-icon.png -resize 256x256 -strip packaging/DuskStudio.png`
+  (ImageMagick 6 spells the command `convert`);
   nothing checks that the two stay in sync.
 
 ## Building the tarball

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -15,6 +15,7 @@ Dusk Studio registers with GNOME Software / KDE Discover and double-clicking
 | `audio.dusk.studio.desktop` | Desktop Entry (XDG) — launcher icon, MIME association, WM class match. Ships a relative `Exec=DuskStudio`; `install.sh` rewrites it to the installed absolute path. Filename matches `<id>` in the AppStream XML per spec (component-id + `.desktop`). |
 | `DuskStudio.appdata.xml` | AppStream component — app-store metadata, summary, description |
 | `DuskStudio.mime.xml` | MIME info — registers `application/x-dusk-studio-session` for `session.json` |
+| `DuskStudio.png` | 256×256 hicolor icon the `Icon=DuskStudio` key resolves. Committed rather than derived at package time so a packager needs no image tooling and every build ships the same bytes. |
 | `README-linux.txt` | End-user run/install notes bundled at the tarball top level |
 
 ## Prerequisites
@@ -28,15 +29,17 @@ Dusk Studio registers with GNOME Software / KDE Discover and double-clicking
   `Native notepad: DPF / DPF-Widgets not found - disabled` line in the
   configure log. Clone instructions and the pinned revisions are in
   `BUILDING-LINUX.md` under "The native notepad".
-- ImageMagick (`magick` or `convert`) on `$PATH` — used to scale the brand
-  icon to the 256×256 PNG the desktop entry references.
-- The brand icon at `assets/ds-icon.png`.
+- The committed 256×256 icon at `packaging/DuskStudio.png` — the size the
+  desktop entry's `Icon=DuskStudio` key resolves. Edit the master
+  `assets/ds-icon.png` and you must regenerate it by hand with
+  `magick assets/ds-icon.png -resize 256x256 -strip packaging/DuskStudio.png`;
+  nothing checks that the two stay in sync.
 
 ## Building the tarball
 
 Done outside CMake by `scripts/package-tarball.sh`, which stages the program
-directory, copies the integration assets, generates the icon, and packs
-everything with `tar`. Run from a clean Ubuntu 22.04 build.
+directory, copies the integration assets, and packs everything with `tar`. Run
+from a clean Ubuntu 22.04 build.
 
 Configure into a fresh `build-linux/`. `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` is a
 cached option: a directory first configured without the DPF checkouts keeps the

--- a/scripts/package-tarball.sh
+++ b/scripts/package-tarball.sh
@@ -5,13 +5,15 @@
 # Reaper ships. Replaces the AppImage.
 #
 # Prerequisites: BUILD_DIR (default build-linux) already configured + built
-# Release, with DuskStudio + dusk-studio-plugin-host artefacts present, and
-# assets/ds-icon.png committed. ImageMagick (magick/convert) for the 256x256
-# icon.
+# Release, with DuskStudio + dusk-studio-plugin-host artefacts present.
 #
 # Output: dusk-studio-<version>-Linux-<arch>.tar.xz in the repo root.
 
 set -euo pipefail
+
+# Directory modes come from mkdir -p, which -m cannot set on the intermediate
+# components, so the staged tree would otherwise inherit the packager's umask.
+umask 022
 
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_DIR"
@@ -28,7 +30,7 @@ BUILD_DIR="${BUILD_DIR:-build-linux}"
 ARTEFACTS="$BUILD_DIR/DuskStudio_artefacts/Release"
 BINARY="$ARTEFACTS/DuskStudio"
 HOST="$ARTEFACTS/dusk-studio-plugin-host"
-ICON_SRC="assets/ds-icon.png"
+ICON_SRC="packaging/DuskStudio.png"
 
 # Map uname -m to the asset arch label the rest of the release flow uses.
 case "$(uname -m)" in
@@ -40,15 +42,10 @@ esac
 for f in "$BINARY" "$HOST"; do
     [[ -x "$f" ]] || { echo "error: $f missing - build $BUILD_DIR (Release) first" >&2; exit 1; }
 done
-[[ -f "$ICON_SRC" ]] || { echo "error: $ICON_SRC missing (brand icon)" >&2; exit 1; }
+[[ -f "$ICON_SRC" ]] || { echo "error: $ICON_SRC missing (256x256 hicolor icon)" >&2; exit 1; }
 for f in LICENSE LICENSES.txt; do
     [[ -f "$f" ]] || { echo "error: $f missing - GPL section 4 requires it in the tarball" >&2; exit 1; }
 done
-
-ICON_TOOL=""
-command -v magick  >/dev/null 2>&1 && ICON_TOOL="magick"
-[[ -z "$ICON_TOOL" ]] && command -v convert >/dev/null 2>&1 && ICON_TOOL="convert"
-[[ -n "$ICON_TOOL" ]] || { echo "error: ImageMagick (magick/convert) not on PATH" >&2; exit 1; }
 
 TOPDIR="dusk-studio-${VERSION}-Linux-${ARCH}"
 STAGE="$(mktemp -d)"
@@ -67,11 +64,10 @@ install -m 0755 "$HOST"   "$APPDIR/dusk-studio-plugin-host"
 # Integration assets (installed by install.sh; ignored for a portable run). The
 # .desktop ships a relative Exec=DuskStudio; install.sh rewrites it to the
 # installed absolute path.
-cp packaging/audio.dusk.studio.desktop "$APPDIR/share/applications/"
-cp packaging/DuskStudio.appdata.xml    "$APPDIR/share/metainfo/"
-cp packaging/DuskStudio.mime.xml       "$APPDIR/share/mime/packages/"
-"$ICON_TOOL" "$ICON_SRC" -resize 256x256 \
-    "$APPDIR/share/icons/hicolor/256x256/apps/DuskStudio.png"
+install -m 0644 packaging/audio.dusk.studio.desktop "$APPDIR/share/applications/"
+install -m 0644 packaging/DuskStudio.appdata.xml    "$APPDIR/share/metainfo/"
+install -m 0644 packaging/DuskStudio.mime.xml       "$APPDIR/share/mime/packages/"
+install -m 0644 "$ICON_SRC"                         "$APPDIR/share/icons/hicolor/256x256/apps/"
 
 # Installer, readme, and the license texts live at the tarball top level, beside
 # the program dir. LICENSE + LICENSES.txt are not optional: GPL section 4 makes


### PR DESCRIPTION
Fixes #212.

scripts/package-tarball.sh derived its own 256x256 icon from assets/ds-icon.png with ImageMagick on every run; packaging/DuskStudio.png is the committed result of that exact derivation (verified byte-for-byte against the documented magick command). The script now stages the committed file, and the ImageMagick requirement is retired everywhere it was written down: the script's tool probe, the release runner's apt list, and the two docs that named it as a prerequisite.

The staged tarball is byte-identical apart from the icon itself, which loses 231 bytes of ancillary PNG chunks, one of them a wall-clock timestamp - so the tarball icon is now reproducible across package runs. Staging also switched from cp to install -m 0644 with a pinned umask, so file and directory modes no longer depend on the packager's environment (a umask 077 run previously produced a tarball with 0700 directories).

Nothing verifies packaging/DuskStudio.png stays in sync with assets/ds-icon.png; the regeneration one-liner is documented beside both files, and regeneration is on whoever edits the master asset.

Verification: full build, packaging script run before and after against the same build tree (one-line diff, the icon size), script run on a PATH without ImageMagick (old script fails, new one produces an identical tree), bash -n, workflow YAML parse, juce-gate unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Linux release packaging now includes the application icon directly, improving consistency across distributed archives.
  - Packaged files use predictable permissions for more reliable extraction and installation.

- **Documentation**
  - Updated Linux build and packaging guidance to remove the ImageMagick prerequisite.
  - Added instructions for maintaining the packaged application icon when its source changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->