### PR TITLE
Complete loop-record take stacking integration

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1102,7 +1102,11 @@ To repeat a section while you experiment:
 2. Click the **Loop** button on the transport bar.
 3. Press Play (for loop playback) or Record (for loop recording).
 
-In loop play, the transport wraps at the loop boundary indefinitely. In loop record, playback wraps but recording stays linear — you get a single take that extends from the loop start to wherever you press Stop. There is no take-stacking loop recording.
+In loop play, the transport wraps at the loop boundary indefinitely. Loop recording also wraps and creates a new take on each pass. The current pass plus up to **8 previous passes** stay attached to one range-aligned region, so you can cycle performances after stopping. A loop must be at least 128 samples long to record.
+
+With Punch enabled, each pass records only the overlap between the loop and punch ranges. Pressing Record anywhere inside the loop aligns the gesture to that effective capture start before count-in or pre-roll begins, so every pass covers the same timeline range. Punch post-roll auto-stop is suspended during loop recording; press Stop when you are finished.
+
+Silent audio passes remain available as takes. Empty MIDI passes are omitted because they contain no note or controller performance to recall.
 
 ## Where files are saved
 

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -1,5 +1,6 @@
 #include "AudioEngine.h"
 #include "BounceEngine.h"
+#include "LoopTimeline.h"
 #include "PdcMath.h"
 #include "RtPriority.h"
 #include "../dsp/OutputPairRouting.h"
@@ -1313,41 +1314,48 @@ void AudioEngine::play()
 
 void AudioEngine::stop()
 {
-    if (transport.isStopped())
+    if (transport.isStopped() && ! recordManager.isActive())
     {
         performPendingDspRestartIfIdle();
         return;
     }
 
-    const bool wasRecording = transport.isRecording();
-    transport.setState (Transport::State::Stopped);
-
-    if (wasRecording)
+    suspendProcessing();
     {
-        recordManager.stopRecording (transport.getPlayhead());
-        activeRecordStart.store (std::numeric_limits<std::int64_t>::min(),
-                                  std::memory_order_relaxed);
-
-        // RecordManager already mutated state; action captures the
-        // before/after snapshot. First perform() is a no-op (state
-        // already applied); redo-after-undo re-applies after-state.
-        const auto& diff = recordManager.getLastCommitDiff();
-        if (! diff.empty())
+        struct ResumeGuard
         {
-            std::vector<RecordCommitAction::TrackDiff> wrapped;
-            wrapped.reserve (diff.size());
-            for (const auto& d : diff)
-                wrapped.push_back ({ d.trackIndex,
-                                      d.audioBefore, d.audioAfter,
-                                      d.midiBefore,  d.midiAfter });
-            undoManager.beginNewTransaction ("Record");
-            undoManager.perform (new RecordCommitAction (
-                session, *this, std::move (wrapped)));
-            recordManager.clearLastCommitDiff();
-        }
-    }
+            AudioEngine& engine;
+            ~ResumeGuard() { engine.resumeProcessing(); }
+        } resumeGuard { *this };
 
-    playbackEngine.stopPlayback();
+        const bool wasRecording = transport.isRecording() || recordManager.isActive();
+        transport.setState (Transport::State::Stopped);
+
+        if (wasRecording)
+        {
+            recordManager.stopRecording (transport.getPlayhead());
+            activeRecordStart.store (std::numeric_limits<std::int64_t>::min(),
+                                      std::memory_order_relaxed);
+            activeLoopRecordPassOrdinal.store (0, std::memory_order_relaxed);
+            lastBlockWasLoopRecording = false;
+
+            const auto& diff = recordManager.getLastCommitDiff();
+            if (! diff.empty())
+            {
+                std::vector<RecordCommitAction::TrackDiff> wrapped;
+                wrapped.reserve (diff.size());
+                for (const auto& d : diff)
+                    wrapped.push_back ({ d.trackIndex,
+                                          d.audioBefore, d.audioAfter,
+                                          d.midiBefore,  d.midiAfter });
+                undoManager.beginNewTransaction ("Record");
+                undoManager.perform (new RecordCommitAction (
+                    session, *this, std::move (wrapped)));
+                recordManager.clearLastCommitDiff();
+            }
+        }
+
+        playbackEngine.stopPlayback();
 
     // Honour the user's Settings choice for Stop behaviour.
     // 0 = PauseInPlace (leave playhead where it landed)
@@ -1356,16 +1364,17 @@ void AudioEngine::stop()
     //     back to pause-in-place when nothing was clicked yet).
     // Callers that want unconditional stop+rewind (the '.' hotkey, Home
     // key) still call setPlayhead(0) explicitly after stop().
-    const int behavior = session.stopBehavior.load (std::memory_order_relaxed);
-    if (behavior == 1)
-    {
-        transport.setPlayhead (0);
-    }
-    else if (behavior == 2)
-    {
-        const auto last = session.lastClickedTimelineSample.load (std::memory_order_relaxed);
-        if (last >= 0)
-            transport.setPlayhead (last);
+        const int behavior = session.stopBehavior.load (std::memory_order_relaxed);
+        if (behavior == 1)
+        {
+            transport.setPlayhead (0);
+        }
+        else if (behavior == 2)
+        {
+            const auto last = session.lastClickedTimelineSample.load (std::memory_order_relaxed);
+            if (last >= 0)
+                transport.setPlayhead (last);
+        }
     }
 
     performPendingDspRestartIfIdle();
@@ -1442,19 +1451,79 @@ void AudioEngine::record()
         return;
     }
 
-    // With punch on, the WAV's first audible sample is at punchIn so
-    // the region's timelineStart must be punchIn. Audio thread skips
-    // writes until playhead reaches punchIn so WAV time-zero lines up.
-    // Inside / past the window = fall back to playhead (no truncation).
+    RecordManager::LoopCapturePlan loopPlan;
+    if (transport.isLoopEnabled())
+    {
+        const auto loopStart = transport.getLoopStart();
+        const auto loopEnd   = transport.getLoopEnd();
+        if (loopEnd > loopStart)
+        {
+            // Match Play: engaging a loop means the gesture begins inside it.
+            // These bounds are snapshotted for the whole gesture; UI changes
+            // while rolling affect the next record press, not an in-flight take.
+            loopPlan.enabled = true;
+            loopPlan.loopStartSample = loopStart;
+            loopPlan.loopEndSample = loopEnd;
+            loopPlan.captureStartSample = loopStart;
+            loopPlan.captureEndSample = loopEnd;
+
+            constexpr std::int64_t kMinLoopRecordSamples = 128;
+            if (loopEnd - loopStart < kMinLoopRecordSamples)
+            {
+                std::fprintf (stderr,
+                              "[Dusk Studio/AudioEngine] record(): loop is shorter than "
+                              "%lld samples; recording blocked.\n",
+                              (long long) kMinLoopRecordSamples);
+                if (onRecordBlocked_)
+                    onRecordBlocked_ ("Loop recording could not start.\n\nThe loop must "
+                                      "be at least 128 samples long.");
+                return;
+            }
+
+            if (transport.isPunchEnabled())
+            {
+                const auto punchIn  = transport.getPunchIn();
+                const auto punchOut = transport.getPunchOut();
+                loopPlan.captureStartSample = std::max (loopStart, punchIn);
+                loopPlan.captureEndSample   = std::min (loopEnd, punchOut);
+                if (punchOut <= punchIn
+                    || loopPlan.captureEndSample <= loopPlan.captureStartSample)
+                {
+                    std::fprintf (stderr,
+                                  "[Dusk Studio/AudioEngine] record(): loop and punch "
+                                  "ranges do not overlap; recording blocked.\n");
+                    if (onRecordBlocked_)
+                        onRecordBlocked_ ("Loop recording could not start.\n\nThe punch "
+                                          "range must overlap the active loop.");
+                    return;
+                }
+            }
+        }
+    }
+
+    // The logical take starts at the effective loop/punch boundary. Snapping
+    // every loop gesture there keeps every pass and take reference range-aligned.
     std::int64_t startSample = transport.getPlayhead();
