### PR TITLE
fix: retain SF2 preset after failed browse (#275)

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1592,9 +1592,9 @@ Click a track's **Insert** slot and choose **Soundfont (.sfz / .sf2 / .bank.xml)
 
 When a `.sf2` holds more than one preset (most GM/GS/XG SoundFonts do), a **preset picker** appears. Click it to open a filterable browser: start typing to filter presets by name or number, or read across the columns. Presets are grouped program-first — an instrument and its bank variations list together, drum kits last — each shown as `program [bank] name`.
 
-The loaded file path and the chosen preset are saved with the session.
+The loaded file path and the chosen preset are saved with the session. If that preset can no longer be loaded, Dusk Studio reports the problem and falls back to preset 0 so the slot remains playable.
 
-If a soundfont can't be loaded — a corrupt file, or an `.sfz` whose `sample=` files can't be found or read — the editor shows the reason. A failed first load leaves the slot empty; a failed Reload or Browse keeps the last successful file reference so Reload and Clear remain available and the next session save does not discard it.
+If a soundfont can't be loaded — a corrupt file, or an `.sfz` whose `sample=` files can't be found or read — the editor shows the reason. A failed first load leaves the slot empty; a failed Reload or Browse keeps the last successful file reference and remembers its SF2 preset for Reload or session restore, while Reload and Clear remain available.
 
 \newpage
 

--- a/src/engine/multisample/DuskMultisampleProcessor.cpp
+++ b/src/engine/multisample/DuskMultisampleProcessor.cpp
@@ -11,6 +11,12 @@
 
 namespace duskstudio
 {
+namespace
+{
+constexpr auto kSf2PresetFallbackMessage =
+    "SF2 preset could not be loaded; using preset 0";
+}
+
 struct DuskMultisampleProcessor::Impl
 {
     sfizz_synth_t* synth { nullptr };
@@ -124,16 +130,23 @@ DuskMultisampleProcessor::~DuskMultisampleProcessor()
         impl->sf2TempDir.deleteRecursively();
 }
 
-void DuskMultisampleProcessor::publishLoadedPath (const juce::String& path)
+void DuskMultisampleProcessor::publishLoadedState (const juce::String& path,
+                                                    int presetIndex)
 {
     const std::lock_guard<std::mutex> lock (loadedPathLock);
     loadedPathShared = path.toStdString();
+    persistedSf2PresetIndex = presetIndex;
+}
+
+std::pair<std::string, int> DuskMultisampleProcessor::getPersistedStateSnapshot() const
+{
+    const std::lock_guard<std::mutex> lock (loadedPathLock);
+    return { loadedPathShared, persistedSf2PresetIndex };
 }
 
 std::string DuskMultisampleProcessor::getLoadedPathSnapshot() const
 {
-    const std::lock_guard<std::mutex> lock (loadedPathLock);
-    return loadedPathShared;
+    return getPersistedStateSnapshot().first;
 }
 
 void DuskMultisampleProcessor::cancelPendingLoads()
@@ -148,14 +161,18 @@ void DuskMultisampleProcessor::cancelPendingLoads()
 
 bool DuskMultisampleProcessor::create (const MultisampleBundle& bundle,
                                         const std::string&,
-                                        std::string& errorOut)
+                                        std::string& errorOut,
+                                        bool preserveExistingError)
 {
+    const auto retainedError = lastLoadError;
     const juce::File file (juce::String::fromUTF8 (bundle.getFile().u8string().c_str()));
     juce::String err;
     const bool ok = file.getFileExtension().toLowerCase() == ".sf2"
                         ? loadSf2File (file, err)
                         : loadSfzFile (file, err);
     if (! ok) errorOut = err.toStdString();
+    else if (preserveExistingError && retainedError.isNotEmpty())
+        lastLoadError = retainedError;
     return ok;
 }
 
@@ -214,12 +231,14 @@ bool DuskMultisampleProcessor::reloadCurrentFile (juce::String& errorMessage)
         return false;
     }
     const juce::File f (loadedFilePath);
-    return f.getFileExtension().toLowerCase() == ".sf2"
-             ? loadSf2File (f, errorMessage)
-             : loadSfzFile (f, errorMessage);
+    if (f.getFileExtension().toLowerCase() != ".sf2")
+        return loadSfzFile (f, errorMessage);
+
+    const int presetToRestore = getPersistedStateSnapshot().second;
+    return loadSf2File (f, errorMessage, presetToRestore);
 }
 
