### PR TITLE
fix(ui): keep narrow faders usable

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -145,7 +145,7 @@ This chapter is a visual reference. Every numbered callout on the figures below 
 | --- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | 1   | Menu bar          | `File` and `Settings` menus only. No tabs, no hidden submenus.                                                                    |
 | 2   | Stage selector    | Four buttons: **RECORDING**, **MIXING**, **MASTERING**, **AUX** (Cmd/Ctrl+1 to 4). Picks which view fills the console area.            |
-| 3   | Bank selector     | The visible page of channel strips (e.g. `1-6`, `7-12`, ...), switched with the plain number keys 1 to 4. Only visible when the window is too narrow to show all 24 at once. |
+| 3   | Bank selector     | The visible page of channel strips (e.g. `1-3`, `4-6`, ...), switched with the plain number keys 1 to 8. Only visible when the window is too narrow to show all 24 at once. |
 | 4   | Transport bar     | Play, record, loop, punch, BPM, time signature, clock, tuner. See the next figure for the inventory.                              |
 | 5   | Tape strip toggle | `▾ TIMELINE` / `▴ TAPE`. Collapses or expands the timeline view below the bar.                                                     |
 | 6   | Console view      | Holds 24 channel strips, 4 buses, and the master strip. Replaced by the aux lane or mastering chain when those stages are active. |
@@ -482,7 +482,7 @@ The window is structured as a stack of horizontal bands.
 ├───────────────────────────────────────────────────────┤
 │  RECORDING   MIXING   MASTERING   AUX                 │  Stage selector
 ├───────────────────────────────────────────────────────┤
-│  1-6   7-12   13-18   19-24                           │  Bank selector
+│  1-3  4-6  7-9  10-12  13-15  16-18  19-21  22-24   │  Bank selector
 ├───────────────────────────────────────────────────────┤
 │ ◀◀  ▶  ▶▶  ●  ⟳  ◉   CLK ♩=120 4/4 00:01:23         │  Transport bar
 ├───────────────────────────────────────────────────────┤
