### PR TITLE
Harden release publishing checks

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -66,10 +66,15 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASES_REPO_TOKEN }}
         run: |
           set -euo pipefail
-          # .permissions.push reflects contents:write for the token; a read-only
-          # token can fetch repo metadata and would pass a bare existence probe.
-          if [[ "$(gh api "repos/${RELEASES_REPO}" --jq '.permissions.push // false' 2>/dev/null)" != "true" ]]; then
-            echo "::error::RELEASES_REPO_TOKEN cannot WRITE to ${RELEASES_REPO} (expired, revoked, or missing contents:write). Rotate the RELEASES_REPO_TOKEN secret with contents:write on that repo, then re-run this workflow." >&2
+          preflight_error=$(mktemp -t duskstudio-preflight.XXXXXX)
+          trap 'rm -f "$preflight_error"' EXIT
+          probe_tag="duskstudio-token-preflight-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          # This endpoint creates no release, but requires contents:write.
+          if ! gh api --method POST \
+              "repos/${RELEASES_REPO}/releases/generate-notes" \
+              -f "tag_name=${probe_tag}" >/dev/null 2>"$preflight_error"; then
+            echo "::error::write-capability preflight for ${RELEASES_REPO} failed. Check the API details below and verify RELEASES_REPO_TOKEN has repository access and contents:write; rotate the secret if needed, then re-run." >&2
+            cat "$preflight_error" >&2
             exit 1
           fi
 
@@ -182,12 +187,12 @@ jobs:
         # Pins + rationale live in .github/actions/clone-dpf-stack.
         uses: ./.github/actions/clone-dpf-stack
 
-      - name: Refresh Patreon supporters (best-effort)
+      - name: Refresh Patreon supporters
         # Bakes the live supporters list into the release binary via
         # PatreonBackers.h (rewritten in the freshly-cloned plugins checkout
-        # before configure). Best-effort: with no secrets, or on any API
-        # failure, the build ships the committed list. The refresh token must be
-        # reusable (Patreon creator tokens are); rotate the secret if invalidated.
+        # before configure). Missing secrets ship the committed list; with all
+        # secrets configured, a refresh failure blocks the build. The refresh
+        # token must be reusable; rotate the secret if invalidated.
         shell: bash
         env:
           PATREON_ACCESS_TOKEN: ${{ secrets.PATREON_ACCESS_TOKEN }}

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -49,6 +49,26 @@ jobs:
           # persisted GITHUB_TOKEN — don't leave it in git config.
           persist-credentials: false
 
+      - name: Preflight - releases-repo token is valid (tag builds only)
+        # Fail fast before the full build if RELEASES_REPO_TOKEN is dead.
+        # The non-mutating generate-notes endpoint rejects read-only tokens.
+        if: ${{ github.ref_type == 'tag' }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASES_REPO_TOKEN }}
+        run: |
+          set -euo pipefail
+          preflight_error=$(mktemp -t duskstudio-preflight.XXXXXX)
+          trap 'rm -f "$preflight_error"' EXIT
+          probe_tag="duskstudio-token-preflight-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          # This endpoint creates no release, but requires contents:write.
+          if ! gh api --method POST \
+              "repos/${RELEASES_REPO}/releases/generate-notes" \
+              -f "tag_name=${probe_tag}" >/dev/null 2>"$preflight_error"; then
+            echo "::error::write-capability preflight for ${RELEASES_REPO} failed. Check the API details below and verify RELEASES_REPO_TOKEN has repository access and contents:write; rotate the secret if needed, then re-run." >&2
+            cat "$preflight_error" >&2
+            exit 1
+          fi
+
       - name: Verify tag matches VERSION
         # Assets are named from the VERSION file, not the tag — a mismatch
         # would publish wrongly-labelled artifacts silently.
@@ -126,9 +146,10 @@ jobs:
         # Pins + rationale live in .github/actions/clone-dpf-stack.
         uses: ./.github/actions/clone-dpf-stack
 
-      - name: Refresh Patreon supporters (best-effort)
+      - name: Refresh Patreon supporters
         # See linux-release.yml for the rationale. Bakes the live list into the
-        # DMG; best-effort, ships the committed list with no secrets / on failure.
+        # DMG. Missing secrets ship the committed list; a configured refresh
+        # failure blocks the build.
         shell: bash
         env:
           PATREON_ACCESS_TOKEN: ${{ secrets.PATREON_ACCESS_TOKEN }}

--- a/.github/workflows/manual-pdf.yml
+++ b/.github/workflows/manual-pdf.yml
@@ -11,7 +11,7 @@ name: Manual PDF
 #
 # Triggers:
 #   - push of a v* tag   -> attaches MANUAL.pdf to that tag's release.
-#   - workflow_dispatch  -> build-numbered pre-release for hand-offs.
+#   - workflow_dispatch  -> uploads MANUAL.pdf as a workflow artifact only.
 #
 # Uses docs/build-pdf.sh, the same renderer a maintainer runs locally, so
 # the CI PDF is byte-for-byte the local one given the same toolchain.
@@ -47,6 +47,26 @@ jobs:
           # Publish goes through RELEASES_REPO_TOKEN, not the persisted
           # GITHUB_TOKEN — don't leave it in git config.
           persist-credentials: false
+
+      - name: Preflight - releases-repo token is valid (tag builds only)
+        # Fail fast before rendering if RELEASES_REPO_TOKEN is dead. The
+        # non-mutating generate-notes endpoint rejects read-only tokens.
+        if: ${{ github.ref_type == 'tag' }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASES_REPO_TOKEN }}
+        run: |
+          set -euo pipefail
+          preflight_error=$(mktemp -t duskstudio-preflight.XXXXXX)
+          trap 'rm -f "$preflight_error"' EXIT
+          probe_tag="duskstudio-token-preflight-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          # This endpoint creates no release, but requires contents:write.
+          if ! gh api --method POST \
+              "repos/${RELEASES_REPO}/releases/generate-notes" \
+              -f "tag_name=${probe_tag}" >/dev/null 2>"$preflight_error"; then
+            echo "::error::write-capability preflight for ${RELEASES_REPO} failed. Check the API details below and verify RELEASES_REPO_TOKEN has repository access and contents:write; rotate the secret if needed, then re-run." >&2
+            cat "$preflight_error" >&2
+            exit 1
+          fi
 
       - name: Verify tag matches VERSION
         # Same gate as the three binary release workflows. Without it, a

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -54,6 +54,27 @@ jobs:
           # GITHUB_TOKEN — don't leave it in git config.
           persist-credentials: false
 
