### PR TITLE
Loop-record take stacking core

### DIFF
--- a/src/engine/LoopTimeline.h
+++ b/src/engine/LoopTimeline.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <utility>
+
+namespace duskstudio
+{
+struct LoopTimelineSpan
+{
+    std::int64_t timelineStart = 0;
+    int          bufferOffset  = 0;
+    int          length        = 0;
+    bool         wrappedBefore = false;
+};
+
+namespace detail
+{
+// Returns start + distance without overflowing a signed intermediate. Callers
+// guarantee that the mathematical result is representable as int64_t.
+constexpr std::int64_t addTimelineDistance (std::int64_t start,
+                                             std::uint64_t distance) noexcept
+{
+    if (start >= 0)
+        return start + static_cast<std::int64_t> (distance);
+
+    const auto magnitude = static_cast<std::uint64_t> (-(start + 1)) + 1;
+    if (distance >= magnitude)
+        return static_cast<std::int64_t> (distance - magnitude);
+
+    const auto remaining = magnitude - distance;
+    if (remaining == static_cast<std::uint64_t> (std::numeric_limits<std::int64_t>::max()) + 1)
+        return std::numeric_limits<std::int64_t>::min();
+    return -static_cast<std::int64_t> (remaining);
+}
+} // namespace detail
+
+// Enumerates the timeline portions represented by one host buffer. A valid loop
+// wraps only at loopEnd: a block beginning before loopStart (for example during
+// count-in) therefore continues linearly through loopStart before its first
+// wrap. The callback is invoked directly, so this helper owns no storage and
+// performs no allocation or synchronization.
+template <typename Callback>
+void forEachLoopTimelineSpan (std::int64_t blockStart,
+                              int numSamples,
+                              bool loopEnabled,
+                              std::int64_t loopStart,
+                              std::int64_t loopEnd,
+                              Callback&& callback)
+    noexcept (noexcept (std::declval<Callback&>() (std::declval<const LoopTimelineSpan&>())))
+{
+    if (numSamples <= 0)
+        return;
+
+    if (! loopEnabled || loopEnd <= loopStart)
+    {
+        const LoopTimelineSpan span { blockStart, 0, numSamples, false };
+        callback (span);
+        return;
+    }
+
+    const auto loopLength = static_cast<std::uint64_t> (loopEnd)
+                          - static_cast<std::uint64_t> (loopStart);
+    std::int64_t position = blockStart;
+    bool wrappedBefore = false;
+
+    if (position >= loopEnd)
+    {
+        const auto distancePastEnd = static_cast<std::uint64_t> (position)
+                                   - static_cast<std::uint64_t> (loopEnd);
+        position = detail::addTimelineDistance (loopStart, distancePastEnd % loopLength);
+        wrappedBefore = true;
+    }
+
+    int bufferOffset = 0;
+    while (bufferOffset < numSamples)
+    {
+        const auto distanceToEnd = static_cast<std::uint64_t> (loopEnd)
+                                 - static_cast<std::uint64_t> (position);
+        const int remaining = numSamples - bufferOffset;
+        const int length = distanceToEnd < static_cast<std::uint64_t> (remaining)
+                         ? static_cast<int> (distanceToEnd)
+                         : remaining;
+
+        const LoopTimelineSpan span { position, bufferOffset, length, wrappedBefore };
+        callback (span);
+        bufferOffset += length;
+        position = detail::addTimelineDistance (position, static_cast<std::uint64_t> (length));
+
+        if (bufferOffset < numSamples && position == loopEnd)
+        {
+            position = loopStart;
+            wrappedBefore = true;
+        }
+        else
+        {
+            wrappedBefore = false;
+        }
+    }
+}
+} // namespace duskstudio

--- a/src/engine/RecordManager.cpp
+++ b/src/engine/RecordManager.cpp
@@ -738,7 +738,8 @@ void RecordManager::stopRecording (std::int64_t endSample)
                         reset.channel = key / 128 + 1;
                         reset.controller = key % 128;
                         reset.value = 0;
-                        reset.atTick = passRegion.lengthInTicks;
+                        reset.atTick = std::max<std::int64_t> (
+                            0, passRegion.lengthInTicks - 1);
                         passRegion.ccs.push_back (reset);
                     }
                 }
