### PR TITLE
chore(release): publish one canonical body and verify the asset set

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -271,7 +271,6 @@ jobs:
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
           ARCH="${{ matrix.arch }}"
-          NOTES="Unsigned Linux tarball: extract, then run ./DuskStudio/DuskStudio (or ./install.sh for a menu entry, dock/taskbar icon, PATH launcher, and session-file association - on Wayland the dock icon only appears after install.sh). The aarch64 build targets 64-bit Raspberry Pi OS (Pi 3/4/5)."
 
           shopt -s nullglob
           # Validate the TARBALL glob alone - a combined array would always carry
@@ -291,11 +290,15 @@ jobs:
           # existence - only a still-absent release is fatal, and we surface the
           # actual create error before exiting. Asset names carry the arch, so
           # the two jobs never overwrite each other's tarballs on upload.
+          #
+          # Body comes from the tagged tree, not from this workflow: all four
+          # release jobs pass the same file, so the create-race winner cannot
+          # decide what the notes say.
           if ! gh release view "$TAG" --repo "$RELEASES_REPO" >/dev/null 2>&1; then
             if ! create_err=$(gh release create "$TAG" \
               --repo "$RELEASES_REPO" \
               --title "Dusk Studio $TAG" \
-              --notes "$NOTES" 2>&1); then
+              --notes-file packaging/RELEASE-NOTES.md 2>&1); then
               if gh release view "$TAG" --repo "$RELEASES_REPO" >/dev/null 2>&1; then
                 echo "release create raced with the sibling arch job; the release now exists, uploading."
               else

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -208,7 +208,6 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
-          NOTES="Unsigned macOS build. Right-click the app -> Open to bypass Gatekeeper on first launch."
 
           shopt -s nullglob
           ASSETS=( *.dmg SHA256SUMS.macos )
@@ -217,11 +216,14 @@ jobs:
             exit 1
           fi
 
+          # Body comes from the tagged tree, not from this workflow: all four
+          # release jobs pass the same file, so the create-race winner cannot
+          # decide what the notes say.
           if ! gh release view "$TAG" --repo "$RELEASES_REPO" >/dev/null 2>&1; then
             if ! create_err=$(gh release create "$TAG" \
               --repo "$RELEASES_REPO" \
               --title "Dusk Studio $TAG" \
-              --notes "$NOTES" 2>&1); then
+              --notes-file packaging/RELEASE-NOTES.md 2>&1); then
               if gh release view "$TAG" --repo "$RELEASES_REPO" >/dev/null 2>&1; then
                 echo "release create raced with another release job; the release now exists, uploading."
               else

--- a/.github/workflows/manual-pdf.yml
+++ b/.github/workflows/manual-pdf.yml
@@ -92,15 +92,17 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
-          NOTES="Dusk Studio user manual (PDF)."
 
           ASSETS=( MANUAL.pdf SHA256SUMS.manual )
 
+          # Body comes from the tagged tree, not from this workflow: all four
+          # release jobs pass the same file, so the create-race winner cannot
+          # decide what the notes say.
           if ! gh release view "$TAG" --repo "$RELEASES_REPO" >/dev/null 2>&1; then
             if ! create_err=$(gh release create "$TAG" \
               --repo "$RELEASES_REPO" \
               --title "Dusk Studio $TAG" \
-              --notes "$NOTES" 2>&1); then
+              --notes-file packaging/RELEASE-NOTES.md 2>&1); then
               if gh release view "$TAG" --repo "$RELEASES_REPO" >/dev/null 2>&1; then
                 echo "release create raced with another release job; the release now exists, uploading."
               else

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -12,8 +12,8 @@ name: Windows build
 #   - push of a v* tag  → publishes the MSI onto the SAME private release
 #                          the mac DMG lands on (shared tag, distinct asset
 #                          names), so one tag yields a cross-platform set.
-#   - workflow_dispatch  → publishes a build-numbered pre-release for
-#                          hand-offs to testers.
+#   - workflow_dispatch  → builds and packages the MSI for validation only;
+#                          nothing is published.
 #
 # The MSI is UNSIGNED by design (no Authenticode cert) — users see a
 # SmartScreen prompt and choose "More info -> Run anyway" on first launch.
@@ -270,9 +270,9 @@ jobs:
           }
 
       - name: Publish MSI to the PRIVATE releases repo
