### PR TITLE
fix(lv2): abandon stale macOS editors safely

### DIFF
--- a/src/engine/lv2/Lv2Editor.cpp
+++ b/src/engine/lv2/Lv2Editor.cpp
@@ -71,6 +71,7 @@ struct Lv2Editor::Impl
     static int uiResize (LV2UI_Feature_Handle handle, int w, int h)
     {
         auto* self = static_cast<Impl*> (handle);
+        if (self->instance == nullptr) return 1;
         if (w <= 0 || h <= 0) return 1;
         self->prefW = w; self->prefH = h;
         if (self->display != nullptr && self->hostWindow != 0)
@@ -292,6 +293,19 @@ void Lv2Editor::hide()
     XUnmapWindow ((Display*) impl->display, (Window) impl->hostWindow);
     XFlush ((Display*) impl->display);
     impl->mapped = false;
+}
+
+void Lv2Editor::quiesce() noexcept
+{
+    hide();
+}
+
+void Lv2Editor::abandonPluginAndContainer() noexcept
+{
+    // The plugin's window is a foreign X11 child of ours: destroying the host
+    // window and display in close() delivers no in-process Cocoa-style detach,
+    // so there is nothing extra to give up here.
+    abandonPlugin();
 }
 
 void Lv2Editor::close()

--- a/src/engine/lv2/Lv2Editor.h
+++ b/src/engine/lv2/Lv2Editor.h
@@ -42,6 +42,11 @@ public:
     void setBounds (int x, int y, int w, int h);
     void reveal();   // Show the native child container (idempotent).
     void hide();     // Hide the native child container (idempotent).
+
+    // Hide the host container while the instance/module are still valid. Cocoa
+    // abandonment must quiesce before disposal because setHidden: notifies the
+    // embedded plugin view.
+    void quiesce() noexcept;
     void close();
 
     // X11 geometry diagnostics: the host window's REAL geometry (position
@@ -57,10 +62,16 @@ public:
     // can hang on the way out (same rationale as the CLAP editor leak path).
     void setLeakOnClose (bool b) noexcept;
 
-    // The DSP instance was destroyed out from under this editor. Drops the
-    // reference the suil callbacks dereference, so close() can still free the UI
-    // without writing ports into a freed plugin.
+    // The instance is going away but is STILL ALIVE. Drop the reference the suil
+    // callbacks dereference, then close() may run normal UI teardown while the
+    // plugin/module are still valid.
     void abandonPlugin() noexcept;
+
+    // Same, for an ALREADY-destroyed instance. On Cocoa, leak the whole Impl
+    // because suil retains it as its controller and resize handle; close() must
+    // not call suil or message/detach/release the embedded view hierarchy. X11
+    // has no in-process child-view hazard, so it still closes its host resources.
+    void abandonPluginAndContainer() noexcept;
 
     // Message thread, ~60 Hz: drive ui:idleInterface and platform event work.
     void pump();

