### PR TITLE
feat: add signed SFZ catalog trust foundation

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -54,7 +54,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             build-essential cmake ninja-build pkg-config ccache \
-            libasound2-dev libjack-jackd2-dev libmp3lame-dev libsndfile1-dev \
+            libasound2-dev libjack-jackd2-dev libmp3lame-dev libsndfile1-dev libsodium-dev \
             libpipewire-0.3-dev \
             liblilv-dev libsuil-dev lv2-dev \
             ladspa-sdk \

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -95,7 +95,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             build-essential cmake ninja-build pkg-config \
-            libasound2-dev libjack-jackd2-dev libmp3lame-dev libsndfile1-dev \
+            libasound2-dev libjack-jackd2-dev libmp3lame-dev libsndfile1-dev libsodium-dev \
             libpipewire-0.3-dev \
             liblilv-dev libsuil-dev lv2-dev \
             ladspa-sdk \
@@ -231,6 +231,11 @@ jobs:
 
       - name: Build (Release)
         run: cmake --build build-linux -j
+
+      - name: Verify libsodium runtime linkage
+        run: |
+          readelf -d build-linux/DuskStudio_artefacts/Release/DuskStudio \
+            | grep -Eq '\(NEEDED\).*libsodium\.so\.'
 
       - name: Build + run tests (release gate)
         # No artifact ships unless the full Catch2 suite passes.

--- a/.github/workflows/linux-sanitizer.yml
+++ b/.github/workflows/linux-sanitizer.yml
@@ -70,7 +70,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             build-essential cmake ninja-build pkg-config ccache \
             llvm \
-            libasound2-dev libjack-jackd2-dev libmp3lame-dev libsndfile1-dev \
+            libasound2-dev libjack-jackd2-dev libmp3lame-dev libsndfile1-dev libsodium-dev \
             libpipewire-0.3-dev \
             liblilv-dev libsuil-dev lv2-dev \
             ladspa-sdk \

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -48,6 +48,31 @@ jobs:
         # lame: libmp3lame for MP3 bounce/export (CMake auto-detects it).
         run: brew install ninja ccache lame libsndfile lilv suil lv2
 
+      - name: Build static libsodium (pinned)
+        # Homebrew's bottle is built for the runner OS, newer than the app's
+        # macOS 11 deployment target. Build the audited source at that target
+        # instead, and keep the app free of a Homebrew dylib dependency.
+        env:
+          SODIUM_VERSION: 1.0.22
+          SODIUM_SHA256: adbdd8f16149e81ac6078a03aca6fc03b592b89ef7b5ed83841c086191be3349
+        run: |
+          set -euo pipefail
+          archive="${RUNNER_TEMP}/libsodium-${SODIUM_VERSION}.tar.gz"
+          source_dir="${RUNNER_TEMP}/libsodium-source"
+          prefix="${RUNNER_TEMP}/libsodium"
+          curl --fail --location --retry 3 \
+            --output "${archive}" \
+            "https://download.libsodium.org/libsodium/releases/libsodium-${SODIUM_VERSION}.tar.gz"
+          echo "${SODIUM_SHA256}  ${archive}" | shasum -a 256 --check
+          mkdir -p "${source_dir}"
+          tar -xzf "${archive}" -C "${source_dir}" --strip-components=1
+          cd "${source_dir}"
+          export MACOSX_DEPLOYMENT_TARGET=11.0
+          ./configure \
+            --prefix="${prefix}" --disable-shared --enable-static
+          make -j"$(sysctl -n hw.ncpu)" check
+          make install
+
       - name: Cache ccache objects
         uses: actions/cache@v6
         with:
@@ -89,6 +114,7 @@ jobs:
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_PREFIX_PATH="$(brew --prefix)" \
+            -DDUSKSTUDIO_SODIUM_ROOT="${RUNNER_TEMP}/libsodium" \
             -DJUCE_PATH="${RUNNER_TEMP}/JUCE" \
             -DDUSK_PLUGINS_PATH="${RUNNER_TEMP}/plugins-main" \
             -DDPF_PATH="${RUNNER_TEMP}/DPF" \
@@ -100,6 +126,8 @@ jobs:
             grep -q "^${option}:BOOL=ON$" build/CMakeCache.txt || {
               echo "::error::${option} was not enabled in the app configure" >&2; exit 1; }
           done
+          grep -Eq '^DUSKSTUDIO_SODIUM_STATIC_LIBRARY:FILEPATH=.*/libsodium\.a$' build/CMakeCache.txt || {
+            echo "::error::macOS app configure did not select static libsodium" >&2; exit 1; }
 
       - name: Build (Release)
         run: cmake --build build -j
@@ -113,6 +141,7 @@ jobs:
           cmake -S . -B build-tests -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_PREFIX_PATH="$(brew --prefix)" \
+            -DDUSKSTUDIO_SODIUM_ROOT="${RUNNER_TEMP}/libsodium" \
             -DDUSKSTUDIO_BUILD_TESTS=ON \
             -DJUCE_PATH="${RUNNER_TEMP}/JUCE" \
             -DDUSK_PLUGINS_PATH="${RUNNER_TEMP}/plugins-main" \
@@ -125,6 +154,8 @@ jobs:
             grep -q "^${option}:BOOL=ON$" build-tests/CMakeCache.txt || {
               echo "::error::${option} was not enabled in the test configure" >&2; exit 1; }
           done
+          grep -Eq '^DUSKSTUDIO_SODIUM_STATIC_LIBRARY:FILEPATH=.*/libsodium\.a$' build-tests/CMakeCache.txt || {
+            echo "::error::macOS test configure did not select static libsodium" >&2; exit 1; }
           cmake --build build-tests --target dusk-studio-tests -j
           ctest --test-dir build-tests --output-on-failure
 

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -61,6 +61,31 @@ jobs:
         # lame: libmp3lame for MP3 bounce/export (CMake auto-detects it).
         run: brew install ninja ccache lame libsndfile lilv suil lv2
 
+      - name: Build static libsodium (pinned)
+        # Homebrew's bottle is built for the runner OS, newer than the app's
+        # macOS 11 deployment target. Build the audited source at that target
+        # instead, and keep the DMG free of a Homebrew dylib dependency.
+        env:
+          SODIUM_VERSION: 1.0.22
+          SODIUM_SHA256: adbdd8f16149e81ac6078a03aca6fc03b592b89ef7b5ed83841c086191be3349
+        run: |
+          set -euo pipefail
+          archive="${RUNNER_TEMP}/libsodium-${SODIUM_VERSION}.tar.gz"
+          source_dir="${RUNNER_TEMP}/libsodium-source"
+          prefix="${RUNNER_TEMP}/libsodium"
+          curl --fail --location --retry 3 \
+            --output "${archive}" \
+            "https://download.libsodium.org/libsodium/releases/libsodium-${SODIUM_VERSION}.tar.gz"
+          echo "${SODIUM_SHA256}  ${archive}" | shasum -a 256 --check
+          mkdir -p "${source_dir}"
+          tar -xzf "${archive}" -C "${source_dir}" --strip-components=1
+          cd "${source_dir}"
+          export MACOSX_DEPLOYMENT_TARGET=11.0
+          ./configure \
+            --prefix="${prefix}" --disable-shared --enable-static
+          make -j"$(sysctl -n hw.ncpu)" check
+          make install
+
       - name: Cache ccache objects
         uses: actions/cache@v6
         with:
@@ -142,6 +167,7 @@ jobs:
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_PREFIX_PATH="$(brew --prefix)" \
+            -DDUSKSTUDIO_SODIUM_ROOT="${RUNNER_TEMP}/libsodium" \
             -DJUCE_PATH="${RUNNER_TEMP}/JUCE" \
             -DDUSK_PLUGINS_PATH="${RUNNER_TEMP}/plugins-main" \
             -DDPF_PATH="${RUNNER_TEMP}/DPF" \
@@ -154,6 +180,8 @@ jobs:
             grep -q "^${option}:BOOL=ON$" build/CMakeCache.txt || {
               echo "::error::${option} was not enabled in the app configure" >&2; exit 1; }
           done
+          grep -Eq '^DUSKSTUDIO_SODIUM_STATIC_LIBRARY:FILEPATH=.*/libsodium\.a$' build/CMakeCache.txt || {
+            echo "::error::macOS release configure did not select static libsodium" >&2; exit 1; }
 
       - name: Build (Release)
         run: cmake --build build -j
@@ -165,6 +193,7 @@ jobs:
           cmake -S . -B build-tests -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_PREFIX_PATH="$(brew --prefix)" \
+            -DDUSKSTUDIO_SODIUM_ROOT="${RUNNER_TEMP}/libsodium" \
             -DDUSKSTUDIO_BUILD_TESTS=ON \
             -DJUCE_PATH="${RUNNER_TEMP}/JUCE" \
             -DDUSK_PLUGINS_PATH="${RUNNER_TEMP}/plugins-main" \
@@ -177,6 +206,8 @@ jobs:
             grep -q "^${option}:BOOL=ON$" build-tests/CMakeCache.txt || {
               echo "::error::${option} was not enabled in the test configure" >&2; exit 1; }
           done
+          grep -Eq '^DUSKSTUDIO_SODIUM_STATIC_LIBRARY:FILEPATH=.*/libsodium\.a$' build-tests/CMakeCache.txt || {
+            echo "::error::macOS release tests did not select static libsodium" >&2; exit 1; }
           cmake --build build-tests --target dusk-studio-tests -j
           ctest --test-dir build-tests --output-on-failure
 

--- a/.github/workflows/raspberry-pi-build.yml
+++ b/.github/workflows/raspberry-pi-build.yml
@@ -56,7 +56,7 @@ jobs:
           for i in 1 2 3; do
             sudo apt-get update && sudo apt-get install -y --no-install-recommends \
               build-essential cmake ninja-build pkg-config ccache \
-              libasound2-dev libjack-jackd2-dev libmp3lame-dev libsndfile1-dev \
+              libasound2-dev libjack-jackd2-dev libmp3lame-dev libsndfile1-dev libsodium-dev \
               libpipewire-0.3-dev \
               liblilv-dev libsuil-dev lv2-dev \
               ladspa-sdk \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -619,6 +619,66 @@ target_sources(DuskStudio PRIVATE
     src/engine/audiofile/WriterDrainPool.cpp)
 target_link_libraries(DuskStudio PRIVATE dusk_sndfile)
 
+# Signed SFZ catalogs use detached Ed25519 signatures. Windows consumes the
+# static vcpkg manifest prefix, Linux uses the distro library, and macOS links
+# a deployment-target-matched static archive so the app has no extra dylib.
+add_library(dusk_sodium INTERFACE)
+set(DUSKSTUDIO_SODIUM_ROOT "" CACHE PATH
+    "Optional libsodium installation prefix for Dusk Studio")
+if(APPLE)
+    find_path(DUSKSTUDIO_SODIUM_INCLUDE_DIR sodium.h
+        HINTS "${DUSKSTUDIO_SODIUM_ROOT}"
+        PATH_SUFFIXES include)
+    find_file(DUSKSTUDIO_SODIUM_STATIC_LIBRARY NAMES libsodium.a
+        HINTS "${DUSKSTUDIO_SODIUM_ROOT}"
+        PATH_SUFFIXES lib lib64)
+    if(NOT (DUSKSTUDIO_SODIUM_INCLUDE_DIR AND DUSKSTUDIO_SODIUM_STATIC_LIBRARY))
+        message(FATAL_ERROR
+            "Static libsodium is required for signed SFZ catalogs on macOS. "
+            "Build it for the app's deployment target and set "
+            "DUSKSTUDIO_SODIUM_ROOT to its installation prefix.")
+    endif()
+    target_include_directories(dusk_sodium SYSTEM INTERFACE
+        "${DUSKSTUDIO_SODIUM_INCLUDE_DIR}")
+    target_link_libraries(dusk_sodium INTERFACE
+        "${DUSKSTUDIO_SODIUM_STATIC_LIBRARY}")
+    message(STATUS "libsodium: ${DUSKSTUDIO_SODIUM_STATIC_LIBRARY} (static)")
+else()
+    # vcpkg's config file expects variables supplied by its toolchain. The
+    # Windows workflows intentionally pass only the installed static prefix,
+    # so they use the direct lookup below rather than creating an imported
+    # target with no location.
+    if(DEFINED VCPKG_TARGET_TRIPLET AND DEFINED _VCPKG_INSTALLED_DIR)
+        find_package(unofficial-sodium CONFIG QUIET)
+    endif()
+    if(TARGET unofficial-sodium::sodium)
+        target_link_libraries(dusk_sodium INTERFACE unofficial-sodium::sodium)
+        message(STATUS "libsodium: config package")
+    else()
+        find_path(DUSKSTUDIO_SODIUM_INCLUDE_DIR sodium.h
+            HINTS "${DUSKSTUDIO_SODIUM_ROOT}"
+            PATH_SUFFIXES include)
+        find_library(DUSKSTUDIO_SODIUM_LIBRARY NAMES sodium libsodium
+            HINTS "${DUSKSTUDIO_SODIUM_ROOT}"
+            PATH_SUFFIXES lib lib64)
+        if(NOT (DUSKSTUDIO_SODIUM_INCLUDE_DIR AND DUSKSTUDIO_SODIUM_LIBRARY))
+            message(FATAL_ERROR
+                "libsodium development files are required for signed SFZ catalogs. "
+                "Ubuntu/Debian: install libsodium-dev. Windows: install the vcpkg manifest. "
+                "For a custom prefix, set DUSKSTUDIO_SODIUM_ROOT.")
+        endif()
+        target_include_directories(dusk_sodium SYSTEM INTERFACE
+            "${DUSKSTUDIO_SODIUM_INCLUDE_DIR}")
+        target_link_libraries(dusk_sodium INTERFACE "${DUSKSTUDIO_SODIUM_LIBRARY}")
+        message(STATUS "libsodium: ${DUSKSTUDIO_SODIUM_LIBRARY}")
+    endif()
+endif()
+
+target_sources(DuskStudio PRIVATE
+    src/engine/sfz/SfzCatalog.cpp
+    src/engine/sfz/SfzCatalogEnvelope.cpp)
+target_link_libraries(DuskStudio PRIVATE dusk_sodium)
+
 # DeviceManager backing: Linux uses the native orchestrator (owns the device
 # types, drives open/start/stop/close and the callback fan-out itself); macOS /
 # Windows keep the JUCE-wrapped implementation. Same public dusk API either way.

