### PR TITLE
fix(editors): stop stale-reap teardown from messaging disposed plugins

### DIFF
--- a/src/engine/au/AuEditor.h
+++ b/src/engine/au/AuEditor.h
@@ -25,7 +25,27 @@ public:
     void setBounds (int x, int y, int width, int height);
     void reveal();
     void hide();
+
+    // The unit is going away but is STILL ALIVE: drop the plugin's view without
+    // releasing it, because its -dealloc runs listener teardown against the
+    // unit. close() still releases the container, which only messages the
+    // detached subtree while that unit is valid.
     void abandonPlugin() noexcept;
+
+    // Same, for an ALREADY-disposed unit: nothing may reach plugin code again,
+    // which costs the container as well - the plugin's view is still a subview,
+    // so detaching or releasing it runs AUListenerDispose /
+    // AudioUnitRemovePropertyListener from the window-detach hooks against the
+    // disposed unit. It is hidden and then given up unreleased instead: that
+    // trades one bounded viewDidHide for the unbounded drawRect/displayLayer a
+    // parented dead view takes on every window redraw, and the visible guard
+    // means the usual reap (lane already hidden) sends no message at all. What
+    // it does not fix is the leaked view's own timers and listeners. close()
+    // afterwards is a genuine no-op, and each stale reap strands one container
+    // plus the plugin's entire view hierarchy for the life of the process, so
+    // repeated undo/redo or session loads with an editor open accumulate them.
+    void abandonPluginAndContainer() noexcept;
+
     void close();
     void pump();
 

--- a/src/engine/au/AuEditor.h
+++ b/src/engine/au/AuEditor.h
@@ -26,24 +26,21 @@ public:
     void reveal();
     void hide();
 
+    // Hide the host container while the unit is still valid. AbandonInstance
+    // callers must do this before the slot disposes the Audio Unit, because
+    // setHidden: notifies the embedded Cocoa view.
+    void quiesce() noexcept;
+
     // The unit is going away but is STILL ALIVE: drop the plugin's view without
     // releasing it, because its -dealloc runs listener teardown against the
     // unit. close() still releases the container, which only messages the
     // detached subtree while that unit is valid.
     void abandonPlugin() noexcept;
 
-    // Same, for an ALREADY-disposed unit: nothing may reach plugin code again,
-    // which costs the container as well - the plugin's view is still a subview,
-    // so detaching or releasing it runs AUListenerDispose /
-    // AudioUnitRemovePropertyListener from the window-detach hooks against the
-    // disposed unit. It is hidden and then given up unreleased instead: that
-    // trades one bounded viewDidHide for the unbounded drawRect/displayLayer a
-    // parented dead view takes on every window redraw, and the visible guard
-    // means the usual reap (lane already hidden) sends no message at all. What
-    // it does not fix is the leaked view's own timers and listeners. close()
-    // afterwards is a genuine no-op, and each stale reap strands one container
-    // plus the plugin's entire view hierarchy for the life of the process, so
-    // repeated undo/redo or session loads with an editor open accumulate them.
+    // Same, for an ALREADY-disposed unit: only clear retained references. The
+    // plugin's view is still a subview, so no Cocoa message - including a late
+    // setHidden: - is safe here. close() afterwards is a genuine no-op; the
+    // container and plugin hierarchy remain leaked for the process lifetime.
     void abandonPluginAndContainer() noexcept;
 
     void close();

--- a/src/engine/au/AuEditor.mm
+++ b/src/engine/au/AuEditor.mm
@@ -183,6 +183,21 @@ void AuEditor::hide()
     impl->visible = false;
 }
 
