### PR TITLE
Correct the 0.13 release documentation

### DIFF
--- a/BUILDING-LINUX.md
+++ b/BUILDING-LINUX.md
@@ -15,7 +15,7 @@ sudo apt-get update
 sudo apt-get install -y --no-install-recommends \
   build-essential cmake ninja-build pkg-config git \
   libasound2-dev libjack-jackd2-dev libpipewire-0.3-dev \
-  libsndfile1-dev libmp3lame-dev \
+  libsndfile1-dev libsodium-dev libmp3lame-dev \
   liblilv-dev libsuil-dev lv2-dev \
   ladspa-sdk \
   libcurl4-openssl-dev libfreetype-dev libfontconfig1-dev \
@@ -31,7 +31,7 @@ sudo apt-get install -y --no-install-recommends \
 sudo dnf install -y \
   gcc-c++ cmake ninja-build pkgconf-pkg-config git \
   alsa-lib-devel pipewire-jack-audio-connection-kit-devel pipewire-devel \
-  libsndfile-devel lame-devel \
+  libsndfile-devel libsodium-devel lame-devel \
   lilv-devel suil-devel lv2-devel \
   ladspa-devel \
   libcurl-devel freetype-devel fontconfig-devel \
@@ -41,7 +41,14 @@ sudo dnf install -y \
   wayland-devel libxkbcommon-devel libdecor-devel
 ```
 
-libsndfile is not optional — all audio file I/O goes through it and configure fails without it. The PipeWire, LV2-host and MP3-bounce packages are probed at configure time and quietly drop their feature when absent; each miss costs you one easy-to-miss line in the configure log, so read it. On Fedora, take the `pipewire-jack-*` JACK headers rather than `jack-audio-connection-kit-devel`: the two conflict, and dnf will refuse the transaction on a PipeWire box.
+libsndfile and libsodium are not optional: all audio file I/O goes through
+libsndfile, and the signed SFZ catalog groundwork uses libsodium. Configure
+fails when either development package is missing. The PipeWire, LV2-host and
+MP3-bounce packages are probed at configure time and quietly drop their feature
+when absent; each miss costs you one easy-to-miss line in the configure log, so
+read it. On Fedora, take the `pipewire-jack-*` JACK headers rather than
+`jack-audio-connection-kit-devel`: the two conflict, and dnf will refuse the
+transaction on a PipeWire box.
 
 ## Repository layout
 

--- a/BUILDING-WINDOWS.md
+++ b/BUILDING-WINDOWS.md
@@ -10,7 +10,7 @@ This document is aimed at a developer with a Windows machine who has been handed
    - During install, check the **"Desktop development with C++"** workload.
    - This brings MSVC, the Windows 10/11 SDK, and CMake. No separate CMake install needed.
 2. **Git for Windows**: https://git-scm.com/download/win
-3. **vcpkg**, for libsndfile and LAME. libsndfile is not optional on any platform — all audio file I/O goes through it and configure hard-fails without it ([CMakeLists.txt:594-612](CMakeLists.txt#L594-L612)). LAME is what enables MP3 bounce. Both are declared in [vcpkg.json](vcpkg.json) at the repo root, with a `builtin-baseline` that pins the exact codec versions, so run vcpkg in manifest mode from the checkout root and it installs what CI installs:
+3. **vcpkg**, for libsndfile, libsodium and LAME. libsndfile is not optional on any platform: all audio file I/O goes through it and configure hard-fails without it ([CMakeLists.txt:603-628](CMakeLists.txt#L603-L628)). libsodium provides the signed SFZ catalog verification layer and is also required. LAME enables MP3 bounce. All three are declared in [vcpkg.json](vcpkg.json) at the repo root, with a `builtin-baseline` that pins the exact codec versions, so run vcpkg in manifest mode from the checkout root and it installs what CI installs:
 
    ```cmd
    vcpkg install --triplet x64-windows-static
