### PR TITLE
Fix startup audio backend fallback detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -698,12 +698,10 @@ target_link_libraries(DuskStudio PRIVATE dusk_sodium)
 # DeviceManager backing: Linux uses the native orchestrator (owns the device
 # types, drives open/start/stop/close and the callback fan-out itself); macOS /
 # Windows keep the JUCE-wrapped implementation. Same public dusk API either way.
+target_sources(DuskStudio PRIVATE
+    src/engine/device/DeviceStateBlob.cpp)
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    # The native manager reads/writes the state blob directly (dusk JSON + legacy
-    # XML migration); off Linux the JUCE-wrapped manager keeps its own XML path.
-    target_sources(DuskStudio PRIVATE
-        src/engine/device/DeviceManager.cpp
-        src/engine/device/DeviceStateBlob.cpp)
+    target_sources(DuskStudio PRIVATE src/engine/device/DeviceManager.cpp)
 else()
     target_sources(DuskStudio PRIVATE src/engine/device/DeviceManagerJuce.cpp)
 endif()

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2168,11 +2168,11 @@ If the disconnect happened during a take, the WAV that was being written is comm
 If the interface saved in your settings is held by another application when Dusk Studio launches — PipeWire or the JACK/PipeWire server, an ASIO driver another DAW already opened, a screen recorder, or browser audio holding the device in exclusive mode — Dusk Studio can't open it. Rather than load a silent, dead session, it recovers and tells you what happened:
 
 - On Linux it tries the PipeWire backend, then each ALSA device in turn. PipeWire can still reach an interface that another PipeWire client is using, since they share the graph; but if something holds the raw ALSA device exclusively (a JACK server, or an app talking to the hardware directly), PipeWire is locked out too and the fallback moves on.
-- On any platform, the last resort is the default device of every other backend that is present — on Windows that's what carries you off a busy or powered-down ASIO driver onto shared Windows Audio.
-- If that lands on a **different** working device, you keep working and see *"Your saved audio device … could not be opened … audio has switched to …"*. Your saved device is **not** changed — it's tried again on the next launch once you free it.
+- On any platform, the last resort is the default device of every other backend that is present — on Windows that's what carries you off a busy or powered-down ASIO driver onto shared Windows Audio. Shared and exclusive Windows backends can expose the same endpoint name; Dusk Studio still detects the backend change.
+- If that lands on a **different** working device or backend, you keep working and see *"Your saved audio setup for … could not be opened … Audio has switched to …"*. Your saved setup is **not** changed — it's tried again on the next launch once you free it.
 - If nothing opens, you get a clear warning. With no device open the playhead and meters won't move, recording is disabled, and plugin and soundfont loading is refused — the channel strips take their sample rate and block size from the running device, so there is nothing to prepare an insert against until one opens.
 
-Either way, free the device in the other app (or run `pactl suspend-sink <sink-name> 1` to release a PipeWire/PulseAudio hold), then pick it again in **Settings → Audio**. Your saved device returns automatically next launch once it's free.
+Either way, free the device in the other app (or run `pactl suspend-sink <sink-name> 1` to release a PipeWire/PulseAudio hold), then pick it again in **Settings → Audio**. Your saved setup returns automatically next launch once it's free.
 
 # Accessibility
 

--- a/docs/dejuce-device-phase3-audio-plan.md
+++ b/docs/dejuce-device-phase3-audio-plan.md
@@ -150,7 +150,7 @@ AudioEngine/UI) never changes.
     failure with selectDefaultOnFailure, open the type's default device with
     default masks WITHOUT clobbering `lastExplicitSettings` (saved intent
     must survive a busy device — `DeviceFallbackMessage` and
-    `outputDeviceNameFromState` depend on it).
+    `deviceIdentityFromState` depend on it).
   - `setCurrentDeviceType`: arm `deviceChangePending` only for a
     will-actually-move request (same two-step check as today,
     DeviceManager.cpp:327-345), close the device, switch type, broadcast,
@@ -200,11 +200,12 @@ New clean unit `src/engine/device/DeviceStateBlob.{h,cpp}`:
   legacy blob, so conversion happens without a re-pick and selection can
   never be silently dropped). Unparseable blob ⇒ behave exactly like empty
   (fresh default), same as JUCE today.