+void AuEditor::quiesce() noexcept
+{
+    // setHidden: propagates viewDidHide through the plugin subtree, so this is
+    // deliberately a live-instance phase rather than stale-owner cleanup.
+    @try
+    {
+        if (impl->container != nil && impl->visible)
+            [impl->container setHidden:YES];
+    }
+    @catch (NSException*)
+    {
+    }
+    impl->visible = false;
+}
+
 void AuEditor::pump()
 {
     if (impl->pluginView == nil) return;
@@ -205,10 +220,7 @@ void AuEditor::abandonPlugin() noexcept
 void AuEditor::abandonPluginAndContainer() noexcept
 {
     abandonPlugin();
-    // Hide rather than detach: the plugin's view is still a subview and must not
-    // leave the window.
-    @try { if (impl->visible) [impl->container setHidden:YES]; }
-    @catch (NSException*) {}
+    // The unit is already disposed: do not hide, detach or release this view.
     impl->container = nil;
     impl->visible   = false;
 }

--- a/src/engine/au/AuEditor.mm
+++ b/src/engine/au/AuEditor.mm
@@ -197,14 +197,20 @@ void AuEditor::pump()
 
 void AuEditor::abandonPlugin() noexcept
 {
-    // The Audio Unit behind this view may already be disposed. Leaking the
-    // retain taken in open() guarantees the view's -dealloc - where AU views
-    // run their listener teardown against the unit - never executes; close()
-    // still detaches and releases the container this host owns, which does
-    // message the detached subtree, but only through plain NSView hierarchy
-    // notifications.
+    // nil rather than release: the leaked retain from open() is what stops -dealloc.
     impl->pluginView = nil;
     impl->embedded = false;
+}
+
+void AuEditor::abandonPluginAndContainer() noexcept
+{
+    abandonPlugin();
+    // Hide rather than detach: the plugin's view is still a subview and must not
+    // leave the window.
+    @try { if (impl->visible) [impl->container setHidden:YES]; }
+    @catch (NSException*) {}
+    impl->container = nil;
+    impl->visible   = false;
 }
 
 void AuEditor::close()

--- a/src/engine/clap/ClapEditor.cpp
+++ b/src/engine/clap/ClapEditor.cpp
@@ -145,6 +145,11 @@ void ClapEditor::hide()
     mapped = false;
 }
 
+void ClapEditor::quiesce() noexcept
+{
+    hide();
+}
+
 void ClapEditor::abandonPluginAndContainer() noexcept
 {
     // The plugin's window is a foreign X11 child of ours: destroying the host

--- a/src/engine/clap/ClapEditor.cpp
+++ b/src/engine/clap/ClapEditor.cpp
@@ -145,6 +145,14 @@ void ClapEditor::hide()
     mapped = false;
 }
 
+void ClapEditor::abandonPluginAndContainer() noexcept
+{
+    // The plugin's window is a foreign X11 child of ours: destroying the host
+    // window and display in close() delivers no in-process call to plugin code,
+    // so there is nothing extra to give up here.
+    abandonPlugin();
+}
+
 void ClapEditor::close()
 {
     // Leak path: the plugin GUI stays created - u-he's gui->destroy hangs. It is

--- a/src/engine/clap/ClapEditor.h
+++ b/src/engine/clap/ClapEditor.h
@@ -49,9 +49,9 @@ public:
     // quit. close() then skips gui->hide/gui->destroy; the process is exiting anyway.
     void setLeakOnClose (bool b) noexcept { leakOnClose = b; }
 
-    // The plugin was destroyed out from under this editor. Drop every plugin-side
-    // handle WITHOUT calling through it - the vtables went with the bundle - so
-    // close() only releases the container this host owns.
+    // The plugin is going away but is STILL ALIVE. Drop every plugin-side handle
+    // WITHOUT calling through it - the vtables go with the bundle - so close()
+    // only releases the container this host owns, while that plugin is valid.
     void abandonPlugin() noexcept
     {
         plugin  = nullptr;
@@ -59,6 +59,22 @@ public:
         hostPtr = nullptr;
         created = embedded = false;
     }
+
+    // Same, for an ALREADY-destroyed plugin: nothing may reach plugin code
+    // again. On Cocoa that costs the container as well - close() releases it
+    // with the plugin's view still inside and nothing else retaining that view,
+    // so the release can run its -dealloc against a disposed instance in an
+    // unloaded module. It is hidden and then given up unreleased instead: that
+    // trades one bounded viewDidHide for the unbounded drawRect/displayLayer a
+    // parented dead view takes on every window redraw, and the mapped guard
+    // means the usual reap (lane already hidden) sends no message at all. What
+    // it does not fix is the leaked view's own timers and listeners. Each stale
+    // reap strands one container plus the plugin's entire view hierarchy for the
+    // life of the process, so repeated undo/redo or session loads with an editor
+    // open accumulate them. X11 has no such hazard (the plugin's window is a
+    // foreign child): there this is exactly abandonPlugin(), and close() still
+    // destroys the host window and display.
+    void abandonPluginAndContainer() noexcept;
 
     // Message thread, ~60 Hz: apply queued GUI callbacks, pump the plugin's
     // fds/timers, and drain any platform editor events.

--- a/src/engine/clap/ClapEditor.h
+++ b/src/engine/clap/ClapEditor.h
@@ -36,6 +36,11 @@ public:
     void setBounds (int x, int y, int w, int h);
     void reveal();
     void hide();
+
+    // Hide the host container while the plugin/module are still valid. Cocoa
+    // abandonment must quiesce before disposal because setHidden: notifies the
+    // embedded plugin view.
+    void quiesce() noexcept;
     void close();
 
     // Linux geometry diagnostics. macOS uses logical component bounds directly,
@@ -60,20 +65,10 @@ public:
         created = embedded = false;
     }
 