@@ -968,7 +969,8 @@ void RecordManager::stopRecording (std::int64_t endSample)
             for (int i = 0; i < slot->loopPassCount; ++i)
             {
                 const auto& pass = slot->loopPasses[(size_t) i];
-                if (pass.lengthInSamples <= 0 || trim >= pass.lengthInSamples)
+                if (pass.writeFailed || pass.lengthInSamples <= 0
+                    || trim >= pass.lengthInSamples)
                     continue;
                 AudioRegion passRegion;
                 passRegion.file = slot->file;
@@ -1245,6 +1247,12 @@ void RecordManager::writeMidiBlock (int trackIndex,
         // dropped - they're not part of the per-track musical content.
         const auto status = (std::uint8_t) raw[0];
         if (status < 0x80 || status >= 0xF0) continue;
+        const auto statusType = status & 0xF0;
+        const int expectedSize = (statusType == 0xC0 || statusType == 0xD0)
+                               ? 2 : 3;
+        if (sz != expectedSize || raw[1] >= 0x80
+            || (expectedSize == 3 && raw[2] >= 0x80))
+            continue;
 
         // Loop spans accept the original callback buffer. inputOffset names
         // the first event position in the captured slice; normalize retained
@@ -1265,7 +1273,18 @@ void RecordManager::writeMidiBlock (int trackIndex,
         if (cap->fifo.getFreeSpace() < needed)
         {
             cap->overflowCount.fetch_add (1, std::memory_order_relaxed);
-            continue;  // FIFO full -> drop this event, try next
+            // stopRecording cannot consume until active is cleared and this
+            // AudioInFlightScope exits, so the producer may safely retire the
+            // oldest slot here. Keep the bounded capture biased toward the
+            // newest events and loop passes.
+            int r1 = 0, rsz1 = 0, r2 = 0, rsz2 = 0;
+            cap->fifo.prepareToRead (needed, r1, rsz1, r2, rsz2);
+            if (rsz1 + rsz2 < needed)
+            {
+                cap->fifo.finishedRead (0);
+                continue;
+            }
+            cap->fifo.finishedRead (needed);
         }
         int s1 = 0, sz1 = 0, s2 = 0, sz2 = 0;
         cap->fifo.prepareToWrite (needed, s1, sz1, s2, sz2);
@@ -1324,37 +1343,45 @@ void RecordManager::writeInputBlock (int trackIndex,
     jassert (channels[0] != nullptr
              && (slot->numChannels < 2 || channels[1] != nullptr));
     const auto sourceOffset = slot->framesWritten;
+    PassDescriptor* descriptor = nullptr;
+    if (loopPlan.enabled)
+    {
+        if (slot->loopPassCount > 0
+            && slot->loopPasses[(size_t) (slot->loopPassCount - 1)].passOrdinal
+                   == currentLoopSpan.passOrdinal)
+        {
+            descriptor = &slot->loopPasses[(size_t) (slot->loopPassCount - 1)];
+        }
+        else
+        {
+            if (slot->loopPassCount == kRetainedLoopPasses)
+            {
+                std::move (slot->loopPasses.begin() + 1, slot->loopPasses.end(),
+                           slot->loopPasses.begin());
+                --slot->loopPassCount;
+            }
+            descriptor = &slot->loopPasses[(size_t) slot->loopPassCount++];
+            *descriptor = {};
+            descriptor->passOrdinal = currentLoopSpan.passOrdinal;
+            descriptor->timelineStart = loopPlan.captureStartSample;
+            descriptor->sourceOffset = sourceOffset;
+        }
+    }
+
     if (slot->writer->push (channels, slot->numChannels, samplesToWrite))
     {
         slot->framesWritten += samplesToWrite;
-        if (loopPlan.enabled)
+        if (descriptor != nullptr)
         {
-            PassDescriptor* descriptor = nullptr;
-            if (slot->loopPassCount > 0
-                && slot->loopPasses[(size_t) (slot->loopPassCount - 1)].passOrdinal
-                       == currentLoopSpan.passOrdinal)
-            {
-                descriptor = &slot->loopPasses[(size_t) (slot->loopPassCount - 1)];
-            }
-            else
-            {
-                if (slot->loopPassCount == kRetainedLoopPasses)
-                {
-                    std::move (slot->loopPasses.begin() + 1, slot->loopPasses.end(),
-                               slot->loopPasses.begin());
-                    --slot->loopPassCount;
-                }
-                descriptor = &slot->loopPasses[(size_t) slot->loopPassCount++];
-                *descriptor = {};
-                descriptor->passOrdinal = currentLoopSpan.passOrdinal;
-                descriptor->timelineStart = loopPlan.captureStartSample;
-                descriptor->sourceOffset = sourceOffset;
-            }
             descriptor->lengthInSamples += samplesToWrite;
             descriptor->endsPass = descriptor->endsPass || currentLoopSpan.endsPass;
         }
     }
     else
+    {
         slot->writeFailures.fetch_add (1, std::memory_order_relaxed);
+        if (descriptor != nullptr)
+            descriptor->writeFailed = true;
+    }
 }
 } // namespace duskstudio

--- a/src/engine/RecordManager.cpp
+++ b/src/engine/RecordManager.cpp
@@ -1,6 +1,8 @@
 #include "RecordManager.h"
 #include "audiofile/FileWriter.h"
 #include <algorithm>
+#include <chrono>
+#include <cmath>
 #include <new>
 #include <thread>
 #include <unordered_map>
@@ -22,6 +24,118 @@ void trimTakeHistory (Region& region) noexcept
 {
     if ((int) region.previousTakes.size() > kMaxTakesPerRegion)
         region.previousTakes.resize ((size_t) kMaxTakesPerRegion);
+}
+
+bool sameProvenance (const TakeProvenance& a, const TakeProvenance& b) noexcept
+{
+    return a.capturedAtMs == b.capturedAtMs
+        && a.loopPassOrdinal == b.loopPassOrdinal
+        && a.partialPass == b.partialPass;
+}
+
+bool sameMidiNote (const MidiNote& a, const MidiNote& b) noexcept
+{
+    return a.channel == b.channel && a.noteNumber == b.noteNumber
+        && a.velocity == b.velocity && a.startTick == b.startTick
+        && a.lengthInTicks == b.lengthInTicks;
+}
+
+bool sameMidiCc (const MidiCc& a, const MidiCc& b) noexcept
+{
+    return a.channel == b.channel && a.controller == b.controller
+        && a.value == b.value && a.atTick == b.atTick;
+}
+
+bool sameAudioTake (const TakeRef& a, const TakeRef& b) noexcept
+{
+    return a.file == b.file && a.sourceOffset == b.sourceOffset
+        && a.lengthInSamples == b.lengthInSamples
+        && sameProvenance (a.provenance, b.provenance);
+}
+
+bool sameMidiTake (const MidiTakeRef& a, const MidiTakeRef& b) noexcept
+{
+    return a.lengthInTicks == b.lengthInTicks
+        && sameProvenance (a.provenance, b.provenance)
+        && a.notes.size() == b.notes.size()
+        && a.ccs.size() == b.ccs.size()
+        && std::equal (a.notes.begin(), a.notes.end(), b.notes.begin(), sameMidiNote)
+        && std::equal (a.ccs.begin(), a.ccs.end(), b.ccs.begin(), sameMidiCc);
+}
+
+bool sameAudioRegion (const AudioRegion& a, const AudioRegion& b) noexcept
+{
+    return a.file == b.file && a.timelineStart == b.timelineStart
+        && a.lengthInSamples == b.lengthInSamples && a.sourceOffset == b.sourceOffset
+        && a.previousTakes.size() == b.previousTakes.size()
+        && sameProvenance (a.provenance, b.provenance)
+        && std::equal (a.previousTakes.begin(), a.previousTakes.end(),
+                       b.previousTakes.begin(), sameAudioTake);
+}
+
+bool sameMidiRegion (const MidiRegion& a, const MidiRegion& b) noexcept
+{
+    return a.timelineStart == b.timelineStart
+        && a.lengthInSamples == b.lengthInSamples
+        && a.lengthInTicks == b.lengthInTicks
+        && sameProvenance (a.provenance, b.provenance)
+        && a.notes.size() == b.notes.size() && a.ccs.size() == b.ccs.size()
+        && a.previousTakes.size() == b.previousTakes.size()
+        && std::equal (a.notes.begin(), a.notes.end(), b.notes.begin(), sameMidiNote)
+        && std::equal (a.ccs.begin(), a.ccs.end(), b.ccs.begin(), sameMidiCc)
+        && std::equal (a.previousTakes.begin(), a.previousTakes.end(),
+                       b.previousTakes.begin(), sameMidiTake);
+}
+
+bool sliceMidiTake (const MidiTakeRef& source,
+                    std::int64_t containingSamples,
+                    std::int64_t sliceOffsetSamples,
+                    std::int64_t sliceLengthSamples,
+                    MidiTakeRef& result)
+{
+    if (containingSamples <= 0 || source.lengthInTicks <= 0
+        || sliceOffsetSamples < 0 || sliceLengthSamples <= 0
+        || sliceOffsetSamples + sliceLengthSamples > containingSamples)
+        return false;
+
+    const auto sampleToTick = [&source, containingSamples] (std::int64_t sample)
+    {
+        return (std::int64_t) std::llround (
+            (double) sample * (double) source.lengthInTicks
+            / (double) containingSamples);
+    };
+    const auto firstTick = std::clamp<std::int64_t> (
+        sampleToTick (sliceOffsetSamples), 0, source.lengthInTicks);
+    const auto lastTick = std::clamp<std::int64_t> (
+        sampleToTick (sliceOffsetSamples + sliceLengthSamples),
+        firstTick, source.lengthInTicks);
+    if (lastTick <= firstTick)
+        return false;
+
+    result = {};
+    result.lengthInTicks = lastTick - firstTick;
+    result.provenance = source.provenance;
+    for (const auto& note : source.notes)
+    {
+        const auto noteStart = note.startTick;
+        const auto noteEnd = note.startTick + note.lengthInTicks;
+        const auto overlapStart = std::max (noteStart, firstTick);
+        const auto overlapEnd = std::min (noteEnd, lastTick);
+        if (overlapEnd <= overlapStart) continue;
+        auto sliced = note;
+        sliced.startTick = overlapStart - firstTick;
+        sliced.lengthInTicks = std::max<std::int64_t> (
+            1, overlapEnd - overlapStart);
+        result.notes.push_back (sliced);
+    }
+    for (const auto& cc : source.ccs)
+    {
+        if (cc.atTick < firstTick || cc.atTick >= lastTick) continue;
+        auto sliced = cc;
+        sliced.atTick -= firstTick;
+        result.ccs.push_back (sliced);
+    }
+    return true;
 }
 } // namespace
 
@@ -61,6 +175,14 @@ RecordManager::~RecordManager()
 bool RecordManager::startRecording (double sampleRate, std::int64_t startSample,
                                     int latencyOffsetSamples)
 {
+    return startRecording (sampleRate, startSample, latencyOffsetSamples,
+                           LoopCapturePlan {});
+}
+
+bool RecordManager::startRecording (double sampleRate, std::int64_t startSample,
+                                    int latencyOffsetSamples,
+                                    const LoopCapturePlan& loopCapturePlan)
+{
     if (active.load (std::memory_order_relaxed))
         return true;
 
@@ -85,6 +207,18 @@ bool RecordManager::startRecording (double sampleRate, std::int64_t startSample,
         return false;
     }
 
+    if (loopCapturePlan.enabled
+        && (loopCapturePlan.loopStartSample >= loopCapturePlan.loopEndSample
+            || loopCapturePlan.captureStartSample < loopCapturePlan.loopStartSample
+            || loopCapturePlan.captureStartSample >= loopCapturePlan.captureEndSample
+            || loopCapturePlan.captureEndSample > loopCapturePlan.loopEndSample))
+    {
+        std::fprintf (stderr,
+                      "[Dusk Studio/RecordManager] startRecording: enabled loop plan has "
+                      "an empty or out-of-loop effective capture; refusing to arm.\n");
+        return false;
+    }
+
     auto audioDir = session.getAudioDirectory();
     if (! audioDir.exists())
         audioDir.createDirectory();
@@ -92,6 +226,12 @@ bool RecordManager::startRecording (double sampleRate, std::int64_t startSample,
     recordStartSample = startSample;
     recordSampleRate  = sampleRate;
     recordLatencyOffsetSamples = latencyOffsetSamples;
+    loopPlan = loopCapturePlan;
+    currentLoopSpan = {};
+    loopPassCount = 0;
+    highestLoopPassOrdinal = 0;
+    gestureCapturedAtMs = std::chrono::duration_cast<std::chrono::milliseconds> (
+        std::chrono::system_clock::now().time_since_epoch()).count();
 
     lastSetupFailures.clear();
     lastRecordErrors.clear();
@@ -249,6 +389,78 @@ bool RecordManager::startRecording (double sampleRate, std::int64_t startSample,
     return true;
 }
 
+RecordManager::LoopCaptureSpan RecordManager::coordinateLoopCaptureSpan (
+    int passOrdinal, std::int64_t transportStartSample,
+    int callbackBaseOffset, int remainingSamples) const noexcept
+{
+    LoopCaptureSpan span;
+    // startRecording publishes the immutable plan before its active release;
+    // this acquire is the audio-thread half of that handoff.
+    if (! active.load (std::memory_order_acquire))
+        return span;
+    if (! loopPlan.enabled || passOrdinal < 1
+        || callbackBaseOffset < 0 || remainingSamples <= 0)
+        return span;
+
+    const auto inputOffset64 = std::max<std::int64_t> (
+        0, loopPlan.captureStartSample - transportStartSample);
+    if (inputOffset64 >= remainingSamples)
+        return span;
+
+    const auto capturedStart = transportStartSample + inputOffset64;
+    if (capturedStart < loopPlan.captureStartSample
+        || capturedStart >= loopPlan.captureEndSample)
+        return span;
+
+    const auto available = std::min<std::int64_t> (
+        remainingSamples - inputOffset64,
+        loopPlan.captureEndSample - capturedStart);
+    if (available <= 0)
+        return span;
+
+    span.passOrdinal = passOrdinal;
+    span.timelineStart = capturedStart;
+    span.callbackBaseOffset = callbackBaseOffset;
+    span.inputOffset = callbackBaseOffset + (int) inputOffset64;
+    span.numSamples = (int) available;
+    span.startsPass = capturedStart == loopPlan.captureStartSample;
+    span.endsPass = capturedStart + available == loopPlan.captureEndSample;
+    return span;
+}
+
+void RecordManager::beginLoopCaptureSpan (const LoopCaptureSpan& span) noexcept
+{
+    AudioInFlightScope guard (audioInFlight);
+    if (! active.load (std::memory_order_acquire) || ! loopPlan.enabled)
+        return;
+
+    currentLoopSpan = span;
+    if (span.passOrdinal < 1 || span.numSamples <= 0)
+        return;
+    highestLoopPassOrdinal = std::max (highestLoopPassOrdinal, span.passOrdinal);
+
+    PassDescriptor* descriptor = nullptr;
+    if (loopPassCount > 0
+        && loopPasses[(size_t) (loopPassCount - 1)].passOrdinal == span.passOrdinal)
+    {
+        descriptor = &loopPasses[(size_t) (loopPassCount - 1)];
+    }
+    else
+    {
+        if (loopPassCount == kRetainedLoopPasses)
+        {
+            std::move (loopPasses.begin() + 1, loopPasses.end(), loopPasses.begin());
+            --loopPassCount;
+        }
+        descriptor = &loopPasses[(size_t) loopPassCount++];
+        *descriptor = {};
+        descriptor->passOrdinal = span.passOrdinal;
+        descriptor->timelineStart = loopPlan.captureStartSample;
+    }
+    descriptor->lengthInSamples += span.numSamples;
+    descriptor->endsPass = descriptor->endsPass || span.endsPass;
+}
+
 void RecordManager::stopRecording (std::int64_t endSample)
 {
     if (! active.load (std::memory_order_relaxed))
@@ -375,6 +587,229 @@ void RecordManager::stopRecording (std::int64_t endSample)
 
         if (drained.empty())
         {
+            if (! loopPlan.enabled)
+            {
+                cap.reset();
+                continue;
+            }
+        }
+
+        if (loopPlan.enabled)
+        {
+            struct ActiveNote
+            {
+                bool active = false;
+                int velocity = 0;
+                std::int64_t startSample = 0;
+            };
+            std::array<ActiveNote, 16 * 128> activeNotes {};
+            std::array<int, 16 * 128> controllerState {};
+            controllerState.fill (-1);
+            std::vector<MidiRegion> nonemptyPasses;
+            nonemptyPasses.reserve ((size_t) kRetainedLoopPasses);
+            const auto captureLength = loopPlan.captureEndSample
+                                     - loopPlan.captureStartSample;
+            size_t drainedIndex = 0;
+
+            for (int passOrdinal = 1;
+                 passOrdinal <= highestLoopPassOrdinal; ++passOrdinal)
+            {
+                PassDescriptor pass;
+                pass.passOrdinal = passOrdinal;
+                pass.timelineStart = loopPlan.captureStartSample;
+                pass.lengthInSamples = captureLength;
+                pass.endsPass = true;
+                for (int i = 0; i < loopPassCount; ++i)
+                    if (loopPasses[(size_t) i].passOrdinal == passOrdinal)
+                    {
+                        pass = loopPasses[(size_t) i];
+                        break;
+                    }
+                if (pass.lengthInSamples <= 0) continue;
+
+                MidiRegion passRegion;
+                passRegion.timelineStart = loopPlan.captureStartSample;
+                passRegion.lengthInSamples = pass.lengthInSamples;
+                passRegion.lengthInTicks = samplesToTicks (
+                    pass.lengthInSamples, recordSampleRate, bpm);
+                passRegion.recordedAtBPM = (double) bpm;
+                passRegion.provenance = {
+                    gestureCapturedAtMs, pass.passOrdinal,
+                    ! pass.endsPass || pass.lengthInSamples < captureLength
+                };
+
+                if (passOrdinal > 1)
+                {
+                    for (int key = 0; key < (int) activeNotes.size(); ++key)
+                        if (activeNotes[(size_t) key].active)
+                            activeNotes[(size_t) key].startSample = 0;
+
+                    for (int key = 0; key < (int) controllerState.size(); ++key)
+                    {
+                        const int value = controllerState[(size_t) key];
+                        if (value <= 0) continue;
+                        MidiCc chased;
+                        chased.channel = key / 128 + 1;
+                        chased.controller = key % 128;
+                        chased.value = value;
+                        chased.atTick = 0;
+                        passRegion.ccs.push_back (chased);
+                    }
+                }
+
+                while (drainedIndex < drained.size()
+                       && drained[drainedIndex].passOrdinal < pass.passOrdinal)
+                    ++drainedIndex;
+                while (drainedIndex < drained.size()
+                       && drained[drainedIndex].passOrdinal == pass.passOrdinal)
+                {
+                    const auto& ev = drained[drainedIndex++];
+                    if (ev.passOrdinal != pass.passOrdinal
+                        || ev.samplePos < 0
+                        || ev.samplePos >= pass.lengthInSamples)
+                        continue;
+
+                    const int channel = (ev.status & 0x0F) + 1;
+                    const int statusType = ev.status & 0xF0;
+                    const int noteKey = (channel - 1) * 128 + ev.data1;
+                    if (statusType == 0x90 && ev.data2 > 0)
+                    {
+                        auto& note = activeNotes[(size_t) noteKey];
+                        note.active = true;
+                        note.velocity = ev.data2;
+                        note.startSample = ev.samplePos;
+                    }
+                    else if (statusType == 0x80
+                             || (statusType == 0x90 && ev.data2 == 0))
+                    {
+                        auto& note = activeNotes[(size_t) noteKey];
+                        if (! note.active) continue;
+                        MidiNote committed;
+                        committed.channel = channel;
+                        committed.noteNumber = ev.data1;
+                        committed.velocity = note.velocity;
+                        committed.startTick = samplesToTicks (
+                            note.startSample, recordSampleRate, bpm);
+                        const auto offTick = samplesToTicks (
+                            ev.samplePos, recordSampleRate, bpm);
+                        committed.lengthInTicks = std::max<std::int64_t> (
+                            1, offTick - committed.startTick);
+                        passRegion.notes.push_back (committed);
+                        note.active = false;
+                    }
+                    else if (statusType == 0xB0)
+                    {
+                        MidiCc committed;
+                        committed.channel = channel;
+                        committed.controller = ev.data1;
+                        committed.value = ev.data2;
+                        committed.atTick = samplesToTicks (
+                            ev.samplePos, recordSampleRate, bpm);
+                        passRegion.ccs.push_back (committed);
+                        controllerState[(size_t) ((channel - 1) * 128 + ev.data1)]
+                            = ev.data2;
+                    }
+                }
+
+                // A held note is closed at every seam and remains active so
+                // the following pass begins with an implicit tick-zero
+                // retrigger. This keeps each take independently playable.
+                for (int key = 0; key < (int) activeNotes.size(); ++key)
+                {
+                    const auto& note = activeNotes[(size_t) key];
+                    if (! note.active) continue;
+                    MidiNote committed;
+                    committed.channel = key / 128 + 1;
+                    committed.noteNumber = key % 128;
+                    committed.velocity = note.velocity;
+                    committed.startTick = samplesToTicks (
+                        note.startSample, recordSampleRate, bpm);
+                    committed.lengthInTicks = std::max<std::int64_t> (
+                        1, passRegion.lengthInTicks - committed.startTick);
+                    passRegion.notes.push_back (committed);
+                }
+
+                if (passOrdinal < highestLoopPassOrdinal)
+                {
+                    for (int key = 0; key < (int) controllerState.size(); ++key)
+                    {
+                        if (controllerState[(size_t) key] <= 0) continue;
+                        MidiCc reset;
+                        reset.channel = key / 128 + 1;
+                        reset.controller = key % 128;
+                        reset.value = 0;
+                        reset.atTick = passRegion.lengthInTicks;
+                        passRegion.ccs.push_back (reset);
+                    }
+                }
+
+                if (! passRegion.notes.empty() || ! passRegion.ccs.empty())
+                {
+                    if ((int) nonemptyPasses.size() == kRetainedLoopPasses)
+                        nonemptyPasses.erase (nonemptyPasses.begin());
+                    nonemptyPasses.push_back (std::move (passRegion));
+                }
+            }
+
+            if (nonemptyPasses.empty())
+            {
+                cap.reset();
+                continue;
+            }
+
+            MidiRegion region = std::move (nonemptyPasses.back());
+            for (auto it = nonemptyPasses.rbegin() + 1;
+                 it != nonemptyPasses.rend(); ++it)
+            {
+                region.previousTakes.push_back (makeMidiTakeRef (*it));
+                trimTakeHistory (region);
+            }
+
+            const auto newStart = region.timelineStart;
+            const auto newEnd = newStart + region.lengthInSamples;
+            session.track (t).midiRegions.mutate (
+                [&region, newStart, newEnd] (std::vector<MidiRegion>& regions)
+                {
+                    for (auto it = regions.begin(); it != regions.end(); )
+                    {
+                        const auto existingStart = it->timelineStart;
+                        const auto existingEnd = existingStart + it->lengthInSamples;
+                        const bool fullyContained = existingStart >= newStart
+                                                 && existingEnd <= newEnd;
+                        if (fullyContained)
+                        {
+                            region.previousTakes.push_back (makeMidiTakeRef (*it));
+                            for (auto& deeper : it->previousTakes)
+                                region.previousTakes.push_back (std::move (deeper));
+                            trimTakeHistory (region);
+                            it = regions.erase (it);
+                            continue;
+                        }
+
+                        // A final partial pass may sit inside a longer MIDI
+                        // region. Preserve the longer region on the timeline,
+                        // but add compatible, range-sliced payloads after the
+                        // loop-pass history so cycling remains aligned.
+                        if (existingStart <= newStart && existingEnd >= newEnd)
+                        {
+                            const auto sliceOffset = newStart - existingStart;
+                            const auto sliceLength = newEnd - newStart;
+                            MidiTakeRef sliced;
+                            if (sliceMidiTake (makeMidiTakeRef (*it),
+                                               it->lengthInSamples,
+                                               sliceOffset, sliceLength, sliced))
+                                region.previousTakes.push_back (std::move (sliced));
+                            for (const auto& deeper : it->previousTakes)
+                                if (sliceMidiTake (deeper, it->lengthInSamples,
+                                                   sliceOffset, sliceLength, sliced))
+                                    region.previousTakes.push_back (std::move (sliced));
+                            trimTakeHistory (region);
+                        }
+                        ++it;
+                    }
+                    regions.push_back (std::move (region));
+                });
+
             cap.reset();
             continue;
         }
@@ -483,11 +918,7 @@ void RecordManager::stopRecording (std::int64_t endSample)
                     const bool fullyContained = exStart >= newStart && exEnd <= newEnd;
                     if (! fullyContained) { ++it; continue; }
 
-                    MidiTakeRef ref;
-                    ref.lengthInTicks = it->lengthInTicks;
-                    ref.notes = std::move (it->notes);
-                    ref.ccs   = std::move (it->ccs);
-                    region.previousTakes.push_back (std::move (ref));
+                    region.previousTakes.push_back (makeMidiTakeRef (*it));
 
                     for (auto& deeper : it->previousTakes)
                         region.previousTakes.push_back (std::move (deeper));
@@ -517,32 +948,73 @@ void RecordManager::stopRecording (std::int64_t endSample)
         drainPool.remove (slot->writer.get());
         slot->writer.reset();  // flush + close
 
-        // When the latency shift pulls the start before 0 we can't move the
-        // take earlier than the timeline origin, so trim that much off the
-        // head instead - otherwise the take plays late by the clamped amount.
-        const std::int64_t shifted = recordStartSample - recordLatencyOffsetSamples;
-        const std::int64_t trim    = shifted < 0 ? -shifted : 0;
+        // Latency compensation is applied independently to every loop pass.
+        // The writer remains one continuous spool; only each take reference's
+        // source offset and length are head-trimmed at commit.
+        const std::int64_t shifted = (loopPlan.enabled
+                                          ? loopPlan.captureStartSample
+                                          : recordStartSample)
+                                   - recordLatencyOffsetSamples;
+        const std::int64_t trim = shifted < 0 ? -shifted : 0;
+        AudioRegion region;
+        bool hasRegion = false;
 
-        if (frames > 0 && trim < frames)
+        if (loopPlan.enabled)
         {
-            AudioRegion region;
+            std::vector<AudioRegion> committedPasses;
+            committedPasses.reserve ((size_t) slot->loopPassCount);
+            const auto captureLength = loopPlan.captureEndSample
+                                     - loopPlan.captureStartSample;
+            for (int i = 0; i < slot->loopPassCount; ++i)
+            {
+                const auto& pass = slot->loopPasses[(size_t) i];
+                if (pass.lengthInSamples <= 0 || trim >= pass.lengthInSamples)
+                    continue;
+                AudioRegion passRegion;
+                passRegion.file = slot->file;
+                passRegion.timelineStart = std::max<std::int64_t> (0, shifted);
+                passRegion.lengthInSamples = pass.lengthInSamples - trim;
+                passRegion.sourceOffset = pass.sourceOffset + trim;
+                passRegion.numChannels = slot->numChannels;
+                passRegion.provenance = {
+                    gestureCapturedAtMs, pass.passOrdinal,
+                    ! pass.endsPass || pass.lengthInSamples < captureLength
+                };
+                committedPasses.push_back (std::move (passRegion));
+            }
+
+            if (! committedPasses.empty())
+            {
+                region = std::move (committedPasses.back());
+                for (auto it = committedPasses.rbegin() + 1;
+                     it != committedPasses.rend(); ++it)
+                {
+                    region.previousTakes.push_back (makeAudioTakeRef (*it));
+                    trimTakeHistory (region);
+                }
+                hasRegion = true;
+            }
+        }
+        else if (frames > 0 && trim < frames)
+        {
             region.file = slot->file;
             region.timelineStart = std::max<std::int64_t> (0, shifted);
             region.lengthInSamples = frames - trim;
             region.sourceOffset = trim;
             region.numChannels = slot->numChannels;
+            hasRegion = true;
+        }
 
+        if (hasRegion)
+        {
             // Take-history capture: any existing region whose timeline range
             // is FULLY CONTAINED within the new take's range gets absorbed
             // into previousTakes. The user can then cycle through them via
             // the badge UI without losing access to earlier takes.
             //
             // Partial overlaps (e.g. punch-in over the middle of a longer
-            // take) are intentionally NOT absorbed - the longer region stays
-            // visible on either side of the new take, and the painter just
-            // draws the new region on top inside the punch range. Phase 3
-            // proper will handle splitting a partially-overlapping region
-            // into outer fragments + a new take cycle slot.
+            // take) are not absorbed wholesale: Pass 2 retains their outer
+            // fragments and saves the overwritten compatible slice as a take.
             const std::int64_t newStart = region.timelineStart;
             const std::int64_t newEnd   = newStart + region.lengthInSamples;
             auto& regs = session.track (t).regions;
@@ -568,11 +1040,7 @@ void RecordManager::stopRecording (std::int64_t endSample)
                 const bool fullyContained = exStart >= newStart && exEnd <= newEnd;
                 if (! fullyContained) { ++it; continue; }
 
-                TakeRef ref;
-                ref.file            = it->file;
-                ref.sourceOffset    = it->sourceOffset;
-                ref.lengthInSamples = it->lengthInSamples;
-                region.previousTakes.push_back (std::move (ref));
+                region.previousTakes.push_back (makeAudioTakeRef (*it));
 
                 // Carry forward the displaced region's own history so we
                 // don't drop deeper takes when overdubbing repeatedly. The
@@ -605,6 +1073,31 @@ void RecordManager::stopRecording (std::int64_t endSample)
 
                 const bool spansLeft  = exStart < newStart;
                 const bool spansRight = exEnd   > newEnd;
+                const bool containsActive = exStart <= newStart && exEnd >= newEnd;
+
+                if (containsActive)
+                {
+                    // Keep the overwritten payload as a cycle slot even when
+                    // the new partial pass shares one edge with the old take.
+                    // Deeper history is compatible only when it covers the
+                    // same source-domain slice.
+                    const auto sliceOffset = newStart - exStart;
+                    const auto sliceLength = newEnd - newStart;
+                    TakeRef middle = makeAudioTakeRef (*it);
+                    middle.sourceOffset += sliceOffset;
+                    middle.lengthInSamples = sliceLength;
+                    region.previousTakes.push_back (std::move (middle));
+                    for (const auto& deeper : it->previousTakes)
+                    {
+                        if (deeper.lengthInSamples < sliceOffset + sliceLength)
+                            continue;
+                        auto sliced = deeper;
+                        sliced.sourceOffset += sliceOffset;
+                        sliced.lengthInSamples = sliceLength;
+                        region.previousTakes.push_back (std::move (sliced));
+                    }
+                    trimTakeHistory (region);
+                }
 
                 if (spansLeft && spansRight)
                 {
@@ -705,11 +1198,7 @@ void RecordManager::stopRecording (std::int64_t endSample)
         const bool audioChanged = ! (afterA.size() == beforeAudio[(size_t) t].size()
                                       && std::equal (afterA.begin(), afterA.end(),
                                                       beforeAudio[(size_t) t].begin(),
-                                                      [] (const AudioRegion& a, const AudioRegion& b)
-                                                      { return a.file == b.file
-                                                               && a.timelineStart == b.timelineStart
-                                                               && a.lengthInSamples == b.lengthInSamples
-                                                               && a.sourceOffset == b.sourceOffset; }));
+                                                      sameAudioRegion));
         // Deep-compare like the audio path: an overdub that replaces exactly
         // one region keeps the count equal, so size alone misses it and the
         // take becomes un-undoable. Event contents matter too - with
@@ -718,29 +1207,7 @@ void RecordManager::stopRecording (std::int64_t endSample)
         const bool midiChanged  = ! (afterM.size() == beforeMidi[(size_t) t].size()
                                       && std::equal (afterM.begin(), afterM.end(),
                                                       beforeMidi[(size_t) t].begin(),
-                                                      [] (const MidiRegion& a, const MidiRegion& b)
-                                                      {
-                                                          auto sameNote = [] (const MidiNote& x, const MidiNote& y)
-                                                          { return x.channel == y.channel
-                                                                   && x.noteNumber == y.noteNumber
-                                                                   && x.velocity == y.velocity
-                                                                   && x.startTick == y.startTick
-                                                                   && x.lengthInTicks == y.lengthInTicks; };
-                                                          auto sameCc = [] (const MidiCc& x, const MidiCc& y)
-                                                          { return x.channel == y.channel
-                                                                   && x.controller == y.controller
-                                                                   && x.value == y.value
-                                                                   && x.atTick == y.atTick; };
-                                                          return a.timelineStart == b.timelineStart
-                                                               && a.lengthInTicks == b.lengthInTicks
-                                                               && a.previousTakes.size() == b.previousTakes.size()
-                                                               && a.notes.size() == b.notes.size()
-                                                               && a.ccs.size() == b.ccs.size()
-                                                               && std::equal (a.notes.begin(), a.notes.end(),
-                                                                               b.notes.begin(), sameNote)
-                                                               && std::equal (a.ccs.begin(), a.ccs.end(),
-                                                                               b.ccs.begin(), sameCc);
-                                                      }));
+                                                      sameMidiRegion));
         if (! audioChanged && ! midiChanged) continue;
 
         TrackCommitDiff diff;
@@ -779,10 +1246,19 @@ void RecordManager::writeMidiBlock (int trackIndex,
         const auto status = (std::uint8_t) raw[0];
         if (status < 0x80 || status >= 0xF0) continue;
 
-        // Drop events whose absolute take-relative position is negative
-        // (count-in pre-roll). They'd be filtered at stopRecording anyway;
-        // gating here saves FIFO space and keeps stored samplePos non-negative.
-        const auto samplePos = blockStartFromRecord + meta.samplePosition;
+        // Loop spans accept the original callback buffer. inputOffset names
+        // the first event position in the captured slice; normalize retained
+        // events back to pass-relative coordinates before the FIFO write.
+        if (loopPlan.enabled
+            && (currentLoopSpan.passOrdinal < 1
+                || meta.samplePosition < currentLoopSpan.inputOffset
+                || meta.samplePosition
+                     >= currentLoopSpan.inputOffset + currentLoopSpan.numSamples))
+            continue;
+        const auto samplePos = loopPlan.enabled
+            ? (currentLoopSpan.timelineStart - loopPlan.captureStartSample
+               + meta.samplePosition - currentLoopSpan.inputOffset)
+            : (blockStartFromRecord + meta.samplePosition);
         if (samplePos < 0) continue;
 
         int needed = 1;
@@ -811,6 +1287,7 @@ void RecordManager::writeMidiBlock (int trackIndex,
         slot.status = status;
         slot.data1  = sz >= 2 ? (std::uint8_t) raw[1] : 0;
         slot.data2  = sz >= 3 ? (std::uint8_t) raw[2] : 0;
+        slot.passOrdinal = loopPlan.enabled ? currentLoopSpan.passOrdinal : 0;
         cap->fifo.finishedWrite (needed);
     }
 }
@@ -836,11 +1313,47 @@ void RecordManager::writeInputBlock (int trackIndex,
     //   - Stereo writer (numChannels == 2): if R is null we duplicate L so
     //     the second channel is never a missing pointer.
     jassert (L != nullptr);
+    if (loopPlan.enabled
+        && (currentLoopSpan.passOrdinal < 1 || currentLoopSpan.numSamples <= 0))
+        return;
+    const int samplesToWrite = loopPlan.enabled
+        ? std::min (numSamples, currentLoopSpan.numSamples) : numSamples;
+    if (samplesToWrite <= 0) return;
+
     const float* channels[2] = { L, (R != nullptr) ? R : L };
     jassert (channels[0] != nullptr
              && (slot->numChannels < 2 || channels[1] != nullptr));
-    if (slot->writer->push (channels, slot->numChannels, numSamples))
-        slot->framesWritten += numSamples;
+    const auto sourceOffset = slot->framesWritten;
+    if (slot->writer->push (channels, slot->numChannels, samplesToWrite))
+    {
+        slot->framesWritten += samplesToWrite;
+        if (loopPlan.enabled)
+        {
+            PassDescriptor* descriptor = nullptr;
+            if (slot->loopPassCount > 0
+                && slot->loopPasses[(size_t) (slot->loopPassCount - 1)].passOrdinal
+                       == currentLoopSpan.passOrdinal)
+            {
+                descriptor = &slot->loopPasses[(size_t) (slot->loopPassCount - 1)];
+            }
+            else
+            {
+                if (slot->loopPassCount == kRetainedLoopPasses)
+                {
+                    std::move (slot->loopPasses.begin() + 1, slot->loopPasses.end(),
+                               slot->loopPasses.begin());
+                    --slot->loopPassCount;
+                }
+                descriptor = &slot->loopPasses[(size_t) slot->loopPassCount++];
+                *descriptor = {};
+                descriptor->passOrdinal = currentLoopSpan.passOrdinal;
+                descriptor->timelineStart = loopPlan.captureStartSample;
+                descriptor->sourceOffset = sourceOffset;
+            }
+            descriptor->lengthInSamples += samplesToWrite;
+            descriptor->endsPass = descriptor->endsPass || currentLoopSpan.endsPass;
+        }
+    }
     else
         slot->writeFailures.fetch_add (1, std::memory_order_relaxed);
 }

--- a/src/engine/RecordManager.h
+++ b/src/engine/RecordManager.h
@@ -21,12 +21,50 @@ public:
     explicit RecordManager (Session& s);
     ~RecordManager();
 
+    // Immutable message-thread snapshot supplied when a loop-record gesture
+    // starts. capture is the already punch-intersected portion of the loop;
+    // an enabled plan must satisfy loopStart <= captureStart < captureEnd <= loopEnd.
+    struct LoopCapturePlan
+    {
+        bool enabled = false;
+        std::int64_t loopStartSample = 0;
+        std::int64_t loopEndSample = 0;
+        std::int64_t captureStartSample = 0;
+        std::int64_t captureEndSample = 0;
+    };
+
+    // Fixed-size coordinate handed to all armed-track writes for one split
+    // device callback span. transportStart passed to the coordinate method is
+    // the timeline position at callbackBaseOffset; inputOffset returned here is
+    // absolute in the original callback. Audio advances its channel pointers by
+    // inputOffset, while MIDI keeps passing the unsliced original buffer.
+    struct LoopCaptureSpan
+    {
+        int passOrdinal = 0;              // 1-based; 0 is legacy/non-loop
+        std::int64_t timelineStart = 0;   // absolute captured position
+        int callbackBaseOffset = 0;
+        int inputOffset = 0;              // absolute in original callback
+        int numSamples = 0;
+        bool startsPass = false;
+        bool endsPass = false;
+    };
+
     // Message thread. False if no tracks armed. latencyOffsetSamples is
     // subtracted from committed AUDIO region starts (see stopRecording) to
     // compensate for input round-trip delay; the write gate and MIDI
     // placement are unaffected.
     bool startRecording (double sampleRate, std::int64_t startSample,
                           int latencyOffsetSamples = 0);
+    bool startRecording (double sampleRate, std::int64_t startSample,
+                          int latencyOffsetSamples,
+                          const LoopCapturePlan& loopCapturePlan);
+
+    LoopCaptureSpan coordinateLoopCaptureSpan (int passOrdinal,
+                                                std::int64_t transportStartSample,
+                                                int callbackBaseOffset,
+                                                int remainingSamples) const noexcept;
+    void beginLoopCaptureSpan (const LoopCaptureSpan& span) noexcept;
+    const LoopCapturePlan& getLoopCapturePlan() const noexcept { return loopPlan; }
 
     // Message thread. Closes writers, finalizes WAV, appends regions.
     void stopRecording (std::int64_t endSample);
@@ -88,6 +126,16 @@ public:
 private:
     Session& session;
 
+    static constexpr int kRetainedLoopPasses = 9; // current + eight prior
+    struct PassDescriptor
+    {
+        int passOrdinal = 0;
+        std::int64_t timelineStart = 0;
+        std::int64_t sourceOffset = 0;
+        std::int64_t lengthInSamples = 0;
+        bool endsPass = false;
+    };
+
     struct PerTrackWriter
     {
         std::unique_ptr<dusk::audio::ThreadedFileWriter> writer;
@@ -95,6 +143,8 @@ private:
         std::int64_t framesWritten = 0;
         int numChannels = 1;
         std::atomic<std::uint64_t> writeFailures { 0 };
+        std::array<PassDescriptor, kRetainedLoopPasses> loopPasses {};
+        int loopPassCount = 0;
     };
 
     std::array<std::unique_ptr<PerTrackWriter>, Session::kNumTracks> writers;
@@ -114,6 +164,7 @@ private:
             std::uint8_t status = 0;
             std::uint8_t data1 = 0;
             std::uint8_t data2 = 0;
+            int passOrdinal = 0;
         };
         static constexpr int kCapacity = 65536;
         std::vector<RawEvent>  events;
@@ -157,6 +208,13 @@ private:
 
     std::int64_t recordStartSample = 0;
     double      recordSampleRate  = 0.0;
+
+    LoopCapturePlan loopPlan;
+    LoopCaptureSpan currentLoopSpan;
+    std::array<PassDescriptor, kRetainedLoopPasses> loopPasses {};
+    int loopPassCount = 0;
+    int highestLoopPassOrdinal = 0;
+    std::int64_t gestureCapturedAtMs = 0;
 
     // Subtracted from committed audio region starts; may be negative. The
     // derived region.timelineStart (not the offset) is clamped >= 0 in

--- a/src/engine/RecordManager.h
+++ b/src/engine/RecordManager.h
@@ -134,6 +134,7 @@ private:
         std::int64_t sourceOffset = 0;
         std::int64_t lengthInSamples = 0;
         bool endsPass = false;
+        bool writeFailed = false;
     };
 
     struct PerTrackWriter