-void DuskMultisampleProcessor::clearRuntimeState()
+void DuskMultisampleProcessor::clearRuntimeState (bool preservePresetMetadata)
 {
     if (impl != nullptr && impl->synth != nullptr)
     {
@@ -231,23 +250,26 @@ void DuskMultisampleProcessor::clearRuntimeState()
         impl->sf2TempDir.deleteRecursively();
         impl->sf2TempDir = juce::File();
     }
+    if (! preservePresetMetadata)
     {
         const juce::ScopedLock sl (sf2PresetsLock);
         sf2Presets.clear();
     }
     sf2PresetIndex.store (-1, std::memory_order_relaxed);
+    runtimeLoaded.store (false, std::memory_order_release);
 }
 
 void DuskMultisampleProcessor::clearLoadedFile()
 {
     clearRuntimeState();
     loadedFilePath.clear();
-    publishLoadedPath ({});
+    publishLoadedState ({}, -1);
     lastLoadError.clear();
 }
 
 bool DuskMultisampleProcessor::loadSf2File (const juce::File& sf2,
-                                              juce::String& errorMessage)
+                                              juce::String& errorMessage,
+                                              int initialPresetIndex)
 {
     if (impl == nullptr || impl->synth == nullptr)
     {
@@ -264,8 +286,8 @@ bool DuskMultisampleProcessor::loadSf2File (const juce::File& sf2,
     // Cache display metadata without disturbing source indices. SF2 does not
     // require PHDR records to be ordered, while the source index is persisted
     // in sessions and passed to the converter. Build it in temporary storage
-    // and commit only after the preset-0 load below succeeds, so a failed load
-    // leaves the previously loaded SF2's metadata intact.
+    // so the requested load is published and clamped against the new file's
+    // metadata rather than the previously loaded SF2's list.
     std::vector<Sf2PresetInfo> candidates;
     if (auto parsed = readSf2 (std::filesystem::u8path (sf2.getFullPathName().toStdString())); parsed.ok)
     {
@@ -278,13 +300,33 @@ bool DuskMultisampleProcessor::loadSf2File (const juce::File& sf2,
         sortSf2PresetsForDisplay (candidates);
     }
 
-    if (! applySf2Preset (sf2, 0, errorMessage))
-        return false;
+    const int presetCount = (int) candidates.size();
+    const bool requestedPresetInRange = initialPresetIndex >= 0
+                                          && initialPresetIndex < presetCount;
+    int presetToLoad = requestedPresetInRange ? initialPresetIndex : 0;
+    bool usedPresetFallback = initialPresetIndex >= 0 && ! requestedPresetInRange;
+    if (! applySf2Preset (sf2, presetToLoad, errorMessage, false))
+    {
+        if (presetToLoad == 0)
+            return false;
+        presetToLoad = 0;
+        usedPresetFallback = true;
+        errorMessage.clear();
+        if (! applySf2Preset (sf2, presetToLoad, errorMessage, false))
+            return false;
+    }
 
     {
         const juce::ScopedLock sl (sf2PresetsLock);
         sf2Presets = std::move (candidates);
     }
+    // applySf2Preset cannot clamp against the new metadata before it is
+    // committed, so publish the already-clamped source index afterwards.
+    sf2PresetIndex.store (presetToLoad, std::memory_order_relaxed);
+    loadedFilePath = sf2.getFullPathName();
+    publishLoadedState (loadedFilePath, presetToLoad);
+    if (usedPresetFallback)
+        lastLoadError = kSf2PresetFallbackMessage;
     return true;
 }
 
@@ -297,7 +339,22 @@ bool DuskMultisampleProcessor::loadSf2Preset (int presetIndex,
         errorMessage = "No SF2 loaded";
         return false;
     }
-    return applySf2Preset (juce::File (loadedFilePath), presetIndex, errorMessage);
+    const auto file = juce::File (loadedFilePath);
+    if (applySf2Preset (file, presetIndex, errorMessage))
+        return true;
+    if (presetIndex == 0)
+        return false;
+
+    const auto requestedPresetError = errorMessage;
+    errorMessage.clear();
+    if (applySf2Preset (file, 0, errorMessage))
+    {
+        lastLoadError = kSf2PresetFallbackMessage;
+        return true;
+    }
+    if (errorMessage.isEmpty())
+        errorMessage = requestedPresetError;
+    return false;
 }
 
 void DuskMultisampleProcessor::loadFileAsync (
@@ -367,7 +424,8 @@ void DuskMultisampleProcessor::loadSf2PresetAsync (
 
 bool DuskMultisampleProcessor::applySf2Preset (const juce::File& sf2,
                                                  int presetIndex,
-                                                 juce::String& errorMessage)
+                                                 juce::String& errorMessage,
+                                                 bool publishState)
 {
     // Native SF2 -> SFZ: convert one preset into an SFZ body plus a dir
     // of extracted WAVs, then load it through sfizz. No fluidsynth.
@@ -393,35 +451,54 @@ bool DuskMultisampleProcessor::applySf2Preset (const juce::File& sf2,
     // Only the sfizz call itself is serialised against processBlock - the
     // expensive conversion above runs unlocked so the audio thread keeps
     // rendering during it.
-    const juce::SpinLock::ScopedLockType lock (sfizzLock);
-    if (! sfizz_load_string (impl->synth, pathStr.c_str(), body.c_str()))
+    bool loaded = false;
+    int regions = 0;
+    {
+        const juce::SpinLock::ScopedLockType lock (sfizzLock);
+        loaded = sfizz_load_string (impl->synth, pathStr.c_str(), body.c_str());
+        if (loaded)
+            regions = sfizz_get_num_regions (impl->synth);
+    }
+    if (! loaded)
     {
         errorMessage = "sfizz rejected the converted SF2 preset";
-        lastLoadError = errorMessage;
         newDir.deleteRecursively();
+        clearRuntimeState (publishState);
+        lastLoadError = errorMessage;
         return false;
     }
+    if (regions == 0)
+    {
+        errorMessage = "Converted SF2 preset contains no playable regions";
+        newDir.deleteRecursively();
+        // sfizz accepted the SFZ text but discarded every region, so its old
+        // instrument is already gone. Clear the matching active metadata and
+        // temp samples while retaining the persisted path/preset for retry.
+        clearRuntimeState (publishState);
+        lastLoadError = errorMessage;
+        return false;
+    }
+    runtimeLoaded.store (true, std::memory_order_release);
 
     // New sample set is live - drop the previous load's temp dir.
     if (impl->sf2TempDir != juce::File() && impl->sf2TempDir != newDir)
         impl->sf2TempDir.deleteRecursively();
     impl->sf2TempDir = newDir;
 
-    int presetCount;
+    if (publishState)
     {
-        const juce::ScopedLock sl (sf2PresetsLock);
-        presetCount = (int) sf2Presets.size();
+        int presetCount;
+        {
+            const juce::ScopedLock sl (sf2PresetsLock);
+            presetCount = (int) sf2Presets.size();
+        }
+        const int appliedPresetIndex = presetCount > 0
+                                         ? std::clamp (presetIndex, 0, presetCount - 1)
+                                         : std::max (0, presetIndex);
+        sf2PresetIndex.store (appliedPresetIndex, std::memory_order_relaxed);
+        loadedFilePath = sf2.getFullPathName();
+        publishLoadedState (loadedFilePath, appliedPresetIndex);
     }
-    // Clamp only against real metadata: sf2Presets is stale during
-    // loadSf2File's preset-0 load (previous file's list, committed after)
-    // and empty when the metadata parse failed - forcing the index into
-    // those ranges would misreport the preset the converter actually loaded.
-    sf2PresetIndex.store (presetCount > 0
-                            ? juce::jlimit (0, presetCount - 1, presetIndex)
-                            : juce::jmax (0, presetIndex),
-                          std::memory_order_relaxed);
-    loadedFilePath = sf2.getFullPathName();
-    publishLoadedPath (loadedFilePath);
     lastLoadError.clear();
     return true;
 }
@@ -496,8 +573,9 @@ bool DuskMultisampleProcessor::loadSfzFile (const juce::File& sfz,
         sf2Presets.clear();
     }
     sf2PresetIndex.store (-1, std::memory_order_relaxed);
+    runtimeLoaded.store (true, std::memory_order_release);
     loadedFilePath = sfz.getFullPathName();
-    publishLoadedPath (loadedFilePath);
+    publishLoadedState (loadedFilePath, -1);
     lastLoadError.clear();
     return true;
 }
@@ -619,8 +697,9 @@ void DuskMultisampleProcessor::processBlock (const hosting::PortBuffers& io) noe
 
 bool DuskMultisampleProcessor::saveState (std::vector<uint8_t>& out) const
 {
+    const auto persistedState = getPersistedStateSnapshot();
     juce::ValueTree state ("DuskMultisample");
-    state.setProperty ("file", juce::String::fromUTF8 (getLoadedPathSnapshot().c_str()),
+    state.setProperty ("file", juce::String::fromUTF8 (persistedState.first.c_str()),
                         nullptr);
     state.setProperty ("masterVolDb",
                         overrides.masterVolDb.load (std::memory_order_relaxed),
@@ -631,7 +710,7 @@ bool DuskMultisampleProcessor::saveState (std::vector<uint8_t>& out) const
     state.setProperty ("polyphony",
                         overrides.polyphony.load (std::memory_order_relaxed),
                         nullptr);
-    state.setProperty ("sf2Preset", sf2PresetIndex.load (std::memory_order_relaxed), nullptr);
+    state.setProperty ("sf2Preset", persistedState.second, nullptr);
 
     // Persist any CC the UI has set (custom-UI knob/fader positions).
     // Only non-default (>= 0) entries are written so the blob stays
@@ -666,18 +745,23 @@ bool DuskMultisampleProcessor::loadState (const std::vector<uint8_t>& in)
     if (! state.isValid()) return false;
 
     const auto path = state.getProperty ("file").toString();
-    // Skip the re-load when create() already loaded this exact file from the
-    // slot's bundle path (the common session-restore path). Loading a
+    // Skip the re-load when a caller already loaded this exact file. Loading a
     // soundfont is the single most expensive thing this plugin does (~1.5s of
     // sample decode); doing it twice per restored instance is pure waste.
     bool fileLoadOk = true;
-    if (path.isNotEmpty() && path != loadedFilePath)
+    bool presetRestoredByFileLoad = false;
+    if (path.isNotEmpty()
+        && (path != loadedFilePath || ! runtimeLoaded.load (std::memory_order_acquire)))
     {
         const auto file = juce::File (path);
         const auto ext = file.getFileExtension().toLowerCase();
+        const int requestedPreset = state.hasProperty ("sf2Preset")
+                                      ? (int) state.getProperty ("sf2Preset")
+                                      : 0;
         juce::String err;
-        const bool ok = (ext == ".sf2") ? loadSf2File (file, err)
+        const bool ok = (ext == ".sf2") ? loadSf2File (file, err, requestedPreset)
                                         : loadSfzFile (file, err);
+        presetRestoredByFileLoad = ok && ext == ".sf2";
         if (! ok)
         {
             // Non-fatal: keep any retained reference so the user can retry or
@@ -700,14 +784,12 @@ bool DuskMultisampleProcessor::loadState (const std::vector<uint8_t>& in)
     if (state.hasProperty ("polyphony"))
         setPolyphony (std::clamp ((int) state.getProperty ("polyphony"), 1, 256));
 
-    // Restore the SF2 preset selection (no-op for SFZ). Must run after
-    // the file load above so the SF2 metadata + sfizz state exist.
-    // Skipped when that load failed: the runtime and preset list are empty while
-    // loadedFilePath retains the retry reference, so the saved index is not active.
-    // idx == 0 is deliberately skipped: loadSf2File already loaded
-    // preset 0, so re-loading it would be redundant work. Only a
-    // non-default saved preset needs an explicit switch.
-    if (fileLoadOk && state.hasProperty ("sf2Preset"))
+    // Restore the SF2 preset selection (no-op for SFZ). A new SF2 path loaded
+    // the requested preset directly above; this handles callers that already
+    // loaded the same file at a different preset.
+    // Skipped when a load failed. When the saved and active indices match,
+    // avoid a redundant conversion.
+    if (fileLoadOk && ! presetRestoredByFileLoad && state.hasProperty ("sf2Preset"))
     {
         const int idx = (int) state.getProperty ("sf2Preset");
         int presetCount;
@@ -715,10 +797,30 @@ bool DuskMultisampleProcessor::loadState (const std::vector<uint8_t>& in)
             const juce::ScopedLock sl (sf2PresetsLock);
             presetCount = (int) sf2Presets.size();
         }
-        if (idx > 0 && idx < presetCount)
+        const int activePreset = sf2PresetIndex.load (std::memory_order_relaxed);
+        const bool savedPresetOutOfRange = presetCount > 0
+                                             && idx >= presetCount;
+        const int presetToRestore = presetCount > 0
+                                      ? (idx >= 0 && idx < presetCount ? idx : 0)
+                                      : -1;
+        if (presetToRestore >= 0 && presetToRestore != activePreset)
         {
             juce::String err;
-            loadSf2Preset (idx, err);
+            if (loadSf2Preset (presetToRestore, err))
+            {
+                if (savedPresetOutOfRange)
+                    lastLoadError = kSf2PresetFallbackMessage;
+            }
+            else
+            {
+                lastLoadError = err.isNotEmpty()
+                                  ? err
+                                  : "Failed to restore the saved SF2 preset";
+            }
+        }
+        else if (savedPresetOutOfRange)
+        {
+            lastLoadError = kSf2PresetFallbackMessage;
         }
     }
 
@@ -733,6 +835,8 @@ bool DuskMultisampleProcessor::loadState (const std::vector<uint8_t>& in)
             setHDCC ((int) e.getProperty ("n"), (float) e.getProperty ("v"));
         }
     }
+    // A syntactically valid state restores best-effort: missing files and
+    // unusable presets remain soft failures surfaced through lastLoadError.
     return true;
 }
 } // namespace duskstudio

--- a/src/engine/multisample/DuskMultisampleProcessor.cpp
+++ b/src/engine/multisample/DuskMultisampleProcessor.cpp
@@ -304,10 +304,13 @@ bool DuskMultisampleProcessor::loadSf2File (const juce::File& sf2,
     const bool requestedPresetInRange = initialPresetIndex >= 0
                                           && initialPresetIndex < presetCount;
     int presetToLoad = requestedPresetInRange ? initialPresetIndex : 0;
-    bool usedPresetFallback = initialPresetIndex >= 0 && ! requestedPresetInRange;
+    bool usedPresetFallback = initialPresetIndex > 0 && ! requestedPresetInRange;
     if (! applySf2Preset (sf2, presetToLoad, errorMessage, false))
     {
-        if (presetToLoad == 0)
+        // Conversion failures leave the current instrument intact. Do not
+        // replace a working preset with preset 0 unless the failed attempt
+        // actually cleared the runtime and recovery is required.
+        if (presetToLoad == 0 || hasLoadedRuntime())
             return false;
         presetToLoad = 0;
         usedPresetFallback = true;
@@ -342,7 +345,9 @@ bool DuskMultisampleProcessor::loadSf2Preset (int presetIndex,
     const auto file = juce::File (loadedFilePath);
     if (applySf2Preset (file, presetIndex, errorMessage))
         return true;
-    if (presetIndex == 0)
+    // A conversion failure occurs before sfizz is touched, so retain the
+    // working preset. Retry preset 0 only after a destructive load failure.
+    if (presetIndex == 0 || hasLoadedRuntime())
         return false;
 
     const auto requestedPresetError = errorMessage;
@@ -453,6 +458,7 @@ bool DuskMultisampleProcessor::applySf2Preset (const juce::File& sf2,
     // rendering during it.
     bool loaded = false;
     int regions = 0;
+    const bool preservePresetMetadata = publishState;
     {
         const juce::SpinLock::ScopedLockType lock (sfizzLock);
         loaded = sfizz_load_string (impl->synth, pathStr.c_str(), body.c_str());
@@ -463,7 +469,7 @@ bool DuskMultisampleProcessor::applySf2Preset (const juce::File& sf2,
     {
         errorMessage = "sfizz rejected the converted SF2 preset";
         newDir.deleteRecursively();
-        clearRuntimeState (publishState);
+        clearRuntimeState (preservePresetMetadata);
         lastLoadError = errorMessage;
         return false;
     }
@@ -472,9 +478,10 @@ bool DuskMultisampleProcessor::applySf2Preset (const juce::File& sf2,
         errorMessage = "Converted SF2 preset contains no playable regions";
         newDir.deleteRecursively();
         // sfizz accepted the SFZ text but discarded every region, so its old
-        // instrument is already gone. Clear the matching active metadata and
-        // temp samples while retaining the persisted path/preset for retry.
-        clearRuntimeState (publishState);
+        // instrument is already gone. Clear its runtime and temp samples while
+        // leaving the persisted retry snapshot untouched; direct preset
+        // switches also preserve the cached preset list.
+        clearRuntimeState (preservePresetMetadata);
         lastLoadError = errorMessage;
         return false;
     }
@@ -541,6 +548,9 @@ bool DuskMultisampleProcessor::loadSfzFile (const juce::File& sfz,
         ok = sfizz_load_file (impl->synth, path.c_str());
         if (ok) regions = sfizz_get_num_regions (impl->synth);
     }
+    // Once an SFZ attempt reaches sfizz, stale SF2 choices no longer describe
+    // its runtime. Both destructive failure paths discard that cached list,
+    // while the retained path and preset index remain available for Retry.
     if (! ok)
     {
         errorMessage = "sfizz_load_file failed for " + sfz.getFileName();

--- a/src/engine/multisample/DuskMultisampleProcessor.h
+++ b/src/engine/multisample/DuskMultisampleProcessor.h
@@ -12,6 +12,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace duskstudio
@@ -32,7 +33,7 @@ public:
     // NativeInsertSlot construction hook: load the bundle's soundfont. The
     // multisample rung has exactly one plugin per bundle, so pluginId is unused.
     bool create (const MultisampleBundle& bundle, const std::string& pluginId,
-                 std::string& errorOut);
+                 std::string& errorOut, bool preserveExistingError = false);
 
     // hosting::INativeInstance.
     const hosting::PortLayout& portLayout() const noexcept override { return layout; }
@@ -49,11 +50,12 @@ public:
     // true + clears errorMessage on success.
     bool loadSfzFile (const juce::File& sfz, juce::String& errorMessage);
 
-    // Load an .sf2 (SoundFont 2) file. Converts the first preset to SFZ
+    // Load an .sf2 (SoundFont 2) file. Converts the requested preset to SFZ
     // + extracted WAVs (Sf2Reader + Sf2ToSfz) and plays it through the
     // vendored sfizz engine - no fluidsynth dependency. Caches preset
     // display metadata for the editor's program switcher.
-    bool loadSf2File (const juce::File& sf2, juce::String& errorMessage);
+    bool loadSf2File (const juce::File& sf2, juce::String& errorMessage,
+                      int initialPresetIndex = 0);
 
     // Switch the retained SF2 reference to another preset (re-converts + reloads).
     // No-op error when the retained reference isn't an SF2.
@@ -85,6 +87,10 @@ public:
     // True if a soundfont path is retained. Used by editor UI to show
     // "(no file)" vs the file name and keep Reload available after failure.
     bool hasLoadedFile() const noexcept { return loadedFilePath.isNotEmpty(); }
+    bool hasLoadedRuntime() const noexcept
+    {
+        return runtimeLoaded.load (std::memory_order_acquire);
+    }
     const juce::String& getLoadedFilePath() const noexcept { return loadedFilePath; }
 
     // Number of regions sfizz holds from the active .sfz. 0 when the runtime
@@ -190,11 +196,12 @@ public:
     std::vector<std::pair<int, juce::String>> getControlCcLabels() const;
 
 private:
-    // Convert + load one preset of an SF2 through sfizz. Shared by
-    // loadSf2File (index 0 + name caching) and loadSf2Preset (switch).
+    // Convert + load one preset of an SF2 through sfizz. Initial file loads
+    // defer state publication until their new preset metadata is committed;
+    // direct preset switches publish immediately.
     bool applySf2Preset (const juce::File& sf2, int presetIndex,
-                          juce::String& errorMessage);
-    void clearRuntimeState();
+                          juce::String& errorMessage, bool publishState = true);
+    void clearRuntimeState (bool preservePresetMetadata = false);
 
     hosting::PortLayout layout;
     std::atomic<bool>   active { false };
@@ -204,14 +211,18 @@ private:
     // sfizz_set_samples_per_block and read by the audio thread under the same
     // lock, so the guard can never see a size sfizz has not applied yet.
     std::atomic<int> currentBlockSize { 512 };
+    // Distinguishes a retained retry path from an instrument sfizz still holds.
+    std::atomic<bool> runtimeLoaded { false };
     juce::String loadedFilePath;     // retained across failed loads
 
-    // Cross-thread copy of loadedFilePath (see getLoadedPathSnapshot). Written
-    // wherever loadedFilePath is, read by the message thread. Never the audio
-    // thread, so a plain mutex is fine.
+    // Cross-thread persisted path + SF2 preset snapshot. State saves read the
+    // pair atomically so a loader cannot publish a new path with an old preset.
+    // Never touched by the audio thread, so a plain mutex is fine.
     mutable std::mutex loadedPathLock;
     std::string        loadedPathShared;
-    void publishLoadedPath (const juce::String& path);
+    int                persistedSf2PresetIndex { -1 };
+    void publishLoadedState (const juce::String& path, int presetIndex);
+    std::pair<std::string, int> getPersistedStateSnapshot() const;
     juce::String lastLoadError;      // most recent loadState / load failure
     Overrides overrides;
 
@@ -222,7 +233,7 @@ private:
     juce::CriticalSection      sf2PresetsLock;
     // Written by the loader thread, read by the editor timer - atomic so the
     // int itself can't tear (the presets vector has its own lock).
-    std::atomic<int>           sf2PresetIndex { 0 };
+    std::atomic<int>           sf2PresetIndex { -1 };
 
     // CC control plumbing. ccCache holds the last value the UI set per
     // CC (-1 = unset) for read-back + state save. ccDirty flags which of

--- a/src/engine/multisample/DuskMultisampleProcessor.h
+++ b/src/engine/multisample/DuskMultisampleProcessor.h
@@ -93,8 +93,8 @@ public:
     }
     const juce::String& getLoadedFilePath() const noexcept { return loadedFilePath; }
 
-    // Number of regions sfizz holds from the active .sfz. 0 when the runtime
-    // state is empty, including after a failed reload.
+    // Number of regions sfizz currently holds. A failure before sfizz is
+    // touched retains the previous count; destructive failures return 0.
     int getNumRegions() const noexcept;
 
     // Reload the retained soundfont path from disk. No-op when no path is

--- a/src/engine/multisample/NativeMultisampleSlot.h
+++ b/src/engine/multisample/NativeMultisampleSlot.h
@@ -46,6 +46,19 @@ public:
         if (instance != nullptr) instance->cancelPendingLoads();
     }
 
+    // State's retained soundfont reference is authoritative. Keep the generic
+    // slot path in step when an in-editor file swap made it differ from the
+    // bundle that originally constructed the slot.
+    bool loadState (const std::vector<uint8_t>& in)
+    {
+        if (instance == nullptr || ! instance->loadState (in))
+            return false;
+        const auto retainedPath = instance->getLoadedPathSnapshot();
+        if (! retainedPath.empty())
+            loadedPath = retainedPath;
+        return true;
+    }
+
     // Two-phase load, for callers with a live engine. Parsing a soundfont takes
     // seconds on a GM bank, so it must not happen inside the engine's process
     // gate: prime() builds + activates + parses + restores state with the audio
@@ -78,16 +91,24 @@ public:
         }
 
         auto inst = std::make_unique<DuskMultisampleProcessor>();
-        if (! inst->create (*b, {}, err)) { errorOut = "create: " + err;   return primed; }
+        const bool hasState = state != nullptr && ! state->empty();
+        if (hasState)
+            inst->loadState (*state);
+        const bool stateRuntimeLoaded = inst->hasLoadedRuntime();
+        if (! stateRuntimeLoaded)
+        {
+            // The state loader already applied non-file settings. When its file
+            // was unavailable, keep that diagnostic while loading the bundle
+            // instead of parsing the failed state file a second time.
+            if (! inst->create (*b, {}, err, hasState && ! stateRuntimeLoaded))
+            { errorOut = "create: " + err; return primed; }
+        }
         if (! inst->activate (sampleRate, maxBlock, err))
         { errorOut = "activate: " + err; return primed; }
-        // State carries the SF2 preset index, which can trigger a second parse -
-        // also expensive, so it belongs on this side of the gate.
-        if (state != nullptr && ! state->empty()) inst->loadState (*state);
 
         primed.bundle   = std::move (b);
         primed.instance = std::move (inst);
-        primed.path     = path.u8string();
+        primed.path     = primed.instance->getLoadedPathSnapshot();
         return primed;
     }
 

--- a/src/engine/multisample/NativeMultisampleSlot.h
+++ b/src/engine/multisample/NativeMultisampleSlot.h
@@ -100,7 +100,7 @@ public:
             // The state loader already applied non-file settings. When its file
             // was unavailable, keep that diagnostic while loading the bundle
             // instead of parsing the failed state file a second time.
-            if (! inst->create (*b, {}, err, hasState && ! stateRuntimeLoaded))
+            if (! inst->create (*b, {}, err, hasState))
             { errorOut = "create: " + err; return primed; }
         }
         if (! inst->activate (sampleRate, maxBlock, err))

--- a/src/ui/multisample/DuskMultisampleEditor.cpp
+++ b/src/ui/multisample/DuskMultisampleEditor.cpp
@@ -151,13 +151,16 @@ void DuskMultisampleEditor::timerCallback()
 
     const auto err  = processor.getLastLoadError();
     const auto path = processor.getLoadedFilePath();
+    const auto fileName = juce::File (path).getFileName();
     juce::String display;
     if (err.isNotEmpty())
-        display = "(" + err + ")";
+        display = processor.hasLoadedRuntime() && fileName.isNotEmpty()
+                    ? fileName + " (" + err + ")"
+                    : "(" + err + ")";
     else if (path.isEmpty())
         display = "(no file)";
     else
-        display = juce::File (path).getFileName();
+        display = fileName;
     if (filePathLabel.getText() != display)
         filePathLabel.setText (display, juce::dontSendNotification);
 

--- a/src/ui/multisample/DuskMultisampleEditor.cpp
+++ b/src/ui/multisample/DuskMultisampleEditor.cpp
@@ -178,10 +178,13 @@ void DuskMultisampleEditor::timerCallback()
     // same path, which a path-only check would miss.
     const auto modTime = path.isNotEmpty() ? juce::File (path).getLastModificationTime()
                                             : juce::Time();
-    if (path != currentSkinPath || modTime != currentSkinModTime)
+    const bool runtimeLoaded = processor.hasLoadedRuntime();
+    if (path != currentSkinPath || modTime != currentSkinModTime
+        || runtimeLoaded != currentSkinRuntimeLoaded)
     {
-        currentSkinPath    = path;
-        currentSkinModTime = modTime;
+        currentSkinPath          = path;
+        currentSkinModTime       = modTime;
+        currentSkinRuntimeLoaded = runtimeLoaded;
         rebuildSkin();
     }
 }
@@ -272,7 +275,7 @@ void DuskMultisampleEditor::rebuildSkin()
             sf2PresetSelector.addItem (number + " [" + juce::String (preset.bank) + "] " + name,
                                         preset.sourceIndex + 1);
         }
-        sf2PresetSelector.setSelectedId (juce::jmax (1, processor.getSf2PresetIndex() + 1),
+        sf2PresetSelector.setSelectedId (processor.getSf2PresetIndex() + 1,
                                           juce::dontSendNotification);
     }
     sf2PresetLabel   .setVisible (showSf2Presets);
@@ -382,26 +385,21 @@ void DuskMultisampleEditor::startAsyncLoad (const juce::File& file, int presetIn
                             juce::dontSendNotification);
 
     juce::Component::SafePointer<DuskMultisampleEditor> safe (this);
-    auto onDone = [safe, presetIndex] (bool ok, juce::String err)
+    auto onDone = [safe, presetIndex] (bool, juce::String)
     {
         // The processor outlives a closed editor (worker joins in ITS
         // destructor) - only the UI refresh needs the guard.
         if (auto* self = safe.getComponent())
         {
             self->setLoadControlsEnabled (true);
-            if (! ok)
+            if (presetIndex >= 0
+                && self->processor.getSf2PresetIndex() != presetIndex)
             {
-                self->filePathLabel.setText ("(" + err + ")", juce::dontSendNotification);
-                // A failed preset switch leaves the selector on the choice that
-                // didn't load; snap it back to the preset still playing so the
-                // UI doesn't misreport the active program.
-                if (presetIndex >= 0)
-                    self->sf2PresetSelector.setSelectedId (
-                        juce::jmax (1, self->processor.getSf2PresetIndex() + 1),
-                        juce::dontSendNotification);
+                self->sf2PresetSelector.setSelectedId (
+                    self->processor.getSf2PresetIndex() + 1,
+                    juce::dontSendNotification);
             }
-            else
-                self->timerCallback();
+            self->timerCallback();
         }
     };
 

--- a/src/ui/multisample/DuskMultisampleEditor.h
+++ b/src/ui/multisample/DuskMultisampleEditor.h
@@ -75,10 +75,13 @@ private:
     // an ARIA bank.xml + GUI XML). nullptr = fall back to the
     // 3-knob default. Rebuilt whenever the retained file path changes OR
     // the same file's on-disk mtime changes (Reload after an external
-    // edit re-loads the same path, so a path-only check would miss it).
+    // edit re-loads the same path, so a path-only check would miss it). Runtime
+    // transitions also rebuild so a failed initial load cannot leave a stale
+    // SF2 preset selector.
     std::unique_ptr<AriaGuiComponent> ariaSkin;
     juce::String                      currentSkinPath;
     juce::Time                        currentSkinModTime;
+    bool                              currentSkinRuntimeLoaded { false };
 
     void rebuildSkin();
 };

