### PR TITLE
packaging: keep install set scoped

### DIFF
--- a/scripts/package-windows.ps1
+++ b/scripts/package-windows.ps1
@@ -55,7 +55,17 @@ try {
             throw "install layout missing required license text: $InstalledDoc"
         }
     }
-    Write-Host "Validated install layout: app + plugin scan host + license texts"
+
+    $ForbiddenDirs = @(
+        (Join-Path $InstallCheckDir "include"),
+        (Join-Path (Join-Path $InstallCheckDir "lib") "cmake")
+    )
+    foreach ($ForbiddenDir in $ForbiddenDirs) {
+        if (Test-Path -PathType Container $ForbiddenDir) {
+            throw "install layout contains forbidden directory: $ForbiddenDir"
+        }
+    }
+    Write-Host "Validated install layout: app + plugin scan host + license texts; no development files"
 } finally {
     Remove-Item -Recurse -Force $InstallCheckDir -ErrorAction SilentlyContinue
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,15 @@ FetchContent_Declare(
     GIT_SHALLOW    TRUE)
 FetchContent_MakeAvailable(Catch2)
 
+FetchContent_GetProperties(Catch2)
+if(catch2_POPULATED AND IS_DIRECTORY "${catch2_SOURCE_DIR}")
+    get_property(testSubdirectories DIRECTORY PROPERTY SUBDIRECTORIES)
+    list(FIND testSubdirectories "${catch2_SOURCE_DIR}" catch2DirectoryIndex)
+    if(NOT catch2DirectoryIndex EQUAL -1)
+        set_property(DIRECTORY "${catch2_SOURCE_DIR}" PROPERTY EXCLUDE_FROM_ALL TRUE)
+    endif()
+endif()
+
 add_executable(dusk-studio-tests
     # Shared native-host foundation (PortLayout / PortBuffers / INativeInstance)
     # is header-only + platform-neutral, so it links in the base target.


### PR DESCRIPTION
## Summary

- keep the fetched Catch2 subdirectory out of the test-build install set
- make the Windows packaging gate reject leaked `include/` and `lib/cmake/` development trees
- retain the existing required app, plugin-host, and license payload checks

## Validation

- production target build passed
- test target build passed
- serial CTest passed: 651/651
- test-tree install produced 9 payload files with no `include/` or `lib/cmake/` directories
- JUCE gate remained at 179 files / 9239 uses
- `git diff --check` passed

Closes #218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Windows packages now reject layouts containing development files and clearly report when those files are absent.
  * Test configuration avoids building an already-populated testing dependency by default while keeping it available for test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->