-- `outputDeviceNameFromState` handles both formats.
-- mac/win keep the JUCE XML blob untouched in DeviceManagerJuce.cpp (state
-  file is per-machine; no cross-OS migration exists).
+- `deviceIdentityFromState` handles the backend and endpoint in both formats.
+- mac/win keep the persisted JUCE XML blob untouched in DeviceManagerJuce.cpp
+  (state file is per-machine; no cross-OS migration exists), while the common
+  JUCE-free identity reader parses it through `DeviceStateBlob`.
 
-### D4 — Non-Linux structure: two TUs, zero `#if` sprawl
+### D4 — Platform-specific implementations, zero `#if` sprawl
 
 - `DeviceManager.h`: API unchanged. The `juceManager()` hatch + gated `juce`
   forward-decl stay; header remains allowlisted (ground truth 5).
@@ -216,6 +217,8 @@ New clean unit `src/engine/device/DeviceStateBlob.{h,cpp}`:
   NOT-Linux in CMake. Byte-minimal diff = lowest risk for a path we cannot
   execute locally; macOS CI build + Windows CI tests are the compile proof
   (native-MIDI-tower precedent, PR #98).
+- `src/engine/device/DeviceStateBlob.cpp`: common JUCE-free saved-identity
+  reader, compiled on every platform.
 
 ### D5 — ALSA thread swap: JUCE Thread → std::thread (semantics to preserve)
 
@@ -287,8 +290,8 @@ PR-A merges (squash-merge hygiene: retire the PR-A branch).
   ⇒ useDefault; legacy XML A/B vs the JUCE parser + BigInteger base-2 parse
   on: full attribute set, missing chans attrs, entity-laden device names
   (incl. UTF-8), MSB-first mask strings ("110" ≠ "011"), malformed input ⇒
-  empty-equivalent; `outputDeviceNameFromState` on both formats incl.
-  output-empty-falls-to-input.
+  empty-equivalent. `deviceIdentityFromState` covers both formats, including
+  output-empty-falls-to-input, through the DeviceManager tests.
 - Not wired into the app yet — zero runtime risk.
 
 ### P2 — native DeviceManager on Linux (RT-RISKY: dispatch ownership moves)

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -559,10 +559,10 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
                 && d->getActiveOutputChannels().count() > 0;
         };
 
-        // The user's INTENDED output device (from the saved blob), not whatever
-        // initialise() landed on - so a saved device that failed to open is still
-        // named in the startup message even after a silent fallback.
-        const std::string savedName = deviceManager.outputDeviceNameFromState (savedDeviceState);
+        // The user's INTENDED backend + output device (from the saved blob), not
+        // whatever initialise() landed on. Windows shared and exclusive modes
+        // can expose the same endpoint name, so both fields identify a fallback.
+        const auto savedDevice = deviceManager.deviceIdentityFromState (savedDeviceState);
 
         if (! working())
         {
@@ -647,8 +647,15 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
         // the saved device opened, so the normal path stays silent.
         auto* dev = deviceManager.getCurrentDevice();
         const bool opened = working();
+        device::DeviceIdentity liveDevice;
+        if (opened)
+        {
+            liveDevice.outputName = dev->getName();
+            if (auto* liveType = deviceManager.getCurrentDeviceType())
+                liveDevice.backendName = liveType->getTypeName();
+        }
         startupDeviceMessage_ = duskstudio::startupDeviceMessage (
-            opened, savedName, opened ? dev->getName() : std::string());
+            opened, savedDevice, liveDevice);
     }
 
    #if ! defined(__linux__)

--- a/src/engine/DeviceFallbackMessage.h
+++ b/src/engine/DeviceFallbackMessage.h
@@ -1,43 +1,63 @@
 #pragma once
 