-    if (transport.isPunchEnabled()
+    if (loopPlan.enabled)
+        startSample = loopPlan.captureStartSample;
+    else if (transport.isPunchEnabled()
         && transport.getPunchOut() > transport.getPunchIn()
         && startSample < transport.getPunchIn())
     {
         startSample = transport.getPunchIn();
     }
 
-    if (! recordManager.startRecording (sr, startSample, recordingLatencyOffsetSamples_))
+    suspendProcessing();
+    struct ResumeGuard
+    {
+        AudioEngine& engine;
+        ~ResumeGuard() { engine.resumeProcessing(); }
+    } resumeGuard { *this };
+
+    lastBlockWasLoopRecording = false;
+
+    if (! recordManager.startRecording (sr, startSample,
+                                         recordingLatencyOffsetSamples_, loopPlan))
     {
         std::fprintf (stderr, "[Dusk Studio/AudioEngine] record(): startRecording failed; "
                               "no armed track could be set up (e.g. all frozen, or the take "
@@ -1466,7 +1535,12 @@ void AudioEngine::record()
         return;
     }
 
+    if (loopPlan.enabled)
+        transport.setPlayhead (startSample);
+
     activeRecordStart.store (startSample, std::memory_order_relaxed);
+    activeLoopRecordPassOrdinal.store (loopPlan.enabled ? 1 : 0,
+                                        std::memory_order_release);
 
     // STOP+FFWD jumps the user back to their last take start. Persisted.
     session.lastRecordPointSamples.store (startSample, std::memory_order_relaxed);
@@ -2463,6 +2537,14 @@ void AudioEngine::audioDeviceAboutToStart (device::IODevice* device)
 
 void AudioEngine::stageTestMidiInjection (int inputIdx, juce::MidiBuffer events)
 {
+    dusk::MidiBuffer nativeEvents;
+    for (const auto meta : events)
+        nativeEvents.addEvent (meta.data, meta.numBytes, meta.samplePosition);
+    stageTestMidiInjection (inputIdx, std::move (nativeEvents));
+}
+
+void AudioEngine::stageTestMidiInjection (int inputIdx, dusk::MidiBuffer events)
+{
     // SPSC: wait for any previously staged buffer to be consumed before we
     // touch testInjectMidi. The synchronous self-test caller drives the
     // audio callback after every stage, so this normally observes false on
@@ -2486,7 +2568,7 @@ void AudioEngine::stageTestMidiInjection (int inputIdx, juce::MidiBuffer events)
         return;
     }
 
-    testInjectMidi.swapWith (events);
+    testInjectMidi = std::move (events);
     testInjectInputIdx.store (inputIdx, std::memory_order_relaxed);
     testInjectReady.store (true, std::memory_order_release);
 }
@@ -2627,11 +2709,11 @@ void AudioEngine::prepareForSelfTest (double sr, int bs)
     for (auto& v : auxLaneR)  v.assign ((size_t) bs, 0.0f);
     for (auto& v : playbackScratch)  v.assign ((size_t) bs, 0.0f);
     for (auto& v : playbackScratchR) v.assign ((size_t) bs, 0.0f);
-    // Growth hint only, but it has to track the dusk ceiling: this buffer is
-    // refilled from perInputMidi every block, and a juce event costs 6 bytes of
-    // header against dusk's 8, so a hint at the shared size means one drained
-    // block never reallocs here on the audio thread.
-    for (auto& m : perTrackMidiScratch) m.ensureSize (dusk::kMidiBlockBytes);
+    // Live input, scheduled events, and loop-seam reset/chase messages share
+    // this routing buffer. Four input-block ceilings cover two live sources
+    // plus the worst 8192-frame/128-sample seam-reset burst off the RT path.
+    for (auto& m : perTrackMidiScratch) m.ensureSize (4 * dusk::kMidiBlockBytes);
+    liveRecordMidiScratch.ensureSize (2 * dusk::kMidiBlockBytes);
     midiClockOutScratch.reserveBytes (dusk::kMidiBlockBytes);
     midiOutTrackScratch.reserveBytes (dusk::kMidiBlockBytes);
     silentInputScratch.assign ((size_t) bs, 0.0f);
@@ -4133,19 +4215,84 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
     const auto state = transport.getState();
     const bool isPlaying   = (state == Transport::State::Playing);
     const bool isRecording = (state == Transport::State::Recording);
-    const std::int64_t blockStartSamples = transport.getPlayhead();
+    std::int64_t blockStartSamples = transport.getPlayhead();
 
     // Offline renders must be deterministic - live input never prints. An offline
     // bounce/stem/freeze drives this callback from a worker thread while the MIDI
     // input path stays open, so this latch gates every live-MIDI pull below.
     const bool offlineRender = offlineRenderActive.load (std::memory_order_acquire);
 
-    // Loop-aware disk reads: mirrors the wrap gate at the bottom of the
-    // callback (plain playback only - recording keeps the playhead linear).
-    const bool loopReadActive = isPlaying && ! isRecording && transport.isLoopEnabled()
+    // Loop recording uses the immutable plan published before Record entered
+    // the rolling state. Live Loop/Punch edits apply to the next gesture, so a
+    // current take cannot change shape halfway through a callback or pass.
+    const bool recordManagerActive = isRecording && recordManager.isActive();
+    const auto loopRecordPlan = recordManagerActive
+                              ? recordManager.getLoopCapturePlan()
+                              : RecordManager::LoopCapturePlan {};
+    const bool loopRecordingActive = recordManagerActive && loopRecordPlan.enabled;
+    const auto captureTrackMask = recordManagerActive
+        ? recordManager.getActiveCaptureTrackMask() : std::uint32_t { 0 };
+    const auto midiCaptureTrackMask = recordManagerActive
+        ? recordManager.getActiveMidiCaptureTrackMask() : std::uint32_t { 0 };
+    const auto stereoCaptureTrackMask = recordManagerActive
+        ? recordManager.getActiveStereoCaptureTrackMask() : std::uint32_t { 0 };
+    if (loopRecordingActive && lastBlockWasLoopRecording
+        && blockStartSamples != lastBlockEndSample)
+    {
+        // Loop-record seeks are deferred until the gesture ends. Restoring the
+        // expected wrapped endpoint keeps pass coordinates and writer offsets
+        // contiguous even if a ruler click lands between callbacks.
+        blockStartSamples = lastBlockEndSample;
+        transport.setPlayhead (blockStartSamples);
+    }
+    const int loopRecordPassAtBlockStart = loopRecordingActive
+        ? std::max (1, activeLoopRecordPassOrdinal.load (std::memory_order_acquire)) : 0;
+
+    // Unarmed/frozen accompaniment must hear the same seam as the recorder.
+    // Plain playback still follows the live transport bounds.
+    const bool playbackLoopActive = isPlaying && transport.isLoopEnabled()
                                  && transport.getLoopEnd() > transport.getLoopStart();
-    const std::int64_t loopReadStart = loopReadActive ? transport.getLoopStart() : -1;
-    const std::int64_t loopReadEnd   = loopReadActive ? transport.getLoopEnd()   : -1;
+    const std::int64_t loopReadStart = loopRecordingActive
+        ? loopRecordPlan.loopStartSample
+        : (playbackLoopActive ? transport.getLoopStart() : -1);
+    const std::int64_t loopReadEnd = loopRecordingActive
+        ? loopRecordPlan.loopEndSample
+        : (playbackLoopActive ? transport.getLoopEnd() : -1);
+
+    // Re-enumerated at each capture site instead of storing a variable-size
+    // span list. The helper invokes callbacks directly, so the audio thread
+    // performs no allocation or synchronization at a seam.
+    auto forEachRecordCaptureSpan = [&] (auto&& callback) noexcept
+    {
+        if (! loopRecordingActive)
+            return;
+
+        int passOrdinal = loopRecordPassAtBlockStart;
+        forEachLoopTimelineSpan (
+            blockStartSamples, numSamples, true,
+            loopRecordPlan.loopStartSample, loopRecordPlan.loopEndSample,
+            [&] (const LoopTimelineSpan& timelineSpan) noexcept
+            {
+                if (timelineSpan.wrappedBefore)
+                    ++passOrdinal;
+
+                auto timelineStart = timelineSpan.timelineStart;
+                int callbackOffset = timelineSpan.bufferOffset;
+                int remaining = timelineSpan.length;
+                const auto captureSpan = recordManager.coordinateLoopCaptureSpan (
+                    passOrdinal, timelineStart, callbackOffset, remaining);
+                if (captureSpan.passOrdinal > 0 && captureSpan.numSamples > 0)
+                    callback (captureSpan);
+            });
+    };
+
+    // Gesture-global pass descriptors are registered exactly once. MIDI and
+    // audio re-enumerate the same immutable coordinates below but use explicit
+    // spans, so neither path mutates or double-counts this shared descriptor.
+    forEachRecordCaptureSpan ([&] (const RecordManager::LoopCaptureSpan& span) noexcept
+    {
+        recordManager.beginLoopCaptureSpan (span);
+    });
 
     // Hanging-note protection. Detect two events that warrant a per-MIDI-
     // track "All Notes Off" flush this block:
@@ -4159,8 +4306,7 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
                               && lastBlockEndSample != 0
                               && blockStartSamples != lastBlockEndSample;
     const bool flushHangingMidi = transportJustStopped || playheadJumped;
-    wasRolling         = isRolling;
-    lastBlockEndSample = blockStartSamples + numSamples;
+    wasRolling = isRolling;
 
     for (int t = 0; t < Session::kNumTracks; ++t)
     {
@@ -4244,10 +4390,17 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
         // mute and solo state.
         const bool muted   = trackParams.liveMute.load (std::memory_order_relaxed);
         const bool soloed  = trackParams.liveSolo.load (std::memory_order_relaxed);
-        const bool armed   = session.track (t).recordArmed.load (std::memory_order_relaxed);
+        const bool liveArmed = session.track (t).recordArmed.load (std::memory_order_relaxed);
+        const auto trackBit = std::uint32_t { 1 } << t;
+        const bool capturedTrack = (captureTrackMask & trackBit) != 0;
+        const bool armed = isRecording
+            ? capturedTrack
+            : liveArmed;
         const bool monitorEnabled = session.track (t).inputMonitor.load (std::memory_order_relaxed);
-        const bool midiTrack = session.track (t).mode.load (std::memory_order_relaxed)
-                                   == (int) Track::Mode::Midi;
+        const int liveTrackMode = session.track (t).mode.load (std::memory_order_relaxed);
+        const bool midiTrack = isRecording && capturedTrack
+            ? (midiCaptureTrackMask & trackBit) != 0
+            : liveTrackMode == (int) Track::Mode::Midi;
         // Frozen: this track plays a pre-rendered WAV through the strip with the
         // instrument/insert + EQ/comp bypassed (baked in). Works for MIDI and
         // audio tracks alike. Acquire pairs with the release store in
@@ -4329,8 +4482,9 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
         //     for monitoring.
         //   - Stopped & un-armed & IN off: monoIn null -> strip is silent.
         const float* monoIn = nullptr;
-        const bool stereoTrackInput = session.track (t).mode.load (std::memory_order_relaxed)
-                                          == (int) Track::Mode::Stereo;
+        const bool stereoTrackInput = isRecording && capturedTrack
+            ? (stereoCaptureTrackMask & trackBit) != 0
+            : liveTrackMode == (int) Track::Mode::Stereo;
 
         if (willReadFromDisk)
         {
@@ -4456,16 +4610,66 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
         const bool perTrackFlush = flushHangingMidi || midiInputSwapped;
 
         perTrackMidiScratch[(size_t) t].clear();
-        if (midiTrack && perTrackFlush)
+        liveRecordMidiScratch.clear();
+        constexpr int kGeneratedEventBytes = 6 + 3;
+        constexpr int kGeneratedMidiBudget = 2 * (int) dusk::kMidiBlockBytes;
+        constexpr int kMidiScheduleScanBudget = 32768;
+        constexpr int kHangingResetMessageCount = 16 * 2;
+        constexpr int kHangingResetBytes = kHangingResetMessageCount
+                                         * kGeneratedEventBytes;
+        static_assert (kGeneratedMidiBudget
+                       >= (8192 / 128 + 1) * kHangingResetBytes);
+        int generatedMidiBytesRemaining = kGeneratedMidiBudget;
+        int reservedStructuralResetBytes = midiTrack && perTrackFlush
+                                         ? kHangingResetBytes : 0;
+        int midiScheduleScansRemaining = kMidiScheduleScanBudget;
+        auto addGeneratedMidi = [&] (const auto& message, int sampleOffset) noexcept
         {
+            if (generatedMidiBytesRemaining - reservedStructuralResetBytes
+                    < kGeneratedEventBytes)
+                return false;
+            perTrackMidiScratch[(size_t) t].addEvent (message, sampleOffset);
+            generatedMidiBytesRemaining -= kGeneratedEventBytes;
+            return true;
+        };
+        auto addGeneratedController = [&] (int channel, int controller,
+                                           int value, int sampleOffset) noexcept
+        {
+            if (generatedMidiBytesRemaining - reservedStructuralResetBytes
+                    < kGeneratedEventBytes)
+                return false;
+            const std::array<std::uint8_t, 3> bytes {
+                (std::uint8_t) (0xB0 | (channel - 1)),
+                (std::uint8_t) controller,
+                (std::uint8_t) value
+            };
+            perTrackMidiScratch[(size_t) t].addEvent (
+                bytes.data(), (int) bytes.size(), sampleOffset);
+            generatedMidiBytesRemaining -= kGeneratedEventBytes;
+            return true;
+        };
+        auto emitHangingMidiReset = [&] (int sampleOffset) noexcept
+        {
+            // A reset is structural: either all 32 three-byte messages fit or
+            // none are emitted. Discretionary scheduling reserves this exact
+            // capacity before it can consume the shared generated-event budget.
+            if (generatedMidiBytesRemaining < kHangingResetBytes)
+                return false;
+
+            if (reservedStructuralResetBytes >= kHangingResetBytes)
+                reservedStructuralResetBytes -= kHangingResetBytes;
             for (int ch = 1; ch <= 16; ++ch)
             {
                 perTrackMidiScratch[(size_t) t].addEvent (
-                    juce::MidiMessage::controllerEvent (ch, 64,  0), 0);
+                    juce::MidiMessage::controllerEvent (ch, 64, 0), sampleOffset);
                 perTrackMidiScratch[(size_t) t].addEvent (
-                    juce::MidiMessage::controllerEvent (ch, 123, 0), 0);
+                    juce::MidiMessage::controllerEvent (ch, 123, 0), sampleOffset);
             }
-        }
+            generatedMidiBytesRemaining -= kHangingResetBytes;
+            return true;
+        };
+        if (midiTrack && perTrackFlush)
+            emitHangingMidiReset (0);
 
         // Build this block's per-track MIDI buffer. Two source paths,
         // mutually exclusive (matches the audio source decision above):
@@ -4505,6 +4709,10 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
                 perTrackMidiScratch[(size_t) t].addEvent (v.getRawData(),
                                                           v.getRawDataSize(),
                                                           meta.samplePosition);
+                if (isRecording && armed && midiTrack)
+                    liveRecordMidiScratch.addEvent (v.getRawData(),
+                                                    v.getRawDataSize(),
+                                                    meta.samplePosition);
             }
         };
         auto pullLiveMidi = [&] ()
@@ -4526,9 +4734,8 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
             // user expects an armed instrument track to play from the
             // virtual keyboard. Skip when the explicit input already IS
             // the VK so events aren't doubled.
-            const bool trackArmed = session.track (t).recordArmed.load (std::memory_order_relaxed);
             const int vkbIdx = midiIn.getVirtualKeyboardIndex();
-            if (trackArmed && vkbIdx != currentMidiIdx)
+            if (armed && vkbIdx != currentMidiIdx)
                 pullInput (vkbIdx, chFilter);
         };
 
@@ -4560,7 +4767,6 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
                 ? (std::int64_t) strips[(size_t) t].getPluginSlot().getLatencySamples()
                 : 0;
             const auto schedStart = blockStartSamples + pluginLatency;
-            const auto blockEnd   = schedStart + numSamples;
 
             // Acquire-load the track's MIDI region snapshot once for the
             // block. Mutated on the message thread by RecordManager (when
@@ -4570,94 +4776,227 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
             // construction time so this pointer is non-null.
             const auto& midiRegionsForBlock = *session.track (t).midiRegions.read();
 
