### PR TITLE
chore(release): harden the 0.13.0 release mechanics

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -217,16 +217,19 @@ jobs:
             exit 1
           fi
 
-          # Create the release on first push of this tag, else add the
-          # assets (idempotent re-run). --clobber overwrites a same-named
-          # asset from a previous attempt.
           if ! gh release view "$TAG" --repo "$RELEASES_REPO" >/dev/null 2>&1; then
-            gh release create "$TAG" \
+            if ! create_err=$(gh release create "$TAG" \
               --repo "$RELEASES_REPO" \
               --title "Dusk Studio $TAG" \
-              --notes "$NOTES" \
-              "${ASSETS[@]}"
-          else
-            gh release upload "$TAG" --repo "$RELEASES_REPO" --clobber "${ASSETS[@]}"
+              --notes "$NOTES" 2>&1); then
+              if gh release view "$TAG" --repo "$RELEASES_REPO" >/dev/null 2>&1; then
+                echo "release create raced with another release job; the release now exists, uploading."
+              else
+                echo "::error::gh release create failed for ${TAG} and no release exists:" >&2
+                echo "${create_err}" >&2
+                exit 1
+              fi
+            fi
           fi
+          gh release upload "$TAG" --repo "$RELEASES_REPO" --clobber "${ASSETS[@]}"
           echo "Published ${#ASSETS[@]} asset(s) to ${RELEASES_REPO} @ ${TAG}"

--- a/.github/workflows/manual-pdf.yml
+++ b/.github/workflows/manual-pdf.yml
@@ -96,20 +96,21 @@ jobs:
 
           ASSETS=( MANUAL.pdf SHA256SUMS.manual )
 
-          # Create the release on first push of this tag, else just add the
-          # assets (idempotent re-run). --clobber overwrites a same-named
-          # asset from a previous attempt. The macOS/Windows workflows share
-          # this tag; whichever job runs first creates the release, the rest
-          # upload onto it (asset names are distinct, so they coexist).
           if ! gh release view "$TAG" --repo "$RELEASES_REPO" >/dev/null 2>&1; then
-            gh release create "$TAG" \
+            if ! create_err=$(gh release create "$TAG" \
               --repo "$RELEASES_REPO" \
               --title "Dusk Studio $TAG" \
-              --notes "$NOTES" \
-              "${ASSETS[@]}"
-          else
-            gh release upload "$TAG" --repo "$RELEASES_REPO" --clobber "${ASSETS[@]}"
+              --notes "$NOTES" 2>&1); then
+              if gh release view "$TAG" --repo "$RELEASES_REPO" >/dev/null 2>&1; then
+                echo "release create raced with another release job; the release now exists, uploading."
+              else
+                echo "::error::gh release create failed for ${TAG} and no release exists:" >&2
+                echo "${create_err}" >&2
+                exit 1
+              fi
+            fi
           fi
+          gh release upload "$TAG" --repo "$RELEASES_REPO" --clobber "${ASSETS[@]}"
           echo "Published ${#ASSETS[@]} asset(s) to ${RELEASES_REPO} @ ${TAG}"
 
       - name: Upload MANUAL.pdf as a workflow artifact (dispatch validation)

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -305,16 +305,19 @@ jobs:
             exit 1
           fi
 
-          # Create the release on first push of this tag, else just add
-          # the assets (idempotent re-run). --clobber overwrites a same-
-          # named asset from a previous attempt.
           if ! gh release view "$TAG" --repo "$RELEASES_REPO" >/dev/null 2>&1; then
-            gh release create "$TAG" \
+            if ! create_err=$(gh release create "$TAG" \
               --repo "$RELEASES_REPO" \
               --title "Dusk Studio $TAG" \
-              --notes "$NOTES" \
-              "${ASSETS[@]}"
-          else
-            gh release upload "$TAG" --repo "$RELEASES_REPO" --clobber "${ASSETS[@]}"
+              --notes "$NOTES" 2>&1); then
+              if gh release view "$TAG" --repo "$RELEASES_REPO" >/dev/null 2>&1; then
+                echo "release create raced with another release job; the release now exists, uploading."
+              else
+                echo "::error::gh release create failed for ${TAG} and no release exists:" >&2
+                echo "${create_err}" >&2
+                exit 1
+              fi
+            fi
           fi