--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -445,6 +445,35 @@ libsndfile (all audio file I/O — required on every platform)
   Upstream : https://github.com/libsndfile/libsndfile ,
              https://www.mpg123.de/ , https://opus-codec.org/
 
+libsodium (signed SFZ catalog authentication — required on every platform)
+  License  : ISC
+  Path     : not vendored — resolved at configure time through vcpkg's
+             unofficial-sodium::sodium config target or a direct sodium.h /
+             libsodium library lookup. A missing implementation is a configure
+             FATAL_ERROR, and both the app and test binary link the common
+             dusk_sodium interface target.
+  Notes    : The app uses detached Ed25519 verification and canonical base64
+             helpers only; no private signing key is distributed. Linux CI,
+             sanitizer, release, and Raspberry Pi builds install
+             libsodium-dev and link the distro shared object. Debian package
+             runtime dependency discovery is handled by dpkg-shlibdeps. RPM
+             packages rely on rpmbuild's automatic ELF requirements under
+             CPack. The portable tarball does not copy system shared libraries,
+             so its host must provide libsodium like the other documented
+             desktop/runtime libraries.
+             On macOS and Windows the same fail-closed discovery contract
+             requires the platform build to supply compatible headers and a
+             library. The current upstream audit reference is release 1.0.22,
+             commit
+             77e1ce5d6dee871c49ef211222ba18ef0c486bda; its release source
+             archive SHA-256 is
+             adbdd8f16149e81ac6078a03aca6fc03b592b89ef7b5ed83841c086191be3349,
+             and its LICENSE SHA-256 is
+             508a76d186356c0dd807a670ef510964f8724557024796a2c426c6c0e19ab683.
+             Platform package managers may resolve a different compatible
+             version; their package metadata records those bytes.
+  Upstream : https://github.com/jedisct1/libsodium , https://libsodium.org/
+
 lilv / suil / lv2 (native LV2 host — Linux builds only)
   License  : ISC (lilv, suil), ISC (lv2 headers)
   Path     : not vendored — system shared libraries found at configure time via
@@ -3561,3 +3590,23 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+libsodium 1.0.22 — ISC
+LICENSE at upstream rev 77e1ce5d6dee871c49ef211222ba18ef0c486bda
+--------------------------------------------------------------------------------
+
+Copyright (c) 2013-2026
+Frank Denis <j at pureftpd dot org>
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/packaging/README-linux.txt
+++ b/packaging/README-linux.txt
@@ -35,7 +35,8 @@ A normal desktop Linux (X11 or Wayland). Audio runs over PipeWire/JACK
 (preferred) or ALSA. The PipeWire client library is linked in, so
 libpipewire-0.3-0 must be present even if you only use ALSA. On a minimal
 system, install the usual desktop libraries (X11, freetype, fontconfig, alsa)
-if the binary reports a missing library.
+if the binary reports a missing library. Signed SFZ catalog authentication also
+requires libsodium.so.23; on Ubuntu 22.04, install the libsodium23 package.
 
 
 LICENSE

--- a/src/engine/sfz/SfzCatalog.cpp
+++ b/src/engine/sfz/SfzCatalog.cpp
@@ -1,6 +1,5 @@
 #include "SfzCatalog.h"
-
-#include "../../foundation/Json.h"
+#include "SfzCatalogJson.h"
 
 #include <algorithm>
 #include <initializer_list>
@@ -71,7 +70,9 @@ bool equalsAsciiCaseInsensitive (std::string_view value, std::string_view expect
 bool isWindowsReservedBasename (std::string_view segment)
 {
     const auto dot = segment.find ('.');
-    const auto basename = segment.substr (0, dot);
+    auto basename = segment.substr (0, dot);
+    while (! basename.empty() && (basename.back() == ' ' || basename.back() == '.'))
+        basename.remove_suffix (1);
     if (equalsAsciiCaseInsensitive (basename, "CON")
         || equalsAsciiCaseInsensitive (basename, "PRN")
         || equalsAsciiCaseInsensitive (basename, "AUX")
@@ -112,7 +113,8 @@ struct Parser
             const auto known = std::any_of (allowed.begin(), allowed.end(),
                 [&item] (std::string_view key) { return item.key() == key; });
             if (! known)
-                return fail (path + "." + item.key(), "unknown field");
+                return fail (path + "." + detail::sanitizeJsonKeyForDiagnostic (item.key()),
+                             "unknown field");
         }
         return true;
     }
@@ -571,41 +573,13 @@ CatalogParseResult parseCatalogPayload (std::string_view source) noexcept
         if (source.size() > kMaxPayloadBytes)
             return { std::nullopt, "root: payload exceeds the 8 MiB limit" };
 
-        std::vector<std::unordered_set<std::string>> objectKeys;
-        bool duplicateKeyFound = false;
-        std::string duplicateKey;
-        const auto callback = [&objectKeys, &duplicateKeyFound, &duplicateKey] (
-            int, Json::parse_event_t event, Json& parsed)
-        {
-            if (event == Json::parse_event_t::object_start)
-            {
-                objectKeys.emplace_back();
-            }
-            else if (event == Json::parse_event_t::key && ! objectKeys.empty())
-            {
-                const auto& key = parsed.get_ref<const std::string&>();
-                if (! objectKeys.back().insert (key).second && ! duplicateKeyFound)
-                {
-                    duplicateKeyFound = true;
-                    duplicateKey = key;
-                }
-            }
-            else if (event == Json::parse_event_t::object_end && ! objectKeys.empty())
-            {
-                objectKeys.pop_back();
-            }
-            return true;
-        };
-
-        const auto root = Json::parse (source.begin(), source.end(), callback, false);
-        if (root.is_discarded())
-            return { std::nullopt, "root: malformed JSON" };
-        if (duplicateKeyFound)
-            return { std::nullopt, "root: duplicate object key '" + duplicateKey + "'" };
+        auto parsedJson = detail::parseJsonRejectingDuplicateKeys (source, "root");
+        if (! parsedJson)
+            return { std::nullopt, std::move (parsedJson.error) };
 
         Parser parser;
         CatalogPayload catalog;
-        if (! parser.parse (root, catalog))
+        if (! parser.parse (*parsedJson.root, catalog))
             return { std::nullopt, std::move (parser.error) };
         return { std::move (catalog), {} };
     }