-            // Chase pass: when the playhead jumps INTO the middle of a
-            // sustained note (transport start after seek, loop wrap, etc.)
-            // the synth would otherwise sit silent until the Note Off fires
-            // since the Note On is in the past. Emit Note On at sample 1
-            // (one sample after the All Notes Off the flush block already
-            // emitted at sample 0, so the synth doesn't immediately silence
-            // the chase) for every note whose on-time is before blockStart
-            // and off-time is after blockStart.
-            if (flushHangingMidi)
+            // Loop recording already rejects ranges shorter than 128 samples.
+            // Plain playback still permits them, so keep its pre-existing
+            // bounded linear MIDI window instead of enumerating more seam
+            // resets than the fixed generated-event budget can represent.
+            constexpr std::int64_t kMinMidiLoopScheduleSamples = 128;
+            const bool midiLoopActive = loopReadEnd > loopReadStart
+                && static_cast<std::uint64_t> (loopReadEnd)
+                     - static_cast<std::uint64_t> (loopReadStart)
+                   >= static_cast<std::uint64_t> (kMinMidiLoopScheduleSamples);
+            std::array<int, 16 * 128> chasedControllerValue;
+            std::array<std::int64_t, 16 * 128> chasedControllerAt;
+            std::array<bool, 16 * 128> chasedControllerSeen;
+            std::array<bool, 16 * 128> controllerExplicitAtStart;
+            std::array<int, 16 * 128> chasedControllerKeys;
+            int chasedControllerKeyCount = 0;
+
+            // Reserve every reset before discretionary notes/controllers can
+            // consume their bytes. At the supported 8192-frame maximum and
+            // 128-sample minimum loop this is at most 64 complete resets.
+            if (midiTrack)
             {
-                for (const auto& region : midiRegionsForBlock)
+                int futureSeamResetCount = 0;
+                forEachLoopTimelineSpan (
+                    schedStart, numSamples, midiLoopActive, loopReadStart, loopReadEnd,
+                    [&] (const LoopTimelineSpan& span) noexcept
+                    {
+                        if (span.wrappedBefore)
+                            ++futureSeamResetCount;
+                    });
+                reservedStructuralResetBytes += futureSeamResetCount
+                                              * kHangingResetBytes;
+            }
+
+            auto takeScheduleScan = [&] () noexcept
+            {
+                if (midiScheduleScansRemaining <= 0)
+                    return false;
+                --midiScheduleScansRemaining;
+                return true;
+            };
+            forEachLoopTimelineSpan (
+                schedStart, numSamples, midiLoopActive, loopReadStart, loopReadEnd,
+                [&] (const LoopTimelineSpan& span) noexcept
                 {
-                    if (region.muted) continue;
-                    const auto regStart = region.timelineStart;
-                    const auto regStartTick = useMap ? tm->samplesToTicks (regStart, sr) : (std::int64_t) 0;
-                    auto absOf = [&] (std::int64_t relTick)
+                    // Structural resets are emitted before every overload
+                    // bailout. Their capacity was reserved exactly above, so
+                    // an exhausted musical-event or scan budget cannot suppress
+                    // this or any later seam reset.
+                    if (midiTrack && span.wrappedBefore
+                        && ! emitHangingMidiReset (span.bufferOffset))
+                        return;
+
+                    if (generatedMidiBytesRemaining - reservedStructuralResetBytes
+                            < kGeneratedEventBytes
+                        || midiScheduleScansRemaining <= 0)
+                        return;
+
+                    const bool chase = midiTrack && (span.wrappedBefore
+                                    || (span.bufferOffset == 0 && flushHangingMidi));
+                    const int chaseOffset = span.bufferOffset;
+                    const auto spanEnd = span.timelineStart + span.length;
+                    if (chase)
                     {
-                        return useMap ? tm->ticksToSamples (regStartTick + relTick, sr)
-                                      : regStart + ticksToSamples (relTick, sr, bpm);
-                    };
-                    for (const auto& n : region.notes)
+                        chasedControllerValue.fill (0);
+                        chasedControllerAt.fill (
+                            std::numeric_limits<std::int64_t>::min());
+                        chasedControllerSeen.fill (false);
+                        controllerExplicitAtStart.fill (false);
+                        chasedControllerKeyCount = 0;
+                    }
+
+                    // Controllers are a distinct first pass. This makes equal-
+                    // sample insertion order reset -> explicit/chased state ->
+                    // every note-on, independent of region storage order.
+                    bool controllerPassComplete = true;
+                    for (const auto& region : midiRegionsForBlock)
                     {
-                        const auto onAbs  = absOf (n.startTick);
-                        const auto offAbs = absOf (n.startTick + n.lengthInTicks);
-                        if (onAbs < blockStartSamples && offAbs > blockStartSamples)
+                        if (! takeScheduleScan())
                         {
-                            perTrackMidiScratch[(size_t) t].addEvent (
-                                juce::MidiMessage::noteOn (n.channel, n.noteNumber,
-                                                            (std::uint8_t) n.velocity),
-                                1);
+                            controllerPassComplete = false;
+                            break;
+                        }
+                        if (region.muted) continue;
+                        const auto regStart = region.timelineStart;
+                        const auto regStartTick = useMap
+                            ? tm->samplesToTicks (regStart, sr) : std::int64_t { 0 };
+                        auto absOf = [&] (std::int64_t relTick)
+                        {
+                            return useMap
+                                ? tm->ticksToSamples (regStartTick + relTick, sr)
+                                : regStart + ticksToSamples (relTick, sr, bpm);
+                        };
+                        const auto regEnd = useMap ? absOf (region.lengthInTicks)
+                                                   : regStart + region.lengthInSamples;
+                        const bool overlapsSpan = regEnd > span.timelineStart
+                                               && regStart < spanEnd;
+                        if (! overlapsSpan && ! chase)
+                            continue;
+
+                        for (const auto& c : region.ccs)
+                        {
+                            if (! takeScheduleScan())
+                            {
+                                controllerPassComplete = false;
+                                break;
+                            }
+                            const auto at = absOf (c.atTick);
+                            const bool validController = c.channel >= 1 && c.channel <= 16
+                                                      && c.controller >= 0
+                                                      && c.controller < 128;
+                            const int controllerKey = validController
+                                ? (c.channel - 1) * 128 + c.controller : -1;
+                            if (chase && controllerKey >= 0)
+                            {
+                                if (at < span.timelineStart
+                                    && (! chasedControllerSeen[(size_t) controllerKey]
+                                        || at >= chasedControllerAt[(size_t) controllerKey]))
+                                {
+                                    if (! chasedControllerSeen[(size_t) controllerKey])
+                                    {
+                                        chasedControllerKeys[(size_t) chasedControllerKeyCount++]
+                                            = controllerKey;
+                                    }
+                                    chasedControllerSeen[(size_t) controllerKey] = true;
+                                    chasedControllerAt[(size_t) controllerKey] = at;
+                                    chasedControllerValue[(size_t) controllerKey] = c.value;
+                                }
+                                if (at == span.timelineStart)
+                                    controllerExplicitAtStart[(size_t) controllerKey] = true;
+                            }
+                            if (at >= span.timelineStart && at < spanEnd)
+                            {
+                                if (! addGeneratedMidi (
+                                    juce::MidiMessage::controllerEvent (
+                                        c.channel, c.controller, c.value),
+                                    span.bufferOffset + (int) (at - span.timelineStart)))
+                                {
+                                    controllerPassComplete = false;
+                                    break;
+                                }
+                            }
+                        }
+                        if (! controllerPassComplete)
+                            break;
+                    }
+
+                    if (! controllerPassComplete)
+                        return;
+
+                    if (chase)
+                    {
+                        for (int i = 0; i < chasedControllerKeyCount; ++i)
+                        {
+                            const int key = chasedControllerKeys[(size_t) i];
+                            if (controllerExplicitAtStart[(size_t) key])
+                                continue;
+                            if (! addGeneratedController (
+                                    key / 128 + 1, key % 128,
+                                    chasedControllerValue[(size_t) key], chaseOffset))
+                                return;
                         }
                     }
-                }
-            }
 
-            for (const auto& region : midiRegionsForBlock)
-            {
-                if (region.muted) continue;
-                const auto regStart = region.timelineStart;
-                const auto regStartTick = useMap ? tm->samplesToTicks (regStart, sr) : (std::int64_t) 0;
-                auto absOf = [&] (std::int64_t relTick)
-                {
-                    return useMap ? tm->ticksToSamples (regStartTick + relTick, sr)
-                                  : regStart + ticksToSamples (relTick, sr, bpm);
-                };
-                // Musical region end (lengthInTicks is the source of truth) so a
-                // region that got longer in samples under a tempo slowdown isn't
-                // skipped by the overlap test.
-                const auto regEnd = useMap ? absOf (region.lengthInTicks)
-                                           : regStart + region.lengthInSamples;
-                // Skip regions that don't overlap the SHIFTED block at all.
-                // schedStart/blockEnd already include the plugin-latency
-                // offset for MIDI tracks; on audio tracks pluginLatency=0
-                // so this collapses to the original [blockStart, blockEnd)
-                // window.
-                if (regEnd <= schedStart || regStart >= blockEnd) continue;
+                    // Notes are deliberately scanned only after all controller
+                    // state has been inserted. Retrigger every sustained note
+                    // occurrence: overlapping regions may legitimately hold the
+                    // same channel/note and must not be key-deduplicated.
+                    for (const auto& region : midiRegionsForBlock)
+                    {
+                        if (! takeScheduleScan())
+                            return;
+                        if (region.muted) continue;
+                        const auto regStart = region.timelineStart;
+                        const auto regStartTick = useMap
+                            ? tm->samplesToTicks (regStart, sr) : std::int64_t { 0 };
+                        auto absOf = [&] (std::int64_t relTick)
+                        {
+                            return useMap
+                                ? tm->ticksToSamples (regStartTick + relTick, sr)
+                                : regStart + ticksToSamples (relTick, sr, bpm);
+                        };
+                        const auto regEnd = useMap ? absOf (region.lengthInTicks)
+                                                   : regStart + region.lengthInSamples;
+                        if (regEnd <= span.timelineStart || regStart >= spanEnd)
+                            continue;
 
-                for (const auto& n : region.notes)
-                {
-                    const auto onAbs  = absOf (n.startTick);
-                    const auto offAbs = absOf (n.startTick + n.lengthInTicks);
-                    if (onAbs >= schedStart && onAbs < blockEnd)
-                    {
-                        perTrackMidiScratch[(size_t) t].addEvent (
-                            juce::MidiMessage::noteOn (n.channel, n.noteNumber,
-                                                        (std::uint8_t) n.velocity),
-                            (int) (onAbs - schedStart));
+                        for (const auto& n : region.notes)
+                        {
+                            if (! takeScheduleScan())
+                                return;
+                            const auto onAbs  = absOf (n.startTick);
+                            const auto offAbs = absOf (n.startTick + n.lengthInTicks);
+                            if (chase && onAbs < span.timelineStart
+                                      && offAbs > span.timelineStart)
+                            {
+                                if (! addGeneratedMidi (
+                                        juce::MidiMessage::noteOn (
+                                            n.channel, n.noteNumber,
+                                            (std::uint8_t) n.velocity),
+                                        chaseOffset))
+                                    return;
+                            }
+                            if (onAbs >= span.timelineStart && onAbs < spanEnd)
+                            {
+                                if (! addGeneratedMidi (
+                                        juce::MidiMessage::noteOn (
+                                            n.channel, n.noteNumber,
+                                            (std::uint8_t) n.velocity),
+                                        span.bufferOffset + (int) (onAbs - span.timelineStart)))
+                                    return;
+                            }
+                            if (offAbs >= span.timelineStart && offAbs < spanEnd)
+                            {
+                                if (! addGeneratedMidi (
+                                        juce::MidiMessage::noteOff (n.channel, n.noteNumber),
+                                        span.bufferOffset + (int) (offAbs - span.timelineStart)))
+                                    return;
+                            }
+                        }
                     }
-                    if (offAbs >= schedStart && offAbs < blockEnd)
-                    {
-                        perTrackMidiScratch[(size_t) t].addEvent (
-                            juce::MidiMessage::noteOff (n.channel, n.noteNumber),
-                            (int) (offAbs - schedStart));
-                    }
-                }
-                for (const auto& c : region.ccs)
-                {
-                    const auto sAbs = absOf (c.atTick);
-                    if (sAbs >= schedStart && sAbs < blockEnd)
-                    {
-                        perTrackMidiScratch[(size_t) t].addEvent (
-                            juce::MidiMessage::controllerEvent (c.channel,
-                                                                  c.controller,
-                                                                  c.value),
-                            (int) (sAbs - schedStart));
-                    }
-                }
-            }
+                });
 
             // Play-along overlay. Live-MIDI delivery is a PER-BRANCH obligation:
             // every transport-source branch that builds perTrackMidiScratch must
@@ -4699,11 +5038,27 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
         // MIDI buffer in place, so by the time processAndAccumulate
         // returns, perTrackMidiScratch is typically empty. Writing here
         // captures the events the user actually played.
-        if (isRecording && armed && midiTrack && ! perTrackMidiScratch[(size_t) t].isEmpty())
+        if (isRecording && armed && midiTrack && ! liveRecordMidiScratch.isEmpty())
         {
-            const auto recStart = activeRecordStart.load (std::memory_order_relaxed);
-            const auto blockOffsetFromRecord = blockStartSamples - recStart;
-            recordManager.writeMidiBlock (t, perTrackMidiScratch[(size_t) t], blockOffsetFromRecord);
+            if (loopRecordingActive)
+            {
+                // Pass the SAME unsliced callback buffer to every span. The
+                // explicit absolute inputOffset filters events into exactly one
+                // pass before the instrument is allowed to consume the buffer.
+                forEachRecordCaptureSpan (
+                    [&] (const RecordManager::LoopCaptureSpan& span) noexcept
+                    {
+                        recordManager.writeMidiBlock (
+                            t, liveRecordMidiScratch, 0, &span);
+                    });
+            }
+            else
+            {
+                const auto recStart = activeRecordStart.load (std::memory_order_relaxed);
+                const auto blockOffsetFromRecord = blockStartSamples - recStart;
+                recordManager.writeMidiBlock (
+                    t, liveRecordMidiScratch, blockOffsetFromRecord);
+            }
         }
 
         // External MIDI output. When this MIDI track has a hardware port
@@ -4891,41 +5246,53 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
                 }
             }
 
-            // Unified write-gate - honours BOTH:
-            //   - activeRecordStart  (count-in pre-roll: skip writes until
-            //     the playhead reaches the take's intended start)
-            //   - punch-in / punch-out  (only commit samples in the window
-            //     when punch is on)
-            // Both reduce to a single [from, to) intersection with the
-            // current block.
-            const auto recStart  = activeRecordStart.load (std::memory_order_relaxed);
-            std::int64_t effIn    = recStart;  // floor; never write before this
-            std::int64_t effOut   = std::numeric_limits<std::int64_t>::max();
-            if (transport.isPunchEnabled())
+            if (loopRecordingActive)
             {
-                const auto pIn  = transport.getPunchIn();
-                const auto pOut = transport.getPunchOut();
-                if (pOut > pIn)
-                {
-                    effIn  = std::max (effIn, pIn);
-                    effOut = pOut;
-                }
-                else
-                {
-                    effIn = effOut;  // empty/inverted punch window -> no capture
-                }
+                forEachRecordCaptureSpan (
+                    [&] (const RecordManager::LoopCaptureSpan& span) noexcept
+                    {
+                        const float* writeL = recL + span.inputOffset;
+                        const float* writeR = recR != nullptr
+                            ? recR + span.inputOffset : nullptr;
+                        recordManager.writeInputBlock (
+                            t, writeL, writeR, span.numSamples, &span);
+                    });
             }
