### PR TITLE
fix: reject invalid Windows GL proc addresses

### DIFF
--- a/src/ui/ImGuiGlLoaderWin32.cpp
+++ b/src/ui/ImGuiGlLoaderWin32.cpp
@@ -10,11 +10,24 @@
 
 #include "ImGuiGlLoaderWin32.h"
 
+#include <cstdio>
+
 namespace duskstudio::glloader {
 
 ProcPtr procAddress(const char* const name)
 {
-    return reinterpret_cast<ProcPtr>(::wglGetProcAddress(name));
+    const auto address = ::wglGetProcAddress(name);
+    if (isInvalidWglProcAddressValue (reinterpret_cast<std::intptr_t> (address)))
+    {
+        char message[192] {};
+        std::snprintf (message, sizeof message,
+                       "[Dusk Studio/notepad] OpenGL entry point unavailable: %s\n",
+                       name);
+        std::fputs (message, stderr);
+        ::OutputDebugStringA (message);
+        return nullptr;
+    }
+    return reinterpret_cast<ProcPtr> (address);
 }
 
 }

--- a/src/ui/ImGuiGlLoaderWin32.h
+++ b/src/ui/ImGuiGlLoaderWin32.h
@@ -14,6 +14,7 @@
 #if defined(_WIN32)
 
 #include "OpenGL-include.hpp"
+#include "WglProcAddressSentinel.h"
 
 #include <utility>
 
@@ -28,12 +29,16 @@ struct GlProc
 {
     const char* const name;
     Fn fn = nullptr;
+    bool resolutionAttempted = false;
 
     template <typename... Args>
     auto operator()(Args... args) -> decltype(std::declval<Fn>()(args...))
     {
-        if (fn == nullptr)
+        if (! resolutionAttempted)
+        {
+            resolutionAttempted = true;
             fn = reinterpret_cast<Fn>(procAddress(name));
+        }
 
         // An unresolved entry point costs the drawing; calling through the null pointer
         // would cost the app.

--- a/src/ui/WglProcAddressSentinel.h
+++ b/src/ui/WglProcAddressSentinel.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <cstdint>
+
+namespace duskstudio::glloader {
+
+// Some Windows OpenGL drivers report lookup failure with small non-null
+// sentinel values instead of the null pointer documented by Microsoft.
+constexpr bool isInvalidWglProcAddressValue (std::intptr_t value) noexcept
+{
+    return value == 0 || value == 1 || value == 2 || value == 3 || value == -1;
+}
+
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,6 +67,7 @@ add_executable(dusk-studio-tests
     session_portable_paths.cpp
     session_track_shrink.cpp
     device_fallback_message.cpp
+    imgui_gl_loader_win32.cpp
     device_interfaces.cpp
     device_state_blob.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/device/DeviceStateBlob.cpp

--- a/tests/imgui_gl_loader_win32.cpp
+++ b/tests/imgui_gl_loader_win32.cpp
@@ -1,0 +1,17 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "ui/WglProcAddressSentinel.h"
+
+TEST_CASE ("Windows GL loader rejects every documented failure sentinel", "[notepad][windows]")
+{
+    using duskstudio::glloader::isInvalidWglProcAddressValue;
+
+    REQUIRE (isInvalidWglProcAddressValue (0));
+    REQUIRE (isInvalidWglProcAddressValue (1));
+    REQUIRE (isInvalidWglProcAddressValue (2));
+    REQUIRE (isInvalidWglProcAddressValue (3));
+    REQUIRE (isInvalidWglProcAddressValue (-1));
+
+    REQUIRE_FALSE (isInvalidWglProcAddressValue (4));
+    REQUIRE_FALSE (isInvalidWglProcAddressValue (0x1000));
+}


### PR DESCRIPTION
## Summary

- reject all known invalid wglGetProcAddress sentinel values before the notepad renderer can call them
- report an unavailable entry point once through stderr and the Windows debugger
- add platform-neutral regression coverage for the Windows sentinel contract
- add no JUCE coupling

## Validation

- focused Windows GL loader test: 7 assertions passed
- full test suite: 734/734 passed
- claude-review: clean after review fixes
- JUCE gate: 179 files / 9,215 uses, unchanged

Fixes #273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows OpenGL function loading by detecting invalid procedure addresses.
  * Prevented repeated lookup attempts for unavailable OpenGL functions.
  * Added error reporting when invalid function addresses are encountered.
  * Ensured unresolved functions are safely skipped while valid addresses continue to work.

* **Tests**
  * Added coverage for documented invalid and valid Windows OpenGL procedure addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->