### PR TITLE
fix(ui): re-embed channel native editors after peer recreation

### DIFF
--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -2299,6 +2299,67 @@ bool ChannelStripComponent::isPluginEditorOpen() const noexcept
     return pluginEditorModal.isOpen();
 }
 
+void ChannelStripComponent::parentHierarchyChanged()
+{
+    // A fullscreen transition can briefly remove the top-level peer before the
+    // replacement arrives. Keep cached editors alive across that null interval,
+    // and rebuild only when there is a genuinely different realised peer.
+    const auto& modalStack = EmbeddedModal::activeModalStack();
+    auto* peer = getPeer();
+    const auto transition = observeNativeEditorPeer (
+        lastSeenPeerId,
+        peer != nullptr ? peer->getUniqueID() : 0,
+        static_cast<const void*> (pluginEditorModal.getBody()),
+        ! modalStack.empty() && modalStack.back() == &pluginEditorModal,
+        {
+#if DUSKSTUDIO_HAS_NATIVE_CLAP
+            static_cast<const void*> (clapEditor.get()),
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+            static_cast<const void*> (lv2Editor.get()),
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_VST3
+            static_cast<const void*> (vst3Editor.get()),
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_AU
+            static_cast<const void*> (auEditor.get()),
+#endif
+        });
+
+    if (! transition.rebuildNativeEditors)
+        return;
+
+    // Only reopen when the modal is actually borrowing one of the native editor
+    // bodies. JUCE, OOP and multisample editors do not use these wrappers and
+    // must remain undisturbed by this native-peer repair path.
+    // EmbeddedModal borrows its body, so detach it before destroying a wrapper.
+    // Hidden cached wrappers also need rebuilding: their native child remains
+    // tied to the old peer even though the modal is currently closed.
+    if (transition.reopenNativeEditorNow || transition.deferNativeEditorReopen)
+        pluginEditorModal.close();
+
+#if DUSKSTUDIO_HAS_NATIVE_CLAP
+    clapEditor.reset();
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    lv2Editor.reset();
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_VST3
+    vst3Editor.reset();
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_AU
+    auEditor.reset();
+#endif
+
+    if (transition.deferNativeEditorReopen)
+        nativeEditorReopenPending = true;
+    else if (transition.reopenNativeEditorNow)
+    {
+        nativeEditorReopenPending = false;
+        openPluginEditor();
+    }
+}
+
 void ChannelStripComponent::openPluginEditor()
 {
     if (isPluginEditorOpen()) return;
@@ -2596,6 +2657,10 @@ void ChannelStripComponent::openPluginEditor()
 
 void ChannelStripComponent::closePluginEditor()
 {
+    // Cancels a peer-recreation reopen deferred behind another modal. The peer
+    // callback closes EmbeddedModal directly so its internal repair survives.
+    nativeEditorReopenPending = false;
+
    #if DUSKSTUDIO_HAS_OOP_PLUGINS && ! JUCE_LINUX
     // Mac OOP floating-window path (no embed available): the editor
     // window lives in the child process; the parent has no modal body
@@ -3818,6 +3883,15 @@ void ChannelStripComponent::timerCallback()
     // Plugin-slot button reflects the slot's current load state. Cheap -
     // just an atomic-pointer read + string compare against the cached name.
     refreshPluginSlotButton();
+
+    // A native editor that was covered during peer recreation must stay behind
+    // that cover. Reopen only after every modal has gone, and consume the request
+    // before attempting so a failed attach cannot retry forever.
+    if (nativeEditorReopenPending && EmbeddedModal::activeModalStack().empty())
+    {
+        nativeEditorReopenPending = false;
+        openPluginEditor();
+    }
 
     // PRINT<->FREEZE flips on an audio track the moment a recording lands (or its
     // last region is deleted). Idempotent + cheap (setButtonText/Colour are

--- a/src/ui/ChannelStripComponent.h
+++ b/src/ui/ChannelStripComponent.h
@@ -40,6 +40,7 @@ public:
     void paint (juce::Graphics&) override;
     void resized() override;
     void mouseDown (const juce::MouseEvent& e) override;
+    void parentHierarchyChanged() override;
 
     // Wired to TapeStrip selection so A/S/X target the just-touched strip
     // even when no region was clicked.
@@ -340,6 +341,14 @@ private:
     EmbeddedModal pluginEditorModal;
     std::unique_ptr<juce::AudioProcessorEditor> pluginEditor;
     juce::AudioProcessor* pluginEditorOwner = nullptr;
+
+    // Unique ID of the top-level peer the cached native editor wrappers were
+    // embedded into. Fullscreen can replace that peer without replacing this
+    // component tree; the ID cannot be hidden by allocator address reuse.
+    std::uint32_t lastSeenPeerId = 0;
+    // A peer rebuild that happened under a covering modal reopens only after the
+    // app-wide modal stack empties, so the editor cannot surface above the cover.
+    bool nativeEditorReopenPending = false;
 
     // Native CLAP insert editor (shares the strip's NativeClapSlot instance). Kept
     // alive across modal opens - showBorrowed hides on close rather than destroying

--- a/src/ui/NativeEditorOwner.h
+++ b/src/ui/NativeEditorOwner.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <initializer_list>
 #include <memory>
 
 namespace duskstudio
@@ -54,6 +55,37 @@ enum class NativeEditorTeardown
     // together with the container + display it is still drawing into.
     LeakForExit,
 };
+
+// Decision shared by channel-strip peer recreation and its unit tests. A null
+// peer is the transient gap while a top-level window is being recreated, so it
+// must not replace the last realised identity. A new realised peer always
+// invalidates cached native wrappers; only a modal borrowing one of those
+// wrappers should be reopened after teardown.
+struct NativeEditorPeerTransition
+{
+    bool rebuildNativeEditors = false;
+    bool reopenNativeEditorNow = false;
+    bool deferNativeEditorReopen = false;
+};
+
+inline NativeEditorPeerTransition observeNativeEditorPeer (
+    std::uint32_t& lastPeerId,
+    std::uint32_t currentPeerId,
+    const void* modalBody,
+    bool nativeEditorModalIsTopmost,
+    std::initializer_list<const void*> nativeEditorBodies) noexcept
+{
+    if (currentPeerId == 0 || currentPeerId == lastPeerId)
+        return {};
+
+    lastPeerId = currentPeerId;
+    for (auto* nativeBody : nativeEditorBodies)
+        if (nativeBody != nullptr && modalBody == nativeBody)
+            return { true, nativeEditorModalIsTopmost,
+                     ! nativeEditorModalIsTopmost };
+
+    return { true, false, false };
+}
 
 // Enforce the AbandonInstance ordering above. The normal path is called before
 // slot disposal and may safely hide the native container; stale cleanup must

--- a/tests/native_editor_owner.cpp
+++ b/tests/native_editor_owner.cpp
@@ -216,3 +216,84 @@ TEST_CASE ("syncNativeEditorOwner reaps an editor that abandoned itself")
     REQUIRE (editor == nullptr);
     REQUIRE (detached == 1);
 }