--- a/tests/multisample_state_roundtrip.cpp
+++ b/tests/multisample_state_roundtrip.cpp
@@ -1,12 +1,16 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
-#include "engine/multisample/DuskMultisampleProcessor.h"
+#include "engine/multisample/NativeMultisampleSlot.h"
 
 #include <juce_data_structures/juce_data_structures.h>
 
 #include <cstdint>
 #include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <random>
+#include <string>
 #include <vector>
 
 using Catch::Matchers::WithinAbs;
@@ -152,15 +156,24 @@ void sf2Chunk (Sf2Buf& out, const char* cid, const std::vector<std::uint8_t>& bo
     if (body.size() & 1) out.u8 (0);
 }
 
-std::vector<std::uint8_t> twoPresetSf2()
+std::vector<std::uint8_t> testSf2 (bool secondPresetPlayable = true,
+                                   bool includeSecondPreset = true)
 {
     Sf2Buf phdr;
     phdr.name ("pre0"); phdr.u16 (0); phdr.u16 (0); phdr.u16 (0); phdr.u32 (0); phdr.u32 (0); phdr.u32 (0);
-    phdr.name ("pre1"); phdr.u16 (1); phdr.u16 (0); phdr.u16 (1); phdr.u32 (0); phdr.u32 (0); phdr.u32 (0);
-    phdr.name ("EOP");  phdr.u16 (0); phdr.u16 (0); phdr.u16 (2); phdr.u32 (0); phdr.u32 (0); phdr.u32 (0);
+    if (includeSecondPreset)
+        { phdr.name ("pre1"); phdr.u16 (1); phdr.u16 (0); phdr.u16 (1); phdr.u32 (0); phdr.u32 (0); phdr.u32 (0); }
+    phdr.name ("EOP"); phdr.u16 (0); phdr.u16 (0); phdr.u16 (includeSecondPreset ? 2 : 1); phdr.u32 (0); phdr.u32 (0); phdr.u32 (0);
 
-    Sf2Buf pbag; pbag.u16 (0); pbag.u16 (0); pbag.u16 (1); pbag.u16 (0); pbag.u16 (2); pbag.u16 (0);
-    Sf2Buf pgen; pgen.u16 (41); pgen.u16 (0); pgen.u16 (41); pgen.u16 (0); pgen.u16 (0); pgen.u16 (0);
+    Sf2Buf pbag;
+    pbag.u16 (0); pbag.u16 (0);
+    if (includeSecondPreset) { pbag.u16 (1); pbag.u16 (0); }
+    pbag.u16 (includeSecondPreset ? 2 : 1); pbag.u16 (0);
+    Sf2Buf pgen;
+    pgen.u16 (41); pgen.u16 (0);
+    if (includeSecondPreset)
+        { pgen.u16 (41); pgen.u16 (secondPresetPlayable ? 0 : 1); }
+    pgen.u16 (0);  pgen.u16 (0);
 
     Sf2Buf inst;
     inst.name ("inst0"); inst.u16 (0);
@@ -191,6 +204,21 @@ std::vector<std::uint8_t> twoPresetSf2()
 
     Sf2Buf file; file.id ("RIFF"); file.u32 ((std::uint32_t) content.b.size()); file.raw (content.b);
     return file.b;
+}
+
+std::filesystem::path createUniqueTempSoundfontDirectory()
+{
+    std::random_device random;
+    for (int attempt = 0; attempt < 16; ++attempt)
+    {
+        const auto nonce = (std::uint64_t (random()) << 32) ^ std::uint64_t (random());
+        const auto candidate = std::filesystem::temp_directory_path()
+                             / ("dusk-multisample-" + std::to_string (nonce));
+        std::error_code error;
+        if (std::filesystem::create_directory (candidate, error))
+            return candidate;
+    }
+    return {};
 }
 } // namespace
 