+#include "device/DeviceManager.h"
+
 #include <string>
 
 namespace duskstudio
 {
 // User-facing message after the startup audio-device open + busy-device
-// fallback. Empty string = the saved device opened fine (no alert needed).
+// fallback. Empty string = the saved setup opened fine (no alert needed).
 // Pure + header-only so the branchy copy can be unit-tested without a real
 // audio device (CI has none).
 //
-//   opened     : a device is open at a non-zero sample rate after the fallback.
-//   savedName  : the device name the persisted setup asked for ("" if none).
-//   actualName : the device actually open now ("" when opened == false).
+//   opened       : a device is open at a non-zero sample rate after fallback.
+//   saved        : the persisted endpoint/backend intent (empty if unspecified).
+//   actual       : the endpoint/backend open now (empty when unavailable).
 inline std::string startupDeviceMessage (bool opened,
-                                         const std::string& savedName,
-                                         const std::string& actualName)
+                                         const device::DeviceIdentity& saved,
+                                         const device::DeviceIdentity& actual)
 {
+    const auto describe = [] (const device::DeviceIdentity& identity)
+    {
+        std::string description = identity.outputName.empty()
+                                    ? "the default device"
+                                    : ("\"" + identity.outputName + "\"");
+        if (! identity.backendName.empty())
+            description += " on the " + identity.backendName + " backend";
+        return description;
+    };
+
     if (opened)
     {
-        // The saved device opened (or there was nothing specific to compare) -
-        // nothing to report.
-        if (savedName.empty() || actualName == savedName)
+        const bool hasSavedIdentity = ! saved.outputName.empty() || ! saved.backendName.empty();
+        const bool endpointChanged = ! saved.outputName.empty()
+                                      && actual.outputName != saved.outputName;
+        const bool backendChanged = ! saved.backendName.empty()
+                                     && ! actual.backendName.empty()
+                                     && actual.backendName != saved.backendName;
+        // The saved setup opened (or there was nothing specific to compare) -
+        // nothing to report. Endpoint names alone are insufficient on Windows:
+        // shared and exclusive backends expose the same friendly device name.
+        if (! hasSavedIdentity || (! endpointChanged && ! backendChanged))
             return {};
 
-        // Fell back to a different device that works.
-        return "Your saved audio device \"" + savedName + "\" could not be opened - it "
+        // Fell back to a different endpoint or backend that works.
+        return "Your saved audio setup for " + describe (saved)
+             + " could not be opened - it "
                "may be in use by another application (another DAW, browser audio, or "
                "anything holding an exclusive driver) or no longer available.\n\n"
-               "Audio has switched to \"" + actualName
-             + "\" so you can keep working. To use your original device, free it in "
+               "Audio has switched to " + describe (actual)
+             + " so you can keep working. To use your original setup, free it in "
                "the other app, then reselect it in Audio Settings. Dusk Studio did not "
-               "change your saved device - it will be tried again next launch.";
+               "change your saved setup - it will be tried again next launch.";
     }
 
     // Nothing opened at all - the session is silent until a device frees up.
     std::string msg = "No audio device could be opened.\n\n";
-    if (! savedName.empty())
-        msg += "Your saved device \"" + savedName + "\" appears to be in use by another "
-               "application, and no other backend opened.";
+    if (! saved.outputName.empty() || ! saved.backendName.empty())
+        msg += "Your saved audio setup for " + describe (saved)
+             + " appears to be in use by another application, and no other backend opened.";
     else
         msg += "No backend reported an available device.";
     // The load guards on every channel-strip insert refuse while the strips have

--- a/src/engine/device/DeviceManager.cpp
+++ b/src/engine/device/DeviceManager.cpp
@@ -444,7 +444,7 @@ std::string DeviceManager::initialise (int numInputChannels, int numOutputChanne
 
     // Fallback: open the type's default device WITHOUT clobbering
     // lastExplicitSettings, so the saved intent survives a busy device (the
-    // engine's DeviceFallbackMessage + outputDeviceNameFromState depend on it).
+    // engine's DeviceFallbackMessage + deviceIdentityFromState depend on it).
     return impl->openDeviceFromSetup (impl->defaultSetupFor (type), /*treatAsChosen*/ false);
 }
 
@@ -452,11 +452,6 @@ std::string DeviceManager::getStateBlob() const
 {
     if (! impl->lastExplicitSettings) return {};
     return impl->lastExplicitSettings->toJson();
-}
-
-std::string DeviceManager::outputDeviceNameFromState (const std::string& savedState) const
-{
-    return DeviceStateBlob::outputDeviceName (savedState);
 }
 
 IODevice* DeviceManager::getCurrentDevice() { return impl->currentDevice.get(); }

--- a/src/engine/device/DeviceManager.h
+++ b/src/engine/device/DeviceManager.h
@@ -29,6 +29,12 @@ namespace duskstudio::device
 {
 class IODeviceCallback;
 
+struct DeviceIdentity
+{
+    std::string backendName;
+    std::string outputName;
+};
+
 class DeviceManager
 {
 public:
@@ -48,10 +54,10 @@ public:
     // caller writes it to disk and hands it back to initialise()).
     std::string getStateBlob() const;
 
-    // The output device name recorded in a saved state blob (falling back to the
-    // input device name), or empty. Reads the user's INTENDED device, which may
-    // differ from the one initialise() actually opened on failure.
-    std::string outputDeviceNameFromState (const std::string& savedState) const;
+    // The backend and output device recorded in a saved state blob (falling
+    // back to the input device name). Reads the user's INTENDED setup, which
+    // may differ from the one initialise() actually opened on failure.
+    DeviceIdentity deviceIdentityFromState (const std::string& savedState) const;
 
     // A view of the live device, repointed on each call - use it, don't cache it
     // (a later call reflects a different device through the same object).

--- a/src/engine/device/DeviceManagerJuce.cpp
+++ b/src/engine/device/DeviceManagerJuce.cpp
@@ -293,15 +293,6 @@ std::string DeviceManager::getStateBlob() const
     return {};
 }
 
-std::string DeviceManager::outputDeviceNameFromState (const std::string& savedState) const
-{
-    if (savedState.empty()) return {};
-    if (auto xml = juce::parseXML (juce::String (savedState)))
-        return xml->getStringAttribute ("audioOutputDeviceName",
-                   xml->getStringAttribute ("audioInputDeviceName")).toStdString();
-    return {};
-}
-
 IODevice* DeviceManager::getCurrentDevice()
 {
     auto* d = impl->mgr.getCurrentAudioDevice();

--- a/src/engine/device/DeviceStateBlob.cpp
+++ b/src/engine/device/DeviceStateBlob.cpp
@@ -1,4 +1,5 @@
 #include "DeviceStateBlob.h"
+#include "DeviceManager.h"
 
 #include "../../foundation/Json.h"
 
@@ -251,11 +252,14 @@ std::optional<DeviceStateBlob> DeviceStateBlob::parse (const std::string& blob)
     return std::nullopt;
 }
 
-std::string DeviceStateBlob::outputDeviceName (const std::string& blob)
+DeviceIdentity DeviceManager::deviceIdentityFromState (
+    const std::string& savedState) const
 {
-    const auto b = parse (blob);
-    if (! b) return {};
-    return ! b->setup.outputDeviceName.empty() ? b->setup.outputDeviceName
-                                               : b->setup.inputDeviceName;
+    const auto saved = DeviceStateBlob::parse (savedState);
+    if (! saved) return {};
+    const auto outputName = ! saved->setup.outputDeviceName.empty()
+                              ? saved->setup.outputDeviceName
+                              : saved->setup.inputDeviceName;
+    return { saved->deviceType, outputName };
 }
 } // namespace duskstudio::device

--- a/src/engine/device/DeviceStateBlob.h
+++ b/src/engine/device/DeviceStateBlob.h
@@ -28,10 +28,5 @@ struct DeviceStateBlob
     // Parse either supported form. nullopt on an empty or unparseable blob - the
     // caller then behaves as a fresh machine, matching JUCE's parse-fail contract.
     static std::optional<DeviceStateBlob> parse (const std::string& blob);
-
-    // The output device name a blob records, falling back to the input device
-    // name, or empty. Reads the user's intended device from either form without
-    // opening anything.
-    static std::string outputDeviceName (const std::string& blob);
 };
 } // namespace duskstudio::device