@@ -166,7 +167,9 @@ private:
             std::uint8_t data2 = 0;
             int passOrdinal = 0;
         };
-        static constexpr int kCapacity = 65536;
+        // AbstractFifo keeps one sentinel slot, so 65,537 registered slots
+        // provide a bounded usable capacity of 65,536 events.
+        static constexpr int kCapacity = 65536 + 1;
         std::vector<RawEvent>  events;
         juce::AbstractFifo     fifo { kCapacity };
         std::atomic<std::uint64_t> overflowCount { 0 };

--- a/src/session/Session.h
+++ b/src/session/Session.h
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <limits>
 #include <memory>
+#include <type_traits>
 #include <vector>
 #include "AtomicSnapshot.h"
 #include "MidiBindings.h"
@@ -309,6 +310,16 @@ struct ChannelStripParams
     static constexpr float kBandQMin = 0.4f, kBandQMax = 4.0f;
 };
 
+struct TakeProvenance
+{
+    std::int64_t capturedAtMs = 0;
+    int loopPassOrdinal = 0;
+    bool partialPass = false;
+};
+
+static_assert (std::is_trivially_copyable<TakeProvenance>::value,
+               "TakeProvenance must remain trivially copyable");
+
 // Take-history slot - timeline position is NOT stored so rotating
 // preserves the region's timelineStart (same spot in the song).
 struct TakeRef