+      - name: Preflight - releases-repo token is valid (tag builds only)
+        # Fail fast before the full build if RELEASES_REPO_TOKEN is dead.
+        # The non-mutating generate-notes endpoint rejects read-only tokens.
+        if: ${{ github.ref_type == 'tag' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.RELEASES_REPO_TOKEN }}
+        run: |
+          set -euo pipefail
+          preflight_error=$(mktemp -t duskstudio-preflight.XXXXXX)
+          trap 'rm -f "$preflight_error"' EXIT
+          probe_tag="duskstudio-token-preflight-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          # This endpoint creates no release, but requires contents:write.
+          if ! gh api --method POST \
+              "repos/${RELEASES_REPO}/releases/generate-notes" \
+              -f "tag_name=${probe_tag}" >/dev/null 2>"$preflight_error"; then
+            echo "::error::write-capability preflight for ${RELEASES_REPO} failed. Check the API details below and verify RELEASES_REPO_TOKEN has repository access and contents:write; rotate the secret if needed, then re-run." >&2
+            cat "$preflight_error" >&2
+            exit 1
+          fi
+
       - name: Verify tag matches VERSION
         # Assets are named from the VERSION file, not the tag — a mismatch
         # would publish wrongly-labelled artifacts silently.
@@ -94,9 +115,10 @@ jobs:
         # Pins + rationale live in .github/actions/clone-dpf-stack.
         uses: ./.github/actions/clone-dpf-stack
 
-      - name: Refresh Patreon supporters (best-effort)
+      - name: Refresh Patreon supporters
         # See linux-release.yml for the rationale. Bakes the live list into the
-        # MSI; best-effort, ships the committed list with no secrets / on failure.
+        # MSI. Missing secrets ship the committed list; a configured refresh
+        # failure blocks the build.
         shell: bash
         env:
           PATREON_ACCESS_TOKEN: ${{ secrets.PATREON_ACCESS_TOKEN }}

--- a/docs/MAINTAINER-GUIDE.md
+++ b/docs/MAINTAINER-GUIDE.md
@@ -531,14 +531,16 @@ A complete `vX.Y.Z` release has exactly these ten assets:
 Before announcement, run
 [`scripts/verify-release-assets.sh`](../scripts/verify-release-assets.sh)
 `vX.Y.Z`. It fails if an expected asset class is missing or duplicated, an
-unexpected asset exists, or the release body is empty. Its macOS and Windows
-checks currently accept wildcard architecture suffixes, so it does not
-prove those two exact filenames or payload architectures. Download the assets
-into a clean directory and perform the manual checks that the script cannot
-cover:
+unexpected asset exists, or the release body's summary slot is missing or
+empty. Its macOS and Windows checks currently accept wildcard architecture
+suffixes, so it does not prove those two exact filenames or payload
+architectures. Summary-slot validation applies to v0.13.0 and later; older
+release bodies predate the markers and are expected to fail that check.
+Download the assets into a clean directory and perform the
+manual checks that the script cannot cover:
 
-- Confirm the release body contains the version's summary, not only the static
-  Downloads section.
+- Confirm the populated release summary is correct for this version. The
+  verifier rejects an empty slot but cannot judge editorial accuracy.
 - Confirm all ten filenames exactly match the list above. Inspect the
   executable inside the DMG and MSI and confirm arm64 and x64 respectively;
   do not infer architecture from the filename.

--- a/docs/handoff-013-milestone.md
+++ b/docs/handoff-013-milestone.md
@@ -6,23 +6,23 @@ Paste everything below as the opening prompt of the session that will do the wor
 
 You are the orchestrator for Dusk Studio (`/home/marc/projects/DuskStudio`). Read
 `CLAUDE.md` first; its audio-thread, de-JUCE, and verification requirements are
-absolute. Finish only the still-open 0.13.0 milestone issues: #178, #266, #271,
-#272, and #274. Verify their current GitHub state and each finding against the
-current source before acting. Do not reopen or reimplement closed issues.
+absolute. Of the 0.13.0 milestone, finish only issues #178, #266, #271, #272,
+and #274. Verify their current GitHub state and each finding against the current
+source before acting. Do not reopen or reimplement closed issues.
 
-The release metadata is already prepared on `release/0.13.0-metadata`; commit
-`b4daede` contains the 0.13.0 bump. Until Marc merges that branch,
-`origin/main:VERSION` remains 0.12.2. Continue from the release branch instead
-of recreating the bump on `main`.
+The 0.13.0 metadata landed on `origin/main` as `e4ac7d6` through #284, and
+`origin/main:VERSION` is 0.13.0. Do not continue on the merged
+`release/0.13.0-metadata` branch. Start any still-valid #178 change from an
+up-to-date `origin/main`, and retire the merged branch only under #271 after
+Marc authorizes cleanup.
 
 The working tree also contains unrelated, user-owned edits in
 `BUILDING-LINUX.md`, `CLAUDE.md`, `docs/capture-screenshots.sh`, and
 `docs/lv2-dsp-integration-handoff.md`. Do not stage, rewrite, or discard them.
 
-Keep the metadata branch limited to #178 and this handoff. Create separate
-issue branches from an up-to-date `origin/main` for #266, #272, and any code
-resulting from #274; each gets its own review and PR. #271 is Marc-gated
-repository maintenance, not a code branch.
+For issues #178, #266, and #272, and for any code resulting from #274, create
+a separate branch from an up-to-date `origin/main`. Each gets its own review and
+PR. Issue #271 is Marc-gated repository maintenance, not a code branch.
 
 ## Working model
 
