### PR TITLE
fix(multisample): preserve path after failed reload

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1594,7 +1594,7 @@ When a `.sf2` holds more than one preset (most GM/GS/XG SoundFonts do), a **pres
 
 The loaded file path and the chosen preset are saved with the session.
 
-If a soundfont can't be loaded — a corrupt file, or an `.sfz` whose `sample=` files can't be found or read — the slot is left empty and the editor shows the reason, rather than holding an instrument that makes no sound.
+If a soundfont can't be loaded — a corrupt file, or an `.sfz` whose `sample=` files can't be found or read — the editor shows the reason. A failed first load leaves the slot empty; a failed Reload or Browse keeps the last successful file reference so Reload and Clear remain available and the next session save does not discard it.
 
 \newpage
 

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -1773,16 +1773,16 @@ void AudioEngine::publishPluginStateForSave (bool audioCallbackDetached)
         }
 #endif
 #if DUSKSTUDIO_HAS_MULTISAMPLE
-        // The editor can swap or CLEAR the soundfont in place, so the live path
-        // off the instance - not the slot's original bundle path - decides
-        // whether this strip still hosts a multisample at all.
-        const auto liveSoundfont = strip.isNativeMultisampleLoaded()
+        // The editor can swap or CLEAR the soundfont in place, so the retained
+        // reference off the instance - not the slot's original bundle path - is
+        // what the session persists. It deliberately survives a failed load.
+        const auto persistedSoundfont = strip.isNativeMultisampleLoaded()
             ? juce::String::fromUTF8 (
                   strip.getNativeMultisampleSlot().getLoadedSoundfontPath().c_str())
             : juce::String();
-        if (liveSoundfont.isNotEmpty())
+        if (persistedSoundfont.isNotEmpty())
         {
-            track.nativeMultisamplePath = liveSoundfont;
+            track.nativeMultisamplePath = persistedSoundfont;
             std::vector<uint8_t> blob;
             if (strip.getNativeMultisampleSlot().saveState (blob) && ! blob.empty())
                 track.nativeMultisampleStateBase64 = juce::Base64::toBase64 (blob.data(), blob.size());

--- a/src/engine/multisample/DuskMultisampleProcessor.cpp
+++ b/src/engine/multisample/DuskMultisampleProcessor.cpp
@@ -93,7 +93,7 @@ juce::File DuskMultisampleProcessor::getControlImagePath() const
     if (rel.isEmpty()) return {};
     if (juce::File::isAbsolutePath (rel))
         return juce::File (rel);
-    // Relative to the loaded .sfz's directory.
+    // Relative to the active .sfz's directory.
     return juce::File (juce::String (path)).getParentDirectory().getChildFile (rel);
 }
 
@@ -219,27 +219,28 @@ bool DuskMultisampleProcessor::reloadCurrentFile (juce::String& errorMessage)
              : loadSfzFile (f, errorMessage);
 }
 
