### PR TITLE
ci: isolate manual release dispatches

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -26,7 +26,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: linux-release-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -25,7 +25,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: macos-release-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/manual-pdf.yml
+++ b/.github/workflows/manual-pdf.yml
@@ -25,7 +25,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: manual-pdf-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -27,7 +27,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: windows-build-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release and build workflow handling to prevent unrelated manual runs from being cancelled or grouped together.
  * Tag-triggered runs continue to be grouped by their associated reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->