-        # Only publish on a real release tag. Manual/branch dispatches are
-        # for build validation — publishing a build.N pre-release on each
-        # would pollute the private releases repo (and use the stale VERSION).
+        # Only publish on a real release tag. Manual/branch dispatches are for
+        # build validation - publishing on each would pollute the private
+        # releases repo (and use the stale VERSION).
         if: ${{ github.ref_type == 'tag' }}
         shell: bash
         # MSI + SHA256SUMS.windows live at the repo root after
@@ -288,15 +288,7 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASES_REPO_TOKEN }}
         run: |
           set -euo pipefail
-          # Tag: the pushed v* tag, else a VERSION-derived build tag for a
-          # manual dispatch (run number keeps dispatch builds unique).
-          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            TAG="${GITHUB_REF_NAME}"
-            NOTES="Automated Windows build."
-          else
-            TAG="v$(tr -d '[:space:]' < VERSION)+build.${GITHUB_RUN_NUMBER}"
-            NOTES="Unsigned Windows build. SmartScreen may warn — choose More info -> Run anyway. Statically linked, no vc_redist needed."
-          fi
+          TAG="${GITHUB_REF_NAME}"
 
           shopt -s nullglob
           ASSETS=( *.msi SHA256SUMS.windows )
@@ -305,11 +297,14 @@ jobs:
             exit 1
           fi
 
+          # Body comes from the tagged tree, not from this workflow: all four
+          # release jobs pass the same file, so the create-race winner cannot
+          # decide what the notes say.
           if ! gh release view "$TAG" --repo "$RELEASES_REPO" >/dev/null 2>&1; then
             if ! create_err=$(gh release create "$TAG" \
               --repo "$RELEASES_REPO" \
               --title "Dusk Studio $TAG" \
-              --notes "$NOTES" 2>&1); then
+              --notes-file packaging/RELEASE-NOTES.md 2>&1); then
               if gh release view "$TAG" --repo "$RELEASES_REPO" >/dev/null 2>&1; then
                 echo "release create raced with another release job; the release now exists, uploading."
               else

--- a/packaging/RELEASE-NOTES.md
+++ b/packaging/RELEASE-NOTES.md
@@ -1,0 +1,17 @@
+<!-- summary-start -->
+<!-- summary-end -->
+
+### Downloads
+
+- **Linux** (`.tar.xz`, x86_64 and aarch64): unsigned. Extract, then run
+  `./DuskStudio/DuskStudio`, or `./install.sh` for a menu entry, dock/taskbar
+  icon, PATH launcher and session-file association. On Wayland the dock icon
+  only appears after `install.sh`. The aarch64 build targets 64-bit Raspberry Pi
+  OS (Pi 3/4/5).
+- **macOS** (`.dmg`, Apple Silicon / arm64 only): unsigned. Right-click the app
+  -> Open to bypass Gatekeeper on first launch.
+- **Windows** (`.msi`, x64): unsigned. SmartScreen may warn - choose More info
+  -> Run anyway. Statically linked, no vc_redist needed.
+- **Manual** (`MANUAL.pdf`): the Dusk Studio user manual for this release.
+
+Check a download against the matching `SHA256SUMS.*` asset before installing.

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # Bump the project version. Updates:
-#   • VERSION  - top-level file CMake reads via file(READ)
-#   • packaging/DuskStudio.appdata.xml - prepends a new <release> entry
-#                                          dated today
+#   - VERSION  - top-level file CMake reads via file(READ)
+#   - packaging/DuskStudio.appdata.xml - prepends a new <release> entry
+#     dated today
+#   - packaging/RELEASE-NOTES.md - rewrites the summary slot of the canonical
+#     release body every tag workflow publishes
 # Then prints what to do next (git commit + tag).
 #
 # Usage:   scripts/bump-version.sh 1.0.0
@@ -93,14 +95,81 @@ fi
 
 TODAY="$(date -u +%Y-%m-%d)"
 
