### PR TITLE
Fix/mininndrum editor

### DIFF
--- a/src/engine/PluginSlot.h
+++ b/src/engine/PluginSlot.h
@@ -85,6 +85,11 @@ public:
 
     bool isLoaded() const noexcept;
     juce::String getLoadedName() const;
+    bool isLoadedStandardVst3() const noexcept
+    {
+        return loadedDescriptor.has_value()
+            && loadedDescriptor->formatName == "VST3";
+    }
 
     void setBypassed (bool shouldBypass) noexcept { bypassed.store (shouldBypass, std::memory_order_relaxed); }
     bool isBypassed() const noexcept             { return bypassed.load (std::memory_order_relaxed); }

--- a/src/engine/vst3/Vst3Editor.cpp
+++ b/src/engine/vst3/Vst3Editor.cpp
@@ -136,6 +136,11 @@ bool Vst3Editor::embed (std::uintptr_t parentHandle, int x, int y, int w, int h,
                               kPlatformTypeX11EmbedWindowID) != kResultOk)
     { errorOut = "IPlugView::attached failed"; close(); return false; }
 
+    // Some VSTGUI editors attach an unmapped child, so mapping only the host
+    // container leaves their editor permanently black.
+    XMapSubwindows (dpy, (Window) impl->hostWindow);
+    XSync (dpy, False);
+
     // attached() may have re-decided the size (resizeView fires synchronously
     // through the frame) - re-query so the owner adopts the real one.
     ViewRect size {};

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -42,6 +42,9 @@ namespace duskstudio
 
 namespace
 {
+constexpr const char* kPeerBoundStandardVst3EditorTag =
+    "dusk_peerBoundStandardVst3Editor";
+
 // clamp with jlimit's argument order (lo, hi, value).
 template <typename T>
 inline T jlimit (T lo, T hi, T value) noexcept { return std::clamp (value, lo, std::max (lo, hi)); }
@@ -2311,12 +2314,14 @@ void ChannelStripComponent::parentHierarchyChanged()
     // replacement arrives. Keep cached editors alive across that null interval,
     // and rebuild only when there is a genuinely different realised peer.
     const auto& modalStack = EmbeddedModal::activeModalStack();
+    const bool pluginEditorModalIsTopmost = ! modalStack.empty()
+        && modalStack.back() == &pluginEditorModal;
     auto* peer = getPeer();
     const auto transition = observeNativeEditorPeer (
         lastSeenPeerId,
         peer != nullptr ? peer->getUniqueID() : 0,
         static_cast<const void*> (pluginEditorModal.getBody()),
-        ! modalStack.empty() && modalStack.back() == &pluginEditorModal,
+        pluginEditorModalIsTopmost,
         {
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
             static_cast<const void*> (clapEditor.get()),
@@ -2331,17 +2336,29 @@ void ChannelStripComponent::parentHierarchyChanged()
             static_cast<const void*> (auEditor.get()),
 #endif
         });
+    const bool isPeerBoundStandardVst3 = pluginEditor != nullptr
+        && (bool) pluginEditor->getProperties().getWithDefault (
+            kPeerBoundStandardVst3EditorTag, false);
+    const auto standardVst3Reborrow = decidePeerBoundEditorReborrow (
+        isPeerBoundStandardVst3,
+        pluginEditorModal.getBody() == pluginEditor.get(),
+        transition.rebuildNativeEditors,
+        pluginEditorModalIsTopmost,
+        pluginEditorModalIsTopmost,
+        pluginEditorModal.showGeneration(),
+        pluginEditorModal.showGeneration());
 
     if (! transition.rebuildNativeEditors)
         return;
 
-    // Only reopen when the modal is actually borrowing one of the native editor
-    // bodies. JUCE, OOP and multisample editors do not use these wrappers and
-    // must remain undisturbed by this native-peer repair path.
+    // Only reopen when the modal is actually borrowing one of the peer-bound
+    // editor bodies. OOP and multisample editors do not use these wrappers and
+    // must remain undisturbed by this peer-repair path.
     // EmbeddedModal borrows its body, so detach it before destroying a wrapper.
     // Hidden cached wrappers also need rebuilding: their native child remains
     // tied to the old peer even though the modal is currently closed.
-    if (transition.reopenNativeEditorNow || transition.deferNativeEditorReopen)
+    if (transition.reopenNativeEditorNow || transition.deferNativeEditorReopen
+        || standardVst3Reborrow.reopenNow || standardVst3Reborrow.deferReopen)
         pluginEditorModal.close();
 
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
@@ -2357,9 +2374,9 @@ void ChannelStripComponent::parentHierarchyChanged()
     auEditor.reset();
 #endif
 
-    if (transition.deferNativeEditorReopen)
+    if (standardVst3Reborrow.deferReopen || transition.deferNativeEditorReopen)
         nativeEditorReopenPending = true;
-    else if (transition.reopenNativeEditorNow)
+    else if (standardVst3Reborrow.reopenNow || transition.reopenNativeEditorNow)
     {
         nativeEditorReopenPending = false;
         openPluginEditor();
@@ -2647,10 +2664,20 @@ void ChannelStripComponent::openPluginEditor()
             fresh.reset (instance->createEditorIfNeeded());
             duskstudio::platform::clearPreferX11ForNativeWindow();
         }
+        const bool isCustomEditor = fresh != nullptr;
         if (fresh == nullptr)
             fresh = std::make_unique<juce::GenericAudioProcessorEditor> (*instance);
         pluginEditor      = std::move (fresh);
         pluginEditorOwner = instance;
+#if JUCE_LINUX
+        constexpr bool isLinux = true;
+#else
+        constexpr bool isLinux = false;
+#endif
+        pluginEditor->getProperties().set (
+            kPeerBoundStandardVst3EditorTag,
+            isPeerBoundStandardVst3Editor (
+                isLinux, pluginSlot.isLoadedStandardVst3(), isCustomEditor));
     }
 
     // Tag so EmbeddedModal hides the editor when a settings / quit /