@@ -346,7 +374,7 @@ TEST_CASE ("DuskMultisampleProcessor: failed loadState leaves the old SF2's pres
     duskstudio::DuskMultisampleProcessor proc;
 
     const auto aFile = juce::File::createTempFile (".sf2");
-    const auto bytes = twoPresetSf2();
+    const auto bytes = testSf2();
     aFile.replaceWithData (bytes.data(), bytes.size());
 
     juce::String loadErr;
@@ -378,4 +406,266 @@ TEST_CASE ("DuskMultisampleProcessor: failed loadState leaves the old SF2's pres
     REQUIRE (proc.getLoadedPathSnapshot() == aPath.toStdString());
 
     aFile.deleteFile();
+}
+
+TEST_CASE ("DuskMultisampleProcessor: failed SFZ browse preserves the retained SF2 preset",
+           "[multisample]")
+{
+    const auto tempDirectory = createUniqueTempSoundfontDirectory();
+    REQUIRE_FALSE (tempDirectory.empty());
+    const auto sf2Path = tempDirectory / "source.sf2";
+    const auto brokenSfzPath = tempDirectory / "broken.sfz";
+    struct ScopedPathCleanup
+    {
+        std::filesystem::path path;
+        ~ScopedPathCleanup()
+        {
+            std::error_code ignored;
+            std::filesystem::remove_all (path, ignored);
+        }
+    } cleanup { tempDirectory };
+
+    const auto sf2Bytes = testSf2();
+    {
+        std::ofstream out (sf2Path, std::ios::binary);
+        out.write (reinterpret_cast<const char*> (sf2Bytes.data()),
+                   static_cast<std::streamsize> (sf2Bytes.size()));
+        out.flush();
+        REQUIRE (out.good());
+    }
+
+    duskstudio::MultisampleBundle sf2Bundle;
+    std::string createError;
+    REQUIRE (sf2Bundle.load (sf2Path.string(), createError));
+
+    duskstudio::DuskMultisampleProcessor source;
+    REQUIRE (source.create (sf2Bundle, {}, createError));
+    auto error = source.getLastLoadError();
+    REQUIRE (source.loadSf2Preset (1, error));
+    REQUIRE (source.getSf2PresetIndex() == 1);
+
+    {
+        std::ofstream out (brokenSfzPath, std::ios::binary);
+        out << "<region> key=60 sample=not-here.wav\n";
+        out.flush();
+        REQUIRE (out.good());
+    }
+    duskstudio::MultisampleBundle brokenSfzBundle;
+    REQUIRE (brokenSfzBundle.load (brokenSfzPath.string(), createError));
+    REQUIRE_FALSE (source.create (brokenSfzBundle, {}, createError));
+    REQUIRE (source.getNumRegions() == 0);
+    REQUIRE (source.getSf2Presets().empty());
+    REQUIRE (source.getSf2PresetIndex() == -1);
+    REQUIRE (source.getLoadedPathSnapshot() == sf2Path.string());
+
+    SECTION ("state restore")
+    {
+        std::vector<std::uint8_t> savedState;
+        REQUIRE (source.saveState (savedState));
+
+        duskstudio::DuskMultisampleProcessor restored;
+        REQUIRE (restored.loadState (savedState));
+        REQUIRE (restored.getLoadedPathSnapshot() == sf2Path.string());
+        REQUIRE (restored.getSf2PresetIndex() == 1);
+        REQUIRE (restored.getLastLoadError().isEmpty());
+    }
+
+    SECTION ("same-processor state restore")
+    {
+        std::vector<std::uint8_t> savedState;
+        REQUIRE (source.saveState (savedState));
+
+        REQUIRE (source.loadState (savedState));
+        REQUIRE (source.getLoadedPathSnapshot() == sf2Path.string());
+        REQUIRE (source.getSf2PresetIndex() == 1);
+        REQUIRE (source.getLastLoadError().isEmpty());
+    }
+
+    SECTION ("native slot prime restores the retained preset directly")
+    {
+        std::vector<std::uint8_t> savedState;
+        REQUIRE (source.saveState (savedState));
+        std::string primeError;
+        auto primed = duskstudio::NativeMultisampleSlot::prime (
+            sf2Path, 48000.0, 512, primeError, &savedState);
+
+        INFO ("Prime error: " << primeError);
+        REQUIRE (primed);
+        REQUIRE (primed.instance->hasLoadedRuntime());
+        REQUIRE (primed.instance->getLoadedPathSnapshot() == sf2Path.string());
+        REQUIRE (primed.instance->getSf2PresetIndex() == 1);
+        REQUIRE (primed.instance->getLastLoadError().isEmpty());
+    }
+
+    SECTION ("same-path state restore selects preset zero")
+    {
+        REQUIRE (source.reloadCurrentFile (error));
+        REQUIRE (source.getSf2PresetIndex() == 1);
+
+        duskstudio::DuskMultisampleProcessor presetZero;
+        REQUIRE (presetZero.create (sf2Bundle, {}, createError));
+        std::vector<std::uint8_t> savedState;
+        REQUIRE (presetZero.saveState (savedState));
+
+        REQUIRE (source.loadState (savedState));
+        REQUIRE (source.getLoadedPathSnapshot() == sf2Path.string());
+        REQUIRE (source.getSf2PresetIndex() == 0);
+        REQUIRE (source.getLastLoadError().isEmpty());
+    }
+
+    SECTION ("editor reload")
+    {
+        REQUIRE (source.reloadCurrentFile (error));
+        REQUIRE (source.getLoadedPathSnapshot() == sf2Path.string());
+        REQUIRE (source.getSf2PresetIndex() == 1);
+        REQUIRE (source.getLastLoadError().isEmpty());
+    }
+}
+
+TEST_CASE ("DuskMultisampleProcessor: an unplayable saved SF2 preset falls back to preset zero",
+           "[multisample]")
+{
+    const auto tempDirectory = createUniqueTempSoundfontDirectory();
+    REQUIRE_FALSE (tempDirectory.empty());
+    const auto sf2Path = tempDirectory / "fallback.sf2";
+    struct ScopedPathCleanup
+    {
+        std::filesystem::path path;
+        ~ScopedPathCleanup()
+        {
+            std::error_code ignored;
+            std::filesystem::remove_all (path, ignored);
+        }
+    } cleanup { tempDirectory };
+
+    const auto writeSoundfont = [&sf2Path] (const std::vector<std::uint8_t>& bytes)
+    {
+        std::ofstream out (sf2Path, std::ios::binary | std::ios::trunc);
+        out.write (reinterpret_cast<const char*> (bytes.data()),
+                   static_cast<std::streamsize> (bytes.size()));
+        out.flush();
+        return out.good();
+    };
+
+    const auto playableBytes = testSf2();
+    REQUIRE (writeSoundfont (playableBytes));
+
+    duskstudio::MultisampleBundle bundle;
+    std::string createError;
+    REQUIRE (bundle.load (sf2Path.string(), createError));
+
+    duskstudio::DuskMultisampleProcessor source;
+    REQUIRE (source.create (bundle, {}, createError));
+    auto error = source.getLastLoadError();
+    REQUIRE (source.loadSf2Preset (1, error));
+    std::vector<std::uint8_t> savedState;
+    REQUIRE (source.saveState (savedState));
+
+    REQUIRE (writeSoundfont (testSf2 (false)));
+
+    duskstudio::DuskMultisampleProcessor restored;
+    REQUIRE (restored.loadState (savedState));
+    REQUIRE (restored.getSf2PresetIndex() == 0);
+    REQUIRE (restored.getNumRegions() > 0);
+    REQUIRE (restored.getLastLoadError().contains ("using preset 0"));
+
+    error.clear();
+    REQUIRE (restored.loadSf2Preset (1, error));
+    REQUIRE (restored.getSf2PresetIndex() == 0);
+    REQUIRE (restored.getSf2Presets().size() == 2);
+    REQUIRE (restored.getNumRegions() > 0);
+    REQUIRE (restored.getLastLoadError().contains ("using preset 0"));
+
+    // The same-path restore takes a separate code path and must also recover.
+    REQUIRE (restored.loadState (savedState));
+    REQUIRE (restored.getSf2PresetIndex() == 0);
+    REQUIRE (restored.getNumRegions() > 0);
+    REQUIRE (restored.getLastLoadError().contains ("using preset 0"));
+
+    // The failed selection must not become authoritative in the next save.
+    std::vector<std::uint8_t> fallbackState;
+    REQUIRE (restored.saveState (fallbackState));
+    REQUIRE (writeSoundfont (playableBytes));
+
+    duskstudio::DuskMultisampleProcessor reopened;
+    REQUIRE (reopened.loadState (fallbackState));
+    REQUIRE (reopened.getSf2PresetIndex() == 0);
+    REQUIRE (reopened.getLastLoadError().isEmpty());
+
+    REQUIRE (writeSoundfont (testSf2 (true, false)));
+    duskstudio::DuskMultisampleProcessor outOfRange;
+    REQUIRE (outOfRange.loadState (savedState));
+    REQUIRE (outOfRange.getSf2PresetIndex() == 0);
+    REQUIRE (outOfRange.getNumRegions() > 0);
+    REQUIRE (outOfRange.getLastLoadError().contains ("using preset 0"));
+
+    duskstudio::DuskMultisampleProcessor samePathOutOfRange;
+    REQUIRE (samePathOutOfRange.create (bundle, {}, createError));
+    REQUIRE (samePathOutOfRange.loadState (savedState));
+    REQUIRE (samePathOutOfRange.getSf2PresetIndex() == 0);
+    REQUIRE (samePathOutOfRange.getNumRegions() > 0);
+    REQUIRE (samePathOutOfRange.getLastLoadError().contains ("using preset 0"));
+}
+
+TEST_CASE ("NativeMultisampleSlot prime keeps a missing-state diagnostic and loads its bundle",
+           "[multisample]")
+{
+    const auto tempDirectory = createUniqueTempSoundfontDirectory();
+    REQUIRE_FALSE (tempDirectory.empty());
+    const auto statePath = tempDirectory / "missing-after-save.sfz";
+    const auto bundlePath = tempDirectory / "fallback.sfz";
+    struct ScopedPathCleanup
+    {
+        std::filesystem::path path;
+        ~ScopedPathCleanup()
+        {
+            std::error_code ignored;
+            std::filesystem::remove_all (path, ignored);
+        }
+    } cleanup { tempDirectory };
+
+    for (const auto& path : { statePath, bundlePath })
+    {
+        std::ofstream out (path, std::ios::binary);
+        out << "<region> key=60 sample=*sine\n";
+        out.flush();
+        REQUIRE (out.good());
+    }
+
+    duskstudio::MultisampleBundle stateBundle;
+    std::string error;
+    REQUIRE (stateBundle.load (statePath.string(), error));
+    duskstudio::DuskMultisampleProcessor source;
+    REQUIRE (source.create (stateBundle, {}, error));
+    std::vector<std::uint8_t> state;
+    REQUIRE (source.saveState (state));
+
+    // The retained state path is authoritative when it names another valid
+    // file, and prime must publish the same path sfizz actually loaded.
+    auto mismatched = duskstudio::NativeMultisampleSlot::prime (
+        bundlePath, 48000.0, 512, error, &state);
+    INFO ("Prime error: " << error);
+    REQUIRE (mismatched);
+    REQUIRE (mismatched.instance->hasLoadedRuntime());
+    REQUIRE (mismatched.path == statePath.string());
+    REQUIRE (mismatched.instance->getLoadedPathSnapshot() == statePath.string());
+    REQUIRE (mismatched.instance->getNumRegions() == 1);
+    REQUIRE (mismatched.instance->getLastLoadError().isEmpty());
+
+    duskstudio::NativeMultisampleSlot deferred;
+    REQUIRE (deferred.load (bundlePath, 48000.0, 512, error));
+    REQUIRE (deferred.loadState (state));
+    REQUIRE (deferred.getPath() == statePath.string());
+    REQUIRE (deferred.getLoadedSoundfontPath() == statePath.string());
+
+    REQUIRE (std::filesystem::remove (statePath));
+
+    auto primed = duskstudio::NativeMultisampleSlot::prime (
+        bundlePath, 48000.0, 512, error, &state);
+    INFO ("Prime error: " << error);
+    REQUIRE (primed);
+    REQUIRE (primed.instance->hasLoadedRuntime());
+    REQUIRE (primed.instance->getLoadedPathSnapshot() == bundlePath.string());
+    REQUIRE (primed.instance->getNumRegions() == 1);
+    REQUIRE (primed.instance->getLastLoadError().contains ("File does not exist"));
 }

--- a/tests/multisample_state_roundtrip.cpp
+++ b/tests/multisample_state_roundtrip.cpp
@@ -220,6 +220,18 @@ std::filesystem::path createUniqueTempSoundfontDirectory()
     }
     return {};
 }
