### PR TITLE
Load GL 3.x entry points for the ImGui notepad backend on Windows

### DIFF
--- a/.github/actions/clone-dpf-stack/action.yml
+++ b/.github/actions/clone-dpf-stack/action.yml
@@ -17,7 +17,7 @@ runs:
         DPF_REPO: https://github.com/dusk-audio/DPF.git
         DPF_REV: f9fbc62af6fa7ce638a6f1e1482896c385a4955e
         DPF_WIDGETS_REPO: https://github.com/dusk-audio/DPF-Widgets.git
-        DPF_WIDGETS_REV: 730da6397904da66d99667c1cb30fc77fc3d794a
+        DPF_WIDGETS_REV: 668de17f06abdeb98d5a4b62594bd634f8d1ac2e
       run: |
         set -euo pipefail
         git init -q "${RUNNER_TEMP}/DPF"

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -144,6 +144,14 @@ jobs:
         shell: bash
         run: cmake --build build-tests --config Release --target dusk-studio-tests -j
 
+      - name: Build the native notepad UI
+        # The Catch2 target does not reach the DPF/DGL + Dear ImGui notepad, so
+        # nothing on a push ever compiled it on MSVC - the ImGui OpenGL3 backend
+        # failing to build here only surfaced in windows-build.yml, which runs on
+        # a release tag. Compiling the one target keeps that off tag day.
+        shell: bash
+        run: cmake --build build-tests --config Release --target dusk_notepad_ui -j
+
       - name: Run tests
         # Full Catch2 suite on MSVC, minus the FileImporter cases. Those write
         # a temp WAV and immediately re-open it; on the GitHub windows-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -477,6 +477,22 @@ if(DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD)
         "${DUSKSTUDIO_DPF_WIDGETS_SOURCE_DIR}/opengl/DearImGui.cpp")
     target_include_directories(dusk_notepad_ui PRIVATE
         "${DUSKSTUDIO_DPF_WIDGETS_SOURCE_DIR}/opengl")
