### PR TITLE
Fix Windows plugin scanning and SFZ loading failures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1110,7 +1110,9 @@ if(_duskstudio_oop_enabled)
         juce::juce_recommended_config_flags
         juce::juce_recommended_warning_flags)
     if(WIN32)
-        target_link_libraries(dusk-studio-plugin-host PRIVATE synchronization)
+        # shell32: CommandLineToArgvW, which the child uses to read its own
+        # arguments as UTF-16 instead of trusting the ANSI-converted argv.
+        target_link_libraries(dusk-studio-plugin-host PRIVATE synchronization shell32)
     endif()
     target_include_directories(dusk-studio-plugin-host PRIVATE src)
     target_include_directories(dusk-studio-plugin-host SYSTEM PRIVATE external/json)

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1594,6 +1594,8 @@ When a `.sf2` holds more than one preset (most GM/GS/XG SoundFonts do), a **pres
 
 The loaded file path and the chosen preset are saved with the session.
 
+If a soundfont can't be loaded — a corrupt file, or an `.sfz` whose `sample=` files aren't sitting next to it — the slot is left empty and the editor shows the reason, rather than holding an instrument that makes no sound.
+
 \newpage
 
 # Hardware inserts

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2163,11 +2163,12 @@ If the disconnect happened during a take, the WAV that was being written is comm
 
 ## Audio device in use, or won't open at startup
 
-If the interface saved in your settings is held by another application when Dusk Studio launches — PipeWire or the JACK/PipeWire server, another DAW (Ardour, Reaper), a screen recorder, or browser audio holding the device in exclusive mode — Dusk Studio can't open it. Rather than load a silent, dead session, it recovers and tells you what happened:
+If the interface saved in your settings is held by another application when Dusk Studio launches — PipeWire or the JACK/PipeWire server, an ASIO driver another DAW already opened, a screen recorder, or browser audio holding the device in exclusive mode — Dusk Studio can't open it. Rather than load a silent, dead session, it recovers and tells you what happened:
 
-- It tries the PipeWire backend, then the next available device. PipeWire can still reach an interface that another PipeWire client is using, since they share the graph; but if something holds the raw ALSA device exclusively (a JACK server, or an app talking to the hardware directly), PipeWire is locked out too and the fallback moves on to the next device.
+- On Linux it tries the PipeWire backend, then each ALSA device in turn. PipeWire can still reach an interface that another PipeWire client is using, since they share the graph; but if something holds the raw ALSA device exclusively (a JACK server, or an app talking to the hardware directly), PipeWire is locked out too and the fallback moves on.
+- On any platform, the last resort is the default device of every other backend that is present — on Windows that's what carries you off a busy or powered-down ASIO driver onto shared Windows Audio.
 - If that lands on a **different** working device, you keep working and see *"Your saved audio device … could not be opened … audio has switched to …"*. Your saved device is **not** changed — it's tried again on the next launch once you free it.
-- If nothing opens, you get a clear warning: the playhead and meters won't move and recording is disabled until a device is available.
+- If nothing opens, you get a clear warning. With no device open the playhead and meters won't move, recording is disabled, and plugin and soundfont loading is refused — the channel strips take their sample rate and block size from the running device, so there is nothing to prepare an insert against until one opens.
 
 Either way, free the device in the other app (or run `pactl suspend-sink <sink-name> 1` to release a PipeWire/PulseAudio hold), then pick it again in **Settings → Audio**. Your saved device returns automatically next launch once it's free.
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1594,7 +1594,7 @@ When a `.sf2` holds more than one preset (most GM/GS/XG SoundFonts do), a **pres
 
 The loaded file path and the chosen preset are saved with the session.
 
-If a soundfont can't be loaded — a corrupt file, or an `.sfz` whose `sample=` files aren't sitting next to it — the slot is left empty and the editor shows the reason, rather than holding an instrument that makes no sound.
+If a soundfont can't be loaded — a corrupt file, or an `.sfz` whose `sample=` files can't be found or read — the slot is left empty and the editor shows the reason, rather than holding an instrument that makes no sound.
 
 \newpage
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -1,5 +1,26 @@
 #include "DuskStudioApp.h"
 
+#if defined (_WIN32)
+#include <clocale>
+
+namespace
+{
+// Dusk Studio hands vendored libraries UTF-8 paths, but MSVC decodes a narrow
+// path with the CRT code page - the ANSI one unless told otherwise. sfizz is
+// where that bites: its C entry points take const char* and convert through
+// std::filesystem, so a soundfont anywhere under a non-ASCII path (an accented
+// user name is enough) fails to load even though the file opens fine through
+// the wide Win32 API. LC_CTYPE only - LC_NUMERIC must stay in the C locale or
+// every decimal number the session writes would follow the user's regional
+// separator.
+struct UseUtf8ForNarrowPaths
+{
+    UseUtf8ForNarrowPaths() { std::setlocale (LC_CTYPE, ".UTF8"); }
+};
+const UseUtf8ForNarrowPaths useUtf8ForNarrowPaths;
+} // namespace
+#endif
+
 #if defined (__linux__)
 #include <cerrno>
 #include <cstdlib>

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -537,16 +537,17 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
                       err.c_str());
     }
 