--- a/src/engine/sfz/SfzCatalog.cpp
+++ b/src/engine/sfz/SfzCatalog.cpp
@@ -1,0 +1,617 @@
+#include "SfzCatalog.h"
+
+#include "../../foundation/Json.h"
+
+#include <algorithm>
+#include <initializer_list>
+#include <limits>
+#include <string>
+#include <unordered_set>
+#include <utility>
+
+namespace duskstudio::sfz
+{
+namespace
+{
+using Json = dusk::json::Json;
+
+constexpr std::uint32_t kSchemaVersion = 1;
+constexpr std::size_t kMaxPayloadBytes = 8ULL * 1024ULL * 1024ULL;
+constexpr std::size_t kMaxCatalogIdLength = 64;
+constexpr std::size_t kMaxStableIdLength = 64;
+constexpr std::size_t kMaxReleaseIdLength = 128;
+constexpr std::size_t kMaxNameLength = 256;
+constexpr std::size_t kMaxUrlLength = 2048;
+constexpr std::size_t kMaxTimestampLength = 64;
+constexpr std::size_t kMaxPathLength = 512;
+constexpr std::size_t kMaxPathDepth = 32;
+constexpr std::size_t kMaxPacks = 4096;
+constexpr std::size_t kMaxInstrumentsPerPack = 4096;
+constexpr std::size_t kMaxTagsPerPack = 64;
+constexpr std::size_t kMaxTagLength = 64;
+constexpr std::uint64_t kMaxCompressedBytes = 8ULL * 1024ULL * 1024ULL * 1024ULL;
+constexpr std::uint64_t kMaxExpandedBytes = 32ULL * 1024ULL * 1024ULL * 1024ULL;
+constexpr std::uint32_t kMaxFilesPerPack = 100000;
+
+bool isAsciiAlpha (unsigned char c)
+{
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+}
+
+bool isAsciiDigit (unsigned char c)
+{
+    return c >= '0' && c <= '9';
+}
+
+bool isAsciiAlphaNumeric (unsigned char c)
+{
+    return isAsciiAlpha (c) || isAsciiDigit (c);
+}
+
+bool isLowerHex (unsigned char c)
+{
+    return isAsciiDigit (c) || (c >= 'a' && c <= 'f');
+}
+
+bool equalsAsciiCaseInsensitive (std::string_view value, std::string_view expected)
+{
+    if (value.size() != expected.size())
+        return false;
+    for (std::size_t i = 0; i < value.size(); ++i)
+    {
+        auto c = static_cast<unsigned char> (value[i]);
+        if (c >= 'a' && c <= 'z')
+            c = static_cast<unsigned char> (c - 'a' + 'A');
+        if (c != static_cast<unsigned char> (expected[i]))
+            return false;
+    }
+    return true;
+}
+
+bool isWindowsReservedBasename (std::string_view segment)
+{
+    const auto dot = segment.find ('.');
+    const auto basename = segment.substr (0, dot);
+    if (equalsAsciiCaseInsensitive (basename, "CON")
+        || equalsAsciiCaseInsensitive (basename, "PRN")
+        || equalsAsciiCaseInsensitive (basename, "AUX")
+        || equalsAsciiCaseInsensitive (basename, "NUL"))
+        return true;
+
+    if (basename.size() < 4)
+        return false;
+    if (! equalsAsciiCaseInsensitive (basename.substr (0, 3), "COM")
+        && ! equalsAsciiCaseInsensitive (basename.substr (0, 3), "LPT"))
+        return false;
+
+    const auto suffix = basename.substr (3);
+    if (suffix.size() == 1)
+        return suffix[0] >= '1' && suffix[0] <= '9';
+    return suffix.size() == 2
+        && static_cast<unsigned char> (suffix[0]) == 0xc2
+        && (static_cast<unsigned char> (suffix[1]) == 0xb9
+            || static_cast<unsigned char> (suffix[1]) == 0xb2
+            || static_cast<unsigned char> (suffix[1]) == 0xb3);
+}
+
+struct Parser
+{
+    std::string error;
+
+    bool fail (std::string path, std::string reason)
+    {
+        error = std::move (path) + ": " + std::move (reason);
+        return false;
+    }
+
+    bool validateKeys (const Json& object, const std::string& path,
+                       std::initializer_list<std::string_view> allowed)
+    {
+        for (const auto& item : object.items())
+        {
+            const auto known = std::any_of (allowed.begin(), allowed.end(),
+                [&item] (std::string_view key) { return item.key() == key; });
+            if (! known)
+                return fail (path + "." + item.key(), "unknown field");
+        }
+        return true;
+    }
+
+    const Json* required (const Json& object, const char* key,
+                          const std::string& path)
+    {
+        const auto it = object.find (key);
+        if (it == object.end())
+        {
+            fail (path + "." + key, "required field is missing");
+            return nullptr;
+        }
+        return &*it;
+    }
+
+    bool readString (const Json& object, const char* key, const std::string& path,
+                     std::string& out, std::size_t maxLength)
+    {
+        const auto* value = required (object, key, path);
+        if (value == nullptr)
+            return false;
+        if (! value->is_string())
+            return fail (path + "." + key, "expected a string");
+
+        out = value->get<std::string>();
+        if (out.empty())
+            return fail (path + "." + key, "must not be empty");
+        if (out.size() > maxLength)
+            return fail (path + "." + key, "exceeds the length limit");
+        if (std::any_of (out.begin(), out.end(), [] (unsigned char c)
+            { return c == 0 || c < 0x20 || c == 0x7f; }))
+            return fail (path + "." + key, "contains a control character");
+        return true;
+    }
+
+    bool readPositiveInteger (const Json& object, const char* key,
+                              const std::string& path, std::uint64_t maximum,
+                              std::uint64_t& out)
+    {
+        const auto* value = required (object, key, path);
+        if (value == nullptr)
+            return false;
+        if (! value->is_number_integer() && ! value->is_number_unsigned())
+            return fail (path + "." + key, "expected a positive integer");
+
+        std::uint64_t candidate = 0;
+        if (value->is_number_unsigned())
+        {
+            candidate = value->get<std::uint64_t>();
+        }
+        else
+        {
+            const auto signedCandidate = value->get<std::int64_t>();
+            if (signedCandidate <= 0)
+                return fail (path + "." + key, "must be greater than zero");
+            candidate = static_cast<std::uint64_t> (signedCandidate);
+        }
+
+        if (candidate == 0)
+            return fail (path + "." + key, "must be greater than zero");
+        if (candidate > maximum)
+            return fail (path + "." + key, "exceeds the supported limit");
+        out = candidate;
+        return true;
+    }
+
+    bool readTrue (const Json& object, const char* key, const std::string& path,
+                   bool& out)
+    {
+        const auto* value = required (object, key, path);
+        if (value == nullptr)
+            return false;
+        if (! value->is_boolean())
+            return fail (path + "." + key, "expected a boolean");
+        if (! value->get<bool>())
+            return fail (path + "." + key, "must be true");
+        out = true;
+        return true;
+    }
+
+    bool validateStableId (const std::string& value, const std::string& path,
+                           std::size_t maxLength = kMaxStableIdLength)
+    {
+        if (value.size() > maxLength)
+            return fail (path, "exceeds the identifier length limit");
+
+        const auto isLowerAlphaNumeric = [] (unsigned char c)
+        {
+            return (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9');
+        };
+        if (! isLowerAlphaNumeric (static_cast<unsigned char> (value.front()))
+            || ! isLowerAlphaNumeric (static_cast<unsigned char> (value.back())))
+            return fail (path, "must start and end with a lowercase letter or digit");
+
+        for (const auto c : value)
+        {
+            const auto byte = static_cast<unsigned char> (c);
+            if (! isLowerAlphaNumeric (byte) && c != '-' && c != '_' && c != '.')
+                return fail (path, "contains a character outside [a-z0-9._-]");
+        }
+        return true;
+    }
+
+    bool validateReleaseId (const std::string& value, const std::string& path)
+    {
+        if (value.size() > kMaxReleaseIdLength)
+            return fail (path, "exceeds the release identifier length limit");
+
+        if (! isAsciiAlphaNumeric (static_cast<unsigned char> (value.front()))
+            || ! isAsciiAlphaNumeric (static_cast<unsigned char> (value.back())))
+            return fail (path, "must start and end with an ASCII letter or digit");
+
+        for (const auto c : value)
+        {
+            const auto byte = static_cast<unsigned char> (c);
+            if (! isAsciiAlphaNumeric (byte)
+                && c != '-' && c != '_' && c != '.' && c != '+')
+                return fail (path, "contains an unsupported character");
+        }
+        return true;
+    }
+
+    bool validateHttpsUrl (const std::string& value, const std::string& path)
+    {
+        constexpr std::string_view scheme { "https://" };
+        if (value.compare (0, scheme.size(), scheme) != 0)
+            return fail (path, "must use HTTPS");
+        if (value.size() == scheme.size() || value[scheme.size()] == '/')
+            return fail (path, "must include a host");
+
+        const auto hostEnd = value.find_first_of ("/?#", scheme.size());
+        const auto host = value.substr (scheme.size(), hostEnd - scheme.size());
+        if (host.empty() || host.size() > 253)
+            return fail (path, "has an invalid DNS host length");
+
+        std::size_t begin = 0;
+        while (begin <= host.size())
+        {
+            const auto end = host.find ('.', begin);
+            const auto length = (end == std::string::npos ? host.size() : end) - begin;
+            if (length == 0 || length > 63)
+                return fail (path, "has an invalid DNS label length");
+
+            const auto label = std::string_view (host).substr (begin, length);
+            if (! isAsciiAlphaNumeric (static_cast<unsigned char> (label.front()))
+                || ! isAsciiAlphaNumeric (static_cast<unsigned char> (label.back())))
+                return fail (path, "DNS labels must have alphanumeric edges");
+            if (! std::all_of (label.begin(), label.end(), [] (unsigned char c)
+                { return isAsciiAlphaNumeric (c) || c == '-'; }))
+                return fail (path, "DNS labels must contain only ASCII alphanumerics or hyphens");
+
+            if (end == std::string::npos)
+                break;
+            begin = end + 1;
+        }
+        return true;
+    }
+
+    bool validateSha256 (const std::string& value, const std::string& path)
+    {
+        if (value.size() != 64)
+            return fail (path, "must contain exactly 64 lowercase hexadecimal digits");
+        if (! std::all_of (value.begin(), value.end(), isLowerHex))
+            return fail (path, "must contain only lowercase hexadecimal digits");
+        return true;
+    }
+
+    bool validateGitObjectId (const std::string& value, const std::string& path)
+    {
+        if (value.size() != 40 && value.size() != 64)
+            return fail (path, "must contain exactly 40 or 64 hexadecimal digits");
+        if (! std::all_of (value.begin(), value.end(), isLowerHex))
+            return fail (path, "must contain only lowercase hexadecimal digits");
+        return true;
+    }
+
+    bool validateRelativePath (const std::string& value, const std::string& path)
+    {
+        if (value.size() > kMaxPathLength)
+            return fail (path, "exceeds the path length limit");
+        if (value.front() == '/' || value.find ('\\') != std::string::npos)
+            return fail (path, "must be a forward-slash relative path");
+        if (value.find_first_of (":<>\"|?*") != std::string::npos)
+            return fail (path, "contains a Win32-invalid filename character");
+
+        std::size_t depth = 0;
+        std::size_t begin = 0;
+        while (begin <= value.size())
+        {
+            const auto end = value.find ('/', begin);
+            const auto length = (end == std::string::npos ? value.size() : end) - begin;
+            if (length == 0)
+                return fail (path, "must not contain empty path segments");
+
+            const auto segment = value.substr (begin, length);
+            if (segment == "." || segment == "..")
+                return fail (path, "must not contain dot path segments");
+            if (segment.back() == '.' || segment.back() == ' ')
+                return fail (path, "path segments must not end in a dot or space");
+            if (std::any_of (segment.begin(), segment.end(), [] (unsigned char c)
+                { return c == 0 || c < 0x20 || c == 0x7f; }))
+                return fail (path, "contains a control character");
+            if (isWindowsReservedBasename (segment))
+                return fail (path, "contains a reserved Windows device basename");
+
+            if (++depth > kMaxPathDepth)
+                return fail (path, "exceeds the path depth limit");
+            if (end == std::string::npos)
+                break;
+            begin = end + 1;
+        }
+        return true;
+    }
+
+    bool parseLicense (const Json& object, const std::string& path,
+                       CatalogLicense& out)
+    {
+        if (! object.is_object())
+            return fail (path, "expected an object");
+        if (! validateKeys (object, path,
+                            { "spdx", "source_url", "file", "file_sha256",
+                              "redistribution_allowed", "mirror_allowed" }))
+            return false;
+        if (! readString (object, "spdx", path, out.spdx, 32)
+            || ! readString (object, "source_url", path, out.sourceUrl, kMaxUrlLength)
+            || ! readString (object, "file", path, out.file, kMaxPathLength)
+            || ! readString (object, "file_sha256", path, out.fileSha256, 64)
+            || ! readTrue (object, "redistribution_allowed", path,
+                           out.redistributionAllowed)
+            || ! readTrue (object, "mirror_allowed", path, out.mirrorAllowed))
+            return false;
+
+        if (out.spdx != "CC0-1.0")
+            return fail (path + ".spdx", "license is not allowed by catalog schema v1");
+        return validateHttpsUrl (out.sourceUrl, path + ".source_url")
+            && validateRelativePath (out.file, path + ".file")
+            && validateSha256 (out.fileSha256, path + ".file_sha256");
+    }
+
+    bool parseInstrument (const Json& object, const std::string& path,
+                          CatalogInstrument& out)
+    {
+        if (! object.is_object())
+            return fail (path, "expected an object");
+        if (! validateKeys (object, path, { "id", "name", "relative_entrypoint" }))
+            return false;
+        if (! readString (object, "id", path, out.id, kMaxStableIdLength)
+            || ! readString (object, "name", path, out.name, kMaxNameLength)
+            || ! readString (object, "relative_entrypoint", path,
+                             out.relativeEntrypoint, kMaxPathLength))
+            return false;
+        if (! validateStableId (out.id, path + ".id")
+            || ! validateRelativePath (out.relativeEntrypoint,
+                                       path + ".relative_entrypoint"))
+            return false;
+
+        const auto hasSupportedExtension =
+            out.relativeEntrypoint.size() >= 4
+            && (out.relativeEntrypoint.compare (
+                    out.relativeEntrypoint.size() - 4, 4, ".sfz") == 0
+                || out.relativeEntrypoint.compare (
+                    out.relativeEntrypoint.size() - 4, 4, ".sf2") == 0);
+        return hasSupportedExtension
+            || fail (path + ".relative_entrypoint", "must end in .sfz or .sf2");
+    }
+
+    bool parseTags (const Json& object, const std::string& path,
+                    std::vector<std::string>& out)
+    {
+        const auto it = object.find ("tags");
+        if (it == object.end())
+            return true;
+        if (! it->is_array())
+            return fail (path + ".tags", "expected an array");
+        if (it->size() > kMaxTagsPerPack)
+            return fail (path + ".tags", "contains too many tags");
+
+        std::unordered_set<std::string> seen;
+        out.reserve (it->size());
+        for (std::size_t i = 0; i < it->size(); ++i)
+        {
+            const auto& value = (*it)[i];
+            const auto itemPath = path + ".tags[" + std::to_string (i) + "]";
+            if (! value.is_string())
+                return fail (itemPath, "expected a string");
+            auto tag = value.get<std::string>();
+            if (tag.empty() || tag.size() > kMaxTagLength)
+                return fail (itemPath, "has an invalid length");
+            if (! validateStableId (tag, itemPath, kMaxTagLength))
+                return false;
+            if (! seen.insert (tag).second)
+                return fail (itemPath, "duplicates an earlier tag");
+            out.push_back (std::move (tag));
+        }
+        return true;
+    }
+
+    bool parseOptionalYanked (const Json& object, const std::string& path, bool& out)
+    {
+        const auto it = object.find ("yanked");
+        if (it == object.end())
+            return true;
+        if (! it->is_boolean())
+            return fail (path + ".yanked", "expected a boolean");
+        out = it->get<bool>();
+        return true;
+    }
+
+    bool parsePack (const Json& object, const std::string& path, CatalogPack& out)
+    {
+        if (! object.is_object())
+            return fail (path, "expected an object");
+        if (! validateKeys (object, path,
+                            { "id", "release_id", "display_name", "author",
+                              "source_url", "source_revision", "download_url",
+                              "archive_sha256", "archive_format", "expected_root",
+                              "compressed_bytes", "expanded_bytes", "max_files",
+                              "license", "instruments", "tags", "yanked" }))
+            return false;
+        if (! readString (object, "id", path, out.id, kMaxStableIdLength)
+            || ! readString (object, "release_id", path, out.releaseId,
+                             kMaxReleaseIdLength)
+            || ! readString (object, "display_name", path, out.displayName,
+                             kMaxNameLength)
+            || ! readString (object, "author", path, out.author, kMaxNameLength)
+            || ! readString (object, "source_url", path, out.sourceUrl, kMaxUrlLength)
+            || ! readString (object, "source_revision", path, out.sourceRevision, 64)
+            || ! readString (object, "download_url", path, out.downloadUrl,
+                             kMaxUrlLength)
+            || ! readString (object, "archive_sha256", path, out.archiveSha256, 64)
+            || ! readString (object, "archive_format", path, out.archiveFormat, 16)
+            || ! readString (object, "expected_root", path, out.expectedRoot,
+                             kMaxPathLength))
+            return false;
+
+        std::uint64_t maxFiles = 0;
+        if (! readPositiveInteger (object, "compressed_bytes", path,
+                                   kMaxCompressedBytes, out.compressedBytes)
+            || ! readPositiveInteger (object, "expanded_bytes", path,
+                                      kMaxExpandedBytes, out.expandedBytes)
+            || ! readPositiveInteger (object, "max_files", path,
+                                      kMaxFilesPerPack, maxFiles))
+            return false;
+        out.maxFiles = static_cast<std::uint32_t> (maxFiles);
+
+        if (! validateStableId (out.id, path + ".id")
+            || ! validateReleaseId (out.releaseId, path + ".release_id")
+            || ! validateHttpsUrl (out.sourceUrl, path + ".source_url")
+            || ! validateGitObjectId (out.sourceRevision, path + ".source_revision")
+            || ! validateHttpsUrl (out.downloadUrl, path + ".download_url")
+            || ! validateSha256 (out.archiveSha256, path + ".archive_sha256")
+            || ! validateRelativePath (out.expectedRoot, path + ".expected_root"))
+            return false;
+        if (out.archiveFormat != "zip")
+            return fail (path + ".archive_format", "must be zip");
+        if (out.expectedRoot.find ('/') != std::string::npos)
+            return fail (path + ".expected_root", "must contain exactly one segment");
+        if (out.expectedRoot != out.id)
+            return fail (path + ".expected_root", "must equal the pack id");
+
+        const auto* license = required (object, "license", path);
+        if (license == nullptr || ! parseLicense (*license, path + ".license", out.license))
+            return false;
+
+        const auto* instruments = required (object, "instruments", path);
+        if (instruments == nullptr)
+            return false;
+        if (! instruments->is_array())
+            return fail (path + ".instruments", "expected an array");
+        if (instruments->empty())
+            return fail (path + ".instruments", "must not be empty");
+        if (instruments->size() > kMaxInstrumentsPerPack)
+            return fail (path + ".instruments", "contains too many instruments");
+
+        std::unordered_set<std::string> instrumentIds;
+        out.instruments.reserve (instruments->size());
+        for (std::size_t i = 0; i < instruments->size(); ++i)
+        {
+            const auto itemPath = path + ".instruments[" + std::to_string (i) + "]";
+            CatalogInstrument instrument;
+            if (! parseInstrument ((*instruments)[i], itemPath, instrument))
+                return false;
+            if (! instrumentIds.insert (instrument.id).second)
+                return fail (itemPath + ".id", "duplicates an instrument identity");
+            out.instruments.push_back (std::move (instrument));
+        }
+
+        return parseTags (object, path, out.tags)
+            && parseOptionalYanked (object, path, out.yanked);
+    }
+
+    bool parse (const Json& root, CatalogPayload& out)
+    {
+        if (! root.is_object())
+            return fail ("root", "expected an object");
+        if (! validateKeys (root, "root",
+                            { "catalog_id", "schema_version", "catalog_revision",
+                              "generated_at", "packs" }))
+            return false;
+
+        if (! readString (root, "catalog_id", "root", out.catalogId,
+                          kMaxCatalogIdLength)
+            || ! validateStableId (out.catalogId, "root.catalog_id",
+                                   kMaxCatalogIdLength))
+            return false;
+
+        std::uint64_t schemaVersion = 0;
+        if (! readPositiveInteger (root, "schema_version", "root",
+                                   std::numeric_limits<std::uint32_t>::max(),
+                                   schemaVersion))
+            return false;
+        if (schemaVersion != kSchemaVersion)
+            return fail ("root.schema_version", "unsupported catalog schema version");
+        out.schemaVersion = static_cast<std::uint32_t> (schemaVersion);
+
+        if (! readPositiveInteger (root, "catalog_revision", "root",
+                                   std::numeric_limits<std::uint64_t>::max(),
+                                   out.catalogRevision)
+            || ! readString (root, "generated_at", "root", out.generatedAt,
+                             kMaxTimestampLength))
+            return false;
+
+        const auto* packs = required (root, "packs", "root");
+        if (packs == nullptr)
+            return false;
+        if (! packs->is_array())
+            return fail ("root.packs", "expected an array");
+        if (packs->empty())
+            return fail ("root.packs", "must not be empty");
+        if (packs->size() > kMaxPacks)
+            return fail ("root.packs", "contains too many packs");
+
+        std::unordered_set<std::string> packReleaseIds;
+        out.packs.reserve (packs->size());
+        for (std::size_t i = 0; i < packs->size(); ++i)
+        {
+            const auto itemPath = "root.packs[" + std::to_string (i) + "]";
+            CatalogPack pack;
+            if (! parsePack ((*packs)[i], itemPath, pack))
+                return false;
+            const auto identity = pack.id + '\0' + pack.releaseId;
+            if (! packReleaseIds.insert (identity).second)
+                return fail (itemPath, "duplicates a pack and release identity");
+            out.packs.push_back (std::move (pack));
+        }
+        return true;
+    }
+};
+} // namespace
+
+CatalogParseResult parseCatalogPayload (std::string_view source) noexcept
+{
+    try
+    {
+        if (source.size() > kMaxPayloadBytes)
+            return { std::nullopt, "root: payload exceeds the 8 MiB limit" };
+
+        std::vector<std::unordered_set<std::string>> objectKeys;
+        bool duplicateKeyFound = false;
+        std::string duplicateKey;
+        const auto callback = [&objectKeys, &duplicateKeyFound, &duplicateKey] (
+            int, Json::parse_event_t event, Json& parsed)
+        {
+            if (event == Json::parse_event_t::object_start)
+            {
+                objectKeys.emplace_back();
+            }
+            else if (event == Json::parse_event_t::key && ! objectKeys.empty())
+            {
+                const auto& key = parsed.get_ref<const std::string&>();
+                if (! objectKeys.back().insert (key).second && ! duplicateKeyFound)
+                {
+                    duplicateKeyFound = true;
+                    duplicateKey = key;
+                }
+            }
+            else if (event == Json::parse_event_t::object_end && ! objectKeys.empty())
+            {
+                objectKeys.pop_back();
+            }
+            return true;
+        };
+
+        const auto root = Json::parse (source.begin(), source.end(), callback, false);
+        if (root.is_discarded())
+            return { std::nullopt, "root: malformed JSON" };
+        if (duplicateKeyFound)
+            return { std::nullopt, "root: duplicate object key '" + duplicateKey + "'" };
+
+        Parser parser;
+        CatalogPayload catalog;
+        if (! parser.parse (root, catalog))
+            return { std::nullopt, std::move (parser.error) };
+        return { std::move (catalog), {} };
+    }
+    catch (...)
+    {
+        return { std::nullopt, "root: catalog parsing failed" };
+    }
+}
+} // namespace duskstudio::sfz

--- a/src/engine/sfz/SfzCatalog.h
+++ b/src/engine/sfz/SfzCatalog.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace duskstudio::sfz
+{
+struct CatalogLicense
+{
+    std::string spdx;
+    std::string sourceUrl;
+    std::string file;
+    std::string fileSha256;
+    bool redistributionAllowed { false };
+    bool mirrorAllowed { false };
+};
+
+struct CatalogInstrument
+{
+    std::string id;
+    std::string name;
+    std::string relativeEntrypoint;
+};
+
+struct CatalogPack
+{
+    std::string id;
+    std::string releaseId;
+    std::string displayName;
+    std::string author;
+    std::string sourceUrl;
+    std::string sourceRevision;
+    std::string downloadUrl;
+    std::string archiveSha256;
+    std::string archiveFormat;
+    std::string expectedRoot;
+    std::uint64_t compressedBytes { 0 };
+    std::uint64_t expandedBytes { 0 };
+    std::uint32_t maxFiles { 0 };
+    CatalogLicense license;
+    std::vector<CatalogInstrument> instruments;
+    std::vector<std::string> tags;
+    bool yanked { false };
+};
+
+struct CatalogPayload
+{
+    std::string catalogId;
+    std::uint32_t schemaVersion { 0 };
+    std::uint64_t catalogRevision { 0 };
+    std::string generatedAt;
+    std::vector<CatalogPack> packs;
+};
+
+struct CatalogParseResult
+{
+    std::optional<CatalogPayload> catalog;
+    std::string error;
+
+    explicit operator bool() const noexcept { return catalog.has_value(); }
+};
+
+CatalogParseResult parseCatalogPayload (std::string_view source) noexcept;
+} // namespace duskstudio::sfz

--- a/src/engine/sfz/SfzCatalogEnvelope.cpp
+++ b/src/engine/sfz/SfzCatalogEnvelope.cpp
@@ -1,6 +1,5 @@
 #include "SfzCatalogEnvelope.h"
-
-#include "../../foundation/Json.h"
+#include "SfzCatalogJson.h"
 
 #include <sodium.h>
 
@@ -65,7 +64,8 @@ struct EnvelopeParser
             const auto known = std::any_of (allowed.begin(), allowed.end(),
                 [&item] (std::string_view key) { return item.key() == key; });
             if (! known)
-                return fail (path + "." + item.key(), "unknown field");
+                return fail (path + "." + detail::sanitizeJsonKeyForDiagnostic (item.key()),
+                             "unknown field");
         }
         return true;
     }