@@ -494,7 +494,7 @@ The window is structured as a stack of horizontal bands.
 └───────────────────────────────────────────────────────┘
 ```
 
-The bank selector appears only when the window is too narrow for all 24 strips, and it pages the console by whatever does fit — as few as six strips on the narrowest window, never more than four pages. Each button names its range: in the compact transport layout drawn above (window under 1850 pixels) the label is the bare range, `1-6`; at full size it reads `BANK 1  (1-6)`. The range widens with the window. A control surface's bank is a separate, fixed axis: eight strips at a time, tracks 1–8, 9–16, or 17–24. The two stay in step. Picking a page moves the surface to the bank holding that page's first track, and **Bank Left** / **Bank Right** on the surface moves the page to the one holding that bank's first track. When every strip fits on screen there is no page to pick, so the surface — and the bank-relative MIDI bindings that follow it — stays where you left it.
+The bank selector appears only when the window is too narrow for all 24 strips, and it pages the console by whatever does fit — as few as three strips on the narrowest window, never more than eight pages. Each button names its range when space permits: in the compact transport layout the label is the bare range, `1-3`; at full size it reads `BANK 1  (1-3)`. At the tightest button width only the page number is shown; its tooltip still gives the channel range. The range widens with the window. A control surface's bank is a separate, fixed axis: eight strips at a time, tracks 1–8, 9–16, or 17–24. The two stay in step. Picking a page moves the surface to the bank holding that page's first track, and **Bank Left** / **Bank Right** on the surface moves the page to the one holding that bank's first track. When every strip fits on screen there is no page to pick, so the surface — and the bank-relative MIDI bindings that follow it — stays where you left it.
 
 Modal dialogs (audio settings, plugin picker, region editor, piano roll, import target picker) appear centered with a dimmed backdrop behind them. Press **Esc** or click outside the modal to dismiss.
 
@@ -509,7 +509,7 @@ Only one stage is visible at a time, but the same engine drives all four. Switch
 - **MASTERING** swaps the console view for the mastering chain, including a file picker for loading a finished mix.
 - **AUX** swaps the console view for the four aux return lanes, with a full-width view of each lane's plugin chain.
 
-Press **Cmd/Ctrl+1 / 2 / 3 / 4** to jump straight to RECORDING / MIXING / MASTERING / AUX. The bank selector has the plain number keys **1 / 2 / 3 / 4**, so a modified digit changes stage and a plain digit changes the visible page of strips. Hovering any tab or bank button shows its shortcut, and **?** opens a full keyboard-shortcut list (also under **Settings → Keyboard Shortcuts**).
+Press **Cmd/Ctrl+1 / 2 / 3 / 4** to jump straight to RECORDING / MIXING / MASTERING / AUX. The bank selector has the plain number keys **1 through 8**, so a modified digit changes stage and a plain digit changes the visible page of strips. Hovering any tab or bank button shows its shortcut, and **?** opens a full keyboard-shortcut list (also under **Settings → Keyboard Shortcuts**).
 
 Switching into or out of MASTERING force-stops the transport. The mix engine and the mastering engine cannot run at the same time. Changing stage also closes the notepad, saving it — the two cannot share the window.
 
@@ -1946,7 +1946,7 @@ Shortcuts use **Cmd** on macOS and **Ctrl** on Linux and Windows unless noted.
 | Shortcut             | Action                                  |
 | -------------------- | --------------------------------------- |
 | **Cmd+1 … Cmd+4**    | Recording / Mixing / Mastering / Aux    |
-| **1 … 4**            | Select strip page 1 to 4 (bank selector) |
+| **1 … 8**            | Select strip page 1 to 8 (bank selector) |
 
 ## Timeline
 
@@ -2522,7 +2522,7 @@ The hardware-insert ping reports its result inline on the editor (not a modal), 
 
 **Opto compressor.** A compressor whose gain reduction is performed by a photo-resistor, in the classic optical tradition.
 
-**Page (console).** The set of channel strips on screen at once, chosen by the bank selector. As narrow as six strips, never more than four pages; a window wide enough for all 24 has a single page and no selector. Independent of the fixed bank of 8.
+**Page (console).** The set of channel strips on screen at once, chosen by the bank selector. As narrow as three strips, never more than eight pages; a window wide enough for all 24 has a single page and no selector. Independent of the fixed bank of 8.
 
 **Program EQ.** A passive program-EQ topology with separately controllable boost and cut at the same frequency.
 

--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -101,7 +101,7 @@ public:
         setResizable (true, false);
         // Min height keeps the console usable; the tape strip is collapsible
         // so we don't need to budget for it in the floor.
-        setResizeLimits (ConsoleView::minimumContentWidth() + 24, 750, 32768, 32768);
+        refreshResizeLimits();
 
         // Restore prior session's window geometry. JUCE's
         // restoreWindowStateFromString rebuilds bounds + fullscreen state
@@ -148,6 +148,7 @@ public:
         // Stops a dying OOP plugin editor window from core-dumping the host.
         duskstudio::platform::installNonFatalXErrorHandler();
        #endif
+        refreshResizeLimits();
 
         // Brand icon on the live peer. macOS / Windows already pick this
         // up from the bundled .icns / PE .ico, but JUCE 8 does NOT auto-
@@ -175,9 +176,48 @@ public:
             auto* self = safeThis.getComponent();
             if (self == nullptr) return;
             self->setVisible (true);
+            self->refreshResizeLimits();
             if (auto* peer = self->getPeer())
                 duskstudio::platform::bringWindowToFront (*peer);
+            dusk::Timer::callAfterDelay (250, [safeThis]
+            {
+                if (auto* window = safeThis.getComponent())
+                    window->refreshResizeLimits();
+            });
         });
+    }
+
+    void refreshResizeLimits()
+    {
+        int frameWidth = 0;
+        int frameHeight = 0;
+        if (auto* peer = getPeer())
+        {
+            if (const auto frame = peer->getFrameSizeIfPresent())
+            {
+                frameWidth = frame->getLeftAndRight();
+                frameHeight = frame->getTopAndBottom();
+            }
+        }
+
+        int contentInsetWidth = 0;
+        int contentInsetHeight = 0;
+        if (auto* content = getContentComponent())
+        {
+            contentInsetWidth = std::max (0, getWidth() - content->getWidth());
+            contentInsetHeight = std::max (0, getHeight() - content->getHeight());
+        }
+
+        const int minimumWidth = consolelayout::responsiveMinimumMainComponentWidth()
+                               + contentInsetWidth + frameWidth;
+        const int minimumHeight = 750 + contentInsetHeight + frameHeight;
+        if (minimumWidth == configuredMinimumWidth
+            && minimumHeight == configuredMinimumHeight)
+            return;
+
+        configuredMinimumWidth = minimumWidth;
+        configuredMinimumHeight = minimumHeight;
+        setResizeLimits (minimumWidth, minimumHeight, 32768, 32768);
     }
 
     void closeButtonPressed() override
@@ -195,6 +235,10 @@ public:
         // to immediate quit so the X still works.
         JUCEApplication::getInstance()->systemRequestedQuit();
     }
+
+private:
+    int configuredMinimumWidth = 0;
+    int configuredMinimumHeight = 0;
 };
 
 DuskStudioApp::DuskStudioApp() = default;

--- a/src/session/Session.h
+++ b/src/session/Session.h
@@ -1142,7 +1142,7 @@ class Session
 {
 public:
     static constexpr int kNumTracks   = SessionLayout::kNumTracks;
-    static constexpr int kNumBuses    = 4;
+    static constexpr int kNumBuses    = SessionLayout::kNumBuses;
     static constexpr int kNumAuxLanes = 4;
     static constexpr int kBankSize    = SessionLayout::kBankSize;
     static constexpr int kNumBanks    = SessionLayout::kNumBanks;

--- a/src/session/SessionLayout.h
+++ b/src/session/SessionLayout.h
@@ -5,6 +5,7 @@ namespace duskstudio
 struct SessionLayout
 {
     static constexpr int kNumTracks = 24;
+    static constexpr int kNumBuses  = 4;
     static constexpr int kBankSize  = 8;
     static constexpr int kNumBanks  = kNumTracks / kBankSize;
 };

--- a/src/ui/BankMapping.h
+++ b/src/ui/BankMapping.h
@@ -6,7 +6,7 @@
 
 namespace duskstudio
 {
-// The console pages its 24 strips in width-derived screen pages (stride 6..24),
+// The console pages its 24 strips in width-derived screen pages (stride 3..24),
 // while bank-relative MIDI bindings and the MCU surface address a fixed
 // kNumBanks x kBankSize hardware bank. The two indices only coincide when the
 // stride happens to be kBankSize, so they must be translated, never shared:
@@ -30,6 +30,20 @@ inline int screenBankForHardwareBank (int hardwareBank,
     const int firstTrack = std::clamp (hardwareBank, 0, SessionLayout::kNumBanks - 1)
                          * SessionLayout::kBankSize;
     return std::clamp (firstTrack / screenStride, 0, screenBankCount - 1);
+}
+
+inline int screenBankForTrack (int track, int screenStride, int screenBankCount) noexcept
+{
+    if (screenStride <= 0 || screenBankCount <= 1) return 0;
+    track = std::clamp (track, 0, SessionLayout::kNumTracks - 1);
+    return std::clamp (track / screenStride, 0, screenBankCount - 1);
+}
+
+inline int screenPageForDigitKey (int keyCode, int screenPageCount) noexcept
+{
+    if (keyCode < '1' || keyCode > '8') return -1;
+    const int page = keyCode - '1';
+    return page < screenPageCount ? page : -1;
 }
 
 // What the console must publish to the session atoms after a transition.
@@ -72,7 +86,7 @@ struct ConsoleBankState
         BankTransition t;
         t.pageMoved = true;
 
-        // A page is stride-wide (6..24); the surface and the bank-relative
+        // A page is stride-wide (3..24); the surface and the bank-relative
         // bindings are kBankSize-wide, so the page index is never a valid bank
         // - publish the hardware bank holding the page's first track instead.
         // With every track on screen there is only one page and it carries no

--- a/src/ui/ConsoleLayout.h
+++ b/src/ui/ConsoleLayout.h
@@ -1,0 +1,239 @@
+#pragma once
+
+#include "../session/SessionLayout.h"
+
+#include <algorithm>
+#include <cmath>
+#include <utility>
+
+namespace duskstudio::consolelayout
+{
+constexpr int kMinChannelWidth = 154;
+constexpr int kMinBusWidth     = 172;
+constexpr int kMinMasterWidth  = 210;
+constexpr int kRefChannelWidth = 188;
+constexpr int kRefBusWidth     = 192;
+constexpr int kRefMasterWidth  = 260;
+constexpr int kStripGap        = 4;
+constexpr int kSectionGap      = 12;
+constexpr int kComponentInset  = 6;
+constexpr int kOuterPadding    = kComponentInset * 2;
+constexpr int kMainPadding     = 8;
+constexpr int kMaxScreenPages  = 8;
+constexpr int kMinStride = (SessionLayout::kNumTracks + kMaxScreenPages - 1)
+                         / kMaxScreenPages;
+constexpr int kMinPageButtonWidth = 32;
+constexpr int kMinPageButtonGap   = 2;
+
+constexpr int rightColumnWidth() noexcept
+{
+    return SessionLayout::kNumBuses * kMinBusWidth
+         + (SessionLayout::kNumBuses - 1) * kStripGap
+         + kSectionGap * 2
+         + kMinMasterWidth;
+}
+
+constexpr int fullFloorContentWidthForStride (int stride) noexcept
+{
+    return stride * kMinChannelWidth
+         + (stride - 1) * kStripGap
+         + rightColumnWidth()
+         + kOuterPadding;
+}
+
+constexpr int fullFloorPageContentWidth() noexcept
+{
+    return fullFloorContentWidthForStride (kMinStride);
+}
+
+constexpr int oneChannelFloorContentWidth() noexcept
+{
+    return fullFloorContentWidthForStride (1);
+}
+
+constexpr int minimumPageButtonBandWidth() noexcept
+{
+    return kMaxScreenPages * kMinPageButtonWidth
+         + (kMaxScreenPages - 1) * kMinPageButtonGap;
+}
+
+// In compact transport layout, the fixed playback/clock and right utility
+// clusters plus their safety insets consume 892 px of MainComponent width.
+// Keeping this named makes the true resize floor reflect the tightest usable
+// eight-page button band, rather than the much wider three-strip control floor.
+constexpr int compactPageButtonBandWidthForMainWidth (int mainWidth) noexcept
+{
+    return std::max (0, mainWidth - 892);
+}
+
+constexpr int responsiveMinimumMainComponentWidth() noexcept
+{
+    const int oneChannelMainWidth = oneChannelFloorContentWidth() + kMainPadding * 2;
+    const int pageButtonMainWidth = 892 + minimumPageButtonBandWidth();
+    return std::max (oneChannelMainWidth, pageButtonMainWidth);
+}
+
+constexpr int responsiveMinimumContentWidth() noexcept
+{
+    return responsiveMinimumMainComponentWidth() - kMainPadding * 2;
+}
+
+constexpr int allTracksContentWidth() noexcept
+{
+    return fullFloorContentWidthForStride (SessionLayout::kNumTracks);
+}
+
+struct PageButtonMetrics
+{
+    int width = 0;
+    int gap = 0;
+    int clusterWidth = 0;
+
+    bool fits (int bandWidth) const noexcept { return clusterWidth <= bandWidth; }
+};
+
+inline PageButtonMetrics fitPageButtons (int bandWidth,
+                                         int pageCount,
+                                         int preferredWidth,
+                                         int preferredGap) noexcept
+{
+    PageButtonMetrics result;
+    if (pageCount <= 0) return result;
+
+    result.gap = preferredGap;
+    if (pageCount > 1)
+        result.gap = std::clamp ((bandWidth - pageCount * kMinPageButtonWidth)
+                                   / (pageCount - 1),
+                                 kMinPageButtonGap, preferredGap);
+    result.width = std::clamp ((bandWidth - (pageCount - 1) * result.gap) / pageCount,
+                               kMinPageButtonWidth, preferredWidth);
+    result.clusterWidth = pageCount * result.width + (pageCount - 1) * result.gap;
+    return result;
+}
+
+inline int channelsThatFitForWidth (int componentWidth) noexcept
+{
+    const int available = std::max (0, componentWidth - kOuterPadding - rightColumnWidth());
+    const int perSlot = kMinChannelWidth + kStripGap;
+    if (available <= 0) return kMinStride;
+    const int fit = (available + kStripGap) / perSlot;
+    return std::clamp (fit, kMinStride, SessionLayout::kNumTracks);
+}
+
+inline int screenPageCountForWidth (int componentWidth) noexcept
+{
+    const int stride = channelsThatFitForWidth (componentWidth);
+    return (SessionLayout::kNumTracks + stride - 1) / stride;
+}
+
+inline std::pair<int, int> channelRangeForPage (int page, int componentWidth) noexcept
+{
+    const int stride = channelsThatFitForWidth (componentWidth);
+    const int pages = screenPageCountForWidth (componentWidth);
+    page = std::clamp (page, 0, std::max (0, pages - 1));
+    const int first = page * stride;
+    return { first + 1, std::min (SessionLayout::kNumTracks, first + stride) };
+}
+
+// Complete horizontal geometry for a realised ConsoleView width. At the named
+// full-floor width the normal path preserves every documented strip minimum.
+// Responsive legal widths and direct native-window resizes use the defensive
+// path, progressively compressing strips and then gaps. Both paths share one
+// budget and therefore cannot place the last channel underneath Bus 1.
+struct StripGeometry
+{
+    int componentWidth   = 0;
+    int budgetedChannels = 0;
+    int visibleChannels  = 0;
+    int channelWidth     = 0;
+    int busWidth         = 0;
+    int masterWidth      = 0;
+    int stripGap         = 0;
+    int sectionGap       = 0;
+    int contentLeft      = kComponentInset;
+    int contentRight     = kComponentInset;
+    int busColumnLeft    = kComponentInset;
+    int lastChannelRight = kComponentInset;
+
+    bool channelsClearBus() const noexcept
+    {
+        return lastChannelRight + sectionGap <= busColumnLeft;
+    }
+};
+
+inline StripGeometry makeStripGeometry (int componentWidth,
+                                        int budgetedChannels,
+                                        int visibleChannels) noexcept
+{
+    StripGeometry g;
+    g.componentWidth = std::max (0, componentWidth);
+    g.budgetedChannels = std::clamp (budgetedChannels, 1, SessionLayout::kNumTracks);
+    g.visibleChannels = std::clamp (visibleChannels, 0, g.budgetedChannels);
+    g.contentRight = std::max (g.contentLeft, g.componentWidth - kComponentInset);
+
+    const int areaWidth = std::max (0, g.contentRight - g.contentLeft);
+    g.stripGap = kStripGap;
+    g.sectionGap = kSectionGap;
+
+    const int fixedGapCount = (g.budgetedChannels - 1) + (SessionLayout::kNumBuses - 1);
+    const int initialGapWidth = fixedGapCount * g.stripGap + 2 * g.sectionGap;
+    const int availableForStrips = std::max (0, areaWidth - initialGapWidth);
+    const int refTotal = g.budgetedChannels * kRefChannelWidth
+                       + SessionLayout::kNumBuses * kRefBusWidth
+                       + kRefMasterWidth;
+    const double scale = refTotal > 0
+                       ? std::min (1.0, static_cast<double> (availableForStrips)
+                                       / static_cast<double> (refTotal))
+                       : 0.0;
+
+    g.channelWidth = std::max (kMinChannelWidth,
+                               static_cast<int> (std::lround (kRefChannelWidth * scale)));
+    g.busWidth = std::max (kMinBusWidth,
+                           static_cast<int> (std::lround (kRefBusWidth * scale)));
+    g.masterWidth = std::max (kMinMasterWidth,
+                              static_cast<int> (std::lround (kRefMasterWidth * scale)));
+
+    const auto totalWidth = [&]
+    {
+        return g.budgetedChannels * g.channelWidth
+             + SessionLayout::kNumBuses * g.busWidth
+             + g.masterWidth
+             + fixedGapCount * g.stripGap
+             + 2 * g.sectionGap;
+    };
+    const auto overflow = [&] { return std::max (0, totalWidth() - areaWidth); };
+    auto reduceRepeated = [&] (int& value, int count, int floor)
+    {
+        const int excess = overflow();
+        if (excess <= 0 || count <= 0 || value <= floor) return;
+        const int perItem = std::min (value - floor, (excess + count - 1) / count);
+        value -= perItem;
+    };
+
+    // Normal fit: retain all control-size floors.
+    reduceRepeated (g.channelWidth, g.budgetedChannels, kMinChannelWidth);
+    reduceRepeated (g.busWidth, SessionLayout::kNumBuses, kMinBusWidth);
+    reduceRepeated (g.masterWidth, 1, kMinMasterWidth);
+
+    // Defensive fit for native or scripted resizes that bypass the window
+    // constraint. Compact mode engages when the channel falls below its normal
+    // floor; preserving separation is more important than clipping controls.
+    reduceRepeated (g.channelWidth, g.budgetedChannels, 1);
+    reduceRepeated (g.busWidth, SessionLayout::kNumBuses, 1);
+    reduceRepeated (g.masterWidth, 1, 1);
+    reduceRepeated (g.sectionGap, 2, 0);
+    reduceRepeated (g.stripGap, fixedGapCount, 0);
+    reduceRepeated (g.channelWidth, g.budgetedChannels, 0);
+    reduceRepeated (g.busWidth, SessionLayout::kNumBuses, 0);
+    reduceRepeated (g.masterWidth, 1, 0);
+
+    const int busColumnWidth = SessionLayout::kNumBuses * g.busWidth
+                             + (SessionLayout::kNumBuses - 1) * g.stripGap;
+    const int rightColumnWidth = busColumnWidth + g.sectionGap + g.masterWidth;
+    g.busColumnLeft = g.contentRight - rightColumnWidth;
+    g.lastChannelRight = g.contentLeft
+                       + g.visibleChannels * g.channelWidth
+                       + std::max (0, g.visibleChannels - 1) * g.stripGap;
+    return g;
+}
+} // namespace duskstudio::consolelayout

--- a/src/ui/ConsoleView.cpp
+++ b/src/ui/ConsoleView.cpp
@@ -41,38 +41,14 @@ ConsoleView::ConsoleView (Session& session, AudioEngine& engine) : sessionRef (s
     updateBankVisibility();
 }
 
-int ConsoleView::minimumContentWidth()
+int ConsoleView::allTracksContentWidth() const
 {
-    // Floor: at least ONE channel strip + buses + master + their gaps.
-    // Narrower than this and the layout has no useful state to land in;
-    // MainWindow's resize limit takes the larger of this and the OS
-    // minimum, so the user can't drag the window below it.
-    const int gaps = kSectionGap
-                   + (Session::kNumBuses - 1) * kStripGap
-                   + kSectionGap;
-    return /*one channel*/ kMinChannelWidth
-         + Session::kNumBuses * kMinBusWidth
-         + kMinMasterWidth
-         + gaps
-         + 12;  // outer padding
-}
-
-int ConsoleView::fixedWidthFor16Tracks() const
-{
-    // Width at which all 16 strips fit at the MINIMUM strip width with
+    // Width at which all 24 strips fit at the MINIMUM strip width with
     // buses + master at their MIN widths. Above this we drop banking
     // entirely and show every track at once. Using min (not ref) makes
-    // "show all 16" trigger as aggressively as the layout allows
+    // "show all" trigger as aggressively as the layout allows
     // without violating the no-shrink-below-kMin rule.
-    const int gaps = (Session::kNumTracks - 1) * kStripGap
-                   + kSectionGap
-                   + (Session::kNumBuses - 1) * kStripGap
-                   + kSectionGap;
-    return Session::kNumTracks * kMinChannelWidth
-         + Session::kNumBuses * kMinBusWidth
-         + kMinMasterWidth
-         + gaps
-         + 12;
+    return consolelayout::allTracksContentWidth();
 }
 
 int ConsoleView::channelsThatFitForWidth (int componentWidth) noexcept
@@ -81,26 +57,7 @@ int ConsoleView::channelsThatFitForWidth (int componentWidth) noexcept
     // right) and their inter-strip + section gaps. Divide by the
     // per-channel slot (strip + gap) to get the count.
     //
-    // Lower bound is ceil(kNumTracks / kMaxBanks) so the resulting bank
-    // count never exceeds kMaxBanks. Without this, a snap-narrow window
-    // could produce 6-16 bank buttons (16 tracks / 3-1 per bank),
-    // overflowing the bank-row UI. Going wider than the strip's natural
-    // min on a very narrow window is the lesser evil.
-    constexpr int kMaxBanks = 4;
-    constexpr int kMinStride = (Session::kNumTracks + kMaxBanks - 1) / kMaxBanks;
-    const int outerPad  = 12;
-    const int rightCol  = Session::kNumBuses * kMinBusWidth
-                        + (Session::kNumBuses - 1) * kStripGap
-                        + kSectionGap     // gap between channels and buses
-                        + kSectionGap     // gap between buses and master
-                        + kMinMasterWidth;
-    const int avail     = std::max (0, componentWidth - outerPad - rightCol);
-    // Per-strip slot = strip width + inter-channel gap. We add one gap
-    // back so the LAST strip doesn't reserve a trailing gap.
-    const int perSlot   = kMinChannelWidth + kStripGap;
-    if (perSlot <= 0 || avail <= 0) return kMinStride;
-    const int fit = (avail + kStripGap) / perSlot;
-    return std::clamp (fit, kMinStride, Session::kNumTracks);
+    return consolelayout::channelsThatFitForWidth (componentWidth);
 }
 
 int ConsoleView::channelsThatFit() const
@@ -110,14 +67,18 @@ int ConsoleView::channelsThatFit() const
 
 int ConsoleView::numBanksForWidth (int componentWidth) noexcept
 {
-    const int fit = channelsThatFitForWidth (componentWidth);
-    if (fit >= Session::kNumTracks) return 1;
-    return (Session::kNumTracks + fit - 1) / fit;
+    return consolelayout::screenPageCountForWidth (componentWidth);
 }
 
 int ConsoleView::numBanks() const noexcept
 {
     return numBanksForWidth (getWidth());
+}
+
+void ConsoleView::synchroniseBankStateForWidth (int componentWidth) noexcept
+{
+    bankState.resize (numBanksForWidth (componentWidth),
+                      channelsThatFitForWidth (componentWidth));
 }
 
 int ConsoleView::bankStride() const noexcept
@@ -128,10 +89,7 @@ int ConsoleView::bankStride() const noexcept
 std::pair<int, int> ConsoleView::rangeForBankAtWidth (int bankIndex,
                                                         int componentWidth) noexcept
 {
-    const int stride = channelsThatFitForWidth (componentWidth);
-    const int first  = bankIndex * stride;
-    const int last   = std::min (Session::kNumTracks - 1, first + stride - 1);
-    return { first + 1, last + 1 };
+    return consolelayout::channelRangeForPage (bankIndex, componentWidth);
 }
 
 std::pair<int, int> ConsoleView::rangeForBank (int bankIndex) const noexcept
@@ -203,18 +161,17 @@ void ConsoleView::resized()
 {
     auto area = getLocalBounds().reduced (6);
 
-    // "Show all 16" trigger: window wide enough to seat every channel
+    // "Show all" trigger: window wide enough to seat every channel
     // strip at kMinChannelWidth alongside the always-anchored bus +
     // master column. Below this we fall back to dynamic banking - bank
     // stride = channelsThatFit().
-    showingAllTracks = (area.getWidth() >= fixedWidthFor16Tracks() - 12);
+    showingAllTracks = (getWidth() >= allTracksContentWidth());
 
     const int stride = bankStride();
-    const int pages  = numBanks();
     // Re-derives the page against the new width and queues any surface move it
     // implies for the poll tick. Publishes nothing itself - a drag-resize
     // storing mcu.bank here would swallow a Bank Left/Right press.
-    bankState.resize (pages, stride);
+    synchroniseBankStateForWidth (getWidth());
     updateBankVisibility();
 
     int visibleChannels;
@@ -230,9 +187,10 @@ void ConsoleView::resized()
         visibleChannels = std::min (stride, Session::kNumTracks - firstIdx);
     }
 
-    // Channels stay at *reference* width unless even that won't fit - in which
-    // case we scale down, but only as far as the per-strip minimum. We do not
-    // scale up: extra horizontal space stays as whitespace on the right.
+    // Channels stay at *reference* width unless even that won't fit. The shared
+    // geometry then compacts them as needed, including below the documented
+    // per-strip floor at legal responsive widths. We do not scale up: extra
+    // horizontal space stays as whitespace on the right.
     //
     // Scale based on the FULL-BANK width (stride * kRefChannelWidth) rather
     // than visibleChannels - so a sparse last bank uses the SAME channel
@@ -240,86 +198,11 @@ void ConsoleView::resized()
     // be wider than bank 1 with 14 strips on the same window: bank 2's
     // refTotal would fit and skip the scale-down branch.
     const int widthRefChannels = showingAllTracks ? Session::kNumTracks : stride;
-    const int gaps = (widthRefChannels - 1) * kStripGap
-                   + kSectionGap
-                   + (Session::kNumBuses - 1) * kStripGap
-                   + kSectionGap;
-    const int availForStrips = std::max (0, area.getWidth() - gaps);
-    const int refTotal = widthRefChannels * kRefChannelWidth
-                       + Session::kNumBuses * kRefBusWidth
-                       + kRefMasterWidth;
-
-    int channelW = kRefChannelWidth;
-    int busW     = kRefBusWidth;
-    int masterW  = kRefMasterWidth;
-
-    if (availForStrips < refTotal)
-    {
-        // Window is narrower than the reference - shrink proportionally.
-        const float scale = (float) availForStrips / (float) refTotal;
-        channelW = std::max (kMinChannelWidth, (int) std::round (kRefChannelWidth * scale));
-        busW     = std::max (kMinBusWidth,     (int) std::round (kRefBusWidth     * scale));
-        masterW  = std::max (kMinMasterWidth,  (int) std::round (kRefMasterWidth  * scale));
-
-        // Secondary fit-to-budget pass: if the kMin floors pushed total
-        // above availForStrips, shrink CHANNELS first (they have the most
-        // budget and channel-strip widgets tolerate cramping better than
-        // the master's 5-knob comp row). Only spill into bus + master
-        // shrinks once channels can't compress any further. Master is
-        // protected the longest because its 5 × 40 px comp knob row will
-        // clip the rightmost knob the instant the strip goes below 210.
-        // Secondary fit pass uses widthRefChannels (the bank-stride
-        // budget) - same reason as the primary scale: width stays
-        // stable across banks regardless of how many strips are
-        // visible RIGHT NOW.
-        const auto totalOf = [&]
-        {
-            return widthRefChannels * channelW
-                 + Session::kNumBuses * busW
-                 + masterW;
-        };
-        if (totalOf() > availForStrips)
-        {
-            int overflow = totalOf() - availForStrips;
-            // Step 1: shrink channels (floor 1 px).
-            if (overflow > 0 && widthRefChannels > 0)
-            {
-                const int channelGiveable = std::max (0, channelW - 1);
-                // Ceiling division so the per-channel shrink covers the
-                // remainder without the extra +1 that overshoots when
-                // overflow divides evenly.
-                const int eachReducible   = std::min (
-                    (overflow + widthRefChannels - 1) / widthRefChannels,
-                    channelGiveable);
-                channelW -= eachReducible;
-                overflow = totalOf() - availForStrips;
-            }
-            // Step 2: shrink buses if channels couldn't absorb everything.
-            if (overflow > 0 && Session::kNumBuses > 0)
-            {
-                const int busGiveable   = std::max (0, busW - 1);
-                const int eachReducible = std::min (
-                    (overflow + Session::kNumBuses - 1) / Session::kNumBuses,
-                    busGiveable);
-                busW -= eachReducible;
-                overflow = totalOf() - availForStrips;
-            }
-            // Step 3: as a last resort, shrink master (the comp row will
-            // start clipping past here).
-            if (overflow > 0)
-                masterW = std::max (1, masterW - overflow);
-        }
-        // After all three steps, channelW / busW / masterW are clamped
-        // to a minimum of 1 via std::max, so totalOf() can still
-        // exceed availForStrips in pathologically narrow windows
-        // (visibleChannels + Session::kNumBuses + 1 px per strip is
-        // the hard floor). That case is treated as a window-sizing
-        // bug; minimumContentWidth() returns the threshold below
-        // which the OS-enforced resize floor should never let the
-        // user drag the window, so we don't add a runtime guard here.
-        // If you see this trigger at runtime, raise the resize-limit
-        // floor in MainWindow rather than papering over it in layout.
-    }
+    const auto geometry = consolelayout::makeStripGeometry (
+        getWidth(), widthRefChannels, visibleChannels);
+    const int channelW = geometry.channelWidth;
+    const int busW     = geometry.busWidth;
+    const int masterW  = geometry.masterWidth;
 
     const int y = area.getY();
     const int h = area.getHeight();
@@ -329,12 +212,7 @@ void ConsoleView::resized()
     // room sits as a flex gap between the channel column and the bus
     // column. Sparse last banks therefore show the strips left-aligned
     // (visible space to the right) rather than stretching widths.
-    const int busColW = Session::kNumBuses * busW
-                      + (Session::kNumBuses - 1) * kStripGap;
-    const int rightColW = busColW + kSectionGap + masterW;
-    const int rightColX = area.getRight() - rightColW;
-
-    int x = area.getX();
+    int x = geometry.contentLeft;
     for (int i = 0; i < visibleChannels; ++i)
     {
         const int trackIdx = showingAllTracks
@@ -342,16 +220,16 @@ void ConsoleView::resized()
                               : (bankState.screenBank * stride + i);
         if (trackIdx >= Session::kNumTracks) break;
         strips[(size_t) trackIdx]->setBounds (x, y, channelW, h);
-        x += channelW + (i + 1 < visibleChannels ? kStripGap : 0);
+        x += channelW + (i + 1 < visibleChannels ? geometry.stripGap : 0);
     }
 
-    x = rightColX;
+    x = geometry.busColumnLeft;
     for (int i = 0; i < Session::kNumBuses; ++i)
     {
         busStrips[(size_t) i]->setBounds (x, y, busW, h);
-        x += busW + (i + 1 < Session::kNumBuses ? kStripGap : 0);
+        x += busW + (i + 1 < Session::kNumBuses ? geometry.stripGap : 0);
     }
-    x += kSectionGap;
+    x += geometry.sectionGap;
     masterStrip->setBounds (x, y, masterW, h);
 
     // Auto-engage TIMELINE when the strip's vertical space is too short for
@@ -426,7 +304,7 @@ void ConsoleView::focusStrip (int track)
     if (! showingAllTracks)
     {
         const int stride = bankStride();
-        if (stride > 0) setBank (track / stride);
+        if (stride > 0) setBank (screenBankForTrack (track, stride, numBanks()));
     }
     repaint();
     if (stripFocusCb) stripFocusCb (track);

--- a/src/ui/ConsoleView.h
+++ b/src/ui/ConsoleView.h
@@ -6,6 +6,7 @@
 #include <functional>
 #include <memory>
 #include "BankMapping.h"
+#include "ConsoleLayout.h"
 #include "BusComponent.h"
 #include "ChannelStripComponent.h"
 #include "MasterStripComponent.h"
@@ -36,19 +37,19 @@ public:
     int  getFocusedStrip() const noexcept { return focusedStrip; }
 
     // Min: VCA comp's "513 ms" / "0.2 ms" textboxes don't clip.
-    static constexpr int kMinChannelWidth = 154;
+    static constexpr int kMinChannelWidth = consolelayout::kMinChannelWidth;
     // Min: single-row 4-knob COMP labels ("4.0:1", "AUTO", "10.0") fit.
-    static constexpr int kMinBusWidth     = 172;
+    static constexpr int kMinBusWidth     = consolelayout::kMinBusWidth;
     // Min: with the Pultec HF split across two 2-cell rows, the widest EQ row
     // is the LF 3-cell row; "HF− ATTEN FREQ" now gets a half-strip cell so the
     // floor drops well below the old 4-cell-row constraint.
-    static constexpr int kMinMasterWidth  = 210;
+    static constexpr int kMinMasterWidth  = consolelayout::kMinMasterWidth;
 
     // Ref widths add ~25 px so "VCA 513 ms" / "HF BOOST FREQ" labels
     // never clip in the comfortable-default layout.
-    static constexpr int kRefChannelWidth = 188;
-    static constexpr int kRefBusWidth     = 192;
-    static constexpr int kRefMasterWidth  = 260;
+    static constexpr int kRefChannelWidth = consolelayout::kRefChannelWidth;
+    static constexpr int kRefBusWidth     = consolelayout::kRefBusWidth;
+    static constexpr int kRefMasterWidth  = consolelayout::kRefMasterWidth;
 
     // Auto-compact triggers (TIMELINE mode independent of user toggle):
     //   Height: the recording-stage module stack leaves about 185 px of
@@ -58,13 +59,11 @@ public:
     static constexpr int kAutoCompactStripHeight = 820;
     static constexpr int kAutoCompactChannelWidth = 110;
 
-    static constexpr int kStripGap     = 4;
-    static constexpr int kSectionGap   = 12;
-
-    static int minimumContentWidth();
+    static constexpr int kStripGap     = consolelayout::kStripGap;
+    static constexpr int kSectionGap   = consolelayout::kSectionGap;
 
     // Above this width we drop banking and show all 24 strips.
-    int fixedWidthFor16Tracks() const;
+    int allTracksContentWidth() const;
 
     // Strips that fit at kMinChannelWidth given current width. Buses +
     // master always reserved. Capped at kNumTracks.
@@ -81,6 +80,10 @@ public:
     int  bankStride()  const noexcept;
 
     static int numBanksForWidth (int componentWidth) noexcept;
+
+    // MainComponent calls this before laying out page buttons and timeline
+    // rows, so both observe the page normalised for the incoming width.
+    void synchroniseBankStateForWidth (int componentWidth) noexcept;
 
     // Inclusive 1-based range (e.g. {1, 13} for first bank when
     // stride==13). Used by the dynamic bank-button row.

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -46,6 +46,7 @@
 #include "../engine/DpAligner.h"
 #include "../engine/audiofile/FileReader.h"
 #include "../engine/audiofile/FileWriter.h"
+#include "../foundation/Text.h"
 #include <algorithm>
 
 namespace duskstudio
@@ -703,7 +704,7 @@ MainComponent::MainComponent()
     refreshSnapUi();
 
     // Bank-button row is rebuilt by syncBankButtons() each layout pass
-    // (visible only when the window can't fit all 16 strips at min
+    // (visible only when the window can't fit all 24 strips at min
     // width). Sits on a row directly below the stage selector so the
     // channel strips inside ConsoleView get the full body height.
 
@@ -804,7 +805,7 @@ MainComponent::MainComponent()
         h = std::min (kPreferredH, userArea.getHeight() - 24);
     }
 
-    const int minContentW = ConsoleView::minimumContentWidth() + 16;  // + outer padding
+    const int minContentW = consolelayout::responsiveMinimumMainComponentWidth();
     const int minContentH = 480 + kTopBarH;
     w = std::max (w, minContentW);
     h = std::max (h, minContentH);
@@ -1097,14 +1098,14 @@ bool MainComponent::keyPressed (const juce::KeyPress& key)
         return true;
     }
 
-    // Bank switching: plain 1/2/3/4 select the visible channel bank. Maps to
+    // Bank switching: plain 1 through 8 select the visible channel page. Maps to
     // ConsoleView::setBank which also publishes the active bank to the audio
     // thread so bank-relative MIDI bindings retarget. Out-of-range digits (more
     // banks than the window currently shows) fall through unhandled.
     if (noMods && consoleView != nullptr)
     {
-        const int bankIndex = (code >= '1' && code <= '4') ? (code - '1') : -1;
-        if (bankIndex >= 0 && bankIndex < consoleView->numBanks())
+        const int bankIndex = screenPageForDigitKey (code, consoleView->numBanks());
+        if (bankIndex >= 0)
         {
             consoleView->setBank (bankIndex);
             return true;
@@ -1580,11 +1581,9 @@ void MainComponent::syncBankButtons (int desiredCount)
         {
             if (consoleView != nullptr) consoleView->setBank (idx);
         };
-        // Banks 1-4 are reachable via the plain number keys 1/2/3/4 (see keyPressed).
-        juce::String hint;
-        if (idx < 4)
-            hint = "  (press " + juce::String (idx + 1) + ")";
-        btn->setTooltip ("Channel bank " + juce::String (idx + 1) + hint);
+        // Every possible screen page is reachable through the plain digits 1-8.
+        btn->setTooltip (dusk::text::format ("Channel page %d (press %d)",
+                                             idx + 1, idx + 1));
         addAndMakeVisible (btn.get());
         bankButtons.push_back (std::move (btn));
     }
@@ -1709,7 +1708,7 @@ void MainComponent::resized()
 
     // Banking decision: ConsoleView reports how many channel strips fit
     // alongside the always-anchored bus + master column at min width.
-    // When all 16 fit we render NO bank buttons (numBanks == 1). When
+    // When all 24 fit we render NO bank buttons (numBanks == 1). When
     // they don't fit, we render one button per bank with the actual
     // 1-based range as the label ("1-13", "14-16", etc.) - bank size
     // tracks the window width, not a fixed stride of 8.
@@ -1720,6 +1719,8 @@ void MainComponent::resized()
     // render labels one frame stale (showed "1-6" with only 3 strips
     // visible).
     const int consoleTargetWidth = area.getWidth();
+    if (consoleView != nullptr && ! inFullscreenView)
+        consoleView->synchroniseBankStateForWidth (consoleTargetWidth);
     const int numBanks = (consoleView != nullptr && ! inFullscreenView)
                             ? ConsoleView::numBanksForWidth (consoleTargetWidth) : 1;
     const bool needsBanking = numBanks > 1;
@@ -1729,8 +1730,8 @@ void MainComponent::resized()
     // (now centered) transport cluster at the OS minimum window width.
     const int stageW = transportCompact ? 92 : 110;
     const int stageBlockW = stageW * 4;
-    const int  kBankBtnW   = transportCompact ? 70 : 100;
-    constexpr int kBankBtnGap = 6;
+    const int preferredBankBtnW = transportCompact ? 70 : 100;
+    constexpr int preferredBankBtnGap = 6;
     constexpr int kBankBtnH  = 26;
 
     // Stage selector lives in the TOP menu row, centered between the File /
@@ -1784,14 +1785,26 @@ void MainComponent::resized()
 
     syncBankButtons (needsBanking ? numBanks : 0);
     const int bankY = rowBounds.getY() + (rowBounds.getHeight() - kBankBtnH) / 2;
-    const int bankClusterW = needsBanking
-                           ? (numBanks * kBankBtnW + (numBanks - 1) * kBankBtnGap) : 0;
-
     const int clockRight = rowBounds.getX()
                          + (transportBar != nullptr ? transportBar->getClockRightX() : 0);
-    const int tunerLeft  = rowBounds.getX()
-                         + (transportBar != nullptr ? transportBar->getTunerLeftX()
+    const int utilityLeft = rowBounds.getX()
+                         + (transportBar != nullptr ? transportBar->getUtilityClusterLeftX()
                                                       : rowBounds.getWidth());
+    const int bankBandLeft  = clockRight + 12;
+    const int bankBandRight = utilityLeft - 12;
+    const int bankBandW = std::max (0, bankBandRight - bankBandLeft);
+
+    // Up to eight three-strip pages can exist at the minimum window width.
+    // Fit their buttons inside the actual clock-to-tuner band: reduce the gap
+    // first, then the button width. Labels below follow the resulting width.
+    const auto pageButtons = needsBanking
+                           ? consolelayout::fitPageButtons (bankBandW, numBanks,
+                                                            preferredBankBtnW,
+                                                            preferredBankBtnGap)
+                           : consolelayout::PageButtonMetrics {};
+    const int bankBtnGap = pageButtons.gap;
+    const int bankBtnW = pageButtons.width;
+    const int bankClusterW = pageButtons.clusterWidth;
 
     // The toolbar joins the group only with the tape strip open AND when the
     // combined group still fits between the clock and the BPM / tuner cluster.
@@ -1802,7 +1815,7 @@ void MainComponent::resized()
     {
         const int combinedW = bankClusterW + (needsBanking ? kBankToolbarGap : 0) + kHdrClusterW;
         const int gX = std::max (clockRight + 12, stageCentreX - combinedW / 2);
-        if (gX + combinedW <= tunerLeft - 12)
+        if (gX + combinedW <= utilityLeft - 12)
         {
             toolbarVisible = true;
             groupW = combinedW;
@@ -1810,7 +1823,9 @@ void MainComponent::resized()
     }
 
     // Centre the group under the stage selector, clamped past the clock.
-    const int groupX = std::max (clockRight + 12, stageCentreX - groupW / 2);
+    const int groupX = std::clamp (stageCentreX - groupW / 2,
+                                   bankBandLeft,
+                                   std::max (bankBandLeft, bankBandRight - groupW));
 
     if (needsBanking && consoleView != nullptr)
     {
@@ -1820,14 +1835,20 @@ void MainComponent::resized()
         {
             auto* btn = bankButtons[(size_t) i].get();
             const auto range = ConsoleView::rangeForBankAtWidth (i, consoleTargetWidth);
-            btn->setButtonText (transportCompact
-                                  ? (juce::String (range.first) + "-" + juce::String (range.second))
-                                  : (juce::String ("BANK ") + juce::String (i + 1) + "  ("
-                                       + juce::String (range.first) + "-"
-                                       + juce::String (range.second) + ")"));
-            btn->setBounds (bankX, bankY, kBankBtnW, kBankBtnH);
+            std::string label;
+            if (bankBtnW >= 90 && ! transportCompact)
+                label = dusk::text::format ("BANK %d  (%d-%d)", i + 1, range.first, range.second);
+            else if (bankBtnW >= 44)
+                label = dusk::text::format ("%d-%d", range.first, range.second);
+            else
+                label = dusk::text::format ("%d", i + 1);
+            btn->setButtonText (label);
+            btn->setTooltip (dusk::text::format (
+                "Channel page %d: channels %d-%d (press %d)",
+                i + 1, range.first, range.second, i + 1));
+            btn->setBounds (bankX, bankY, bankBtnW, kBankBtnH);
             btn->setToggleState (i == activeBank, juce::dontSendNotification);
-            bankX += kBankBtnW + kBankBtnGap;
+            bankX += bankBtnW + bankBtnGap;
         }
     }
 

--- a/src/ui/MainComponent.h
+++ b/src/ui/MainComponent.h
@@ -230,7 +230,7 @@ private:
     juce::TextButton auxStageBtn       { "AUX" };
     juce::TextButton masteringStageBtn { "MASTERING" };
 
-    // Rebuilt by syncBankButtons to match ConsoleView::numBanks() (1..16).
+    // Rebuilt by syncBankButtons to match ConsoleView::numBanks() (1..8).
     // All hidden when console shows every track at once (numBanks==1).
     // Lives here (not in ConsoleView) so the row sits below the stage
     // selector and freed vertical space inside the console goes to

--- a/src/ui/ShortcutsPanel.h
+++ b/src/ui/ShortcutsPanel.h
@@ -31,8 +31,9 @@ public:
             { "Stages", {
                 { mod ('1'), "Recording" }, { mod ('2'), "Mixing" },
                 { mod ('3'), "Mastering" }, { mod ('4'), "Aux" } } },
-            { "Channel banks", {
-                { "1", "Bank 1" }, { "2", "Bank 2" }, { "3", "Bank 3" }, { "4", "Bank 4" } } },
+            { "Channel pages", {
+                { "1", "Page 1" }, { "2", "Page 2" }, { "3", "Page 3" }, { "4", "Page 4" },
+                { "5", "Page 5" }, { "6", "Page 6" }, { "7", "Page 7" }, { "8", "Page 8" } } },
             { "Transport", {
                 { "Space", "Play / Stop" }, { "R", "Record" },
                 { "Home", "Playhead to start" }, { ".", "Stop + rewind to start" },

--- a/src/ui/TapeStrip.cpp
+++ b/src/ui/TapeStrip.cpp
@@ -789,7 +789,7 @@ void TapeStrip::resized()
 void TapeStrip::timerCallback()
 {
     // Detect track color / name changes and repaint the whole strip if
-    // anything changed. Cheap - there are 16 tracks and we just compare
+    // anything changed. Cheap - there are 24 tracks and we just compare
     // a String + a Colour each tick.
     bool stateChanged = false;
     bool namesChanged = false;

--- a/src/ui/TransportBar.h
+++ b/src/ui/TransportBar.h
@@ -64,14 +64,18 @@ public:
     // left by ~376 px in expanded mode and ~280 px in compact mode.
     int getTunerLeftX() const noexcept { return tuneButton.getX(); }
 
+    // Left edge of the complete right-side utility cluster. The notepad sits
+    // immediately before the tuner, so overlays must stop here rather than at
+    // the tuner itself.
+    int getUtilityClusterLeftX() const noexcept { return notepadButton.getX(); }
+
     // MainComponent clamps the centered stage-tab overlay against this
     // so RECORDING/MIXING/MASTERING/AUX never slide left over the clock.
     int getClockRightX() const noexcept { return clockLabel.getRight(); }
 
-    // Below this width SNAP->S, TIMELINE->chevron, clock shrinks,
-    // MainComponent's bank overlay shrinks to match. Calibrated to
-    // fire just above the OS-enforced resize floor (~1790 px) - the
-    // previous 1600 never triggered.
+    // Below this width SNAP->S, TIMELINE->chevron, the clock shrinks, and
+    // MainComponent's bank overlay uses its compact layout so the transport
+    // and centered overlay keep clear of each other as the window narrows.
     static constexpr int kCompactTransportWidth = 1850;
 
     // After engine.stop() drains, RecordManager populates

--- a/tests/console_bank_mapping.cpp
+++ b/tests/console_bank_mapping.cpp
@@ -1,10 +1,11 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "ui/BankMapping.h"
+#include "ui/ConsoleLayout.h"
 
 using namespace duskstudio;
 
-// Screen pages are bankStride()-wide (channelsThatFit(), clamped to [6, 24]);
+// Screen pages are bankStride()-wide (channelsThatFit(), clamped to [3, 24]);
 // hardware banks are always kBankSize-wide and there are always kNumBanks of
 // them. Each case below names the page's first track, which is what decides
 // the hardware bank it resolves to.
@@ -147,12 +148,8 @@ TEST_CASE ("Bank mapping: indices past the end of a range clamp into it", "[cons
 TEST_CASE ("Bank mapping: the widest page count the console builds stays in range",
            "[console][bank]")
 {
-    // channelsThatFitForWidth floors the stride at ceil(kNumTracks / 4), so the
-    // console can build a 4th page. Stored raw, that page index names a bank
-    // that does not exist: past kNumBanks for the surface, and past kNumTracks
-    // once the audio thread multiplies it by kBankSize.
-    constexpr int kNarrowestStride = 6;
-    constexpr int kMostPages       = 4;
+    constexpr int kNarrowestStride = consolelayout::kMinStride;
+    constexpr int kMostPages       = consolelayout::kMaxScreenPages;
 
     for (int page = 0; page < kMostPages; ++page)
     {
@@ -164,6 +161,141 @@ TEST_CASE ("Bank mapping: the widest page count the console builds stays in rang
     }
 
     REQUIRE (hardwareBankForScreenBank (kMostPages - 1, kNarrowestStride) == 2);
+}
+
+TEST_CASE ("Console layout: default width preserves the channel minimum",
+           "[console][layout]")
+{
+    // A 1440 px MainComponent gives the console the local width minus its
+    // 8 px outer inset on both sides.
+    constexpr int kDefaultConsoleWidth = 1440 - 16;
+    REQUIRE (consolelayout::channelsThatFitForWidth (kDefaultConsoleWidth) == 3);
+    REQUIRE (consolelayout::screenPageCountForWidth (kDefaultConsoleWidth) == 8);
+}
+
+TEST_CASE ("Console layout: full-floor page width preserves every documented minimum",
+           "[console][layout]")
+{
+    constexpr int width = consolelayout::fullFloorPageContentWidth();
+    REQUIRE (consolelayout::channelsThatFitForWidth (width) == consolelayout::kMinStride);
+    REQUIRE (width == consolelayout::kMinStride * consolelayout::kMinChannelWidth
+                   + (consolelayout::kMinStride - 1) * consolelayout::kStripGap
+                   + consolelayout::rightColumnWidth()
+                   + consolelayout::kOuterPadding);
+
+    const auto geometry = consolelayout::makeStripGeometry (
+        width, consolelayout::kMinStride, consolelayout::kMinStride);
+    REQUIRE (geometry.channelWidth >= consolelayout::kMinChannelWidth);
+    REQUIRE (geometry.busWidth >= consolelayout::kMinBusWidth);
+    REQUIRE (geometry.masterWidth >= consolelayout::kMinMasterWidth);
+    REQUIRE (geometry.channelsClearBus());
+    REQUIRE (geometry.lastChannelRight + consolelayout::kSectionGap
+             == geometry.busColumnLeft);
+}
+
+TEST_CASE ("Console layout: forced sub-minimum bounds never overlap Bus 1",
+           "[console][layout]")
+{
+    constexpr int forcedWidth = consolelayout::fullFloorPageContentWidth() - 64;
+    const auto geometry = consolelayout::makeStripGeometry (
+        forcedWidth, consolelayout::kMinStride, consolelayout::kMinStride);
+
+    REQUIRE (geometry.channelWidth < consolelayout::kMinChannelWidth);
+    REQUIRE (geometry.channelsClearBus());
+    REQUIRE (geometry.lastChannelRight + geometry.sectionGap
+             <= geometry.busColumnLeft);
+}
+
+TEST_CASE ("Console layout: eight narrow pages cover every channel exactly",
+           "[console][layout]")
+{
+    constexpr int width = consolelayout::fullFloorPageContentWidth();
+    const std::pair<int, int> expected[] = {
+        { 1, 3 }, { 4, 6 }, { 7, 9 }, { 10, 12 },
+        { 13, 15 }, { 16, 18 }, { 19, 21 }, { 22, 24 }
+    };
+
+    REQUIRE (consolelayout::screenPageCountForWidth (width) == 8);
+    for (int page = 0; page < 8; ++page)
+        REQUIRE (consolelayout::channelRangeForPage (page, width) == expected[page]);
+}
+
+TEST_CASE ("Console layout: responsive window floor keeps three strips clear of Bus 1",
+           "[console][layout]")
+{
+    constexpr int mainWidth = consolelayout::responsiveMinimumMainComponentWidth();
+    constexpr int consoleWidth = consolelayout::responsiveMinimumContentWidth();
+    static_assert (mainWidth == consoleWidth + consolelayout::kMainPadding * 2);
+    static_assert (mainWidth == 1162);
+
+    const auto geometry = consolelayout::makeStripGeometry (
+        consoleWidth, consolelayout::kMinStride, consolelayout::kMinStride);
+    REQUIRE (consolelayout::screenPageCountForWidth (consoleWidth) == 8);
+    REQUIRE (geometry.channelsClearBus());
+    REQUIRE (geometry.lastChannelRight + geometry.sectionGap
+             <= geometry.busColumnLeft);
+
+    const int bandWidth = consolelayout::compactPageButtonBandWidthForMainWidth (mainWidth);
+    const auto buttons = consolelayout::fitPageButtons (bandWidth, 8, 70, 6);
+    REQUIRE (bandWidth == consolelayout::minimumPageButtonBandWidth());
+    REQUIRE (buttons.width == consolelayout::kMinPageButtonWidth);
+    REQUIRE (buttons.gap == consolelayout::kMinPageButtonGap);
+    REQUIRE (buttons.fits (bandWidth));
+}
+
+TEST_CASE ("Console layout: 1366 display startup stays screen-fit and usable",
+           "[console][layout]")
+{
+    constexpr int displayWidth = 1366;
+    constexpr int mainTargetWidth = displayWidth - 24;
+    constexpr int consoleTargetWidth = mainTargetWidth - consolelayout::kMainPadding * 2;
+    static_assert (mainTargetWidth == 1342);
+    static_assert (consoleTargetWidth == 1326);
+
+    REQUIRE (consolelayout::responsiveMinimumMainComponentWidth() <= mainTargetWidth);
+    REQUIRE (consolelayout::screenPageCountForWidth (consoleTargetWidth) == 8);
+
+    const auto geometry = consolelayout::makeStripGeometry (
+        consoleTargetWidth, consolelayout::kMinStride, consolelayout::kMinStride);
+    REQUIRE (geometry.channelsClearBus());
+    REQUIRE (geometry.lastChannelRight + geometry.sectionGap
+             <= geometry.busColumnLeft);
+
+    const int bandWidth = consolelayout::compactPageButtonBandWidthForMainWidth (mainTargetWidth);
+    const auto buttons = consolelayout::fitPageButtons (bandWidth, 8, 70, 6);
+    REQUIRE (bandWidth == 450);
+    REQUIRE (buttons.width >= consolelayout::kMinPageButtonWidth);
+    REQUIRE (buttons.fits (bandWidth));
+}
+
+TEST_CASE ("Bank mapping: every three-strip page resolves to its exact hardware bank",
+           "[console][bank]")
+{
+    constexpr int expected[] = { 0, 0, 0, 1, 1, 1, 2, 2 };
+    for (int page = 0; page < 8; ++page)
+        REQUIRE (hardwareBankForScreenBank (page, 3) == expected[page]);
+}
+
+TEST_CASE ("Bank mapping: focused tracks cross three-strip page boundaries",
+           "[console][bank]")
+{
+    REQUIRE (screenBankForTrack (0, 3, 8) == 0);
+    REQUIRE (screenBankForTrack (2, 3, 8) == 0);
+    REQUIRE (screenBankForTrack (3, 3, 8) == 1);
+    REQUIRE (screenBankForTrack (20, 3, 8) == 6);
+    REQUIRE (screenBankForTrack (21, 3, 8) == 7);
+    REQUIRE (screenBankForTrack (23, 3, 8) == 7);
+}
+
+TEST_CASE ("Bank mapping: plain digits select exactly pages one through eight",
+           "[console][bank]")
+{
+    for (int digit = '1'; digit <= '8'; ++digit)
+        REQUIRE (screenPageForDigitKey (digit, 8) == digit - '1');
+
+    REQUIRE (screenPageForDigitKey ('0', 8) == -1);
+    REQUIRE (screenPageForDigitKey ('9', 8) == -1);
+    REQUIRE (screenPageForDigitKey ('8', 7) == -1);
 }
 
 // The remaining cases drive ConsoleBankState the way the console does: a page
@@ -237,6 +369,47 @@ TEST_CASE ("Console bank state: a resize that only relocates the page queues the
     REQUIRE (c.activeBankAtom == 1);
     REQUIRE (c.state.lastKnownMcuBank == 1);
     REQUIRE (c.state.pendingMcuBank == -1);
+}
+
+TEST_CASE ("Console bank state: page eight normalises before a five-strip layout",
+           "[console][bank]")
+{
+    Console c;
+    c.pages = 8;
+    c.stride = 3;
+    c.pressPage (7);
+    REQUIRE (c.state.screenBank == 7);
+    REQUIRE (c.mcuBankAtom == 2);
+
+    // The selected page no longer exists. The fixed hardware bank survives,
+    // and its first track is immediately mapped into the new page geometry.
+    c.resizeTo (5, 5);
+    REQUIRE (c.state.screenBank == 3);
+    REQUIRE_FALSE (c.state.followsScreen);
+    REQUIRE (c.state.pendingMcuBank == -1);
+}
+
+TEST_CASE ("Console bank state: surface Bank Left and Right map at stride three",
+           "[console][bank]")
+{
+    Console c;
+    c.pages = 8;
+    c.stride = 3;
+
+    c.surfaceBankRight();
+    c.poll();
+    REQUIRE (c.activeBankAtom == 1);
+    REQUIRE (c.state.screenBank == 2);
+
+    c.surfaceBankRight();
+    c.poll();
+    REQUIRE (c.activeBankAtom == 2);
+    REQUIRE (c.state.screenBank == 5);
+
+    --c.mcuBankAtom;
+    c.poll();
+    REQUIRE (c.activeBankAtom == 1);
+    REQUIRE (c.state.screenBank == 2);
 }
 
 TEST_CASE ("Console bank state: a widen that destroys the page hands the bank to the surface",

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -71,7 +71,7 @@ src/ui/BounceDialog.cpp	45
 src/ui/BounceDialog.h	12
 src/ui/BusComponent.cpp	329
 src/ui/BusComponent.h	47
-src/ui/ChannelCompEditor.cpp	133
+src/ui/ChannelCompEditor.cpp	128
 src/ui/ChannelCompEditor.h	20
 src/ui/ChannelEqEditor.cpp	93
 src/ui/ChannelEqEditor.h	13
@@ -117,7 +117,7 @@ src/ui/ImportTargetPicker.cpp	97
 src/ui/ImportTargetPicker.h	11
 src/ui/Lv2PluginEditorComponent.cpp	3
 src/ui/Lv2PluginEditorComponent.h	4
-src/ui/MainComponent.cpp	467
+src/ui/MainComponent.cpp	458
 src/ui/MainComponent.h	57
 src/ui/MasterStripComponent.cpp	402
 src/ui/MasterStripComponent.h	59


### PR DESCRIPTION
## Summary
- centralize responsive console sizing and strip geometry so narrow windows retain usable faders without overlapping the bus/master columns
- allow three-channel screen pages at the minimum width, with up to eight compact page buttons and matching digit shortcuts
- keep screen pages synchronized with fixed eight-channel hardware banks across resize and navigation
- update the manual and add focused layout, page-button, geometry, and bank-mapping coverage

## Validation
- production and test builds
- serial CTest suite: 651/651 passed
- private-Xvfb application self-test
- responsive-layout screenshot harness and visual review
- de-JUCE gate: 179 files / 9239 uses, no new literal `juce::`
- `git diff --check`

Closes #115