### PR TITLE
ci: supersede stale PR runs on the dev workflows

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -7,6 +7,14 @@ on:
     branches: [main, 'release/**']
   workflow_dispatch:
 
+# PR runs group by repository PR number, so a newer push supersedes only that
+# PR (fork branches sharing a name can't collide on it). Push and dispatch
+# runs get a run-id group of one: any shared key lets Actions drop a pending
+# run regardless of cancel-in-progress, costing a landed commit its verdict.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   juce-gate:
     name: De-JUCE ratchet

--- a/.github/workflows/linux-sanitizer.yml
+++ b/.github/workflows/linux-sanitizer.yml
@@ -13,6 +13,14 @@ on:
     branches: [main, 'release/**']
   workflow_dispatch:
 
+# PR runs group by repository PR number, so a newer push supersedes only that
+# PR (fork branches sharing a name can't collide on it). Push and dispatch
+# runs get a run-id group of one: any shared key lets Actions drop a pending
+# run regardless of cancel-in-progress, costing a landed commit its verdict.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   tsan-tests:
     name: Catch2 tests (TSan, Ubuntu 22.04)

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -13,11 +13,13 @@ on:
     branches: [main, 'release/**']
   workflow_dispatch:
 
-# A new push to the same ref cancels an in-flight run — the macOS runner
-# is slow (~40 min cold) so don't let stale runs queue up behind it.
+# PR runs group by repository PR number, so a newer push supersedes only that
+# PR (fork branches sharing a name can't collide on it). Push and dispatch
+# runs get a run-id group of one: any shared key lets Actions drop a pending
+# run regardless of cancel-in-progress, costing a landed commit its verdict.
 concurrency:
-  group: macos-build-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/raspberry-pi-build.yml
+++ b/.github/workflows/raspberry-pi-build.yml
@@ -14,6 +14,14 @@ on:
     branches: [main, 'release/**']
   workflow_dispatch:
 
+# PR runs group by repository PR number, so a newer push supersedes only that
+# PR (fork branches sharing a name can't collide on it). Push and dispatch
+# runs get a run-id group of one: any shared key lets Actions drop a pending
+# run regardless of cancel-in-progress, costing a landed commit its verdict.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     name: Build + tests (GCC Release, Ubuntu 22.04, arm64)

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -18,9 +18,13 @@ on:
 permissions:
   contents: read
 
+# PR runs group by repository PR number, so a newer push supersedes only that
+# PR (fork branches sharing a name can't collide on it). Push and dispatch
+# runs get a run-id group of one: any shared key lets Actions drop a pending
+# run regardless of cancel-in-progress, costing a landed commit its verdict.
 concurrency:
-  group: windows-tests-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   tests:


### PR DESCRIPTION
Closes #208.

All five dev workflows (linux-build, linux-sanitizer, macos-build, raspberry-pi-build, windows-tests) get the same concurrency block: PR runs group by `github.event.pull_request.number`, so a newer push to a PR cancels the superseded run; push and dispatch runs get a run-id group of one. The issue asked for ref keying, and the diff deliberately does not do that: any shared group key lets Actions drop a *pending* run regardless of cancel-in-progress (a burst of merges to main would silently lose verdicts), and fork PRs sharing a branch name would collide on `head_ref`. The PR number is allocated by the base repo, so it cannot collide across forks.

Behavior changes worth naming:
- The issue's premise that windows-tests had no concurrency group was wrong; macos-build and windows-tests both had ref-keyed groups with unconditional cancel. Their push runs previously superseded each other; they now each run to completion. A verdict per landed commit beats the runner minutes.
- Cancelled superseded PR runs skip their ccache save step. Slowdown only; the prefix restore-keys keep builds warm from the last completed run.
- Manually re-running an older *cancelled* PR run lands in the same group and cancels the current head's run, leaving a cancelled required check until the newest run is re-run or a new push arrives. Recoverable, and inherent to any PR-scoped grouping.

Release workflows are untouched; their own ref-keyed groups carry a separate dispatch hazard, tracked as #228 (its suggested fix text was corrected in a comment there — it referenced the head_ref scheme this PR rejects).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Updated automated build and test workflows to cancel superseded pull-request runs.
  * Preserved independent push and manually triggered runs, preventing unrelated jobs from being canceled.
  * Improved CI resource usage and reduced redundant feedback from outdated pull-request runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->