-
-            const auto blockEnd = blockStartSamples + numSamples;
-            const auto sliceStart = std::max (blockStartSamples, effIn);
-            const auto sliceEnd   = std::min (blockEnd,        effOut);
-            if (sliceEnd > sliceStart)
+            else
             {
-                const int writeOffset = (int) (sliceStart - blockStartSamples);
-                const int writeLength = (int) (sliceEnd - sliceStart);
-                const float* writeL = recL + writeOffset;
-                const float* writeR = (recR != nullptr) ? recR + writeOffset : nullptr;
-                recordManager.writeInputBlock (t, writeL, writeR, writeLength);
+                // Unified linear write-gate - honours BOTH:
+                //   - activeRecordStart (count-in/pre-roll)
+                //   - punch-in / punch-out
+                // Loop capture uses the immutable per-pass spans above.
+                const auto recStart = activeRecordStart.load (std::memory_order_relaxed);
+                std::int64_t effIn  = recStart;
+                std::int64_t effOut = std::numeric_limits<std::int64_t>::max();
+                if (transport.isPunchEnabled())
+                {
+                    const auto pIn  = transport.getPunchIn();
+                    const auto pOut = transport.getPunchOut();
+                    if (pOut > pIn)
+                    {
+                        effIn  = std::max (effIn, pIn);
+                        effOut = pOut;
+                    }
+                    else
+                    {
+                        effIn = effOut;
+                    }
+                }
+
+                const auto blockEnd = blockStartSamples + numSamples;
+                const auto sliceStart = std::max (blockStartSamples, effIn);
+                const auto sliceEnd   = std::min (blockEnd, effOut);
+                if (sliceEnd > sliceStart)
+                {
+                    const int writeOffset = (int) (sliceStart - blockStartSamples);
+                    const int writeLength = (int) (sliceEnd - sliceStart);
+                    const float* writeL = recL + writeOffset;
+                    const float* writeR = recR != nullptr ? recR + writeOffset : nullptr;
+                    recordManager.writeInputBlock (t, writeL, writeR, writeLength);
+                }
             }
         }
 
@@ -5329,7 +5696,9 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
     metronome.setPolyphonic (polyphonic);
     {
         const auto recStart   = activeRecordStart.load (std::memory_order_relaxed);
-        const bool inCountIn  = isRecording && blockStartSamples < recStart;
+        const bool inCountIn = isRecording && blockStartSamples < recStart
+                            && (! loopRecordingActive
+                                || loopRecordPassAtBlockStart == 1);
 
         // Decide whether the click is eligible this block.
         //   - Recording (post-count-in): gated by clickWhileRecording AND
@@ -5366,16 +5735,31 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
 
     if (isPlaying || isRecording)
     {
-        transport.advancePlayhead (numSamples);
+        // A ruler/marker seek can race a live callback. Loop-record gestures
+        // deliberately defer seeks until Stop, so advance from the immutable
+        // block coordinate instead of adding onto a concurrently replaced
+        // playhead. Plain playback keeps its normal seekable fetch-add path.
+        if (loopRecordingActive)
+            transport.setPlayhead (blockStartSamples + numSamples);
+        else
+            transport.advancePlayhead (numSamples);
 
-        // Loop wrap-around. Only honoured during plain playback - during
-        // Recording we keep the playhead linear so the captured WAV maps
-        // cleanly onto the timeline (loop-take-stacking is a future
-        // feature). Wrap is whole-block accurate: we do not split the
-        // current block, so the playhead may briefly read up to one block
-        // past loopEnd before snapping back. That overshoot is silent
-        // because PlaybackEngine returns silence outside region bounds.
-        if (isPlaying && ! isRecording && transport.isLoopEnabled())
+        if (loopRecordingActive)
+        {
+            const auto curr = transport.getPlayhead();
+            const auto loopStart = loopRecordPlan.loopStartSample;
+            const auto loopEnd   = loopRecordPlan.loopEndSample;
+            if (curr >= loopEnd)
+            {
+                const auto loopLength = loopEnd - loopStart;
+                const auto distancePastEnd = curr - loopEnd;
+                const auto crossings = 1 + distancePastEnd / loopLength;
+                transport.setPlayhead (loopStart + distancePastEnd % loopLength);
+                activeLoopRecordPassOrdinal.fetch_add ((int) crossings,
+                                                        std::memory_order_relaxed);
+            }
+        }
+        else if (isPlaying && transport.isLoopEnabled())
         {
             const auto lStart = transport.getLoopStart();
             const auto lEnd   = transport.getLoopEnd();
@@ -5391,6 +5775,10 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
             }
         }
     }
+
+    lastBlockWasLoopRecording = loopRecordingActive;
+    lastBlockEndSample = isRolling ? transport.getPlayhead()
+                                   : blockStartSamples + numSamples;
 
     // Detect xrun: callback work shouldn't exceed the buffer's wall-clock
     // budget. If it does, we'd glitch on the next callback. Track the count

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -1,5 +1,6 @@
 #include "AudioEngine.h"
 #include "BounceEngine.h"
+#include "GeneratedMidiBudget.h"
 #include "LoopTimeline.h"
 #include "PdcMath.h"
 #include "RtPriority.h"
@@ -25,6 +26,8 @@
 
 namespace duskstudio
 {
+constexpr std::int64_t kMinLoopRecordSamples = 128;
+
 // Log-span of the HPF sweep band, precomputed once. The MIDI-CC HPF map runs
 // on the audio thread per controller event; without this it would recompute
 // std::log(max/min) on every CC message.
@@ -1467,7 +1470,6 @@ void AudioEngine::record()
             loopPlan.captureStartSample = loopStart;
             loopPlan.captureEndSample = loopEnd;
 
-            constexpr std::int64_t kMinLoopRecordSamples = 128;
             if (loopEnd - loopStart < kMinLoopRecordSamples)
             {
                 std::fprintf (stderr,
@@ -1475,8 +1477,12 @@ void AudioEngine::record()
                               "%lld samples; recording blocked.\n",
                               (long long) kMinLoopRecordSamples);
                 if (onRecordBlocked_)
-                    onRecordBlocked_ ("Loop recording could not start.\n\nThe loop must "
-                                      "be at least 128 samples long.");
+                {
+                    const auto message = std::string (
+                        "Loop recording could not start.\n\nThe loop must be at least ")
+                        + std::to_string (kMinLoopRecordSamples) + " samples long.";
+                    onRecordBlocked_ (message.c_str());
+                }
                 return;
             }
 
@@ -4618,25 +4624,28 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
         constexpr int kHangingResetBytes = kHangingResetMessageCount
                                          * kGeneratedEventBytes;
         static_assert (kGeneratedMidiBudget
-                       >= (8192 / 128 + 1) * kHangingResetBytes);
-        int generatedMidiBytesRemaining = kGeneratedMidiBudget;
-        int reservedStructuralResetBytes = midiTrack && perTrackFlush
-                                         ? kHangingResetBytes : 0;
+                       >= (8192 / kMinLoopRecordSamples + 1)
+                            * kHangingResetBytes);
+        GeneratedMidiBudget generatedMidiBudget (kGeneratedMidiBudget);
+        if (midiTrack && perTrackFlush)
+        {
+            const bool reserved = generatedMidiBudget.reserveStructural (
+                kHangingResetBytes);
+            jassert (reserved);
+            (void) reserved;
+        }
         int midiScheduleScansRemaining = kMidiScheduleScanBudget;
         auto addGeneratedMidi = [&] (const auto& message, int sampleOffset) noexcept
         {
-            if (generatedMidiBytesRemaining - reservedStructuralResetBytes
-                    < kGeneratedEventBytes)
+            if (! generatedMidiBudget.spendDiscretionary (kGeneratedEventBytes))
                 return false;
             perTrackMidiScratch[(size_t) t].addEvent (message, sampleOffset);
-            generatedMidiBytesRemaining -= kGeneratedEventBytes;
             return true;
         };
         auto addGeneratedController = [&] (int channel, int controller,
                                            int value, int sampleOffset) noexcept
         {
-            if (generatedMidiBytesRemaining - reservedStructuralResetBytes
-                    < kGeneratedEventBytes)
+            if (! generatedMidiBudget.spendDiscretionary (kGeneratedEventBytes))
                 return false;
             const std::array<std::uint8_t, 3> bytes {
                 (std::uint8_t) (0xB0 | (channel - 1)),
@@ -4645,7 +4654,6 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
             };
             perTrackMidiScratch[(size_t) t].addEvent (
                 bytes.data(), (int) bytes.size(), sampleOffset);
-            generatedMidiBytesRemaining -= kGeneratedEventBytes;
             return true;
         };
         auto emitHangingMidiReset = [&] (int sampleOffset) noexcept
@@ -4653,11 +4661,8 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
             // A reset is structural: either all 32 three-byte messages fit or
             // none are emitted. Discretionary scheduling reserves this exact
             // capacity before it can consume the shared generated-event budget.
-            if (generatedMidiBytesRemaining < kHangingResetBytes)
+            if (! generatedMidiBudget.consumeStructural (kHangingResetBytes))
                 return false;
-
-            if (reservedStructuralResetBytes >= kHangingResetBytes)
-                reservedStructuralResetBytes -= kHangingResetBytes;
             for (int ch = 1; ch <= 16; ++ch)
             {
                 perTrackMidiScratch[(size_t) t].addEvent (
@@ -4665,7 +4670,6 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
                 perTrackMidiScratch[(size_t) t].addEvent (
                     juce::MidiMessage::controllerEvent (ch, 123, 0), sampleOffset);
             }
-            generatedMidiBytesRemaining -= kHangingResetBytes;
             return true;
         };
         if (midiTrack && perTrackFlush)
@@ -4776,15 +4780,15 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
             // construction time so this pointer is non-null.
             const auto& midiRegionsForBlock = *session.track (t).midiRegions.read();
 
-            // Loop recording already rejects ranges shorter than 128 samples.
+            // Loop recording already rejects ranges shorter than the shared
+            // recording minimum.
             // Plain playback still permits them, so keep its pre-existing
             // bounded linear MIDI window instead of enumerating more seam
             // resets than the fixed generated-event budget can represent.
-            constexpr std::int64_t kMinMidiLoopScheduleSamples = 128;
             const bool midiLoopActive = loopReadEnd > loopReadStart
                 && static_cast<std::uint64_t> (loopReadEnd)
                      - static_cast<std::uint64_t> (loopReadStart)
-                   >= static_cast<std::uint64_t> (kMinMidiLoopScheduleSamples);
+                   >= static_cast<std::uint64_t> (kMinLoopRecordSamples);
             std::array<int, 16 * 128> chasedControllerValue;
             std::array<std::int64_t, 16 * 128> chasedControllerAt;
             std::array<bool, 16 * 128> chasedControllerSeen;
@@ -4805,8 +4809,10 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
                         if (span.wrappedBefore)
                             ++futureSeamResetCount;
                     });
-                reservedStructuralResetBytes += futureSeamResetCount
-                                              * kHangingResetBytes;
+                const bool reserved = generatedMidiBudget.reserveStructural (
+                    futureSeamResetCount * kHangingResetBytes);
+                jassert (reserved);
+                (void) reserved;
             }
 
             auto takeScheduleScan = [&] () noexcept
@@ -4828,7 +4834,7 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
                         && ! emitHangingMidiReset (span.bufferOffset))
                         return;
 
