### PR TITLE
chore(win): pin the vcpkg codec chain in a manifest

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -163,9 +163,14 @@ jobs:
         # /MT objects. They link into the binary, so no DLLs ship in the MSI.
         # CMake's find_library/find_path pick them up via CMAKE_PREFIX_PATH
         # (forward-slashed so cmake parses the path cleanly).
+        # Manifest mode: versions come from vcpkg.json's builtin-baseline and
+        # install under <manifest-root>/vcpkg_installed, not the image's vcpkg
+        # tree. That baseline tracks the runner image's own vcpkg clone commit:
+        # vcpkg cannot fetch a baseline it does not already have, so never bump
+        # it past what the current windows-2022 image ships.
         run: |
-          vcpkg install mp3lame:x64-windows-static libsndfile:x64-windows-static
-          echo "VCPKG_PREFIX=${VCPKG_INSTALLATION_ROOT//\\//}/installed/x64-windows-static" >> "$GITHUB_ENV"
+          vcpkg install --triplet x64-windows-static
+          echo "VCPKG_PREFIX=${GITHUB_WORKSPACE//\\//}/vcpkg_installed/x64-windows-static" >> "$GITHUB_ENV"
 
       - name: Configure (CMake / Visual Studio 17 2022 / x64)
         shell: bash

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -106,10 +106,14 @@ jobs:
         # x64-windows-static = static libs + /MT static CRT, matching the whole
         # tree's CMAKE_MSVC_RUNTIME_LIBRARY (sfizz forces /MT). The -md triplet
         # (/MD) would LNK2038 against the /MT objects. CMake finds them via
-        # CMAKE_PREFIX_PATH.
+        # CMAKE_PREFIX_PATH. Manifest mode: versions come from vcpkg.json's
+        # builtin-baseline and install under <manifest-root>/vcpkg_installed,
+        # not the image's vcpkg tree. That baseline tracks the runner image's
+        # own vcpkg clone commit: vcpkg cannot fetch a baseline it does not
+        # already have, so never bump it past what the current image ships.
         run: |
-          vcpkg install mp3lame:x64-windows-static libsndfile:x64-windows-static
-          echo "VCPKG_PREFIX=${VCPKG_INSTALLATION_ROOT//\\//}/installed/x64-windows-static" >> "$GITHUB_ENV"
+          vcpkg install --triplet x64-windows-static
+          echo "VCPKG_PREFIX=${GITHUB_WORKSPACE//\\//}/vcpkg_installed/x64-windows-static" >> "$GITHUB_ENV"
 
       - name: Configure tests (CMake / Visual Studio 17 2022 / x64)
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 build/
 build-*/
 cmake-build-*/
+# Windows: manifest-mode vcpkg installs the codec chain here (vcpkg.json)
+vcpkg_installed/
 .cache/
 # Symlink to build/compile_commands.json for clangd (scripts/dev.sh
 # refreshes it). The real file lives in the gitignored build dir.

--- a/BUILDING-WINDOWS.md
+++ b/BUILDING-WINDOWS.md
@@ -10,14 +10,14 @@ This document is aimed at a developer with a Windows machine who has been handed
    - During install, check the **"Desktop development with C++"** workload.
    - This brings MSVC, the Windows 10/11 SDK, and CMake. No separate CMake install needed.
 2. **Git for Windows**: https://git-scm.com/download/win