--- a/tests/device_fallback_message.cpp
+++ b/tests/device_fallback_message.cpp
@@ -6,24 +6,46 @@
 #include <string>
 
 using duskstudio::startupDeviceMessage;
+using duskstudio::device::DeviceIdentity;
 using dusk::text::contains;
 using dusk::text::containsIgnoreCase;
 
-// The startup busy-device fallback resolves (opened?, savedName, actualName)
-// into the alert copy. The JUCE device switching itself needs real hardware, so
-// only this decision is unit-tested — but it's the only branchy part.
+// The startup busy-device fallback resolves the saved and live endpoint/backend
+// identities into alert copy. Switching itself needs real hardware, so the pure
+// decision seam carries the platform-independent regression coverage.
+
+namespace
+{
+DeviceIdentity identity (const std::string& outputName, const std::string& backendName)
+{
+    DeviceIdentity result;
+    result.outputName = outputName;
+    result.backendName = backendName;
+    return result;
+}
+} // namespace
 
 TEST_CASE ("startupDeviceMessage: saved device opened -> no alert", "[audio][device]")
 {
     // Same device that was saved opened fine.
-    REQUIRE (startupDeviceMessage (true, "UMC1820", "UMC1820").empty());
+    REQUIRE (startupDeviceMessage (true,
+                                   identity ("UMC1820", "ALSA"),
+                                   identity ("UMC1820", "ALSA")).empty());
     // No saved device to compare (fresh machine) and something opened.
-    REQUIRE (startupDeviceMessage (true, "", "Built-in Audio").empty());
+    REQUIRE (startupDeviceMessage (true,
+                                   identity ("", ""),
+                                   identity ("Built-in Audio", "ALSA")).empty());
+    // An unavailable live backend name cannot prove that the saved backend changed.
+    REQUIRE (startupDeviceMessage (true,
+                                   identity ("UMC1820", "ALSA"),
+                                   identity ("UMC1820", "")).empty());
 }
 
 TEST_CASE ("startupDeviceMessage: fell back to a different device -> names both", "[audio][device]")
 {
-    const auto m = startupDeviceMessage (true, "UMC1820", "Built-in Audio");
+    const auto m = startupDeviceMessage (true,
+                                         identity ("UMC1820", "ALSA"),
+                                         identity ("Built-in Audio", "ALSA"));
     REQUIRE_FALSE (m.empty());
     REQUIRE (contains (m, "UMC1820"));          // the saved device that was busy
     REQUIRE (contains (m, "Built-in Audio"));   // the substitute now in use
@@ -32,11 +54,39 @@ TEST_CASE ("startupDeviceMessage: fell back to a different device -> names both"
     REQUIRE (containsIgnoreCase (m, "next launch"));
 }
 
+TEST_CASE ("startupDeviceMessage: same endpoint on a different backend alerts",
+           "[audio][device]")
+{
+    const auto m = startupDeviceMessage (
+        true,
+        identity ("Speakers", "Windows Audio (Exclusive Mode)"),
+        identity ("Speakers", "Windows Audio"));
+    REQUIRE_FALSE (m.empty());
+    REQUIRE (contains (m, "Speakers"));
+    REQUIRE (contains (m, "Windows Audio (Exclusive Mode)"));
+    REQUIRE (contains (m, "Windows Audio backend"));
+    REQUIRE (containsIgnoreCase (m, "switched"));
+}
+
+TEST_CASE ("startupDeviceMessage: backend-only saved identity detects fallback",
+           "[audio][device]")
+{
+    const auto m = startupDeviceMessage (true,
+                                         identity ("", "ALSA"),
+                                         identity ("Built-in Audio", "PipeWire"));
+    REQUIRE_FALSE (m.empty());
+    REQUIRE (contains (m, "the default device on the ALSA backend"));
+    REQUIRE (contains (m, "Built-in Audio"));
+    REQUIRE (contains (m, "PipeWire backend"));
+}
+
 TEST_CASE ("startupDeviceMessage: nothing opened -> silent-session warning", "[audio][device]")
 {
     SECTION ("names the saved device")
     {
-        const auto m = startupDeviceMessage (false, "UMC1820", "");
+        const auto m = startupDeviceMessage (false,
+                                             identity ("UMC1820", "ALSA"),
+                                             identity ("", ""));
         REQUIRE (contains (m, "UMC1820"));
         REQUIRE (containsIgnoreCase (m, "no audio device"));
         REQUIRE (containsIgnoreCase (m, "recording is disabled"));
@@ -46,7 +96,9 @@ TEST_CASE ("startupDeviceMessage: nothing opened -> silent-session warning", "[a
     }
     SECTION ("no saved device still warns, no dangling name")
     {
-        const auto m = startupDeviceMessage (false, "", "");
+        const auto m = startupDeviceMessage (false,
+                                             identity ("", ""),
+                                             identity ("", ""));
         REQUIRE (containsIgnoreCase (m, "no audio device"));
         REQUIRE (containsIgnoreCase (m, "recording is disabled"));
         REQUIRE (containsIgnoreCase (m, "soundfonts cannot be loaded"));

--- a/tests/device_manager_native.cpp
+++ b/tests/device_manager_native.cpp
@@ -339,11 +339,72 @@ TEST_CASE ("DeviceManager initialise: busy saved device falls back but keeps sav
     REQUIRE (dm.getCurrentDevice()->getName() == "hw0");
 
     // The saved intent survives the fallback: getStateBlob still names busyDev,
-    // and outputDeviceNameFromState reports the user's INTENDED device.
+    // and deviceIdentityFromState reports the user's intended backend + device.
     const auto out = DeviceStateBlob::parse (dm.getStateBlob());
     REQUIRE (out.has_value());
     REQUIRE (out->setup.outputDeviceName == "busyDev");
-    REQUIRE (dm.outputDeviceNameFromState (saved.toJson()) == "busyDev");
+    const auto identity = dm.deviceIdentityFromState (saved.toJson());
+    REQUIRE (identity.backendName == "ALSA");
+    REQUIRE (identity.outputName == "busyDev");
+}
+
+TEST_CASE ("DeviceManager reads backend identity from saved device state", "[audio][device]")
+{
+    DeviceManager dm;
+
+    SECTION ("unparseable state has no identity")
+    {
+        const auto empty = dm.deviceIdentityFromState ("");
+        REQUIRE (empty.backendName.empty());
+        REQUIRE (empty.outputName.empty());
+
+        const auto corrupt = dm.deviceIdentityFromState ("garbage");
+        REQUIRE (corrupt.backendName.empty());
+        REQUIRE (corrupt.outputName.empty());
+    }
+
+    SECTION ("JSON output wins over input")
+    {
+        DeviceStateBlob saved;
+        saved.deviceType = "ALSA";
+        saved.setup.outputDeviceName = "Main Output";
+        saved.setup.inputDeviceName = "Main Input";
+
+        const auto identity = dm.deviceIdentityFromState (saved.toJson());
+        REQUIRE (identity.backendName == "ALSA");
+        REQUIRE (identity.outputName == "Main Output");
+    }
+
+    SECTION ("JSON empty output falls back to input")
+    {
+        DeviceStateBlob saved;
+        saved.deviceType = "ALSA";
+        saved.setup.inputDeviceName = "Input Only";
+
+        const auto identity = dm.deviceIdentityFromState (saved.toJson());
+        REQUIRE (identity.backendName == "ALSA");
+        REQUIRE (identity.outputName == "Input Only");
+    }
+
+    SECTION ("legacy output wins")
+    {
+        const auto identity = dm.deviceIdentityFromState (
+            "<DEVICESETUP deviceType=\"Windows Audio\" "
+            "audioOutputDeviceName=\"Speakers\" audioInputDeviceName=\"Microphone\"/>");
+
+        REQUIRE (identity.backendName == "Windows Audio");
+        REQUIRE (identity.outputName == "Speakers");
+    }
+
+    SECTION ("legacy empty output falls back to input")
+    {
+        const auto identity = dm.deviceIdentityFromState (
+            "<DEVICESETUP deviceType=\"Windows Audio (Exclusive Mode)\" "
+            "audioInputDeviceName=\"Speakers\"/>");
+
+        REQUIRE (identity.backendName == "Windows Audio (Exclusive Mode)");
+        REQUIRE (identity.outputName == "Speakers");
+    }
 }
 
 TEST_CASE ("DeviceManager setSetup: changed reopens stop->close->create->open->start", "[audio][device]")

--- a/tests/device_state_blob.cpp
+++ b/tests/device_state_blob.cpp
@@ -232,38 +232,3 @@ TEST_CASE ("DeviceStateBlob malformed input => empty-equivalent", "[audio][devic
     // A non-object JSON value is not a valid blob.
     REQUIRE_FALSE (DeviceStateBlob::parse ("[1,2,3]").has_value());
 }
-
-TEST_CASE ("DeviceStateBlob outputDeviceName on both formats", "[audio][device]")
-{
-    SECTION ("JSON: output name wins")
-    {
-        DeviceStateBlob in;
-        in.setup.outputDeviceName = "MainOut";
-        in.setup.inputDeviceName  = "MainIn";
-        REQUIRE (DeviceStateBlob::outputDeviceName (in.toJson()) == "MainOut");
-    }
-
-    SECTION ("JSON: empty output falls back to input")
-    {
-        DeviceStateBlob in;
-        in.setup.inputDeviceName = "OnlyIn";
-        REQUIRE (DeviceStateBlob::outputDeviceName (in.toJson()) == "OnlyIn");
-    }
-
-    SECTION ("legacy XML: output name wins")
-    {
-        const auto blob = makeLegacyXml ("ALSA", "MainOut", "MainIn", 48000.0, 256, nullptr, nullptr);
-        REQUIRE (DeviceStateBlob::outputDeviceName (blob) == "MainOut");
-    }
-
-    SECTION ("legacy XML: empty output falls back to input")
-    {
-        const auto blob = makeLegacyXml ("ALSA", "", "OnlyIn", 48000.0, 256, nullptr, nullptr);
-        REQUIRE (DeviceStateBlob::outputDeviceName (blob) == "OnlyIn");
-    }
-
-    SECTION ("unparseable => empty")
-    {
-        REQUIRE (DeviceStateBlob::outputDeviceName ("garbage").empty());
-    }
-}

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -31,7 +31,7 @@ src/engine/PluginSlot.h	42
 src/engine/RecordManager.cpp	4
 src/engine/RecordManager.h	5
 src/engine/device/DeviceManager.h	3
-src/engine/device/DeviceManagerJuce.cpp	46
+src/engine/device/DeviceManagerJuce.cpp	44
 src/engine/hosting/NativePluginId.h	8
 src/engine/ipc/IpcSelfTest.cpp	5
 src/engine/ipc/PluginHostMain.cpp	52


### PR DESCRIPTION
## Summary
- compare the persisted and live audio backend as well as the endpoint name, so same-named Windows shared and exclusive endpoints still report a fallback
- use typed device identities and the common JSON/legacy-XML state parser across platform managers
- update user-facing guidance and add regression coverage for backend-only, corrupt-state, and output-precedence cases
- remove two JUCE references and tighten the wrapped manager allowlist from 46 to 44

## Validation
- DuskStudio application target builds
- dusk-studio-tests target builds
- focused audio/device suite: 254 assertions passed
- full suite: 736 of 736 tests passed
- JUCE gate: 179 coupled files, 9213 uses
- final claude-review: no correctness defects

## Hardware verification
Windows exclusive-to-shared recovery could not be exercised on this Linux machine. The pure decision seam covers the same-endpoint/different-backend case, but the Windows hardware path should still be verified before release.

Fixes #276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved audio-device fallback detection by identifying both the device endpoint and audio backend.
  * Startup messages now clearly indicate endpoint changes, backend changes, or backend-only fallback.
  * Saved audio configuration remains unchanged when fallback devices or backends are selected.
  * Device identity is recognized from both current JSON and legacy XML settings.

* **Documentation**
  * Updated audio fallback guidance and archived planning documentation.

* **Tests**
  * Expanded coverage for backend changes, device identity resolution, and input-device fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->