+          gh release upload "$TAG" --repo "$RELEASES_REPO" --clobber "${ASSETS[@]}"
           echo "Published ${#ASSETS[@]} asset(s) to ${RELEASES_REPO} @ ${TAG}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -270,7 +270,7 @@ playback.
   its sends (headphone reverb/delay while tracking) sound in every transport
   state. The audio twin of the 0.12.1 live-play-along fix.
 
-## [0.12.2] - 2026-07-12
+## [0.12.2] - 2026-07-13
 
 Beta patch on the 0.12 line: fixes a crash when bouncing, rendering stems,
 or freezing a track through a CLAP (or VST3/LV2) plugin insert.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-622 Catch2 unit tests across 142 files. Linux (amd64 + arm64) + macOS + Windows builds run on every push; Windows tests run on every push + PR; Linux ThreadSanitizer runs on every PR + push.
+The C++ suite declares 660 Catch2 test cases across 143 test source files. Linux (amd64 + arm64) + macOS + Windows builds run on every push; Windows tests run on every push + PR; Linux ThreadSanitizer runs on every PR + push.
 
 ## Bug reports
 
@@ -103,7 +103,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 622 Catch2 unit tests (session, recording, MIDI, IPC, DSP)
+tests/         # 660 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/packaging/DuskStudio.appdata.xml
+++ b/packaging/DuskStudio.appdata.xml
@@ -50,7 +50,7 @@
         <p>Input monitoring now feeds aux sends during playback.</p>
       </description>
     </release>
-    <release version="0.12.2" date="2026-07-12">
+    <release version="0.12.2" date="2026-07-13">
       <description>
         <p>Beta patch: fixes a mixdown/stems/freeze crash with CLAP (and VST3/LV2) plugin inserts.</p>
       </description>
@@ -83,7 +83,7 @@
         (arm64) Linux tarball.</p>
       </description>
     </release>
-    <release version="0.11.0" date="2026-06-12">
+    <release version="0.11.0" date="2026-06-22">
       <description>
         <p>Beta release. Optional out-of-process plugin sandbox with
         crash-isolated plugin scanning on all three OSes,

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -93,15 +93,16 @@ fi
 
 TODAY="$(date -u +%Y-%m-%d)"
 
-echo "$NEW_VERSION" > VERSION
-
 # Prepend a <release> block to the <releases> list in the AppStream
 # metadata. Insertion point: the line immediately AFTER the opening
-# <releases> tag. The xml comment "<!-- scripts/bump-version.sh prepends
-# new <release> entries here. -->" pins the position deterministically.
+# <releases> tag, pinned by the anchor comment below. Match the whole
+# comment, not the bare phrase - release notes that quote the phrase would
+# otherwise become anchors too and nest the next entry inside an old
+# <description>.
 APPDATA="packaging/DuskStudio.appdata.xml"
+ANCHOR='<!-- scripts/bump-version.sh prepends new <release> entries here. -->'
 if [[ -f "$APPDATA" ]]; then
-    if grep -q "scripts/bump-version.sh prepends new" "$APPDATA"; then
+    if grep -qF "$ANCHOR" "$APPDATA"; then
         # Compose the new <release> block in a temp file (real newlines)
         # and have awk splice it in after the anchor comment. awk's
         # -v assignment rejects literal newlines on BSD awk (macOS), so
@@ -109,17 +110,35 @@ if [[ -f "$APPDATA" ]]; then
         # not from a string variable.
         RELEASE_FILE=$(mktemp -t duskstudio-release.XXXXXX)
         trap 'rm -f "$RELEASE_FILE" "$APPDATA.tmp"' EXIT