-void DuskMultisampleProcessor::clearLoadedFile()
+void DuskMultisampleProcessor::clearRuntimeState()
 {
-    if (impl == nullptr) return;
-    if (impl->synth != nullptr)
+    if (impl != nullptr && impl->synth != nullptr)
     {
         const juce::SpinLock::ScopedLockType lock (sfizzLock);
-        // sfizz_load_string with empty body unloads the current file.
         sfizz_load_string (impl->synth, "", "");
     }
-    if (impl->sf2TempDir != juce::File())
+    if (impl != nullptr && impl->sf2TempDir != juce::File())
     {
         impl->sf2TempDir.deleteRecursively();
         impl->sf2TempDir = juce::File();
     }
-    // Drop SF2 preset state too so the editor's program switcher doesn't
-    // show stale presets from the just-unloaded SoundFont.
     {
         const juce::ScopedLock sl (sf2PresetsLock);
         sf2Presets.clear();
     }
     sf2PresetIndex.store (-1, std::memory_order_relaxed);
+}
+
+void DuskMultisampleProcessor::clearLoadedFile()
+{
+    clearRuntimeState();
     loadedFilePath.clear();
     publishLoadedPath ({});
     lastLoadError.clear();
@@ -256,6 +257,7 @@ bool DuskMultisampleProcessor::loadSf2File (const juce::File& sf2,
     if (! sf2.existsAsFile())
     {
         errorMessage = "File does not exist: " + sf2.getFullPathName();
+        lastLoadError = errorMessage;
         return false;
     }
 
@@ -451,6 +453,7 @@ bool DuskMultisampleProcessor::loadSfzFile (const juce::File& sfz,
     if (! sfz.existsAsFile())
     {
         errorMessage = "File does not exist: " + sfz.getFullPathName();
+        lastLoadError = errorMessage;
         return false;
     }
     const auto path = sfz.getFullPathName().toStdString();
@@ -461,16 +464,10 @@ bool DuskMultisampleProcessor::loadSfzFile (const juce::File& sfz,
         ok = sfizz_load_file (impl->synth, path.c_str());
         if (ok) regions = sfizz_get_num_regions (impl->synth);
     }
-    // sfizz clears the loaded instrument before it parses, so from here on the
-    // previous soundfont is gone whatever we report. Both failures below drop
-    // the rest of the load state with it - keeping the old file's name, its SF2
-    // program list and its extracted samples would describe an instrument the
-    // synth no longer holds. clearLoadedFile() resets lastLoadError, so the
-    // reason is stored after it.
     if (! ok)
     {
         errorMessage = "sfizz_load_file failed for " + sfz.getFileName();
-        clearLoadedFile();
+        clearRuntimeState();
         lastLoadError = errorMessage;
         return false;
     }
@@ -481,7 +478,7 @@ bool DuskMultisampleProcessor::loadSfzFile (const juce::File& sfz,
     {
         errorMessage = "No playable regions in " + sfz.getFileName()
                      + " - its sample files were not found next to it";
-        clearLoadedFile();
+        clearRuntimeState();
         lastLoadError = errorMessage;
         return false;
     }
@@ -683,9 +680,8 @@ bool DuskMultisampleProcessor::loadState (const std::vector<uint8_t>& in)
                                         : loadSfzFile (file, err);
         if (! ok)
         {
-            // Non-fatal: processor stays in no-file state so the user
-            // can pick a replacement via the editor. lastLoadError
-            // surfaces the reason - editor polls + displays it.
+            // Non-fatal: keep any retained reference so the user can retry or
+            // pick a replacement. lastLoadError surfaces the reason.
             lastLoadError = err.isNotEmpty()
                               ? err
                               : ("File not found: " + path);
@@ -706,9 +702,8 @@ bool DuskMultisampleProcessor::loadState (const std::vector<uint8_t>& in)
 
     // Restore the SF2 preset selection (no-op for SFZ). Must run after
     // the file load above so the SF2 metadata + sfizz state exist.
-    // Skipped when that load failed: sf2Presets + loadedFilePath then describe
-    // whatever survived the failure, not the file the saved index belongs to,
-    // so restoring that index would clobber lastLoadError for nothing.
+    // Skipped when that load failed: the runtime and preset list are empty while
+    // loadedFilePath retains the retry reference, so the saved index is not active.
     // idx == 0 is deliberately skipped: loadSf2File already loaded
     // preset 0, so re-loading it would be redundant work. Only a
     // non-default saved preset needs an explicit switch.

--- a/src/engine/multisample/DuskMultisampleProcessor.h
+++ b/src/engine/multisample/DuskMultisampleProcessor.h
@@ -55,8 +55,8 @@ public:
     // display metadata for the editor's program switcher.
     bool loadSf2File (const juce::File& sf2, juce::String& errorMessage);
 
-    // Switch the loaded SF2 to another preset (re-converts + reloads).
-    // No-op error when the current file isn't an SF2.
+    // Switch the retained SF2 reference to another preset (re-converts + reloads).
+    // No-op error when the retained reference isn't an SF2.
     bool loadSf2Preset (int presetIndex, juce::String& errorMessage);
 
     struct Sf2PresetInfo
@@ -82,17 +82,17 @@ public:
     }
     int getSf2PresetIndex() const noexcept { return sf2PresetIndex.load (std::memory_order_relaxed); }
 
-    // True if a soundfont has been loaded. Used by editor UI to show
-    // "(no file)" vs the loaded file name.
+    // True if a soundfont path is retained. Used by editor UI to show
+    // "(no file)" vs the file name and keep Reload available after failure.
     bool hasLoadedFile() const noexcept { return loadedFilePath.isNotEmpty(); }
     const juce::String& getLoadedFilePath() const noexcept { return loadedFilePath; }
 
-    // Number of regions sfizz parsed from the loaded .sfz. 0 when
-    // no file is loaded. Editor polls this on its refresh timer.
+    // Number of regions sfizz holds from the active .sfz. 0 when the runtime
+    // state is empty, including after a failed reload.
     int getNumRegions() const noexcept;
 
-    // Reload the currently-loaded .sfz from disk. No-op when no
-    // file is loaded. Returns true on success.
+    // Reload the retained soundfont path from disk. No-op when no path is
+    // retained. Returns true on success.
     bool reloadCurrentFile (juce::String& errorMessage);
 
     // Background variants: the load (SF2 sample extraction + sfizz parse can
@@ -116,15 +116,15 @@ public:
     // seconds - parking the audio thread across it is an audible stall.
     void cancelPendingLoads();
 
-    // Thread-safe copy of the loaded soundfont path, empty when none is loaded.
+    // Thread-safe copy of the persisted soundfont path, empty after Clear.
     // loadedFilePath itself is written by the loader thread, so JUCE's String
     // refcount must not be shared across the hand-off; this hands back an
     // independent std::string taken under a lock. Never reflects an in-flight
     // load - the shared value only advances once a load has succeeded.
     std::string getLoadedPathSnapshot() const;
 
-    // Drop the loaded soundfont. After this call the processor
-    // renders silence; subsequent loadSfzFile / loadState can replace it.
+    // Drop the runtime soundfont and its persisted reference. After this call
+    // the processor renders silence; subsequent loadSfzFile / loadState can replace it.
     void clearLoadedFile();
 
     // Polyphony change. Per sfizz.h, sfizz_set_num_voices is marked
@@ -194,6 +194,7 @@ private:
     // loadSf2File (index 0 + name caching) and loadSf2Preset (switch).
     bool applySf2Preset (const juce::File& sf2, int presetIndex,
                           juce::String& errorMessage);
+    void clearRuntimeState();
 
     hosting::PortLayout layout;
     std::atomic<bool>   active { false };
@@ -203,7 +204,7 @@ private:
     // sfizz_set_samples_per_block and read by the audio thread under the same
     // lock, so the guard can never see a size sfizz has not applied yet.
     std::atomic<int> currentBlockSize { 512 };
-    juce::String loadedFilePath;     // empty when no file loaded
+    juce::String loadedFilePath;     // retained across failed loads
 
     // Cross-thread copy of loadedFilePath (see getLoadedPathSnapshot). Written
     // wherever loadedFilePath is, read by the message thread. Never the audio

--- a/src/engine/multisample/NativeMultisampleSlot.h
+++ b/src/engine/multisample/NativeMultisampleSlot.h
@@ -30,10 +30,10 @@ struct MultisampleSlotTraits
 class NativeMultisampleSlot final : public hosting::NativeInsertSlot<MultisampleSlotTraits>
 {
 public:
-    // The soundfont playing RIGHT NOW, empty when none is. The editor swaps
-    // files in place (Browse / Reload / SF2 preset switch / Clear) without going
-    // through load(), so the slot's own bundle path goes stale - never fall back
-    // to it, or a save would resurrect a soundfont the user cleared.
+    // The retained soundfont reference used by session persistence and Reload.
+    // It can name the last successful file while the runtime is silent after a
+    // failed load. The editor swaps files in place without going through load(),
+    // so the slot's bundle path goes stale and must never be used as a fallback.
     std::string getLoadedSoundfontPath() const
     {
         return instance != nullptr ? instance->getLoadedPathSnapshot() : std::string();

--- a/src/ui/multisample/DuskMultisampleEditor.cpp
+++ b/src/ui/multisample/DuskMultisampleEditor.cpp
@@ -165,11 +165,11 @@ void DuskMultisampleEditor::timerCallback()
     if (zoneCountLabel.getText() != zones)
         zoneCountLabel.setText (zones, juce::dontSendNotification);
 
-    const bool fileLoaded = processor.hasLoadedFile();
-    reloadButton.setEnabled (fileLoaded);
-    clearButton .setEnabled (fileLoaded);
+    const bool pathRetained = processor.hasLoadedFile();
+    reloadButton.setEnabled (pathRetained);
+    clearButton .setEnabled (pathRetained);
 
-    // Skin lives or dies with the loaded file path. Rebuild on a path
+    // Skin follows the retained file path. Rebuild on a path
     // change (load, clear, different file, state restore) OR on a same-
     // path mtime change - Reload after an external edit re-loads the
     // same path, which a path-only check would miss.

--- a/src/ui/multisample/DuskMultisampleEditor.h
+++ b/src/ui/multisample/DuskMultisampleEditor.h
@@ -13,11 +13,11 @@ class AriaGuiComponent;
 class DuskMultisampleProcessor;
 
 // Phase 1 editor for the native Multisample instrument. Minimal
-// surface: shows the loaded .sfz path, master volume / tune /
+// surface: shows the retained soundfont path, master volume / tune /
 // polyphony knobs that drive the processor's override atoms, and
 // a read-only region count. Reload + Clear + Browse buttons let
-// the user swap the loaded soundfont without going back to the
-// plugin picker. ADSR / filter / LFO controls + zone mapping
+// the user retry, replace, or clear that reference without going
+// back to the plugin picker. ADSR / filter / LFO controls + zone mapping
 // editor land in Phase 2 / Phase 3 per the plan.
 class DuskMultisampleEditor final : public juce::Component,
                                      private dusk::Timer
@@ -37,7 +37,7 @@ private:
     // Kick a background soundfont load (loadFileAsync / loadSf2PresetAsync):
     // shows "(loading ...)", disables the load controls, re-enables and
     // refreshes when the worker finishes. presetIndex >= 0 switches the
-    // loaded SF2's preset instead of loading `file`.
+    // retained SF2's preset instead of loading `file`.
     void startAsyncLoad (const juce::File& file, int presetIndex = -1);
     void setLoadControlsEnabled (bool enabled);
 
@@ -71,9 +71,9 @@ private:
     std::vector<juce::File>  ariaProgramFiles;   // parallel to selector items
 
 
-    // Skin = the per-soundfont custom UI (when the loaded .sfz ships
+    // Skin = the per-soundfont custom UI (when the active .sfz ships
     // an ARIA bank.xml + GUI XML). nullptr = fall back to the
-    // 3-knob default. Rebuilt whenever the loaded file path changes OR
+    // 3-knob default. Rebuilt whenever the retained file path changes OR
     // the same file's on-disk mtime changes (Reload after an external
     // edit re-loads the same path, so a path-only check would miss it).
     std::unique_ptr<AriaGuiComponent> ariaSkin;

--- a/tests/multisample_state_roundtrip.cpp
+++ b/tests/multisample_state_roundtrip.cpp
@@ -54,33 +54,77 @@ TEST_CASE ("DuskMultisampleProcessor rejects an SFZ with no resolvable samples",
     REQUIRE (error.contains ("No playable regions"));
 }
 
-TEST_CASE ("DuskMultisampleProcessor reports no file after a failed load replaced one",
+TEST_CASE ("DuskMultisampleProcessor preserves its persisted path after a failed load",
            "[multisample][sfz]")
 {
     const auto tempDir = juce::File::getSpecialLocation (juce::File::tempDirectory);
     const auto good = tempDir.getNonexistentChildFile ("Dusk SFZ good", ".sfz", false);
-    const auto broken = tempDir.getNonexistentChildFile ("Dusk SFZ broken", ".sfz", false);
+    const auto missingSample = tempDir.getNonexistentChildFile ("Dusk SFZ missing", ".sfz", false);
+    const auto regionless = tempDir.getNonexistentChildFile ("Dusk SFZ regionless", ".sfz", false);
     struct ScopedFileCleanup
     {
-        juce::File a, b;
-        ~ScopedFileCleanup() { a.deleteFile(); b.deleteFile(); }
-    } cleanup { good, broken };
+        juce::File a, b, c;
+        ~ScopedFileCleanup() { a.deleteFile(); b.deleteFile(); c.deleteFile(); }
+    } cleanup { good, missingSample, regionless };
 
     REQUIRE (good.replaceWithText ("<region> key=60 sample=*sine\n"));
-    REQUIRE (broken.replaceWithText ("<region> key=60 sample=not-here.wav\n"));
+    REQUIRE (missingSample.replaceWithText ("<region> key=60 sample=not-here.wav\n"));
+    REQUIRE (regionless.replaceWithText (""));
 
     duskstudio::DuskMultisampleProcessor processor;
     juce::String error;
     REQUIRE (processor.loadSfzFile (good, error));
     REQUIRE (processor.hasLoadedFile());
+    REQUIRE (processor.getLoadedPathSnapshot() == good.getFullPathName().toStdString());
 
-    // sfizz has already dropped the good instrument by the time the region
-    // count is read, so the failure must not leave the old file's name behind -
-    // that would name a soundfont the synth no longer holds.
-    REQUIRE_FALSE (processor.loadSfzFile (broken, error));
-    REQUIRE_FALSE (processor.hasLoadedFile());
-    REQUIRE (processor.getLoadedFilePath().isEmpty());
-    REQUIRE (processor.getLastLoadError().contains ("No playable regions"));
+    SECTION ("sfizz rejects an existing regionless file")
+    {
+        REQUIRE_FALSE (processor.loadSfzFile (regionless, error));
+        REQUIRE (error.contains ("sfizz_load_file failed"));
+        REQUIRE (processor.getNumRegions() == 0);
+        REQUIRE (processor.hasLoadedFile());
+        REQUIRE (processor.getLoadedFilePath() == good.getFullPathName());
+        REQUIRE (processor.getLoadedPathSnapshot() == good.getFullPathName().toStdString());
+        REQUIRE (processor.getLastLoadError() == error);
+
+        processor.clearLoadedFile();
+        REQUIRE_FALSE (processor.hasLoadedFile());
+        REQUIRE (processor.getLoadedFilePath().isEmpty());
+        REQUIRE (processor.getLoadedPathSnapshot().empty());
+        REQUIRE (processor.getLastLoadError().isEmpty());
+    }
+
+    SECTION ("sfizz drops regions whose samples cannot be resolved")
+    {
+        REQUIRE_FALSE (processor.loadSfzFile (missingSample, error));
+        REQUIRE (error.contains ("No playable regions"));
+        REQUIRE (processor.getNumRegions() == 0);
+        REQUIRE (processor.hasLoadedFile());
+        REQUIRE (processor.getLoadedFilePath() == good.getFullPathName());
+        REQUIRE (processor.getLoadedPathSnapshot() == good.getFullPathName().toStdString());
+        REQUIRE (processor.getLastLoadError() == error);
+
+        processor.clearLoadedFile();
+        REQUIRE_FALSE (processor.hasLoadedFile());
+        REQUIRE (processor.getLoadedFilePath().isEmpty());
+        REQUIRE (processor.getLoadedPathSnapshot().empty());
+        REQUIRE (processor.getLastLoadError().isEmpty());
+    }
+
+    SECTION ("a missing retained file keeps its reload error visible")
+    {
+        REQUIRE (good.deleteFile());
+        REQUIRE_FALSE (processor.reloadCurrentFile (error));
+        REQUIRE (error.contains ("File does not exist"));
+        REQUIRE (processor.hasLoadedFile());
+        REQUIRE (processor.getLoadedFilePath() == good.getFullPathName());
+        REQUIRE (processor.getLoadedPathSnapshot() == good.getFullPathName().toStdString());
+        REQUIRE (processor.getLastLoadError() == error);
+
+        processor.clearLoadedFile();
+        REQUIRE_FALSE (processor.hasLoadedFile());
+        REQUIRE (processor.getLastLoadError().isEmpty());
+    }
 }
 
 namespace


### PR DESCRIPTION
Closes #262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved soundfont load-failure handling.
  * Initial failures leave the slot empty, while later failures retain the last successful file for reload and clear actions.
  * Session saves now preserve retained soundfont references after failed reloads.
  * Clear actions reliably remove retained file and runtime state.
* **Tests**
  * Added coverage for failed loads, retained references, reload errors, and clearing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->