-# Prepend a <release> block to the <releases> list in the AppStream
-# metadata. Insertion point: the line immediately AFTER the opening
-# <releases> tag, pinned by the anchor comment below. Match the whole
-# comment, not the bare phrase - release notes that quote the phrase would
-# otherwise become anchors too and nest the next entry inside an old
-# <description>.
+# Both splices are staged to temp files and validated before either lands,
+# then everything is moved into place together: an abort in either stage
+# leaves the whole tree untouched, and nothing non-idempotent (the appdata
+# prepend) can land ahead of a later failure.
+NOTES_FILE="packaging/RELEASE-NOTES.md"
+NOTES_START='<!-- summary-start -->'
+NOTES_END='<!-- summary-end -->'
 APPDATA="packaging/DuskStudio.appdata.xml"
 ANCHOR='<!-- scripts/bump-version.sh prepends new <release> entries here. -->'
+NOTES_READY=0
+APPDATA_READY=0
+trap 'rm -f ${SUMMARY_FILE:+"$SUMMARY_FILE"} ${RELEASE_FILE:+"$RELEASE_FILE"} "$NOTES_FILE.tmp" "$APPDATA.tmp"' EXIT
+
+# Stage the summary slot of the canonical release body. Every tag-triggered
+# workflow publishes this file verbatim, so the summary is script-managed:
+# nothing hand-written there can lag behind the tag.
+if [[ -f "$NOTES_FILE" ]]; then
+    # The splice replaces whole lines, so each marker has to sit alone on its
+    # own line, exactly once, start before end. Anything else - including both
+    # markers sharing a line - would swallow the rest of the file.
+    SLOT_LAYOUT=$(awk -v start="$NOTES_START" -v end="$NOTES_END" '
+        { trimmed = $0; sub(/^[ \t]+/, "", trimmed); sub(/[ \t]+$/, "", trimmed) }
+        trimmed == start { starts++; if (startAt == 0) startAt = NR }
+        trimmed == end   { ends++;   if (endAt == 0)   endAt = NR }
+        END { print (starts == 1 && ends == 1 && startAt < endAt) ? "ok" : "bad" }
+    ' "$NOTES_FILE")
+
+    if [[ "$SLOT_LAYOUT" == "ok" ]]; then
+        # awk reads the summary from a file: BSD awk rejects literal newlines
+        # in a -v assignment.
+        SUMMARY_FILE=$(mktemp -t duskstudio-summary.XXXXXX)
+        printf '%s\n' "$NOTES" > "$SUMMARY_FILE"
+
+        awk -v summary_file="$SUMMARY_FILE" -v start="$NOTES_START" -v end="$NOTES_END" '
+            { trimmed = $0; sub(/^[ \t]+/, "", trimmed); sub(/[ \t]+$/, "", trimmed) }
+            trimmed == start {
+                print
+                while ((getline line < summary_file) > 0) print line
+                close (summary_file)
+                inside = 1
+                next
+            }
+            trimmed == end { inside = 0 }
+            !inside { print }
+        ' "$NOTES_FILE" > "$NOTES_FILE.tmp" \
+            || { echo "error: awk failed to update $NOTES_FILE" >&2; exit 1; }
+
+        # Validate before the file lands: the slot must now hold exactly the
+        # release notes and nothing else.
+        SPLICED=$(awk -v start="$NOTES_START" -v end="$NOTES_END" '
+            { trimmed = $0; sub(/^[ \t]+/, "", trimmed); sub(/[ \t]+$/, "", trimmed) }
+            trimmed == start { inside = 1; next }
+            trimmed == end   { inside = 0; next }
+            inside { print }
+        ' "$NOTES_FILE.tmp")
+        if [[ "$SPLICED" != "$NOTES" ]]; then
+            echo "error: the summary slot in $NOTES_FILE did not take the release" >&2
+            echo "       notes; $NOTES_FILE left unchanged." >&2
+            exit 1
+        fi
+        NOTES_READY=1
+    else
+        echo "warning: $NOTES_FILE has no usable summary slot (needs one" >&2
+        echo "         $NOTES_START line before one $NOTES_END line);" >&2
+        echo "         skipping the summary splice" >&2
+    fi
+else
+    echo "warning: $NOTES_FILE not found; skipping the summary splice" >&2
+fi
+
+# Stage the AppStream <release> entry. Insertion point: the line immediately
+# AFTER the opening <releases> tag, pinned by the anchor comment. Match the
+# whole comment, not the bare phrase - release notes that quote the phrase
+# would otherwise become anchors too and nest the next entry inside an old
+# <description>.
 if [[ -f "$APPDATA" ]]; then
     if grep -qF "$ANCHOR" "$APPDATA"; then
         # Compose the new <release> block in a temp file (real newlines)
@@ -109,7 +178,6 @@ if [[ -f "$APPDATA" ]]; then
         # the multi-line block has to come from a file via getline,
         # not from a string variable.
         RELEASE_FILE=$(mktemp -t duskstudio-release.XXXXXX)
-        trap 'rm -f "$RELEASE_FILE" "$APPDATA.tmp"' EXIT
         XML_NOTES=$(printf '%s' "$NOTES" \
             | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g')
         printf '    <release version="%s" date="%s">\n      <description>\n        <p>%s</p>\n      </description>\n    </release>\n' \
@@ -139,37 +207,44 @@ if [[ -f "$APPDATA" ]]; then
             echo "warning: xmllint not found - skipping XML validation of $APPDATA" >&2
         fi
 
-        mv "$APPDATA.tmp" "$APPDATA"
-        rm -f "$RELEASE_FILE"
-        trap - EXIT
-
-        # Sanity check: the new version string MUST be present in the
-        # file after the insert. Cheap, catches the case where awk
-        # exited 0 but the anchor comment was missing/different.
-        if ! grep -q "version=\"$NEW_VERSION\"" "$APPDATA"; then
+        # Sanity check on the staged file: the new version string MUST be
+        # present after the insert. Cheap, catches the case where awk exited
+        # 0 but the anchor comment was missing/different.
+        if ! grep -q "version=\"$NEW_VERSION\"" "$APPDATA.tmp"; then
             echo "error: $APPDATA was not updated with version $NEW_VERSION " \
                  "(the anchor comment may have moved)." >&2
             exit 1
         fi
+        APPDATA_READY=1
     else
         echo "warning: $APPDATA missing the anchor comment; skipping <release> insert" >&2
     fi
 fi
 
-# Written last so an aborted appdata update leaves the tree untouched.
+# Everything above validated its staged copy; land the results together and
+# write VERSION last, so any abort leaves the tree untouched.
+if [[ "$NOTES_READY" == 1 ]]; then
+    mv "$NOTES_FILE.tmp" "$NOTES_FILE"
+fi
+if [[ "$APPDATA_READY" == 1 ]]; then
+    mv "$APPDATA.tmp" "$APPDATA"
+fi
+trap - EXIT
+rm -f ${SUMMARY_FILE:+"$SUMMARY_FILE"} ${RELEASE_FILE:+"$RELEASE_FILE"}
 echo "$NEW_VERSION" > VERSION
 
 echo
 echo "Bumped VERSION  -> $NEW_VERSION"
 echo "Today's date     -> $TODAY"
 echo "Updated files:"
-git status --short VERSION "$APPDATA" 2>/dev/null || true
+git status --short VERSION "$APPDATA" "$NOTES_FILE" 2>/dev/null || true
 echo
 echo "Next steps:"
 echo "  1) Date the changelog: CHANGELOG.md \"## [$NEW_VERSION] - Unreleased\" -> \"- $TODAY\""
 echo "  2) Refresh patrons:   scripts/update-patrons.py   (commit in the plugins repo)"
-echo "  3) Review the diff:   git diff VERSION $APPDATA CHANGELOG.md"
+echo "  3) Review the diff:   git diff VERSION $APPDATA $NOTES_FILE CHANGELOG.md"
 echo "  4) Rebuild + smoke:   cmake --build build -j && DUSKSTUDIO_RUN_SELFTEST=1 build/.../DuskStudio"
 echo "  5) Commit:            git commit -am \"Release v$NEW_VERSION\""
 echo "  6) Tag:               git tag -a v$NEW_VERSION -m \"Dusk Studio $NEW_VERSION\""
 echo "  7) Package:           scripts/package-{tarball,macos}.sh, scripts/package-windows.ps1"
+echo "  8) Verify assets:     scripts/verify-release-assets.sh"

--- a/scripts/verify-release-assets.sh
+++ b/scripts/verify-release-assets.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Verify a release in the PRIVATE releases repo carries its complete asset set
+# before it is announced. Read-only: reads one release, changes nothing.
+#
+#   scripts/verify-release-assets.sh            # tag v$(cat VERSION)
+#   scripts/verify-release-assets.sh v0.13.0
+#
+# Four workflows publish to the same tag (linux-release once per arch,
+# macos-release, windows-build, manual-pdf). A platform that fails leaves a
+# release that looks finished but is short its assets, so the set is the check:
+# ten assets, no more, no fewer, plus a non-empty body. Exits nonzero if
+# anything is missing, duplicated or unexpected.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+REPO="${RELEASES_REPO:-dusk-audio/dusk-studio-releases}"
+
+TAG="${1:-}"
+if [[ -z "$TAG" ]]; then
+    if [[ ! -f "$ROOT/VERSION" ]]; then
+        echo "error: no tag argument and no VERSION file at $ROOT/VERSION" >&2
+        exit 2
+    fi
+    TAG="v$(tr -d '[:space:]' < "$ROOT/VERSION")"
+fi
+VER="${TAG#v}"
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "error: gh is not installed" >&2
+    exit 2
+fi
+
+# label|glob. The glob is matched against the asset name. Versioned names carry
+# the tag's version, so an asset built from a stale VERSION reads as MISSING
+# instead of passing; the SHA256SUMS.* names carry no version.
+EXPECTED=(
+    "Linux tarball x86_64|dusk-studio-${VER}-Linux-x86_64.tar.xz"
+    "Linux sums x86_64|SHA256SUMS.linux-x86_64"
+    "Linux tarball aarch64|dusk-studio-${VER}-Linux-aarch64.tar.xz"
+    "Linux sums aarch64|SHA256SUMS.linux-aarch64"
+    "macOS DMG|dusk-studio-${VER}-macOS-*.dmg"
+    "macOS sums|SHA256SUMS.macos"
+    "Windows MSI|dusk-studio-${VER}-Windows-*.msi"
+    "Windows sums|SHA256SUMS.windows"
+    "User manual|MANUAL.pdf"
+    "Manual sums|SHA256SUMS.manual"
+)
+
+# One API call, one record per line as "kind<TAB>value": the body is multi-line
+# and would otherwise be indistinguishable from the asset names.
+if ! RECORDS=$(gh release view "$TAG" --repo "$REPO" --json assets,body \
+        --jq '"body\t\(.body | utf8bytelength)", (.assets[] | "asset\t\(.name)")' 2>&1); then
+    echo "error: cannot read release ${TAG} from ${REPO}:" >&2
+    echo "$RECORDS" >&2
+    exit 2
+fi
+
+NAMES=()
+BODY_BYTES=0
+while IFS=$'\t' read -r kind value; do
+    case "$kind" in
+        asset) NAMES+=("$value") ;;
+        body)  BODY_BYTES="$value" ;;
+    esac
+done <<< "$RECORDS"
+
+MATCHED=()
+for ((i = 0; i < ${#NAMES[@]}; i++)); do
+    MATCHED[i]=0
+done
+
+status=0
+printf '%-8s %-24s %s\n' "STATUS" "EXPECTED" "ASSET"
+printf '%-8s %-24s %s\n' "------" "--------" "-----"
+
+for entry in "${EXPECTED[@]}"; do
+    label="${entry%%|*}"
+    pattern="${entry#*|}"
+    hits=()
+    for ((i = 0; i < ${#NAMES[@]}; i++)); do
+        # shellcheck disable=SC2053  # unquoted RHS: glob match is the point
+        if [[ "${NAMES[i]}" == $pattern ]]; then
+            hits+=("${NAMES[i]}")
+            MATCHED[i]=1
+        fi
+    done
+    case ${#hits[@]} in
+        0)
+            printf '%-8s %-24s %s\n' "MISSING" "$label" "nothing matches ${pattern}"
+            status=1
+            ;;
+        1)
+            printf '%-8s %-24s %s\n' "ok" "$label" "${hits[0]}"
+            ;;
+        *)
+            printf '%-8s %-24s %s\n' "DUP" "$label" "${#hits[@]} match ${pattern}: ${hits[*]}"
+            status=1
+            ;;
+    esac
+done
+
+for ((i = 0; i < ${#NAMES[@]}; i++)); do
+    if [[ ${MATCHED[i]} -eq 0 ]]; then
+        printf '%-8s %-24s %s\n' "EXTRA" "(unexpected)" "${NAMES[i]}"
+        status=1
+    fi
+done
+
+if [[ "$BODY_BYTES" -gt 0 ]]; then
+    printf '%-8s %-24s %s\n' "ok" "release body" "${BODY_BYTES} bytes"
+else
+    printf '%-8s %-24s %s\n' "EMPTY" "release body" "no notes - the create step lost packaging/RELEASE-NOTES.md"
+    status=1
+fi
+
+echo
+echo "release ${TAG} in ${REPO}: ${#NAMES[@]} asset(s), expected ${#EXPECTED[@]}"
+if [[ $status -ne 0 ]]; then
+    echo "FAIL: incomplete release, do not announce it." >&2
+else
+    echo "PASS: all ${#EXPECTED[@]} assets present."
+fi
+exit $status

--- a/tests/release_mechanics.sh
+++ b/tests/release_mechanics.sh
@@ -31,6 +31,15 @@ printf '%s\n' \
     '  </releases>' \
     '</component>' \
     > "$FIXTURE/packaging/DuskStudio.appdata.xml"
+printf '%s\n' \
+    '<!-- summary-start -->' \
+    'stale summary that must not survive the bump' \
+    '<!-- summary-end -->' \
+    '' \
+    '### Downloads' \
+    '' \
+    '- **Linux** (`.tar.xz`): unsigned.' \
+    > "$FIXTURE/packaging/RELEASE-NOTES.md"
 
 NOTES='Gain & grit <hot> > cool ]]> "quoted" café — release'
 (
@@ -57,6 +66,11 @@ if command -v xmllint >/dev/null 2>&1; then
         '  </releases>' \
         '</component>' \
         > "$FIXTURE_BAD/packaging/DuskStudio.appdata.xml"
+    printf '%s\n' \
+        '<!-- summary-start -->' \
+        'stale summary that must not survive the bump' \
+        '<!-- summary-end -->' \
+        > "$FIXTURE_BAD/packaging/RELEASE-NOTES.md"
     BAD_NOTES=$(printf 'bad\013note')
     if (cd "$FIXTURE_BAD" && bash scripts/bump-version.sh 9.9.9 "$BAD_NOTES" >/dev/null 2>&1); then
         echo "FAIL: control-character note must abort the bump" >&2
@@ -70,6 +84,10 @@ if command -v xmllint >/dev/null 2>&1; then
         echo "FAIL: aborted bump must leave the appdata untouched" >&2
         exit 1
     fi
+    if ! grep -q 'stale summary' "$FIXTURE_BAD/packaging/RELEASE-NOTES.md"; then
+        echo "FAIL: aborted bump must leave the release notes untouched" >&2
+        exit 1
+    fi
 fi
 
 if [[ "$(cat "$FIXTURE/VERSION")" != "9.9.9" ]]; then
@@ -77,7 +95,8 @@ if [[ "$(cat "$FIXTURE/VERSION")" != "9.9.9" ]]; then
     exit 1
 fi
 
-"$PYTHON" - "$FIXTURE/packaging/DuskStudio.appdata.xml" "$NOTES" "$SOURCE_ROOT" <<'PY'
+"$PYTHON" - "$FIXTURE/packaging/DuskStudio.appdata.xml" "$NOTES" "$SOURCE_ROOT" \
+    "$FIXTURE/packaging/RELEASE-NOTES.md" <<'PY'
 from pathlib import Path
 import re
 import sys
@@ -89,6 +108,18 @@ if not __debug__:
 appdata_path = Path(sys.argv[1])
 expected_notes = sys.argv[2]
 source_root = Path(sys.argv[3])
+bumped_notes_path = Path(sys.argv[4])
+
+SUMMARY_START = "<!-- summary-start -->"
+SUMMARY_END = "<!-- summary-end -->"
+
+
+def summary_slot(text):
+    before, start, rest = text.partition(SUMMARY_START)
+    assert start, "release notes must carry the summary start marker"
+    slot, end, after = rest.partition(SUMMARY_END)
+    assert end, "release notes must carry the summary end marker"
+    return before, slot.strip("\n"), after
 
 root = ET.parse(appdata_path).getroot()
 releases = root.findall("./releases/release")
@@ -109,15 +140,46 @@ workflows = (
 create_marker = 'if ! create_err=$(gh release create "$TAG"'
 recheck_marker = 'if gh release view "$TAG" --repo "$RELEASES_REPO" >/dev/null 2>&1; then'
 upload_line = 'gh release upload "$TAG" --repo "$RELEASES_REPO" --clobber "${ASSETS[@]}"'
+notes_marker = "--notes-file packaging/RELEASE-NOTES.md"
+
+# All four workflows race to create the same release, so the body must come
+# from one file in the tagged tree rather than from whichever job wins.
+notes_path = source_root / "packaging" / "RELEASE-NOTES.md"
+assert notes_path.is_file(), "packaging/RELEASE-NOTES.md must exist"
+notes_text = notes_path.read_text(encoding="utf-8")
+summary_slot(notes_text)  # markers present, else the bump silently skips it
+visible_notes = re.sub(r"<!--.*?-->", "", notes_text, flags=re.S).strip()
+assert visible_notes, "release notes must carry a body, not just comments"
+
+# The summary is script-managed: the bump replaces the whole slot with the
+# release notes verbatim and touches nothing outside it.
+bumped_text = bumped_notes_path.read_text(encoding="utf-8")
+before, slot, after = summary_slot(bumped_text)
+assert slot == expected_notes, (slot, expected_notes)
+assert before == "", "nothing may precede the summary slot"
+assert "stale summary" not in bumped_text, "the old summary must be gone"
+assert "### Downloads" in after, "the Downloads section must survive the bump"
 
 for name in workflows:
     text = (source_root / ".github" / "workflows" / name).read_text(encoding="utf-8")
     assert text.count(create_marker) == 1, f"{name}: missing race-checked create"
     create_at = text.index(create_marker)
     create_end = text.index("2>&1); then", create_at)
-    assert '"${ASSETS[@]}"' not in text[create_at:create_end], (
+    create_block = text[create_at:create_end]
+    assert '"${ASSETS[@]}"' not in create_block, (
         f"{name}: create must not own asset upload"
     )
+    assert notes_marker in create_block, (
+        f"{name}: create must publish the canonical release notes file"
+    )
+    # Only the gh release commands are banned from carrying an inline body;
+    # prose and other steps may say "--notes". Backslash continuations are
+    # folded first so a multi-line invocation counts as one line.
+    folded = re.sub(r"\\\n\s*", " ", text)
+    for line in folded.splitlines():
+        assert not ("gh release" in line and '--notes "' in line), (
+            f"{name}: release body must not be composed per workflow"
+        )
     recheck_at = text.index(recheck_marker, create_end)
     upload_matches = list(re.finditer(
         rf"^\s+{re.escape(upload_line)}$", text, re.MULTILINE


### PR DESCRIPTION
All four tag workflows raced to create the private release, and whichever won determined the body - three of the four platforms' install notes were lost every time, and the Windows tag path shipped a useless one-liner while its informative SmartScreen text sat in an unreachable dispatch branch.

gh release create now reads packaging/RELEASE-NOTES.md in every workflow, so the body is byte-identical no matter which workflow wins the create race. The file is a script-managed summary slot plus a static Downloads section carrying every platform's install steps, signing status and architecture (the DMG is Apple Silicon only, the MSI x64 - previously unstated). scripts/bump-version.sh splices its release-notes argument into the slot, so one bump argument now feeds the appdata entry and the release body and nothing hand-written can go stale; the script was restructured so both splices stage to temp files and validate before either lands - an abort anywhere leaves the tree untouched, and the non-idempotent appdata prepend can never land ahead of a later failure (a re-run after a half-bump used to duplicate the appdata entry).

scripts/verify-release-assets.sh is the pre-announce gate: one read-only gh call asserting the release holds exactly the ten expected assets - both Linux tarballs and their checksums, DMG + checksum, MSI + checksum, MANUAL.pdf + checksum - with the tag's version in each versioned filename, and a non-empty body. Exit nonzero on anything missing, duplicated, extra or empty.

The windows-build dispatch path never published (the publish step is tag-gated), so its dead tag-composition branch and the header claiming a dispatch pre-release are deleted.

The release-mechanics contract test pins the new shape: the markers exist, the splice round-trips exactly, an aborted bump leaves both files untouched, and no workflow composes a per-run body (the --notes ban is scoped to gh release lines).