@@ -2658,7 +2685,41 @@ void ChannelStripComponent::openPluginEditor()
     // foreign-window embeds can paint above the modal otherwise.
     pluginEditor->getProperties().set (kPluginEditorTag, true);
 
-    pluginEditorModal.showBorrowed (*parent, *pluginEditor, onClose);
+    auto* expectedEditor = pluginEditor.get();
+    auto onEditorHostResized = [safe, expectedEditor] (
+        unsigned long long borrowGeneration, bool editorWasTopmost)
+    {
+        dusk::callAsync ([safe, expectedEditor, borrowGeneration, editorWasTopmost]
+        {
+            auto* self = safe.getComponent();
+            if (self == nullptr || self->pluginEditor.get() != expectedEditor)
+                return;
+
+            const bool isPeerBoundStandardVst3 = (bool) expectedEditor
+                ->getProperties().getWithDefault (
+                    kPeerBoundStandardVst3EditorTag, false);
+            const auto& modalStack = EmbeddedModal::activeModalStack();
+            const bool editorIsCurrentlyTopmost = ! modalStack.empty()
+                && modalStack.back() == &self->pluginEditorModal;
+            const auto disposition = decidePeerBoundEditorReborrow (
+                    isPeerBoundStandardVst3,
+                    self->pluginEditorModal.getBody() == expectedEditor,
+                    true,
+                    editorWasTopmost,
+                    editorIsCurrentlyTopmost,
+                    borrowGeneration,
+                    self->pluginEditorModal.showGeneration());
+            if (! disposition.reopenNow && ! disposition.deferReopen)
+                return;
+
+            self->pluginEditorModal.close();
+            self->nativeEditorReopenPending = disposition.deferReopen;
+            if (disposition.reopenNow)
+                self->openPluginEditor();
+        });
+    };
+    pluginEditorModal.showBorrowed (*parent, *pluginEditor, onClose,
+                                    std::move (onEditorHostResized));
 }
 
 void ChannelStripComponent::closePluginEditor()

--- a/src/ui/EmbeddedModal.h
+++ b/src/ui/EmbeddedModal.h
@@ -255,7 +255,7 @@ public:
     {
         if (auto hook = beforeModalShown()) hook();
         close();
-        ++modalGeneration();
+        showGeneration_ = ++modalGeneration();
         host = &parent;
         body_ = std::move (body);
         userOnDismiss = std::move (onDismiss);
@@ -334,11 +334,12 @@ public:
     // it as a child is significantly more stable.
     void showBorrowed (juce::Component& parent,
                        juce::Component& body,
-                       std::function<void()> onDismiss = {})
+                       std::function<void()> onDismiss = {},
+                       std::function<void (unsigned long long, bool)> onHostResized = {})
     {
         if (auto hook = beforeModalShown()) hook();
         close();
-        ++modalGeneration();
+        showGeneration_ = ++modalGeneration();
         host = &parent;
         borrowedBody_ = &body;
         // Borrowed modals are plugin editors: always forward transport shortcuts
@@ -351,6 +352,7 @@ public:
         dim_ = std::make_unique<DimOverlay> (kEditorDimAlpha);
         dim_->setBounds (parent.getLocalBounds());
         userOnDismiss = std::move (onDismiss);
+        borrowedHostResized = std::move (onHostResized);
         dim_->onClick = [this]
         {
             // See owning show()'s onClick - topmost-only guard + local copy
@@ -376,6 +378,11 @@ public:
         parent.addAndMakeVisible (backdrop_.get());
 
         body.setBounds (bodyBounds);
+        // Install before attachment: native/custom editors can synchronously
+        // announce their real size while addAndMakeVisible creates the peer.
+        // Missing that first resize leaves the new extent anchored at the old
+        // centred top-left until the editor is closed and shown again.
+        body.addComponentListener (this);
         parent.addAndMakeVisible (&body);
         dim_     ->toFront (false);
         backdrop_->toFront (false);
@@ -387,7 +394,6 @@ public:
         // window embeds (after this show) and can rescale live from
         // their own UI - track it, or the body grows down-right from
         // the stale centre and the backdrop stays at the old size.
-        body.addComponentListener (this);
         // Track the host too: resizing the main window with an editor
         // open otherwise leaves the modal at the old centre, clipped at
         // the new edges. Borrowed-only - owned bodies include anchored
@@ -454,6 +460,7 @@ public:
             dim_.reset();
             userOnDismiss = {};
             userOnDismissOutside = {};
+            borrowedHostResized = {};
             return;
         }
 
@@ -543,6 +550,7 @@ public:
         host = nullptr;
         userOnDismiss = {};
         userOnDismissOutside = {};
+        borrowedHostResized = {};
     }
 
     // Shutdown-only teardown. close() defers body destruction to the