+
+TEST_CASE ("Native editor peer transitions preserve realised peer identity")
+{
+    constexpr std::uint32_t peerAId = 41;
+    constexpr std::uint32_t peerBId = 42;
+    std::uint32_t lastPeerId = 0;
+
+    const auto initial = duskstudio::observeNativeEditorPeer (
+        lastPeerId, peerAId, nullptr, false, {});
+    REQUIRE (initial.rebuildNativeEditors);
+    REQUIRE_FALSE (initial.reopenNativeEditorNow);
+    REQUIRE_FALSE (initial.deferNativeEditorReopen);
+    REQUIRE (lastPeerId == peerAId);
+
+    const auto transientNull = duskstudio::observeNativeEditorPeer (
+        lastPeerId, 0, nullptr, false, {});
+    REQUIRE_FALSE (transientNull.rebuildNativeEditors);
+    REQUIRE (lastPeerId == peerAId);
+
+    const auto samePeer = duskstudio::observeNativeEditorPeer (
+        lastPeerId, peerAId, nullptr, false, {});
+    REQUIRE_FALSE (samePeer.rebuildNativeEditors);
+    REQUIRE (lastPeerId == peerAId);
+
+    // Distinct unique IDs still detect replacement if the allocator reuses the
+    // old ComponentPeer address for the new top-level window.
+    const auto replacement = duskstudio::observeNativeEditorPeer (
+        lastPeerId, peerBId, nullptr, false, {});
+    REQUIRE (replacement.rebuildNativeEditors);
+    REQUIRE_FALSE (replacement.reopenNativeEditorNow);
+    REQUIRE_FALSE (replacement.deferNativeEditorReopen);
+    REQUIRE (lastPeerId == peerBId);
+}
+
+TEST_CASE ("Native editor peer transitions reopen only a borrowed native body")
+{
+    constexpr std::uint32_t oldPeerId = 41;
+    constexpr std::uint32_t newPeerId = 42;
+    int nativeEditor = 0;
+    int unrelatedEditor = 0;
+
+    SECTION ("a topmost native editor reopens immediately")
+    {
+        std::uint32_t lastPeerId = oldPeerId;
+        const auto transition = duskstudio::observeNativeEditorPeer (
+            lastPeerId, newPeerId, &nativeEditor, true, { &nativeEditor });
+        REQUIRE (transition.rebuildNativeEditors);
+        REQUIRE (transition.reopenNativeEditorNow);
+        REQUIRE_FALSE (transition.deferNativeEditorReopen);
+    }
+
+    SECTION ("a covered native editor defers reopening")
+    {
+        std::uint32_t lastPeerId = oldPeerId;
+        const auto transition = duskstudio::observeNativeEditorPeer (
+            lastPeerId, newPeerId, &nativeEditor, false, { &nativeEditor });
+        REQUIRE (transition.rebuildNativeEditors);
+        REQUIRE_FALSE (transition.reopenNativeEditorNow);
+        REQUIRE (transition.deferNativeEditorReopen);
+    }
+
+    SECTION ("a hidden cached editor is rebuilt without reopening")
+    {
+        std::uint32_t lastPeerId = oldPeerId;
+        const auto transition = duskstudio::observeNativeEditorPeer (
+            lastPeerId, newPeerId, nullptr, false, { &nativeEditor });
+        REQUIRE (transition.rebuildNativeEditors);
+        REQUIRE_FALSE (transition.reopenNativeEditorNow);
+        REQUIRE_FALSE (transition.deferNativeEditorReopen);
+    }
+
+    SECTION ("an unrelated modal body is not reopened")
+    {
+        std::uint32_t lastPeerId = oldPeerId;
+        const auto transition = duskstudio::observeNativeEditorPeer (
+            lastPeerId, newPeerId, &unrelatedEditor, false, { &nativeEditor });
+        REQUIRE (transition.rebuildNativeEditors);
+        REQUIRE_FALSE (transition.reopenNativeEditorNow);
+        REQUIRE_FALSE (transition.deferNativeEditorReopen);
+    }
+}


### PR DESCRIPTION
## Summary

- track the realised top-level peer by stable unique ID in channel strips
- rebuild cached CLAP, LV2, VST3, and AU editor wrappers when fullscreen or another transition replaces that peer
- reopen immediately only for the top native modal, defer behind covering modals, and leave unrelated editor bodies undisturbed
- add focused transition coverage for transient-null peers, allocator reuse, hidden caches, and immediate/deferred reopen decisions

## Validation

- focused native-editor peer transition tests passed
- production target build passed
- test target build passed
- serial CTest passed: 651/651
- private-Xvfb application self-test passed
- JUCE gate remained at 179 files / 9239 uses
- `git diff --check` passed

Closes #236