-                    if (generatedMidiBytesRemaining - reservedStructuralResetBytes
+                    if (generatedMidiBudget.discretionaryBytesAvailable()
                             < kGeneratedEventBytes
                         || midiScheduleScansRemaining <= 0)
                         return;

--- a/src/engine/AudioEngine.h
+++ b/src/engine/AudioEngine.h
@@ -136,6 +136,8 @@ public:
     Transport&        getTransport()      noexcept { return transport; }
     const Transport&  getTransport() const noexcept { return transport; }
     RecordManager&    getRecordManager()   noexcept { return recordManager; }
+    bool              isLoopRecordingActive() const noexcept
+        { return recordManager.isLoopCaptureActive(); }
     PlaybackEngine&   getPlaybackEngine()  noexcept { return playbackEngine; }
     PluginManager&    getPluginManager()   noexcept { return pluginManager; }
     MasteringPlayer&  getMasteringPlayer() noexcept { return masteringPlayer; }
@@ -436,6 +438,7 @@ public:
     // Test-only. Next callback merges `events` into perInputMidi[inputIdx]
     // AFTER collector drain. Cleared after one block.
     void stageTestMidiInjection (int inputIdx, juce::MidiBuffer events);
+    void stageTestMidiInjection (int inputIdx, dusk::MidiBuffer events);
 
     // Bookends around SessionSerializer save/load. publish copies each
     // PluginSlot's description + state into the Track fields; consume
@@ -778,18 +781,22 @@ private:
     // reserveBytes'd off the RT path in rebuildMidiBanks so the drain and the
     // test-inject merge never allocate on the audio thread.
     std::vector<dusk::MidiBuffer> perInputMidi;
-    // Per-track routing buffer feeding the strip's instrument + the recorder -
-    // both take juce::MidiBuffer, so this stays juce-typed.
+    // Per-track routing buffer feeding the strip's instrument.
     std::array<juce::MidiBuffer, Session::kNumTracks> perTrackMidiScratch;
+    // Timestamp-sorted raw live input accepted by pullInput for the armed MIDI
+    // recorder. Separate from routing so generated flush/chase events can never
+    // become performance data; one buffer is enough because tracks are captured
+    // serially within the callback.
+    decltype (perTrackMidiScratch)::value_type liveRecordMidiScratch;
     // juce->dusk bridge for a MIDI track's external output: perTrackMidiScratch
     // (juce) is copied into this before midiOut.queueRt (dusk). Pre-reserved.
     dusk::MidiBuffer midiOutTrackScratch;
 
     // SPSC handoff. Producer must not touch testInjectMidi while
     // testInjectReady==true. Single relaxed load + branch per block in
-    // production. Staged as juce (the test builds a juce buffer); merged into
-    // the dusk perInputMidi slot on the audio thread.
-    juce::MidiBuffer  testInjectMidi;
+    // production. Staged in the native MIDI buffer and merged into the matching
+    // perInputMidi slot on the audio thread.
+    dusk::MidiBuffer  testInjectMidi;
     std::atomic<int>  testInjectInputIdx { -1 };
     std::atomic<bool> testInjectReady    { false };
 
@@ -954,6 +961,11 @@ private:
     // INT64_MIN = no record active.
     std::atomic<std::int64_t> activeRecordStart { std::numeric_limits<std::int64_t>::min() };
 
+    // 1-based pass containing the next callback's first sample. Reset from the
+    // message thread before entering Recording; advanced only by the audio
+    // thread when the snapshotted loop gesture crosses its end boundary.
+    std::atomic<int> activeLoopRecordPassOrdinal { 0 };
+
     // Manual recording latency offset in samples (message-thread only).
     int recordingLatencyOffsetSamples_ = 0;
 
@@ -978,5 +990,6 @@ private:
     //     Off is past the jump never fire - synth stuck.
     bool         wasRolling          = false;
     std::int64_t  lastBlockEndSample  = 0;
+    bool         lastBlockWasLoopRecording = false;
 };
 } // namespace duskstudio

--- a/src/engine/AudioPipelineSelfTest.cpp
+++ b/src/engine/AudioPipelineSelfTest.cpp
@@ -1,5 +1,7 @@
 #include "AudioPipelineSelfTest.h"
+#include "../foundation/Fs.h"
 #include "../foundation/Text.h"
+#include "audiofile/FileReader.h"
 #if defined(__linux__)
  #include "alsa/AlsaAudioIODevice.h"
 #endif
@@ -8,7 +10,9 @@
  #include "pipewire/PipeWireAudioIODevice.h"
 #endif
 #include <array>
+#include <chrono>
 #include <cmath>
+#include <filesystem>
 
 namespace duskstudio
 {
@@ -29,6 +33,13 @@ float ampToDb (float a, float ref = 1.0f)
 }
 
 std::string fmtPassFail (bool pass) { return pass ? "[PASS]" : "[FAIL]"; }
+
+void addMidi3 (dusk::MidiBuffer& buffer, std::uint8_t status,
+               std::uint8_t data1, std::uint8_t data2, int samplePosition)
+{
+    const std::array<std::uint8_t, 3> bytes { status, data1, data2 };
+    buffer.addEvent (bytes.data(), (int) bytes.size(), samplePosition);
+}
 } // namespace
 
 AudioPipelineSelfTest::AudioPipelineSelfTest (AudioEngine& e,
@@ -1234,8 +1245,8 @@ std::string AudioPipelineSelfTest::testMidiPlayAlongMonitor()
         if (t0.midiActivity.load (std::memory_order_relaxed))
             flushInert = false;
 
-        juce::MidiBuffer m;
-        m.addEvent (juce::MidiMessage::noteOn (1, 60, (juce::uint8) 100), 0);
+        dusk::MidiBuffer m;
+        addMidi3 (m, 0x90, 60, 100, 0);
         engine.stageTestMidiInjection (vkbIdx, std::move (m));
         t0.midiActivity.store (false, std::memory_order_relaxed);
         runBlock();
@@ -1423,8 +1434,252 @@ std::string AudioPipelineSelfTest::testAudioPlayAlongSends()
         pass ? "" : "<-- monitored send dropped (must feed aux while rolling)");
 }
 