@@ -196,8 +196,8 @@ desktop-session failure.
 
 The ALSA sequence-subscription test can be flaky under parallel load. CTest's
 `-R` option takes a test-name regular expression, not an ordinal such as test
-#7. List the registered tests, identify the exact name, and rerun that name with
-failure output enabled:
+number 7. List the registered tests, identify the exact name, and rerun that
+name with failure output enabled:
 
 ```bash
 ctest --test-dir build-tests-w -N | grep -E 'ALSA seq.*subscription'
@@ -212,18 +212,35 @@ and #267-#270. Those parts are complete. In particular, #266's documentation
 half had to land before tagging and is independently complete. Its remaining
 CMake half is separately closable and may land after the v0.13.0 tag.
 
-- #178, release mechanics: verify the metadata branch and current repository
-  against the issue's still-valid acceptance criteria and prepare it for Marc
-  to land on `origin/main`. Leave merging and tagging to Marc. Do not redo
-  release chores already completed. The untagged 0.12.7 wave is folded into
-  the 0.13.0 notes; do not create a 0.12.7 tag unless Marc reverses that
-  decision. Ask Marc for the real package-contact address that must replace
-  `support@duskaudio.example`; never invent one. Do not run
-  `scripts/update-patrons.py` locally: the tag workflow refreshes patrons in its
-  isolated donor checkout and refuses to ship stale data. The local patrons step
-  printed at `scripts/bump-version.sh:342` at this handoff revision is superseded
-  and must be corrected under #178 before tagging. Follow the tracked release
-  procedures in `packaging/README.md` and `docs/MAINTAINER-GUIDE.md`.
+- #178, release mechanics: verify the metadata on `origin/main` and the current
+  repository against the issue's still-valid acceptance criteria. Leave tagging
+  to Marc and do not redo release chores already completed. The untagged 0.12.7
+  wave is folded into the 0.13.0 notes; do not create a 0.12.7 tag unless Marc
+  reverses that decision. Ask Marc for the real package-contact address that
+  must replace `support@duskaudio.example`; never invent one. The binary release
+  workflows refresh patrons in isolated donor checkouts when all four Patreon
+  secrets are available, but warn and ship the committed supporters list when
+  any secret is missing. With all four secrets configured, a refresh failure
+  fails the release build. Before tagging, configure local Patreon credentials
+  and run the freshness check from the root checkout, where sibling discovery
+  can reach the normal working donor checkout rather than the detached `$DONOR`
+  verification checkout:
+
+  ```bash
+  (cd /home/marc/projects/DuskStudio && \
+    env -u DUSK_PLUGINS_PATH scripts/update-patrons.py --dry-run)
+  ```
+
+  Reconcile any out-of-sync sibling headers and rerun the check. Compare the
+  reported tiers with the header in the pinned donor checkout at
+  `/home/marc/projects/dusk-plugins-013/plugins/shared/PatreonBackers.h`. If they differ,
+  require all four repository secrets before tagging so the workflows inject
+  the live list. If the secrets are unavailable, stop and ask Marc whether to
+  update the donor list and pin; never advance `DONOR_REV` without that separate
+  decision. The local patrons step printed by `scripts/bump-version.sh` must be
+  updated under issue #178 to describe that
+  freshness check. Follow the tracked release procedures in
+  `packaging/README.md` and `docs/MAINTAINER-GUIDE.md`.
 - #266, CMake half: add a dependency-aware opt-out for the unconditional
   libsodium dependency, keeping missing libsodium fatal when catalog support is
   explicitly requested. Gate the SFZ catalog sources and tests, verify deb/rpm
@@ -240,10 +257,12 @@ CMake half is separately closable and may land after the v0.13.0 tag.
   library cache entry; any match is a failure.
 - #271, repository maintenance: each push, discard, branch deletion, and
   worktree removal needs Marc's explicit authorization.
-- #272, release workflows: add token preflights where missing and make release
-  body verification detect an unfilled summary slot. Marc must decide before
-  tagging: merge #272 first so it protects v0.13.0, or explicitly defer it to
-  v0.14. Landing it after the v0.13.0 tag cannot protect that tag.
+- #272, release workflows: token preflights and a release-summary-slot check
+  were implemented under this issue. Confirm those changes are present on
+  `origin/main` before acting; do not reimplement an already-landed change. The
+  issue does not gate v0.13.0. Token preflights protect only tags created after
+  they land; the verifier can still protect the announcement if its summary-slot
+  check lands before the post-build check.
 - #274, product decision: ask Marc whether to rename `vca_overeasy`. If yes,
   scope the change to the session serializer's write and read sites
   (`SessionSerializer.cpp:629` and `:1285` at this handoff revision): write the

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -98,5 +98,5 @@ straight from the extracted tarball.
    `SHA256SUMS.manual`.
 5. Before announcing the release, run
    `scripts/verify-release-assets.sh vX.Y.Z`. Do not announce unless it reports
-   all ten assets and a non-empty release body.
+   all ten assets and a populated release-summary slot.
 6. Pinned support note: paste `DuskStudio --version` output into any DM.

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -16,6 +16,24 @@
 
 set -euo pipefail
 
+strip_html_comments() {
+    local remaining=$1
+    local visible=''
+    local comment_start='<!--'
+    local comment_end='-->'
+    while [[ "$remaining" == *"$comment_start"* ]]; do
+        visible+=${remaining%%"$comment_start"*}
+        remaining=${remaining#*"$comment_start"}
+        if [[ "$remaining" != *"$comment_end"* ]]; then
+            remaining=''
+            break
+        fi
+        remaining=${remaining#*"$comment_end"}
+    done
+    visible+=$remaining
+    printf '%s' "$visible"
+}
+
 if [[ $# -lt 1 ]]; then
     echo "usage: $0 <semver> [release notes ...]" >&2
     exit 2
@@ -23,7 +41,24 @@ fi
 
 NEW_VERSION="$1"
 shift
-NOTES="${*:-Patch release.}"
+if [[ $# -eq 0 ]]; then
+    NOTES='Patch release.'
+else
+    NOTES="$*"
+fi
+
+VISIBLE_NOTES=$(strip_html_comments "$NOTES")
+while [[ "$VISIBLE_NOTES" == [[:space:]]* ]]; do
+    VISIBLE_NOTES=${VISIBLE_NOTES#?}
+done
+while [[ "$VISIBLE_NOTES" == *[[:space:]] ]]; do
+    VISIBLE_NOTES=${VISIBLE_NOTES%?}
+done
+if [[ -z "${VISIBLE_NOTES//[[:space:]]/}" ]]; then
+    echo "error: release notes must contain visible text" >&2
+    exit 2
+fi
+NOTES="$VISIBLE_NOTES"
 
 if [[ ! "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     echo "error: '$NEW_VERSION' is not a semver triple (MAJOR.MINOR.PATCH)" >&2

--- a/scripts/verify-release-assets.sh
+++ b/scripts/verify-release-assets.sh
@@ -8,14 +8,45 @@
 # Four workflows publish to the same tag (linux-release once per arch,
 # macos-release, windows-build, manual-pdf). A platform that fails leaves a
 # release that looks finished but is short its assets, so the set is the check:
-# ten assets, no more, no fewer, plus a non-empty body. Exits nonzero if
-# anything is missing, duplicated or unexpected.
+# ten assets, no more, no fewer, plus a populated release-summary slot. Exits
+# nonzero if anything is missing, duplicated or unexpected.
 
 set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 REPO="${RELEASES_REPO:-dusk-audio/dusk-studio-releases}"
+SUMMARY_START='<!-- summary-start -->'
+SUMMARY_END='<!-- summary-end -->'
+
+count_occurrences() {
+    local remaining=$1
+    local needle=$2
+    local count=0
+    while [[ "$remaining" == *"$needle"* ]]; do
+        remaining=${remaining#*"$needle"}
+        ((count += 1))
+    done
+    printf '%s' "$count"
+}
+
+strip_html_comments() {
+    local remaining=$1
+    local visible=''
+    local comment_start='<!--'
+    local comment_end='-->'
+    while [[ "$remaining" == *"$comment_start"* ]]; do
+        visible+=${remaining%%"$comment_start"*}
+        remaining=${remaining#*"$comment_start"}
+        if [[ "$remaining" != *"$comment_end"* ]]; then
+            remaining=''
+            break
+        fi
+        remaining=${remaining#*"$comment_end"}
+    done
+    visible+=$remaining
+    printf '%s' "$visible"
+}
 
 TAG="${1:-}"
 if [[ -z "$TAG" ]]; then
@@ -48,22 +79,33 @@ EXPECTED=(
     "Manual sums|SHA256SUMS.manual"
 )
 
-# One API call, one record per line as "kind<TAB>value": the body is multi-line
-# and would otherwise be indistinguishable from the asset names.
-if ! RECORDS=$(gh release view "$TAG" --repo "$REPO" --json assets,body \
-        --jq '"body\t\(.body | utf8bytelength)", (.assets[] | "asset\t\(.name)")' 2>&1); then
+GH_ERROR=$(mktemp "${TMPDIR:-/tmp}/duskstudio-release-verify.XXXXXX")
+cleanup() {
+    rm -f "$GH_ERROR"
+}
+trap cleanup EXIT
+
+# Fetch asset names separately because summary validation needs the complete
+# body text while asset matching needs one name per line.
+if ! RECORDS=$(gh release view "$TAG" --repo "$REPO" --json assets \
+        --jq '.assets[].name' 2>"$GH_ERROR"); then
     echo "error: cannot read release ${TAG} from ${REPO}:" >&2
-    echo "$RECORDS" >&2
+    cat "$GH_ERROR" >&2
     exit 2
 fi
 
+: > "$GH_ERROR"
+if ! BODY=$(gh release view "$TAG" --repo "$REPO" --json body --jq '.body // ""' \
+        2>"$GH_ERROR"); then
+    echo "error: cannot read release body for ${TAG} from ${REPO}:" >&2
+    cat "$GH_ERROR" >&2
+    exit 2
+fi
+BODY_BYTES=$(printf '%s' "$BODY" | wc -c | tr -d '[:space:]')
+
 NAMES=()
-BODY_BYTES=0
-while IFS=$'\t' read -r kind value; do
-    case "$kind" in
-        asset) NAMES+=("$value") ;;
-        body)  BODY_BYTES="$value" ;;
-    esac
+while IFS= read -r name; do
+    [[ -n "$name" ]] && NAMES+=("$name")
 done <<< "$RECORDS"
 
 MATCHED=()
@@ -108,11 +150,31 @@ for ((i = 0; i < ${#NAMES[@]}; i++)); do
     fi
 done
 
-if [[ "$BODY_BYTES" -gt 0 ]]; then
-    printf '%-8s %-24s %s\n' "ok" "release body" "${BODY_BYTES} bytes"
-else
-    printf '%-8s %-24s %s\n' "EMPTY" "release body" "no notes - the create step lost packaging/RELEASE-NOTES.md"
+if [[ "$BODY_BYTES" -eq 0 ]]; then
+    printf '%-8s %-24s %s\n' "EMPTY" "release body" \
+        "no notes - the create step lost packaging/RELEASE-NOTES.md"
     status=1
+else
+    START_COUNT=$(count_occurrences "$BODY" "$SUMMARY_START")
+    END_COUNT=$(count_occurrences "$BODY" "$SUMMARY_END")
+    SUMMARY=${BODY#*"$SUMMARY_START"}
+    if (( START_COUNT != 1 || END_COUNT != 1 )) \
+        || [[ "$SUMMARY" != *"$SUMMARY_END"* ]]; then
+        printf '%-8s %-24s %s\n' "INVALID" "release body" \
+            "summary markers are missing, duplicated, or out of order"
+        status=1
+    else
+        SUMMARY=${SUMMARY%%"$SUMMARY_END"*}
+        SUMMARY_CONTENT=$(strip_html_comments "$SUMMARY" | tr -d '[:space:]')
+        if [[ -z "$SUMMARY_CONTENT" ]]; then
+            printf '%-8s %-24s %s\n' "PLACEHOLDER" "release body" \
+                "summary slot is empty"
+            status=1
+        else
+            printf '%-8s %-24s %s\n' "ok" "release body" \
+                "${BODY_BYTES} bytes, summary populated"
+        fi
+    fi
 fi
 
 echo

--- a/tests/release_mechanics.sh
+++ b/tests/release_mechanics.sh
@@ -87,6 +87,47 @@ printf '%s\n' \
     '- **Linux** (`.tar.xz`): unsigned.' \
     > "$FIXTURE/packaging/RELEASE-NOTES.md"
 
+WHITESPACE_ERROR="$SCRATCH/whitespace-notes-error.txt"
+if (cd "$FIXTURE" \
+    && bash scripts/bump-version.sh 9.9.9 '' \
+        >/dev/null 2>"$WHITESPACE_ERROR"); then
+    echo "FAIL: an explicitly empty release summary must be rejected" >&2
+    exit 1
+fi
+if ! grep -qF 'release notes must contain visible text' \
+    "$WHITESPACE_ERROR"; then
+    echo "FAIL: an empty release summary reported the wrong failure" >&2
+    cat "$WHITESPACE_ERROR" >&2
+    exit 1
+fi
+if (cd "$FIXTURE" \
+    && bash scripts/bump-version.sh 9.9.9 '   ' \
+        >/dev/null 2>"$WHITESPACE_ERROR"); then
+    echo "FAIL: whitespace-only release notes must be rejected" >&2
+    exit 1
+fi
+if ! grep -qF 'release notes must contain visible text' \
+    "$WHITESPACE_ERROR"; then
+    echo "FAIL: whitespace-only release notes reported the wrong failure" >&2
+    cat "$WHITESPACE_ERROR" >&2
+    exit 1
+fi
+if [[ "$(cat "$FIXTURE/VERSION")" != "0.0.0" ]]; then
+    echo "FAIL: whitespace-only release notes must leave VERSION untouched" >&2
+    exit 1
+fi
+if (cd "$FIXTURE" \
+    && bash scripts/bump-version.sh 9.9.9 '<!-- TODO: write summary -->' \
+        >/dev/null 2>"$WHITESPACE_ERROR"); then
+    echo "FAIL: comment-only release notes must be rejected before publishing" >&2
+    exit 1
+fi
+if ! grep -qF 'release notes must contain visible text' "$WHITESPACE_ERROR"; then
+    echo "FAIL: comment-only release notes reported the wrong failure" >&2
+    cat "$WHITESPACE_ERROR" >&2
+    exit 1
+fi
+
 # An anchor quoted inside a nested release description is a decoy, not the
 # direct child insertion point. A file containing only that decoy must abort
 # before any metadata lands.
@@ -215,6 +256,257 @@ if find "$FIXTURE_ROLLBACK" -type f \
     exit 1
 fi
 
+# The release body always has a static Downloads section, so byte length alone
+# cannot prove that bump-version.sh populated the summary slot. Exercise the
+# verifier with a fake gh response while keeping the complete asset set valid.
+VERIFIER_BIN="$SCRATCH/verifier-bin"
+mkdir -p "$VERIFIER_BIN"
+cat > "$VERIFIER_BIN/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ -n "${FAKE_GH_STDERR:-}" ]]; then
+    printf '%s\n' "$FAKE_GH_STDERR" >&2
+fi
+if [[ -n "${FAKE_GH_FAIL_JSON:-}" \
+    && " $* " == *" --json ${FAKE_GH_FAIL_JSON} "* ]]; then
+    printf 'fake gh %s failure\n' "$FAKE_GH_FAIL_JSON" >&2
+    exit 73
+fi
+case " $* " in
+    *" --json body "*)
+        printf '%s\n' "${FAKE_RELEASE_BODY-}"
+        ;;
+    *" --json assets "*)
+        if [[ ${FAKE_RELEASE_ASSETS+x} == x ]]; then
+            printf '%s\n' "$FAKE_RELEASE_ASSETS"
+        else
+            printf '%s\n' \
+                'dusk-studio-9.9.9-Linux-x86_64.tar.xz' \
+                'SHA256SUMS.linux-x86_64' \
+                'dusk-studio-9.9.9-Linux-aarch64.tar.xz' \
+                'SHA256SUMS.linux-aarch64' \
+                'dusk-studio-9.9.9-macOS-arm64.dmg' \
+                'SHA256SUMS.macos' \
+                'dusk-studio-9.9.9-Windows-x64.msi' \
+                'SHA256SUMS.windows' \
+                'MANUAL.pdf' \
+                'SHA256SUMS.manual'
+        fi
+        ;;
+    *)
+        echo "unexpected fake gh invocation: $*" >&2
+        exit 2
+        ;;
+esac
+SH
+chmod +x "$VERIFIER_BIN/gh"
+
+PLACEHOLDER_BODY=$(printf '%s\n' \
+    '<!-- summary-start -->' \
+    '<!-- summary-end -->' \
+    '' \
+    '### Downloads')
+COMMENT_ONLY_BODY=$(printf '%s\n' \
+    '<!-- summary-start -->' \
+    '<!-- TODO: write the release summary -->' \
+    '<!-- summary-end -->' \
+    '' \
+    '### Downloads')
+INVALID_BODY='### Downloads'
+INVALID_ORDER_BODY=$(printf '%s\n' \
+    '<!-- summary-end -->' \
+    '<!-- summary-start -->' \
+    'Release summary for 9.9.9.' \
+    '' \
+    '### Downloads')
+DUPLICATE_START_BODY=$(printf '%s\n' \
+    '<!-- summary-start -->' \
+    'Release summary for 9.9.9.' \
+    '<!-- summary-start -->' \
+    '<!-- summary-end -->' \
+    '' \
+    '### Downloads')
+LEADING_END_BODY=$(printf '%s\n' \
+    '<!-- summary-end -->' \
+    '<!-- summary-start -->' \
+    'Release summary for 9.9.9.' \
+    '<!-- summary-end -->' \
+    '' \
+    '### Downloads')
+TRUNCATED_BODY=$(printf '%s\n' \
+    '<!-- summary-start -->' \
+    'Release summary for 9.9.9.' \
+    '' \
+    '### Downloads')
+POPULATED_BODY=$(printf '%s\n' \
+    '<!-- summary-start -->' \
+    'Release summary for 9.9.9.' \
+    '<!-- summary-end -->' \
+    '' \
+    '### Downloads')
+MISSING_ASSETS=$(printf '%s\n' \
+    'dusk-studio-9.9.9-Linux-x86_64.tar.xz' \
+    'SHA256SUMS.linux-x86_64' \
+    'dusk-studio-9.9.9-Linux-aarch64.tar.xz' \
+    'SHA256SUMS.linux-aarch64' \
+    'dusk-studio-9.9.9-macOS-arm64.dmg' \
+    'SHA256SUMS.macos' \
+    'dusk-studio-9.9.9-Windows-x64.msi' \
+    'SHA256SUMS.windows' \
+    'MANUAL.pdf')
+VERIFIER_OUTPUT="$SCRATCH/verifier-output.txt"
+VERIFIER_ERROR="$SCRATCH/verifier-error.txt"
+if PATH="$VERIFIER_BIN:$PATH" FAKE_GH_FAIL_JSON=assets \
+    bash "$SOURCE_ROOT/scripts/verify-release-assets.sh" v9.9.9 \
+    >"$VERIFIER_OUTPUT" 2>&1; then
+    echo "FAIL: an asset API failure must abort verification" >&2
+    exit 1
+fi
+if ! grep -qF 'cannot read release v9.9.9' "$VERIFIER_OUTPUT" \
+    || ! grep -qF 'fake gh assets failure' "$VERIFIER_OUTPUT"; then
+    echo "FAIL: asset API failure diagnostics were lost" >&2
+    cat "$VERIFIER_OUTPUT" >&2
+    exit 1
+fi
+if PATH="$VERIFIER_BIN:$PATH" FAKE_GH_FAIL_JSON=body \
+    bash "$SOURCE_ROOT/scripts/verify-release-assets.sh" v9.9.9 \
+    >"$VERIFIER_OUTPUT" 2>&1; then
+    echo "FAIL: a body API failure must abort verification" >&2
+    exit 1
+fi
+if ! grep -qF 'cannot read release body for v9.9.9' "$VERIFIER_OUTPUT" \
+    || ! grep -qF 'fake gh body failure' "$VERIFIER_OUTPUT"; then
+    echo "FAIL: body API failure diagnostics were lost" >&2
+    cat "$VERIFIER_OUTPUT" >&2
+    exit 1
+fi
+if PATH="$VERIFIER_BIN:$PATH" FAKE_RELEASE_ASSETS='' \
+    FAKE_RELEASE_BODY="$POPULATED_BODY" \
+    bash "$SOURCE_ROOT/scripts/verify-release-assets.sh" v9.9.9 \
+    >"$VERIFIER_OUTPUT" 2>&1; then
+    echo "FAIL: a release with no assets must fail verification" >&2
+    exit 1
+fi
+if ! grep -qE '^MISSING[[:space:]]+' "$VERIFIER_OUTPUT"; then
+    echo "FAIL: an empty asset list reported the wrong failure" >&2
+    cat "$VERIFIER_OUTPUT" >&2
+    exit 1
+fi
+if PATH="$VERIFIER_BIN:$PATH" FAKE_RELEASE_ASSETS="$MISSING_ASSETS" \
+    FAKE_RELEASE_BODY="$POPULATED_BODY" \
+    bash "$SOURCE_ROOT/scripts/verify-release-assets.sh" v9.9.9 \
+    >"$VERIFIER_OUTPUT" 2>&1; then
+    echo "FAIL: a release missing one asset must fail verification" >&2
+    exit 1
+fi
+if ! grep -qE '^MISSING[[:space:]].*SHA256SUMS\.manual$' "$VERIFIER_OUTPUT"; then
+    echo "FAIL: a missing release asset reported the wrong failure" >&2
+    cat "$VERIFIER_OUTPUT" >&2
+    exit 1
+fi
+if PATH="$VERIFIER_BIN:$PATH" FAKE_RELEASE_BODY='' \
+    bash "$SOURCE_ROOT/scripts/verify-release-assets.sh" v9.9.9 \
+    >"$VERIFIER_OUTPUT" 2>&1; then
+    echo "FAIL: an empty release body must fail verification" >&2
+    exit 1
+fi
+if ! grep -qE '^EMPTY[[:space:]]+release body' "$VERIFIER_OUTPUT"; then
+    echo "FAIL: empty release body reported the wrong failure" >&2
+    cat "$VERIFIER_OUTPUT" >&2
+    exit 1
+fi
+if PATH="$VERIFIER_BIN:$PATH" FAKE_RELEASE_BODY="$PLACEHOLDER_BODY" \
+    bash "$SOURCE_ROOT/scripts/verify-release-assets.sh" v9.9.9 \
+    >"$VERIFIER_OUTPUT" 2>&1; then
+    echo "FAIL: an empty release-summary slot must fail verification" >&2
+    exit 1
+fi
+if ! grep -qE '^PLACEHOLDER[[:space:]]+release body' "$VERIFIER_OUTPUT"; then
+    echo "FAIL: empty release-summary slot reported the wrong failure" >&2
+    cat "$VERIFIER_OUTPUT" >&2
+    exit 1
+fi
+if PATH="$VERIFIER_BIN:$PATH" FAKE_RELEASE_BODY="$COMMENT_ONLY_BODY" \
+    bash "$SOURCE_ROOT/scripts/verify-release-assets.sh" v9.9.9 \
+    >"$VERIFIER_OUTPUT" 2>&1; then
+    echo "FAIL: a comment-only release-summary slot must fail verification" >&2
+    exit 1
+fi
+if ! grep -qE '^PLACEHOLDER[[:space:]]+release body' "$VERIFIER_OUTPUT"; then
+    echo "FAIL: comment-only release summary reported the wrong failure" >&2
+    cat "$VERIFIER_OUTPUT" >&2
+    exit 1
+fi
+if PATH="$VERIFIER_BIN:$PATH" FAKE_RELEASE_BODY="$INVALID_BODY" \
+    bash "$SOURCE_ROOT/scripts/verify-release-assets.sh" v9.9.9 \
+    >"$VERIFIER_OUTPUT" 2>&1; then
+    echo "FAIL: missing release-summary markers must fail verification" >&2
+    exit 1
+fi
+if ! grep -qE '^INVALID[[:space:]]+release body' "$VERIFIER_OUTPUT"; then
+    echo "FAIL: missing release-summary markers reported the wrong failure" >&2
+    cat "$VERIFIER_OUTPUT" >&2
+    exit 1
+fi
+if PATH="$VERIFIER_BIN:$PATH" FAKE_RELEASE_BODY="$INVALID_ORDER_BODY" \
+    bash "$SOURCE_ROOT/scripts/verify-release-assets.sh" v9.9.9 \
+    >"$VERIFIER_OUTPUT" 2>&1; then
+    echo "FAIL: out-of-order release-summary markers must fail verification" >&2
+    exit 1
+fi
+if ! grep -qE '^INVALID[[:space:]]+release body' "$VERIFIER_OUTPUT"; then
+    echo "FAIL: out-of-order release-summary markers reported the wrong failure" >&2
+    cat "$VERIFIER_OUTPUT" >&2
+    exit 1
+fi
+if PATH="$VERIFIER_BIN:$PATH" FAKE_RELEASE_BODY="$DUPLICATE_START_BODY" \
+    bash "$SOURCE_ROOT/scripts/verify-release-assets.sh" v9.9.9 \
+    >"$VERIFIER_OUTPUT" 2>&1; then
+    echo "FAIL: duplicate release-summary start markers must fail verification" >&2
+    exit 1
+fi
+if ! grep -qE '^INVALID[[:space:]]+release body' "$VERIFIER_OUTPUT"; then
+    echo "FAIL: duplicate release-summary start markers reported the wrong failure" >&2
+    cat "$VERIFIER_OUTPUT" >&2
+    exit 1
+fi
+if PATH="$VERIFIER_BIN:$PATH" FAKE_RELEASE_BODY="$LEADING_END_BODY" \
+    bash "$SOURCE_ROOT/scripts/verify-release-assets.sh" v9.9.9 \
+    >"$VERIFIER_OUTPUT" 2>&1; then
+    echo "FAIL: duplicate release-summary end markers must fail verification" >&2
+    exit 1
+fi
+if ! grep -qE '^INVALID[[:space:]]+release body' "$VERIFIER_OUTPUT"; then
+    echo "FAIL: duplicate release-summary end markers reported the wrong failure" >&2
+    cat "$VERIFIER_OUTPUT" >&2
+    exit 1
+fi
+if PATH="$VERIFIER_BIN:$PATH" FAKE_RELEASE_BODY="$TRUNCATED_BODY" \
+    bash "$SOURCE_ROOT/scripts/verify-release-assets.sh" v9.9.9 \
+    >"$VERIFIER_OUTPUT" 2>&1; then
+    echo "FAIL: a release-summary slot without an end marker must fail verification" >&2
+    exit 1
+fi
+if ! grep -qE '^INVALID[[:space:]]+release body' "$VERIFIER_OUTPUT"; then
+    echo "FAIL: truncated release-summary slot reported the wrong failure" >&2
+    cat "$VERIFIER_OUTPUT" >&2
+    exit 1
+fi
+PATH="$VERIFIER_BIN:$PATH" FAKE_RELEASE_BODY="$POPULATED_BODY" \
+    FAKE_GH_STDERR='benign gh diagnostic' \
+    bash "$SOURCE_ROOT/scripts/verify-release-assets.sh" v9.9.9 \
+    >"$VERIFIER_OUTPUT" 2>"$VERIFIER_ERROR"
+if ! grep -qF "summary populated" "$VERIFIER_OUTPUT"; then
+    echo "FAIL: populated release summary was not accepted" >&2
+    cat "$VERIFIER_OUTPUT" >&2
+    exit 1
+fi
+if grep -qF 'EXTRA' "$VERIFIER_OUTPUT"; then
+    echo "FAIL: gh stderr must not be parsed as a release asset" >&2
+    cat "$VERIFIER_OUTPUT" >&2
+    exit 1
+fi
+
 # An interrupt after a metadata move must use the same rollback path instead
 # of letting the EXIT cleanup discard the recovery copies.
 FIXTURE_SIGNAL="$SCRATCH/repo-signal"
@@ -270,10 +562,11 @@ cmp "$FIXTURE/packaging/DuskStudio.appdata.xml" \
     "$FIXTURE_VERSION_STAGE/packaging/DuskStudio.appdata.xml"
 
 NOTES='Gain & grit <hot> > cool ]]> "quoted" café — release'
+RAW_NOTES="$NOTES <!-- internal release-note comment -->"
 BUMP_OUTPUT="$SCRATCH/bump-output.txt"
 (
     cd "$FIXTURE"
-    bash scripts/bump-version.sh 9.9.9 "$NOTES" > "$BUMP_OUTPUT"
+    bash scripts/bump-version.sh 9.9.9 "$RAW_NOTES" > "$BUMP_OUTPUT"
 )
 
 if command -v xmllint >/dev/null 2>&1; then
@@ -407,6 +700,7 @@ create_marker = 'if ! create_err=$(gh release create "$TAG"'
 recheck_marker = 'if gh release view "$TAG" --repo "$RELEASES_REPO" >/dev/null 2>&1; then'
 upload_line = 'gh release upload "$TAG" --repo "$RELEASES_REPO" --clobber "${ASSETS[@]}"'
 notes_marker = "--notes-file packaging/RELEASE-NOTES.md"
+preflight_marker = "- name: Preflight - releases-repo token is valid (tag builds only)"
 
 # The release-day self-test must be isolated from the maintainer's live
 # Wayland session and must fail closed if its private X server cannot start.
@@ -453,9 +747,19 @@ for label, path in safe_selftest_callers.items():
 notes_path = source_root / "packaging" / "RELEASE-NOTES.md"
 assert notes_path.is_file(), "packaging/RELEASE-NOTES.md must exist"
 notes_text = notes_path.read_text(encoding="utf-8")
-summary_slot(notes_text)  # markers present, else the bump silently skips it
-visible_notes = re.sub(r"<!--.*?-->", "", notes_text, flags=re.S).strip()
-assert visible_notes, "release notes must carry a body, not just comments"
+assert notes_text.count(SUMMARY_START) == 1, (
+    "tracked notes must contain exactly one summary start marker"
+)
+assert notes_text.count(SUMMARY_END) == 1, (
+    "tracked notes must contain exactly one summary end marker"
+)
+assert notes_text.index(SUMMARY_START) < notes_text.index(SUMMARY_END), (
+    "tracked notes summary markers must be in order"
+)
+_, tracked_slot, tracked_after = summary_slot(notes_text)
+visible_summary = re.sub(r"<!--.*?-->", "", tracked_slot, flags=re.S).strip()
+assert visible_summary, "release-summary slot must carry visible content"
+assert "### Downloads" in tracked_after, "tracked notes must keep the Downloads section"
 
 # The summary is script-managed: the bump replaces the whole slot with the
 # release notes verbatim and touches nothing outside it.
@@ -508,6 +812,9 @@ for display_name in workflows.values():
 verifier_text = (source_root / "scripts" / "verify-release-assets.sh").read_text(
     encoding="utf-8"
 )
+assert "--jq '.body // \"\"'" in verifier_text, (
+    "verifier must normalize a null release body to empty"
+)
 expected_assets = re.findall(r'^\s+"[^"\n]+\|[^"\n]+"$', verifier_text, re.MULTILINE)
 expected_asset_count = 10
 assert len(expected_assets) == expected_asset_count, (
@@ -530,6 +837,36 @@ for name, display_name in workflows.items():
     assert workflow_name and workflow_name.group(1).strip() == display_name, (
         f"{name}: printed checklist name is stale"
     )
+    assert text.count(preflight_marker) == 1, (
+        f"{name}: release token preflight must appear exactly once"
+    )
+    preflight_at = text.index(preflight_marker)
+    tag_check_at = text.index("- name: Verify tag matches VERSION")
+    assert preflight_at < tag_check_at, (
+        f"{name}: token preflight must run before release validation/build work"
+    )
+    preflight_block = text[preflight_at:tag_check_at]
+    for required in (
+        "set -euo pipefail",
+        "if: ${{ github.ref_type == 'tag' }}",
+        "GH_TOKEN: ${{ secrets.RELEASES_REPO_TOKEN }}",
+        "preflight_error=$(mktemp -t duskstudio-preflight.XXXXXX)",
+        "trap 'rm -f \"$preflight_error\"' EXIT",
+        'probe_tag="duskstudio-token-preflight-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
+        "if ! gh api --method POST",
+        '"repos/${RELEASES_REPO}/releases/generate-notes"',
+        '-f "tag_name=${probe_tag}" >/dev/null 2>"$preflight_error"; then',
+        "write-capability preflight for ${RELEASES_REPO} failed",
+        'cat "$preflight_error" >&2',
+        "exit 1",
+    ):
+        assert required in preflight_block, (
+            f"{name}: token preflight lost required check: {required}"
+        )
+    if name == "windows-build.yml":
+        assert "shell: bash" in preflight_block, (
+            "windows-build.yml: token preflight must override the pwsh default"
+        )
     assert text.count(create_marker) == 1, f"{name}: missing race-checked create"
     create_at = text.index(create_marker)
     create_end = text.index("2>&1); then", create_at)


### PR DESCRIPTION
## Summary
- fail fast on tag builds with a non-mutating Contents-write capability probe in all four publishing workflows
- reject missing, empty, truncated, or out-of-order release-summary slots during asset verification
- align maintainer and milestone guidance with Patreon fallback and refresh behavior
- extend the release-mechanics contract and behavioral verifier coverage

## Validation
- `bash -n scripts/verify-release-assets.sh`
- `bash -n tests/release_mechanics.sh`
- `bash tests/release_mechanics.sh "$PWD" /usr/bin/python3`
- parsed all four changed workflow YAML files with Ruby
- `git diff --check origin/main...HEAD`
- `bash tools/juce-gate.sh` (179 files, 9,213 uses)
- `claude-review`
- live non-mutating generate-notes probe against the private releases repository; confirmed no release was created

Closes #272

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Release workflows now validate release-token permissions before building and provide clearer diagnostics when access is missing or insufficient.
  - Configured Patreon refresh failures now stop releases, while missing credentials continue using the committed supporters list.
  - Release verification now requires a populated, correctly formatted release summary.
  - Release notes now default to “Patch release.” and reject blank notes.

- **Documentation**
  - Updated release procedures and verification guidance.

- **Tests**
  - Added coverage for release-summary validation and workflow preflight checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->