@@ -85,7 +85,7 @@ From the Dusk Studio directory:
 ```cmd
 cd C:\dev\dusk-studio
 cmake -S . -B build -G "Visual Studio 17 2022" -A x64 ^
-  -DCMAKE_PREFIX_PATH=%VCPKG_INSTALLATION_ROOT%/installed/x64-windows-static ^
+  -DCMAKE_PREFIX_PATH="%CD%/vcpkg_installed/x64-windows-static" ^
   -DASIOSDK_PATH=C:/dev/asiosdk
 cmake --build build --config Release -j
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,12 +84,11 @@ fixes are ported here and are listed below rather than under a 0.12.7 heading.
   math utilities are now Dusk Studio's own code rather than the application
   framework's. Behaviour is unchanged by design; this is the groundwork for
   the interface rewrite.
-- **Groundwork for signed SFZ catalogs.** Dusk Studio can read a catalog of
-  downloadable SFZ instruments and verify its detached Ed25519 signature
-  against a built-in trusted key, rejecting anything malformed, oversized or
-  unsigned. Nothing in the interface offers a catalog yet; this release only
-  lays the trust layer. Source builds now need libsodium (`libsodium-dev` on
-  Debian and Ubuntu, the vcpkg manifest on Windows).
+- **Groundwork for signed SFZ catalogs.** Catalog parsing and detached Ed25519
+  signature verification now exist and are covered by tests. Verification uses
+  trusted keys supplied by its caller; the application does not consume the
+  catalog layer yet, and no key is built in. Source builds now need libsodium
+  (`libsodium-dev` on Debian and Ubuntu, the vcpkg manifest on Windows).
 - **License texts ship with the packages.** The tarball, the deb and rpm,
   the DMG and the MSI now carry `LICENSE` and `LICENSES.txt`, and the
   attribution list credits the notepad's UI stack (DPF, Dear ImGui, pugl and
@@ -173,8 +172,8 @@ fixes are ported here and are listed below rather than under a 0.12.7 heading.
   after a reload. Going fullscreen, or anything else that rebuilds the main
   window, used to leave a channel's native editor stranded; the editor is
   rebuilt into the new window instead, reopening straight away unless a modal
-  is covering it. An embedded VST3 view no longer comes back blank or
-  off-centre after a resize, and its child windows map correctly on Linux.
+  is covering it. On Linux, an embedded VST3 view no longer comes back blank or
+  off-centre after a resize, and its child windows map correctly.
 - **MIDI and soundfonts.** Hung notes no longer lose their tail, CC values no
   longer diverge from what was sent, and several SF2-to-SFZ translation faults
   are corrected. A dense burst that filled the input ring but overflowed a

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 [![Linux build](https://github.com/dusk-audio/dusk-studio/actions/workflows/linux-build.yml/badge.svg)](https://github.com/dusk-audio/dusk-studio/actions/workflows/linux-build.yml)
 [![macOS build](https://github.com/dusk-audio/dusk-studio/actions/workflows/macos-build.yml/badge.svg)](https://github.com/dusk-audio/dusk-studio/actions/workflows/macos-build.yml)
-[![Windows build](https://github.com/dusk-audio/dusk-studio/actions/workflows/windows-build.yml/badge.svg)](https://github.com/dusk-audio/dusk-studio/actions/workflows/windows-build.yml)
 [![Windows tests](https://github.com/dusk-audio/dusk-studio/actions/workflows/windows-tests.yml/badge.svg)](https://github.com/dusk-audio/dusk-studio/actions/workflows/windows-tests.yml)
 [![Linux sanitizer (TSan)](https://github.com/dusk-audio/dusk-studio/actions/workflows/linux-sanitizer.yml/badge.svg)](https://github.com/dusk-audio/dusk-studio/actions/workflows/linux-sanitizer.yml)
 
@@ -12,7 +11,11 @@ A deliberately constrained, portastudio-style DAW for Linux, macOS, and Windows.
 
 > *"Fixed signal chain, finite track count, one page per stage. You commit, you move on."*
 
-JUCE 8 / C++17. On Linux, a native PipeWire backend (primary) when the PipeWire development libraries are present at configure time, with a native ALSA backend as the fallback and for builds without them, plus USB hot-unplug recovery; macOS CoreAudio + Windows WASAPI / ASIO via JUCE. Authoritative spec: [DuskStudio.md](DuskStudio.md). User manual: [MANUAL.md](MANUAL.md).
+JUCE 8 / C++17. Dusk Studio's native audio-device layer talks directly to
+PipeWire (primary when available) or ALSA on Linux, with USB hot-unplug
+recovery, and uses framework adapters for CoreAudio on macOS and WASAPI / ASIO
+on Windows. Authoritative spec: [DuskStudio.md](DuskStudio.md). User manual:
+[MANUAL.md](MANUAL.md).
 
 ## Get Dusk Studio
 
@@ -35,16 +38,19 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | Out-of-process plugin sandbox — audio, opt-in (Linux + macOS + Windows; scanning always sandboxed) | Working |
 | Out-of-process plugin sandbox — editor embed (Linux XEmbed, Windows SetParent, macOS in-process shell) | Working |
 | Mastering view (waveform + 5-band EQ + multiband comp + brick-wall limiter + BS.1770) | Working |
-| Bounce / mixdown export (master or stems) | Working |
+| Offline bounce / mixdown export (master) | Working |
+| Single-pass stem export (tracks + buses + aux returns) | Working |
+| Realtime bounce (hardware inserts print wet) | Working |
 | Aux sends + reverb / delay returns | Working |
 | External hardware inserts (per channel + per aux, with auto-latency ping) | Working |
 | MIDI tracks + instrument plugins + piano roll editor | Working |
 | Audio region editor (non-destructive trim / fade / gain) + 8-take history | Working |
-| Take cycling + comping (cycle previousTakes — Option A) | Working |
+| Take cycling + comping | Working |
 | Loop-record take stacking (each pass kept as its own take) | Working |
 | Cross-track plugin delay compensation (PDC) | Working |
 | Console automation (Write / Read / Touch on channels + aux + master) | Working |
 | MIDI Clock sync + MTC slave + master | Working |
+| MIDI hot-plug detection (Linux) | Working |
 | MIDI bindings + MIDI Learn (transport / strip / sends / EQ / comp / plugin params) | Working |
 | Mackie Control surface (tested against Tascam DP-24SD) | Working |
 | Multi-file audio + MIDI import with target-track picker | Working |
@@ -54,7 +60,9 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 743 Catch2 test cases across 150 test source files. Linux (amd64 + arm64) + macOS + Windows builds run on every push; Windows tests run on every push + PR; Linux ThreadSanitizer runs on every PR + push.
+The C++ suite declares 742 Catch2 test cases across 150 test source files. Linux
+(amd64 + arm64) and macOS builds run on every push; Windows tests run on every
+push + PR; Linux ThreadSanitizer runs on every PR + push.
 
 ## Bug reports
 
@@ -104,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 743 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 742 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)
@@ -114,17 +122,26 @@ MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)
 
 Precompiled (unsigned) binaries delivered via Patreon — Linux tarball + Windows MSI + macOS DMG, all published to the private releases repo on each tag. Self-build is fully supported and equivalent at the source level — no support tier for self-builders.
 
+Source builds require libsndfile and libsodium; MP3 bounce additionally uses
+LAME. The Linux and Windows guides list the exact package or manifest setup.
+
 | Platform | Doc |
 |----------|-----|
 | Linux | [BUILDING-LINUX.md](BUILDING-LINUX.md) |
 | Windows | [BUILDING-WINDOWS.md](BUILDING-WINDOWS.md) |
-| macOS | Mirror of Linux flow; upstream JUCE 8.0.4, sibling `plugins`, and the same pinned DPF stack. Smoke-built per push on `macos-14` (Apple Silicon Sonoma) — see [.github/workflows/macos-build.yml](.github/workflows/macos-build.yml). |
+| macOS | Mirror of Linux flow; upstream JUCE 8.0.4, sibling `plugins`, the same pinned DPF stack, and static libsodium supplied through `DUSKSTUDIO_SODIUM_ROOT`. Built and tested per push on `macos-14` (Apple Silicon Sonoma) - see [.github/workflows/macos-build.yml](.github/workflows/macos-build.yml). |
 | Linux tarball packaging | [packaging/README.md](packaging/README.md) |
 | End-user manual / troubleshooting | [MANUAL.md](MANUAL.md) |
 
 After a build, sanity check with `DuskStudio --version` — prints app + JUCE + platform string and exits 0. Useful as a paste-target for Patreon support DMs.
 
-CI runs on every push to `main` against Linux (Ubuntu 22.04 GCC), macOS (14 Apple Silicon, Ninja + ccache), and Windows (Server 2022 MSVC). Windows tests (`windows-tests.yml`) exercise the Catch2 suite on every push + PR. Linux ThreadSanitizer (`linux-sanitizer.yml`) runs the Catch2 suite under TSan on every PR + push. Tagged releases (`v*`) trigger the Windows MSI, macOS DMG, and Linux tarball workflows — each builds an unsigned binary and publishes it to the private releases repo (one shared release per tag, distinct asset names).
+CI builds and tests on every push to `main` on Linux (Ubuntu 22.04 GCC) and
+macOS (14 Apple Silicon, Ninja + ccache). Windows tests (`windows-tests.yml`)
+exercise the Catch2 suite on every push + PR using Server 2022 MSVC. Linux
+ThreadSanitizer (`linux-sanitizer.yml`) runs the Catch2 suite under TSan on
+every PR + push. Tagged releases (`v*`) trigger the Windows MSI, macOS DMG,
+Linux tarball and manual PDF workflows; they publish the unsigned binaries and
+rendered manual to one shared release in the private releases repo.
 
 ## License
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -79,9 +79,24 @@ straight from the extracted tarball.
 
 ## Patreon delivery checklist
 
-1. Tag the release: `git tag vX.Y.Z && git push --tags`.
-2. Wait for the `Linux build` workflow to upload the build artefacts.
-3. Pull the artefacts, run `scripts/package-tarball.sh` to produce the `.tar.xz`.
-4. SHA256 the file: `sha256sum dusk-studio-*-Linux-*.tar.xz > SHA256`.
-5. Upload the tarball + SHA256 + `RELEASE_NOTES.md` to the Patreon post.
+1. Prepare the release metadata before tagging. Add the `CHANGELOG.md` section,
+   then run `scripts/bump-version.sh X.Y.Z "Release summary"` to update
+   `VERSION`, `packaging/DuskStudio.appdata.xml`, and
+   `packaging/RELEASE-NOTES.md`.
+2. Date the changelog, review the complete metadata diff, and commit it. Land
+   that commit on `origin/main` and confirm the remote branch contains it before
+   creating the tag.
+3. Tag that exact commit and push the tag:
+   `git tag -a vX.Y.Z -m "Dusk Studio X.Y.Z"` followed by
+   `git push origin vX.Y.Z`.
+4. Wait for the `Linux release (tarball)`, `macOS release (unsigned DMG)`,
+   `Windows build`, and `Manual PDF` workflows. They publish exactly
+   ten assets to the private `dusk-audio/dusk-studio-releases` release: two
+   Linux tarballs plus `SHA256SUMS.linux-x86_64` and
+   `SHA256SUMS.linux-aarch64`, one macOS DMG plus `SHA256SUMS.macos`, one
+   Windows MSI plus `SHA256SUMS.windows`, and `MANUAL.pdf` plus
+   `SHA256SUMS.manual`.
+5. Before announcing the release, run
+   `scripts/verify-release-assets.sh vX.Y.Z`. Do not announce unless it reports
+   all ten assets and a non-empty release body.
 6. Pinned support note: paste `DuskStudio --version` output into any DM.

--- a/packaging/copyright
+++ b/packaging/copyright
@@ -11,8 +11,9 @@ License: GPL-3.0-or-later
  option) any later version.
  .
  The complete text of the GNU General Public License version 3 is
- installed alongside this file as
- /usr/share/doc/dusk-studio/LICENSE.
+ installed alongside this file as /usr/share/doc/dusk-studio/LICENSE.
+ Debian systems also provide the standard copy at
+ /usr/share/common-licenses/GPL-3.
 Comment:
  Third-party components linked into or shipped with this package, their
  copyright holders, licenses and full license texts are inventoried in


### PR DESCRIPTION
## Summary

- correct the 0.13 changelog claims for the signed SFZ catalog groundwork and Linux VST3 resize fix
- document the required libsodium dependency on Linux, Windows, and macOS
- refresh README feature, platform, test-count, badge, and CI claims
- replace the legacy Patreon packaging checklist with the real four-workflow, ten-asset release flow
- make the Debian copyright pointer accurate for both DEB and RPM installs

## Validation

- `bash tests/release_mechanics.sh "$PWD" "$(command -v python3)"`
- `bash tools/juce-gate.sh` (179 files, 9220 uses)
- 742 Catch2 cases across 150 test source files
- `git diff --check`
- workflow names, tag triggers, and ten assets cross-checked against CI and `scripts/verify-release-assets.sh`

Closes #264

Documents the pre-tag half of #266; the CMake opt-out remains post-tag.

Closes #268
Closes #270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Linux, Windows, and macOS build requirements, including signed SFZ catalog support and required libraries.
  * Clarified optional audio dependencies and platform-specific build behavior.
  * Refreshed README details on testing, audio backends, MIDI hot-plugging, bounce features, and release assets.
  * Documented the automated multi-platform release and delivery process.
  * Clarified signed SFZ catalog verification and Linux VST3 editor resizing in the changelog.
  * Updated GPL license reference information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->