@@ -584,9 +592,11 @@ public:
         host = nullptr;
         userOnDismiss = {};
         userOnDismissOutside = {};
+        borrowedHostResized = {};
     }
 
     bool isOpen() const noexcept { return body_ != nullptr || borrowedBody_ != nullptr; }
+    unsigned long long showGeneration() const noexcept { return showGeneration_; }
 
     juce::Component* getBody() const noexcept
     {
@@ -731,6 +741,10 @@ private:
             recenterBody();
             if (dim_ != nullptr && host != nullptr)
                 dim_->setBounds (host->getLocalBounds());
+            if (&c == host.getComponent())
+                if (auto callback = borrowedHostResized)
+                    callback (showGeneration_, ! activeModalStack().empty()
+                                                   && activeModalStack().back() == this);
         }
     }
 
@@ -764,6 +778,8 @@ private:
     juce::Component* borrowedBody_ = nullptr;
     std::function<void()> userOnDismiss;
     std::function<void()> userOnDismissOutside;
+    std::function<void (unsigned long long, bool)> borrowedHostResized;
+    unsigned long long showGeneration_ = 0;
     bool escapeDismisses = true;
     bool forwardShortcuts_ = true;
     bool listeningForOutsideClicks = false;

--- a/src/ui/NativeEditorOwner.h
+++ b/src/ui/NativeEditorOwner.h
@@ -68,6 +68,36 @@ struct NativeEditorPeerTransition
     bool deferNativeEditorReopen = false;
 };
 
+inline bool isPeerBoundStandardVst3Editor (bool isLinux,
+                                           bool isStandardVst3,
+                                           bool isCustomEditor) noexcept
+{
+    return isLinux && isStandardVst3 && isCustomEditor;
+}
+
+struct PeerBoundEditorReborrowDisposition
+{
+    bool reopenNow = false;
+    bool deferReopen = false;
+};
+
+inline PeerBoundEditorReborrowDisposition decidePeerBoundEditorReborrow (
+    bool isPeerBoundEditor,
+    bool editorIsVisible,
+    bool editorHostChanged,
+    bool editorWasTopmost,
+    bool editorIsCurrentlyTopmost,
+    std::uint64_t queuedBorrowGeneration,
+    std::uint64_t currentBorrowGeneration) noexcept
+{
+    if (! isPeerBoundEditor || ! editorIsVisible || ! editorHostChanged
+        || queuedBorrowGeneration != currentBorrowGeneration)
+        return {};
+
+    const bool reopenNow = editorWasTopmost && editorIsCurrentlyTopmost;
+    return { reopenNow, ! reopenNow };
+}
+
 inline NativeEditorPeerTransition observeNativeEditorPeer (
     std::uint32_t& lastPeerId,
     std::uint32_t currentPeerId,

--- a/tests/native_editor_owner.cpp
+++ b/tests/native_editor_owner.cpp
@@ -250,7 +250,7 @@ TEST_CASE ("Native editor peer transitions preserve realised peer identity")
     REQUIRE (lastPeerId == peerBId);
 }
 