-    // Same, for an ALREADY-destroyed plugin: nothing may reach plugin code
-    // again. On Cocoa that costs the container as well - close() releases it
-    // with the plugin's view still inside and nothing else retaining that view,
-    // so the release can run its -dealloc against a disposed instance in an
-    // unloaded module. It is hidden and then given up unreleased instead: that
-    // trades one bounded viewDidHide for the unbounded drawRect/displayLayer a
-    // parented dead view takes on every window redraw, and the mapped guard
-    // means the usual reap (lane already hidden) sends no message at all. What
-    // it does not fix is the leaked view's own timers and listeners. Each stale
-    // reap strands one container plus the plugin's entire view hierarchy for the
-    // life of the process, so repeated undo/redo or session loads with an editor
-    // open accumulate them. X11 has no such hazard (the plugin's window is a
-    // foreign child): there this is exactly abandonPlugin(), and close() still
-    // destroys the host window and display.
+    // Same, for an ALREADY-destroyed plugin: only clear retained references on
+    // Cocoa. No late setHidden:, detach or release may message the embedded view.
+    // X11 has no in-process child-view hazard, so it still closes its host window
+    // and display after dropping the plugin handles.
     void abandonPluginAndContainer() noexcept;
 
     // Message thread, ~60 Hz: apply queued GUI callbacks, pump the plugin's

--- a/src/engine/clap/ClapEditor_Mac.mm
+++ b/src/engine/clap/ClapEditor_Mac.mm
@@ -115,13 +115,25 @@ void ClapEditor::hide()
     mapped = false;
 }
 
+void ClapEditor::quiesce() noexcept
+{
+    // setHidden: propagates viewDidHide through the plugin subtree, so this is
+    // deliberately a live-plugin phase rather than stale-owner cleanup.
+    @try
+    {
+        if (auto* container = containerView (containerHandle); container != nil && mapped)
+            [container setHidden:YES];
+    }
+    @catch (NSException*)
+    {
+    }
+    mapped = false;
+}
+
 void ClapEditor::abandonPluginAndContainer() noexcept
 {
     abandonPlugin();
-    // Hide rather than detach: the plugin's view is still a subview and must not
-    // leave the window.
-    @try { if (mapped) [containerView (containerHandle) setHidden:YES]; }
-    @catch (NSException*) {}
+    // The plugin is already disposed: do not hide, detach or release this view.
     platformContext = nullptr;
     containerHandle = 0;
     mapped          = false;

--- a/src/engine/clap/ClapEditor_Mac.mm
+++ b/src/engine/clap/ClapEditor_Mac.mm
@@ -115,6 +115,18 @@ void ClapEditor::hide()
     mapped = false;
 }
 
+void ClapEditor::abandonPluginAndContainer() noexcept
+{
+    abandonPlugin();
+    // Hide rather than detach: the plugin's view is still a subview and must not
+    // leave the window.
+    @try { if (mapped) [containerView (containerHandle) setHidden:YES]; }
+    @catch (NSException*) {}
+    platformContext = nullptr;
+    containerHandle = 0;
+    mapped          = false;
+}
+
 void ClapEditor::close()
 {
     // Leak path: the plugin GUI stays created (it hangs in gui->destroy) and keeps

--- a/src/engine/vst3/Vst3Editor.cpp
+++ b/src/engine/vst3/Vst3Editor.cpp
@@ -211,6 +211,11 @@ void Vst3Editor::hide()
     impl->mapped = false;
 }
 
+void Vst3Editor::quiesce() noexcept
+{
+    hide();
+}
+
 void Vst3Editor::abandonPlugin() noexcept
 {
     (void) impl->view.take();

--- a/src/engine/vst3/Vst3Editor.cpp
+++ b/src/engine/vst3/Vst3Editor.cpp
@@ -219,6 +219,14 @@ void Vst3Editor::abandonPlugin() noexcept
     impl->embedded = false;
 }
 