@@ -316,6 +327,7 @@ struct TakeRef
     juce::File file;
     std::int64_t sourceOffset    = 0;
     std::int64_t lengthInSamples = 0;
+    TakeProvenance provenance;
 };
 
 // 480 PPQN matches every modern DAW + .mid convention; high enough
@@ -622,6 +634,7 @@ struct MidiTakeRef
     std::int64_t           lengthInTicks = 0;
     std::vector<MidiNote> notes;
     std::vector<MidiCc>   ccs;
+    TakeProvenance provenance;
 };
 
 struct MidiRegion
@@ -632,6 +645,7 @@ struct MidiRegion
 
     std::vector<MidiNote> notes;
     std::vector<MidiCc>   ccs;
+    TakeProvenance provenance;
 
     // Front = next to surface on cycle. Same semantics as AudioRegion.
     std::vector<MidiTakeRef> previousTakes;
@@ -651,6 +665,28 @@ struct MidiRegion
     // Conversion anchor for tempo-locked retime.
     double recordedAtBPM = 120.0;
 };
+
+inline MidiTakeRef makeMidiTakeRef (const MidiRegion& region)
+{
+    return { region.lengthInTicks, region.notes, region.ccs, region.provenance };
+}
+
+inline void applyMidiTakeRef (MidiRegion& region, const MidiTakeRef& take)
+{
+    region.lengthInTicks = take.lengthInTicks;
+    region.notes = take.notes;
+    region.ccs = take.ccs;
+    region.provenance = take.provenance;
+}
+
+inline void swapMidiTakePayload (MidiRegion& region, MidiTakeRef& take)
+{
+    using std::swap;
+    swap (region.lengthInTicks, take.lengthInTicks);
+    swap (region.notes, take.notes);
+    swap (region.ccs, take.ccs);
+    swap (region.provenance, take.provenance);
+}
 
 // All shapes: shape(0)=0, shape(1)=1. EqualPower is constant-power for
 // crossfades. RaisedCosine has zero slope at both endpoints - the right
@@ -715,6 +751,8 @@ struct AudioRegion
     // processing so strip EQ/comp sees the user's chosen level.
     float gainDb = 0.0f;
 
+    TakeProvenance provenance;
+
     // Default-constructed (transparent) = "use track colour".
     juce::Colour customColour;
     juce::String label;
@@ -731,6 +769,29 @@ struct AudioRegion
     // Front = next to surface on cycle.
     std::vector<TakeRef> previousTakes;
 };
+
+inline TakeRef makeAudioTakeRef (const AudioRegion& region)
+{
+    return { region.file, region.sourceOffset, region.lengthInSamples,
+             region.provenance };
+}
+
+inline void applyAudioTakeRef (AudioRegion& region, const TakeRef& take)
+{
+    region.file = take.file;
+    region.sourceOffset = take.sourceOffset;
+    region.lengthInSamples = take.lengthInSamples;
+    region.provenance = take.provenance;
+}
+
+inline void swapAudioTakePayload (AudioRegion& region, TakeRef& take)
+{
+    using std::swap;
+    swap (region.file, take.file);
+    swap (region.sourceOffset, take.sourceOffset);
+    swap (region.lengthInSamples, take.lengthInSamples);
+    swap (region.provenance, take.provenance);
+}
 
 struct Track
 {

--- a/src/session/SessionSerializer.cpp
+++ b/src/session/SessionSerializer.cpp
@@ -54,14 +54,46 @@ inline std::optional<PluginDescriptor> descriptorFromObject (
     return std::nullopt;
 }
 
-// Bump whenever the JSON shape gains a NEW required field or changes
-// the meaning of an existing one. Adding optional fields that default
-// sensibly when absent does NOT require a bump - the load path
-// gracefully ignores unknown keys.
+// Bump whenever an older build could misread or silently discard meaningful
+// data from a newer session. Optional fields that are safe to lose do not
+// require a bump; persistent take provenance is not safe to lose on re-save.
 // Loader rejects sessions with version > kFormatVersion (newer Dusk Studio
 // can read older files via migrateSession; older Dusk Studio refusing
 // newer files is safer than silently dropping fields).
-constexpr int kFormatVersion = 4;
+constexpr int kFormatVersion = 5;
+
+inline bool hasTakeProvenance (const TakeProvenance& provenance) noexcept
+{
+    return provenance.capturedAtMs > 0
+        || provenance.loopPassOrdinal > 0
+        || provenance.partialPass;
+}
+
+inline void addTakeProvenance (JObj& parent, const TakeProvenance& provenance)
+{
+    if (! hasTakeProvenance (provenance)) return;
+
+    JObj value;
+    if (provenance.capturedAtMs > 0)
+        value["captured_at_ms"] = provenance.capturedAtMs;
+    if (provenance.loopPassOrdinal > 0)
+        value["loop_pass"] = provenance.loopPassOrdinal;
+    if (provenance.partialPass)
+        value["partial"] = true;
+    parent["take_provenance"] = std::move (value);
+}
+
+inline TakeProvenance parseTakeProvenance (const nlohmann::json& parent) noexcept
+{
+    const auto& value = json::child (parent, "take_provenance");
+    TakeProvenance provenance;
+    provenance.capturedAtMs = std::max (
+        (std::int64_t) 0, json::getInt64 (value, "captured_at_ms", 0));
+    provenance.loopPassOrdinal = std::max (
+        0, json::getInt (value, "loop_pass", 0));
+    provenance.partialPass = json::getBool (value, "partial", false);
+    return provenance;
+}
 
 // Store a float from JSON only when it's finite, so a corrupt or hand-edited
 // session.json can't push NaN / inf into a DSP parameter - the in-memory
@@ -262,6 +294,15 @@ bool migrateSession (nlohmann::json& root, int from)
                 // structured saves instead of silently dropping plugin slots.
                 if (root.is_object())
                     root["version"] = 4;
+                ++v;
+                break;
+
+            case 4:
+                // v4 -> v5: audio and MIDI takes may now carry optional
+                // capture provenance. Absent data is the all-default value,
+                // so legacy payloads only need the version stamp advanced.
+                if (root.is_object())
+                    root["version"] = 5;
                 ++v;
                 break;
 
@@ -647,6 +688,7 @@ JObj trackToObject (const Track& t, const juce::File& sessionDir)
             rObj["label"] = toStd (r.label);
         if (r.muted)  rObj["muted"]  = true;
         if (r.locked) rObj["locked"] = true;
+        addTakeProvenance (rObj, r.provenance);
 
         // Take history. Empty array on the common case (no overdubs); only
         // serialised when at least one prior take has been captured to keep
@@ -660,6 +702,7 @@ JObj trackToObject (const Track& t, const juce::File& sessionDir)
                 tObj["file"]          = toStd (portablePath (take.file, sessionDir));
                 tObj["source_offset"] = (std::int64_t) take.sourceOffset;
                 tObj["length"]        = (std::int64_t) take.lengthInSamples;
+                addTakeProvenance (tObj, take.provenance);
                 prior.push_back (std::move (tObj));
             }
             rObj["previous_takes"] = std::move (prior);
@@ -720,6 +763,7 @@ JObj trackToObject (const Track& t, const juce::File& sessionDir)
                 rObj["label"] = toStd (r.label);
             if (r.muted)  rObj["muted"]  = true;
             if (r.locked) rObj["locked"] = true;
+            addTakeProvenance (rObj, r.provenance);
 
             // BPM-change semantics (DuskStudio.md §5b). Default is locked,
             // so emit only when the user has explicitly unlocked. recorded_at_bpm
