### PR TITLE
fix(au): give the AU editor the native-owner lifetime contract

### DIFF
--- a/src/engine/au/AuEditor.h
+++ b/src/engine/au/AuEditor.h
@@ -25,6 +25,7 @@ public:
     void setBounds (int x, int y, int width, int height);
     void reveal();
     void hide();
+    void abandonPlugin() noexcept;
     void close();
     void pump();
 

--- a/src/engine/au/AuEditor.mm
+++ b/src/engine/au/AuEditor.mm
@@ -195,6 +195,18 @@ void AuEditor::pump()
     if (onResize) onResize (width, height);
 }
 
+void AuEditor::abandonPlugin() noexcept
+{
+    // The Audio Unit behind this view may already be disposed. Leaking the
+    // retain taken in open() guarantees the view's -dealloc - where AU views
+    // run their listener teardown against the unit - never executes; close()
+    // still detaches and releases the container this host owns, which does
+    // message the detached subtree, but only through plain NSView hierarchy
+    // notifications.
+    impl->pluginView = nil;
+    impl->embedded = false;
+}
+
 void AuEditor::close()
 {
     if (impl->pluginView != nil)

--- a/src/ui/AuxLaneComponent.cpp
+++ b/src/ui/AuxLaneComponent.cpp
@@ -1337,6 +1337,9 @@ void AuxLaneComponent::syncNativeEditorOwnersForSlot (int slotIdx)
 #if DUSKSTUDIO_HAS_NATIVE_VST3
     syncNativeEditorOwner (ui.vst3Editor, detach);
 #endif
+#if DUSKSTUDIO_HAS_NATIVE_AU
+    syncNativeEditorOwner (ui.auEditor, detach);
+#endif
 }
 
 void AuxLaneComponent::dropAllNativeEditors (NativeEditorTeardown teardown)
@@ -1376,7 +1379,12 @@ void AuxLaneComponent::dropAllNativeEditors (NativeEditorTeardown teardown)
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_AU
     for (int i = 0; i < AuxLaneParams::kMaxLanePlugins; ++i)
+    {
+        if (auto& ed = slots[(size_t) i].auEditor;
+            ed != nullptr && teardown == NativeEditorTeardown::AbandonInstance)
+            ed->abandonInstance();
         detachAuEditorForSlot (i);
+    }
 #endif
 }
 
@@ -1628,6 +1636,7 @@ void AuxLaneComponent::rebuildSlots()
                     if (ed->attach (*auInst, err))
                     {
                         ui.auEditor = std::move (ed);
+                        ui.auEditor->bindOwner (strip.getNativeAuSlot (i));
                         addAndMakeVisible (*ui.auEditor);
                         layoutEditorForSlot (i);
                     }

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -2388,6 +2388,7 @@ void ChannelStripComponent::openPluginEditor()
                 auEditor.reset();
                 return;
             }
+            auEditor->bindOwner (engine.getChannelStrip (trackIndex).getNativeAuSlot());
         }
         pluginEditorModal.showBorrowed (*parent, *auEditor, onClose);
         return;
@@ -2653,7 +2654,11 @@ void ChannelStripComponent::dropPluginEditor (NativeEditorTeardown teardown)
     }
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_AU
-    auEditor.reset();
+    if (auEditor != nullptr)
+    {
+        if (teardown == NativeEditorTeardown::AbandonInstance) auEditor->abandonInstance();
+        auEditor.reset();
+    }
 #endif
 #if DUSKSTUDIO_HAS_MULTISAMPLE
     multisampleEditor.reset();   // pure Dusk UI - plain teardown
@@ -3054,6 +3059,9 @@ void ChannelStripComponent::syncNativeEditorOwners()
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_VST3
     syncNativeEditorOwner (vst3Editor, dismiss);
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_AU
+    syncNativeEditorOwner (auEditor, dismiss);
 #endif
 }
 

--- a/src/ui/Vst3PluginEditorComponent.cpp
+++ b/src/ui/Vst3PluginEditorComponent.cpp
@@ -258,6 +258,7 @@ AuPluginEditorComponent::AuPluginEditorComponent()
 AuPluginEditorComponent::~AuPluginEditorComponent()
 {
     stopTimer();
+    if (ownerIsStale()) editor.abandonPlugin();
     editor.close();
 }
 