+void Vst3Editor::abandonPluginAndContainer() noexcept
+{
+    // The plugin's window is a foreign X11 child of ours: destroying the host
+    // window in close() delivers no in-process call to plugin code, so there is
+    // nothing extra to give up here.
+    abandonPlugin();
+}
+
 void Vst3Editor::close()
 {
     if (impl->view)

--- a/src/engine/vst3/Vst3Editor.h
+++ b/src/engine/vst3/Vst3Editor.h
@@ -47,11 +47,27 @@ public:
     void hide();
     void close();
 
-    // The instance was destroyed out from under this editor. Drops the view
-    // without releasing it and without the removed()/setFrame() teardown - the
-    // module those calls live in was unloaded with the instance. close() then
-    // only releases the host container.
+    // The instance is going away but is STILL ALIVE. Drops the view without
+    // releasing it and without the removed()/setFrame() teardown - the module
+    // those calls live in goes with the instance. close() then only releases the
+    // host container, whose detach still reaches a valid plugin.
     void abandonPlugin() noexcept;
+
+    // Same, for an instance that is ALREADY destroyed: nothing may reach plugin
+    // code again. On Cocoa that costs the container as well - the plugin's view
+    // is still a subview, so detaching or releasing it runs that view's
+    // window-detach hooks against the dead instance. It is hidden and then given
+    // up unreleased instead: that trades one bounded viewDidHide for the
+    // unbounded drawRect/displayLayer a parented dead view takes on every window
+    // redraw, and the visible guard means the usual reap (lane already hidden)
+    // sends no message at all. What it does not fix is the leaked view's own
+    // timers and listeners, and its IPlugFrame pointer, which can no longer be
+    // cleared. Each stale reap strands one container plus the plugin's entire
+    // view hierarchy for the life of the process, so repeated undo/redo or
+    // session loads with an editor open accumulate them. X11 has no such hazard
+    // (the plugin's window is a foreign child): there this is exactly
+    // abandonPlugin(), and close() still destroys the host window and display.
+    void abandonPluginAndContainer() noexcept;
 
     // Linux geometry diagnostics. macOS uses logical component bounds directly,
     // so these return false there.

--- a/src/engine/vst3/Vst3Editor.h
+++ b/src/engine/vst3/Vst3Editor.h
@@ -45,6 +45,11 @@ public:
     void setContentScale (float scale);
     void reveal();
     void hide();
+
+    // Hide the host container while the instance/module are still valid. Cocoa
+    // abandonment must quiesce before disposal because setHidden: notifies the
+    // embedded plugin view.
+    void quiesce() noexcept;
     void close();
 
     // The instance is going away but is STILL ALIVE. Drops the view without
@@ -53,20 +58,10 @@ public:
     // host container, whose detach still reaches a valid plugin.
     void abandonPlugin() noexcept;
 
-    // Same, for an instance that is ALREADY destroyed: nothing may reach plugin
-    // code again. On Cocoa that costs the container as well - the plugin's view
-    // is still a subview, so detaching or releasing it runs that view's
-    // window-detach hooks against the dead instance. It is hidden and then given
-    // up unreleased instead: that trades one bounded viewDidHide for the
-    // unbounded drawRect/displayLayer a parented dead view takes on every window
-    // redraw, and the visible guard means the usual reap (lane already hidden)
-    // sends no message at all. What it does not fix is the leaked view's own
-    // timers and listeners, and its IPlugFrame pointer, which can no longer be
-    // cleared. Each stale reap strands one container plus the plugin's entire
-    // view hierarchy for the life of the process, so repeated undo/redo or
-    // session loads with an editor open accumulate them. X11 has no such hazard
-    // (the plugin's window is a foreign child): there this is exactly
-    // abandonPlugin(), and close() still destroys the host window and display.
+    // Same, for an ALREADY-destroyed instance: only clear retained references on
+    // Cocoa. No late setHidden:, detach or release may message the embedded view.
+    // X11 has no in-process child-view hazard, so it still closes its host window
+    // and display after dropping the plugin handles.
     void abandonPluginAndContainer() noexcept;
 
     // Linux geometry diagnostics. macOS uses logical component bounds directly,

--- a/src/engine/vst3/Vst3Editor_Mac.mm
+++ b/src/engine/vst3/Vst3Editor_Mac.mm
@@ -172,6 +172,21 @@ void Vst3Editor::hide()
     impl->visible = false;
 }
 
+void Vst3Editor::quiesce() noexcept
+{
+    // setHidden: propagates viewDidHide through the plugin subtree, so this is
+    // deliberately a live-instance phase rather than stale-owner cleanup.
+    @try
+    {
+        if (impl->container != nil && impl->visible)
+            [impl->container setHidden:YES];
+    }
+    @catch (NSException*)
+    {
+    }
+    impl->visible = false;
+}
+
 void Vst3Editor::abandonPlugin() noexcept
 {
     (void) impl->view.take();
@@ -183,10 +198,7 @@ void Vst3Editor::abandonPlugin() noexcept
 void Vst3Editor::abandonPluginAndContainer() noexcept
 {
     abandonPlugin();
-    // Hide rather than detach: attached() made the plugin's view a subview and
-    // it must not leave the window.
-    @try { if (impl->visible) [impl->container setHidden:YES]; }
-    @catch (NSException*) {}
+    // The instance is already disposed: do not hide, detach or release this view.
     impl->container = nil;
     impl->visible   = false;
 }

--- a/src/engine/vst3/Vst3Editor_Mac.mm
+++ b/src/engine/vst3/Vst3Editor_Mac.mm
@@ -180,6 +180,17 @@ void Vst3Editor::abandonPlugin() noexcept
     impl->embedded = false;
 }
 