-   #if defined(DUSKSTUDIO_HAS_ALSA)
-    // The saved setup can pin an ALSA hw: device that another app (PipeWire,
-    // JACK, another DAW) holds exclusively. JUCE's selectDefaultDeviceOnFailure
-    // only re-picks another device NAME on the same ALSA type - the same hw
-    // conflict - so it never falls through to the graph. Recover explicitly: the
-    // native PipeWire backend (reaches the interface through the graph even while
-    // the raw hw handle is held) -> the first ALSA device that opens -> give up
-    // and tell the user. This runs BEFORE addCallback / addChangeListener: the audio
-    // thread isn't attached and no change handler is wired yet, so the
-    // setup-switch broadcasts reach no one (no re-entrancy, no fallback loop).
+    // The saved setup can pin a device another app holds exclusively - an ALSA
+    // hw: handle taken by PipeWire/JACK/another DAW, an ASIO driver taken by
+    // whatever the user opened before us. The device manager's
+    // selectDefaultDeviceOnFailure only re-picks another device NAME on the same
+    // type, which is the same conflict, so recover across backends explicitly.
+    // Nothing else in the app works without an open device: the channel strips
+    // are prepared from the device callback, and every plugin and soundfont load
+    // is refused until they are. This runs BEFORE addCallback /
+    // addChangeListener: the audio thread isn't attached and no change handler is
+    // wired yet, so the setup-switch broadcasts reach no one (no re-entrancy, no
+    // fallback loop).
     {
         auto working = [this]
         {
@@ -573,7 +574,7 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
 
             // Clear the pinned (busy) device name + use default channels, else
             // setSetup can short-circuit to a non-started, sr-0 setup.
-            auto openDefaultOnType = [this] (const char* typeName, const std::string& devName)
+            auto openDefaultOnType = [this] (const std::string& typeName, const std::string& devName)
             {
                 deviceManager.setCurrentDeviceType (typeName, /*treatAsChosen*/ true);
                 auto s = deviceManager.getSetup();
@@ -596,6 +597,7 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
 
             // 2) Walk ALSA device names; the busy one fails, the next (Built-in
             //    / HDMI / other interface) opens.
+           #if defined(DUSKSTUDIO_HAS_ALSA)
             if (! working())
                 for (auto* t : deviceManager.getAvailableDeviceTypes())
                 {
@@ -608,6 +610,25 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
                     }
                     break;
                 }
+           #endif
+
+            // 3) Any remaining backend's default device. On Windows this is what
+            //    carries the session off a busy or powered-down ASIO driver onto
+            //    the shared Windows Audio path. The type we are already on is the
+            //    one that just failed - re-opening its default would re-enter the
+            //    same driver (and, for ASIO, its control panel).
+            if (! working())
+            {
+                auto* failedType = deviceManager.getCurrentDeviceType();
+                const std::string failedTypeName =
+                    failedType != nullptr ? failedType->getTypeName() : std::string();
+                for (auto* t : deviceManager.getAvailableDeviceTypes())
+                {
+                    if (t == nullptr || t->getTypeName() == failedTypeName) continue;
+                    openDefaultOnType (t->getTypeName(), {});
+                    if (working()) break;
+                }
+            }
         }
 
         // Resolve the outcome unconditionally: this also catches the case where
@@ -620,7 +641,6 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
         startupDeviceMessage_ = duskstudio::startupDeviceMessage (
             opened, savedName, opened ? dev->getName() : std::string());
     }
-   #endif
 
    #if ! defined(__linux__)
     // The JUCE MIDI fallback drives its input enable/callback lifecycle through

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -572,10 +572,19 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
             // (merely busy) device. Hold persistence until an explicit pick.
             deviceFallbackHold_ = true;
 
+            std::vector<std::string> attemptedTypes;
+            auto attempted = [&attemptedTypes] (const std::string& typeName)
+            {
+                return std::find (attemptedTypes.begin(), attemptedTypes.end(), typeName)
+                         != attemptedTypes.end();
+            };
+
             // Clear the pinned (busy) device name + use default channels, else
             // setSetup can short-circuit to a non-started, sr-0 setup.
-            auto openDefaultOnType = [this] (const std::string& typeName, const std::string& devName)
+            auto openDefaultOnType = [this, &attemptedTypes, &attempted]
+                                     (const std::string& typeName, const std::string& devName)
             {
+                if (! attempted (typeName)) attemptedTypes.push_back (typeName);
                 deviceManager.setCurrentDeviceType (typeName, /*treatAsChosen*/ true);
                 auto s = deviceManager.getSetup();
                 s.inputDeviceName.clear();
@@ -612,19 +621,19 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
                 }
            #endif
 