@@ -738,6 +782,7 @@ JObj trackToObject (const Track& t, const juce::File& sessionDir)
                 {
                     JObj tObj;
                     tObj["length_ticks"] = (std::int64_t) take.lengthInTicks;
+                    addTakeProvenance (tObj, take.provenance);
                     JObj tnotes = JObj::array();
                     for (const auto& n : take.notes)
                     {
@@ -1347,6 +1392,7 @@ void restoreTrack (Track& t, int trackIndex, const nlohmann::json& v,
             r.label           = json::getString (rv, "label");
             r.muted           = json::getBool (rv, "muted", false);
             r.locked          = json::getBool (rv, "locked", false);
+            r.provenance      = parseTakeProvenance (rv);
 
             {
                 const auto& prior = json::array (rv, "previous_takes");
@@ -1358,6 +1404,7 @@ void restoreTrack (Track& t, int trackIndex, const nlohmann::json& v,
                                                                  sessionDir, missingFiles);
                     take.sourceOffset    = std::max ((std::int64_t) 0, (std::int64_t) json::getInt64 (tv, "source_offset", 0));
                     take.lengthInSamples = std::max ((std::int64_t) 0, (std::int64_t) json::getInt64 (tv, "length", 0));
+                    take.provenance      = parseTakeProvenance (tv);
                     r.previousTakes.push_back (std::move (take));
                 }
             }
@@ -1422,6 +1469,7 @@ void restoreTrack (Track& t, int trackIndex, const nlohmann::json& v,
             r.label           = json::getString (rv, "label");
             r.muted           = json::getBool (rv, "muted", false);
             r.locked          = json::getBool (rv, "locked", false);
+            r.provenance      = parseTakeProvenance (rv);
 
             // tempo_lock defaults true (spec §5b: locked is the default).
             // recorded_at_bpm defaults to the session's tempo at load time,
@@ -1445,6 +1493,7 @@ void restoreTrack (Track& t, int trackIndex, const nlohmann::json& v,
                     if (! tv.is_object()) continue;
                     MidiTakeRef take;
                     take.lengthInTicks = std::max ((std::int64_t) 0, (std::int64_t) json::getInt64 (tv, "length_ticks", 0));
+                    take.provenance = parseTakeProvenance (tv);
                     parseNotes (json::array (tv, "notes"), take.notes);
                     parseCcs   (json::array (tv, "ccs"),   take.ccs);
                     r.previousTakes.push_back (std::move (take));

--- a/src/ui/TapeStrip.cpp
+++ b/src/ui/TapeStrip.cpp
@@ -1229,13 +1229,10 @@ void TapeStrip::mouseDown (const juce::MouseEvent& e)
         {
             AudioRegion before = cur;
             AudioRegion after  = cur;
-            const TakeRef current { after.file, after.sourceOffset, after.lengthInSamples };
-            const TakeRef next = after.previousTakes.front();
+            TakeRef next = std::move (after.previousTakes.front());
             after.previousTakes.erase (after.previousTakes.begin());
-            after.previousTakes.push_back (current);
-            after.file            = next.file;
-            after.sourceOffset    = next.sourceOffset;
-            after.lengthInSamples = next.lengthInSamples;
+            swapAudioTakePayload (after, next);
+            after.previousTakes.push_back (std::move (next));
 
             selectedTrack  = hit.track;
             selectedRegion = hit.regionIdx;
@@ -2716,16 +2713,8 @@ void TapeStrip::showRegionContextMenu (const RegionHit& hit, juce::Point<int> sc
 
                     AudioRegion before = cur;
                     AudioRegion after  = cur;
-                    TakeRef oldLive;
-                    oldLive.file            = after.file;
-                    oldLive.sourceOffset    = after.sourceOffset;
-                    oldLive.lengthInSamples = after.lengthInSamples;
-
-                    const TakeRef chosen = after.previousTakes[(size_t) takeIdx];
-                    after.file            = chosen.file;
-                    after.sourceOffset    = chosen.sourceOffset;
-                    after.lengthInSamples = chosen.lengthInSamples;
-                    after.previousTakes[(size_t) takeIdx] = oldLive;
+                    swapAudioTakePayload (
+                        after, after.previousTakes[(size_t) takeIdx]);
 
                     auto& um = safeThis->engine.getUndoManager();
                     um.beginNewTransaction (
@@ -2937,15 +2926,8 @@ void TapeStrip::showMidiRegionContextMenu (int trackIdx, int regionIdx,
 
                     MidiRegion before = cur;
                     MidiRegion after  = cur;
-                    MidiTakeRef oldLive;
-                    oldLive.lengthInTicks = after.lengthInTicks;
-                    oldLive.notes         = std::move (after.notes);
-                    oldLive.ccs           = std::move (after.ccs);
-
-                    after.lengthInTicks = after.previousTakes[(size_t) takeIdx].lengthInTicks;
-                    after.notes         = std::move (after.previousTakes[(size_t) takeIdx].notes);
-                    after.ccs           = std::move (after.previousTakes[(size_t) takeIdx].ccs);
-                    after.previousTakes[(size_t) takeIdx] = std::move (oldLive);
+                    swapMidiTakePayload (
+                        after, after.previousTakes[(size_t) takeIdx]);
 
                     // Recompute lengthInSamples from the new lengthInTicks
                     // at the session's current tempo. PlaybackEngine will
@@ -4388,13 +4370,10 @@ bool TapeStrip::cycleSelectedTakeForward()
 
             AudioRegion before = cur;
             AudioRegion after  = cur;
-            TakeRef oldLive { after.file, after.sourceOffset, after.lengthInSamples };
-            const TakeRef chosen = after.previousTakes.front();
+            TakeRef chosen = std::move (after.previousTakes.front());
             after.previousTakes.erase (after.previousTakes.begin());
-            after.file            = chosen.file;
-            after.sourceOffset    = chosen.sourceOffset;
-            after.lengthInSamples = chosen.lengthInSamples;
-            after.previousTakes.push_back (oldLive);
+            swapAudioTakePayload (after, chosen);
+            after.previousTakes.push_back (std::move (chosen));
 
             if (! didAny) um.beginNewTransaction ("Cycle take");
             um.perform (new RegionEditAction (session, engine,
@@ -4415,14 +4394,10 @@ bool TapeStrip::cycleSelectedTakeForward()
             {
                 MidiRegion before = cur;
                 MidiRegion after  = cur;
-                MidiTakeRef oldLive { after.lengthInTicks,
-                                       std::move (after.notes),
-                                       std::move (after.ccs) };
-                after.lengthInTicks = after.previousTakes.front().lengthInTicks;
-                after.notes         = std::move (after.previousTakes.front().notes);
-                after.ccs           = std::move (after.previousTakes.front().ccs);
+                MidiTakeRef chosen = std::move (after.previousTakes.front());
                 after.previousTakes.erase (after.previousTakes.begin());
-                after.previousTakes.push_back (std::move (oldLive));
+                swapMidiTakePayload (after, chosen);
+                after.previousTakes.push_back (std::move (chosen));
 
                 const double sr = engine.getCurrentSampleRate();
                 const float bpm = session.tempoBpm.load (std::memory_order_relaxed);
@@ -4465,13 +4440,11 @@ bool TapeStrip::cycleSelectedTakeBackward()
 
             AudioRegion before = cur;
             AudioRegion after  = cur;
-            TakeRef oldLive { after.file, after.sourceOffset, after.lengthInSamples };
-            const TakeRef chosen = after.previousTakes.back();
+            TakeRef chosen = std::move (after.previousTakes.back());
             after.previousTakes.pop_back();
-            after.file            = chosen.file;
-            after.sourceOffset    = chosen.sourceOffset;
-            after.lengthInSamples = chosen.lengthInSamples;
-            after.previousTakes.insert (after.previousTakes.begin(), oldLive);
+            swapAudioTakePayload (after, chosen);
+            after.previousTakes.insert (
+                after.previousTakes.begin(), std::move (chosen));
 
             if (! didAny) um.beginNewTransaction ("Cycle take");
             um.perform (new RegionEditAction (session, engine,
@@ -4492,15 +4465,11 @@ bool TapeStrip::cycleSelectedTakeBackward()
             {
                 MidiRegion before = cur;
                 MidiRegion after  = cur;
-                MidiTakeRef oldLive { after.lengthInTicks,
-                                       std::move (after.notes),
-                                       std::move (after.ccs) };
-                after.lengthInTicks = after.previousTakes.back().lengthInTicks;
-                after.notes         = std::move (after.previousTakes.back().notes);
-                after.ccs           = std::move (after.previousTakes.back().ccs);
+                MidiTakeRef chosen = std::move (after.previousTakes.back());
                 after.previousTakes.pop_back();
+                swapMidiTakePayload (after, chosen);
                 after.previousTakes.insert (after.previousTakes.begin(),
-                                              std::move (oldLive));
+                                              std::move (chosen));
 
                 const double sr = engine.getCurrentSampleRate();
                 const float bpm = session.tempoBpm.load (std::memory_order_relaxed);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,6 +95,7 @@ add_executable(dusk-studio-tests
     session_apply_tempo_change.cpp
     session_fader_group.cpp
     transport_state_machine.cpp
+    loop_timeline.cpp
     session_mcu_roundtrip.cpp
     console_bank_mapping.cpp
     track_meter_source.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,6 +129,7 @@ add_executable(dusk-studio-tests
     ${CMAKE_SOURCE_DIR}/src/engine/DpImporter.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/DpAligner.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/RecordManager.cpp
+    record_loop_take_stacking.cpp
     record_midi_overdub_diff.cpp
     record_offset_placement.cpp
     playback_loop_read.cpp

--- a/tests/loop_timeline.cpp
+++ b/tests/loop_timeline.cpp
@@ -1,0 +1,136 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/LoopTimeline.h"
+
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+namespace
+{
+using duskstudio::LoopTimelineSpan;
+
+std::vector<LoopTimelineSpan> collectSpans (std::int64_t blockStart,
+                                            int numSamples,
+                                            bool loopEnabled,
+                                            std::int64_t loopStart,
+                                            std::int64_t loopEnd)
+{
+    std::vector<LoopTimelineSpan> spans;
+    duskstudio::forEachLoopTimelineSpan (
+        blockStart, numSamples, loopEnabled, loopStart, loopEnd,
+        [&spans] (const LoopTimelineSpan& span) { spans.push_back (span); });
+    return spans;
+}
+
+void requireSpan (const LoopTimelineSpan& span,
+                  std::int64_t timelineStart,
+                  int bufferOffset,
+                  int length,
+                  bool wrappedBefore)
+{
+    REQUIRE (span.timelineStart == timelineStart);
+    REQUIRE (span.bufferOffset == bufferOffset);
+    REQUIRE (span.length == length);
+    REQUIRE (span.wrappedBefore == wrappedBefore);
+}
+} // namespace
+
+TEST_CASE ("LoopTimeline emits one linear span when looping is disabled or invalid",
+           "[loop][timeline]")
+{
+    const auto disabled = collectSpans (75, 32, false, 100, 200);
+    REQUIRE (disabled.size() == 1);
+    requireSpan (disabled[0], 75, 0, 32, false);
+
+    const auto empty = collectSpans (75, 32, true, 100, 100);
+    REQUIRE (empty.size() == 1);
+    requireSpan (empty[0], 75, 0, 32, false);
+
+    const auto inverted = collectSpans (75, 32, true, 200, 100);
+    REQUIRE (inverted.size() == 1);
+    requireSpan (inverted[0], 75, 0, 32, false);
+}
+
+TEST_CASE ("LoopTimeline splits a block exactly at an in-block seam",
+           "[loop][timeline]")
+{
+    const auto endingAtSeam = collectSpans (180, 20, true, 100, 200);
+    REQUIRE (endingAtSeam.size() == 1);
+    requireSpan (endingAtSeam[0], 180, 0, 20, false);
+
+    const auto spans = collectSpans (180, 40, true, 100, 200);
+
+    REQUIRE (spans.size() == 2);
+    requireSpan (spans[0], 180, 0, 20, false);
+    requireSpan (spans[1], 100, 20, 20, true);
+}
+
+TEST_CASE ("LoopTimeline keeps count-in before loop start linear until loop end",
+           "[loop][timeline]")
+{
+    const auto spans = collectSpans (50, 180, true, 100, 200);
+
+    REQUIRE (spans.size() == 2);
+    requireSpan (spans[0], 50, 0, 150, false);
+    requireSpan (spans[1], 100, 150, 30, true);
+}
+
+TEST_CASE ("LoopTimeline normalizes starts at and beyond loop end",
+           "[loop][timeline]")
+{
+    const auto atEnd = collectSpans (200, 10, true, 100, 200);
+    REQUIRE (atEnd.size() == 1);
+    requireSpan (atEnd[0], 100, 0, 10, true);
+
+    const auto beyond = collectSpans (455, 10, true, 100, 200);
+    REQUIRE (beyond.size() == 1);
+    requireSpan (beyond[0], 155, 0, 10, true);
+
+    const auto exactCycles = collectSpans (500, 10, true, 100, 200);
+    REQUIRE (exactCycles.size() == 1);
+    requireSpan (exactCycles[0], 100, 0, 10, true);
+
+    const auto farBeyond = collectSpans (
+        std::numeric_limits<std::int64_t>::max(), 10, true, 100, 200);
+    REQUIRE (farBeyond.size() == 1);
+    requireSpan (farBeyond[0], 107, 0, 10, true);
+}
+
+TEST_CASE ("LoopTimeline emits every wrap when one host block spans many loops",
+           "[loop][timeline]")
+{
+    const auto spans = collectSpans (12, 10, true, 10, 13);
+
+    REQUIRE (spans.size() == 4);
+    requireSpan (spans[0], 12, 0, 1, false);
+    requireSpan (spans[1], 10, 1, 3, true);
+    requireSpan (spans[2], 10, 4, 3, true);
+    requireSpan (spans[3], 10, 7, 3, true);
+}
+
+TEST_CASE ("LoopTimeline handles negative timeline positions without signed overflow",
+           "[loop][timeline]")
+{
+    const auto crossing = collectSpans (-120, 40, true, -200, -100);
+    REQUIRE (crossing.size() == 2);
+    requireSpan (crossing[0], -120, 0, 20, false);
+    requireSpan (crossing[1], -200, 20, 20, true);
+
+    const auto nearMinimum = collectSpans (
+        std::numeric_limits<std::int64_t>::min(), 10, true, -200, -100);
+    REQUIRE (nearMinimum.size() == 1);
+    requireSpan (nearMinimum[0], std::numeric_limits<std::int64_t>::min(),
+                 0, 10, false);
+}
+
+TEST_CASE ("LoopTimeline does not call back for an empty block",
+           "[loop][timeline]")
+{
+    int callbacks = 0;
+    duskstudio::forEachLoopTimelineSpan (
+        180, 0, true, 100, 200,
+        [&callbacks] (const LoopTimelineSpan&) { ++callbacks; });
+
+    REQUIRE (callbacks == 0);
+}

--- a/tests/record_loop_take_stacking.cpp
+++ b/tests/record_loop_take_stacking.cpp
@@ -1,0 +1,709 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/RecordManager.h"
+#include "session/Session.h"
+
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_core/juce_core.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+using namespace duskstudio;
+
+namespace
+{
+struct ScopedDir
+{
+    juce::File dir;
+    ~ScopedDir() { dir.deleteRecursively(); }
+};
+
+ScopedDir makeSessionDir (const char* tag)
+{
+    auto dir = juce::File::getSpecialLocation (juce::File::tempDirectory)
+                   .getChildFile (juce::String (tag)
+                                  + juce::String (juce::Random::getSystemRandom().nextInt()));
+    REQUIRE (dir.createDirectory().wasOk());
+    return { dir };
+}
+
+RecordManager::LoopCapturePlan loopPlan (std::int64_t start = 100,
+                                         std::int64_t end = 108)
+{
+    RecordManager::LoopCapturePlan plan;
+    plan.enabled = true;
+    plan.loopStartSample = start;
+    plan.loopEndSample = end;
+    plan.captureStartSample = start;
+    plan.captureEndSample = end;
+    return plan;
+}
+
+void armTrack (Session& session, const juce::File& dir, Track::Mode mode)
+{
+    session.setSessionDirectory (dir);
+    session.track (0).mode.store ((int) mode, std::memory_order_relaxed);
+    session.setTrackArmed (0, true);
+}
+
+void writeAudioPass (RecordManager& manager,
+                     int ordinal,
+                     std::int64_t timelineStart,
+                     int samples,
+                     float value = 0.25f)
+{
+    const auto span = manager.coordinateLoopCaptureSpan (
+        ordinal, timelineStart, 0, samples);
+    REQUIRE (span.passOrdinal == ordinal);
+    REQUIRE (span.numSamples == samples);
+    manager.beginLoopCaptureSpan (span);
+    std::vector<float> block ((size_t) samples, value);
+    manager.writeInputBlock (0, block.data() + span.inputOffset, nullptr, span.numSamples);
+}
+
+void writeMidiPass (RecordManager& manager,
+                    int ordinal,
+                    std::int64_t timelineStart,
+                    juce::MidiBuffer events,
+                    int samples = 8)
+{
+    const auto span = manager.coordinateLoopCaptureSpan (
+        ordinal, timelineStart, 0, samples);
+    REQUIRE (span.passOrdinal == ordinal);
+    REQUIRE (span.numSamples == samples);
+    manager.beginLoopCaptureSpan (span);
+    manager.writeMidiBlock (0, events, 0);
+}
+
+const AudioRegion& loopAudioRegion (const Session& session)
+{
+    const auto& regions = session.track (0).regions;
+    const auto it = std::find_if (regions.begin(), regions.end(), [] (const AudioRegion& region)
+    {
+        return region.provenance.loopPassOrdinal > 0;
+    });
+    REQUIRE (it != regions.end());
+    return *it;
+}
+
+juce::MidiBuffer oneNote (int note, int onSample = 1, int offSample = 6)
+{
+    juce::MidiBuffer events;
+    events.addEvent (juce::MidiMessage::noteOn (1, note, (juce::uint8) 100), onSample);
+    events.addEvent (juce::MidiMessage::noteOff (1, note), offSample);
+    return events;
+}
+} // namespace
+
+TEST_CASE ("Loop audio stores two full passes as one spool with exact take offsets",
+           "[recording][recordmanager][loop-takes]")
+{
+    const auto temp = makeSessionDir ("dusk-loop-audio-two-");
+    Session session;
+    armTrack (session, temp.dir, Track::Mode::Mono);
+    RecordManager manager (session);
+    const auto plan = loopPlan();
+
+    REQUIRE (manager.startRecording (48000.0, 100, 0, plan));
+    writeAudioPass (manager, 1, 100, 8);
+    writeAudioPass (manager, 2, 100, 8);
+    manager.stopRecording (108);
+
+    const auto& region = loopAudioRegion (session);
+    REQUIRE (region.timelineStart == 100);
+    REQUIRE (region.sourceOffset == 8);
+    REQUIRE (region.lengthInSamples == 8);
+    REQUIRE (region.provenance.loopPassOrdinal == 2);
+    REQUIRE_FALSE (region.provenance.partialPass);
+    REQUIRE (region.provenance.capturedAtMs > 0);
+    REQUIRE (region.previousTakes.size() == 1);
+    REQUIRE (region.previousTakes[0].file == region.file);
+    REQUIRE (region.previousTakes[0].sourceOffset == 0);
+    REQUIRE (region.previousTakes[0].lengthInSamples == 8);
+    REQUIRE (region.previousTakes[0].provenance.loopPassOrdinal == 1);
+    REQUIRE (region.previousTakes[0].provenance.capturedAtMs
+             == region.provenance.capturedAtMs);
+}
+
+TEST_CASE ("Loop audio commits a final partial pass and no exact-boundary empty pass",
+           "[recording][recordmanager][loop-takes]")
+{
+    const auto temp = makeSessionDir ("dusk-loop-audio-partial-");
+    Session session;
+    armTrack (session, temp.dir, Track::Mode::Mono);
+    RecordManager manager (session);
+    const auto plan = loopPlan();
+
+    REQUIRE (manager.startRecording (48000.0, 100, 0, plan));
+    writeAudioPass (manager, 1, 100, 8);
+
+    SECTION ("final partial")
+    {
+        writeAudioPass (manager, 2, 100, 3);
+        manager.stopRecording (103);
+        const auto& region = loopAudioRegion (session);
+        REQUIRE (region.provenance.loopPassOrdinal == 2);
+        REQUIRE (region.provenance.partialPass);
+        REQUIRE (region.sourceOffset == 8);
+        REQUIRE (region.lengthInSamples == 3);
+        REQUIRE (region.previousTakes.size() == 1);
+    }
+
+    SECTION ("exact loop boundary")
+    {
+        writeAudioPass (manager, 2, 100, 8);
+        manager.stopRecording (108);
+        const auto& region = loopAudioRegion (session);
+        REQUIRE (region.provenance.loopPassOrdinal == 2);
+        REQUIRE_FALSE (region.provenance.partialPass);
+        REQUIRE (region.previousTakes.size() == 1);
+    }
+}
+
+TEST_CASE ("Loop audio history is newest-first capped and then retains compatible old takes",
+           "[recording][recordmanager][loop-takes][history]")
+{
+    const auto temp = makeSessionDir ("dusk-loop-audio-history-");
+    Session session;
+    armTrack (session, temp.dir, Track::Mode::Mono);
+
+    AudioRegion existing;
+    existing.file = temp.dir.getChildFile ("existing.wav");
+    existing.timelineStart = 100;
+    existing.lengthInSamples = 8;
+    existing.sourceOffset = 40;
+    existing.provenance.capturedAtMs = 77;
+    existing.previousTakes.push_back (
+        { temp.dir.getChildFile ("existing-older.wav"), 20, 8, { 66, 0, false } });
+    session.track (0).regions.push_back (existing);
+
+    RecordManager manager (session);
+    const auto plan = loopPlan();
+    REQUIRE (manager.startRecording (48000.0, 100, 0, plan));
+    for (int ordinal = 1; ordinal <= 7; ++ordinal)
+        writeAudioPass (manager, ordinal, 100, 8);
+    manager.stopRecording (108);
+
+    const auto& region = loopAudioRegion (session);
+    REQUIRE (region.provenance.loopPassOrdinal == 7);
+    REQUIRE (region.previousTakes.size() == 8);
+    for (int i = 0; i < 6; ++i)
+        REQUIRE (region.previousTakes[(size_t) i].provenance.loopPassOrdinal == 6 - i);
+    REQUIRE (region.previousTakes[6].file == existing.file);
+    REQUIRE (region.previousTakes[6].provenance.capturedAtMs == 77);
+    REQUIRE (region.previousTakes[7].file == existing.previousTakes[0].file);
+}
+
+TEST_CASE ("Loop audio retention drops oldest passes after current plus eight prior",
+           "[recording][recordmanager][loop-takes][history]")
+{
+    const auto temp = makeSessionDir ("dusk-loop-audio-cap-");
+    Session session;
+    armTrack (session, temp.dir, Track::Mode::Mono);
+    RecordManager manager (session);
+    const auto plan = loopPlan();
+    REQUIRE (manager.startRecording (48000.0, 100, 0, plan));
+    for (int ordinal = 1; ordinal <= 10; ++ordinal)
+        writeAudioPass (manager, ordinal, 100, 8);
+    manager.stopRecording (108);
+
+    const auto& region = loopAudioRegion (session);
+    REQUIRE (region.provenance.loopPassOrdinal == 10);
+    REQUIRE (region.previousTakes.size() == 8);
+    for (int i = 0; i < 8; ++i)
+        REQUIRE (region.previousTakes[(size_t) i].provenance.loopPassOrdinal == 9 - i);
+}
+
+TEST_CASE ("Loop audio retains a silent pass and trims latency per pass",
+           "[recording][recordmanager][loop-takes][latency]")
+{
+    const auto temp = makeSessionDir ("dusk-loop-audio-latency-");
+    Session session;
+    armTrack (session, temp.dir, Track::Mode::Mono);
+    RecordManager manager (session);
+    const auto plan = loopPlan (0, 8);
+    REQUIRE (manager.startRecording (48000.0, 0, 3, plan));
+    writeAudioPass (manager, 1, 0, 8, 0.0f);
+    writeAudioPass (manager, 2, 0, 8, 0.5f);
+    manager.stopRecording (8);
+
+    const auto& region = loopAudioRegion (session);
+    REQUIRE (region.timelineStart == 0);
+    REQUIRE (region.sourceOffset == 11);
+    REQUIRE (region.lengthInSamples == 5);
+    REQUIRE (region.previousTakes.size() == 1);
+    REQUIRE (region.previousTakes[0].sourceOffset == 3);
+    REQUIRE (region.previousTakes[0].lengthInSamples == 5);
+}
+
+TEST_CASE ("Loop punch preserves the overwritten middle of a spanning region as a take",
+           "[recording][recordmanager][loop-takes][punch]")
+{
+    const auto temp = makeSessionDir ("dusk-loop-audio-span-");
+    Session session;
+    armTrack (session, temp.dir, Track::Mode::Mono);
+
+    AudioRegion existing;
+    existing.file = temp.dir.getChildFile ("spanning.wav");
+    existing.timelineStart = 90;
+    existing.lengthInSamples = 30;
+    existing.sourceOffset = 50;
+    existing.provenance = { 42, 0, false };
+    existing.previousTakes.push_back (
+        { temp.dir.getChildFile ("spanning-older.wav"), 10, 30, { 41, 0, false } });
+    existing.previousTakes.push_back (
+        { temp.dir.getChildFile ("spanning-too-short.wav"), 5, 12, { 40, 0, false } });
+    session.track (0).regions.push_back (existing);
+
+    RecordManager manager (session);
+    const auto plan = loopPlan (100, 110);
+    REQUIRE (manager.startRecording (48000.0, 100, 0, plan));
+    writeAudioPass (manager, 1, 100, 10);
+    manager.stopRecording (110);
+
+    const auto& region = loopAudioRegion (session);
+    REQUIRE (region.previousTakes.size() == 2);
+    REQUIRE (region.previousTakes[0].file == existing.file);
+    REQUIRE (region.previousTakes[0].sourceOffset == 60);
+    REQUIRE (region.previousTakes[0].lengthInSamples == 10);
+    REQUIRE (region.previousTakes[0].provenance.capturedAtMs == 42);
+    REQUIRE (region.previousTakes[1].file == existing.previousTakes[0].file);
+    REQUIRE (region.previousTakes[1].sourceOffset == 20);
+    REQUIRE (region.previousTakes[1].lengthInSamples == 10);
+    REQUIRE (std::none_of (region.previousTakes.begin(), region.previousTakes.end(),
+                           [&existing] (const TakeRef& take)
+    {
+        return take.file == existing.previousTakes[1].file;
+    }));
+    REQUIRE (session.track (0).regions.size() == 3);
+}
+
+TEST_CASE ("Final partial audio keeps loop history before sliced containing takes",
+           "[recording][recordmanager][loop-takes][history][punch]")
+{
+    const auto temp = makeSessionDir ("dusk-loop-audio-partial-history-");
+    Session session;
+    armTrack (session, temp.dir, Track::Mode::Mono);
+
+    AudioRegion existing;
+    existing.file = temp.dir.getChildFile ("existing-full.wav");
+    existing.timelineStart = 100;
+    existing.lengthInSamples = 8;
+    existing.sourceOffset = 40;
+    existing.provenance = { 81, 0, false };
+    existing.previousTakes.push_back (
+        { temp.dir.getChildFile ("existing-full-older.wav"), 20, 8,
+          { 80, 0, false } });
+    session.track (0).regions.push_back (existing);
+
+    RecordManager manager (session);
+    const auto plan = loopPlan();
+    REQUIRE (manager.startRecording (48000.0, 100, 0, plan));
+    writeAudioPass (manager, 1, 100, 8);
+    writeAudioPass (manager, 2, 100, 5);
+    manager.stopRecording (105);
+
+    const auto& region = loopAudioRegion (session);
+    REQUIRE (region.provenance.loopPassOrdinal == 2);
+    REQUIRE (region.provenance.partialPass);
+    REQUIRE (region.previousTakes.size() == 3);
+    REQUIRE (region.previousTakes[0].provenance.loopPassOrdinal == 1);
+    REQUIRE (region.previousTakes[1].file == existing.file);
+    REQUIRE (region.previousTakes[1].sourceOffset == 40);
+    REQUIRE (region.previousTakes[1].lengthInSamples == 5);
+    REQUIRE (region.previousTakes[1].provenance.capturedAtMs == 81);
+    REQUIRE (region.previousTakes[2].file == existing.previousTakes[0].file);
+    REQUIRE (region.previousTakes[2].sourceOffset == 20);
+    REQUIRE (region.previousTakes[2].lengthInSamples == 5);
+
+    const auto& regions = session.track (0).regions;
+    const auto tail = std::find_if (regions.begin(), regions.end(),
+                                    [&existing] (const AudioRegion& candidate)
+    {
+        return candidate.file == existing.file
+            && candidate.provenance.loopPassOrdinal == 0;
+    });
+    REQUIRE (tail != regions.end());
+    REQUIRE (tail->timelineStart < 108);
+    REQUIRE (tail->timelineStart + tail->lengthInSamples == 108);
+}
+
+TEST_CASE ("Loop MIDI partitions two passes into current and previous takes",
+           "[recording][recordmanager][loop-takes][midi]")
+{
+    const auto temp = makeSessionDir ("dusk-loop-midi-two-");
+    Session session;
+    armTrack (session, temp.dir, Track::Mode::Midi);
+    RecordManager manager (session);
+    const auto plan = loopPlan();
+    REQUIRE (manager.startRecording (960.0, 100, 0, plan));
+    writeMidiPass (manager, 1, 100, oneNote (60), 8);
+    writeMidiPass (manager, 2, 100, oneNote (64), 8);
+    manager.stopRecording (108);
+
+    const auto regions = session.track (0).midiRegions.current();
+    REQUIRE (regions.size() == 1);
+    const auto& region = regions[0];
+    REQUIRE (region.provenance.loopPassOrdinal == 2);
+    REQUIRE (region.notes.size() == 1);
+    REQUIRE (region.notes[0].noteNumber == 64);
+    REQUIRE (region.previousTakes.size() == 1);
+    REQUIRE (region.previousTakes[0].provenance.loopPassOrdinal == 1);
+    REQUIRE (region.previousTakes[0].notes.size() == 1);
+    REQUIRE (region.previousTakes[0].notes[0].noteNumber == 60);
+}
+
+TEST_CASE ("Loop MIDI history keeps loop passes before compatible existing takes",
+           "[recording][recordmanager][loop-takes][midi][history]")
+{
+    const auto temp = makeSessionDir ("dusk-loop-midi-history-");
+    Session session;
+    armTrack (session, temp.dir, Track::Mode::Midi);
+
+    MidiRegion existing;
+    existing.timelineStart = 100;
+    existing.lengthInSamples = 8;
+    existing.lengthInTicks = 8;
+    existing.provenance = { 70, 0, false };
+    existing.notes.push_back ({ 1, 50, 90, 1, 4 });
+    MidiTakeRef deeper;
+    deeper.lengthInTicks = 8;
+    deeper.provenance = { 60, 0, false };
+    existing.previousTakes.push_back (deeper);
+    session.track (0).midiRegions.publish (
+        std::make_unique<std::vector<MidiRegion>> (1, existing));
+
+    RecordManager manager (session);
+    const auto plan = loopPlan();
+    REQUIRE (manager.startRecording (960.0, 100, 0, plan));
+    for (int ordinal = 1; ordinal <= 7; ++ordinal)
+        writeMidiPass (manager, ordinal, 100, oneNote (59 + ordinal), 8);
+    manager.stopRecording (108);
+
+    const auto region = session.track (0).midiRegions.current().at (0);
+    REQUIRE (region.provenance.loopPassOrdinal == 7);
+    REQUIRE (region.previousTakes.size() == 8);
+    for (int i = 0; i < 6; ++i)
+        REQUIRE (region.previousTakes[(size_t) i].provenance.loopPassOrdinal == 6 - i);
+    REQUIRE (region.previousTakes[6].provenance.capturedAtMs == 70);
+    REQUIRE (region.previousTakes[7].provenance.capturedAtMs == 60);
+}
+
+TEST_CASE ("Loop MIDI closes and retriggers a note crossing the seam",
+           "[recording][recordmanager][loop-takes][midi]")
+{
+    const auto temp = makeSessionDir ("dusk-loop-midi-note-seam-");
+    Session session;
+    armTrack (session, temp.dir, Track::Mode::Midi);
+    RecordManager manager (session);
+    const auto plan = loopPlan();
+    REQUIRE (manager.startRecording (960.0, 100, 0, plan));
+
+    juce::MidiBuffer first;
+    first.addEvent (juce::MidiMessage::noteOn (1, 67, (juce::uint8) 91), 6);
+    writeMidiPass (manager, 1, 100, first, 8);
+    juce::MidiBuffer second;
+    second.addEvent (juce::MidiMessage::noteOff (1, 67), 2);
+    writeMidiPass (manager, 2, 100, second, 8);
+    manager.stopRecording (108);
+
+    const auto region = session.track (0).midiRegions.current().at (0);
+    REQUIRE (region.previousTakes.size() == 1);
+    REQUIRE (region.previousTakes[0].notes.size() == 1);
+    REQUIRE (region.previousTakes[0].notes[0].startTick == 6);
+    REQUIRE (region.previousTakes[0].notes[0].lengthInTicks == 2);
+    REQUIRE (region.notes.size() == 1);
+    REQUIRE (region.notes[0].startTick == 0);
+    REQUIRE (region.notes[0].lengthInTicks == 2);
+    REQUIRE (region.notes[0].velocity == 91);
+}
+
+TEST_CASE ("Loop MIDI resets and chases sustain across a seam",
+           "[recording][recordmanager][loop-takes][midi]")
+{
+    const auto temp = makeSessionDir ("dusk-loop-midi-cc-seam-");
+    Session session;
+    armTrack (session, temp.dir, Track::Mode::Midi);
+    RecordManager manager (session);
+    const auto plan = loopPlan();
+    REQUIRE (manager.startRecording (960.0, 100, 0, plan));
+
+    juce::MidiBuffer first;
+    first.addEvent (juce::MidiMessage::controllerEvent (1, 64, 127), 2);
+    writeMidiPass (manager, 1, 100, first, 8);
+    juce::MidiBuffer second;
+    second.addEvent (juce::MidiMessage::controllerEvent (1, 64, 0), 3);
+    writeMidiPass (manager, 2, 100, second, 8);
+    manager.stopRecording (108);
+
+    const auto region = session.track (0).midiRegions.current().at (0);
+    REQUIRE (region.previousTakes.size() == 1);
+    const auto& priorCcs = region.previousTakes[0].ccs;
+    REQUIRE (priorCcs.size() == 2);
+    REQUIRE (priorCcs[0].controller == 64);
+    REQUIRE (priorCcs[0].value == 127);
+    REQUIRE (priorCcs[1].value == 0);
+    REQUIRE (priorCcs[1].atTick == 8);
+    REQUIRE (region.ccs.size() == 2);
+    REQUIRE (region.ccs[0].controller == 64);
+    REQUIRE (region.ccs[0].value == 127);
+    REQUIRE (region.ccs[0].atTick == 0);
+    REQUIRE (region.ccs[1].value == 0);
+    REQUIRE (region.ccs[1].atTick == 3);
+}
+
+TEST_CASE ("Loop MIDI ignores a truly empty pass and keeps a final partial pass",
+           "[recording][recordmanager][loop-takes][midi]")
+{
+    const auto temp = makeSessionDir ("dusk-loop-midi-empty-");
+    Session session;
+    armTrack (session, temp.dir, Track::Mode::Midi);
+    RecordManager manager (session);
+    const auto plan = loopPlan();
+    REQUIRE (manager.startRecording (960.0, 100, 0, plan));
+    writeMidiPass (manager, 1, 100, {}, 8);
+    writeMidiPass (manager, 2, 100, oneNote (72, 0, 2), 3);
+    manager.stopRecording (103);
+
+    const auto region = session.track (0).midiRegions.current().at (0);
+    REQUIRE (region.provenance.loopPassOrdinal == 2);
+    REQUIRE (region.provenance.partialPass);
+    REQUIRE (region.previousTakes.empty());
+    REQUIRE (region.lengthInSamples == 3);
+}
+
+TEST_CASE ("Loop MIDI accepts original punch callback coordinates",
+           "[recording][recordmanager][loop-takes][midi][punch]")
+{
+    const auto temp = makeSessionDir ("dusk-loop-midi-punch-coordinates-");
+    Session session;
+    armTrack (session, temp.dir, Track::Mode::Midi);
+    RecordManager manager (session);
+    auto plan = loopPlan (100, 120);
+    plan.captureStartSample = 105;
+    plan.captureEndSample = 108;
+    REQUIRE (manager.startRecording (960.0, 105, 0, plan));
+
+    const auto span = manager.coordinateLoopCaptureSpan (1, 100, 0, 12);
+    REQUIRE (span.inputOffset == 5);
+    REQUIRE (span.numSamples == 3);
+    manager.beginLoopCaptureSpan (span);
+
+    juce::MidiBuffer originalCallback;
+    originalCallback.addEvent (juce::MidiMessage::noteOn (
+                                   1, 50, (juce::uint8) 100), 1);
+    originalCallback.addEvent (juce::MidiMessage::noteOff (1, 50), 3);
+    originalCallback.addEvent (juce::MidiMessage::noteOn (
+                                   1, 60, (juce::uint8) 100), 5);
+    originalCallback.addEvent (juce::MidiMessage::noteOff (1, 60), 7);
+    originalCallback.addEvent (juce::MidiMessage::noteOn (
+                                   1, 70, (juce::uint8) 100), 8);
+    originalCallback.addEvent (juce::MidiMessage::noteOff (1, 70), 10);
+    manager.writeMidiBlock (0, originalCallback, 0);
+    manager.stopRecording (108);
+
+    const auto region = session.track (0).midiRegions.current().at (0);
+    REQUIRE (region.notes.size() == 1);
+    REQUIRE (region.notes[0].noteNumber == 60);
+    REQUIRE (region.notes[0].startTick == 0);
+    REQUIRE (region.notes[0].lengthInTicks == 2);
+}
+
+TEST_CASE ("Loop MIDI splits one original callback across a seam without rereading events",
+           "[recording][recordmanager][loop-takes][midi][seam]")
+{
+    const auto temp = makeSessionDir ("dusk-loop-midi-one-callback-seam-");
+    Session session;
+    armTrack (session, temp.dir, Track::Mode::Midi);
+    RecordManager manager (session);
+    const auto plan = loopPlan();
+    REQUIRE (manager.startRecording (960.0, 100, 0, plan));
+
+    // The first six samples of pass 1 arrived in an earlier callback. This
+    // seam callback begins at timeline 106 and wraps after its first 2 samples.
+    auto span = manager.coordinateLoopCaptureSpan (1, 100, 0, 6);
+    REQUIRE (span.inputOffset == 0);
+    REQUIRE (span.numSamples == 6);
+    manager.beginLoopCaptureSpan (span);
+
+    juce::MidiBuffer originalCallback;
+    originalCallback.addEvent (juce::MidiMessage::noteOn (
+                                   1, 60, (juce::uint8) 100), 0);
+    originalCallback.addEvent (juce::MidiMessage::noteOff (1, 60), 1);
+    originalCallback.addEvent (juce::MidiMessage::noteOn (
+                                   1, 64, (juce::uint8) 100), 4);
+    originalCallback.addEvent (juce::MidiMessage::noteOff (1, 64), 5);
+
+    span = manager.coordinateLoopCaptureSpan (1, 106, 0, 6);
+    REQUIRE (span.inputOffset == 0);
+    REQUIRE (span.numSamples == 2);
+    REQUIRE (span.endsPass);
+    manager.beginLoopCaptureSpan (span);
+    manager.writeMidiBlock (0, originalCallback, 0);
+
+    span = manager.coordinateLoopCaptureSpan (2, 100, 2, 4);
+    REQUIRE (span.inputOffset == 2);
+    REQUIRE (span.numSamples == 4);
+    manager.beginLoopCaptureSpan (span);
+    manager.writeMidiBlock (0, originalCallback, 0);
+    manager.stopRecording (104);
+
+    const auto region = session.track (0).midiRegions.current().at (0);
+    REQUIRE (region.provenance.loopPassOrdinal == 2);
+    REQUIRE (region.notes.size() == 1);
+    REQUIRE (region.notes[0].noteNumber == 64);
+    REQUIRE (region.notes[0].startTick == 2);
+    REQUIRE (region.notes[0].lengthInTicks == 1);
+    REQUIRE (region.previousTakes.size() == 1);
+    REQUIRE (region.previousTakes[0].provenance.loopPassOrdinal == 1);
+    REQUIRE (region.previousTakes[0].notes.size() == 1);
+    REQUIRE (region.previousTakes[0].notes[0].noteNumber == 60);
+    REQUIRE (region.previousTakes[0].notes[0].startTick == 6);
+    REQUIRE (region.previousTakes[0].notes[0].lengthInTicks == 1);
+}
+
+TEST_CASE ("Final partial MIDI keeps containing history after loop passes without removal",
+           "[recording][recordmanager][loop-takes][midi][history][punch]")
+{
+    const auto temp = makeSessionDir ("dusk-loop-midi-partial-history-");
+    Session session;
+    armTrack (session, temp.dir, Track::Mode::Midi);
+
+    MidiRegion existing;
+    existing.timelineStart = 100;
+    existing.lengthInSamples = 8;
+    existing.lengthInTicks = 8;
+    existing.provenance = { 91, 0, false };
+    existing.notes.push_back ({ 1, 48, 90, 0, 6 });
+    MidiTakeRef deeper;
+    deeper.lengthInTicks = 8;
+    deeper.notes.push_back ({ 1, 47, 80, 0, 7 });
+    deeper.provenance = { 90, 0, false };
+    existing.previousTakes.push_back (deeper);
+    session.track (0).midiRegions.publish (
+        std::make_unique<std::vector<MidiRegion>> (1, existing));
+
+    RecordManager manager (session);
+    const auto plan = loopPlan();
+    REQUIRE (manager.startRecording (960.0, 100, 0, plan));
+    writeMidiPass (manager, 1, 100, oneNote (60), 8);
+    writeMidiPass (manager, 2, 100, oneNote (64, 0, 2), 3);
+    manager.stopRecording (103);
+
+    const auto regions = session.track (0).midiRegions.current();
+    REQUIRE (regions.size() == 2);
+    const auto current = std::find_if (regions.begin(), regions.end(), [] (const MidiRegion& r)
+    {
+        return r.provenance.loopPassOrdinal == 2;
+    });
+    REQUIRE (current != regions.end());
+    REQUIRE (current->previousTakes.size() == 3);
+    REQUIRE (current->previousTakes[0].provenance.loopPassOrdinal == 1);
+    REQUIRE (current->previousTakes[1].provenance.capturedAtMs == 91);
+    REQUIRE (current->previousTakes[1].lengthInTicks == 3);
+    REQUIRE (current->previousTakes[1].notes.size() == 1);
+    REQUIRE (current->previousTakes[1].notes[0].lengthInTicks == 3);
+    REQUIRE (current->previousTakes[2].provenance.capturedAtMs == 90);
+    REQUIRE (current->previousTakes[2].lengthInTicks == 3);
+    REQUIRE (current->previousTakes[2].notes.size() == 1);
+    REQUIRE (current->previousTakes[2].notes[0].lengthInTicks == 3);
+    REQUIRE (std::any_of (regions.begin(), regions.end(), [] (const MidiRegion& r)
+    {
+        return r.provenance.capturedAtMs == 91 && r.lengthInSamples == 8;
+    }));
+}
+
+TEST_CASE ("Loop commit diff snapshots provenance and take history for undo",
+           "[recording][recordmanager][loop-takes][undo]")
+{
+    const auto temp = makeSessionDir ("dusk-loop-diff-");
+    Session session;
+    armTrack (session, temp.dir, Track::Mode::Mono);
+    AudioRegion before;
+    before.file = temp.dir.getChildFile ("before.wav");
+    before.timelineStart = 100;
+    before.lengthInSamples = 8;
+    before.provenance = { 55, 0, false };
+    session.track (0).regions.push_back (before);
+
+    RecordManager manager (session);
+    const auto plan = loopPlan();
+    REQUIRE (manager.startRecording (48000.0, 100, 0, plan));
+    writeAudioPass (manager, 1, 100, 8);
+    writeAudioPass (manager, 2, 100, 8);
+    manager.stopRecording (108);
+
+    const auto& diff = manager.getLastCommitDiff();
+    REQUIRE (diff.size() == 1);
+    REQUIRE (diff[0].trackIndex == 0);
+    REQUIRE (diff[0].audioBefore.size() == 1);
+    REQUIRE (diff[0].audioBefore[0].provenance.capturedAtMs == 55);
+    REQUIRE (diff[0].audioAfter.size() == 1);
+    REQUIRE (diff[0].audioAfter[0].provenance.loopPassOrdinal == 2);
+    REQUIRE (diff[0].audioAfter[0].previousTakes.size() == 2);
+    REQUIRE (diff[0].audioAfter[0].previousTakes[0].provenance.loopPassOrdinal == 1);
+    REQUIRE (diff[0].audioAfter[0].previousTakes[1].provenance.capturedAtMs == 55);
+}
+
+TEST_CASE ("Loop capture plan rejects an empty effective punch intersection",
+           "[recording][recordmanager][loop-takes][punch]")
+{
+    const auto temp = makeSessionDir ("dusk-loop-empty-plan-");
+    Session session;
+    armTrack (session, temp.dir, Track::Mode::Mono);
+    RecordManager manager (session);
+    auto plan = loopPlan();
+    plan.captureStartSample = plan.captureEndSample;
+    REQUIRE_FALSE (manager.startRecording (48000.0, 100, 0, plan));
+
+    plan = loopPlan();
+    REQUIRE (manager.startRecording (48000.0, 100, 0, plan));
+    const auto preRoll = manager.coordinateLoopCaptureSpan (1, 90, 0, 8);
+    REQUIRE (preRoll.numSamples == 0);
+    manager.stopRecording (100);
+    REQUIRE (session.track (0).regions.empty());
+}
+
+TEST_CASE ("Loop capture snapshots and writes only the effective punch intersection",
+           "[recording][recordmanager][loop-takes][punch]")
+{
+    const auto temp = makeSessionDir ("dusk-loop-punch-intersection-");
+    Session session;
+    armTrack (session, temp.dir, Track::Mode::Mono);
+    RecordManager manager (session);
+    auto plan = loopPlan (100, 120);
+    plan.captureStartSample = 105;
+    plan.captureEndSample = 115;
+    REQUIRE (manager.startRecording (48000.0, 105, 0, plan));
+
+    plan.captureStartSample = 100;
+    REQUIRE (manager.getLoopCapturePlan().captureStartSample == 105);
+
+    std::vector<float> firstBlock (8, 0.25f);
+    auto span = manager.coordinateLoopCaptureSpan (1, 100, 0, 8);
+    REQUIRE (span.inputOffset == 5);
+    REQUIRE (span.numSamples == 3);
+    REQUIRE (span.startsPass);
+    REQUIRE_FALSE (span.endsPass);
+    manager.beginLoopCaptureSpan (span);
+    manager.writeInputBlock (0, firstBlock.data() + span.inputOffset, nullptr,
+                             span.numSamples);
+
+    std::vector<float> secondBlock (12, 0.5f);
+    span = manager.coordinateLoopCaptureSpan (1, 108, 0, 12);
+    REQUIRE (span.inputOffset == 0);
+    REQUIRE (span.numSamples == 7);
+    REQUIRE_FALSE (span.startsPass);
+    REQUIRE (span.endsPass);
+    manager.beginLoopCaptureSpan (span);
+    manager.writeInputBlock (0, secondBlock.data(), nullptr, span.numSamples);
+    manager.stopRecording (115);
+
+    const auto& region = loopAudioRegion (session);
+    REQUIRE (region.timelineStart == 105);
+    REQUIRE (region.lengthInSamples == 10);
+    REQUIRE (region.sourceOffset == 0);
+    REQUIRE_FALSE (region.provenance.partialPass);
+}

--- a/tests/record_loop_take_stacking.cpp
+++ b/tests/record_loop_take_stacking.cpp
@@ -162,6 +162,33 @@ TEST_CASE ("Loop audio commits a final partial pass and no exact-boundary empty 
     }
 }
 
+TEST_CASE ("Loop audio excludes a pass after a failed writer push without compressing it",
+           "[recording][recordmanager][loop-takes][failure]")
+{
+    const auto temp = makeSessionDir ("dusk-loop-audio-failed-pass-");
+    Session session;
+    armTrack (session, temp.dir, Track::Mode::Mono);
+    RecordManager manager (session);
+    const auto plan = loopPlan (0, 65538);
+
+    REQUIRE (manager.startRecording (1.0, 0, 0, plan));
+    writeAudioPass (manager, 1, 0, 65537);
+    writeAudioPass (manager, 1, 65537, 1);
+    writeAudioPass (manager, 2, 0, 4);
+    manager.stopRecording (4);
+
+    const auto& region = loopAudioRegion (session);
+    REQUIRE (region.provenance.loopPassOrdinal == 2);
+    REQUIRE (region.sourceOffset == 1);
+    REQUIRE (region.lengthInSamples == 4);
+    REQUIRE (region.previousTakes.empty());
+
+    const auto& errors = manager.getLastRecordErrors();
+    REQUIRE (errors.size() == 1);
+    REQUIRE (errors[0].kind == RecordManager::RecordErrorKind::WavWrite);
+    REQUIRE (errors[0].count == 1);
+}
+
 TEST_CASE ("Loop audio history is newest-first capped and then retains compatible old takes",
            "[recording][recordmanager][loop-takes][history]")
 {
@@ -445,13 +472,75 @@ TEST_CASE ("Loop MIDI resets and chases sustain across a seam",
     REQUIRE (priorCcs[0].controller == 64);
     REQUIRE (priorCcs[0].value == 127);
     REQUIRE (priorCcs[1].value == 0);
-    REQUIRE (priorCcs[1].atTick == 8);
+    REQUIRE (priorCcs[1].atTick == 7);
+    REQUIRE (priorCcs[1].atTick < region.previousTakes[0].lengthInTicks);
     REQUIRE (region.ccs.size() == 2);
     REQUIRE (region.ccs[0].controller == 64);
     REQUIRE (region.ccs[0].value == 127);
     REQUIRE (region.ccs[0].atTick == 0);
     REQUIRE (region.ccs[1].value == 0);
     REQUIRE (region.ccs[1].atTick == 3);
+}
+
+TEST_CASE ("Loop MIDI rejects malformed channel message sizes and data bytes",
+           "[recording][recordmanager][loop-takes][midi][malformed]")
+{
+    const auto temp = makeSessionDir ("dusk-loop-midi-malformed-");
+    Session session;
+    armTrack (session, temp.dir, Track::Mode::Midi);
+    RecordManager manager (session);
+    const auto plan = loopPlan();
+    REQUIRE (manager.startRecording (960.0, 100, 0, plan));
+
+    const std::uint8_t invalidNoteData[] = { 0x90, 62, 0x80 };
+    const std::uint8_t invalidCcData[] = { 0xB0, 0xFF, 127 };
+    const std::uint8_t truncatedNote[] = { 0x90, 64 };
+    juce::MidiBuffer events;
+    events.addEvent (invalidNoteData, 3, 1);
+    events.addEvent (invalidCcData, 3, 2);
+    events.addEvent (juce::MidiMessage::noteOn (
+                         1, 64, (juce::uint8) 100), 4);
+    events.addEvent (truncatedNote, 2, 5);
+    events.addEvent (juce::MidiMessage::noteOff (1, 64), 6);
+    writeMidiPass (manager, 1, 100, std::move (events), 8);
+    manager.stopRecording (108);
+
+    const auto region = session.track (0).midiRegions.current().at (0);
+    REQUIRE (region.notes.size() == 1);
+    REQUIRE (region.notes[0].noteNumber == 64);
+    REQUIRE (region.notes[0].lengthInTicks == 2);
+    REQUIRE (region.ccs.empty());
+}
+
+TEST_CASE ("Loop MIDI overflow retains the newest pass and latches the loss",
+           "[recording][recordmanager][loop-takes][midi][overflow]")
+{
+    constexpr int capacity = 65536;
+    const auto temp = makeSessionDir ("dusk-loop-midi-newest-overflow-");
+    Session session;
+    armTrack (session, temp.dir, Track::Mode::Midi);
+    RecordManager manager (session);
+    const auto plan = loopPlan (0, capacity);
+    REQUIRE (manager.startRecording (960.0, 0, 0, plan));
+
+    juce::MidiBuffer oldPass;
+    for (int sample = 0; sample < capacity; ++sample)
+        oldPass.addEvent (juce::MidiMessage::controllerEvent (1, 1, 1), sample);
+    writeMidiPass (manager, 1, 0, std::move (oldPass), capacity);
+    writeMidiPass (manager, 2, 0, oneNote (72, 0, 2), 4);
+    manager.stopRecording (4);
+
+    const auto region = session.track (0).midiRegions.current().at (0);
+    REQUIRE (region.provenance.loopPassOrdinal == 2);
+    REQUIRE (region.notes.size() == 1);
+    REQUIRE (region.notes[0].noteNumber == 72);
+    REQUIRE (region.previousTakes.size() == 1);
+    REQUIRE (region.previousTakes[0].provenance.loopPassOrdinal == 1);
+
+    const auto& errors = manager.getLastRecordErrors();
+    REQUIRE (errors.size() == 1);
+    REQUIRE (errors[0].kind == RecordManager::RecordErrorKind::MidiOverflow);
+    REQUIRE (errors[0].count == 2);
 }
 
 TEST_CASE ("Loop MIDI ignores a truly empty pass and keeps a final partial pass",

--- a/tests/session_format_version.cpp
+++ b/tests/session_format_version.cpp
@@ -25,7 +25,7 @@ void writeRaw (const juce::File& target, const juce::String& contents)
 } // namespace
 
 // Format-version contract:
-//   * Manual save writes "version": kFormatVersion (currently 4).
+//   * Manual save writes "version": kFormatVersion (currently 5).
 //   * Load rejects sessions whose version is HIGHER than the build's
 //     kFormatVersion — newer Dusk Studio can read older sessions (via the
 //     migrateSession switch) but older Dusk Studio must refuse newer ones
@@ -87,7 +87,7 @@ TEST_CASE ("SessionSerializer round-trip preserves version field",
     auto root = juce::JSON::parse (target);
     REQUIRE (root.isObject());
     REQUIRE (root.hasProperty ("version"));
-    REQUIRE ((int) root["version"] == 4);
+    REQUIRE ((int) root["version"] == 5);
 
     dir.deleteRecursively();
 }

--- a/tests/session_schema_migration.cpp
+++ b/tests/session_schema_migration.cpp
@@ -80,10 +80,10 @@ TEST_CASE ("migrateSession advances a mock v1 root to the current schema",
     // version field must now match the current build's kFormatVersion.
     // We don't reach kFormatVersion symbolically from the test (it's
     // in an anonymous namespace inside the .cpp), so we check the
-    // H4 owns version 4; the original payload must survive every step.
+    // Take provenance owns version 5; the original payload must survive every step.
     REQUIRE (root.is_object());
     REQUIRE (root.contains ("version"));
-    REQUIRE (root["version"].get<int>() == 4);
+    REQUIRE (root["version"].get<int>() == 5);
     REQUIRE (root.contains ("tempo"));
     REQUIRE (root["tempo"].get<double>() == 98.5);
 }
@@ -111,12 +111,12 @@ TEST_CASE ("SessionSerializer loads a v1-tagged session file end-to-end",
     auto root = nlohmann::json::parse (target.loadFileAsString().toStdString(), nullptr, false);
     REQUIRE (root.is_object());
     REQUIRE (root.contains ("version"));
-    REQUIRE (root["version"].get<int>() == 4);
+    REQUIRE (root["version"].get<int>() == 5);
 
     dir.deleteRecursively();
 }
 
-TEST_CASE ("SessionSerializer migrates a v3 legacy plugin reference to a v4 save",
+TEST_CASE ("SessionSerializer migrates a v3 legacy plugin reference to a v5 save",
            "[session][serializer][migration][plugin-descriptor]")
 {
     using duskstudio::Session;
@@ -146,10 +146,224 @@ TEST_CASE ("SessionSerializer migrates a v3 legacy plugin reference to a v4 save
     const auto saved = nlohmann::json::parse (
         target.loadFileAsString().toStdString(), nullptr, false);
     REQUIRE (saved.is_object());
-    CHECK (saved["version"].get<int>() == 4);
+    CHECK (saved["version"].get<int>() == 5);
     CHECK (saved["tracks"][0]["plugin_desc_xml"].get<std::string>() == legacyXml);
     CHECK (saved["tracks"][0]["plugin_state"].get<std::string>()
            == "bGVnYWN5LXN0YXRl");
 
     dir.deleteRecursively();
+}
+
+TEST_CASE ("SessionSerializer round-trips active and historical take provenance",
+           "[session][serializer][migration][take-provenance]")
+{
+    using duskstudio::AudioRegion;
+    using duskstudio::MidiRegion;
+    using duskstudio::MidiTakeRef;
+    using duskstudio::Session;
+    using duskstudio::SessionSerializer;
+    using duskstudio::TakeRef;
+
+    const auto dir = makeTempMigrationDir();
+    const auto target = dir.getChildFile ("session.json");
+    auto source = std::make_unique<Session>();
+
+    AudioRegion audio;
+    audio.lengthInSamples = 4096;
+    audio.sourceOffset = 32;
+    audio.provenance = { 101, 2, true };
+    TakeRef priorAudio;
+    priorAudio.lengthInSamples = 2048;
+    priorAudio.sourceOffset = 64;
+    priorAudio.provenance = { 102, 3, false };
+    audio.previousTakes.push_back (priorAudio);
+    source->track (0).regions.push_back (audio);
+
+    MidiRegion midi;
+    midi.lengthInSamples = 8192;
+    midi.lengthInTicks = 1920;
+    midi.provenance = { 103, 4, false };
+    MidiTakeRef priorMidi;
+    priorMidi.lengthInTicks = 960;
+    priorMidi.provenance = { 104, 5, true };
+    midi.previousTakes.push_back (priorMidi);
+    source->track (1).midiRegions.mutate (
+        [&] (auto& regions) { regions.push_back (midi); });
+
+    REQUIRE (SessionSerializer::save (*source, target));
+    const auto saved = nlohmann::json::parse (
+        target.loadFileAsString().toStdString(), nullptr, false);
+    REQUIRE (saved["version"].get<int>() == 5);
+    const auto& savedAudio = saved["tracks"][0]["regions"][0];
+    CHECK (savedAudio["take_provenance"]["captured_at_ms"].get<std::int64_t>() == 101);
+    CHECK (savedAudio["take_provenance"]["loop_pass"].get<int>() == 2);
+    CHECK (savedAudio["take_provenance"]["partial"].get<bool>());
+    const auto& savedPriorAudio = savedAudio["previous_takes"][0];
+    CHECK (savedPriorAudio["take_provenance"]["captured_at_ms"].get<std::int64_t>() == 102);
+    CHECK (savedPriorAudio["take_provenance"]["loop_pass"].get<int>() == 3);
+    CHECK_FALSE (savedPriorAudio["take_provenance"].contains ("partial"));
+    const auto& savedMidi = saved["tracks"][1]["midi_regions"][0];
+    CHECK (savedMidi["take_provenance"]["captured_at_ms"].get<std::int64_t>() == 103);
+    CHECK (savedMidi["take_provenance"]["loop_pass"].get<int>() == 4);
+    CHECK_FALSE (savedMidi["take_provenance"].contains ("partial"));
+    const auto& savedPriorMidi = savedMidi["previous_takes"][0];
+    CHECK (savedPriorMidi["take_provenance"]["captured_at_ms"].get<std::int64_t>() == 104);
+    CHECK (savedPriorMidi["take_provenance"]["loop_pass"].get<int>() == 5);
+    CHECK (savedPriorMidi["take_provenance"]["partial"].get<bool>());
+
+    auto loaded = std::make_unique<Session>();
+    REQUIRE (SessionSerializer::load (*loaded, target));
+    const auto& loadedAudio = loaded->track (0).regions[0];
+    CHECK (loadedAudio.provenance.capturedAtMs == 101);
+    CHECK (loadedAudio.provenance.loopPassOrdinal == 2);
+    CHECK (loadedAudio.provenance.partialPass);
+    REQUIRE (loadedAudio.previousTakes.size() == 1);
+    CHECK (loadedAudio.previousTakes[0].provenance.capturedAtMs == 102);
+    CHECK (loadedAudio.previousTakes[0].provenance.loopPassOrdinal == 3);
+    CHECK_FALSE (loadedAudio.previousTakes[0].provenance.partialPass);
+    const auto& loadedMidi = loaded->track (1).midiRegions.current()[0];
+    CHECK (loadedMidi.provenance.capturedAtMs == 103);
+    CHECK (loadedMidi.provenance.loopPassOrdinal == 4);
+    CHECK_FALSE (loadedMidi.provenance.partialPass);
+    REQUIRE (loadedMidi.previousTakes.size() == 1);
+    CHECK (loadedMidi.previousTakes[0].provenance.capturedAtMs == 104);
+    CHECK (loadedMidi.previousTakes[0].provenance.loopPassOrdinal == 5);
+    CHECK (loadedMidi.previousTakes[0].provenance.partialPass);
+
+    dir.deleteRecursively();
+}
+
+TEST_CASE ("SessionSerializer gives legacy v4 takes default provenance",
+           "[session][serializer][migration][take-provenance]")
+{
+    using duskstudio::AudioRegion;
+    using duskstudio::MidiRegion;
+    using duskstudio::MidiTakeRef;
+    using duskstudio::Session;
+    using duskstudio::SessionSerializer;
+    using duskstudio::TakeRef;
+
+    const auto dir = makeTempMigrationDir();
+    const auto target = dir.getChildFile ("session.json");
+    auto source = std::make_unique<Session>();
+
+    AudioRegion audio;
+    audio.lengthInSamples = 256;
+    audio.previousTakes.push_back (TakeRef {});
+    source->track (0).regions.push_back (audio);
+    MidiRegion midi;
+    midi.lengthInSamples = 512;
+    midi.lengthInTicks = 120;
+    midi.previousTakes.push_back (MidiTakeRef {});
+    source->track (1).midiRegions.mutate (
+        [&] (auto& regions) { regions.push_back (midi); });
+
+    REQUIRE (SessionSerializer::save (*source, target));
+    auto legacy = nlohmann::json::parse (
+        target.loadFileAsString().toStdString(), nullptr, false);
+    REQUIRE_FALSE (legacy["tracks"][0]["regions"][0].contains ("take_provenance"));
+    REQUIRE_FALSE (legacy["tracks"][0]["regions"][0]["previous_takes"][0]
+                       .contains ("take_provenance"));
+    REQUIRE_FALSE (legacy["tracks"][1]["midi_regions"][0].contains ("take_provenance"));
+    REQUIRE_FALSE (legacy["tracks"][1]["midi_regions"][0]["previous_takes"][0]
+                       .contains ("take_provenance"));
+    legacy["version"] = 4;
+    writeRaw (target, legacy.dump());
+
+    auto loaded = std::make_unique<Session>();
+    REQUIRE (SessionSerializer::load (*loaded, target));
+    const auto& loadedAudio = loaded->track (0).regions[0];
+    CHECK (loadedAudio.provenance.capturedAtMs == 0);
+    CHECK (loadedAudio.provenance.loopPassOrdinal == 0);
+    CHECK_FALSE (loadedAudio.provenance.partialPass);
+    REQUIRE (loadedAudio.previousTakes.size() == 1);
+    CHECK (loadedAudio.previousTakes[0].provenance.capturedAtMs == 0);
+    CHECK (loadedAudio.previousTakes[0].provenance.loopPassOrdinal == 0);
+    CHECK_FALSE (loadedAudio.previousTakes[0].provenance.partialPass);
+    const auto& loadedMidi = loaded->track (1).midiRegions.current()[0];
+    CHECK (loadedMidi.provenance.capturedAtMs == 0);
+    CHECK (loadedMidi.provenance.loopPassOrdinal == 0);
+    CHECK_FALSE (loadedMidi.provenance.partialPass);
+    REQUIRE (loadedMidi.previousTakes.size() == 1);
+    CHECK (loadedMidi.previousTakes[0].provenance.capturedAtMs == 0);
+    CHECK (loadedMidi.previousTakes[0].provenance.loopPassOrdinal == 0);
+    CHECK_FALSE (loadedMidi.previousTakes[0].provenance.partialPass);
+
+    legacy["tracks"][0]["regions"][0]["take_provenance"] = {
+        { "captured_at_ms", -12 }, { "loop_pass", -4 }, { "partial", true }
+    };
+    writeRaw (target, legacy.dump());
+    auto clamped = std::make_unique<Session>();
+    REQUIRE (SessionSerializer::load (*clamped, target));
+    const auto& clampedProvenance = clamped->track (0).regions[0].provenance;
+    CHECK (clampedProvenance.capturedAtMs == 0);
+    CHECK (clampedProvenance.loopPassOrdinal == 0);
+    CHECK (clampedProvenance.partialPass);
+
+    REQUIRE (SessionSerializer::save (*clamped, target));
+    const auto upgraded = nlohmann::json::parse (
+        target.loadFileAsString().toStdString(), nullptr, false);
+    CHECK (upgraded["version"].get<int>() == 5);
+
+    dir.deleteRecursively();
+}
+
+TEST_CASE ("Take payload helpers keep provenance attached to audio and MIDI takes",
+           "[session][take-provenance]")
+{
+    using namespace duskstudio;
+
+    AudioRegion audio;
+    audio.file = decltype (audio.file) ("/tmp/active-take.wav");
+    audio.sourceOffset = 11;
+    audio.lengthInSamples = 22;
+    audio.provenance = { 100, 1, false };
+
+    TakeRef priorAudio;
+    priorAudio.file = decltype (priorAudio.file) ("/tmp/prior-take.wav");
+    priorAudio.sourceOffset = 33;
+    priorAudio.lengthInSamples = 44;
+    priorAudio.provenance = { 200, 2, true };
+
+    swapAudioTakePayload (audio, priorAudio);
+    CHECK (audio.file.getFileName() == "prior-take.wav");
+    CHECK (audio.sourceOffset == 33);
+    CHECK (audio.provenance.loopPassOrdinal == 2);
+    CHECK (audio.provenance.partialPass);
+    CHECK (priorAudio.file.getFileName() == "active-take.wav");
+    CHECK (priorAudio.sourceOffset == 11);
+    CHECK (priorAudio.provenance.capturedAtMs == 100);
+
+    const auto copiedAudio = makeAudioTakeRef (audio);
+    AudioRegion restoredAudio;
+    applyAudioTakeRef (restoredAudio, copiedAudio);
+    CHECK (restoredAudio.lengthInSamples == 44);
+    CHECK (restoredAudio.provenance.capturedAtMs == 200);
+
+    MidiRegion midi;
+    midi.lengthInTicks = 960;
+    midi.notes.push_back ({ 1, 60, 100, 0, 240 });
+    midi.provenance = { 300, 3, false };
+
+    MidiTakeRef priorMidi;
+    priorMidi.lengthInTicks = 480;
+    priorMidi.notes.push_back ({ 1, 48, 90, 0, 120 });
+    priorMidi.provenance = { 400, 4, true };
+
+    swapMidiTakePayload (midi, priorMidi);
+    CHECK (midi.lengthInTicks == 480);
+    REQUIRE (midi.notes.size() == 1);
+    CHECK (midi.notes[0].noteNumber == 48);
+    CHECK (midi.provenance.loopPassOrdinal == 4);
+    CHECK (midi.provenance.partialPass);
+    CHECK (priorMidi.lengthInTicks == 960);
+    REQUIRE (priorMidi.notes.size() == 1);
+    CHECK (priorMidi.notes[0].noteNumber == 60);
+    CHECK (priorMidi.provenance.capturedAtMs == 300);
+
+    const auto copiedMidi = makeMidiTakeRef (midi);
+    MidiRegion restoredMidi;
+    applyMidiTakeRef (restoredMidi, copiedMidi);
+    CHECK (restoredMidi.lengthInTicks == 480);
+    CHECK (restoredMidi.provenance.capturedAtMs == 400);
 }


### PR DESCRIPTION
## Summary

- add allocation-free loop timeline spans and an immutable loop capture plan
- stack audio and MIDI loop passes as the current take plus eight retained prior takes
- persist per-pass take provenance in session schema v5 and preserve it through take cycling
- reject malformed MIDI and keep newest bounded events on overflow
- exclude failed audio passes without compressing later spool offsets

## Scope

Core recording, take-model, and serialization work for #125. The approved follow-up PR will wire the engine loop callback into this seam and complete the integration and user-facing updates. This PR intentionally does not close #125.

## Validation

- production DuskStudio build
- full CTest suite: 697/697 passed
- focused loop timeline: 90 assertions in 7 cases
- focused take provenance: 75 assertions in 3 cases
- focused RecordManager: 3,472 assertions in 31 cases
- session serializer version tests: 6 assertions in 3 cases
- private-Xvfb audio pipeline self-test passed
- JUCE gate: 179 coupled files, 9,230 uses; zero added production JUCE lines
- git diff check and attribution scan clean
- two independent review rounds completed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loop-based recording with stacked audio and MIDI takes across multiple passes.
  * Preserved take provenance, including capture time, loop pass, and partial-pass status.
  * Added support for loop-aware timeline handling, count-ins, latency adjustment, and MIDI seam reconstruction.
  * Added session format version 5 with migration support for older sessions.

* **Bug Fixes**
  * Improved handling of malformed MIDI events, failed writes, buffer limits, and invalid loop settings.

* **Tests**
  * Added comprehensive coverage for loop recording, take history, timeline wrapping, and session migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->