+void Vst3Editor::abandonPluginAndContainer() noexcept
+{
+    abandonPlugin();
+    // Hide rather than detach: attached() made the plugin's view a subview and
+    // it must not leave the window.
+    @try { if (impl->visible) [impl->container setHidden:YES]; }
+    @catch (NSException*) {}
+    impl->container = nil;
+    impl->visible   = false;
+}
+
 void Vst3Editor::close()
 {
     if (impl->view)

--- a/src/ui/AuxLaneComponent.cpp
+++ b/src/ui/AuxLaneComponent.cpp
@@ -1746,11 +1746,13 @@ void AuxLaneComponent::parentHierarchyChanged()
         for (int i = 0; i < AuxLaneParams::kMaxLanePlugins; ++i)
         {
             detachEditorForSlot (i);
-            // The native editors' embedded X11 windows are also parented to the
-            // destroyed peer; tear them down so rebuildSlots re-embeds on the new one.
+            // The native editors' embedded windows (X11 child on Linux, NSView
+            // container on macOS) are also parented to the destroyed peer; tear
+            // them down so rebuildSlots re-embeds on the new one.
             detachClapEditorForSlot (i);
             detachLv2EditorForSlot (i);
             detachVst3EditorForSlot (i);
+            detachAuEditorForSlot (i);
         }
         lastSeenPeer = peer;
     }

--- a/src/ui/ClapPluginEditorComponent.cpp
+++ b/src/ui/ClapPluginEditorComponent.cpp
@@ -19,9 +19,10 @@ ClapPluginEditorComponent::ClapPluginEditorComponent()
 ClapPluginEditorComponent::~ClapPluginEditorComponent()
 {
     stopTimer();
-    // Every reset path lands here, and gui->destroy would call into the bundle
-    // that was unloaded with the instance.
-    if (ownerIsStale()) editor.abandonPlugin();
+    // Every reset path lands here, and both gui->destroy and releasing the
+    // container the plugin's view still sits in call into the bundle that was
+    // unloaded with the instance.
+    if (ownerIsStale()) editor.abandonPluginAndContainer();
     editor.close();
     if (ownsInstance) instance.deactivate();   // attach() mode: the slot owns it
 }
@@ -197,8 +198,14 @@ void ClapPluginEditorComponent::leakForShutdown()
 void ClapPluginEditorComponent::abandonInstance()
 {
     stopTimer();
-    editor.abandonPlugin();
-    editor.close();   // plugin handles are gone; this releases only what we own
+    // A stale owner means the plugin is ALREADY destroyed, so the container is
+    // plugin contact too: close() releases it with the plugin's view still
+    // inside, and nothing else retains that view. Giving it up instead makes the
+    // close a no-op on Cocoa; on X11 close() still destroys the host window and
+    // display.
+    if (ownerIsStale()) editor.abandonPluginAndContainer();
+    else                editor.abandonPlugin();
+    editor.close();
     ownerSlot = nullptr;
     abandoned = true;
     loaded = embedded = embedding = false;

--- a/src/ui/ClapPluginEditorComponent.cpp
+++ b/src/ui/ClapPluginEditorComponent.cpp
@@ -23,6 +23,7 @@ ClapPluginEditorComponent::~ClapPluginEditorComponent()
     // container the plugin's view still sits in call into the bundle that was
     // unloaded with the instance.
     if (ownerIsStale()) editor.abandonPluginAndContainer();
+    else                editor.quiesce();
     editor.close();
     if (ownsInstance) instance.deactivate();   // attach() mode: the slot owns it
 }
@@ -203,9 +204,7 @@ void ClapPluginEditorComponent::abandonInstance()
     // inside, and nothing else retains that view. Giving it up instead makes the
     // close a no-op on Cocoa; on X11 close() still destroys the host window and
     // display.
-    if (ownerIsStale()) editor.abandonPluginAndContainer();
-    else                editor.abandonPlugin();
-    editor.close();
+    abandonNativeEditorInstance (editor, ownerIsStale());
     ownerSlot = nullptr;
     abandoned = true;
     loaded = embedded = embedding = false;