-            // 3) Any remaining backend's default device. On Windows this is what
-            //    carries the session off a busy or powered-down ASIO driver onto
-            //    the shared Windows Audio path. The type we are already on is the
-            //    one that just failed - re-opening its default would re-enter the
-            //    same driver (and, for ASIO, its control panel).
+            // 3) Any backend not tried above. On Windows this is what carries the
+            //    session off a busy or powered-down ASIO driver onto the shared
+            //    Windows Audio path. A backend that already failed is skipped: a
+            //    second open only repeats the failure, and on an exclusive driver
+            //    it re-enters that driver (and, for ASIO, its control panel).
             if (! working())
             {
-                auto* failedType = deviceManager.getCurrentDeviceType();
-                const std::string failedTypeName =
-                    failedType != nullptr ? failedType->getTypeName() : std::string();
+                if (auto* failedType = deviceManager.getCurrentDeviceType())
+                    if (! attempted (failedType->getTypeName()))
+                        attemptedTypes.push_back (failedType->getTypeName());
                 for (auto* t : deviceManager.getAvailableDeviceTypes())
                 {
-                    if (t == nullptr || t->getTypeName() == failedTypeName) continue;
+                    if (t == nullptr || attempted (t->getTypeName())) continue;
                     openDefaultOnType (t->getTypeName(), {});
                     if (working()) break;
                 }

--- a/src/engine/DeviceFallbackMessage.h
+++ b/src/engine/DeviceFallbackMessage.h
@@ -25,8 +25,9 @@ inline std::string startupDeviceMessage (bool opened,
 
         // Fell back to a different device that works.
         return "Your saved audio device \"" + savedName + "\" could not be opened - it "
-               "may be in use by another application (PipeWire, JACK, browser audio, "
-               "another DAW) or no longer available.\n\nAudio has switched to \"" + actualName
+               "may be in use by another application (another DAW, browser audio, or "
+               "anything holding an exclusive driver) or no longer available.\n\n"
+               "Audio has switched to \"" + actualName
              + "\" so you can keep working. To use your original device, free it in "
                "the other app, then reselect it in Audio Settings. Dusk Studio did not "
                "change your saved device - it will be tried again next launch.";
@@ -36,13 +37,15 @@ inline std::string startupDeviceMessage (bool opened,
     std::string msg = "No audio device could be opened.\n\n";
     if (! savedName.empty())
         msg += "Your saved device \"" + savedName + "\" appears to be in use by another "
-               "application (PipeWire, JACK, browser audio, or another DAW), and no other "
-               "backend opened.";
+               "application, and no other backend opened.";
     else
         msg += "No backend reported an available device.";
-    msg += "\n\nThe playhead and meters will not move and recording is disabled until a "
-           "device is available. Free the device in the other app, then open Audio "
-           "Settings and select one.";
+    // The load guards on every channel-strip insert refuse while the strips have
+    // no sample rate, so name that here - otherwise the only symptom is a plugin
+    // or soundfont that mysteriously won't load.
+    msg += "\n\nThe playhead and meters will not move, recording is disabled, and "
+           "plugins and soundfonts cannot be loaded until a device is open. Free the "
+           "device in the other app, then open Audio Settings and select one.";
     return msg;
 }
 } // namespace duskstudio

--- a/src/engine/PluginManager.h
+++ b/src/engine/PluginManager.h
@@ -28,6 +28,12 @@ public:
     int getLastScanSandboxSkips() const noexcept
     { return lastScanSandboxSkips.load (std::memory_order_relaxed); }
 
+    // Plugins quarantined by an earlier scan (a crash, a hang, or a payload the
+    // child couldn't produce). Every later scan skips them outright, so without
+    // this count a machine that quarantined its library just reports "0 added".
+    int getQuarantinedCount() const
+    { return knownPluginList.getBlacklistedFiles().size(); }
+
     juce::String getHostExecutablePath() const;
 
     std::vector<PluginDescriptor> getInstrumentDescriptions() const;

--- a/src/engine/audiofile/FileReader.cpp
+++ b/src/engine/audiofile/FileReader.cpp
@@ -32,7 +32,15 @@ bool isFloatingPointSubtype (int format) noexcept
 std::unique_ptr<FileReader> FileReader::open (const std::filesystem::path& path)
 {
     SF_INFO si {};
+    // Windows narrows a path through the process ANSI code page in both
+    // path::string() and libsndfile's own open, which loses any character the
+    // code page can't represent - a user profile or sample folder with an
+    // accent then fails to open. The wide entry point keeps the real name.
+   #ifdef _WIN32
+    SNDFILE* h = sf_wchar_open (path.wstring().c_str(), SFM_READ, &si);
+   #else
     SNDFILE* h = sf_open (path.string().c_str(), SFM_READ, &si);
+   #endif
     if (h == nullptr)
         return nullptr;
 

--- a/src/engine/audiofile/FileWriter.cpp
+++ b/src/engine/audiofile/FileWriter.cpp
@@ -43,7 +43,13 @@ std::unique_ptr<FileWriter> FileWriter::create (const std::filesystem::path& pat
     if (sf_format_check (&si) == 0)
         return nullptr;
 
+    // Wide open on Windows for the same reason as FileReader::open: the narrow
+    // path loses every character outside the process ANSI code page.
+   #ifdef _WIN32
+    SNDFILE* h = sf_wchar_open (path.wstring().c_str(), SFM_WRITE, &si);
+   #else
     SNDFILE* h = sf_open (path.string().c_str(), SFM_WRITE, &si);
+   #endif
     if (h == nullptr)
         return nullptr;
 

--- a/src/engine/ipc/PluginHostMain.cpp
+++ b/src/engine/ipc/PluginHostMain.cpp
@@ -63,6 +63,8 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 
 #if defined (_WIN32)
+ #define WIN32_LEAN_AND_MEAN
+ #define NOMINMAX
  #include <windows.h>
  #include <shellapi.h>
 #endif

--- a/src/engine/ipc/PluginHostMain.cpp
+++ b/src/engine/ipc/PluginHostMain.cpp
@@ -62,6 +62,11 @@
 #include <juce_events/juce_events.h>
 #include <juce_gui_basics/juce_gui_basics.h>
 
+#if defined (_WIN32)
+ #include <windows.h>
+ #include <shellapi.h>
+#endif
+
 namespace
 {
 using namespace duskstudio::ipc;
@@ -1023,6 +1028,50 @@ int runScan (int argc, const char* const* argv) noexcept
     std::fflush (stdout);
     return 0;
 }
+
+#if defined (_WIN32)
+// Windows hands a narrow main() an argv converted from the UTF-16 command line
+// through the process ANSI code page, and every argument above is read back as
+// UTF-8. A plugin under a path the code page can't represent would therefore be
+// scanned under a mangled name, find nothing, and report an empty-but-valid
+// payload - the parent adds no plugins and shows no warning. Re-derive the
+// arguments from the real command line the parent built.
+class Utf8CommandLine
+{
+public:
+    Utf8CommandLine()
+    {
+        int count = 0;
+        wchar_t** wide = CommandLineToArgvW (GetCommandLineW(), &count);
+        if (wide == nullptr) return;
+        storage.reserve ((size_t) count);
+        for (int i = 0; i < count; ++i)
+            storage.push_back (toUtf8 (wide[i]));
+        LocalFree (wide);
+        // Only after the vector has stopped growing, or the pointers dangle.
+        pointers.reserve (storage.size());
+        for (const auto& arg : storage)
+            pointers.push_back (arg.c_str());
+    }
+
+    int argc() const noexcept                { return (int) pointers.size(); }
+    const char* const* argv() const noexcept { return pointers.data(); }
+
+private:
+    static std::string toUtf8 (const wchar_t* wide)
+    {
+        const int bytes = WideCharToMultiByte (CP_UTF8, 0, wide, -1,
+                                               nullptr, 0, nullptr, nullptr);
+        if (bytes <= 1) return {};
+        std::string out ((size_t) bytes - 1, '\0');   // -1: drop the terminator
+        WideCharToMultiByte (CP_UTF8, 0, wide, -1, out.data(), bytes, nullptr, nullptr);
+        return out;
+    }
+
+    std::vector<std::string> storage;
+    std::vector<const char*> pointers;
+};
+#endif
 } // namespace
 
 int main (int argc, char** argv)
@@ -1031,22 +1080,32 @@ int main (int argc, char** argv)
     signal (SIGPIPE, SIG_IGN);
    #endif
 
+    const char* const* args = argv;
+   #if defined (_WIN32)
+    const Utf8CommandLine utf8CommandLine;
+    if (utf8CommandLine.argc() > 0)
+    {
+        argc = utf8CommandLine.argc();
+        args = utf8CommandLine.argv();
+    }
+   #endif
+
     bool ipcStub = false;
     bool ipcHost = false;
     bool scan    = false;
     for (int i = 1; i < argc; ++i)
     {
-        if (std::strcmp (argv[i], "--ipc-stub") == 0) ipcStub = true;
-        if (std::strcmp (argv[i], "--ipc-host") == 0) ipcHost = true;
-        if (std::strcmp (argv[i], "--scan")     == 0) scan    = true;
+        if (std::strcmp (args[i], "--ipc-stub") == 0) ipcStub = true;
+        if (std::strcmp (args[i], "--ipc-host") == 0) ipcHost = true;
+        if (std::strcmp (args[i], "--scan")     == 0) scan    = true;
 #if DUSKSTUDIO_HAS_NATIVE_CLAP || DUSKSTUDIO_HAS_NATIVE_VST3
-        if (std::strcmp (argv[i], "--scan-native") == 0) return runScanNative (argc, argv);
+        if (std::strcmp (args[i], "--scan-native") == 0) return runScanNative (argc, args);
 #endif
     }
 
-    if (scan)    return runScan (argc, argv);
-    if (ipcStub) return runIpcStub (argc, argv);
-    if (ipcHost) return runIpcHost (argc, argv);
+    if (scan)    return runScan (argc, args);
+    if (ipcStub) return runIpcStub (argc, args);
+    if (ipcHost) return runIpcHost (argc, args);
 
     std::fprintf (stderr,
                   "dusk-studio-plugin-host: pass --ipc-stub, --ipc-host or --scan.\n");

--- a/src/engine/ipc/PluginHostMain.cpp
+++ b/src/engine/ipc/PluginHostMain.cpp
@@ -62,12 +62,7 @@
 #include <juce_events/juce_events.h>
 #include <juce_gui_basics/juce_gui_basics.h>
 
-#if defined (_WIN32)
- #define WIN32_LEAN_AND_MEAN
- #define NOMINMAX
- #include <windows.h>
- #include <shellapi.h>
-#endif
+#include "Utf8CommandLine.h"
 
 namespace
 {
@@ -1030,50 +1025,6 @@ int runScan (int argc, const char* const* argv) noexcept
     std::fflush (stdout);
     return 0;
 }
-
-#if defined (_WIN32)
-// Windows hands a narrow main() an argv converted from the UTF-16 command line
-// through the process ANSI code page, and every argument above is read back as
-// UTF-8. A plugin under a path the code page can't represent would therefore be
-// scanned under a mangled name, find nothing, and report an empty-but-valid
-// payload - the parent adds no plugins and shows no warning. Re-derive the
-// arguments from the real command line the parent built.
-class Utf8CommandLine
-{
-public:
-    Utf8CommandLine()
-    {
-        int count = 0;
-        wchar_t** wide = CommandLineToArgvW (GetCommandLineW(), &count);
-        if (wide == nullptr) return;
-        storage.reserve ((size_t) count);
-        for (int i = 0; i < count; ++i)
-            storage.push_back (toUtf8 (wide[i]));
-        LocalFree (wide);
-        // Only after the vector has stopped growing, or the pointers dangle.
-        pointers.reserve (storage.size());
-        for (const auto& arg : storage)
-            pointers.push_back (arg.c_str());
-    }
-
-    int argc() const noexcept                { return (int) pointers.size(); }
-    const char* const* argv() const noexcept { return pointers.data(); }
-
-private:
-    static std::string toUtf8 (const wchar_t* wide)
-    {
-        const int bytes = WideCharToMultiByte (CP_UTF8, 0, wide, -1,
-                                               nullptr, 0, nullptr, nullptr);
-        if (bytes <= 1) return {};
-        std::string out ((size_t) bytes - 1, '\0');   // -1: drop the terminator
-        WideCharToMultiByte (CP_UTF8, 0, wide, -1, out.data(), bytes, nullptr, nullptr);
-        return out;
-    }
-
-    std::vector<std::string> storage;
-    std::vector<const char*> pointers;
-};
-#endif
 } // namespace
 
 int main (int argc, char** argv)
@@ -1084,7 +1035,7 @@ int main (int argc, char** argv)
 
     const char* const* args = argv;
    #if defined (_WIN32)
-    const Utf8CommandLine utf8CommandLine;
+    const duskstudio::ipc::Utf8CommandLine utf8CommandLine;
     if (utf8CommandLine.argc() > 0)
     {
         argc = utf8CommandLine.argc();

--- a/src/engine/ipc/Utf8CommandLine.h
+++ b/src/engine/ipc/Utf8CommandLine.h
@@ -59,8 +59,9 @@ private:
         const int bytes = WideCharToMultiByte (CP_UTF8, 0, wide, -1,
                                                nullptr, 0, nullptr, nullptr);
         if (bytes <= 1) return {};
-        std::string out ((size_t) bytes - 1, '\0');   // -1: drop the terminator
+        std::string out ((size_t) bytes, '\0');
         WideCharToMultiByte (CP_UTF8, 0, wide, -1, out.data(), bytes, nullptr, nullptr);
+        out.pop_back();   // the API wrote its own terminator
         return out;
     }
 

--- a/src/engine/ipc/Utf8CommandLine.h
+++ b/src/engine/ipc/Utf8CommandLine.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#if defined (_WIN32)
+
+ #ifndef WIN32_LEAN_AND_MEAN
+  #define WIN32_LEAN_AND_MEAN
+ #endif
+ #ifndef NOMINMAX
+  #define NOMINMAX
+ #endif
+ #include <windows.h>
+ #include <shellapi.h>
+
+ #include <string>
+ #include <vector>
+
+namespace duskstudio::ipc
+{
+// Windows hands a narrow main() an argv converted from the UTF-16 command line
+// through the process ANSI code page, while the plugin host reads every
+// argument back as UTF-8. A plugin under a path the code page cannot represent
+// would therefore be scanned under a mangled name, find nothing, and report an
+// empty-but-valid payload - the parent adds no plugins and shows no warning.
+// Re-derive the arguments from the real command line the parent built.
+class Utf8CommandLine
+{
+public:
+    Utf8CommandLine() { adopt (GetCommandLineW()); }
+
+    // Test seam: the same parse + conversion over a caller-supplied command
+    // line, so the mangling this exists to prevent can be asserted on.
+    explicit Utf8CommandLine (const wchar_t* commandLine) { adopt (commandLine); }
+
+    int argc() const noexcept                { return (int) pointers.size(); }
+    const char* const* argv() const noexcept { return pointers.data(); }
+
+private:
+    void adopt (const wchar_t* commandLine)
+    {
+        if (commandLine == nullptr) return;
+
+        int count = 0;
+        wchar_t** wide = CommandLineToArgvW (commandLine, &count);
+        if (wide == nullptr) return;
+
+        storage.reserve ((size_t) count);
+        for (int i = 0; i < count; ++i)
+            storage.push_back (toUtf8 (wide[i]));
+        LocalFree (wide);
+
+        // Only after the vector has stopped growing, or the pointers dangle.
+        pointers.reserve (storage.size());
+        for (const auto& arg : storage)
+            pointers.push_back (arg.c_str());
+    }
+
+    static std::string toUtf8 (const wchar_t* wide)
+    {
+        const int bytes = WideCharToMultiByte (CP_UTF8, 0, wide, -1,
+                                               nullptr, 0, nullptr, nullptr);
+        if (bytes <= 1) return {};
+        std::string out ((size_t) bytes - 1, '\0');   // -1: drop the terminator
+        WideCharToMultiByte (CP_UTF8, 0, wide, -1, out.data(), bytes, nullptr, nullptr);
+        return out;
+    }
+
+    std::vector<std::string> storage;
+    std::vector<const char*> pointers;
+};
+} // namespace duskstudio::ipc
+
+#endif

--- a/src/engine/multisample/AriaBank.cpp
+++ b/src/engine/multisample/AriaBank.cpp
@@ -100,10 +100,12 @@ std::optional<AriaBank> AriaBank::tryLoadFromSfz(const juce::File& sfzFile)
             parseAriaProgramElement(*child, bank.bankDir, bank.programs);
 
     bank.selectedIndex = -1;
-    const auto target = sfzFile.getFullPathName();
     for (size_t i = 0; i < bank.programs.size(); ++i)
     {
-        if (bank.programs[i].sfzFile.getFullPathName() == target)
+        // File comparison, not string comparison: on Windows the manifest's
+        // casing and the path the user picked with need not match character for
+        // character, and a miss here silently costs the bank's custom skin.
+        if (bank.programs[i].sfzFile == sfzFile)
         {
             bank.selectedIndex = (int) i;
             break;

--- a/src/engine/multisample/AriaBank.cpp
+++ b/src/engine/multisample/AriaBank.cpp
@@ -103,7 +103,7 @@ std::optional<AriaBank> AriaBank::tryLoadFromSfz(const juce::File& sfzFile)
     for (size_t i = 0; i < bank.programs.size(); ++i)
     {
         // File comparison, not string comparison: on Windows the manifest's
-        // casing and the path the user picked with need not match character for
+        // casing and the path the user picked need not match character for
         // character, and a miss here silently costs the bank's custom skin.
         if (bank.programs[i].sfzFile == sfzFile)
         {

--- a/src/engine/multisample/DuskMultisampleProcessor.cpp
+++ b/src/engine/multisample/DuskMultisampleProcessor.cpp
@@ -461,9 +461,16 @@ bool DuskMultisampleProcessor::loadSfzFile (const juce::File& sfz,
         ok = sfizz_load_file (impl->synth, path.c_str());
         if (ok) regions = sfizz_get_num_regions (impl->synth);
     }
+    // sfizz clears the loaded instrument before it parses, so from here on the
+    // previous soundfont is gone whatever we report. Both failures below drop
+    // the rest of the load state with it - keeping the old file's name, its SF2
+    // program list and its extracted samples would describe an instrument the
+    // synth no longer holds. clearLoadedFile() resets lastLoadError, so the
+    // reason is stored after it.
     if (! ok)
     {
         errorMessage = "sfizz_load_file failed for " + sfz.getFileName();
+        clearLoadedFile();
         lastLoadError = errorMessage;
         return false;
     }
@@ -474,6 +481,7 @@ bool DuskMultisampleProcessor::loadSfzFile (const juce::File& sfz,
     {
         errorMessage = "No playable regions in " + sfz.getFileName()
                      + " - its sample files were not found next to it";
+        clearLoadedFile();
         lastLoadError = errorMessage;
         return false;
     }
@@ -698,9 +706,9 @@ bool DuskMultisampleProcessor::loadState (const std::vector<uint8_t>& in)
 
     // Restore the SF2 preset selection (no-op for SFZ). Must run after
     // the file load above so the SF2 metadata + sfizz state exist.
-    // Skipped when that load failed: sf2Presets + loadedFilePath then still
-    // point at the previously loaded SF2, so restoring the saved index would
-    // switch the OLD file to a stale preset and clobber lastLoadError.
+    // Skipped when that load failed: sf2Presets + loadedFilePath then describe
+    // whatever survived the failure, not the file the saved index belongs to,
+    // so restoring that index would clobber lastLoadError for nothing.
     // idx == 0 is deliberately skipped: loadSf2File already loaded
     // preset 0, so re-loading it would be redundant work. Only a
     // non-default saved preset needs an explicit switch.

--- a/src/engine/multisample/DuskMultisampleProcessor.cpp
+++ b/src/engine/multisample/DuskMultisampleProcessor.cpp
@@ -455,13 +455,25 @@ bool DuskMultisampleProcessor::loadSfzFile (const juce::File& sfz,
     }
     const auto path = sfz.getFullPathName().toStdString();
     bool ok = false;
+    int regions = 0;
     {
         const juce::SpinLock::ScopedLockType lock (sfizzLock);
         ok = sfizz_load_file (impl->synth, path.c_str());
+        if (ok) regions = sfizz_get_num_regions (impl->synth);
     }
     if (! ok)
     {
         errorMessage = "sfizz_load_file failed for " + sfz.getFileName();
+        lastLoadError = errorMessage;
+        return false;
+    }
+    // sfizz drops every region whose sample= it cannot resolve and still reports
+    // success, so a zero-region load is a silent instrument. Name the real
+    // problem instead of leaving the user with a loaded slot that makes no sound.
+    if (regions == 0)
+    {
+        errorMessage = "No playable regions in " + sfz.getFileName()
+                     + " - its sample files were not found next to it";
         lastLoadError = errorMessage;
         return false;
     }

--- a/src/ui/DuskAlerts.cpp
+++ b/src/ui/DuskAlerts.cpp
@@ -2,6 +2,7 @@
 #include "EmbeddedModal.h"
 
 #include <algorithm>
+#include <cmath>
 
 namespace duskstudio
 {
@@ -16,14 +17,20 @@ EmbeddedModal& confirmModal()  { static EmbeddedModal m; return m; }
 EmbeddedModal& decisionModal() { static EmbeddedModal m; return m; }
 EmbeddedModal& textModal()     { static EmbeddedModal m; return m; }
 
+const juce::Colour kPanelBg   { 0xff1a1a22 };
+const juce::Colour kTitleText { 0xffffffff };
+const juce::Colour kBodyText  { 0xffd0d0d4 };
+
+juce::Font bodyFont() { return juce::Font (juce::FontOptions (12.5f)); }
+
 void styleAction (juce::TextButton& b, bool destructive = false)
 {
     b.setColour (juce::TextButton::buttonColourId,
                    destructive ? juce::Colour (0xff7a3030)
                                 : juce::Colour (0xff262630));
     b.setColour (juce::TextButton::buttonOnColourId, juce::Colour (0xff5a4880));
-    b.setColour (juce::TextButton::textColourOffId,  juce::Colour (0xffd0d0d4));
-    b.setColour (juce::TextButton::textColourOnId,   juce::Colours::white);
+    b.setColour (juce::TextButton::textColourOffId,  kBodyText);
+    b.setColour (juce::TextButton::textColourOnId,   kTitleText);
 }
 
 void paintTitleAndBody (juce::Graphics& g,
@@ -32,17 +39,17 @@ void paintTitleAndBody (juce::Graphics& g,
                           const juce::String& message,
                           int buttonStripH)
 {
-    g.fillAll (juce::Colour (0xff1a1a22));
+    g.fillAll (kPanelBg);
     auto r = bounds.reduced (20);
 
-    g.setColour (juce::Colours::white);
+    g.setColour (kTitleText);
     g.setFont (juce::Font (juce::FontOptions (15.0f, juce::Font::bold)));
     g.drawText (title, r.removeFromTop (24),
                  juce::Justification::topLeft, false);
     r.removeFromTop (10);
 
-    g.setColour (juce::Colour (0xffd0d0d4));
-    g.setFont (juce::Font (juce::FontOptions (12.5f)));
+    g.setColour (kBodyText);
+    g.setFont (bodyFont());
     auto body = r.withTrimmedBottom (buttonStripH + 8);
     g.drawFittedText (message.isEmpty() ? juce::String ("(no message)") : message,
                         body, juce::Justification::topLeft, 6);
@@ -64,7 +71,7 @@ public:
         okBtn.onClick = [this] { if (onOK) onOK(); };
         addAndMakeVisible (okBtn);
         setWantsKeyboardFocus (true);
-        setSize (460, 220);
+        setSize (kWidth, heightForMessage());
     }
     std::function<void()> onOK;
 
@@ -89,6 +96,28 @@ public:
     }
 
 private:
+    static constexpr int kWidth = 460;
+
+    // drawFittedText stops honouring its line limit as soon as the message
+    // carries a newline: it word-wraps at full size and runs past the body,
+    // through the button strip, to wherever the component clip cuts it. The
+    // plugin-scan report names two filesystem paths and overruns a fixed panel
+    // by several lines, so size the panel to the message instead.
+    int heightForMessage() const
+    {
+        juce::AttributedString body (messageStr);
+        body.setFont (bodyFont());
+        juce::TextLayout layout;
+        // Narrower than it is drawn, plus a line of slack - this pass and
+        // drawFittedText are separate text engines whose wrap points and line
+        // heights need not agree. Over-measuring only pads the panel.
+        layout.createLayout (body, (float) (kWidth - 48));
+        const int chrome = 20 + 24 + 10 + 8 + kButtonStripH + 20 + 16;
+        // Capped: EmbeddedModal clamps the panel to the host window, and a body
+        // taller than that would push the OK button off screen.
+        return std::clamp ((int) std::ceil (layout.getHeight()) + chrome, 220, 620);
+    }
+
     juce::String titleStr, messageStr;
     juce::TextButton okBtn { "OK" };
 };
@@ -237,17 +266,17 @@ public:
 
     void paint (juce::Graphics& g) override
     {
-        g.fillAll (juce::Colour (0xff1a1a22));
+        g.fillAll (kPanelBg);
         auto r = getLocalBounds().reduced (20);
 
-        g.setColour (juce::Colours::white);
+        g.setColour (kTitleText);
         g.setFont (juce::Font (juce::FontOptions (15.0f, juce::Font::bold)));
         g.drawText (titleStr, r.removeFromTop (24),
                      juce::Justification::topLeft, false);
         r.removeFromTop (10);
 
-        g.setColour (juce::Colour (0xffd0d0d4));
-        g.setFont (juce::Font (juce::FontOptions (12.5f)));
+        g.setColour (kBodyText);
+        g.setFont (bodyFont());
         g.drawText (promptStr, r.removeFromTop (18),
                      juce::Justification::topLeft, false);
     }

--- a/src/ui/PluginPickerHelpers.cpp
+++ b/src/ui/PluginPickerHelpers.cpp
@@ -203,12 +203,25 @@ void runScanModal (PluginManager& manager, juce::Component* parent,
                 added, added == 1 ? "" : "s",
                 manager.getPluginCount());
 
+            // On a shipped build this warning means the install lost its child
+            // executable, so name the path that was looked for.
             if (const int skipped = manager.getLastScanSandboxSkips(); skipped > 0)
-                message << juce::String::formatted (
-                    "\n\nWarning: the plugin scanning sandbox was unavailable - "
-                    "%d plugin%s skipped (left unscanned). Rescan once the plugin "
-                    "host is present.",
-                    skipped, skipped == 1 ? "" : "s");
+                message << "\n\nWarning: the plugin scanning sandbox was unavailable - "
+                        << skipped << (skipped == 1 ? " plugin was" : " plugins were")
+                        << " left unscanned. Dusk Studio runs each scan in:\n"
+                        << manager.getHostExecutablePath()
+                        << "\n\nReinstall if that file is missing, then rescan.";
+
+            // A quarantine survives every later scan, so without this a machine
+            // that quarantined its library reports "0 added" forever with no
+            // other symptom to go on.
+            if (const int quarantined = manager.getQuarantinedCount(); quarantined > 0)
+                message << "\n\n" << quarantined
+                        << (quarantined == 1 ? " plugin is" : " plugins are")
+                        << " quarantined after crashing or hanging when last probed, and "
+                           "will be skipped by every scan. To probe them again, quit Dusk "
+                           "Studio and delete:\n"
+                        << manager.getCacheFile().getFullPathName();
 
             if (auto* h = safeHost.getComponent())
                 showDuskAlert (*h, "Plugin scan complete", std::move (message),

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -120,6 +120,8 @@ add_executable(dusk-studio-tests
     metronome_click.cpp
     ${CMAKE_SOURCE_DIR}/src/dsp/Metronome.cpp
     aria_gui_parse.cpp
+    aria_bank_selection.cpp
+    plugin_host_command_line.cpp
     sf2_reader_parse.cpp
     sf2_to_sfz_convert.cpp
     sf2_preset_sort.cpp
@@ -161,6 +163,12 @@ target_include_directories(dusk-studio-tests PRIVATE
     ${CMAKE_SOURCE_DIR}/external/projucer-shim
     ${CMAKE_SOURCE_DIR}/external/clap/include)
 target_include_directories(dusk-studio-tests SYSTEM PRIVATE ${CMAKE_SOURCE_DIR}/external/json)
+
+if(WIN32)
+    # shell32: CommandLineToArgvW, exercised by plugin_host_command_line.cpp
+    # against the same header the plugin host uses.
+    target_link_libraries(dusk-studio-tests PRIVATE shell32)
+endif()
 
 # pffft backend for dusk::audio::Fft, plus its A/B parity suite. The pffft
 # object library (include dir + warning silencing) is defined in the root

--- a/tests/aria_bank_selection.cpp
+++ b/tests/aria_bank_selection.cpp
@@ -1,0 +1,51 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/multisample/AriaBank.h"
+
+namespace
+{
+struct ScopedTempTree
+{
+    juce::File root;
+    ~ScopedTempTree() { root.deleteRecursively(); }
+};
+} // namespace
+
+TEST_CASE ("AriaBank preselects the program that owns the loaded SFZ",
+           "[multisample][aria]")
+{
+    // Own directory: findBankFileNear walks upward and takes the first
+    // *.bank.xml it sees, so a manifest from another test must not be in reach.
+    const auto root = juce::File::getSpecialLocation (juce::File::tempDirectory)
+                          .getNonexistentChildFile ("DuskAriaBank", "", false);
+    const ScopedTempTree cleanup { root };
+    const auto programs = root.getChildFile ("Programs");
+    REQUIRE (programs.createDirectory());
+
+    const auto sfz = programs.getChildFile ("Grand.sfz");
+    REQUIRE (sfz.replaceWithText ("<region> key=60 sample=*sine\n"));
+    REQUIRE (root.getChildFile ("Test.bank.xml").replaceWithText (
+        "<?xml version=\"1.0\"?>\n"
+        "<AriaBank name=\"Test\" vendor=\"Dusk\">\n"
+        "  <AriaProgram name=\"Grand\" gui=\"GUI/Grand.xml\">\n"
+        "    <AriaElement path=\"Programs/Grand.sfz\"/>\n"
+        "  </AriaProgram>\n"
+        "</AriaBank>\n"));
+
+    const auto bank = duskstudio::AriaBank::tryLoadFromSfz (sfz);
+    REQUIRE (bank.has_value());
+    REQUIRE (bank->programs.size() == 1);
+    REQUIRE (bank->selectedIndex == 0);
+
+    // Where the filesystem ignores case (Windows, default macOS) the manifest's
+    // spelling and the path the user picked need not agree character for
+    // character. File comparison follows the platform; the string compare this
+    // replaced did not, and a miss silently costs the bank's custom skin.
+    if (! juce::File::areFileNamesCaseSensitive())
+    {
+        const juce::File shouted (sfz.getFullPathName().toUpperCase());
+        const auto reopened = duskstudio::AriaBank::tryLoadFromSfz (shouted);
+        REQUIRE (reopened.has_value());
+        REQUIRE (reopened->selectedIndex == 0);
+    }
+}

--- a/tests/device_fallback_message.cpp
+++ b/tests/device_fallback_message.cpp
@@ -40,6 +40,9 @@ TEST_CASE ("startupDeviceMessage: nothing opened -> silent-session warning", "[a
         REQUIRE (contains (m, "UMC1820"));
         REQUIRE (containsIgnoreCase (m, "no audio device"));
         REQUIRE (containsIgnoreCase (m, "recording is disabled"));
+        // The strips are prepared from the device callback, so an unopened
+        // device is also why a plugin or soundfont load is refused.
+        REQUIRE (containsIgnoreCase (m, "soundfonts cannot be loaded"));
     }
     SECTION ("no saved device still warns, no dangling name")
     {

--- a/tests/device_fallback_message.cpp
+++ b/tests/device_fallback_message.cpp
@@ -48,6 +48,8 @@ TEST_CASE ("startupDeviceMessage: nothing opened -> silent-session warning", "[a
     {
         const auto m = startupDeviceMessage (false, "", "");
         REQUIRE (containsIgnoreCase (m, "no audio device"));
+        REQUIRE (containsIgnoreCase (m, "recording is disabled"));
+        REQUIRE (containsIgnoreCase (m, "soundfonts cannot be loaded"));
         REQUIRE_FALSE (contains (m, "\"\""));   // no empty-quoted device name
     }
 }

--- a/tests/multisample_state_roundtrip.cpp
+++ b/tests/multisample_state_roundtrip.cpp
@@ -32,6 +32,28 @@ TEST_CASE ("DuskMultisampleProcessor loads an SFZ file path with spaces", "[mult
     REQUIRE (processor.getNumRegions() == 1);
 }
 
+TEST_CASE ("DuskMultisampleProcessor rejects an SFZ with no resolvable samples",
+           "[multisample][sfz]")
+{
+    const auto sfz = juce::File::getSpecialLocation (juce::File::tempDirectory)
+                         .getNonexistentChildFile ("Dusk SFZ missing sample", ".sfz", false);
+    struct ScopedFileCleanup
+    {
+        juce::File file;
+        ~ScopedFileCleanup() { file.deleteFile(); }
+    } cleanup { sfz };
+
+    // sfizz parses this, reports success, and then drops the region because the
+    // sample is not on disk. Without the region check that reads as a soundfont
+    // that loaded fine and plays nothing.
+    REQUIRE (sfz.replaceWithText ("<region> key=60 sample=not-here.wav\n"));
+
+    duskstudio::DuskMultisampleProcessor processor;
+    juce::String error;
+    REQUIRE_FALSE (processor.loadSfzFile (sfz, error));
+    REQUIRE (error.contains ("No playable regions"));
+}
+
 namespace
 {
 // Hand-build a valid two-preset SF2 (both presets share one instrument zone +

--- a/tests/multisample_state_roundtrip.cpp
+++ b/tests/multisample_state_roundtrip.cpp
@@ -54,6 +54,35 @@ TEST_CASE ("DuskMultisampleProcessor rejects an SFZ with no resolvable samples",
     REQUIRE (error.contains ("No playable regions"));
 }
 
+TEST_CASE ("DuskMultisampleProcessor reports no file after a failed load replaced one",
+           "[multisample][sfz]")
+{
+    const auto tempDir = juce::File::getSpecialLocation (juce::File::tempDirectory);
+    const auto good = tempDir.getNonexistentChildFile ("Dusk SFZ good", ".sfz", false);
+    const auto broken = tempDir.getNonexistentChildFile ("Dusk SFZ broken", ".sfz", false);
+    struct ScopedFileCleanup
+    {
+        juce::File a, b;
+        ~ScopedFileCleanup() { a.deleteFile(); b.deleteFile(); }
+    } cleanup { good, broken };
+
+    REQUIRE (good.replaceWithText ("<region> key=60 sample=*sine\n"));
+    REQUIRE (broken.replaceWithText ("<region> key=60 sample=not-here.wav\n"));
+
+    duskstudio::DuskMultisampleProcessor processor;
+    juce::String error;
+    REQUIRE (processor.loadSfzFile (good, error));
+    REQUIRE (processor.hasLoadedFile());
+
+    // sfizz has already dropped the good instrument by the time the region
+    // count is read, so the failure must not leave the old file's name behind -
+    // that would name a soundfont the synth no longer holds.
+    REQUIRE_FALSE (processor.loadSfzFile (broken, error));
+    REQUIRE_FALSE (processor.hasLoadedFile());
+    REQUIRE (processor.getLoadedFilePath().isEmpty());
+    REQUIRE (processor.getLastLoadError().contains ("No playable regions"));
+}
+
 namespace
 {
 // Hand-build a valid two-preset SF2 (both presets share one instrument zone +

--- a/tests/plugin_host_command_line.cpp
+++ b/tests/plugin_host_command_line.cpp
@@ -1,0 +1,35 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/ipc/Utf8CommandLine.h"
+
+#if defined (_WIN32)
+
+#include <string>
+
+// The scan child reads its arguments as UTF-8. Windows builds a narrow argv by
+// converting the UTF-16 command line through the process ANSI code page, which
+// drops every character that page cannot represent - the plugin path arrives
+// mangled, the scan finds nothing, and the parent reports "0 added". These pin
+// the re-derivation that avoids it.
+
+TEST_CASE ("Utf8CommandLine keeps a non-ANSI plugin path intact", "[ipc][windows]")
+{
+    const duskstudio::ipc::Utf8CommandLine cmd (
+        L"host.exe --scan \"C:\\Users\\J\u00FCrgen\\VST3\\Bo\u00EEte \u30B7.vst3\"");
+
+    REQUIRE (cmd.argc() == 3);
+    REQUIRE (std::string (cmd.argv()[0]) == "host.exe");
+    REQUIRE (std::string (cmd.argv()[1]) == "--scan");
+    // Quoted argument arrives whole (spaces preserved), in UTF-8 bytes.
+    REQUIRE (std::string (cmd.argv()[2])
+                 == "C:\\Users\\J\xC3\xBCrgen\\VST3\\Bo\xC3\xAE""te \xE3\x82\xB7.vst3");
+}
+
+TEST_CASE ("Utf8CommandLine reports nothing for an empty command line", "[ipc][windows]")
+{
+    // main() falls back to its own argv when this happens, so the count matters.
+    const duskstudio::ipc::Utf8CommandLine cmd (nullptr);
+    REQUIRE (cmd.argc() == 0);
+}
+
+#endif

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -90,7 +90,7 @@ src/ui/CursorOverlay.h	13
 src/ui/DimOverlay.cpp	4
 src/ui/DimOverlay.h	6
 src/ui/DpImportDialog.h	46
-src/ui/DuskAlerts.cpp	100
+src/ui/DuskAlerts.cpp	96
 src/ui/DuskAlerts.h	19
 src/ui/DuskAudioDeviceSelector.cpp	20
 src/ui/DuskAudioDeviceSelector.h	8

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -140,7 +140,7 @@ src/ui/PlatformWindowing.h	14
 src/ui/PlatformWindowing_Linux.cpp	16
 src/ui/PlatformWindowing_Mac.mm	19
 src/ui/PlatformWindowing_Windows.cpp	7
-src/ui/PluginPickerHelpers.cpp	136
+src/ui/PluginPickerHelpers.cpp	135
 src/ui/PluginPickerHelpers.h	23
 src/ui/PluginPickerPanel.cpp	70
 src/ui/PluginPickerPanel.h	13


### PR DESCRIPTION
Addresses #116 (left open for the hardware test matrix).

Root causes found for both reported symptoms, plus a third defect that hid them.

**Plugin scan reports "0 added" with "Host Unavailable"**
- The scanner child's argv arrives through the ANSI code page but was read back as UTF-8 (src/engine/ipc/PluginHostMain.cpp had a narrow main). Any plugin under a non-ASCII path scans under a mangled name and returns a valid-but-empty payload, which the parent accepted silently. A non-ASCII Windows username breaks the entire per-user VST3 tree. The child now re-derives argv from CommandLineToArgvW and converts through WideCharToMultiByte(CP_UTF8).
- One bad scan run quarantined plugins permanently and invisibly: timeout/empty/malformed payloads blacklist into plugin-cache.xml, every later scan skips those files instantly with no message and no UI to inspect or clear. The scan alert now names the scanner path it looked for and reports the quarantined count with the cache file location.

**SFZ files will not load**
- The startup busy-device recovery was compiled only under DUSKSTUDIO_HAS_ALSA, so Windows had no fallback at all: an ASIO driver held by another application (ASIO is exclusive) left the app deviceless, and every strip refuses plugin/soundfont loads until a device callback has run. The recovery now walks every other backend's default device, skipping the type that just failed so a busy ASIO driver is not re-entered, and always computes the startup message. The message text now also states that loading is refused while no device is open.
- UTF-8 paths were handed to ANSI-decoding seams at three places: sfizz load (std::filesystem narrow decode is the ANSI code page under MSVC), the SF2 temp path, and libsndfile open. Windows startup now sets setlocale(LC_CTYPE, ".UTF8") (LC_CTYPE only, LC_NUMERIC untouched), and FileReader/FileWriter use sf_wchar_open.
- An SFZ whose samples are missing "loaded" successfully with zero regions - a mute instrument and no error. A zero-region load is now a failure naming the missing samples, with a regression test reproducing the old silent success.

MANUAL.md busy-device section updated for the cross-platform fallback.

Verification: Linux app build green with no new warnings; 728/728 Catch2 tests pass including the two new cases; juce-gate passes with the allowlist ratcheted down by one (src/ui/PluginPickerHelpers.cpp 136 -> 135).

Needs verification on real Windows hardware: the UTF-8 CRT locale fixing sfizz loads under a non-ASCII profile path, sf_wchar_open linking against the vcpkg libsndfile, the ASIO-busy fallback behaviour, and the widened scan alert layout. Known follow-ups deliberately not in this PR: a longPathAware manifest, the scan timeout being unreachable on Windows (ChildProcess::readProcessOutput blocks until 8192 bytes), and a UI affordance to clear the plugin quarantine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved audio-device recovery across PipeWire, ALSA, and other available backends.
  - Added clearer plugin scan reporting, including quarantined plugins, host details, and cleanup guidance.
  - Improved Unicode support for Windows file paths and command-line arguments.
  - Added Windows support for launching plugin hosts with command-line arguments.
  - Alert dialogs now resize to fit longer messages.

- **Bug Fixes**
  - Failed or incomplete SFZ loads now clear the insert slot and show the reason.
  - Improved matching of SFZ program paths.
  - Audio features, plugins, and soundfont loading are clearly disabled when no device is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->