+
+struct ScopedPathCleanup
+{
+    std::filesystem::path path;
+    ~ScopedPathCleanup()
+    {
+        std::error_code ignored;
+        std::filesystem::remove_all (path, ignored);
+    }
+};
+
+constexpr auto kPresetFallbackText = "using preset 0";
 } // namespace
 
 // DuskMultisampleProcessor persists its file path + override params
@@ -415,15 +427,7 @@ TEST_CASE ("DuskMultisampleProcessor: failed SFZ browse preserves the retained S
     REQUIRE_FALSE (tempDirectory.empty());
     const auto sf2Path = tempDirectory / "source.sf2";
     const auto brokenSfzPath = tempDirectory / "broken.sfz";
-    struct ScopedPathCleanup
-    {
-        std::filesystem::path path;
-        ~ScopedPathCleanup()
-        {
-            std::error_code ignored;
-            std::filesystem::remove_all (path, ignored);
-        }
-    } cleanup { tempDirectory };
+    ScopedPathCleanup cleanup { tempDirectory };
 
     const auto sf2Bytes = testSf2();
     {
@@ -528,15 +532,7 @@ TEST_CASE ("DuskMultisampleProcessor: an unplayable saved SF2 preset falls back 
     const auto tempDirectory = createUniqueTempSoundfontDirectory();
     REQUIRE_FALSE (tempDirectory.empty());
     const auto sf2Path = tempDirectory / "fallback.sf2";
-    struct ScopedPathCleanup
-    {
-        std::filesystem::path path;
-        ~ScopedPathCleanup()
-        {
-            std::error_code ignored;
-            std::filesystem::remove_all (path, ignored);
-        }
-    } cleanup { tempDirectory };
+    ScopedPathCleanup cleanup { tempDirectory };
 
     const auto writeSoundfont = [&sf2Path] (const std::vector<std::uint8_t>& bytes)
     {
@@ -561,50 +557,78 @@ TEST_CASE ("DuskMultisampleProcessor: an unplayable saved SF2 preset falls back 
     std::vector<std::uint8_t> savedState;
     REQUIRE (source.saveState (savedState));
 
-    REQUIRE (writeSoundfont (testSf2 (false)));
+    SECTION ("unplayable saved preset")
+    {
+        REQUIRE (writeSoundfont (testSf2 (false)));
+        duskstudio::DuskMultisampleProcessor restored;
+        REQUIRE (restored.loadState (savedState));
+        REQUIRE (restored.getSf2PresetIndex() == 0);
+        REQUIRE (restored.getNumRegions() > 0);
+        REQUIRE (restored.getLastLoadError().contains (kPresetFallbackText));
+    }
 
-    duskstudio::DuskMultisampleProcessor restored;
-    REQUIRE (restored.loadState (savedState));
-    REQUIRE (restored.getSf2PresetIndex() == 0);
-    REQUIRE (restored.getNumRegions() > 0);
-    REQUIRE (restored.getLastLoadError().contains ("using preset 0"));
+    SECTION ("explicit preset selection")
+    {
+        REQUIRE (writeSoundfont (testSf2 (false)));
+        duskstudio::DuskMultisampleProcessor restored;
+        REQUIRE (restored.loadState (savedState));
 
-    error.clear();
-    REQUIRE (restored.loadSf2Preset (1, error));
-    REQUIRE (restored.getSf2PresetIndex() == 0);
-    REQUIRE (restored.getSf2Presets().size() == 2);
-    REQUIRE (restored.getNumRegions() > 0);
-    REQUIRE (restored.getLastLoadError().contains ("using preset 0"));
+        error.clear();
+        REQUIRE_FALSE (restored.loadSf2Preset (1, error));
+        REQUIRE (restored.getSf2PresetIndex() == 0);
+        REQUIRE (restored.getSf2Presets().size() == 2);
+        REQUIRE (restored.getNumRegions() > 0);
+        REQUIRE (restored.getLastLoadError() == error);
+        REQUIRE_FALSE (error.contains (kPresetFallbackText));
+    }
 
-    // The same-path restore takes a separate code path and must also recover.
-    REQUIRE (restored.loadState (savedState));
-    REQUIRE (restored.getSf2PresetIndex() == 0);
-    REQUIRE (restored.getNumRegions() > 0);
-    REQUIRE (restored.getLastLoadError().contains ("using preset 0"));
+    SECTION ("same-path restore")
+    {
+        REQUIRE (writeSoundfont (testSf2 (false)));
+        duskstudio::DuskMultisampleProcessor restored;
+        REQUIRE (restored.loadState (savedState));
 
-    // The failed selection must not become authoritative in the next save.
-    std::vector<std::uint8_t> fallbackState;
-    REQUIRE (restored.saveState (fallbackState));
-    REQUIRE (writeSoundfont (playableBytes));
+        REQUIRE (restored.loadState (savedState));
+        REQUIRE (restored.getSf2PresetIndex() == 0);
+        REQUIRE (restored.getNumRegions() > 0);
+        REQUIRE_FALSE (restored.getLastLoadError().contains (kPresetFallbackText));
+    }
 
-    duskstudio::DuskMultisampleProcessor reopened;
-    REQUIRE (reopened.loadState (fallbackState));
-    REQUIRE (reopened.getSf2PresetIndex() == 0);
-    REQUIRE (reopened.getLastLoadError().isEmpty());
+    SECTION ("recovered preset persistence")
+    {
+        REQUIRE (writeSoundfont (testSf2 (false)));
+        duskstudio::DuskMultisampleProcessor restored;
+        REQUIRE (restored.loadState (savedState));
 
-    REQUIRE (writeSoundfont (testSf2 (true, false)));
-    duskstudio::DuskMultisampleProcessor outOfRange;
-    REQUIRE (outOfRange.loadState (savedState));
-    REQUIRE (outOfRange.getSf2PresetIndex() == 0);
-    REQUIRE (outOfRange.getNumRegions() > 0);
-    REQUIRE (outOfRange.getLastLoadError().contains ("using preset 0"));
+        // The failed selection must not become authoritative in the next save.
+        error.clear();
+        REQUIRE_FALSE (restored.loadSf2Preset (1, error));
+        std::vector<std::uint8_t> fallbackState;
+        REQUIRE (restored.saveState (fallbackState));
+        REQUIRE (writeSoundfont (playableBytes));
 
-    duskstudio::DuskMultisampleProcessor samePathOutOfRange;
-    REQUIRE (samePathOutOfRange.create (bundle, {}, createError));
-    REQUIRE (samePathOutOfRange.loadState (savedState));
-    REQUIRE (samePathOutOfRange.getSf2PresetIndex() == 0);
-    REQUIRE (samePathOutOfRange.getNumRegions() > 0);
-    REQUIRE (samePathOutOfRange.getLastLoadError().contains ("using preset 0"));
+        duskstudio::DuskMultisampleProcessor reopened;
+        REQUIRE (reopened.loadState (fallbackState));
+        REQUIRE (reopened.getSf2PresetIndex() == 0);
+        REQUIRE (reopened.getLastLoadError().isEmpty());
+    }
+
+    SECTION ("out-of-range saved preset")
+    {
+        REQUIRE (writeSoundfont (testSf2 (true, false)));
+        duskstudio::DuskMultisampleProcessor outOfRange;
+        REQUIRE (outOfRange.loadState (savedState));
+        REQUIRE (outOfRange.getSf2PresetIndex() == 0);
+        REQUIRE (outOfRange.getNumRegions() > 0);
+        REQUIRE (outOfRange.getLastLoadError().contains (kPresetFallbackText));
+
+        duskstudio::DuskMultisampleProcessor samePathOutOfRange;
+        REQUIRE (samePathOutOfRange.create (bundle, {}, createError));
+        REQUIRE (samePathOutOfRange.loadState (savedState));
+        REQUIRE (samePathOutOfRange.getSf2PresetIndex() == 0);
+        REQUIRE (samePathOutOfRange.getNumRegions() > 0);
+        REQUIRE (samePathOutOfRange.getLastLoadError().contains (kPresetFallbackText));
+    }
 }
 
 TEST_CASE ("NativeMultisampleSlot prime keeps a missing-state diagnostic and loads its bundle",
@@ -614,15 +638,7 @@ TEST_CASE ("NativeMultisampleSlot prime keeps a missing-state diagnostic and loa
     REQUIRE_FALSE (tempDirectory.empty());
     const auto statePath = tempDirectory / "missing-after-save.sfz";
     const auto bundlePath = tempDirectory / "fallback.sfz";
-    struct ScopedPathCleanup
-    {
-        std::filesystem::path path;
-        ~ScopedPathCleanup()
-        {
-            std::error_code ignored;
-            std::filesystem::remove_all (path, ignored);
-        }
-    } cleanup { tempDirectory };
+    ScopedPathCleanup cleanup { tempDirectory };
 
     for (const auto& path : { statePath, bundlePath })
     {

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -41,7 +41,7 @@ src/engine/multisample/AriaBank.cpp	12
 src/engine/multisample/AriaBank.h	9
 src/engine/multisample/AriaGui.cpp	23
 src/engine/multisample/AriaGui.h	18
-src/engine/multisample/DuskMultisampleProcessor.cpp	70
+src/engine/multisample/DuskMultisampleProcessor.cpp	68
 src/engine/multisample/DuskMultisampleProcessor.h	24
 src/engine/multisample/Sf2ToSfz.cpp	9
 src/engine/multisample/Sf2ToSfz.h	4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Soundfont sessions now remember the selected SF2 preset across reloads and session restoration.
  * Invalid or unavailable presets automatically fall back to preset 0.
  * Failed file loads and browses retain the last successful soundfont and preset for recovery.
* **Bug Fixes**
  * Improved handling of missing files, unusable presets, and failed soundfont restoration.
  * Error messages now include the loaded soundfont filename when applicable.
  * The interface now refreshes reliably after soundfont loading and preset changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->