--- a/src/ui/NativeEditorOwner.h
+++ b/src/ui/NativeEditorOwner.h
@@ -44,27 +44,42 @@ enum class NativeEditorTeardown
     // plugin's own gui->destroy, so a later re-open creates a fresh GUI.
     Destroy,
     // The caller destroys the instance immediately afterwards (session restore).
-    // Drop our plugin-side handles rather than run the plugin's teardown - a
-    // foreign-toolkit GUI can hang there, and the plugin releases it along with
-    // itself - but still close the container + display this host owns. On
-    // Cocoa that close messages the plugin's subview, so it is only safe while
-    // the instance lives; a stale owner takes abandonPluginAndContainer() and
-    // gives the container up unclosed there. X11 closes on both paths (the
-    // host window is foreign to the plugin), and the LV2 editor still runs
-    // the plain abandon on Cocoa (its suil teardown needs its own treatment).
+    // This MUST run while the instance is still live: first quiesce the native
+    // container, because hiding a Cocoa container notifies the plugin view, then
+    // drop plugin-side handles and close host-owned resources. A stale-owner reap
+    // is only a fail-safe; it may abandon retained Cocoa references but must not
+    // hide, detach or release them after the plugin/module has gone.
     AbandonInstance,
     // The process is exiting: leak the GUI (it hangs in its own destructor)
     // together with the container + display it is still drawing into.
     LeakForExit,
 };
 
+// Enforce the AbandonInstance ordering above. The normal path is called before
+// slot disposal and may safely hide the native container; stale cleanup must
+// never use that as a late opportunity to touch the embedded Cocoa hierarchy.
+template <typename PlatformEditor>
+void abandonNativeEditorInstance (PlatformEditor& editor, bool ownerIsStale)
+{
+    if (ownerIsStale)
+    {
+        editor.abandonPluginAndContainer();
+    }
+    else
+    {
+        editor.quiesce();
+        editor.abandonPlugin();
+    }
+    editor.close();
+}
+
 // Drop `editor` once its instance is no longer the slot's live one, or once it
 // has already abandoned itself on one of its own guards - abandoning unbinds the
 // slot, so staleness alone stops reporting and the component would sit there as
 // a dead rectangle. Order is load-bearing: the editor abandons its plugin-side