-TEST_CASE ("Native editor peer transitions reopen only a borrowed native body")
+TEST_CASE ("Native editor peer transitions reopen only a borrowed peer-bound body")
 {
     constexpr std::uint32_t oldPeerId = 41;
     constexpr std::uint32_t newPeerId = 42;
@@ -295,5 +295,89 @@ TEST_CASE ("Native editor peer transitions reopen only a borrowed native body")
         REQUIRE (transition.rebuildNativeEditors);
         REQUIRE_FALSE (transition.reopenNativeEditorNow);
         REQUIRE_FALSE (transition.deferNativeEditorReopen);
+    }
+}
+
+TEST_CASE ("Only Linux custom standard VST3 editors are peer-bound")
+{
+    for (const bool isLinux : { false, true })
+        for (const bool isStandardVst3 : { false, true })
+            for (const bool isCustomEditor : { false, true })
+                CHECK (duskstudio::isPeerBoundStandardVst3Editor (
+                           isLinux, isStandardVst3, isCustomEditor)
+                       == (isLinux && isStandardVst3 && isCustomEditor));
+}
+
+TEST_CASE ("Peer-bound editor reborrow preserves disposition and rejects stale callbacks")
+{
+    constexpr std::uint64_t currentBorrowGeneration = 42;
+    for (const bool isPeerBoundEditor : { false, true })
+        for (const bool editorIsVisible : { false, true })
+            for (const bool editorHostChanged : { false, true })
+                for (const bool editorWasTopmost : { false, true })
+                    for (const bool editorIsCurrentlyTopmost : { false, true })
+                    {
+                        const auto disposition = duskstudio::decidePeerBoundEditorReborrow (
+                            isPeerBoundEditor, editorIsVisible, editorHostChanged,
+                            editorWasTopmost, editorIsCurrentlyTopmost,
+                            currentBorrowGeneration, currentBorrowGeneration);
+                        const bool shouldReborrow = isPeerBoundEditor
+                            && editorIsVisible && editorHostChanged;
+                        const bool reopenNow = shouldReborrow && editorWasTopmost
+                            && editorIsCurrentlyTopmost;
+                        CHECK (disposition.reopenNow == reopenNow);
+                        CHECK (disposition.deferReopen
+                               == (shouldReborrow && ! reopenNow));
+                    }
+
+    const auto stale = duskstudio::decidePeerBoundEditorReborrow (
+        true, true, true, true, true,
+        currentBorrowGeneration - 1, currentBorrowGeneration);
+    CHECK_FALSE (stale.reopenNow);
+    CHECK_FALSE (stale.deferReopen);
+
+    const auto newlyCovered = duskstudio::decidePeerBoundEditorReborrow (
+        true, true, true, true, false,
+        currentBorrowGeneration, currentBorrowGeneration);
+    CHECK_FALSE (newlyCovered.reopenNow);
+    CHECK (newlyCovered.deferReopen);
+
+    const auto originallyCovered = duskstudio::decidePeerBoundEditorReborrow (
+        true, true, true, false, true,
+        currentBorrowGeneration, currentBorrowGeneration);
+    CHECK_FALSE (originallyCovered.reopenNow);
+    CHECK (originallyCovered.deferReopen);
+}
+
+TEST_CASE ("Stacked standard and native editors preserve the prior top editor")
+{
+    int nativeEditor = 0;
+
+    SECTION ("top native editor reopens before covered standard editor")
+    {
+        const auto standardDisposition = duskstudio::decidePeerBoundEditorReborrow (
+            true, true, true, false, false, 42, 42);
+        std::uint32_t lastPeerId = 41;
+        const auto nativeTransition = duskstudio::observeNativeEditorPeer (
+            lastPeerId, 42, &nativeEditor, true, { &nativeEditor });
+
+        REQUIRE (standardDisposition.deferReopen);
+        REQUIRE_FALSE (standardDisposition.reopenNow);
+        REQUIRE (nativeTransition.reopenNativeEditorNow);
+        REQUIRE_FALSE (nativeTransition.deferNativeEditorReopen);
+    }
+
+    SECTION ("top standard editor reopens before covered native editor")
+    {
+        std::uint32_t lastPeerId = 41;
+        const auto nativeTransition = duskstudio::observeNativeEditorPeer (
+            lastPeerId, 42, &nativeEditor, false, { &nativeEditor });
+        const auto standardDisposition = duskstudio::decidePeerBoundEditorReborrow (
+            true, true, true, true, true, 42, 42);
+
+        REQUIRE (nativeTransition.deferNativeEditorReopen);
+        REQUIRE_FALSE (nativeTransition.reopenNativeEditorNow);
+        REQUIRE (standardDisposition.reopenNow);
+        REQUIRE_FALSE (standardDisposition.deferReopen);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when reopening embedded Standard VST3 editors after window or host resizing.
  * Preserved editor visibility, focus, stacking order, and modal behavior during peer changes.
  * Prevented stale editor callbacks from reopening outdated editor instances.
  * Ensured embedded VST3 views display correctly on Linux.

* **Tests**
  * Added coverage for editor reopening, resizing, visibility, stacking order, and stale callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->