--- a/src/engine/lv2/Lv2Editor_Mac.mm
+++ b/src/engine/lv2/Lv2Editor_Mac.mm
@@ -62,6 +62,7 @@ struct Lv2Editor::Impl
     static int uiResize (LV2UI_Feature_Handle handle, int w, int h)
     {
         auto* self = static_cast<Impl*> (handle);
+        if (self->instance == nullptr) return 1;
         if (w <= 0 || h <= 0) return 1;
 
         self->prefW = w;
@@ -85,12 +86,19 @@ struct Lv2Editor::Impl
 Lv2Editor::Lv2Editor() : impl (std::make_unique<Impl>()) { impl->owner = this; }
 Lv2Editor::~Lv2Editor() { close(); }
 
-void Lv2Editor::setLeakOnClose (bool b) noexcept { impl->leakOnClose = b; }
-void Lv2Editor::abandonPlugin() noexcept { impl->instance = nullptr; }
-int  Lv2Editor::preferredWidth()  const noexcept { return impl->prefW; }
-int  Lv2Editor::preferredHeight() const noexcept { return impl->prefH; }
-bool Lv2Editor::isOpen()     const noexcept { return impl->discovered; }
-bool Lv2Editor::isEmbedded() const noexcept { return impl->embedded; }
+void Lv2Editor::setLeakOnClose (bool b) noexcept
+{
+    if (impl != nullptr) impl->leakOnClose = b;
+}
+
+void Lv2Editor::abandonPlugin() noexcept
+{
+    if (impl != nullptr) impl->instance = nullptr;
+}
+int  Lv2Editor::preferredWidth()  const noexcept { return impl != nullptr ? impl->prefW : 0; }
+int  Lv2Editor::preferredHeight() const noexcept { return impl != nullptr ? impl->prefH : 0; }
+bool Lv2Editor::isOpen()     const noexcept { return impl != nullptr && impl->discovered; }
+bool Lv2Editor::isEmbedded() const noexcept { return impl != nullptr && impl->embedded; }
 
 bool Lv2Editor::open (Lv2Instance& inst, std::string& errorOut)
 {
@@ -270,8 +278,37 @@ void Lv2Editor::hide()
     impl->visible = false;
 }
 
+void Lv2Editor::quiesce() noexcept
+{
+    if (impl == nullptr) return;
+    // setHidden: propagates viewDidHide through the plugin subtree, so this is
+    // deliberately a live-instance phase rather than stale-owner cleanup.
+    @try
+    {
+        if (impl->container != nil && impl->visible)
+            [impl->container setHidden:YES];
+    }
+    @catch (NSException*)
+    {
+    }
+    impl->visible = false;
+}
+
+void Lv2Editor::abandonPluginAndContainer() noexcept
+{
+    if (impl == nullptr) return;
+    // suil retains Impl as both its controller and resize feature handle. The
+    // instance is already disposed, so no suil call or Cocoa hierarchy message
+    // is safe: strand the complete callback state for the life of the process
+    // and leave close() a true no-op in the allocation-free terminal state.
+    impl->owner    = nullptr;
+    impl->instance = nullptr;
+    (void) impl.release();
+}
+
 void Lv2Editor::close()
 {
+    if (impl == nullptr) return;
     if (impl->leakOnClose && impl->suilInstance != nullptr)
     {
         // Shutdown path: the suil instance is deliberately leaked because a

--- a/src/ui/Lv2PluginEditorComponent.cpp
+++ b/src/ui/Lv2PluginEditorComponent.cpp
@@ -21,9 +21,10 @@ Lv2PluginEditorComponent::Lv2PluginEditorComponent()
 Lv2PluginEditorComponent::~Lv2PluginEditorComponent()
 {
     stopTimer();
-    // Every reset path lands here, and the suil callbacks still hold the
-    // instance that went.
-    if (ownerIsStale()) editor.abandonPlugin();
+    // Every reset path lands here, and both suil teardown and releasing the
+    // container its plugin view still sits in can call into an unloaded module.
+    if (ownerIsStale()) editor.abandonPluginAndContainer();
+    else                editor.quiesce();
     editor.close();
 }
 
@@ -179,8 +180,10 @@ void Lv2PluginEditorComponent::leakForShutdown()
 void Lv2PluginEditorComponent::abandonInstance()
 {
     stopTimer();
-    editor.abandonPlugin();
-    editor.close();   // plugin handles are gone; this releases only what we own
+    // A stale owner means the instance is ALREADY disposed. On Cocoa the suil
+    // callbacks and attached view hierarchy must therefore be leaked untouched;
+    // on X11 close() can still release the host window and display.
+    abandonNativeEditorInstance (editor, ownerIsStale());
     ownerSlot = nullptr;
     abandoned = true;
     attachedInstance = nullptr;


### PR DESCRIPTION
## Summary

- split LV2 editor teardown into live quiesce and stale abandonment paths
- make the stale Cocoa path leak the complete suil callback and container state without calling suil or messaging the disposed plugin view
- guard resize callbacks after instance abandonment and keep X11 teardown aligned with the shared native-editor contract

## Validation

- production target build passed on Linux
- test target build passed on Linux
- serial CTest passed: 651/651
- private-Xvfb application self-test passed
- JUCE gate remained at 179 files / 9239 uses
- `git diff --check` passed

The `_Mac.mm` path cannot compile on the Linux development host; macOS CI is its first compile and is required before merge.

Closes #235