@@ -143,48 +143,6 @@ struct EnvelopeParser
         return true;
     }
 };
-
-bool parseEnvelopeJson (std::string_view source, Json& root, std::string& error)
-{
-    std::vector<std::unordered_set<std::string>> objectKeys;
-    bool duplicateKeyFound = false;
-    std::string duplicateKey;
-    const auto callback = [&objectKeys, &duplicateKeyFound, &duplicateKey] (
-        int, Json::parse_event_t event, Json& parsed)
-    {
-        if (event == Json::parse_event_t::object_start)
-        {
-            objectKeys.emplace_back();
-        }
-        else if (event == Json::parse_event_t::key && ! objectKeys.empty())
-        {
-            const auto& key = parsed.get_ref<const std::string&>();
-            if (! objectKeys.back().insert (key).second && ! duplicateKeyFound)
-            {
-                duplicateKeyFound = true;
-                duplicateKey = key;
-            }
-        }
-        else if (event == Json::parse_event_t::object_end && ! objectKeys.empty())
-        {
-            objectKeys.pop_back();
-        }
-        return true;
-    };
-
-    root = Json::parse (source.begin(), source.end(), callback, false);
-    if (root.is_discarded())
-    {
-        error = "envelope: malformed JSON";
-        return false;
-    }
-    if (duplicateKeyFound)
-    {
-        error = "envelope: duplicate object key '" + duplicateKey + "'";
-        return false;
-    }
-    return true;
-}
 
 bool decodeCanonicalBase64 (const std::string& encoded, std::size_t maximum,
                             const char* field, std::vector<unsigned char>& decoded,
@@ -279,16 +237,16 @@ CatalogEnvelopeResult verifyCatalogEnvelope (
         if (sodium_init() < 0)
             return { std::nullopt, {}, "envelope: cryptographic initialization failed" };
 
-        Json root;
         std::string error;
-        if (! parseEnvelopeJson (envelope, root, error))
-            return { std::nullopt, {}, std::move (error) };
+        auto parsedJson = detail::parseJsonRejectingDuplicateKeys (envelope, "envelope");
+        if (! parsedJson)
+            return { std::nullopt, {}, std::move (parsedJson.error) };
 
         EnvelopeParser parser;
         std::string keyId;
         std::string payloadBase64;
         std::string signatureBase64;
-        if (! parser.parse (root, keyId, payloadBase64, signatureBase64))
+        if (! parser.parse (*parsedJson.root, keyId, payloadBase64, signatureBase64))
             return { std::nullopt, {}, std::move (parser.error) };
 
         const auto* key = validateAndFindKey (trustedKeys, keyId, error);

--- a/src/engine/sfz/SfzCatalogEnvelope.cpp
+++ b/src/engine/sfz/SfzCatalogEnvelope.cpp
@@ -1,0 +1,332 @@
+#include "SfzCatalogEnvelope.h"
+
+#include "../../foundation/Json.h"
+
+#include <sodium.h>
+
+#include <algorithm>
+#include <array>
+#include <initializer_list>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace duskstudio::sfz
+{
+namespace
+{
+using Json = dusk::json::Json;
+
+constexpr std::uint32_t kEnvelopeSchemaVersion = 1;
+constexpr std::size_t kMaxEnvelopeBytes = 12ULL * 1024ULL * 1024ULL;
+constexpr std::size_t kMaxPayloadBytes = 8ULL * 1024ULL * 1024ULL;
+constexpr std::size_t kMaxPayloadBase64Bytes = ((kMaxPayloadBytes + 2ULL) / 3ULL) * 4ULL;
+constexpr std::size_t kMaxKeyIdBytes = 64;
+constexpr std::size_t kMaxTrustedKeys = 16;
+constexpr std::string_view kExpectedCatalogId { "dusk.sfz" };
+
+static_assert (std::tuple_size<decltype (TrustedCatalogKey::publicKey)>::value
+               == crypto_sign_PUBLICKEYBYTES);
+
+bool isLowerAlphaNumeric (unsigned char c)
+{
+    return (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9');
+}
+
+bool isValidKeyId (std::string_view value)
+{
+    if (value.empty() || value.size() > kMaxKeyIdBytes
+        || ! isLowerAlphaNumeric (static_cast<unsigned char> (value.front()))
+        || ! isLowerAlphaNumeric (static_cast<unsigned char> (value.back())))
+        return false;
+
+    return std::all_of (value.begin(), value.end(), [] (unsigned char c)
+    {
+        return isLowerAlphaNumeric (c) || c == '-' || c == '_' || c == '.';
+    });
+}
+
+struct EnvelopeParser
+{
+    std::string error;
+
+    bool fail (std::string path, std::string reason)
+    {
+        error = std::move (path) + ": " + std::move (reason);
+        return false;
+    }
+
+    bool validateKeys (const Json& object, const std::string& path,
+                       std::initializer_list<std::string_view> allowed)
+    {
+        for (const auto& item : object.items())
+        {
+            const auto known = std::any_of (allowed.begin(), allowed.end(),
+                [&item] (std::string_view key) { return item.key() == key; });
+            if (! known)
+                return fail (path + "." + item.key(), "unknown field");
+        }
+        return true;
+    }
+
+    const Json* required (const Json& object, const char* key)
+    {
+        const auto it = object.find (key);
+        if (it == object.end())
+        {
+            fail (std::string ("envelope.") + key, "required field is missing");
+            return nullptr;
+        }
+        return &*it;
+    }
+
+    bool readString (const Json& object, const char* key, std::string& out,
+                     std::size_t maximum)
+    {
+        const auto* value = required (object, key);
+        if (value == nullptr)
+            return false;
+        if (! value->is_string())
+            return fail (std::string ("envelope.") + key, "expected a string");
+
+        out = value->get<std::string>();
+        if (out.empty())
+            return fail (std::string ("envelope.") + key, "must not be empty");
+        if (out.size() > maximum)
+            return fail (std::string ("envelope.") + key, "exceeds the length limit");
+        return true;
+    }
+
+    bool parse (const Json& root, std::string& keyId, std::string& payloadBase64,
+                std::string& signatureBase64)
+    {
+        if (! root.is_object())
+            return fail ("envelope", "expected an object");
+        if (! validateKeys (root, "envelope",
+                            { "envelope_schema_version", "algorithm", "key_id",
+                              "payload_base64", "signature_base64" }))
+            return false;
+
+        const auto* schema = required (root, "envelope_schema_version");
+        if (schema == nullptr)
+            return false;
+        if (! schema->is_number_unsigned() && ! schema->is_number_integer())
+            return fail ("envelope.envelope_schema_version", "expected an integer");
+
+        std::uint64_t schemaVersion = 0;
+        if (schema->is_number_unsigned())
+            schemaVersion = schema->get<std::uint64_t>();
+        else
+        {
+            const auto signedVersion = schema->get<std::int64_t>();
+            if (signedVersion <= 0)
+                return fail ("envelope.envelope_schema_version", "must be positive");
+            schemaVersion = static_cast<std::uint64_t> (signedVersion);
+        }
+        if (schemaVersion != kEnvelopeSchemaVersion)
+            return fail ("envelope.envelope_schema_version",
+                         "unsupported envelope schema version");
+
+        std::string algorithm;
+        if (! readString (root, "algorithm", algorithm, 32)
+            || ! readString (root, "key_id", keyId, kMaxKeyIdBytes)
+            || ! readString (root, "payload_base64", payloadBase64,
+                             kMaxPayloadBase64Bytes)
+            || ! readString (root, "signature_base64", signatureBase64, 128))
+            return false;
+
+        if (algorithm != "Ed25519")
+            return fail ("envelope.algorithm", "must be Ed25519");
+        if (! isValidKeyId (keyId))
+            return fail ("envelope.key_id", "contains an unsupported key identifier");
+        return true;
+    }
+};
+
+bool parseEnvelopeJson (std::string_view source, Json& root, std::string& error)
+{
+    std::vector<std::unordered_set<std::string>> objectKeys;
+    bool duplicateKeyFound = false;
+    std::string duplicateKey;
+    const auto callback = [&objectKeys, &duplicateKeyFound, &duplicateKey] (
+        int, Json::parse_event_t event, Json& parsed)
+    {
+        if (event == Json::parse_event_t::object_start)
+        {
+            objectKeys.emplace_back();
+        }
+        else if (event == Json::parse_event_t::key && ! objectKeys.empty())
+        {
+            const auto& key = parsed.get_ref<const std::string&>();
+            if (! objectKeys.back().insert (key).second && ! duplicateKeyFound)
+            {
+                duplicateKeyFound = true;
+                duplicateKey = key;
+            }
+        }
+        else if (event == Json::parse_event_t::object_end && ! objectKeys.empty())
+        {
+            objectKeys.pop_back();
+        }
+        return true;
+    };
+
+    root = Json::parse (source.begin(), source.end(), callback, false);
+    if (root.is_discarded())
+    {
+        error = "envelope: malformed JSON";
+        return false;
+    }
+    if (duplicateKeyFound)
+    {
+        error = "envelope: duplicate object key '" + duplicateKey + "'";
+        return false;
+    }
+    return true;
+}
+
+bool decodeCanonicalBase64 (const std::string& encoded, std::size_t maximum,
+                            const char* field, std::vector<unsigned char>& decoded,
+                            std::string& error)
+{
+    decoded.resize (std::min (encoded.size(), maximum));
+    std::size_t decodedBytes = 0;
+    const char* end = nullptr;
+    if (sodium_base642bin (decoded.data(), decoded.size(), encoded.data(), encoded.size(),
+                           nullptr, &decodedBytes, &end,
+                           sodium_base64_VARIANT_ORIGINAL) != 0
+        || end != encoded.data() + encoded.size())
+    {
+        error = std::string ("envelope.") + field + ": invalid base64";
+        return false;
+    }
+    decoded.resize (decodedBytes);
+
+    const auto canonicalBytes = sodium_base64_encoded_len (
+        decoded.size(), sodium_base64_VARIANT_ORIGINAL);
+    std::string canonical (canonicalBytes, '\0');
+    if (sodium_bin2base64 (canonical.data(), canonical.size(), decoded.data(),
+                           decoded.size(), sodium_base64_VARIANT_ORIGINAL) == nullptr)
+    {
+        error = std::string ("envelope.") + field + ": base64 decoding failed";
+        return false;
+    }
+    canonical.resize (canonicalBytes - 1);
+    if (canonical != encoded)
+    {
+        error = std::string ("envelope.") + field + ": base64 is not canonical";
+        return false;
+    }
+    return true;
+}
+
+const TrustedCatalogKey* validateAndFindKey (
+    const std::vector<TrustedCatalogKey>& trustedKeys, std::string_view wanted,
+    std::string& error)
+{
+    if (trustedKeys.empty() || trustedKeys.size() > kMaxTrustedKeys)
+    {
+        error = "trusted_keys: must contain between 1 and 16 keys";
+        return nullptr;
+    }
+
+    std::unordered_set<std::string> keyIds;
+    std::unordered_set<std::string> publicKeys;
+    const TrustedCatalogKey* selected = nullptr;
+    for (const auto& key : trustedKeys)
+    {
+        if (! isValidKeyId (key.id))
+        {
+            error = "trusted_keys: contains an invalid key identifier";
+            return nullptr;
+        }
+        if (! keyIds.insert (key.id).second)
+        {
+            error = "trusted_keys: contains a duplicate key identifier";
+            return nullptr;
+        }
+        if (crypto_core_ed25519_is_valid_point (key.publicKey.data()) != 1)
+        {
+            error = "trusted_keys: contains an invalid public key";
+            return nullptr;
+        }
+        const std::string keyMaterial (
+            reinterpret_cast<const char*> (key.publicKey.data()), key.publicKey.size());
+        if (! publicKeys.insert (keyMaterial).second)
+        {
+            error = "trusted_keys: contains duplicate public key material";
+            return nullptr;
+        }
+        if (key.id == wanted)
+            selected = &key;
+    }
+
+    if (selected == nullptr)
+        error = "envelope.key_id: key is not trusted";
+    return selected;
+}
+} // namespace
+
+CatalogEnvelopeResult verifyCatalogEnvelope (
+    std::string_view envelope,
+    const std::vector<TrustedCatalogKey>& trustedKeys) noexcept
+{
+    try
+    {
+        if (envelope.size() > kMaxEnvelopeBytes)
+            return { std::nullopt, {}, "envelope: exceeds the 12 MiB limit" };
+        if (sodium_init() < 0)
+            return { std::nullopt, {}, "envelope: cryptographic initialization failed" };
+
+        Json root;
+        std::string error;
+        if (! parseEnvelopeJson (envelope, root, error))
+            return { std::nullopt, {}, std::move (error) };
+
+        EnvelopeParser parser;
+        std::string keyId;
+        std::string payloadBase64;
+        std::string signatureBase64;
+        if (! parser.parse (root, keyId, payloadBase64, signatureBase64))
+            return { std::nullopt, {}, std::move (parser.error) };
+
+        const auto* key = validateAndFindKey (trustedKeys, keyId, error);
+        if (key == nullptr)
+            return { std::nullopt, {}, std::move (error) };
+
+        std::vector<unsigned char> signature;
+        if (! decodeCanonicalBase64 (signatureBase64, crypto_sign_BYTES,
+                                     "signature_base64", signature, error))
+            return { std::nullopt, {}, std::move (error) };
+        if (signature.size() != crypto_sign_BYTES)
+            return { std::nullopt, {},
+                     "envelope.signature_base64: decoded signature must be 64 bytes" };
+
+        std::vector<unsigned char> payload;
+        if (! decodeCanonicalBase64 (payloadBase64, kMaxPayloadBytes,
+                                     "payload_base64", payload, error))
+            return { std::nullopt, {}, std::move (error) };
+        if (payload.empty())
+            return { std::nullopt, {}, "envelope.payload_base64: payload is empty" };
+
+        if (crypto_sign_verify_detached (
+                signature.data(), payload.data(),
+                static_cast<unsigned long long> (payload.size()),
+                key->publicKey.data()) != 0)
+            return { std::nullopt, {}, "envelope.signature_base64: signature verification failed" };
+
+        auto parsed = parseCatalogPayload (std::string_view (
+            reinterpret_cast<const char*> (payload.data()), payload.size()));
+        if (! parsed)
+            return { std::nullopt, {}, "payload: " + parsed.error };
+        if (parsed.catalog->catalogId != kExpectedCatalogId)
+            return { std::nullopt, {}, "payload: root.catalog_id is not dusk.sfz" };
+        return { std::move (parsed.catalog), std::move (keyId), {} };
+    }
+    catch (...)
+    {
+        return { std::nullopt, {}, "envelope: verification failed" };
+    }
+}
+} // namespace duskstudio::sfz

--- a/src/engine/sfz/SfzCatalogEnvelope.h
+++ b/src/engine/sfz/SfzCatalogEnvelope.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "SfzCatalog.h"
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace duskstudio::sfz
+{
+struct TrustedCatalogKey
+{
+    std::string id;
+    std::array<std::uint8_t, 32> publicKey {};
+};
+
+struct CatalogEnvelopeResult
+{
+    std::optional<CatalogPayload> catalog;
+    std::string verifiedKeyId;
+    std::string error;
+
+    explicit operator bool() const noexcept { return catalog.has_value(); }
+};
+
+// Verifies the detached Ed25519 signature over the exact decoded payload bytes
+// before handing those bytes to the catalog payload parser. The envelope is a
+// transport container only; its JSON representation is never signed or
+// canonicalized.
+CatalogEnvelopeResult verifyCatalogEnvelope (
+    std::string_view envelope,
+    const std::vector<TrustedCatalogKey>& trustedKeys) noexcept;
+} // namespace duskstudio::sfz

--- a/src/engine/sfz/SfzCatalogJson.h
+++ b/src/engine/sfz/SfzCatalogJson.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "../../foundation/Json.h"
+
+#include <algorithm>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace duskstudio::sfz::detail
+{
+using Json = dusk::json::Json;
+
+inline std::string sanitizeJsonKeyForDiagnostic (std::string_view key)
+{
+    constexpr std::size_t maximumBytes = 64;
+    const auto keptBytes = std::min (key.size(), maximumBytes);
+
+    std::string sanitized;
+    sanitized.reserve (keptBytes + 3);
+    for (std::size_t i = 0; i < keptBytes; ++i)
+    {
+        const auto byte = static_cast<unsigned char> (key[i]);
+        sanitized.push_back (byte >= 0x20 && byte <= 0x7e
+                                 ? static_cast<char> (byte)
+                                 : '?');
+    }
+    if (key.size() > keptBytes)
+        sanitized += "...";
+    return sanitized;
+}
+
+struct JsonParseResult
+{
+    std::optional<Json> root;
+    std::string error;
+
+    explicit operator bool() const noexcept { return root.has_value(); }
+};
+
+inline JsonParseResult parseJsonRejectingDuplicateKeys (
+    std::string_view source, std::string_view errorPrefix)
+{
+    std::vector<std::unordered_set<std::string>> objectKeys;
+    bool duplicateKeyFound = false;
+    std::string duplicateKey;
+    const auto callback = [&objectKeys, &duplicateKeyFound, &duplicateKey] (
+        int, Json::parse_event_t event, Json& parsed)
+    {
+        if (event == Json::parse_event_t::object_start)
+        {
+            objectKeys.emplace_back();
+        }
+        else if (event == Json::parse_event_t::key && ! objectKeys.empty())
+        {
+            const auto& key = parsed.get_ref<const std::string&>();
+            if (! objectKeys.back().insert (key).second && ! duplicateKeyFound)
+            {
+                duplicateKeyFound = true;
+                duplicateKey = key;
+            }
+        }
+        else if (event == Json::parse_event_t::object_end && ! objectKeys.empty())
+        {
+            objectKeys.pop_back();
+        }
+        return true;
+    };
+
+    auto root = Json::parse (source.begin(), source.end(), callback, false);
+    if (root.is_discarded())
+        return { std::nullopt, std::string (errorPrefix) + ": malformed JSON" };
+    if (duplicateKeyFound)
+        return { std::nullopt,
+                 std::string (errorPrefix) + ": duplicate object key '"
+                     + sanitizeJsonKeyForDiagnostic (duplicateKey) + "'" };
+    return { std::move (root), {} };
+}
+} // namespace duskstudio::sfz::detail

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,9 @@ add_executable(dusk-studio-tests
     hosting_port_layout.cpp
     hosting_insert_adapter.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/hosting/InsertAdapter.cpp
+    sfz_catalog.cpp
+    ${CMAKE_SOURCE_DIR}/src/engine/sfz/SfzCatalog.cpp
+    ${CMAKE_SOURCE_DIR}/src/engine/sfz/SfzCatalogEnvelope.cpp
     # Native CLAP tests + sources are added conditionally below.
     plugin_descriptor.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/PluginDescriptor.cpp
@@ -217,6 +220,7 @@ target_sources(dusk-studio-tests PRIVATE
     ${CMAKE_SOURCE_DIR}/src/engine/audiofile/ThreadedFileWriter.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/audiofile/WriterDrainPool.cpp)
 target_link_libraries(dusk-studio-tests PRIVATE dusk_sndfile)
+target_link_libraries(dusk-studio-tests PRIVATE dusk_sodium)
 
 # Console-saturation calibration test + the donor DSP headers it needs
 # (BritishEQProcessor.h + its header-only ConsoleSaturation/ADAA/SafeFloat deps).

--- a/tests/sfz_catalog.cpp
+++ b/tests/sfz_catalog.cpp
@@ -215,6 +215,17 @@ TEST_CASE ("SFZ catalog rejects unknown schema v1 fields", "[sfz][catalog]")
         catalog["packs"][0]["instruments"][0]["future_instrument_field"] = true;
         checkRejected (catalog, "instruments[0].future_instrument_field");
     }
+    SECTION ("diagnostic keys are bounded and sanitized")
+    {
+        auto catalog = validCatalog();
+        const auto key = std::string ("future\n") + std::string (80, 'x');
+        catalog[key] = true;
+
+        const auto result = parse (catalog);
+        CHECK_FALSE (result);
+        CHECK (result.error
+               == "root.future?" + std::string (57, 'x') + "...: unknown field");
+    }
 }
 
 TEST_CASE ("SFZ catalog rejects oversized payloads before JSON parsing",
@@ -249,6 +260,18 @@ TEST_CASE ("SFZ catalog rejects duplicate JSON object keys", "[sfz][catalog]")
         const auto result = parseCatalogPayload (source);
         CHECK_FALSE (result);
         CHECK (result.error == "root: duplicate object key 'spdx'");
+    }
+    SECTION ("diagnostic keys are bounded and sanitized")
+    {
+        auto source = validCatalog().dump();
+        const auto key = std::string ("duplicate\\n") + std::string (80, 'x');
+        source.insert (1, "\"" + key + "\":0,\"" + key + "\":1,");
+
+        const auto result = parseCatalogPayload (source);
+        CHECK_FALSE (result);
+        CHECK (result.error
+               == "root: duplicate object key 'duplicate?"
+                      + std::string (54, 'x') + "...'");
     }
 }
 
@@ -593,8 +616,11 @@ TEST_CASE ("SFZ catalog rejects unsafe or unsupported relative paths",
     SECTION ("segment ending in dot") { entrypoint = "pack./file.sfz"; }
     SECTION ("segment ending in space") { entrypoint = "pack /file.sfz"; }
     SECTION ("reserved basename with extension") { entrypoint = "pack/CON.sfz"; }
+    SECTION ("reserved basename with trailing space") { entrypoint = "pack/CON .sfz"; }
     SECTION ("case-insensitive COM device") { entrypoint = "pack/cOm9.sfz"; }
+    SECTION ("COM device with trailing space") { entrypoint = "pack/COM1 .sfz"; }
     SECTION ("case-insensitive LPT device") { entrypoint = "pack/LpT1.preset.sfz"; }
+    SECTION ("LPT device with trailing space") { entrypoint = "pack/LPT1 .sfz"; }
     SECTION ("COM device with superscript one")
     {
         entrypoint = std::string ("pack/COM") + "\xc2\xb9" + ".sfz";
@@ -837,6 +863,16 @@ TEST_CASE ("SFZ catalog envelope schema is closed and versioned",
         envelope.erase ("signature_base64");
         checkEnvelopeRejected (envelope, { signing.key }, "signature_base64");
     }
+    SECTION ("diagnostic keys are bounded and sanitized")
+    {
+        const auto key = std::string ("future\n") + std::string (80, 'x');
+        envelope[key] = true;
+
+        const auto result = verify (envelope, { signing.key });
+        CHECK_FALSE (result);
+        CHECK (result.error
+               == "envelope.future?" + std::string (57, 'x') + "...: unknown field");
+    }
 }
 
 TEST_CASE ("SFZ catalog envelope rejects duplicate keys and malformed JSON",
@@ -851,6 +887,14 @@ TEST_CASE ("SFZ catalog envelope rejects duplicate keys and malformed JSON",
         const auto result = verifyCatalogEnvelope (source, { signing.key });
         CHECK_FALSE (result);
         CHECK (result.error == "envelope: duplicate object key 'algorithm'");
+    }
+    SECTION ("duplicate diagnostic key is sanitized")
+    {
+        auto source = signedEnvelope (validCatalog().dump(), signing).dump();
+        source.insert (1, R"("duplicate\nkey":0,"duplicate\nkey":1,)");
+        const auto result = verifyCatalogEnvelope (source, { signing.key });
+        CHECK_FALSE (result);
+        CHECK (result.error == "envelope: duplicate object key 'duplicate?key'");
     }
     SECTION ("malformed JSON")
     {

--- a/tests/sfz_catalog.cpp
+++ b/tests/sfz_catalog.cpp
@@ -1,0 +1,911 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/sfz/SfzCatalog.h"
+#include "engine/sfz/SfzCatalogEnvelope.h"
+
+#include <nlohmann/json.hpp>
+#include <sodium.h>
+
+#include <array>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace
+{
+using Json = nlohmann::json;
+using duskstudio::sfz::CatalogEnvelopeResult;
+using duskstudio::sfz::CatalogParseResult;
+using duskstudio::sfz::TrustedCatalogKey;
+using duskstudio::sfz::parseCatalogPayload;
+using duskstudio::sfz::verifyCatalogEnvelope;
+
+const std::string kShaA (64, 'a');
+const std::string kShaB (64, 'b');
+const std::string kGitRevision (40, 'c');
+
+Json validCatalog()
+{
+    return {
+        { "catalog_id", "dusk.sfz" },
+        { "schema_version", 1 },
+        { "catalog_revision", 7 },
+        { "generated_at", "2026-08-10T12:00:00Z" },
+        { "packs", Json::array ({
+            {
+                { "id", "body-percussion" },
+                { "release_id", "v1.0.0+mirror.1" },
+                { "display_name", "Body Percussion" },
+                { "author", "SFZ Instruments" },
+                { "source_url", "https://github.com/example/body/tree/012345" },
+                { "source_revision", kGitRevision },
+                { "download_url", "https://catalog.dusk.audio/body-v1.zip" },
+                { "archive_sha256", kShaA },
+                { "archive_format", "zip" },
+                { "expected_root", "body-percussion" },
+                { "compressed_bytes", 1024 },
+                { "expanded_bytes", 4096 },
+                { "max_files", 12 },
+                { "license", {
+                    { "spdx", "CC0-1.0" },
+                    { "source_url", "https://github.com/example/body/blob/012345/LICENSE" },
+                    { "file", "LICENSE" },
+                    { "file_sha256", kShaB },
+                    { "redistribution_allowed", true },
+                    { "mirror_allowed", true }
+                } },
+                { "instruments", Json::array ({
+                    {
+                        { "id", "full-kit" },
+                        { "name", "Full Kit" },
+                        { "relative_entrypoint", "Instruments/Full Kit.sfz" }
+                    }
+                }) }
+            }
+        }) }
+    };
+}
+
+CatalogParseResult parse (const Json& catalog)
+{
+    return parseCatalogPayload (catalog.dump());
+}
+
+void checkRejected (const Json& catalog, const std::string& errorPath)
+{
+    const auto result = parse (catalog);
+    CHECK_FALSE (result);
+    CHECK_FALSE (result.catalog.has_value());
+    CHECK (result.error.find (errorPath) != std::string::npos);
+}
+
+struct SigningFixture
+{
+    explicit SigningFixture (std::string keyId = "catalog-2026-a",
+                             unsigned char seedByte = 0x2a)
+    {
+        if (sodium_init() < 0)
+            throw std::runtime_error ("libsodium initialization failed");
+
+        std::array<unsigned char, crypto_sign_SEEDBYTES> seed {};
+        seed.fill (seedByte);
+        key.id = std::move (keyId);
+        if (crypto_sign_seed_keypair (key.publicKey.data(), secretKey.data(),
+                                      seed.data()) != 0)
+            throw std::runtime_error ("Ed25519 key generation failed");
+    }
+
+    TrustedCatalogKey key;
+    std::array<unsigned char, crypto_sign_SECRETKEYBYTES> secretKey {};
+};
+
+std::string encodeBase64 (const unsigned char* bytes, std::size_t size)
+{
+    const auto encodedBytes = sodium_base64_encoded_len (
+        size, sodium_base64_VARIANT_ORIGINAL);
+    std::string encoded (encodedBytes, '\0');
+    if (sodium_bin2base64 (encoded.data(), encoded.size(), bytes, size,
+                           sodium_base64_VARIANT_ORIGINAL) == nullptr)
+        throw std::runtime_error ("base64 encoding failed");
+    encoded.resize (encodedBytes - 1);
+    return encoded;
+}
+
+Json signedEnvelope (const std::string& payload, const SigningFixture& signing)
+{
+    std::array<unsigned char, crypto_sign_BYTES> signature {};
+    unsigned long long signatureBytes = 0;
+    if (crypto_sign_detached (
+            signature.data(), &signatureBytes,
+            reinterpret_cast<const unsigned char*> (payload.data()),
+            static_cast<unsigned long long> (payload.size()),
+            signing.secretKey.data()) != 0
+        || signatureBytes != signature.size())
+        throw std::runtime_error ("Ed25519 signing failed");
+
+    return {
+        { "envelope_schema_version", 1 },
+        { "algorithm", "Ed25519" },
+        { "key_id", signing.key.id },
+        { "payload_base64", encodeBase64 (
+            reinterpret_cast<const unsigned char*> (payload.data()), payload.size()) },
+        { "signature_base64", encodeBase64 (signature.data(), signature.size()) }
+    };
+}
+
+CatalogEnvelopeResult verify (const Json& envelope,
+                              const std::vector<TrustedCatalogKey>& keys)
+{
+    return verifyCatalogEnvelope (envelope.dump(), keys);
+}
+
+void checkEnvelopeRejected (const Json& envelope,
+                            const std::vector<TrustedCatalogKey>& keys,
+                            const std::string& errorPath)
+{
+    const auto result = verify (envelope, keys);
+    CHECK_FALSE (result);
+    CHECK_FALSE (result.catalog.has_value());
+    CHECK (result.verifiedKeyId.empty());
+    CHECK (result.error.find (errorPath) != std::string::npos);
+}
+} // namespace
+
+TEST_CASE ("SFZ catalog accepts a complete schema v1 payload", "[sfz][catalog]")
+{
+    auto source = validCatalog();
+    source["packs"][0]["tags"] = Json::array ({ "percussion", "cc0" });
+    source["packs"][0]["yanked"] = true;
+
+    const auto result = parse (source);
+    REQUIRE (result);
+    REQUIRE (result.error.empty());
+    REQUIRE (result.catalog.has_value());
+
+    const auto& catalog = *result.catalog;
+    CHECK (catalog.catalogId == "dusk.sfz");
+    CHECK (catalog.schemaVersion == 1);
+    CHECK (catalog.catalogRevision == 7);
+    CHECK (catalog.generatedAt == "2026-08-10T12:00:00Z");
+    REQUIRE (catalog.packs.size() == 1);
+
+    const auto& pack = catalog.packs.front();
+    CHECK (pack.id == "body-percussion");
+    CHECK (pack.releaseId == "v1.0.0+mirror.1");
+    CHECK (pack.sourceRevision == kGitRevision);
+    CHECK (pack.archiveFormat == "zip");
+    CHECK (pack.expectedRoot == "body-percussion");
+    CHECK (pack.compressedBytes == 1024);
+    CHECK (pack.expandedBytes == 4096);
+    CHECK (pack.maxFiles == 12);
+    CHECK (pack.license.spdx == "CC0-1.0");
+    CHECK (pack.license.redistributionAllowed);
+    CHECK (pack.license.mirrorAllowed);
+    REQUIRE (pack.instruments.size() == 1);
+    CHECK (pack.instruments.front().relativeEntrypoint
+           == "Instruments/Full Kit.sfz");
+    CHECK (pack.tags == std::vector<std::string> { "percussion", "cc0" });
+    CHECK (pack.yanked);
+}
+
+TEST_CASE ("SFZ catalog rejects unknown schema v1 fields", "[sfz][catalog]")
+{
+    SECTION ("root")
+    {
+        auto catalog = validCatalog();
+        catalog["future_root_field"] = true;
+        checkRejected (catalog, "root.future_root_field");
+    }
+    SECTION ("pack")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["future_pack_field"] = true;
+        checkRejected (catalog, "root.packs[0].future_pack_field");
+    }
+    SECTION ("license")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["license"]["future_license_field"] = true;
+        checkRejected (catalog, "license.future_license_field");
+    }
+    SECTION ("instrument")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["instruments"][0]["future_instrument_field"] = true;
+        checkRejected (catalog, "instruments[0].future_instrument_field");
+    }
+}
+
+TEST_CASE ("SFZ catalog rejects oversized payloads before JSON parsing",
+           "[sfz][catalog]")
+{
+    const std::string oversized (8 * 1024 * 1024 + 1, ' ');
+    CatalogParseResult result;
+    REQUIRE_NOTHROW (result = parseCatalogPayload (oversized));
+    CHECK_FALSE (result);
+    CHECK (result.error == "root: payload exceeds the 8 MiB limit");
+}
+
+TEST_CASE ("SFZ catalog rejects duplicate JSON object keys", "[sfz][catalog]")
+{
+    SECTION ("root object")
+    {
+        auto source = validCatalog().dump();
+        source.insert (1, R"("catalog_id":"shadow",)");
+
+        const auto result = parseCatalogPayload (source);
+        CHECK_FALSE (result);
+        CHECK (result.error == "root: duplicate object key 'catalog_id'");
+    }
+    SECTION ("nested object")
+    {
+        auto source = validCatalog().dump();
+        const std::string marker { R"("license":{)" };
+        const auto position = source.find (marker);
+        REQUIRE (position != std::string::npos);
+        source.insert (position + marker.size(), R"("spdx":"shadow",)");
+
+        const auto result = parseCatalogPayload (source);
+        CHECK_FALSE (result);
+        CHECK (result.error == "root: duplicate object key 'spdx'");
+    }
+}
+
+TEST_CASE ("SFZ catalog rejects malformed roots and unsupported schemas",
+           "[sfz][catalog]")
+{
+    SECTION ("malformed JSON does not throw")
+    {
+        CatalogParseResult result;
+        REQUIRE_NOTHROW (result = parseCatalogPayload ("{not-json"));
+        CHECK_FALSE (result);
+        CHECK (result.error.find ("malformed JSON") != std::string::npos);
+    }
+    SECTION ("root must be an object")
+    {
+        const auto result = parseCatalogPayload ("[]");
+        CHECK_FALSE (result);
+        CHECK (result.error.find ("root") != std::string::npos);
+    }
+    SECTION ("schema is required")
+    {
+        auto catalog = validCatalog();
+        catalog.erase ("schema_version");
+        checkRejected (catalog, "root.schema_version");
+    }
+    SECTION ("future schema")
+    {
+        auto catalog = validCatalog();
+        catalog["schema_version"] = 2;
+        checkRejected (catalog, "root.schema_version");
+    }
+    SECTION ("fractional schema")
+    {
+        auto catalog = validCatalog();
+        catalog["schema_version"] = 1.0;
+        checkRejected (catalog, "root.schema_version");
+    }
+    SECTION ("revision must be positive")
+    {
+        auto catalog = validCatalog();
+        catalog["catalog_revision"] = 0;
+        checkRejected (catalog, "root.catalog_revision");
+    }
+    SECTION ("packs must not be empty")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"] = Json::array();
+        checkRejected (catalog, "root.packs");
+    }
+}
+
+TEST_CASE ("SFZ catalog requires typed security fields", "[sfz][catalog]")
+{
+    SECTION ("archive digest cannot default")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0].erase ("archive_sha256");
+        checkRejected (catalog, "archive_sha256");
+    }
+    SECTION ("source revision cannot default")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0].erase ("source_revision");
+        checkRejected (catalog, "source_revision");
+    }
+    SECTION ("license permission cannot default")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["license"].erase ("mirror_allowed");
+        checkRejected (catalog, "mirror_allowed");
+    }
+    SECTION ("instrument entrypoint cannot default")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["instruments"][0].erase ("relative_entrypoint");
+        checkRejected (catalog, "relative_entrypoint");
+    }
+    SECTION ("integer fields reject strings")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["compressed_bytes"] = "1024";
+        checkRejected (catalog, "compressed_bytes");
+    }
+    SECTION ("boolean fields reject integers")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["license"]["mirror_allowed"] = 1;
+        checkRejected (catalog, "mirror_allowed");
+    }
+}
+
+TEST_CASE ("SFZ catalog constrains identities and rejects duplicates",
+           "[sfz][catalog]")
+{
+    SECTION ("stable IDs are conservative lowercase ASCII")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["id"] = "Body Percussion";
+        checkRejected (catalog, "root.packs[0].id");
+    }
+    SECTION ("opaque release IDs remain bounded conservative tokens")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["release_id"] = "release/../../../other";
+        checkRejected (catalog, "root.packs[0].release_id");
+    }
+    SECTION ("release IDs reject non-ASCII bytes")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["release_id"] = std::string ("v1-") + "\xc3\xa9-x";
+        checkRejected (catalog, "root.packs[0].release_id");
+    }
+    SECTION ("pack and release identity is unique")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"].push_back (catalog["packs"][0]);
+        checkRejected (catalog, "root.packs[1]");
+    }
+    SECTION ("instrument identity is unique within a release")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["instruments"].push_back (
+            catalog["packs"][0]["instruments"][0]);
+        checkRejected (catalog, "root.packs[0].instruments[1].id");
+    }
+}
+
+TEST_CASE ("SFZ catalog requires immutable normalized mirror fields",
+           "[sfz][catalog]")
+{
+    SECTION ("40-digit Git object ID")
+    {
+        const auto result = parse (validCatalog());
+        REQUIRE (result);
+        CHECK (result.catalog->packs[0].sourceRevision == kGitRevision);
+    }
+    SECTION ("64-digit Git object ID")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["source_revision"] = std::string (64, 'd');
+        const auto result = parse (catalog);
+        REQUIRE (result);
+        CHECK (result.catalog->packs[0].sourceRevision == std::string (64, 'd'));
+    }
+    SECTION ("Git object ID length")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["source_revision"] = std::string (39, 'c');
+        checkRejected (catalog, "source_revision");
+    }
+    SECTION ("Git object ID lowercase hex")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["source_revision"] = std::string (40, 'C');
+        checkRejected (catalog, "source_revision");
+    }
+    SECTION ("archive format")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["archive_format"] = "tar.gz";
+        checkRejected (catalog, "archive_format");
+    }
+    SECTION ("expected root equals pack ID")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["expected_root"] = "other-root";
+        checkRejected (catalog, "expected_root");
+    }
+    SECTION ("expected root is traversal-safe")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["expected_root"] = "../body-percussion";
+        checkRejected (catalog, "expected_root");
+    }
+}
+
+TEST_CASE ("SFZ catalog requires HTTPS and lowercase SHA-256 fields",
+           "[sfz][catalog]")
+{
+    SECTION ("pack source uses HTTPS")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["source_url"] = "http://example.test/source";
+        checkRejected (catalog, "source_url");
+    }
+    SECTION ("download uses HTTPS")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["download_url"] = "file:///tmp/archive.zip";
+        checkRejected (catalog, "download_url");
+    }
+    SECTION ("archive hash is lowercase hex")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["archive_sha256"] = std::string (64, 'A');
+        checkRejected (catalog, "archive_sha256");
+    }
+    SECTION ("license hash has exact length")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["license"]["file_sha256"] = "abc";
+        checkRejected (catalog, "file_sha256");
+    }
+}
+
+TEST_CASE ("SFZ catalog requires ASCII DNS HTTPS authorities", "[sfz][catalog]")
+{
+    auto catalog = validCatalog();
+    auto& url = catalog["packs"][0]["download_url"];
+
+    SECTION ("space") { url = "https://bad host.example/archive.zip"; }
+    SECTION ("backslash") { url = "https://bad\\host.example/archive.zip"; }
+    SECTION ("percent escape") { url = "https://bad%20host.example/archive.zip"; }
+    SECTION ("empty label") { url = "https://bad..example/archive.zip"; }
+    SECTION ("leading hyphen") { url = "https://-bad.example/archive.zip"; }
+    SECTION ("trailing hyphen") { url = "https://bad-.example/archive.zip"; }
+    SECTION ("non-ASCII")
+    {
+        url = std::string ("https://m") + "\xc3\xbc" + "sic.example/archive.zip";
+    }
+    SECTION ("label longer than 63 bytes")
+    {
+        url = "https://" + std::string (64, 'a') + ".example/archive.zip";
+    }
+    SECTION ("authority longer than 253 bytes")
+    {
+        const auto label = std::string (63, 'a');
+        url = "https://" + label + "." + label + "." + label + "." + label
+            + "/archive.zip";
+    }
+
+    checkRejected (catalog, "download_url");
+}
+
+TEST_CASE ("SFZ catalog bounds extraction declarations", "[sfz][catalog]")
+{
+    SECTION ("compressed size must be positive")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["compressed_bytes"] = 0;
+        checkRejected (catalog, "compressed_bytes");
+    }
+    SECTION ("compressed size has a global ceiling")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["compressed_bytes"] = 8589934593ULL;
+        checkRejected (catalog, "compressed_bytes");
+    }
+    SECTION ("compressed size may exceed expanded size")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["compressed_bytes"] = 4096;
+        catalog["packs"][0]["expanded_bytes"] = 512;
+        const auto result = parse (catalog);
+        REQUIRE (result);
+        CHECK (result.catalog->packs[0].compressedBytes == 4096);
+        CHECK (result.catalog->packs[0].expandedBytes == 512);
+    }
+    SECTION ("expanded size must be positive")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["expanded_bytes"] = 0;
+        checkRejected (catalog, "expanded_bytes");
+    }
+    SECTION ("expanded size has a global ceiling")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["expanded_bytes"] = 34359738369ULL;
+        checkRejected (catalog, "expanded_bytes");
+    }
+    SECTION ("file count has a ceiling")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["max_files"] = 100001;
+        checkRejected (catalog, "max_files");
+    }
+    SECTION ("file count must be integral")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["max_files"] = 12.5;
+        checkRejected (catalog, "max_files");
+    }
+}
+
+TEST_CASE ("SFZ catalog enforces the schema v1 license policy", "[sfz][catalog]")
+{
+    SECTION ("only CC0 is allowed")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["license"]["spdx"] = "CC-BY-4.0";
+        checkRejected (catalog, "license.spdx");
+    }
+    SECTION ("redistribution must be allowed")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["license"]["redistribution_allowed"] = false;
+        checkRejected (catalog, "redistribution_allowed");
+    }
+    SECTION ("mirroring must be allowed")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["license"]["mirror_allowed"] = false;
+        checkRejected (catalog, "mirror_allowed");
+    }
+    SECTION ("license source uses HTTPS")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["license"]["source_url"] = "http://example.test/LICENSE";
+        checkRejected (catalog, "license.source_url");
+    }
+}
+
+TEST_CASE ("SFZ catalog rejects unsafe or unsupported relative paths",
+           "[sfz][catalog]")
+{
+    auto catalog = validCatalog();
+    auto& entrypoint = catalog["packs"][0]["instruments"][0]["relative_entrypoint"];
+
+    SECTION ("absolute path") { entrypoint = "/etc/passwd.sfz"; }
+    SECTION ("UNC path") { entrypoint = "//server/share/file.sfz"; }
+    SECTION ("drive root") { entrypoint = "C:/pack/file.sfz"; }
+    SECTION ("backslash") { entrypoint = "pack\\file.sfz"; }
+    SECTION ("parent segment") { entrypoint = "pack/../file.sfz"; }
+    SECTION ("dot segment") { entrypoint = "pack/./file.sfz"; }
+    SECTION ("empty segment") { entrypoint = "pack//file.sfz"; }
+    SECTION ("trailing slash") { entrypoint = "pack/file.sfz/"; }
+    SECTION ("unsupported extension") { entrypoint = "pack/file.wav"; }
+    SECTION ("uppercase extension") { entrypoint = "pack/file.SFZ"; }
+    SECTION ("NUL") { entrypoint = std::string ("pack/file\0.sfz", 14); }
+    SECTION ("colon") { entrypoint = "pack/file:stream.sfz"; }
+    SECTION ("other Win32-invalid characters")
+    {
+        for (const auto invalid : std::string ("<>\"|?*"))
+        {
+            CAPTURE (invalid);
+            entrypoint = "pack/file.sfz";
+            entrypoint.get_ref<std::string&>().insert (9, 1, invalid);
+            checkRejected (catalog, "relative_entrypoint");
+        }
+        return;
+    }
+    SECTION ("segment ending in dot") { entrypoint = "pack./file.sfz"; }
+    SECTION ("segment ending in space") { entrypoint = "pack /file.sfz"; }
+    SECTION ("reserved basename with extension") { entrypoint = "pack/CON.sfz"; }
+    SECTION ("case-insensitive COM device") { entrypoint = "pack/cOm9.sfz"; }
+    SECTION ("case-insensitive LPT device") { entrypoint = "pack/LpT1.preset.sfz"; }
+    SECTION ("COM device with superscript one")
+    {
+        entrypoint = std::string ("pack/COM") + "\xc2\xb9" + ".sfz";
+    }
+    SECTION ("LPT device with superscript three and extension")
+    {
+        entrypoint = std::string ("pack/LPT") + "\xc2\xb3" + ".preset.sfz";
+    }
+
+    checkRejected (catalog, "relative_entrypoint");
+}
+
+TEST_CASE ("SFZ catalog bounds relative path depth and length", "[sfz][catalog]")
+{
+    SECTION ("path depth")
+    {
+        auto catalog = validCatalog();
+        std::string path;
+        for (int i = 0; i < 33; ++i)
+            path += "dir/";
+        path += "file.sfz";
+        catalog["packs"][0]["instruments"][0]["relative_entrypoint"] = path;
+        checkRejected (catalog, "relative_entrypoint");
+    }
+    SECTION ("path length")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["license"]["file"] = std::string (513, 'a');
+        checkRejected (catalog, "license.file");
+    }
+}
+
+TEST_CASE ("SFZ catalog validates arrays and optional pack metadata",
+           "[sfz][catalog]")
+{
+    SECTION ("instruments must not be empty")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["instruments"] = Json::array();
+        checkRejected (catalog, "instruments");
+    }
+    SECTION ("instruments must be an array")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["instruments"] = Json::object();
+        checkRejected (catalog, "instruments");
+    }
+    SECTION ("tags must be an array")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["tags"] = "percussion";
+        checkRejected (catalog, "tags");
+    }
+    SECTION ("tags are unique")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["tags"] = Json::array ({ "cc0", "cc0" });
+        checkRejected (catalog, "tags[1]");
+    }
+    SECTION ("yanked must be a boolean")
+    {
+        auto catalog = validCatalog();
+        catalog["packs"][0]["yanked"] = "false";
+        checkRejected (catalog, "yanked");
+    }
+}
+
+TEST_CASE ("SFZ catalog envelope verifies exact payload bytes",
+           "[sfz][catalog][envelope]")
+{
+    const SigningFixture signing;
+    const auto payload = validCatalog().dump();
+    const auto envelope = signedEnvelope (payload, signing);
+
+    const auto result = verify (envelope, { signing.key });
+    REQUIRE (result);
+    REQUIRE (result.error.empty());
+    REQUIRE (result.catalog.has_value());
+    CHECK (result.verifiedKeyId == "catalog-2026-a");
+    CHECK (result.catalog->catalogId == "dusk.sfz");
+    CHECK (result.catalog->catalogRevision == 7);
+}
+
+TEST_CASE ("SFZ catalog envelope rejects payload and signature tampering",
+           "[sfz][catalog][envelope]")
+{
+    const SigningFixture signing;
+    const auto originalPayload = validCatalog().dump();
+
+    SECTION ("semantically valid payload with different exact bytes")
+    {
+        auto envelope = signedEnvelope (originalPayload, signing);
+        const auto reformatted = validCatalog().dump (2);
+        envelope["payload_base64"] = encodeBase64 (
+            reinterpret_cast<const unsigned char*> (reformatted.data()),
+            reformatted.size());
+        checkEnvelopeRejected (envelope, { signing.key }, "signature verification failed");
+    }
+    SECTION ("signature bytes")
+    {
+        auto envelope = signedEnvelope (originalPayload, signing);
+        auto& encoded = envelope["signature_base64"].get_ref<std::string&>();
+        encoded[0] = encoded[0] == 'A' ? 'B' : 'A';
+        checkEnvelopeRejected (envelope, { signing.key }, "signature verification failed");
+    }
+    SECTION ("signed malformed payload is rejected after verification")
+    {
+        const auto envelope = signedEnvelope ("{not-json", signing);
+        checkEnvelopeRejected (envelope, { signing.key }, "payload: root: malformed JSON");
+    }
+    SECTION ("signed future payload schema remains fail-closed")
+    {
+        auto catalog = validCatalog();
+        catalog["schema_version"] = 2;
+        const auto envelope = signedEnvelope (catalog.dump(), signing);
+        checkEnvelopeRejected (envelope, { signing.key }, "payload: root.schema_version");
+    }
+    SECTION ("signed payload is bound to the Dusk catalog identity")
+    {
+        auto catalog = validCatalog();
+        catalog["catalog_id"] = "other.catalog";
+        const auto envelope = signedEnvelope (catalog.dump(), signing);
+        checkEnvelopeRejected (envelope, { signing.key },
+                               "payload: root.catalog_id is not dusk.sfz");
+    }
+    SECTION ("signed payload with duplicate keys remains fail-closed")
+    {
+        auto payload = validCatalog().dump();
+        payload.insert (1, R"("catalog_id":"shadow",)");
+        const auto envelope = signedEnvelope (payload, signing);
+        checkEnvelopeRejected (envelope, { signing.key }, "payload: root: duplicate object key");
+    }
+}
+
+TEST_CASE ("SFZ catalog envelope selects only an unambiguous trusted key",
+           "[sfz][catalog][envelope]")
+{
+    const SigningFixture signingA { "catalog-2026-a", 0x2a };
+    const SigningFixture signingB { "catalog-2026-b", 0x5c };
+    auto envelope = signedEnvelope (validCatalog().dump(), signingA);
+
+    SECTION ("unknown key ID")
+    {
+        envelope["key_id"] = "catalog-unknown";
+        checkEnvelopeRejected (envelope, { signingA.key }, "key is not trusted");
+    }
+    SECTION ("rotated key can follow an older trusted key")
+    {
+        const auto rotatedEnvelope = signedEnvelope (validCatalog().dump(), signingB);
+        const auto result = verify (rotatedEnvelope, { signingA.key, signingB.key });
+        REQUIRE (result);
+        CHECK (result.verifiedKeyId == signingB.key.id);
+    }
+    SECTION ("known ID with the wrong public key")
+    {
+        auto wrongKey = signingB.key;
+        wrongKey.id = signingA.key.id;
+        checkEnvelopeRejected (envelope, { wrongKey }, "signature verification failed");
+    }
+    SECTION ("signature key and declared key differ")
+    {
+        envelope["key_id"] = signingB.key.id;
+        checkEnvelopeRejected (envelope, { signingA.key, signingB.key },
+                               "signature verification failed");
+    }
+    SECTION ("empty registry")
+    {
+        checkEnvelopeRejected (envelope, {}, "trusted_keys");
+    }
+    SECTION ("duplicate registry IDs")
+    {
+        checkEnvelopeRejected (envelope, { signingA.key, signingA.key },
+                               "duplicate key identifier");
+    }
+    SECTION ("duplicate registry key material")
+    {
+        auto alias = signingA.key;
+        alias.id = "catalog-2026-alias";
+        checkEnvelopeRejected (envelope, { signingA.key, alias },
+                               "duplicate public key material");
+    }
+    SECTION ("invalid registry ID")
+    {
+        auto invalid = signingA.key;
+        invalid.id = "Invalid Key";
+        checkEnvelopeRejected (envelope, { invalid }, "invalid key identifier");
+    }
+    SECTION ("all-zero public key")
+    {
+        auto invalid = signingA.key;
+        invalid.publicKey.fill (0);
+        checkEnvelopeRejected (envelope, { invalid }, "invalid public key");
+    }
+    SECTION ("registry has a fixed ceiling")
+    {
+        std::vector<TrustedCatalogKey> keys;
+        for (int i = 0; i < 17; ++i)
+        {
+            auto key = signingA.key;
+            key.id = "catalog-key-" + std::to_string (i);
+            keys.push_back (std::move (key));
+        }
+        checkEnvelopeRejected (envelope, keys, "between 1 and 16 keys");
+    }
+}
+
+TEST_CASE ("SFZ catalog envelope schema is closed and versioned",
+           "[sfz][catalog][envelope]")
+{
+    const SigningFixture signing;
+    auto envelope = signedEnvelope (validCatalog().dump(), signing);
+
+    SECTION ("unknown field")
+    {
+        envelope["future_field"] = true;
+        checkEnvelopeRejected (envelope, { signing.key }, "envelope.future_field");
+    }
+    SECTION ("future schema")
+    {
+        envelope["envelope_schema_version"] = 2;
+        checkEnvelopeRejected (envelope, { signing.key }, "envelope_schema_version");
+    }
+    SECTION ("fractional schema")
+    {
+        envelope["envelope_schema_version"] = 1.0;
+        checkEnvelopeRejected (envelope, { signing.key }, "expected an integer");
+    }
+    SECTION ("algorithm confusion")
+    {
+        envelope["algorithm"] = "Ed25519ph";
+        checkEnvelopeRejected (envelope, { signing.key }, "envelope.algorithm");
+    }
+    SECTION ("invalid key ID")
+    {
+        envelope["key_id"] = "Catalog Key";
+        checkEnvelopeRejected (envelope, { signing.key }, "envelope.key_id");
+    }
+    SECTION ("missing signature")
+    {
+        envelope.erase ("signature_base64");
+        checkEnvelopeRejected (envelope, { signing.key }, "signature_base64");
+    }
+}
+
+TEST_CASE ("SFZ catalog envelope rejects duplicate keys and malformed JSON",
+           "[sfz][catalog][envelope]")
+{
+    const SigningFixture signing;
+
+    SECTION ("duplicate envelope key")
+    {
+        auto source = signedEnvelope (validCatalog().dump(), signing).dump();
+        source.insert (1, R"("algorithm":"shadow",)");
+        const auto result = verifyCatalogEnvelope (source, { signing.key });
+        CHECK_FALSE (result);
+        CHECK (result.error == "envelope: duplicate object key 'algorithm'");
+    }
+    SECTION ("malformed JSON")
+    {
+        CatalogEnvelopeResult result;
+        REQUIRE_NOTHROW (result = verifyCatalogEnvelope ("{not-json", { signing.key }));
+        CHECK_FALSE (result);
+        CHECK (result.error == "envelope: malformed JSON");
+    }
+    SECTION ("non-object root")
+    {
+        const auto result = verifyCatalogEnvelope ("[]", { signing.key });
+        CHECK_FALSE (result);
+        CHECK (result.error == "envelope: expected an object");
+    }
+}
+
+TEST_CASE ("SFZ catalog envelope requires canonical bounded base64",
+           "[sfz][catalog][envelope]")
+{
+    const SigningFixture signing;
+    auto envelope = signedEnvelope (validCatalog().dump(), signing);
+
+    SECTION ("signature whitespace")
+    {
+        envelope["signature_base64"] =
+            envelope["signature_base64"].get<std::string>() + " ";
+        checkEnvelopeRejected (envelope, { signing.key }, "signature_base64");
+    }
+    SECTION ("signature padding is required")
+    {
+        auto& encoded = envelope["signature_base64"].get_ref<std::string&>();
+        REQUIRE (encoded.back() == '=');
+        encoded.pop_back();
+        checkEnvelopeRejected (envelope, { signing.key }, "signature_base64");
+    }
+    SECTION ("signature has exact decoded length")
+    {
+        const std::array<unsigned char, 63> shortSignature {};
+        envelope["signature_base64"] = encodeBase64 (
+            shortSignature.data(), shortSignature.size());
+        checkEnvelopeRejected (envelope, { signing.key }, "must be 64 bytes");
+    }
+    SECTION ("payload base64 is syntactically valid")
+    {
+        envelope["payload_base64"] = "***=";
+        checkEnvelopeRejected (envelope, { signing.key }, "payload_base64");
+    }
+}
+
+TEST_CASE ("SFZ catalog envelope bounds raw input before parsing",
+           "[sfz][catalog][envelope]")
+{
+    const std::string oversized (12 * 1024 * 1024 + 1, ' ');
+    CatalogEnvelopeResult result;
+    REQUIRE_NOTHROW (result = verifyCatalogEnvelope (oversized, {}));
+    CHECK_FALSE (result);
+    CHECK (result.error == "envelope: exceeds the 12 MiB limit");
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,6 +8,7 @@
         "mpeg"
       ]
     },
+    "libsodium",
     "mp3lame"
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for parsing and validating SFZ catalog metadata.
  * Added signed catalog verification using trusted Ed25519 keys.
  * Added strict validation for catalog structure, fields, URLs, hashes, licenses, and metadata.
  * Invalid, malformed, oversized, or untrusted catalogs are rejected safely with clear errors.

* **Documentation**
  * Documented the required Linux cryptographic runtime dependency and licensing information.

* **Build & Testing**
  * Added cross-platform cryptographic library support and comprehensive catalog parsing and signature verification tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->