-3. **vcpkg**, for libsndfile and LAME. libsndfile is not optional on any platform — all audio file I/O goes through it and configure hard-fails without it ([CMakeLists.txt:594-607](CMakeLists.txt#L594-L607)). LAME is what enables MP3 bounce. Install the same static triplet CI uses, then hand CMake the prefix:
+3. **vcpkg**, for libsndfile and LAME. libsndfile is not optional on any platform — all audio file I/O goes through it and configure hard-fails without it ([CMakeLists.txt:594-612](CMakeLists.txt#L594-L612)). LAME is what enables MP3 bounce. Both are declared in [vcpkg.json](vcpkg.json) at the repo root, with a `builtin-baseline` that pins the exact codec versions, so run vcpkg in manifest mode from the checkout root and it installs what CI installs:
 
    ```cmd
-   vcpkg install libsndfile:x64-windows-static mp3lame:x64-windows-static
+   vcpkg install --triplet x64-windows-static
    ```
 
-   and add `-DCMAKE_PREFIX_PATH=<vcpkg-root>/installed/x64-windows-static` to the configure line, forward slashes as with the DPF paths below. `%VCPKG_INSTALLATION_ROOT%` holds that root on the CI images; on a hand-installed vcpkg, substitute wherever you cloned it.
-4. **Steinberg ASIO SDK** — effectively required for the Visual Studio flow in this document, despite reading like an extra. A multi-config generator with Release among its configurations fails the configure without it ([CMakeLists.txt:693-700](CMakeLists.txt#L693-L700) and [:727-734](CMakeLists.txt#L727-L734)), which is exactly what `-G "Visual Studio 17 2022"` gives you: a shipping Windows binary must not silently come out WASAPI-only. Download from https://www.steinberg.net/asiosdk, accept the EULA, unzip somewhere stable, then pass `-DASIOSDK_PATH=C:/path/to/asiosdk` (its `common/` must contain `iasiodrv.h`). To skip the download on a first dev build, pass `-DDUSKSTUDIO_REQUIRE_ASIO=OFF` instead and accept WASAPI only.
+   Manifest mode rejects per-package arguments: `vcpkg install libsndfile:x64-windows-static` errors out while `vcpkg.json` is present. Your vcpkg clone must also already contain the baseline commit, because vcpkg resolves it locally and will not fetch it; clones updated on or after 2026-08-01 have it, so `git pull` in the vcpkg clone first if yours is older. The packages land in `vcpkg_installed\x64-windows-static` under the checkout, so add `-DCMAKE_PREFIX_PATH=<repo-root>/vcpkg_installed/x64-windows-static` to the configure line, forward slashes as with the DPF paths below.
+4. **Steinberg ASIO SDK** — effectively required for the Visual Studio flow in this document, despite reading like an extra. A multi-config generator with Release among its configurations fails the configure without it ([CMakeLists.txt:694-701](CMakeLists.txt#L694-L701) and [:728-735](CMakeLists.txt#L728-L735)), which is exactly what `-G "Visual Studio 17 2022"` gives you: a shipping Windows binary must not silently come out WASAPI-only. Download from https://www.steinberg.net/asiosdk, accept the EULA, unzip somewhere stable, then pass `-DASIOSDK_PATH=C:/path/to/asiosdk` (its `common/` must contain `iasiodrv.h`). To skip the download on a first dev build, pass `-DDUSKSTUDIO_REQUIRE_ASIO=OFF` instead and accept WASAPI only.
 
 ## Repository layout
 
@@ -45,9 +45,9 @@ git clone --branch 8.0.4 https://github.com/juce-framework/JUCE.git
 git clone https://github.com/dusk-audio/dusk-audio-plugins.git plugins
 ```
 
-`--recurse-submodules` matters: `external/sfizz` carries the SF2 / multisample instrument engine, and CMake gates it purely on the header being present ([CMakeLists.txt:1163](CMakeLists.txt#L1163)) — clone without it and the feature is gone with no diagnostic. If you already cloned flat, run `git submodule update --init --recursive`.
+`--recurse-submodules` matters: `external/sfizz` carries the SF2 / multisample instrument engine, and CMake gates it purely on the header being present ([CMakeLists.txt:1164](CMakeLists.txt#L1164)) — clone without it and the feature is gone with no diagnostic. If you already cloned flat, run `git submodule update --init --recursive`.
 
-The explicit `plugins` target on the third clone is mandatory: CMake auto-discovery looks for a sibling directory named `plugins\` and nothing else ([CMakeLists.txt:358-367](CMakeLists.txt#L358-L367)). The repo itself is named `dusk-audio-plugins` on GitHub, so without the explicit target you'd get a directory CMake can't find — and it warns rather than failing, leaving you with a recorder that has no EQ, compressor, or tape.
+The explicit `plugins` target on the third clone is mandatory: CMake auto-discovery looks for a sibling directory named `plugins\` and nothing else ([CMakeLists.txt:383-393](CMakeLists.txt#L383-L393)). The repo itself is named `dusk-audio-plugins` on GitHub, so without the explicit target you'd get a directory CMake can't find — and it warns rather than failing, leaving you with a recorder that has no EQ, compressor, or tape.
 
 The Dusk Studio repo's own directory name (`dusk-studio\`) doesn't matter to the build, so rename it if you prefer.
 
@@ -152,9 +152,9 @@ Useful for confirming the audio engine wires up correctly without needing to dri
 
 ## Known caveats on Windows
 
-- **PlatformWindowing_Windows.cpp is a stub.** Most things work; the file exists as the place to land Windows-specific window-management fixes if/when XEmbed-equivalent bugs surface. CMake picks the per-platform implementation at [CMakeLists.txt:640-646](CMakeLists.txt#L640-L646).
+- **PlatformWindowing_Windows.cpp is a stub.** Most things work; the file exists as the place to land Windows-specific window-management fixes if/when XEmbed-equivalent bugs surface. CMake picks the per-platform implementation at [CMakeLists.txt:641-647](CMakeLists.txt#L641-L647).
 - **No ASIO without the SDK.** WASAPI is the default; ASIO requires the SDK download above. Most users will be fine on WASAPI.
-- **The ALSA backend is not compiled.** [CMakeLists.txt:753](CMakeLists.txt#L753) gates Dusk Studio's custom ALSA `AudioIODeviceType` behind `UNIX AND NOT APPLE`. Windows falls through to JUCE's stock WASAPI/ASIO types.
+- **The ALSA backend is not compiled.** [CMakeLists.txt:754](CMakeLists.txt#L754) gates Dusk Studio's custom ALSA `AudioIODeviceType` behind `UNIX AND NOT APPLE`. Windows falls through to JUCE's stock WASAPI/ASIO types.
 - **Compiler warnings.** Project is primarily developed on Clang/GCC. MSVC may emit warnings; none are fatal. `/WX` (warnings-as-errors) is not enabled.
 - **MinGW/MSYS2 not tested.** Stick to MSVC via Visual Studio 2022.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -603,7 +603,8 @@ else()
         message(FATAL_ERROR
             "libsndfile development files are required (all audio file I/O goes "
             "through it). Linux: libsndfile1-dev. macOS: brew install libsndfile. "
-            "Windows: vcpkg install libsndfile:x64-windows-static.")
+            "Windows: vcpkg install --triplet x64-windows-static from the repo "
+            "root (vcpkg.json declares it).")
     endif()
     target_include_directories(dusk_sndfile SYSTEM INTERFACE "${SNDFILE_INCLUDE_DIR}")
     target_link_libraries(dusk_sndfile INTERFACE "${SNDFILE_LIBRARY}")

--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -365,31 +365,44 @@ libsndfile (all audio file I/O — required on every platform)
              library — libsndfile.so.1 on Linux, libsndfile.1.dylib on macOS —
              which is LGPL-2.1 section 6(b), the shared-library mechanism, and
              needs nothing further.
-             Windows takes a different route. The workflows run
-             `vcpkg install mp3lame:x64-windows-static
-             libsndfile:x64-windows-static`, which produces static libraries
-             and pulls libsndfile's codec chain — FLAC, Ogg, Opus, mpg123 —
-             into the executable alongside it, so no DLL ships and 6(b) is not
-             available. That leaves section 6(a), the relink route, and the
-             honest position is that Dusk Studio meets most of it but not all:
-             the application is GPL-3.0-or-later with its complete
-             corresponding source published, and that source carries the exact
-             vcpkg command above, so the build is reproducible in shape. What
-             is missing is a version pin. vcpkg runs there in classic mode with
-             no manifest, so the libsndfile and mpg123 versions baked into any
-             given Windows artifact are whatever that runner's vcpkg baseline
-             supplied on the day, recorded only in the workflow log rather than
-             in this repository. Anyone wanting to relink can obtain those
-             sources from vcpkg upstream, but pinning them here — a vcpkg
-             manifest, or shipping relink materials alongside the artifact —
-             is outstanding work, not something this file should claim is
-             already done.
-             libsndfile is LGPL-2.1-or-later and mpg123 LGPL-2.1-only. FLAC and
-             Ogg are BSD-3-Clause (texts at the foot of this file, from JUCE's
-             vendored copies of the same projects); Opus is BSD-3-Clause
-             (Xiph.Org, Skype, Octasic, Jean-Marc Valin, Timothy B. Terriberry,
-             CSIRO, Gregory Maxwell, Mark Borgerding, Erik de Castro Lopo,
-             Mozilla, Amazon).
+             Windows takes a different route. The workflows run vcpkg in
+             manifest mode from the root of this repository
+             (`vcpkg install --triplet x64-windows-static`), which produces
+             static libraries and pulls libsndfile's codec chain (FLAC, Ogg,
+             Vorbis, Opus, mpg123) into the executable alongside it, so no DLL
+             ships and 6(b) is not available. That leaves section 6(a), the
+             relink route. The identification half of it is met: the
+             application is GPL-3.0-or-later with its complete corresponding
+             source published, and that source now pins the dependencies
+             rather than merely describing them. vcpkg.json at the repository
+             root declares the packages and features, and its
+             builtin-baseline field names a microsoft/vcpkg commit, which is
+             the version pin: for a given Dusk Studio revision, that manifest
+             plus that baseline resolve every port in the chain, direct and
+             transitive, to one recorded version. A Windows artifact is
+             therefore traceable to the commit that built it, and from that
+             commit's baseline to the exact libsndfile, mpg123, FLAC, Ogg,
+             Vorbis and Opus sources. vcpkg hosts none of that source itself:
+             the baseline records each port's upstream source URL and its
+             SHA512, so the versions are identified exactly and verifiably,
+             while retrieval depends on those upstream hosts.
+             What is outstanding is delivery, not identification. Releases
+             carry no object files, no static libraries and no scripted
+             relink recipe next to the MSI, so exercising 6(a) means
+             rebuilding from the pinned sources rather than relinking against
+             supplied objects. Whether to ship those materials, or to move
+             the Windows build to DLLs and section 6(b) instead, is an open
+             maintainer decision; this file does not claim 6(a) is fully
+             discharged today.
+             libsndfile is LGPL-2.1-or-later and mpg123 LGPL-2.1-only. FLAC,
+             Ogg and Vorbis are BSD-3-Clause (texts at the foot of this file,
+             taken from JUCE's vendored copies of the same projects for the
+             terms, not the versions: the Windows static link builds these
+             from the vcpkg ports at the pinned baseline, libflac 1.5.0
+             there rather than the 1.4.3 JUCE vendors, under the same
+             BSD-3-Clause). Opus is BSD-3-Clause (Xiph.Org, Skype, Octasic,
+             Jean-Marc Valin, Timothy B. Terriberry, CSIRO, Gregory Maxwell,
+             Mark Borgerding, Erik de Castro Lopo, Mozilla, Amazon).
   Upstream : https://github.com/libsndfile/libsndfile ,
              https://www.mpg123.de/ , https://opus-codec.org/
 
@@ -407,19 +420,23 @@ lilv / suil / lv2 (native LV2 host — Linux builds only)
   Upstream : https://gitlab.com/lv2 (lilv, suil), https://lv2plug.in (lv2)
 
 LAME / libmp3lame (MP3 bounce export — optional)
-  License  : LGPL-2.1-or-later
+  License  : LGPL-2.0-or-later
   Path     : not vendored — system shared library found at configure time via
              find_library(mp3lame); linked only when present
              (DUSKSTUDIO_HAS_LAME). Builds without it fall back to WAV-only.
   Notes    : On Linux and macOS, linked against the system SHARED library —
              find_library resolves the distro / Homebrew shared object at
              configure time (verified: release Linux build links
-             /usr/lib64/libmp3lame.so), so LGPL-2.1 section 6(b) applies.
-             Windows is the exception: the same vcpkg x64-windows-static
-             command described under libsndfile installs mp3lame statically,
-             so a Windows build links it into the executable and falls under
-             the same section 6(a) route, with the same unpinned-version gap
-             noted there.
+             /usr/lib64/libmp3lame.so), so LGPL-2.1 section 6(b) applies:
+             the shared-library mechanism is a 2.1 addition, relied on here
+             under LAME's or-later grant.
+             Windows is the exception: mp3lame is one of the two packages in
+             the root vcpkg.json, installed statically by the same
+             x64-windows-static manifest run described under libsndfile, so a
+             Windows build links it into the executable and falls under the
+             same section 6(a) route. Its version is pinned by the same
+             manifest baseline, and the same delivery gap (no relink
+             materials shipped with the MSI) applies.
              Present in a binary only if the build was configured with
              libmp3lame available.
   Upstream : https://lame.sourceforge.io/

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "builtin-baseline": "39344dff01c5a5a0134caf2624cdd492f05d30ea",
+  "dependencies": [
+    {
+      "name": "libsndfile",
+      "features": [
+        "external-libs",
+        "mpeg"
+      ]
+    },
+    "mp3lame"
+  ]
+}


### PR DESCRIPTION
Closes #225.

Adds vcpkg.json declaring libsndfile (external-libs, mpeg) and mp3lame with a builtin-baseline, so the exact codec versions inside a given MSI - direct and transitive - are recorded in the repository instead of a workflow log. Both Windows workflows switch to manifest mode with the install prefix under the workspace; the x64-windows-static triplet is unchanged.

The baseline choice is the load-bearing part: it is the windows-2022 image's own vcpkg commit (39344dff01, 2026-08-01), NOT current vcpkg master. Two verified reasons, recorded in the workflow comments: vcpkg resolves builtin baselines against the runner's local clone with no fetch fallback, so a baseline newer than the image's vcpkg fails the install outright; and the image commit pins exactly what previous MSIs shipped (libsndfile 1.2.2#2, mp3lame 3.100#17, mpg123 1.33.4, opus 1.5.2#1) - a review of an earlier draft that pinned next-day master proved it would both fail on the runner and silently bump opus to 1.6.1 and mpg123 to 1.33.7. When bumping the baseline later: never newer than the image's vcpkg, and codec version moves get a changelog note.

LICENSES.txt's Windows LGPL note now claims exactly what the pin delivers: the identification half of the section 6(a) relink route is met (the baseline records each port's upstream source URL and SHA512), while delivery - shipping relink materials or moving to DLLs - remains an open maintainer decision. LAME's entry is corrected to LGPL-2.0-or-later, with the 2.1 shared-library mechanism relied on via the or-later election (LGPL 2.0's section 6 has no shared-library option). The note also clarifies the Windows static link builds libflac 1.5.0 from the pinned ports, not JUCE's vendored 1.4.3, under the same BSD-3-Clause terms.

What CI on this PR must confirm (windows-tests is the live check; windows-build only fires on tag): vcpkg install succeeds in manifest mode on the image, find_package(SndFile CONFIG) resolves from the new vcpkg_installed prefix, DUSKSTUDIO_HAS_LAME stays on, and the /MT static link is clean. Expect the vcpkg step to take longer than before - ports build from the pinned baseline and there is no binary-cache step; adding one is possible follow-up, not done here.

Local developers: BUILDING-WINDOWS.md documents that a vcpkg clone must contain the baseline commit (clones updated on or after 2026-08-01 have it; git pull first otherwise) and that classic per-package installs error out while vcpkg.json is present.