### PR TITLE
chore(release): correct the CLAP host URL and the 0.11.0 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,8 +146,9 @@ application framework and became Dusk Studio's own.
   oversized blocks from the device are guarded, and a channel strip coming out
   of mute no longer replays up to a third of a second of pre-mute audio.
 - **Plugin editors.** Replacing a plugin with its editor open could read freed
-  memory (CLAP, LV2 and VST3); the editor is now dropped with the instance it
-  belongs to. A plugin slot also re-publishes reliably after a reload.
+  memory (CLAP, LV2, VST3, and the macOS AU editor); the editor is now dropped
+  with the instance it belongs to. A plugin slot also re-publishes reliably
+  after a reload.
 - **MIDI and soundfonts.** Hung notes no longer lose their tail, CC values no
   longer diverge from what was sent, and several SF2-to-SFZ translation faults
   are corrected. A dense burst that filled the input ring but overflowed a
@@ -513,7 +514,7 @@ editor grid, shortcut cleanup, and a batch of fixes.
 - **Linux app icon.** The desktop entry's StartupWMClass now matches the window
   class, so the dock / taskbar shows the Dusk Studio icon instead of a generic one.
 
-## [0.11.0] - 2026-06-22
+## [0.11.0] - 2026-06-24
 
 Built to a production-grade bar; shipped as a Beta. 1.0.0 is reserved for
 the public stable declaration.

--- a/packaging/DuskStudio.appdata.xml
+++ b/packaging/DuskStudio.appdata.xml
@@ -83,7 +83,7 @@
         (arm64) Linux tarball.</p>
       </description>
     </release>
-    <release version="0.11.0" date="2026-06-22">
+    <release version="0.11.0" date="2026-06-24">
       <description>
         <p>Beta release. Optional out-of-process plugin sandbox with
         crash-isolated plugin scanning on all three OSes,

--- a/src/engine/clap/ClapHost.cpp
+++ b/src/engine/clap/ClapHost.cpp
@@ -15,7 +15,7 @@ ClapHost::ClapHost()
     host.host_data     = this;
     host.name          = "Dusk Studio";
     host.vendor        = "Dusk Audio";
-    host.url           = "https://dusk-audio.com";
+    host.url           = "https://duskaudio.com";
     host.version       = DUSKSTUDIO_VERSION_STRING;
     host.get_extension = &ClapHost::getExtension;
     host.request_restart  = [] (const clap_host_t*) {};


### PR DESCRIPTION
Three small pre-tag corrections from the release review.

The CLAP host advertised dusk-audio.com to every hosted plugin; the live domain is duskaudio.com (only occurrence repo-wide). The 0.11.0 entries in the appdata and the changelog carried the date of a stale local v0.11.0 tag; the local v0.11.0 and v0.12.6 tags had diverged from the published remote tags (both since re-synced locally), and the published tag's UTC date is 2026-06-24 - UTC being the convention bump-version.sh itself stamps. The 0.12.2 and 0.12.3 dates were re-verified correct against the remote tags. The editor-lifetime changelog entry now names the macOS AU editor alongside CLAP, LV2 and VST3, matching what shipped in the 0.13 cycle.

Verified: full Linux build, 650/650 ctest (one environmental ALSA-seq flake, passes isolated), juce-gate 179/9239 unchanged, appdata validates with xmllint.