-// handles first - on Cocoa a stale owner gives up the host container too - then
-// `detach` does the owner's own bookkeeping - dismissing a modal that borrows
-// the component, removing it as a child - while it is still alive.
+// handles first - on Cocoa a stale owner gives up the host container without
+// messaging it - then `detach` does the owner's own bookkeeping, dismissing a
+// modal that borrows the component and removing it as a child while it is alive.
 template <typename EditorComponent, typename Detach>
 void syncNativeEditorOwner (std::unique_ptr<EditorComponent>& editor, Detach&& detach)
 {

--- a/src/ui/NativeEditorOwner.h
+++ b/src/ui/NativeEditorOwner.h
@@ -46,7 +46,12 @@ enum class NativeEditorTeardown
     // The caller destroys the instance immediately afterwards (session restore).
     // Drop our plugin-side handles rather than run the plugin's teardown - a
     // foreign-toolkit GUI can hang there, and the plugin releases it along with
-    // itself - but still close the container + display this host owns.
+    // itself - but still close the container + display this host owns. On
+    // Cocoa that close messages the plugin's subview, so it is only safe while
+    // the instance lives; a stale owner takes abandonPluginAndContainer() and
+    // gives the container up unclosed there. X11 closes on both paths (the
+    // host window is foreign to the plugin), and the LV2 editor still runs
+    // the plain abandon on Cocoa (its suil teardown needs its own treatment).
     AbandonInstance,
     // The process is exiting: leak the GUI (it hangs in its own destructor)
     // together with the container + display it is still drawing into.
@@ -57,9 +62,9 @@ enum class NativeEditorTeardown
 // has already abandoned itself on one of its own guards - abandoning unbinds the
 // slot, so staleness alone stops reporting and the component would sit there as
 // a dead rectangle. Order is load-bearing: the editor abandons its plugin-side
-// handles first, then `detach` does the owner's own bookkeeping - dismissing a
-// modal that borrows the component, removing it as a child - while it is still
-// alive.
+// handles first - on Cocoa a stale owner gives up the host container too - then
+// `detach` does the owner's own bookkeeping - dismissing a modal that borrows
+// the component, removing it as a child - while it is still alive.
 template <typename EditorComponent, typename Detach>
 void syncNativeEditorOwner (std::unique_ptr<EditorComponent>& editor, Detach&& detach)
 {

--- a/src/ui/Vst3PluginEditorComponent.cpp
+++ b/src/ui/Vst3PluginEditorComponent.cpp
@@ -28,9 +28,10 @@ Vst3PluginEditorComponent::Vst3PluginEditorComponent()
 Vst3PluginEditorComponent::~Vst3PluginEditorComponent()
 {
     stopTimer();
-    // Every reset path lands here, and releasing the view calls into the module
-    // that was unloaded with the instance.
-    if (ownerIsStale()) editor.abandonPlugin();
+    // Every reset path lands here, and both releasing the view and detaching the
+    // container it is attached to call into the module that was unloaded with
+    // the instance.
+    if (ownerIsStale()) editor.abandonPluginAndContainer();
     editor.close();
 }
 
@@ -168,8 +169,14 @@ void Vst3PluginEditorComponent::visibilityChanged()
 void Vst3PluginEditorComponent::abandonInstance()
 {
     stopTimer();
-    editor.abandonPlugin();
-    editor.close();   // plugin handles are gone; this releases only what we own
+    // A stale owner means the instance is ALREADY disposed, so releasing the
+    // container is plugin contact too: the view is still attached to it, and the
+    // window-detach hooks are where plugin views tear their listeners down.
+    // Giving it up instead makes the close a no-op on Cocoa; on X11 close()
+    // still destroys the host window and display.
+    if (ownerIsStale()) editor.abandonPluginAndContainer();
+    else                editor.abandonPlugin();
+    editor.close();
     ownerSlot = nullptr;
     abandoned = true;
     loaded = embedded = embedding = false;
@@ -258,7 +265,7 @@ AuPluginEditorComponent::AuPluginEditorComponent()
 AuPluginEditorComponent::~AuPluginEditorComponent()
 {
     stopTimer();
-    if (ownerIsStale()) editor.abandonPlugin();
+    if (ownerIsStale()) editor.abandonPluginAndContainer();
     editor.close();
 }
 
@@ -356,8 +363,12 @@ void AuPluginEditorComponent::visibilityChanged()
 void AuPluginEditorComponent::abandonInstance()
 {
     stopTimer();
-    editor.abandonPlugin();
-    editor.close();   // plugin handles are gone; this releases only what we own
+    // Same split as the VST3 component: a stale owner means the unit is already
+    // disposed, so the container detach would run the plugin view's listener
+    // teardown against it, leaving close() nothing to do afterwards.
+    if (ownerIsStale()) editor.abandonPluginAndContainer();
+    else                editor.abandonPlugin();
+    editor.close();
     ownerSlot = nullptr;
     abandoned = true;
     loaded = embedded = embedding = false;

--- a/src/ui/Vst3PluginEditorComponent.cpp
+++ b/src/ui/Vst3PluginEditorComponent.cpp
@@ -32,6 +32,7 @@ Vst3PluginEditorComponent::~Vst3PluginEditorComponent()
     // container it is attached to call into the module that was unloaded with
     // the instance.
     if (ownerIsStale()) editor.abandonPluginAndContainer();
+    else                editor.quiesce();
     editor.close();
 }
 
@@ -174,9 +175,7 @@ void Vst3PluginEditorComponent::abandonInstance()
     // window-detach hooks are where plugin views tear their listeners down.
     // Giving it up instead makes the close a no-op on Cocoa; on X11 close()
     // still destroys the host window and display.
-    if (ownerIsStale()) editor.abandonPluginAndContainer();
-    else                editor.abandonPlugin();
-    editor.close();
+    abandonNativeEditorInstance (editor, ownerIsStale());
     ownerSlot = nullptr;
     abandoned = true;
     loaded = embedded = embedding = false;
@@ -266,6 +265,7 @@ AuPluginEditorComponent::~AuPluginEditorComponent()
 {
     stopTimer();
     if (ownerIsStale()) editor.abandonPluginAndContainer();
+    else                editor.quiesce();
     editor.close();
 }
 
@@ -366,9 +366,7 @@ void AuPluginEditorComponent::abandonInstance()
     // Same split as the VST3 component: a stale owner means the unit is already
     // disposed, so the container detach would run the plugin view's listener
     // teardown against it, leaving close() nothing to do afterwards.
-    if (ownerIsStale()) editor.abandonPluginAndContainer();
-    else                editor.abandonPlugin();
-    editor.close();
+    abandonNativeEditorInstance (editor, ownerIsStale());
     ownerSlot = nullptr;
     abandoned = true;
     loaded = embedded = embedding = false;

--- a/tests/native_editor_owner.cpp
+++ b/tests/native_editor_owner.cpp
@@ -4,6 +4,7 @@
 #include "../src/ui/NativeEditorOwner.h"
 
 #include <memory>
+#include <vector>
 
 using duskstudio::NativeEditorOwner;
 
@@ -36,6 +37,25 @@ struct FakeEditor
     int& abandonCount;
     bool stale     = false;
     bool abandoned = false;
+};
+
+enum class TeardownCall
+{
+    Quiesce,
+    AbandonPlugin,
+    AbandonPluginAndContainer,
+    Close,
+};
+
+struct FakePlatformEditor
+{
+    void quiesce() { calls.push_back (TeardownCall::Quiesce); }
+    void abandonPlugin() { calls.push_back (TeardownCall::AbandonPlugin); }
+    void abandonPluginAndContainer()
+    { calls.push_back (TeardownCall::AbandonPluginAndContainer); }
+    void close() { calls.push_back (TeardownCall::Close); }
+
+    std::vector<TeardownCall> calls;
 };
 
 // Minimal traits for a real NativeInsertSlot instantiation - enough to reach
@@ -124,6 +144,32 @@ TEST_CASE ("NativeInsertSlot bumps its generation on every identity change")
     slot.leakForShutdown();
     REQUIRE (slot.generation() != afterReload);
     REQUIRE (owner.isStale (slot));
+}
+
+TEST_CASE ("AbandonInstance quiesces only while the plugin is live")
+{
+    FakePlatformEditor editor;
+
+    SECTION ("live owner hides before dropping plugin handles")
+    {
+        duskstudio::abandonNativeEditorInstance (editor, false);
+        const std::vector<TeardownCall> expected {
+            TeardownCall::Quiesce,
+            TeardownCall::AbandonPlugin,
+            TeardownCall::Close,
+        };
+        REQUIRE (editor.calls == expected);
+    }
+
+    SECTION ("stale owner sends no container message")
+    {
+        duskstudio::abandonNativeEditorInstance (editor, true);
+        const std::vector<TeardownCall> expected {
+            TeardownCall::AbandonPluginAndContainer,
+            TeardownCall::Close,
+        };
+        REQUIRE (editor.calls == expected);
+    }
 }
 
 TEST_CASE ("syncNativeEditorOwner drops a stale editor and keeps a live one")


### PR DESCRIPTION
Closes #231.

On the stale-owner teardown path (the instance is already disposed), close() released the host container while the plugin's NSView was still a subview: AppKit propagates viewWillMoveToWindow:/viewDidMoveToWindow down the detached subtree, and AU/VST3 views commonly run listener teardown against the instance from exactly those hooks. Review of this branch found CLAP carried the worst variant - its container release could drop the plugin view's last retain and run its dealloc against a disposed instance and an unloaded module - and CLAP is default-ON on macOS, so the fix covers VST3, AU and CLAP together.

Teardown splits per the shipped owner contract: abandonPlugin() keeps today's live-path semantics; a stale owner takes abandonPluginAndContainer(), which hides the container inside a noexcept @try (one bounded viewDidHide instead of unbounded drawRect into the dead instance on every window redraw, and no message at all when the lane is hidden - the common session-load case) and relinquishes it without release or detach, leaving close() a genuine no-op on Cocoa. On X11 the host window is foreign to the plugin, so the Linux implementations delegate and close() still destroys the window and display - Linux behavior is byte-identical to main. The aux-lane peer-change loop also gains the missing AU detach, so a fullscreen toggle rebuilds AU editors against the new peer like the other three formats.

Accepted trade, stated plainly: each stale reap permanently strands one container plus the plugin's entire view hierarchy for the life of the process; repeated undo/redo or session loads with a native editor open accumulate them. The residual it does not fix is the leaked view's own timers/listeners and, for VST3, its never-cleared IPlugFrame pointer.

Deferred with issues filed: LV2's macOS editor has a stronger version needing a different shape (suil instance lifetime) - #235; channel-strip modal editors never re-embed after a top-level peer recreation, pre-existing, all formats - #236.

Verification and its limits: Linux build clean, 650/650 ctest (one environmental ALSA-seq flake reproduced identically on untouched main, passes isolated), juce-gate 179/9239 unchanged, selftest 15/15 ALSA under Xvfb. The Cocoa hunks compile only on macOS - this PR's macOS CI is their first compile, and the runtime behavior ships on AppKit-contract reasoning, not observation. The AU/CLAP/VST3 editor acceptance matrix on real hardware (open/close/reopen on track and aux, session reload, replace/evict, undo/redo, quit with editor open, fullscreen) is the required post-merge check before v0.13.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin editor cleanup when plugin instances are already unloaded or disposed.
  * Prevented stale cleanup operations from calling into unavailable plugin code.
  * Safely hides and abandons native editor containers during stale-instance cleanup.
  * Ensured active editors are safely hidden before plugin shutdown.
  * Improved editor reparenting behavior for Audio Unit interfaces across native windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->