+std::string AudioPipelineSelfTest::testLoopRecordTakeStacking()
+{
+    constexpr double sr = 48000.0;
+    constexpr int blockSize = 180;
+    constexpr int numInputs = 2;
+    constexpr int numOutputs = 2;
+
+    const int vkbIdx = engine.getVirtualKeyboardInputIndex();
+    if (vkbIdx < 0)
+        return "[FAIL] Loop-record take stacking: no virtual-keyboard input available";
+
+    prepareCleanState();
+    engine.prepareForSelfTest (sr, blockSize);
+
+    auto& audioTrack = session.track (0);
+    auto& midiTrack  = session.track (1);
+    const auto savedDir = session.getSessionDirectory();
+    const auto savedAudioRegions = audioTrack.regions;
+    const auto savedMidiRegions = midiTrack.midiRegions.current();
+    const int savedMidiInput = midiTrack.midiInputIndex.load (std::memory_order_relaxed);
+    const int savedMidiChannel = midiTrack.midiChannel.load (std::memory_order_relaxed);
+    const bool savedCountIn = session.countInEnabled.load (std::memory_order_relaxed);
+    const float savedBpm = session.tempoBpm.load (std::memory_order_relaxed);
+    const int savedBeatsPerBar = session.beatsPerBar.load (std::memory_order_relaxed);
+    auto& transport = engine.getTransport();
+    const auto savedTransportState = transport.getState();
+    const auto savedPlayhead = transport.getPlayhead();
+    const bool savedLoopEnabled = transport.isLoopEnabled();
+    const auto savedLoopStart = transport.getLoopStart();
+    const auto savedLoopEnd = transport.getLoopEnd();
+    const bool savedPunchEnabled = transport.isPunchEnabled();
+    const auto savedPunchIn = transport.getPunchIn();
+    const auto savedPunchOut = transport.getPunchOut();
+    const auto savedLastRecordPoint = session.lastRecordPointSamples.load (
+        std::memory_order_relaxed);
+
+    const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto testDirPath = dusk::fs::tempDir()
+                           / ("dusk-loop-record-selftest-" + std::to_string (nonce));
+    std::error_code fsError;
+    const bool madeDir = std::filesystem::create_directory (testDirPath, fsError);
+    const decltype (savedDir) testDir (testDirPath.string());
+
+    bool alignedStart = false;
+    bool wrappedPlayhead = false;
+    bool audioMetadata = false;
+    bool audioPayload = false;
+    bool midiMetadata = false;
+    bool midiPayload = false;
+    bool noSyntheticCcs = false;
+    bool recorderInactive = false;
+    std::int64_t wavFrames = 0;
+
+    if (madeDir)
+    {
+        session.setSessionDirectory (testDir);
+        audioTrack.regions.clear();
+        midiTrack.midiRegions.publish (std::make_unique<std::vector<MidiRegion>>());
+
+        audioTrack.mode.store ((int) Track::Mode::Mono, std::memory_order_relaxed);
+        audioTrack.inputSource.store (-2, std::memory_order_relaxed); // follow track -> input 0
+        audioTrack.inputMonitor.store (false, std::memory_order_relaxed);
+        audioTrack.recordArmed.store (true, std::memory_order_relaxed);
+        audioTrack.strip.mute.store (true, std::memory_order_relaxed);
+
+        midiTrack.mode.store ((int) Track::Mode::Midi, std::memory_order_relaxed);
+        midiTrack.midiInputIndex.store (vkbIdx, std::memory_order_relaxed);
+        midiTrack.midiChannel.store (0, std::memory_order_relaxed);
+        midiTrack.inputMonitor.store (false, std::memory_order_relaxed);
+        midiTrack.recordArmed.store (true, std::memory_order_relaxed);
+        midiTrack.strip.mute.store (true, std::memory_order_relaxed);
+        session.recomputeRtCounters();
+
+        // Record is pressed inside the loop. The gesture aligns to the
+        // effective loop/punch start, then the one-bar count-in rolls back by
+        // exactly 48 samples.
+        session.countInEnabled.store (true, std::memory_order_relaxed);
+        session.tempoBpm.store (60000.0f, std::memory_order_relaxed);
+        session.beatsPerBar.store (1, std::memory_order_relaxed);
+        transport.setLoopRange (1000, 1128);
+        transport.setLoopEnabled (true);
+        transport.setPunchRange (1002, 1127);
+        transport.setPunchEnabled (true);
+        transport.setPlayhead (1040);
+
+        std::array<std::array<float, blockSize>, numInputs> firstInputs {};
+        std::array<std::array<float, blockSize>, numInputs> secondInputs {};
+        for (int s = 0; s < blockSize; ++s)
+        {
+            firstInputs[0][(size_t) s] = (float) (s + 1) * 0.001f;
+            secondInputs[0][(size_t) s] = (float) (s + 201) * 0.001f;
+        }
+        std::array<const float*, numInputs> inputPtrs {
+            firstInputs[0].data(), firstInputs[1].data()
+        };
+        std::array<std::array<float, blockSize>, numOutputs> outputs {};
+        std::array<float*, numOutputs> outputPtrs {
+            outputs[0].data(), outputs[1].data()
+        };
+
+        dusk::MidiBuffer originalCallback;
+        addMidi3 (originalCallback, 0x90, 40, 100, 0);
+        addMidi3 (originalCallback, 0x80, 40,   0, 1);
+        addMidi3 (originalCallback, 0x90, 60, 100, 48);
+        addMidi3 (originalCallback, 0x80, 60,   0, 52);
+        addMidi3 (originalCallback, 0x90, 67, 100, 173);
+        addMidi3 (originalCallback, 0x80, 67,   0, 174);
+        addMidi3 (originalCallback, 0x90, 64, 100, 176);
+        addMidi3 (originalCallback, 0x80, 64,   0, 179);
+
+        engine.record();
+        alignedStart = session.lastRecordPointSamples.load (
+                           std::memory_order_relaxed) == 1002
+                    && transport.getPlayhead() == 954;
+        engine.stageTestMidiInjection (vkbIdx, std::move (originalCallback));
+        duskstudio::device::CallbackContext ctx {};
+        engine.audioDeviceIOCallback (inputPtrs.data(), numInputs,
+                                      outputPtrs.data(), numOutputs,
+                                      blockSize, ctx);
+        const bool firstWrap = transport.getPlayhead() == 1006;
+
+        inputPtrs = { secondInputs[0].data(), secondInputs[1].data() };
+        engine.audioDeviceIOCallback (inputPtrs.data(), numInputs,
+                                      outputPtrs.data(), numOutputs,
+                                      blockSize, ctx);
+        wrappedPlayhead = firstWrap && transport.getPlayhead() == 1058;
+
+        // Avoid adding the probe to the user's undo history.
+        transport.setState (Transport::State::Stopped);
+        engine.getRecordManager().stopRecording (transport.getPlayhead());
+        recorderInactive = ! engine.getRecordManager().isActive();
+        engine.getPlaybackEngine().stopPlayback();
+
+        if (audioTrack.regions.size() == 1)
+        {
+            const auto& current = audioTrack.regions.front();
+            audioMetadata = current.timelineStart == 1002
+                         && current.sourceOffset == 250
+                         && current.lengthInSamples == 56
+                         && current.provenance.loopPassOrdinal == 3
+                         && current.provenance.partialPass
+                         && current.previousTakes.size() == 2
+                         && current.previousTakes[0].sourceOffset == 125
+                         && current.previousTakes[0].lengthInSamples == 125
+                         && current.previousTakes[0].provenance.loopPassOrdinal == 2
+                         && ! current.previousTakes[0].provenance.partialPass
+                         && current.previousTakes[1].sourceOffset == 0
+                         && current.previousTakes[1].lengthInSamples == 125
+                         && current.previousTakes[1].provenance.loopPassOrdinal == 1
+                         && ! current.previousTakes[1].provenance.partialPass;
+
+            auto reader = dusk::audio::FileReader::open (
+                std::filesystem::u8path (current.file.getFullPathName().toStdString()));
+            if (reader != nullptr)
+            {
+                wavFrames = reader->info().numFrames;
+                std::array<float, 306> samples {};
+                float* channels[1] = { samples.data() };
+                if (reader->read (channels, 1, 0, (std::int64_t) samples.size())
+                    == (std::int64_t) samples.size())
+                {
+                    std::vector<float> expected;
+                    expected.reserve (samples.size());
+                    expected.insert (expected.end(), firstInputs[0].begin() + 48,
+                                     firstInputs[0].begin() + 173);
+                    expected.insert (expected.end(), firstInputs[0].begin() + 176,
+                                     firstInputs[0].end());
+                    expected.insert (expected.end(), secondInputs[0].begin(),
+                                     secondInputs[0].begin() + 121);
+                    expected.insert (expected.end(), secondInputs[0].begin() + 124,
+                                     secondInputs[0].end());
+                    audioPayload = wavFrames == (std::int64_t) expected.size()
+                                && expected.size() == samples.size();
+                    for (size_t i = 0; i < expected.size() && audioPayload; ++i)
+                        audioPayload = std::abs (samples[i] - expected[i]) < 1.0e-4f;
+                }
+            }
+        }
+
+        const auto& midiRegions = midiTrack.midiRegions.current();
+        if (midiRegions.size() == 1)
+        {
+            const auto& current = midiRegions.front();
+            midiMetadata = current.timelineStart == 1002
+                        && current.lengthInSamples == 125
+                        && current.provenance.loopPassOrdinal == 2
+                        && ! current.provenance.partialPass
+                        && current.previousTakes.size() == 1
+                        && current.previousTakes[0].provenance.loopPassOrdinal == 1
+                        && ! current.previousTakes[0].provenance.partialPass;
+            midiPayload = current.notes.size() == 1
+                       && current.notes[0].noteNumber == 64
+                       && current.previousTakes[0].notes.size() == 1
+                       && current.previousTakes[0].notes[0].noteNumber == 60;
+            noSyntheticCcs = current.ccs.empty()
+                          && current.previousTakes[0].ccs.empty();
+        }
+    }
+
+    // Restore the state not covered by runAll's SavedState before the backend
+    // probes reattach the real device. The outer restore handles the per-track
+    // mode/arm/monitor/mute atoms changed above.
+    transport.setState (savedTransportState);
+    transport.setPlayhead (savedPlayhead);
+    transport.setLoopRange (savedLoopStart, savedLoopEnd);
+    transport.setLoopEnabled (savedLoopEnabled);
+    transport.setPunchRange (savedPunchIn, savedPunchOut);
+    transport.setPunchEnabled (savedPunchEnabled);
+    session.countInEnabled.store (savedCountIn, std::memory_order_relaxed);
+    session.tempoBpm.store (savedBpm, std::memory_order_relaxed);
+    session.beatsPerBar.store (savedBeatsPerBar, std::memory_order_relaxed);
+    session.lastRecordPointSamples.store (savedLastRecordPoint,
+                                          std::memory_order_relaxed);
+    midiTrack.midiInputIndex.store (savedMidiInput, std::memory_order_relaxed);
+    midiTrack.midiChannel.store (savedMidiChannel, std::memory_order_relaxed);
+    audioTrack.regions = savedAudioRegions;
+    midiTrack.midiRegions.publish (
+        std::make_unique<std::vector<MidiRegion>> (savedMidiRegions));
+    session.setSessionDirectory (savedDir);
+    engine.getPlaybackEngine().preparePlayback();
+    std::filesystem::remove_all (testDirPath, fsError);
+
+    const bool pass = madeDir && alignedStart && wrappedPlayhead && audioMetadata
+                   && audioPayload && midiMetadata && midiPayload
+                   && noSyntheticCcs && recorderInactive;
+    return dusk::text::format (
+        "%s Loop-record take stacking (aligned start, two callbacks, punch + seam)\n"
+        "      start=%s  playhead=%s  audio-meta=%s  wav=%lldf/%s  "
+        "midi-meta=%s  midi=%s  raw-only=%s  inactive=%s %s",
+        fmtPassFail (pass).c_str(),
+        alignedStart ? "1002" : "WRONG",
+        wrappedPlayhead ? "1058" : "WRONG",
+        audioMetadata ? "ok" : "FAIL",
+        (long long) wavFrames, audioPayload ? "ok" : "FAIL",
+        midiMetadata ? "ok" : "FAIL",
+        midiPayload ? "60->64" : "FAIL",
+        noSyntheticCcs ? "yes" : "NO",
+        recorderInactive ? "yes" : "NO",
+        pass ? "" : "<-- loop capture orchestration regressed");
+}
+
 std::string AudioPipelineSelfTest::runAll()
 {
+    if (! engine.getTransport().isStopped() || engine.getRecordManager().isActive())
+        return "[FAIL] Audio pipeline self-test refused: stop recording and transport first";
+
     std::vector<std::string> report;
     report.push_back ("=== Dusk Studio Audio Pipeline Self-Test ===");
     report.push_back ("Time: " + juce::Time::getCurrentTime().toString (true, true).toStdString());
@@ -1461,6 +1716,7 @@ std::string AudioPipelineSelfTest::runAll()
     report.push_back (testParallelMatchesSerial());
     report.push_back (testMidiPlayAlongMonitor());
     report.push_back (testAudioPlayAlongSends());
+    report.push_back (testLoopRecordTakeStacking());
     report.push_back ("");
 
    #if defined(__linux__)

--- a/src/engine/AudioPipelineSelfTest.h
+++ b/src/engine/AudioPipelineSelfTest.h
@@ -123,6 +123,7 @@ private:
     std::string testParallelMatchesSerial(); // worker-pool mix == serial mix within float-reassoc tol
     std::string testMidiPlayAlongMonitor();   // armed+IN MIDI track sounds live notes in Stopped AND Playing
     std::string testAudioPlayAlongSends();    // IN audio track feeds its aux send in Stopped AND Playing
+    std::string testLoopRecordTakeStacking(); // one callback crosses loop seam into a second audio+MIDI take
     std::string testBackendsOpenCleanly();
     std::string probeUMC1820AlsaFormat();   // explicitly open UMC1820 ALSA & report format
 

--- a/src/engine/GeneratedMidiBudget.h
+++ b/src/engine/GeneratedMidiBudget.h
@@ -1,0 +1,56 @@
+#pragma once
+
+namespace duskstudio
+{
+// Fixed-capacity accounting for MIDI generated inside the audio callback.
+// Structural bytes are protected from discretionary scheduling until the
+// corresponding all-or-nothing message group is emitted.
+class GeneratedMidiBudget
+{
+public:
+    explicit constexpr GeneratedMidiBudget (int capacityBytes) noexcept
+        : remainingBytes_ (capacityBytes > 0 ? capacityBytes : 0)
+    {}
+
+    constexpr bool reserveStructural (int bytes) noexcept
+    {
+        if (bytes < 0 || bytes > discretionaryBytesAvailable())
+            return false;
+        reservedStructuralBytes_ += bytes;
+        return true;
+    }
+
+    constexpr bool spendDiscretionary (int bytes) noexcept
+    {
+        if (bytes < 0 || bytes > discretionaryBytesAvailable())
+            return false;
+        remainingBytes_ -= bytes;
+        return true;
+    }
+
+    constexpr bool consumeStructural (int bytes) noexcept
+    {
+        if (bytes < 0 || bytes > reservedStructuralBytes_
+            || bytes > remainingBytes_)
+            return false;
+        reservedStructuralBytes_ -= bytes;
+        remainingBytes_ -= bytes;
+        return true;
+    }
+
+    constexpr int discretionaryBytesAvailable() const noexcept
+    {
+        return remainingBytes_ - reservedStructuralBytes_;
+    }
+
+    constexpr int remainingBytes() const noexcept { return remainingBytes_; }
+    constexpr int reservedStructuralBytes() const noexcept
+    {
+        return reservedStructuralBytes_;
+    }
+
+private:
+    int remainingBytes_ = 0;
+    int reservedStructuralBytes_ = 0;
+};
+} // namespace duskstudio

--- a/src/engine/RecordManager.cpp
+++ b/src/engine/RecordManager.cpp
@@ -229,12 +229,14 @@ bool RecordManager::startRecording (double sampleRate, std::int64_t startSample,
     loopPlan = loopCapturePlan;
     currentLoopSpan = {};
     loopPassCount = 0;
-    highestLoopPassOrdinal = 0;
     gestureCapturedAtMs = std::chrono::duration_cast<std::chrono::milliseconds> (
         std::chrono::system_clock::now().time_since_epoch()).count();
 
     lastSetupFailures.clear();
     lastRecordErrors.clear();
+    activeCaptureTrackMask.store (0, std::memory_order_relaxed);
+    activeMidiCaptureTrackMask.store (0, std::memory_order_relaxed);
+    activeStereoCaptureTrackMask.store (0, std::memory_order_relaxed);
 
     // Reset the per-track audio-thread counters before the audio
     // callback can start writing - the counter readout at stopRecording
@@ -247,7 +249,9 @@ bool RecordManager::startRecording (double sampleRate, std::int64_t startSample,
     // Tracks whether any track actually got a writer / MIDI capture. If every
     // armed track is skipped (e.g. all frozen), starting would arm a no-op
     // recording that captures nothing - fail instead so the caller can surface it.
-    bool anyArmedSetup = false;
+    std::uint32_t captureTrackMask = 0;
+    std::uint32_t midiCaptureTrackMask = 0;
+    std::uint32_t stereoCaptureTrackMask = 0;
 
     for (int t = 0; t < Session::kNumTracks; ++t)
     {
@@ -262,17 +266,19 @@ bool RecordManager::startRecording (double sampleRate, std::int64_t startSample,
         if (session.track (t).frozen.load (std::memory_order_relaxed))
             continue;
 
+        const int trackMode = session.track (t).mode.load (std::memory_order_relaxed);
+
         // MIDI tracks: spin up the MIDI capture FIFO and skip the WAV
         // writer entirely. The audio thread will push events into the
         // FIFO via writeMidiBlock; stopRecording drains it into a
         // MidiRegion and pushes onto track.midiRegions.
-        if (session.track (t).mode.load (std::memory_order_relaxed)
-            == (int) Track::Mode::Midi)
+        if (trackMode == (int) Track::Mode::Midi)
         {
             auto cap = std::make_unique<PerTrackMidi>();
             cap->fifo.reset();
             midiCaptures[(size_t) t] = std::move (cap);
-            anyArmedSetup = true;
+            captureTrackMask |= std::uint32_t { 1 } << t;
+            midiCaptureTrackMask |= std::uint32_t { 1 } << t;
             std::fprintf (stderr,
                           "[Dusk Studio/RecordManager] startRecording: track %d set up MIDI capture "
                           "(midiInputIndex=%d, midiChannel=%d).\n",
@@ -301,8 +307,7 @@ bool RecordManager::startRecording (double sampleRate, std::int64_t startSample,
         // Stereo. The writer's channel count is captured here so writeInput-
         // Block builds a matching channel-pointer array on the audio thread.
         const int trackChannels =
-            session.track (t).mode.load (std::memory_order_relaxed)
-                == (int) Track::Mode::Stereo ? 2 : 1;
+            trackMode == (int) Track::Mode::Stereo ? 2 : 1;
 
         dusk::audio::WriteSpec spec;
         spec.sampleRate    = sampleRate;
@@ -361,6 +366,9 @@ bool RecordManager::startRecording (double sampleRate, std::int64_t startSample,
                 }
             for (auto& cap : midiCaptures)
                 cap.reset();
+            activeCaptureTrackMask.store (0, std::memory_order_relaxed);
+            activeMidiCaptureTrackMask.store (0, std::memory_order_relaxed);
+            activeStereoCaptureTrackMask.store (0, std::memory_order_relaxed);
             return false;
         }
 
@@ -375,16 +383,21 @@ bool RecordManager::startRecording (double sampleRate, std::int64_t startSample,
             continue;
         }
         writers[(size_t) t] = std::move (perTrack);
-        anyArmedSetup = true;
+        captureTrackMask |= std::uint32_t { 1 } << t;
+        if (trackMode == (int) Track::Mode::Stereo)
+            stereoCaptureTrackMask |= std::uint32_t { 1 } << t;
     }
 
-    if (! anyArmedSetup)
+    if (captureTrackMask == 0)
     {
         std::fprintf (stderr, "[Dusk Studio/RecordManager] startRecording: every armed track "
                               "was skipped (frozen, or setup failed); nothing to record.\n");
         return false;
     }
 
+    activeCaptureTrackMask.store (captureTrackMask, std::memory_order_relaxed);
+    activeMidiCaptureTrackMask.store (midiCaptureTrackMask, std::memory_order_relaxed);
+    activeStereoCaptureTrackMask.store (stereoCaptureTrackMask, std::memory_order_relaxed);
     active.store (true, std::memory_order_release);
     return true;
 }
@@ -437,7 +450,6 @@ void RecordManager::beginLoopCaptureSpan (const LoopCaptureSpan& span) noexcept
     currentLoopSpan = span;
     if (span.passOrdinal < 1 || span.numSamples <= 0)
         return;
-    highestLoopPassOrdinal = std::max (highestLoopPassOrdinal, span.passOrdinal);
 
     PassDescriptor* descriptor = nullptr;
     if (loopPassCount > 0
@@ -467,6 +479,9 @@ void RecordManager::stopRecording (std::int64_t endSample)
         return;
 
     active.store (false, std::memory_order_release);
+    activeCaptureTrackMask.store (0, std::memory_order_release);
+    activeMidiCaptureTrackMask.store (0, std::memory_order_release);
+    activeStereoCaptureTrackMask.store (0, std::memory_order_release);
 
     // Drain in-flight audio-thread calls before reading per-writer
     // counters or destroying writers / midiCaptures. Both writeInputBlock
@@ -611,21 +626,41 @@ void RecordManager::stopRecording (std::int64_t endSample)
                                      - loopPlan.captureStartSample;
             size_t drainedIndex = 0;
 
-            for (int passOrdinal = 1;
-                 passOrdinal <= highestLoopPassOrdinal; ++passOrdinal)
+            auto seedState = [&] (const PerTrackMidi::RawEvent& ev) noexcept
             {
-                PassDescriptor pass;
-                pass.passOrdinal = passOrdinal;
-                pass.timelineStart = loopPlan.captureStartSample;
-                pass.lengthInSamples = captureLength;
-                pass.endsPass = true;
-                for (int i = 0; i < loopPassCount; ++i)
-                    if (loopPasses[(size_t) i].passOrdinal == passOrdinal)
-                    {
-                        pass = loopPasses[(size_t) i];
-                        break;
-                    }
+                const int channel = (ev.status & 0x0F) + 1;
+                const int statusType = ev.status & 0xF0;
+                const int noteKey = (channel - 1) * 128 + ev.data1;
+                if (statusType == 0x90 && ev.data2 > 0)
+                {
+                    auto& note = activeNotes[(size_t) noteKey];
+                    note.active = true;
+                    note.velocity = ev.data2;
+                    note.startSample = ev.samplePos;
+                }
+                else if (statusType == 0x80
+                         || (statusType == 0x90 && ev.data2 == 0))
+                {
+                    activeNotes[(size_t) noteKey].active = false;
+                }
+                else if (statusType == 0xB0)
+                {
+                    controllerState[(size_t) ((channel - 1) * 128 + ev.data1)]
+                        = ev.data2;
+                }
+            };
+
+            for (int passIndex = 0; passIndex < loopPassCount; ++passIndex)
+            {
+                const auto& pass = loopPasses[(size_t) passIndex];
                 if (pass.lengthInSamples <= 0) continue;
+
+                // Consume discarded older passes once to recover held-note and
+                // controller state at the first retained boundary. The outer
+                // loop is capped at current + eight prior takes.
+                while (drainedIndex < drained.size()
+                       && drained[drainedIndex].passOrdinal < pass.passOrdinal)
+                    seedState (drained[drainedIndex++]);
 
                 MidiRegion passRegion;
                 passRegion.timelineStart = loopPlan.captureStartSample;
@@ -638,7 +673,7 @@ void RecordManager::stopRecording (std::int64_t endSample)
                     ! pass.endsPass || pass.lengthInSamples < captureLength
                 };
 
-                if (passOrdinal > 1)
+                if (passIndex > 0 || pass.passOrdinal > 1)
                 {
                     for (int key = 0; key < (int) activeNotes.size(); ++key)
                         if (activeNotes[(size_t) key].active)
@@ -647,7 +682,7 @@ void RecordManager::stopRecording (std::int64_t endSample)
                     for (int key = 0; key < (int) controllerState.size(); ++key)
                     {
                         const int value = controllerState[(size_t) key];
-                        if (value <= 0) continue;
+                        if (value < 0) continue;
                         MidiCc chased;
                         chased.channel = key / 128 + 1;
                         chased.controller = key % 128;
@@ -657,9 +692,6 @@ void RecordManager::stopRecording (std::int64_t endSample)
                     }
                 }
 
-                while (drainedIndex < drained.size()
-                       && drained[drainedIndex].passOrdinal < pass.passOrdinal)
-                    ++drainedIndex;
                 while (drainedIndex < drained.size()
                        && drained[drainedIndex].passOrdinal == pass.passOrdinal)
                 {
@@ -729,7 +761,7 @@ void RecordManager::stopRecording (std::int64_t endSample)
                     passRegion.notes.push_back (committed);
                 }
 
-                if (passOrdinal < highestLoopPassOrdinal)
+                if (passIndex + 1 < loopPassCount)
                 {
                     for (int key = 0; key < (int) controllerState.size(); ++key)
                     {
@@ -1222,9 +1254,11 @@ void RecordManager::stopRecording (std::int64_t endSample)
     }
 }
 
-void RecordManager::writeMidiBlock (int trackIndex,
-                                     const juce::MidiBuffer& events,
-                                     std::int64_t blockStartFromRecord) noexcept
+template <typename MidiEvents>
+void RecordManager::writeMidiBlockImpl (int trackIndex,
+                                        const MidiEvents& events,
+                                        std::int64_t blockStartFromRecord,
+                                        const LoopCaptureSpan* explicitLoopSpan) noexcept
 {
     AudioInFlightScope guard (audioInFlight);
     if (! active.load (std::memory_order_acquire)) return;
@@ -1233,6 +1267,8 @@ void RecordManager::writeMidiBlock (int trackIndex,
     auto& cap = midiCaptures[(size_t) trackIndex];
     if (cap == nullptr) return;
     writeMidiBlockCalls[(size_t) trackIndex].fetch_add (1, std::memory_order_relaxed);
+    const auto& selectedLoopSpan = explicitLoopSpan != nullptr
+                                 ? *explicitLoopSpan : currentLoopSpan;
 
     for (const auto meta : events)
     {
@@ -1258,14 +1294,14 @@ void RecordManager::writeMidiBlock (int trackIndex,
         // the first event position in the captured slice; normalize retained
         // events back to pass-relative coordinates before the FIFO write.
         if (loopPlan.enabled
-            && (currentLoopSpan.passOrdinal < 1
-                || meta.samplePosition < currentLoopSpan.inputOffset
+            && (selectedLoopSpan.passOrdinal < 1
+                || meta.samplePosition < selectedLoopSpan.inputOffset
                 || meta.samplePosition
-                     >= currentLoopSpan.inputOffset + currentLoopSpan.numSamples))
+                     >= selectedLoopSpan.inputOffset + selectedLoopSpan.numSamples))
             continue;
         const auto samplePos = loopPlan.enabled
-            ? (currentLoopSpan.timelineStart - loopPlan.captureStartSample
-               + meta.samplePosition - currentLoopSpan.inputOffset)
+            ? (selectedLoopSpan.timelineStart - loopPlan.captureStartSample
+               + meta.samplePosition - selectedLoopSpan.inputOffset)
             : (blockStartFromRecord + meta.samplePosition);
         if (samplePos < 0) continue;
 
@@ -1306,15 +1342,32 @@ void RecordManager::writeMidiBlock (int trackIndex,
         slot.status = status;
         slot.data1  = sz >= 2 ? (std::uint8_t) raw[1] : 0;
         slot.data2  = sz >= 3 ? (std::uint8_t) raw[2] : 0;
-        slot.passOrdinal = loopPlan.enabled ? currentLoopSpan.passOrdinal : 0;
+        slot.passOrdinal = loopPlan.enabled ? selectedLoopSpan.passOrdinal : 0;
         cap->fifo.finishedWrite (needed);
     }
+}
+
+void RecordManager::writeMidiBlock (int trackIndex,
+                                    const juce::MidiBuffer& events,
+                                    std::int64_t blockStartFromRecord,
+                                    const LoopCaptureSpan* explicitLoopSpan) noexcept
+{
+    writeMidiBlockImpl (trackIndex, events, blockStartFromRecord, explicitLoopSpan);
+}
+
+void RecordManager::writeMidiBlock (int trackIndex,
+                                    const dusk::MidiBuffer& events,
+                                    std::int64_t blockStartFromRecord,
+                                    const LoopCaptureSpan* explicitLoopSpan) noexcept
+{
+    writeMidiBlockImpl (trackIndex, events, blockStartFromRecord, explicitLoopSpan);
 }
 
 void RecordManager::writeInputBlock (int trackIndex,
                                      const float* L,
                                      const float* R,
-                                     int numSamples) noexcept
+                                     int numSamples,
+                                     const LoopCaptureSpan* explicitLoopSpan) noexcept
 {
     AudioInFlightScope guard (audioInFlight);
     if (! active.load (std::memory_order_acquire)) return;
@@ -1322,6 +1375,8 @@ void RecordManager::writeInputBlock (int trackIndex,
     if (trackIndex < 0 || trackIndex >= Session::kNumTracks) return;
     auto& slot = writers[(size_t) trackIndex];
     if (slot == nullptr || slot->writer == nullptr || L == nullptr) return;
+    const auto& selectedLoopSpan = explicitLoopSpan != nullptr
+                                 ? *explicitLoopSpan : currentLoopSpan;
 
     // Build the channel-pointer array to match the writer's channel count.
     // push() reads numChannels pointers from the array, so each slot it
@@ -1333,10 +1388,10 @@ void RecordManager::writeInputBlock (int trackIndex,
     //     the second channel is never a missing pointer.
     jassert (L != nullptr);
     if (loopPlan.enabled
-        && (currentLoopSpan.passOrdinal < 1 || currentLoopSpan.numSamples <= 0))
+        && (selectedLoopSpan.passOrdinal < 1 || selectedLoopSpan.numSamples <= 0))
         return;
     const int samplesToWrite = loopPlan.enabled
-        ? std::min (numSamples, currentLoopSpan.numSamples) : numSamples;
+        ? std::min (numSamples, selectedLoopSpan.numSamples) : numSamples;
     if (samplesToWrite <= 0) return;
 
     const float* channels[2] = { L, (R != nullptr) ? R : L };
@@ -1348,7 +1403,7 @@ void RecordManager::writeInputBlock (int trackIndex,
     {
         if (slot->loopPassCount > 0
             && slot->loopPasses[(size_t) (slot->loopPassCount - 1)].passOrdinal
-                   == currentLoopSpan.passOrdinal)
+                   == selectedLoopSpan.passOrdinal)
         {
             descriptor = &slot->loopPasses[(size_t) (slot->loopPassCount - 1)];
         }
@@ -1362,7 +1417,7 @@ void RecordManager::writeInputBlock (int trackIndex,
             }
             descriptor = &slot->loopPasses[(size_t) slot->loopPassCount++];
             *descriptor = {};
-            descriptor->passOrdinal = currentLoopSpan.passOrdinal;
+            descriptor->passOrdinal = selectedLoopSpan.passOrdinal;
             descriptor->timelineStart = loopPlan.captureStartSample;
             descriptor->sourceOffset = sourceOffset;
         }
@@ -1374,7 +1429,7 @@ void RecordManager::writeInputBlock (int trackIndex,
         if (descriptor != nullptr)
         {
             descriptor->lengthInSamples += samplesToWrite;
-            descriptor->endsPass = descriptor->endsPass || currentLoopSpan.endsPass;
+            descriptor->endsPass = descriptor->endsPass || selectedLoopSpan.endsPass;
         }
     }
     else

--- a/src/engine/RecordManager.h
+++ b/src/engine/RecordManager.h
@@ -217,6 +217,8 @@ private:
     std::array<std::atomic<int>, Session::kNumTracks> writeMidiBlockCalls {};
 
     std::atomic<bool> active { false };
+    static_assert (Session::kNumTracks <= 32,
+                   "RecordManager capture masks require at most 32 tracks");
     std::atomic<std::uint32_t> activeCaptureTrackMask { 0 };
     std::atomic<std::uint32_t> activeMidiCaptureTrackMask { 0 };
     std::atomic<std::uint32_t> activeStereoCaptureTrackMask { 0 };

--- a/src/engine/RecordManager.h
+++ b/src/engine/RecordManager.h
@@ -5,6 +5,7 @@
 #include <array>
 #include <atomic>
 #include <memory>
+#include "../foundation/MidiBuffer.h"
 #include "../session/Session.h"
 #include "audiofile/ThreadedFileWriter.h"
 #include "audiofile/WriterDrainPool.h"
@@ -65,6 +66,18 @@ public:
                                                 int remainingSamples) const noexcept;
     void beginLoopCaptureSpan (const LoopCaptureSpan& span) noexcept;
     const LoopCapturePlan& getLoopCapturePlan() const noexcept { return loopPlan; }
+    std::uint32_t getActiveCaptureTrackMask() const noexcept
+    {
+        return activeCaptureTrackMask.load (std::memory_order_acquire);
+    }
+    std::uint32_t getActiveMidiCaptureTrackMask() const noexcept
+    {
+        return activeMidiCaptureTrackMask.load (std::memory_order_acquire);
+    }
+    std::uint32_t getActiveStereoCaptureTrackMask() const noexcept
+    {
+        return activeStereoCaptureTrackMask.load (std::memory_order_acquire);
+    }
 
     // Message thread. Closes writers, finalizes WAV, appends regions.
     void stopRecording (std::int64_t endSample);
@@ -73,16 +86,29 @@ public:
     void writeInputBlock (int trackIndex,
                             const float* L,
                             const float* R,
-                            int numSamples) noexcept;
+                            int numSamples,
+                            const LoopCaptureSpan* explicitLoopSpan = nullptr) noexcept;
 
     // Audio thread. blockStartFromRecord can be negative during count-in
     // pre-roll; events with negative sample positions are dropped at
     // drain time. Lock-free push into a pre-sized ring.
     void writeMidiBlock (int trackIndex,
                           const juce::MidiBuffer& events,
-                          std::int64_t blockStartFromRecord) noexcept;
+                          std::int64_t blockStartFromRecord,
+                          const LoopCaptureSpan* explicitLoopSpan = nullptr) noexcept;
+    void writeMidiBlock (int trackIndex,
+                          const dusk::MidiBuffer& events,
+                          std::int64_t blockStartFromRecord,
+                          const LoopCaptureSpan* explicitLoopSpan = nullptr) noexcept;
 
-    bool isActive() const noexcept { return active.load (std::memory_order_relaxed); }
+    bool isActive() const noexcept { return active.load (std::memory_order_acquire); }
+    bool isLoopCaptureActive() const noexcept
+    {
+        // startRecording writes loopPlan before its release-store to active.
+        // The short-circuit keeps the non-atomic immutable plan behind the
+        // acquire load on the message-thread status path.
+        return active.load (std::memory_order_acquire) && loopPlan.enabled;
+    }
 
     // Populated when createOutputStream returns null (disk full /
     // permission denied / parent dir missing) or the writer can't be
@@ -124,6 +150,12 @@ public:
     void clearLastCommitDiff() noexcept { lastCommitDiff.clear(); }
 
 private:
+    template <typename MidiEvents>
+    void writeMidiBlockImpl (int trackIndex,
+                             const MidiEvents& events,
+                             std::int64_t blockStartFromRecord,
+                             const LoopCaptureSpan* explicitLoopSpan) noexcept;
+
     Session& session;
 
     static constexpr int kRetainedLoopPasses = 9; // current + eight prior
@@ -185,6 +217,9 @@ private:
     std::array<std::atomic<int>, Session::kNumTracks> writeMidiBlockCalls {};
 
     std::atomic<bool> active { false };
+    std::atomic<std::uint32_t> activeCaptureTrackMask { 0 };
+    std::atomic<std::uint32_t> activeMidiCaptureTrackMask { 0 };
+    std::atomic<std::uint32_t> activeStereoCaptureTrackMask { 0 };
 
     // Audio thread bumps BEFORE inspecting active / writer / midiCapture
     // and decrements on exit. stopRecording clears active then spins
@@ -216,7 +251,6 @@ private:
     LoopCaptureSpan currentLoopSpan;
     std::array<PassDescriptor, kRetainedLoopPasses> loopPasses {};
     int loopPassCount = 0;
-    int highestLoopPassOrdinal = 0;
     std::int64_t gestureCapturedAtMs = 0;
 
     // Subtracted from committed audio region starts; may be negative. The

--- a/src/session/RegionEditActions.cpp
+++ b/src/session/RegionEditActions.cpp
@@ -987,6 +987,7 @@ bool CloneTrackAction::perform()
     if (srcIdx < 0 || srcIdx >= Session::kNumTracks) return false;
     if (dstIdx < 0 || dstIdx >= Session::kNumTracks) return false;
     if (srcIdx == dstIdx) return false;
+    if (engine.getTransport().isRecording()) return false;
     // The clone snapshot doesn't carry the frozen flag / frozenRegion, so
     // cloning to or from a frozen track would desync. Refuse - unfreeze first.
     if (session.track (srcIdx).frozen.load (std::memory_order_relaxed)
@@ -1014,6 +1015,7 @@ bool CloneTrackAction::undo()
 {
     if (beforeState == nullptr) return false;
     if (dstIdx < 0 || dstIdx >= Session::kNumTracks) return false;
+    if (engine.getTransport().isRecording()) return false;
     // The Impl snapshot doesn't carry frozen state, so restoring beforeState onto a
     // now-frozen destination would desync its baked WAV. Refuse - mirrors perform()'s
     // frozen guard. Unfreeze first to undo.

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -4850,14 +4850,26 @@ void ChannelStripComponent::onTrackModeChanged()
     const int id = modeSelector.getSelectedId();
     const int mode = jlimit (0, 2, id - 1);  // 0..2 = Track::Mode
 
+    const int currentMode = track.mode.load (std::memory_order_relaxed);
+    auto restoreModeSelector = [&]
+    {
+        modeSelector.setSelectedId (currentMode + 1, juce::dontSendNotification);
+    };
+    if (engine.getTransport().isRecording() && mode != currentMode)
+    {
+        restoreModeSelector();
+        showDuskAlert (*this, "Recording in progress",
+                        "Stop recording before changing this track's mode.");
+        return;
+    }
+
     // A frozen track is locked to its current mode - its baked WAV + bypassed
     // DSP assume it. Block ANY change (restoring the selector to the track's
     // real mode) until the user unfreezes. Audio tracks freeze too now, so this
     // must restore Mono/Stereo, not hardcode MIDI.
-    const int currentMode = track.mode.load (std::memory_order_relaxed);
     if (track.frozen.load (std::memory_order_relaxed) && mode != currentMode)
     {
-        modeSelector.setSelectedId (currentMode + 1, juce::dontSendNotification);
+        restoreModeSelector();
         showDuskAlert (*this, "Track is frozen",
                         "Unfreeze this track before changing its mode.");
         return;

--- a/src/ui/TransportBar.cpp
+++ b/src/ui/TransportBar.cpp
@@ -798,7 +798,8 @@ void TransportBar::timerCallback()
     // where punch never auto-stopped); punch-disabled also disables it.
     {
         auto& transport = engine.getTransport();
-        if (transport.isRecording() && transport.isPunchEnabled())
+        if (transport.isRecording() && transport.isPunchEnabled()
+            && ! engine.isLoopRecordingActive())
         {
             const auto pIn  = transport.getPunchIn();
             const auto pOut = transport.getPunchOut();

--- a/src/ui/TransportBar.cpp
+++ b/src/ui/TransportBar.cpp
@@ -795,7 +795,8 @@ void TransportBar::timerCallback()
     // playhead has crossed punchOut + postRoll samples, auto-stop. Done
     // here on the message thread so engine.stop()'s teardown is safe.
     // postRoll == 0 disables the auto-stop (matches the previous behaviour
-    // where punch never auto-stopped); punch-disabled also disables it.
+    // where punch never auto-stopped); punch-disabled and loop recording also
+    // disable it.
     {
         auto& transport = engine.getTransport();
         if (transport.isRecording() && transport.isPunchEnabled()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -96,6 +96,7 @@ add_executable(dusk-studio-tests
     session_fader_group.cpp
     transport_state_machine.cpp
     loop_timeline.cpp
+    generated_midi_budget.cpp
     session_mcu_roundtrip.cpp
     console_bank_mapping.cpp
     track_meter_source.cpp

--- a/tests/generated_midi_budget.cpp
+++ b/tests/generated_midi_budget.cpp
@@ -1,0 +1,38 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/GeneratedMidiBudget.h"
+
+using duskstudio::GeneratedMidiBudget;
+
+TEST_CASE ("Generated MIDI structural reset releases its reserved capacity",
+           "[audio-engine][midi][budget]")
+{
+    constexpr int eventBytes = 9;
+    constexpr int resetBytes = 32 * eventBytes;
+    GeneratedMidiBudget budget (resetBytes + 2 * eventBytes);
+
+    REQUIRE (budget.reserveStructural (resetBytes));
+    CHECK (budget.reservedStructuralBytes() == resetBytes);
+    CHECK (budget.discretionaryBytesAvailable() == 2 * eventBytes);
+    CHECK_FALSE (budget.spendDiscretionary (3 * eventBytes));
+
+    REQUIRE (budget.consumeStructural (resetBytes));
+    CHECK (budget.reservedStructuralBytes() == 0);
+    CHECK (budget.remainingBytes() == 2 * eventBytes);
+    CHECK (budget.spendDiscretionary (eventBytes));
+    CHECK (budget.spendDiscretionary (eventBytes));
+    CHECK_FALSE (budget.spendDiscretionary (eventBytes));
+}
+
+TEST_CASE ("Generated MIDI structural reset consumption is all or nothing",
+           "[audio-engine][midi][budget]")
+{
+    constexpr int eventBytes = 9;
+    constexpr int resetBytes = 32 * eventBytes;
+    GeneratedMidiBudget budget (resetBytes - eventBytes);
+
+    CHECK_FALSE (budget.reserveStructural (resetBytes));
+    CHECK_FALSE (budget.consumeStructural (resetBytes));
+    CHECK (budget.remainingBytes() == resetBytes - eventBytes);
+    CHECK (budget.reservedStructuralBytes() == 0);
+}

--- a/tests/loop_timeline.cpp
+++ b/tests/loop_timeline.cpp
@@ -109,6 +109,19 @@ TEST_CASE ("LoopTimeline emits every wrap when one host block spans many loops",
     requireSpan (spans[3], 10, 7, 3, true);
 }
 
+TEST_CASE ("LoopTimeline exposes every reset reservation at the supported block limit",
+           "[loop][timeline][midi-reset]")
+{
+    constexpr int blockSize = 8192;
+    constexpr int loopLength = 128;
+    const auto spans = collectSpans (loopLength, blockSize,
+                                     true, 0, loopLength);
+
+    REQUIRE (spans.size() == blockSize / loopLength);
+    for (const auto& span : spans)
+        REQUIRE (span.wrappedBefore);
+}
+
 TEST_CASE ("LoopTimeline handles negative timeline positions without signed overflow",
            "[loop][timeline]")
 {

--- a/tests/record_loop_take_stacking.cpp
+++ b/tests/record_loop_take_stacking.cpp
@@ -418,6 +418,66 @@ TEST_CASE ("Loop MIDI history keeps loop passes before compatible existing takes
     REQUIRE (region.previousTakes[7].provenance.capturedAtMs == 60);
 }
 
+TEST_CASE ("Loop capture freezes the successfully armed track set for the gesture",
+           "[recording][recordmanager][loop-takes][arming]")
+{
+    const auto temp = makeSessionDir ("dusk-loop-armed-snapshot-");
+    Session session;
+    armTrack (session, temp.dir, Track::Mode::Mono);
+    session.track (1).mode.store ((int) Track::Mode::Midi, std::memory_order_relaxed);
+    session.setTrackArmed (1, true);
+    session.track (2).mode.store ((int) Track::Mode::Stereo, std::memory_order_relaxed);
+    session.setTrackArmed (2, true);
+
+    RecordManager manager (session);
+    const auto plan = loopPlan();
+    REQUIRE (manager.startRecording (48000.0, 100, 0, plan));
+    REQUIRE (manager.getActiveCaptureTrackMask() == 0x7u);
+    REQUIRE (manager.getActiveMidiCaptureTrackMask() == 0x2u);
+    REQUIRE (manager.getActiveStereoCaptureTrackMask() == 0x4u);
+
+    session.setTrackArmed (0, false);
+    session.setTrackArmed (1, false);
+    session.setTrackArmed (2, false);
+    session.setTrackArmed (3, true);
+    session.track (0).mode.store ((int) Track::Mode::Midi, std::memory_order_relaxed);
+    session.track (1).mode.store ((int) Track::Mode::Stereo, std::memory_order_relaxed);
+    session.track (2).mode.store ((int) Track::Mode::Mono, std::memory_order_relaxed);
+    REQUIRE (manager.getActiveCaptureTrackMask() == 0x7u);
+    REQUIRE (manager.getActiveMidiCaptureTrackMask() == 0x2u);
+    REQUIRE (manager.getActiveStereoCaptureTrackMask() == 0x4u);
+
+    manager.stopRecording (100);
+    REQUIRE (manager.getActiveCaptureTrackMask() == 0u);
+    REQUIRE (manager.getActiveMidiCaptureTrackMask() == 0u);
+    REQUIRE (manager.getActiveStereoCaptureTrackMask() == 0u);
+}
+
+TEST_CASE ("Loop MIDI finalization is bounded to the retained high-ordinal passes",
+           "[recording][recordmanager][loop-takes][midi][history]")
+{
+    const auto temp = makeSessionDir ("dusk-loop-midi-high-ordinal-");
+    Session session;
+    armTrack (session, temp.dir, Track::Mode::Midi);
+    RecordManager manager (session);
+    const auto plan = loopPlan();
+    REQUIRE (manager.startRecording (960.0, 100, 0, plan));
+
+    constexpr int firstOrdinal = 99992;
+    constexpr int lastOrdinal = 100000;
+    for (int ordinal = firstOrdinal; ordinal <= lastOrdinal; ++ordinal)
+        writeMidiPass (manager, ordinal, 100,
+                       oneNote (60 + ordinal - firstOrdinal), 8);
+    manager.stopRecording (108);
+
+    const auto region = session.track (0).midiRegions.current().at (0);
+    REQUIRE (region.provenance.loopPassOrdinal == lastOrdinal);
+    REQUIRE (region.previousTakes.size() == 8);
+    for (int i = 0; i < 8; ++i)
+        REQUIRE (region.previousTakes[(size_t) i].provenance.loopPassOrdinal
+                 == lastOrdinal - 1 - i);
+}
+
 TEST_CASE ("Loop MIDI closes and retriggers a note crossing the seam",
            "[recording][recordmanager][loop-takes][midi]")
 {

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -8,8 +8,8 @@ src/dsp/MasterBus.cpp	3
 src/dsp/MasterBus.h	7
 src/dsp/MasteringChain.h	5
 src/engine/AudioEngine.cpp	140
-src/engine/AudioEngine.h	20
-src/engine/AudioPipelineSelfTest.cpp	26
+src/engine/AudioEngine.h	18
+src/engine/AudioPipelineSelfTest.cpp	23
 src/engine/BounceEngine.cpp	47
 src/engine/BounceEngine.h	18
 src/engine/DpAligner.cpp	5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Loop recording now creates separate, aligned takes for each pass.
  - Retains the current take plus up to eight previous passes.
  - Supports loop/punch overlap recording for audio and MIDI.
  - Silent audio passes remain selectable; empty MIDI passes are omitted.

- **Bug Fixes**
  - Prevents automatic punch post-roll stopping during loop recording.
  - Preserves loop timing, note continuity, and controller state across loop boundaries.
  - Prevents track-mode changes while recording.

- **Tests**
  - Added coverage for loop wrapping, take stacking, timing, and retained pass history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->