+
+    if(MSVC)
+        # Windows' GL header and opengl32 stop at OpenGL 1.1, and DPF-Widgets hands Dear
+        # ImGui's OpenGL3 backend a "custom loader" (DGL's OpenGL.hpp) that carries GL 3.x
+        # prototypes on Linux and macOS only - so DearImGui.cpp does not compile here at
+        # all. Force-include a loader that resolves those entry points through
+        # wglGetProcAddress, the way DGL resolves its own. The header is named without a
+        # path so cl finds it on the include path; a /FI carrying an absolute path breaks
+        # on a source tree whose path contains spaces.
+        target_sources(dusk_notepad_ui PRIVATE src/ui/ImGuiGlLoaderWin32.cpp)
+        target_include_directories(dusk_notepad_ui PRIVATE src/ui)
+        set_source_files_properties(
+            "${DUSKSTUDIO_DPF_WIDGETS_SOURCE_DIR}/opengl/DearImGui.cpp"
+            PROPERTIES COMPILE_OPTIONS "/FIImGuiGlLoaderWin32.h")
+    endif()
+
     target_link_libraries(dusk_notepad_ui PRIVATE
         dgl-opengl3
         dgl-opengl3-definitions

--- a/src/ui/ImGuiGlLoaderWin32.cpp
+++ b/src/ui/ImGuiGlLoaderWin32.cpp
@@ -1,0 +1,22 @@
+#if defined(_WIN32)
+
+#ifndef WIN32_LEAN_AND_MEAN
+# define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+# define NOMINMAX
+#endif
+#include <windows.h>
+
+#include "ImGuiGlLoaderWin32.h"
+
+namespace duskstudio::glloader {
+
+ProcPtr procAddress(const char* const name)
+{
+    return reinterpret_cast<ProcPtr>(::wglGetProcAddress(name));
+}
+
+}
+
+#endif

--- a/src/ui/ImGuiGlLoaderWin32.h
+++ b/src/ui/ImGuiGlLoaderWin32.h
@@ -1,0 +1,90 @@
+#pragma once
+
+// Windows' GL header and opengl32 stop at OpenGL 1.1, so every GL 3.x entry point Dear
+// ImGui's OpenGL3 backend calls is undeclared and unlinkable there. DPF-Widgets compiles
+// that backend with IMGUI_IMPL_OPENGL_LOADER_CUSTOM (opengl/DearImGui.cpp) and points it at
+// DGL's OpenGL.hpp, which carries the prototypes on Linux and macOS only.
+//
+// Resolve the entry points the way DGL resolves its own (dgl/src/OpenGL3.cpp), except on
+// first use: this translation unit is reached from the render path, not from context
+// creation, so there is no one place to load them from.
+//
+// Force-included into the DearImGui.cpp compile - see the notepad block in CMakeLists.txt.
+
+#if defined(_WIN32)
+
+#include "OpenGL-include.hpp"
+
+#include <utility>
+
+namespace duskstudio::glloader {
+
+using ProcPtr = void (*)();
+
+ProcPtr procAddress(const char* name);
+
+template <typename Fn>
+struct GlProc
+{
+    const char* const name;
+    Fn fn = nullptr;
+
+    template <typename... Args>
+    auto operator()(Args... args) -> decltype(std::declval<Fn>()(args...))
+    {
+        if (fn == nullptr)
+            fn = reinterpret_cast<Fn>(procAddress(name));
+
+        // An unresolved entry point costs the drawing; calling through the null pointer
+        // would cost the app.
+        if (fn == nullptr)
+            return decltype(std::declval<Fn>()(args...))();
+
+        return fn(args...);
+    }
+};
+
+}
+
+#define DUSK_GL_PROC(type, name) inline duskstudio::glloader::GlProc<type> name { #name };
+
+DUSK_GL_PROC(PFNGLACTIVETEXTUREPROC,            glActiveTexture)
+DUSK_GL_PROC(PFNGLATTACHSHADERPROC,             glAttachShader)
+DUSK_GL_PROC(PFNGLBINDBUFFERPROC,               glBindBuffer)
+DUSK_GL_PROC(PFNGLBINDSAMPLERPROC,              glBindSampler)
+DUSK_GL_PROC(PFNGLBINDVERTEXARRAYPROC,          glBindVertexArray)
+DUSK_GL_PROC(PFNGLBLENDEQUATIONPROC,            glBlendEquation)
+DUSK_GL_PROC(PFNGLBLENDEQUATIONSEPARATEPROC,    glBlendEquationSeparate)
+DUSK_GL_PROC(PFNGLBLENDFUNCSEPARATEPROC,        glBlendFuncSeparate)
+DUSK_GL_PROC(PFNGLBUFFERDATAPROC,               glBufferData)
+DUSK_GL_PROC(PFNGLBUFFERSUBDATAPROC,            glBufferSubData)
+DUSK_GL_PROC(PFNGLCOMPILESHADERPROC,            glCompileShader)
+DUSK_GL_PROC(PFNGLCREATEPROGRAMPROC,            glCreateProgram)
+DUSK_GL_PROC(PFNGLCREATESHADERPROC,             glCreateShader)
+DUSK_GL_PROC(PFNGLDELETEBUFFERSPROC,            glDeleteBuffers)
+DUSK_GL_PROC(PFNGLDELETEPROGRAMPROC,            glDeleteProgram)
+DUSK_GL_PROC(PFNGLDELETESHADERPROC,             glDeleteShader)
+DUSK_GL_PROC(PFNGLDELETEVERTEXARRAYSPROC,       glDeleteVertexArrays)
+DUSK_GL_PROC(PFNGLDETACHSHADERPROC,             glDetachShader)
+DUSK_GL_PROC(PFNGLDRAWELEMENTSBASEVERTEXPROC,   glDrawElementsBaseVertex)
+DUSK_GL_PROC(PFNGLENABLEVERTEXATTRIBARRAYPROC,  glEnableVertexAttribArray)
+DUSK_GL_PROC(PFNGLGENBUFFERSPROC,               glGenBuffers)
+DUSK_GL_PROC(PFNGLGENVERTEXARRAYSPROC,          glGenVertexArrays)
+DUSK_GL_PROC(PFNGLGETATTRIBLOCATIONPROC,        glGetAttribLocation)
+DUSK_GL_PROC(PFNGLGETPROGRAMINFOLOGPROC,        glGetProgramInfoLog)
+DUSK_GL_PROC(PFNGLGETPROGRAMIVPROC,             glGetProgramiv)
+DUSK_GL_PROC(PFNGLGETSHADERINFOLOGPROC,         glGetShaderInfoLog)
+DUSK_GL_PROC(PFNGLGETSHADERIVPROC,              glGetShaderiv)
+DUSK_GL_PROC(PFNGLGETSTRINGIPROC,               glGetStringi)
+DUSK_GL_PROC(PFNGLGETUNIFORMLOCATIONPROC,       glGetUniformLocation)
+DUSK_GL_PROC(PFNGLISPROGRAMPROC,                glIsProgram)
+DUSK_GL_PROC(PFNGLLINKPROGRAMPROC,              glLinkProgram)
+DUSK_GL_PROC(PFNGLSHADERSOURCEPROC,             glShaderSource)
+DUSK_GL_PROC(PFNGLUNIFORM1IPROC,                glUniform1i)
+DUSK_GL_PROC(PFNGLUNIFORMMATRIX4FVPROC,         glUniformMatrix4fv)
+DUSK_GL_PROC(PFNGLUSEPROGRAMPROC,               glUseProgram)
+DUSK_GL_PROC(PFNGLVERTEXATTRIBPOINTERPROC,      glVertexAttribPointer)
+
+#undef DUSK_GL_PROC
+
+#endif


### PR DESCRIPTION
Closes #257.

The Windows MSI build fails on main: imgui_impl_opengl3.cpp in the pinned DPF-Widgets hits ~68 C3861 errors under MSVC because DGL substitutes itself as the ImGui custom GL loader (IMGUI_IMPL_OPENGL_LOADER_CUSTOM) and defines GL_GLEXT_PROTOTYPES only on non-Windows platforms, leaving MSVC with GL 1.1 prototypes only. DGL resolves its own GL3 calls through wglGetProcAddress at context creation; the ImGui translation unit never got the same treatment. The workflow that would have caught this (windows-build.yml) is tag-only and has not built main since the notepad landed, so a v0.13.0 tag today fails.

Fix, Dusk-side only (no DPF-Widgets fork change, no pin bump):

- src/ui/ImGuiGlLoaderWin32.h declares the 36 post-GL-1.1 functions the ImGui backend calls as GlProc shims that resolve through wglGetProcAddress on first call. Resolution only ever happens inside pugl's draw callback where the GL context is current, the same guarantee DGL's own loader relies on. The per-object function-pointer member is load-bearing: five of the shimmed functions share one PFN typedef, so a static-local cache inside the call operator would alias them.
- src/ui/ImGuiGlLoaderWin32.cpp is the only translation unit that includes windows.h, keeping the ImGui TU's header ordering untouched.
- CMakeLists.txt force-includes the header into DearImGui.cpp with /FI under MSVC only.
- windows-tests.yml gains a dusk_notepad_ui build step, so this class of break now fails on every PR to main instead of on tag day. That step is also this PR's direct validation: it is the first MSVC compile of the notepad target since the failure was found.

The 36-name set was verified complete by scripted audit of every GL call in imgui_impl_opengl3.cpp and DearImGui.cpp against the PFN typedefs in DPF's vendored glext.h; the three GL 2.0 vertex-attrib functions that look missing live in the ES2-only VtxAttribState path, which desktop GL3 compiles out.

Verification: Linux dusk_notepad_ui builds clean with zero warnings (the Win32 loader source is excluded there), juce-gate passes unchanged. MSVC cannot be compiled locally; the windows-tests run on this PR is the proof, and a full MSI dry run is available via gh workflow run windows-build.yml --ref fix/257-msvc-imgui-gl-loader.