### PR TITLE
perf: reduce hardware insert ping callback cost

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1623,7 +1623,7 @@ The status label shows one of:
 - `No input signal - check routing / device.` — the selected return input is unavailable or invalid, so capture cannot run.
 - `Ping failed - check level / cables.` — the return input is valid, but the capture was silent, too quiet, or contained no clear correlation peak.
 
-Measurement time varies with sample rate and block size; the tested range is roughly 1.0 seconds at 48 kHz and 1.3 seconds at 96 kHz with 64-sample blocks. Correlation is spread across audio callbacks so it stays within its processing budget; smaller buffers use more callbacks, with fractional work carried between them.
+Measurement time varies with sample rate and block size; the tested range is roughly 1.1 seconds at 48 kHz and 1.6 seconds at 96 kHz with 64-sample blocks. Correlation is spread across audio callbacks so it stays within its processing budget; smaller buffers use more callbacks, with fractional work carried between them.
 
 Run the ping after any change to your interface routing or your external gear's settings. There is no automatic re-ping on session load; you ping when you set up the insert and re-ping if anything in the chain changes.
 

--- a/src/dsp/HardwareInsertSlot.h
+++ b/src/dsp/HardwareInsertSlot.h
@@ -70,9 +70,10 @@ public:
     // chirpLength + kMaxDelaySamples, so the correlator's lag search
     // covers the full latency-slider range at any sample rate.
     static constexpr int kChirpMaxSamples   = 9600;
-    // Correlation budget in multiply-accumulates per second of audio. Credit
-    // follows callback duration, and each candidate lag consumes chirpLength MACs.
-    static constexpr double kCorrelationMacsPerSecond = 1.5e8;
+    // Match the original 48 kHz / 512-sample callback cost while keeping work
+    // proportional at higher rates and smaller blocks. Each lag consumes
+    // chirpLength MACs and fractional candidate credit carries between blocks.
+    static constexpr double kCorrelationMacsPerSecond = 1.15e8;
 
 private:
     const HardwareInsertParams* paramsRef = nullptr;