@@ -294,6 +295,8 @@ juce::Rectangle<int> AuPluginEditorComponent::editorBoundsInPeer() const
 
 void AuPluginEditorComponent::tryEmbed()
 {
+    if (ownerIsStale()) { abandonInstance(); return; }
+
     // `embedding` breaks re-entry: addSubview can let the plugin's view run
     // AppKit work that ticks this component's timer, and AuEditor only marks
     // itself embedded at the END - a nested call would build a second container.
@@ -321,6 +324,7 @@ void AuPluginEditorComponent::tryEmbed()
 
 void AuPluginEditorComponent::pushBounds()
 {
+    if (ownerIsStale()) return;   // setFrame reaches the plugin's own view
     if (! embedded || getParentComponent() == nullptr || getPeer() == nullptr) return;
     const auto area = editorBoundsInPeer();
     editor.setBounds (area.getX(), area.getY(),
@@ -336,6 +340,10 @@ void AuPluginEditorComponent::parentHierarchyChanged()
 
 void AuPluginEditorComponent::visibilityChanged()
 {
+    // Unhiding the container makes AppKit draw the plugin's Cocoa subview
+    // synchronously, unlike the VST3/X11 case where reveal touches only a
+    // host-owned foreign window.
+    if (ownerIsStale()) { abandonInstance(); return; }
     if (! loaded) return;
     if (isShowing())
     {
@@ -345,8 +353,20 @@ void AuPluginEditorComponent::visibilityChanged()
         editor.hide();
 }
 
+void AuPluginEditorComponent::abandonInstance()
+{
+    stopTimer();
+    editor.abandonPlugin();
+    editor.close();   // plugin handles are gone; this releases only what we own
+    ownerSlot = nullptr;
+    abandoned = true;
+    loaded = embedded = embedding = false;
+}
+
 void AuPluginEditorComponent::timerCallback()
 {
+    if (ownerIsStale()) { abandonInstance(); return; }
+
     if (embedded)
     {
         if (isShowing()) editor.reveal(); else editor.hide();

--- a/src/ui/Vst3PluginEditorComponent.h
+++ b/src/ui/Vst3PluginEditorComponent.h
@@ -8,6 +8,7 @@
 #endif
 #if DUSKSTUDIO_HAS_NATIVE_AU
 #include "../engine/au/AuEditor.h"
+#include "../engine/au/NativeAuSlot.h"
 #endif
 #include "../foundation/MessageThread.h"
 #include "NativeEditorOwner.h"
@@ -97,6 +98,17 @@ public:
     bool attach (au::AuInstance& instance, juce::String& errorOut);
     bool isLoaded() const noexcept { return loaded; }
 
+    // Same owner contract as Vst3PluginEditorComponent above.
+    void bindOwner (au::NativeAuSlot& slot) noexcept
+    { owner.stamp (slot); ownerSlot = &slot; }
+
+    bool ownerIsStale() const noexcept
+    { return ownerSlot != nullptr && owner.isStale (*ownerSlot); }
+
+    bool wasAbandoned() const noexcept { return abandoned; }
+
+    void abandonInstance();
+
     void resized() override;
     void moved() override;
     void parentHierarchyChanged() override;
@@ -109,7 +121,10 @@ private:
     std::uintptr_t peerNativeHandle() const;
     juce::Rectangle<int> editorBoundsInPeer() const;
 
-    au::AuEditor editor;
+    au::AuEditor       editor;
+    NativeEditorOwner  owner;
+    au::NativeAuSlot*  ownerSlot = nullptr;
+    bool abandoned = false;
     bool loaded = false;
     bool embedded = false;
     bool embedding = false;   // guards re-entry while embed() is adding subviews


### PR DESCRIPTION
Closes #195.

Ports the #181 stamp/reap mechanism to the AU editor, which still polled a cached instance pointer while session load, undo replay and insert eviction could destroy the Audio Unit under it. The editor stamps {slot, generation} at attach, checks staleness on the pump tick, the embed, the bounds push and the visibility flip, and is reaped in the same syncNativeEditorOwners pass as CLAP/LV2/VST3. NativeAuSlot needs no change: every AU mutation routes through the base slot's load/unload/leakForShutdown, all of which bump the generation (verified across ChannelStrip, AuxLaneStrip, RegionEditActions and AudioEngine; reactivate keeps the same AudioComponentInstance, so the stamp stays fresh).

AuEditor::abandonPlugin() nulls the plugin-side view without messaging it; the retain taken at open() is deliberately leaked so the view's dealloc, where AU views tear down their listeners against the unit, cannot run against a disposed instance. This is refcount-for-refcount the VST3 contract (Vst3Editor::abandonPlugin drops the IPlugView via take() without Release). close() still detaches and releases the host-owned container on every path. The visibility guard is AU-only by design: unhiding the container draws the plugin's Cocoa subview synchronously, unlike the VST3/X11 case where reveal touches only a host-owned foreign window.

Verification and its limits, stated plainly:
- Linux: app build clean, 649/649 ctest, juce-gate 179 files / 9239 uses unchanged, selftest 15/15 ALSA under Xvfb. However, every AU hunk is behind the Apple-only gate, so zero lines of the new AU code compiled in any of that. macOS CI on this PR is the first compile.
- Owed before this ships in a release: an AU editor smoke on real macOS - open an editor, reload the session, replace and evict the insert, undo across the replacement, quit with the editor open.

Residual, tracked as #231: on the stale-reap path the container release still propagates window-detach notifications through the plugin's view. Inherited from the shipped #181 contract (VST3 has the same shape), so it is filed to fix for both formats together rather than diverging AU here.