+        XML_NOTES=$(printf '%s' "$NOTES" \
+            | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g')
         printf '    <release version="%s" date="%s">\n      <description>\n        <p>%s</p>\n      </description>\n    </release>\n' \
-            "$NEW_VERSION" "$TODAY" "$NOTES" > "$RELEASE_FILE"
+            "$NEW_VERSION" "$TODAY" "$XML_NOTES" > "$RELEASE_FILE"
 
-        awk -v release_file="$RELEASE_FILE" '
+        awk -v release_file="$RELEASE_FILE" -v anchor="$ANCHOR" '
             { print }
-            /scripts\/bump-version.sh prepends new/ {
+            !spliced && index($0, anchor) {
                 while ((getline line < release_file) > 0) print line
                 close (release_file)
+                spliced = 1
             }
         ' "$APPDATA" > "$APPDATA.tmp" \
             || { echo "error: awk failed to update $APPDATA" >&2; exit 1; }
+
+        # XML-illegal control characters (vertical tab, form feed, ESC) pass
+        # straight through the entity escaping above, so validate the result
+        # before it lands in the tree.
+        if command -v xmllint >/dev/null 2>&1; then
+            if ! xmllint --noout "$APPDATA.tmp"; then
+                echo "error: the updated $APPDATA is not well-formed XML;" >&2
+                echo "       $APPDATA left unchanged. Check the release notes" >&2
+                echo "       for characters XML rejects." >&2
+                exit 1
+            fi
+        else
+            echo "warning: xmllint not found - skipping XML validation of $APPDATA" >&2
+        fi
+
         mv "$APPDATA.tmp" "$APPDATA"
         rm -f "$RELEASE_FILE"
         trap - EXIT
@@ -137,6 +156,9 @@ if [[ -f "$APPDATA" ]]; then
     fi
 fi
 
+# Written last so an aborted appdata update leaves the tree untouched.
+echo "$NEW_VERSION" > VERSION
+
 echo
 echo "Bumped VERSION  -> $NEW_VERSION"
 echo "Today's date     -> $TODAY"
@@ -144,9 +166,10 @@ echo "Updated files:"
 git status --short VERSION "$APPDATA" 2>/dev/null || true
 echo
 echo "Next steps:"
-echo "  1) Refresh patrons:   scripts/update-patrons.py   (commit in the plugins repo)"
-echo "  2) Review the diff:   git diff VERSION $APPDATA"
-echo "  3) Rebuild + smoke:   cmake --build build -j && DUSKSTUDIO_RUN_SELFTEST=1 build/.../DuskStudio"
-echo "  4) Commit:            git commit -am \"Release v$NEW_VERSION\""
-echo "  5) Tag:               git tag -a v$NEW_VERSION -m \"Dusk Studio $NEW_VERSION\""
-echo "  6) Package:           scripts/package-{tarball,macos}.sh, scripts/package-windows.ps1"
+echo "  1) Date the changelog: CHANGELOG.md \"## [$NEW_VERSION] - Unreleased\" -> \"- $TODAY\""
+echo "  2) Refresh patrons:   scripts/update-patrons.py   (commit in the plugins repo)"
+echo "  3) Review the diff:   git diff VERSION $APPDATA CHANGELOG.md"
+echo "  4) Rebuild + smoke:   cmake --build build -j && DUSKSTUDIO_RUN_SELFTEST=1 build/.../DuskStudio"
+echo "  5) Commit:            git commit -am \"Release v$NEW_VERSION\""
+echo "  6) Tag:               git tag -a v$NEW_VERSION -m \"Dusk Studio $NEW_VERSION\""
+echo "  7) Package:           scripts/package-{tarball,macos}.sh, scripts/package-windows.ps1"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -491,3 +491,20 @@ catch_discover_tests(dusk-studio-tests
     EXTRA_ARGS --allow-running-no-tests)
 catch_discover_tests(dusk-studio-tests
     TEST_SPEC "~[alsa]")
+
+# Exercise the real release-version insertion script against an isolated fixture,
+# and keep the four private-release publishers on the race-safe create/recheck/
+# upload contract. The release script is Unix-only.
+if(UNIX)
+    find_program(DUSKSTUDIO_BASH_EXECUTABLE bash)
+    find_package(Python3 COMPONENTS Interpreter QUIET)
+    if(DUSKSTUDIO_BASH_EXECUTABLE AND Python3_Interpreter_FOUND)
+        add_test(NAME release-mechanics-contract
+            COMMAND "${DUSKSTUDIO_BASH_EXECUTABLE}"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/release_mechanics.sh"
+                    "${CMAKE_SOURCE_DIR}"
+                    "${Python3_EXECUTABLE}")
+    else()
+        message(WARNING "release-mechanics contract test skipped: bash or python3 not found")
+    endif()
+endif()

--- a/tests/release_mechanics.sh
+++ b/tests/release_mechanics.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "usage: $0 <source-root> <python>" >&2
+    exit 2
+fi
+
+SOURCE_ROOT="$1"
+PYTHON="$2"
+SCRATCH=$(mktemp -d "${TMPDIR:-/tmp}/duskstudio-release-mechanics.XXXXXX")
+trap 'rm -rf "$SCRATCH"' EXIT
+
+FIXTURE="$SCRATCH/repo"
+mkdir -p "$FIXTURE/scripts" "$FIXTURE/packaging"
+cp "$SOURCE_ROOT/scripts/bump-version.sh" "$FIXTURE/scripts/bump-version.sh"
+printf '0.0.0\n' > "$FIXTURE/VERSION"
+printf '## [9.9.9] - Unreleased\n' > "$FIXTURE/CHANGELOG.md"
+printf '%s\n' \
+    '<?xml version="1.0" encoding="UTF-8"?>' \
+    '<component>' \
+    '  <releases>' \
+    '    <!-- scripts/bump-version.sh prepends new <release> entries here. -->' \
+    '    <release version="0.0.0" date="2026-01-01">' \
+    '      <description>' \
+    '        <p>Decoy quoting the anchor:</p>' \
+    '        <!-- scripts/bump-version.sh prepends new <release> entries here. -->' \
+    '      </description>' \
+    '    </release>' \
+    '  </releases>' \
+    '</component>' \
+    > "$FIXTURE/packaging/DuskStudio.appdata.xml"
+
+NOTES='Gain & grit <hot> > cool ]]> "quoted" café — release'
+(
+    cd "$FIXTURE"
+    bash scripts/bump-version.sh 9.9.9 "$NOTES" >/dev/null
+)
+
+if command -v xmllint >/dev/null 2>&1; then
+    xmllint --noout "$FIXTURE/packaging/DuskStudio.appdata.xml"
+
+    # The abort path exists only when xmllint is present: a note carrying an
+    # XML-illegal control character must fail the bump and leave both outputs
+    # untouched.
+    FIXTURE_BAD="$SCRATCH/repo-bad"
+    mkdir -p "$FIXTURE_BAD/scripts" "$FIXTURE_BAD/packaging"
+    cp "$SOURCE_ROOT/scripts/bump-version.sh" "$FIXTURE_BAD/scripts/bump-version.sh"
+    printf '0.0.0\n' > "$FIXTURE_BAD/VERSION"
+    printf '## [9.9.9] - Unreleased\n' > "$FIXTURE_BAD/CHANGELOG.md"
+    printf '%s\n' \
+        '<?xml version="1.0" encoding="UTF-8"?>' \
+        '<component>' \
+        '  <releases>' \
+        '    <!-- scripts/bump-version.sh prepends new <release> entries here. -->' \
+        '  </releases>' \
+        '</component>' \
+        > "$FIXTURE_BAD/packaging/DuskStudio.appdata.xml"
+    BAD_NOTES=$(printf 'bad\013note')
+    if (cd "$FIXTURE_BAD" && bash scripts/bump-version.sh 9.9.9 "$BAD_NOTES" >/dev/null 2>&1); then
+        echo "FAIL: control-character note must abort the bump" >&2
+        exit 1
+    fi
+    if [[ "$(cat "$FIXTURE_BAD/VERSION")" != "0.0.0" ]]; then
+        echo "FAIL: aborted bump must leave VERSION untouched" >&2
+        exit 1
+    fi
+    if grep -q 'version="9.9.9"' "$FIXTURE_BAD/packaging/DuskStudio.appdata.xml"; then
+        echo "FAIL: aborted bump must leave the appdata untouched" >&2
+        exit 1
+    fi
+fi
+
+if [[ "$(cat "$FIXTURE/VERSION")" != "9.9.9" ]]; then
+    echo "FAIL: bump-version.sh must write VERSION" >&2
+    exit 1
+fi
+
+"$PYTHON" - "$FIXTURE/packaging/DuskStudio.appdata.xml" "$NOTES" "$SOURCE_ROOT" <<'PY'
+from pathlib import Path
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+if not __debug__:
+    raise SystemExit("refusing to run with assertions disabled")
+
+appdata_path = Path(sys.argv[1])
+expected_notes = sys.argv[2]
+source_root = Path(sys.argv[3])
+
+root = ET.parse(appdata_path).getroot()
+releases = root.findall("./releases/release")
+assert len(releases) == 2, "expected the new entry plus the fixture's existing one"
+release = releases[0]
+assert release.get("version") == "9.9.9", "new entry must prepend, not append"
+assert releases[1].get("version") == "0.0.0"
+paragraph = release.find("./description/p")
+assert paragraph is not None
+assert paragraph.text == expected_notes, (paragraph.text, expected_notes)
+
+workflows = (
+    "manual-pdf.yml",
+    "macos-release.yml",
+    "windows-build.yml",
+    "linux-release.yml",
+)
+create_marker = 'if ! create_err=$(gh release create "$TAG"'
+recheck_marker = 'if gh release view "$TAG" --repo "$RELEASES_REPO" >/dev/null 2>&1; then'
+upload_line = 'gh release upload "$TAG" --repo "$RELEASES_REPO" --clobber "${ASSETS[@]}"'
+
+for name in workflows:
+    text = (source_root / ".github" / "workflows" / name).read_text(encoding="utf-8")
+    assert text.count(create_marker) == 1, f"{name}: missing race-checked create"
+    create_at = text.index(create_marker)
+    create_end = text.index("2>&1); then", create_at)
+    assert '"${ASSETS[@]}"' not in text[create_at:create_end], (
+        f"{name}: create must not own asset upload"
+    )
+    recheck_at = text.index(recheck_marker, create_end)
+    upload_matches = list(re.finditer(
+        rf"^\s+{re.escape(upload_line)}$", text, re.MULTILINE
+    ))
+    assert len(upload_matches) == 1, f"{name}: upload must be unconditional"
+    assert create_at < recheck_at < upload_matches[0].start()
+PY


### PR DESCRIPTION
Part of #178 (the remaining items there - maintainer email, the bump itself, the tag - are release-day steps done by hand).

- AppStream release dates aligned to their tags in UTC, the convention bump-version.sh itself stamps with `date -u` (0.11.0 -> 2026-06-22, 0.12.2 -> 2026-07-13; 0.12.3 stays 2026-07-15, which is the tag's UTC date). CHANGELOG's 0.12.2 heading synced to match.
- bump-version.sh: the appdata splice anchor now matches the full anchor comment, first occurrence only. The bare-phrase match was reproducibly corruptible: a release note quoting the phrase became a second anchor on the next bump and nested the new entry inside an old description, producing well-formed XML that passed every existing check. The spliced file is validated with xmllint before it replaces the original (control characters pass entity escaping but are XML-illegal; absent xmllint warns and continues), and VERSION is written last so an aborted bump leaves the tree untouched. The next-steps output now includes dating the changelog.
- The macOS, Windows and manual-PDF publishers get the race-checked create/recheck/upload block linux-release.yml already had, so concurrent tag workflows cannot fail on a 422 from a sibling's create. Known trade: a failure between create and upload leaves a published, asset-less release (previously create owned the assets atomically); net better for the race it closes. The single-shot recheck has no retry, matching the existing Linux block. The dead asset-glob length guard in the macOS/Windows copies (always nonzero because the SHA256SUMS literal is in the array) diverges from Linux's validated-glob version; left as is, both platforms catch empty asset sets earlier.
- README test counts corrected (660 cases across 143 files, counted).
- New release-mechanics contract test: exercises the real bump-version.sh against a fixture (splice placement above existing entries, decoy anchor inside an old description, VERSION written, control-character note aborts leaving VERSION and appdata untouched) and pins the four publishers' create/recheck/upload shape. It does not audit the wider release inventory (appdata ordering across files, changelog agreement); scope is the script and the publisher blocks.

One wrinkle for release day: the script stamps the appdata with the bump day's UTC date; tagging on a later day recreates the date drift this PR cleans up. Bump and tag on the same day, or expect a one-day skew.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release publishing reliability by handling concurrent release creation and ensuring installers, PDFs, and checksums are uploaded correctly.
  - Prevented invalid release metadata from being saved during version updates.

- **Documentation**
  - Updated release dates and application metadata for versions 0.12.2 and 0.11.0.
  - Refreshed README test-count and repository information.

- **Tests**
  - Added automated validation for release workflows, version updates, changelog entries, and metadata integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->