--- a/tests/hardware_insert.cpp
+++ b/tests/hardware_insert.cpp
@@ -320,7 +320,8 @@ namespace
 // the slot writes to device output ch 0 reappears on device input ch 0
 // exactly `loopDelay` samples later. Returns the measured pingResult.
 int runPingLoopback (double sampleRate, int loopDelay, int maxBlocks = 2000,
-                     int blockSize = kBlock, int* blocksUsed = nullptr)
+                     int blockSize = kBlock, int* blocksUsed = nullptr,
+                     float returnGain = 1.0f)
 {
     duskstudio::HardwareInsertParams params;
     setRouting (params, 0, 1, 0, 1, 0, 0);
@@ -343,8 +344,8 @@ int runPingLoopback (double sampleRate, int loopDelay, int maxBlocks = 2000,
     {
         for (int i = 0; i < blockSize; ++i)
         {
-            dev.inStore[0][(size_t) i] = loopL.front(); loopL.pop_front();
-            dev.inStore[1][(size_t) i] = loopR.front(); loopR.pop_front();
+            dev.inStore[0][(size_t) i] = returnGain * loopL.front(); loopL.pop_front();
+            dev.inStore[1][(size_t) i] = returnGain * loopR.front(); loopR.pop_front();
         }
         std::fill (L.begin(), L.end(), 0.0f);
         std::fill (R.begin(), R.end(), 0.0f);
@@ -365,6 +366,22 @@ int runPingLoopback (double sampleRate, int loopDelay, int maxBlocks = 2000,
     REQUIRE_FALSE (params.pingPending.load (std::memory_order_acquire));
     return params.pingResult.load (std::memory_order_relaxed);
 }
+
+int expectedPingBlocks (double sampleRate, int blockSize)
+{
+    const int chirpLength = std::max (64, std::min (
+        duskstudio::HardwareInsertSlot::kChirpMaxSamples,
+        (int) std::lround (0.100 * sampleRate)));
+    const int candidateCount = duskstudio::HardwareInsertSlot::kMaxDelaySamples + 1;
+    const int captureBlocks =
+        (chirpLength + candidateCount + blockSize - 1) / blockSize;
+    const double candidatesPerBlock =
+        duskstudio::HardwareInsertSlot::kCorrelationMacsPerSecond
+        * ((double) blockSize / sampleRate) / (double) chirpLength;
+    const int correlationBlocks =
+        (int) std::ceil ((double) candidateCount / candidatesPerBlock);
+    return captureBlocks + correlationBlocks;
+}
 } // namespace
 
 TEST_CASE ("HardwareInsertSlot: ping measures loopback round-trip exactly",
@@ -372,7 +389,9 @@ TEST_CASE ("HardwareInsertSlot: ping measures loopback round-trip exactly",
 {
     SECTION ("short round-trip, well under the chirp length")
     {
-        REQUIRE (runPingLoopback (48000.0, 700) == 700);
+        int blocksUsed = 0;
+        REQUIRE (runPingLoopback (48000.0, 700, 2000, kBlock, &blocksUsed) == 700);
+        REQUIRE (blocksUsed == expectedPingBlocks (48000.0, kBlock));
     }
     SECTION ("round-trip of a couple of device buffers")
     {
@@ -393,29 +412,51 @@ TEST_CASE ("HardwareInsertSlot: ping measures loopback round-trip exactly",
     {
         int blocksUsed = 0;
         REQUIRE (runPingLoopback (96000.0, 1500, 3000, 64, &blocksUsed) == 1500);
-        REQUIRE (blocksUsed > 1800);
-        REQUIRE (blocksUsed < 2300);
+        REQUIRE (blocksUsed == expectedPingBlocks (96000.0, 64));
     }
 
     SECTION ("fractional candidate credit does not overspend on tiny blocks")
     {
         constexpr double sampleRate = 96000.0;
         constexpr int blockSize = 4;
-        constexpr int chirpLength = duskstudio::HardwareInsertSlot::kChirpMaxSamples;
-        constexpr int candidateCount = duskstudio::HardwareInsertSlot::kMaxDelaySamples + 1;
-        constexpr double candidatesPerBlock =
-            duskstudio::HardwareInsertSlot::kCorrelationMacsPerSecond
-            * ((double) blockSize / sampleRate) / (double) chirpLength;
-        constexpr int captureBlocks =
-            (chirpLength + candidateCount + blockSize - 1) / blockSize;
-        const int minimumBlocks = captureBlocks
-                                + (int) std::ceil ((double) candidateCount
-                                                   / candidatesPerBlock);
-
         int blocksUsed = 0;
         REQUIRE (runPingLoopback (sampleRate, 1500, 40000, blockSize, &blocksUsed) == 1500);
-        REQUIRE (blocksUsed >= minimumBlocks);
+        REQUIRE (blocksUsed == expectedPingBlocks (sampleRate, blockSize));
     }
+
+    SECTION ("inclusive maximum latency remains measurable")
+    {
+        REQUIRE (runPingLoopback (48000.0,
+                                  duskstudio::HardwareInsertSlot::kMaxDelaySamples)
+                 == duskstudio::HardwareInsertSlot::kMaxDelaySamples);
+    }
+
+    SECTION ("negative-polarity return uses the absolute correlation peak")
+    {
+        REQUIRE (runPingLoopback (48000.0, 700, 2000, kBlock, nullptr, -1.0f) == 700);
+    }
+
+    SECTION ("return below five percent of the chirp peak is rejected")
+    {
+        REQUIRE (runPingLoopback (48000.0, 700, 2000, kBlock, nullptr, 0.04f) == -1);
+    }
+}
+
+TEST_CASE ("HardwareInsertSlot: ping correlation budget matches callback contract",
+            "[HardwareInsertSlot][ping]")
+{
+    REQUIRE (duskstudio::HardwareInsertSlot::kCorrelationMacsPerSecond == 1.15e8);
+
+    constexpr double sampleRate = 96000.0;
+    constexpr int blockSize = 64;
+    constexpr int chirpLength = duskstudio::HardwareInsertSlot::kChirpMaxSamples;
+    const double macsPerBlock =
+        duskstudio::HardwareInsertSlot::kCorrelationMacsPerSecond
+        * (double) blockSize / sampleRate;
+    const double candidatesPerBlock = macsPerBlock / (double) chirpLength;
+
+    REQUIRE_THAT (macsPerBlock, WithinAbs (76666.66666666667, 1.0e-9));
+    REQUIRE_THAT (candidatesPerBlock, WithinAbs (7.986111111111111, 1.0e-12));
 }
 
 TEST_CASE ("HardwareInsertSlot: ping with silent return reports -1",


### PR DESCRIPTION
## Summary
- reduce the hardware-insert ping correlation budget from 1.50e8 to 1.15e8 MAC/s, restoring the former 48 kHz / 512 callback cost
- preserve the exhaustive scalar search over all 16,385 inclusive lag candidates and the existing detection semantics
- pin exact callback pacing and add maximum-latency, inverted-polarity, and low-return threshold coverage
- update documented ping timing for the lower scheduled callback workload

The scheduled correlation workload is 23.33% lower. Measured pacing is approximately 1.141s at 48 kHz / 512 and 1.639s at 96 kHz / 64.

## Validation
- focused hardware-insert suite: 1,071 assertions / 9 cases passed
- production and test builds
- serial CTest suite: 652/652 passed in 28.03s
- private-Xvfb application self-test: exit 0
- performance guard: no material regression; scalar correlation kernel remains approximately 164ms
- de-JUCE gate: 179 files / 9239 uses, no new literal `juce::`
- `git diff --check`

## Manual follow-up
- physical interface/external-hardware loopback was not available for this pass and remains owed; simulated loopback coverage is green across the named timing and signal boundaries

Closes #167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hardware-insert ping processing to provide more accurate latency detection across supported sample rates and block sizes.
  * Improved handling of returned signals, including polarity changes and low-level returns, for more reliable hardware-insert measurements.

* **Documentation**
  * Updated estimated measurement durations to approximately 1.1 seconds at 48 kHz and 1.6 seconds at 96 kHz with 64-sample blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->