### PR TITLE
chore: set 0.13.0 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Dusk Studio. Format loosely follows
 back-filled from `git log`; once tags exist this file is the
 canonical source.
 
-## [0.13.0] - 2026-08-14
+## [0.13.0] - 2026-08-16
 
 The first release cut from the main line since 0.12 branched. Linux gets a
 native PipeWire backend and MIDI hot-plug; macOS gets Dusk Studio's own plugin

--- a/packaging/DuskStudio.appdata.xml
+++ b/packaging/DuskStudio.appdata.xml
@@ -30,7 +30,7 @@
   <content_rating type="oars-1.1"/>
   <releases>
     <!-- scripts/bump-version.sh prepends new <release> entries here. -->
-    <release version="0.13.0" date="2026-08-14">
+    <release version="0.13.0" date="2026-08-16">
       <description>
         <p>Adds the session notepad, native PipeWire and macOS plugin hosting, MIDI hot-plug, loop take stacking, realtime hardware bounce, and a broad set of session, recording, audio-device, and plug-in fixes.</p>
       </description>


### PR DESCRIPTION
## Summary
- set the 0.13.0 changelog date to 2026-08-16 UTC
- keep the AppStream release date synchronized

## Validation
- `claude-review` (clean, run immediately before push)
- `bash tests/release_mechanics.sh /home/marc/projects/DuskStudio python3`
- `xmllint --noout packaging/DuskStudio.appdata.xml`
- `appstreamcli validate --no-net packaging/DuskStudio.appdata.xml`
- `bash tools/juce-gate.sh` (179 files / 9,213 uses; unchanged)
- `git diff --check`

Patreon freshness was also checked separately before tagging. Live tiers differ from the pinned header, so all four Patreon Actions secrets were refreshed from the verified local 0600 config. No local token rotation occurred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the 0.13.0 release date to August 16, 2026 in the changelog and app metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->