### PR TITLE
UI/fit 8 tracks 1080p

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -611,6 +611,13 @@ the current save state, the latest save time when available, the `notepad.md`
 filename, section count, unique chord count, and the detected key when enough
 chords identify one.
 
+**Source** at the end of the toolbar swaps the chart for the raw `notepad.md`
+text, so ChordPro brackets, section markers and Markdown can be typed or pasted
+directly. The toolbar's chart controls step aside while source view is up,
+leaving **Source** lit as the way back; clicking it again returns to the chart.
+Edits made in source view land in the notepad as a single undo step. **Esc**
+closes the notepad from source view rather than reverting the text.
+
 Click the dimmed area outside the notepad to close it. The notepad also closes
 itself whenever something else needs the window — an alert, a stage switch, or
 the quit prompt — saving as it goes, except on quit, where the notes wait for

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -143,9 +143,9 @@ This chapter is a visual reference. Every numbered callout on the figures below 
 
 | #   | Name              | Description                                                                                                                       |
 | --- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | Menu bar          | `File` and `Settings` menus only. No tabs, no hidden submenus.                                                                    |
+| 1   | Menu bar          | `File`, `View`, and `Settings` menus. View includes fullscreen and timeline visibility.                                           |
 | 2   | Stage selector    | Four buttons: **RECORDING**, **MIXING**, **MASTERING**, **AUX** (Cmd/Ctrl+1 to 4). Picks which view fills the console area.            |
-| 3   | Bank selector     | The visible page of channel strips (e.g. `1-3`, `4-6`, ...), switched with the plain number keys 1 to 8. Only visible when the window is too narrow to show all 24 at once. |
+| 3   | Bank selector     | The visible page of channel strips. A maximized 1920×1080 window at 100% scaling shows `1-8`, `9-16`, or `17-24`; narrower windows use smaller ranges such as `1-3`, `4-6`, .... Switch pages with the plain number keys 1 to 8. Only visible when the window is too narrow to show all 24 at once. |
 | 4   | Transport bar     | Play, record, loop, punch, BPM, time signature, clock, tuner. See the next figure for the inventory.                              |
 | 5   | Tape strip toggle | `▾ TIMELINE` / `▴ TAPE`. Collapses or expands the timeline view below the bar.                                                     |
 | 6   | Console view      | Holds 24 channel strips, 4 buses, and the master strip. Replaced by the aux lane or mastering chain when those stages are active. |
@@ -187,8 +187,8 @@ In compact mode (window narrower than 1850 px) labels shorten: `TIMELINE` become
 | 2   | Insert slot         | One plugin or one hardware insert. 20 ms equal-power crossfade between modes.                               |
 | 3   | HPF                 | High-pass filter, 20–300 Hz. LED green when on.                                                             |
 | 4   | LPF                 | Low-pass filter, 3 kHz–20 kHz.                                                                              |
-| 5   | 4-band EQ           | LF (shelf) / LM (peak) / HM (peak) / HF (shelf). Left-click header to enable, right-click for the EQ menu (E / G character, reset, open editor), double-click to open the editor. |
-| 6   | Compressor          | Opto / FET / VCA. Left-click header to enable, right-click for the COMP menu (mode, reset, open editor), double-click to open the editor. GR meter to the left. |
+| 5   | 4-band EQ           | LF (shelf) / LM (peak) / HM (peak) / HF (shelf). Click the header's left status light to bypass/engage, click the **EQ** label to open the editor, or right-click anywhere on it for the EQ menu (E / G character, reset, open editor). |
+| 6   | Compressor          | Opto / FET / VCA. Click the header's left status light to bypass/engage, click the **COMP** label to open the editor, or right-click anywhere on it for the COMP menu (mode, reset, open editor). GR meter to the left. |
 | 7   | Aux 1 send          | Post-fader by default; right-click to flip pre-fader.                                                       |
 | 8   | Aux 2 send          |                                                                                                             |
 | 9   | Aux 3 send          |                                                                                                             |
@@ -236,8 +236,8 @@ Assign a strip to one of eight fader groups (right-click the strip → **Fader g
 
 | #   | Name                  | Description                                                                                      |
 | --- | --------------------- | ------------------------------------------------------------------------------------------------ |
-| 1   | Program EQ            | Tube-saturated low + high program EQ. Left-click header to enable, right-click for the EQ menu (reset, open editor), double-click to open the editor. |
-| 2   | Master bus compressor | Identical DSP to the bus comp, typically used slower. Left-click header to enable, right-click for the COMP menu (reset, open editor), double-click to open the editor. |
+| 1   | Program EQ            | Tube-saturated low + high program EQ. Click the left status light to bypass/engage, click **EQ** to open the editor, or right-click anywhere for the EQ menu (reset, open editor). |
+| 2   | Master bus compressor | Identical DSP to the bus comp, typically used slower. Click the left status light to bypass/engage, click **COMP** to open the editor, or right-click anywhere for the COMP menu (reset, open editor). |
 | 3   | Tape saturation       | Reel-to-reel model. Oversampling follows the global Effect Oversampling setting (Audio settings). Left-click header to toggle tape on/off, right-click for the TAPE menu (open editor), double-click to open the tape-machine editor. |
 | 4   | Master fader          | −∞ to +12 dB.                                                                                    |
 | 5   | Mono                  | Sums L+R to mono on both legs for phase / single-speaker checks.                                 |
@@ -408,7 +408,7 @@ Verification protects against a bit-flipped download or a man-in-the-middle atta
 
 On first launch Dusk Studio opens a blank session named `Untitled`. The window is divided, top to bottom, into:
 
-- A thin menu bar (File and Settings).
+- A thin menu bar (File, View, and Settings).
 - A row of large coloured buttons for the four stages: **RECORDING**, **MIXING**, **MASTERING**, **AUX** (keys **1–4**).
 - A bank selector (only visible when the window is too narrow to show all 24 channel strips at once).
 - The transport bar.
@@ -453,7 +453,7 @@ All seven are saved with the session, so a project that syncs to an external clo
 
 ### General
 
-- **UI scale**: a global zoom factor for the entire interface. Restart Dusk Studio after changing this for best results.
+- **UI scale**: a global zoom factor for the entire interface. The interface previews changes live while you adjust the slider; the final value is saved per-machine when you release it.
 - **Expand tape strip by default**: show the tape strip on every session open.
 - **Follow playhead by default**: start the timeline and the audio / MIDI editors with Chase engaged, so the view scrolls to keep the playhead in sight during playback. Per-machine; takes effect on next launch.
 - **Stop behavior**: where the playhead lands when playback stops — **Stay where it is** (pause), **Return to start**, or **Return to last clicked point**.
@@ -482,7 +482,7 @@ The window is structured as a stack of horizontal bands.
 ├───────────────────────────────────────────────────────┤
 │  RECORDING   MIXING   MASTERING   AUX                 │  Stage selector
 ├───────────────────────────────────────────────────────┤
-│  1-3  4-6  7-9  10-12  13-15  16-18  19-21  22-24   │  Bank selector
+│             1-8          9-16          17-24          │  Bank selector (1080p)
 ├───────────────────────────────────────────────────────┤
 │ ◀◀  ▶  ▶▶  ●  ⟳  ◉   CLK ♩=120 4/4 00:01:23         │  Transport bar
 ├───────────────────────────────────────────────────────┤
@@ -494,7 +494,9 @@ The window is structured as a stack of horizontal bands.
 └───────────────────────────────────────────────────────┘
 ```
 
-The bank selector appears only when the window is too narrow for all 24 strips, and it pages the console by whatever does fit — as few as three strips on the narrowest window, never more than eight pages. Each button names its range when space permits: in the compact transport layout the label is the bare range, `1-3`; at full size it reads `BANK 1  (1-3)`. At the tightest button width only the page number is shown; its tooltip still gives the channel range. The range widens with the window. A control surface's bank is a separate, fixed axis: eight strips at a time, tracks 1–8, 9–16, or 17–24. The two stay in step. Picking a page moves the surface to the bank holding that page's first track, and **Bank Left** / **Bank Right** on the surface moves the page to the one holding that bank's first track. When every strip fits on screen there is no page to pick, so the surface — and the bank-relative MIDI bindings that follow it — stays where you left it.
+The bank selector appears only when the window is too narrow for all 24 strips, and it pages the console by whatever does fit — as few as three strips on the narrowest window, never more than eight pages. At 1902 px of console width or more (the normal maximized 1920×1080 layout at 100% scaling), the console uses its EightUp density and the three pages are `1-8`, `9-16`, and `17-24`. Each button names its range when space permits: in compact layouts the label is the bare range, `1-3`; at full size it reads `BANK 1  (1-8)`. At the tightest button width only the page number is shown; its tooltip still gives the channel range. Wider windows eventually return to the comfortable strip spacing.
+
+A control surface's bank is a separate, fixed axis: eight strips at a time, tracks 1–8, 9–16, or 17–24. In EightUp the screen pages and hardware banks align exactly. At other window widths they remain separate axes but stay in step: picking a page moves the surface to the bank holding that page's first track, and **Bank Left** / **Bank Right** on the surface moves the page to the one holding that bank's first track. When every strip fits on screen there is no page to pick, so the surface — and the bank-relative MIDI bindings that follow it — stays where you left it.
 
 Modal dialogs (audio settings, plugin picker, region editor, piano roll, import target picker) appear centered with a dimmed backdrop behind them. Press **Esc** or click outside the modal to dismiss.
 
@@ -609,12 +611,12 @@ the current save state, the latest save time when available, the `notepad.md`
 filename, section count, unique chord count, and the detected key when enough
 chords identify one.
 
-Click **Done** or the dimmed area outside the notepad to close it. The notepad
-also closes itself whenever something else needs the window — an alert, a stage
-switch, or the quit prompt — saving as it goes, except on quit, where the notes
-wait for your Save / Don't Save answer like the rest of the session. The header,
-toolbar, and footer stay fixed; mouse-wheel scrolling moves only the note within
-its writing area. Notes are saved atomically to the compatible `notepad.md` file
+Click the dimmed area outside the notepad to close it. The notepad also closes
+itself whenever something else needs the window — an alert, a stage switch, or
+the quit prompt — saving as it goes, except on quit, where the notes wait for
+your Save / Don't Save answer like the rest of the session. The header, toolbar,
+and footer stay fixed; mouse-wheel scrolling moves only the note within its
+writing area. Notes are saved atomically to the compatible `notepad.md` file
 when the notepad closes and on every session save; they follow the session on
 Save As. A failed
 sidecar write remains dirty and can be retried by
@@ -649,7 +651,7 @@ Mute, Solo, and the input-monitor (IN) toggle gate the entire accumulation — w
 
 This is the order the audio actually flows. On screen, controls are arranged for ergonomics — the fader is at the bottom, the EQ in the middle — but the underlying chain never changes.
 
-Every processing section (EQ, compressor, tape) follows one consistent grammar on its header — and on its compact pill when the strip collapses, and on the channel, bus, and master strips alike: **left-click toggles the section on or off, right-click opens the section menu (character / mode where it has one, reset where the section supports it, open editor), and double-click opens the full editor.**
+EQ, COMP, and compact AUX controls are split buttons. The left 20% contains the status light; click it to bypass or engage the section without opening anything. The right 80% contains the label; click it once to open the editor. Right-click anywhere on the unified button for the section menu. Engaged sections have a solid coloured light and bright label; bypassed sections have a dark, hollow light and dim label. The compact AUX bypass mutes all four sends without changing their individual levels, so engaging it restores the previous send mix.
 
 ## Track name and colour
 
@@ -706,7 +708,7 @@ Useful for taming hi-hat bleed, cymbal harshness on a mic that's picking up too 
 
 ![The channel EQ editor — HPF, LPF, and four parametric bands.](docs/images/fx-01-eq.png)
 
-A British console-style 4-band EQ. Left-click the **EQ** header to enable; the LED lights green. Right-click the header for the EQ menu — the saturation character, **Reset EQ**, and **Open editor…** — and double-click the header to open the editor directly. The saturation character:
+A British console-style 4-band EQ. Click the header's left status light to bypass or engage it; click the **EQ** label once to open the editor. Right-click anywhere on the header for the EQ menu — the saturation character, **Reset EQ**, and **Open editor…**. The saturation character:
 
 - **E** (brown, default): brown character — slightly more aggressive midrange.
 - **G** (black): black character — smoother high band.
@@ -730,7 +732,7 @@ EQ in Dusk Studio does **not cramp** near Nyquist; the British EQ does its own i
 
 The channel compressor has three mutually-exclusive modes. Settings are remembered per mode — switch from FET back to Opto and your Opto settings are exactly as you left them.
 
-Left-click the **COMP** header to enable. Right-click the header for the COMP menu — the mode (**Opto**, **FET**, **VCA**), **Reset comp**, and **Open editor…** — and double-click the header to open the editor directly.
+Click the header's left status light to bypass or engage the compressor; click the **COMP** label once to open the editor. Right-click anywhere on the header for the COMP menu — the mode (**Opto**, **FET**, **VCA**), **Reset comp**, and **Open editor…**.
 
 All three modes share one set of knobs — **THRESHOLD, RATIO, ATTACK, RELEASE, MAKEUP** — that route to the right underlying parameter for whichever mode is active. Set the **threshold** by dragging the triangle handle on the gain-reduction meter strip (this also engages the compressor); the remaining knobs sit in a 2×2 grid below the header. The **MAKEUP** knob is the shared makeup gain and is available in every mode; its range follows the active mode — −40 to +40 dB in Opto (the optical gain dial's full span), −20 to +20 dB in FET and VCA. Knob ranges retune per mode, as listed below.
 
@@ -771,7 +773,7 @@ The gain-reduction meter (the thin vertical bar to the left of the comp section)
 In the MIXING stage the input block is replaced by four send knobs, one per aux lane. Each knob is colour-matched to its destination aux.
 
 - **Range**: −60 to +6 dB, or **OFF** (−100 dB, the bottom of the knob's travel).
-- **Pre / post fader**: right-click the knob to toggle. Post-fader is the default. In compact mode, right-click the **AUX** pill for the same per-send pre/post toggles plus **Reset sends** and **Open AUX editor…**.
+- **Pre / post fader**: right-click the knob to toggle. Post-fader is the default. In compact mode, click the **AUX** button's left status light to bypass/restore all four sends without losing their levels, click the **AUX** label to open the editor, or right-click anywhere on it for the per-send pre/post toggles plus **Reset sends** and **Open AUX editor…**.
 
 Pre-fader sends are used for headphone cue mixes: the singer can hear their voice at the same level even when you pull their fader down. Post-fader sends are used for effects: when you pull the channel fader down, the reverb level falls with it.
 
@@ -902,7 +904,7 @@ The program EQ is tube-saturated; pushing the boosts harder adds harmonic conten
 
 ## Master bus compressor
 
-Identical in DSP to the bus-strip compressor but typically used with slower settings: a 10 ms attack, auto-release, 2:1 to 4:1 ratio, and 1–3 dB of gain reduction on peaks. Left-click the **COMP** header to enable; right-click for the COMP menu, double-click to open the editor.
+Identical in DSP to the bus-strip compressor but typically used with slower settings: a 10 ms attack, auto-release, 2:1 to 4:1 ratio, and 1–3 dB of gain reduction on peaks. Click the left status light to bypass/engage, click the **COMP** label to open the editor, or right-click anywhere for the COMP menu.
 
 ## Master fader
 
@@ -1692,7 +1694,7 @@ Once connected:
 - **Motorised faders** mirror Dusk Studio's channel and master faders.
 - The **eight strip faders** drive the active bank (tracks 1–8, 9–16, or 17–24).
 - **Bank Left** / **Bank Right** step the bank by 8.
-- The surface's bank and the console's visible page of strips are separate axes, kept in step: a bank step moves the page to the one holding that bank's first track, and picking a page moves the surface the other way. With all 24 strips on screen there is no page to pick, and the surface keeps whichever bank you left it on.
+- At EightUp density, the surface's three banks match the console pages exactly: 1–8, 9–16, and 17–24. At other widths they are separate axes kept in step: a bank step moves the page to the one holding that bank's first track, and picking a page moves the surface the other way. With all 24 strips on screen there is no page to pick, and the surface keeps whichever bank you left it on.
 - **Channel Left** / **Channel Right** step the selected channel by 1.
 - **Mute / Solo / Arm / Select** buttons mirror and drive the on-screen buttons. LEDs reflect state.
 - **V-pot** rotaries drive pan, sends, EQ band gain, or compressor depending on the **assign mode**. Press **Pan**, **Send** (repeated presses cycle sends 1–4), **EQ**, or the **Track** button (mapped to the compressor in Dusk Studio) to switch. The surface's **Plugin** and **Inst** assign buttons are not mapped.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 748 Catch2 test cases across 151 test source files. Linux
+The C++ suite declares 752 Catch2 test cases across 151 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 748 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 752 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/docs/fit-8-tracks-1080p-plan.md
+++ b/docs/fit-8-tracks-1080p-plan.md
@@ -1,0 +1,119 @@
+# Eight-track 1080p console plan
+
+## Goal
+
+At a maximized 1920x1080 display at 100% UI scaling, show one complete
+eight-track bank together with all four buses and the Master strip. Keep the
+expanded channel EQ available on the strip, keep the buses and Master readable,
+and preserve the existing narrower-window fallbacks.
+
+## Current constraint
+
+The maximized MainComponent gives ConsoleView about 1904 px after the existing
+8 px outer inset on each side. The current documented minimums need 2206 px for
+eight channels:
+
+```text
+8 channels at 154 px                       1232
+4 buses at 172 px                           688
+Master at 210 px                             210
+inter-strip and section gaps                  64
+ConsoleView outer padding                     12
+                                             ----
+                                             2206 px
+```
+
+The four buses and Master already sit at widths chosen to keep their long value
+labels readable. Compressing those strips enough to recover the missing 302 px
+would damage the part of the console with the least horizontal flexibility.
+
+The channel-strip layout has a better breakpoint. At 116 px, the existing
+geometry fits exactly beside the current bus and Master minimums:
+
+```text
+8 channels at 116 px                        928
+4 buses at 172 px                           688
+Master at 210 px                             210
+inter-strip and section gaps                  64
+ConsoleView outer padding                     12
+                                             ----
+                                             1902 px
+```
+
+That leaves 2 px of safety inside the expected 1904 px ConsoleView. It also
+preserves the 12 px visual breaks before the buses and Master, so the console
+does not become one undifferentiated row of narrow strips.
+
+## Recommended design
+
+Add an explicit horizontal `EightUp` density tier. It is separate from the
+existing vertical compact/TIMELINE mode: EightUp keeps the EQ and compressor
+directly operable, while compact mode continues to collapse them into pills
+when vertical space is scarce.
+
+At a ConsoleView width of 1902 px or greater:
+
+- prefer at least eight visible channels;
+- keep each bus at 172 px and Master at 210 px;
+- allow channel strips to reach 116 px;
+- show three screen pages: `1-8`, `9-16`, and `17-24`;
+- keep buses and Master anchored at the right edge;
+- retain the existing 4 px strip gaps and 12 px section gaps.
+
+This also makes the screen pages match the eight-channel MCU hardware banks,
+removing the current mismatch between visible pages and control-surface banks.
+
+## Channel-strip adaptation at 116 px
+
+The widened EQ should remain inline. Use width-aware layout changes only where
+the current controls would become cramped:
+
+1. Reduce the EQ band-name gutter from 28 px to 24 px in EightUp. The remaining
+   width provides three 26 px GAIN/FREQ/Q cells, retaining the current knob size.
+2. Reflow the four compressor controls from one 4-across row to a 2x2 grid in
+   EightUp. This keeps labels and values readable instead of squeezing each
+   control to about 25 px. The 1080p console has enough vertical room for the
+   extra row.
+3. Keep HPF/LPF, the four staggered AUX sends, I/O controls, pan, fader, meters,
+   bus assignments, and M/S/phase controls visible. The existing narrow-fader
+   path already prevents the fader cap and meter cluster from overlapping.
+4. Do not shorten labels as the first response. If visual verification finds a
+   specific value still clipped, adapt only that value formatter in EightUp.
+
+## Implementation sequence
+
+1. Add named EightUp constants and a density result to `ConsoleLayout.h`,
+   including the 1902 px threshold and 116 px channel floor.
+2. Make `channelsThatFitForWidth()` prefer eight channels once the EightUp
+   threshold is available, while retaining the existing behavior below it and
+   the wider-screen behavior above it.
+3. Have `ConsoleView` pass the horizontal density to channel strips without
+   changing the existing user/auto compact state for buses or Master.
+4. Add the narrow EQ gutter and 2x2 compressor layout to
+   `ChannelStripComponent`. Keep the bus and Master layouts unchanged.
+5. Update layout and bank-mapping tests before visual tuning.
+
+## Acceptance checks
+
+- A maximized 1920x1080 window at 100% scaling shows tracks 1-8, all four buses,
+  and Master simultaneously with no overlap or horizontal scrolling.
+- Page buttons read `1-8`, `9-16`, and `17-24`; keyboard focus and MCU bank
+  changes cross 8/9 and 16/17 correctly.
+- EQ knobs and values remain visible on every channel; compressor labels and
+  values do not clip in any compressor mode.
+- Bus and Master labels are unchanged and remain readable.
+- Existing 1366 px and minimum-window tests still pass, including the no-overlap
+  guarantee before Bus 1.
+- A screenshot comparison at 1920x1080 checks alignment, control clipping,
+  fader/meter separation, and the visual distinction between channels, buses,
+  and Master.
+- Keyboard traversal, focus indication, and popup access are tested directly;
+  screenshots alone cannot confirm those accessibility behaviors.
+
+## Trade-off
+
+EightUp is denser than the comfortable layout, so channel compressor controls
+use two rows and the strips have less whitespace. That is preferable to shrinking
+the buses/Master, collapsing the newly widened EQ, or hiding three tracks behind
+an extra page. Wider windows can continue to use the existing comfortable
+geometry.

--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -103,24 +103,22 @@ public:
         // so we don't need to budget for it in the floor.
         refreshResizeLimits();
 
-        // Restore prior session's window geometry. JUCE's
-        // restoreWindowStateFromString rebuilds bounds + fullscreen state
-        // from the same string getWindowStateAsString() produced. We then
-        // sanity-check the restored bounds against connected displays -
-        // if the saved monitor is gone, undo the restore and centre at
-        // MainComponent's default size.
+        // Restore the prior window position and size, but deliberately do not
+        // restore fullscreen. Fullscreen is a temporary viewing mode exposed
+        // through View > Full Screen (and F11); a normal launch should always
+        // return to the prior non-fullscreen bounds. On Linux JUCE maps this
+        // state to native maximisation, which is also intentionally session-
+        // only here so launch still defaults to the user's windowed size.
+        // JUCE prefixes a saved
+        // fullscreen state with "fs ", so removing only that token preserves
+        // the last non-fullscreen bounds encoded in the same state string.
         bool restored = false;
-        const auto savedState = WindowState::load();
+        auto savedState = WindowState::load();
+        if (savedState.startsWithIgnoreCase ("fs "))
+            savedState = savedState.substring (3).trimStart();
         if (savedState.isNotEmpty() && restoreWindowStateFromString (savedState))
         {
-            // Validate using the WINDOWED bounds (so a fullscreen-on-an-
-            // unplugged-monitor case still falls back gracefully).
-            const auto checkRect = isFullScreen()
-                ? juce::Rectangle<int> (0, 0,
-                                          std::max (getWidth(), 800),
-                                          std::max (getHeight(), 600))
-                : getBounds();
-            if (WindowState::rectIsUsable (checkRect))
+            if (WindowState::rectIsUsable (getBounds()))
                 restored = true;
         }
 
@@ -2335,7 +2333,12 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
     // OS-reported DPI scale, so 1.0 here means "let the OS decide" and
     // anything else is the user's manual zoom. Applied BEFORE creating
     // the main window so its initial layout uses the right metrics.
-    juce::Desktop::getInstance().setGlobalScaleFactor (appconfig::getUiScaleOverride());
+    // Capture output must be reproducible across developer machines and must
+    // exercise the documented 100% layout breakpoints, regardless of the
+    // per-machine UI zoom stored in app-config.properties.
+    const bool capturingScreenshots = std::getenv ("DUSKSTUDIO_CAPTURE_DIR") != nullptr;
+    juce::Desktop::getInstance().setGlobalScaleFactor (
+        capturingScreenshots ? 1.0f : appconfig::getUiScaleOverride());
 
     mainWindow = std::make_unique<MainWindow> (getApplicationName());
 
@@ -2364,7 +2367,8 @@ void DuskStudioApp::shutdown()
 
     // Persist window geometry before tearing down the window. Reading
     // getWindowStateAsString() AFTER mainWindow.reset() would crash; doing
-    // it here captures the user's last visible position/size/fullscreen.
+    // it here captures the last visible position/size and current fullscreen
+    // flag. MainWindow intentionally ignores that flag on the next launch.
     if (mainWindow != nullptr)
         WindowState::save (mainWindow->getWindowStateAsString());
 

--- a/src/dsp/ChannelStrip.cpp
+++ b/src/dsp/ChannelStrip.cpp
@@ -345,10 +345,11 @@ void ChannelStrip::updateGainTargets() noexcept
     // manual or lane through it) - same pattern as liveFaderDb / livePan.
     // -100 dB sentinel (knob fully CCW) hard-mutes; the inner loop
     // short-circuits zero-gain sends.
+    const bool auxSendsBypassed = paramsRef->auxSendsBypassed.load (std::memory_order_relaxed);
     for (int i = 0; i < kNumAuxSends; ++i)
     {
         const float db = paramsRef->liveAuxSendDb[(size_t) i].load (std::memory_order_relaxed);
-        const float g  = (db <= ChannelStripParams::kAuxSendOffDb)
+        const float g  = (auxSendsBypassed || db <= ChannelStripParams::kAuxSendOffDb)
                             ? 0.0f
                             : dusk::audio::decibelsToGain (db);
         auxSendGain[(size_t) i].setTargetValue (g);

--- a/src/session/RegionEditActions.cpp
+++ b/src/session/RegionEditActions.cpp
@@ -411,6 +411,7 @@ struct CloneTrackAction::Impl
     float faderDb = 0.0f, pan = 0.0f;
     bool  mute = false, solo = false, phaseInvert = false;
     std::array<bool, ChannelStripParams::kNumBuses> busAssign {};
+    bool auxSendsBypassed = false;
     std::array<float, ChannelStripParams::kNumAuxSends> auxSendDb {};
     std::array<bool,  ChannelStripParams::kNumAuxSends> auxSendPreFader {};
 
@@ -556,6 +557,7 @@ CloneTrackAction::Impl captureTrack (Track& t, AudioEngine& engine, int idx)
     s.phaseInvert = t.strip.phaseInvert.load (std::memory_order_relaxed);
     for (int i = 0; i < ChannelStripParams::kNumBuses; ++i)
         s.busAssign[(size_t) i] = t.strip.busAssign[(size_t) i].load (std::memory_order_relaxed);
+    s.auxSendsBypassed = t.strip.auxSendsBypassed.load (std::memory_order_relaxed);
     for (int i = 0; i < ChannelStripParams::kNumAuxSends; ++i)
     {
         s.auxSendDb      [(size_t) i] = t.strip.auxSendDb[(size_t) i].load (std::memory_order_relaxed);
@@ -742,6 +744,7 @@ void applyTrack (Track& t, AudioEngine& engine, int idx,
     t.strip.phaseInvert.store (s.phaseInvert, std::memory_order_relaxed);
     for (int i = 0; i < ChannelStripParams::kNumBuses; ++i)
         t.strip.busAssign[(size_t) i].store (s.busAssign[(size_t) i], std::memory_order_relaxed);
+    t.strip.auxSendsBypassed.store (s.auxSendsBypassed, std::memory_order_relaxed);
     for (int i = 0; i < ChannelStripParams::kNumAuxSends; ++i)
     {
         t.strip.auxSendDb      [(size_t) i].store (s.auxSendDb[(size_t) i],      std::memory_order_relaxed);

--- a/src/session/Session.h
+++ b/src/session/Session.h
@@ -202,6 +202,9 @@ struct ChannelStripParams
     static constexpr float kAuxSendMinDb = -60.0f;
     static constexpr float kAuxSendMaxDb =   6.0f;
     static constexpr float kAuxSendOffDb = -100.0f;
+    // Whole AUX-send bypass used by the split AUX button. Individual send
+    // levels remain untouched so re-engaging restores the prior mix.
+    std::atomic<bool> auxSendsBypassed { false };
     std::array<std::atomic<float>, kNumAuxSends> auxSendDb {
         std::atomic<float>{ kAuxSendOffDb }, std::atomic<float>{ kAuxSendOffDb },
         std::atomic<float>{ kAuxSendOffDb }, std::atomic<float>{ kAuxSendOffDb }

--- a/src/session/SessionSerializer.cpp
+++ b/src/session/SessionSerializer.cpp
@@ -60,7 +60,7 @@ inline std::optional<PluginDescriptor> descriptorFromObject (
 // Loader rejects sessions with version > kFormatVersion (newer Dusk Studio
 // can read older files via migrateSession; older Dusk Studio refusing
 // newer files is safer than silently dropping fields).
-constexpr int kFormatVersion = 5;
+constexpr int kFormatVersion = 6;
 
 inline bool hasTakeProvenance (const TakeProvenance& provenance) noexcept
 {
@@ -303,6 +303,16 @@ bool migrateSession (nlohmann::json& root, int from)
                 // so legacy payloads only need the version stamp advanced.
                 if (root.is_object())
                     root["version"] = 5;
+                ++v;
+                break;
+
+            case 5:
+                // v5 -> v6: tracks may now carry a whole AUX-send bypass.
+                // An absent field means engaged, so legacy payloads only need
+                // the version stamp advanced. The bump prevents v5 builds
+                // from silently dropping aux_sends_bypassed on re-save.
+                if (root.is_object())
+                    root["version"] = 6;
                 ++v;
                 break;
 
@@ -571,6 +581,7 @@ JObj trackToObject (const Track& t, const juce::File& sessionDir)
 
     // Aux sends (continuous send level + pre/post-fader tap) - distinct
     // from busAssign which is the post-fader on/off routing toggle.
+    obj["aux_sends_bypassed"] = t.strip.auxSendsBypassed.load();
     JObj auxLevels = JObj::array(), auxPrePost = JObj::array();
     for (int i = 0; i < ChannelStripParams::kNumAuxSends; ++i)
     {
@@ -1163,6 +1174,9 @@ void restoreTrack (Track& t, int trackIndex, const nlohmann::json& v,
                                                  std::memory_order_relaxed);
     }
 
+    t.strip.auxSendsBypassed.store (
+        json::getBool (v, "aux_sends_bypassed", false),
+        std::memory_order_relaxed);
     {
         const auto& auxLevels = json::array (v, "aux_send_db");
         for (auto& level : t.strip.auxSendDb)

--- a/src/ui/AudioSettingsPanel.cpp
+++ b/src/ui/AudioSettingsPanel.cpp
@@ -15,6 +15,54 @@
 
 namespace duskstudio
 {
+namespace
+{
+// JUCE refreshes its display model when the global scale changes, but the X11
+// peer's screen-size callback deliberately does not forward the new logical
+// bounds to its Component. Preserve the native window's physical rectangle,
+// convert it through the refreshed display model, and push that new logical
+// rectangle back into the peer so the whole component tree performs a real
+// resize/layout pass. This path is also valid on the other desktop backends.
+void applyGlobalUiScale (juce::Component& source, float scale)
+{
+    auto& desktop = juce::Desktop::getInstance();
+    if (std::abs (desktop.getGlobalScaleFactor() - scale) < 0.0001f)
+        return;
+
+    auto* topLevel = source.getTopLevelComponent();
+    auto* peer = topLevel != nullptr ? topLevel->getPeer() : nullptr;
+    if (peer == nullptr)
+    {
+        desktop.setGlobalScaleFactor (scale);
+        return;
+    }
+
+    juce::Component::SafePointer<juce::Component> safeTopLevel (topLevel);
+    const auto physicalBounds = desktop.getDisplays().logicalToPhysical (peer->getBounds());
+    const bool wasFullScreen = peer->isFullScreen();
+
+    desktop.setGlobalScaleFactor (scale);
+
+    if (auto* component = safeTopLevel.getComponent())
+    {
+        if (auto* refreshedPeer = component->getPeer())
+        {
+            const auto logicalBounds = desktop.getDisplays().physicalToLogical (physicalBounds);
+            const auto componentBoundsBefore = component->getBounds();
+            refreshedPeer->setBounds (logicalBounds, wasFullScreen);
+
+            // The physical-to-logical round trip can produce unchanged JUCE
+            // bounds even though the global scale changed. Force JUCE's base
+            // relayout callback in that case; LinuxComponentPeer's override
+            // otherwise only refreshes frame extents and leaves every child
+            // at the old scale.
+            if (component->getBounds() == componentBoundsBefore)
+                refreshedPeer->juce::ComponentPeer::handleScreenSizeChange();
+        }
+    }
+}
+} // namespace
+
 AudioSettingsPanel::AudioSettingsPanel (device::DeviceManager& dm,
                                           AudioEngine& e, Session& s)
     : deviceManager (dm), engine (e), session (s)
@@ -79,7 +127,7 @@ AudioSettingsPanel::AudioSettingsPanel (device::DeviceManager& dm,
     // 2, 4) so we read the value back without an extra mapping table.
     // CharPointer_UTF8 wrappers are required because the "×" multiplication
     // sign (U+00D7) is two-byte UTF-8; without the explicit ctor JUCE's
-    // juce::String defaults to Latin-1 and renders mojibake ("Ã-").
+    // JUCE String defaults to Latin-1 and renders mojibake ("Ã-").
     addAndMakeVisible (oversamplingLabel);
     oversamplingLabel.setJustificationType (juce::Justification::centredRight);
     oversamplingCombo.addItem (juce::CharPointer_UTF8 ("1× (native)"), 1);
@@ -300,7 +348,7 @@ AudioSettingsPanel::AudioSettingsPanel (device::DeviceManager& dm,
 
     uiScaleSlider.setSliderStyle (juce::Slider::LinearHorizontal);
     uiScaleSlider.setTextBoxStyle (juce::Slider::TextBoxRight, false, 60, 20);
-    uiScaleSlider.setRange (appconfig::kUiScaleMin, appconfig::kUiScaleMax, 0.05);
+    uiScaleSlider.setRange (appconfig::kUiScaleMin, appconfig::kUiScaleMax, 0.01);
     uiScaleSlider.setValue (appconfig::getUiScaleOverride(), juce::dontSendNotification);
     uiScaleSlider.setNumDecimalPlacesToDisplay (2);
     uiScaleSlider.setTextValueSuffix ("x");
@@ -309,11 +357,11 @@ AudioSettingsPanel::AudioSettingsPanel (device::DeviceManager& dm,
         "display DPI. 1.00x = follow the OS. Range "
         "0.50x to 2.00x.");
 
-    // Defer the actual setGlobalScaleFactor call until the user RELEASES
-    // the slider (or commits a typed value). Applying mid-drag re-lays out
-    // the slider itself, which makes the drag handle chase the mouse -
-    // very jumpy. The slider's own textbox still updates live so the user
-    // sees the target value during drag; only the world reflows on release.
+    // Preview at most once per message-loop timer interval. Applying JUCE's
+    // global scale directly from this control's mouse callback re-lays out the
+    // slider and viewport while that input event is still on the stack, which
+    // can strand the drag. Persistence remains write-on-release so a sweep
+    // across the slider does not rewrite the config file for every pixel.
     uiScaleSlider.onDragStart = [this] { uiScaleDragging = true; };
     uiScaleSlider.onDragEnd   = [this]
     {
@@ -322,6 +370,7 @@ AudioSettingsPanel::AudioSettingsPanel (device::DeviceManager& dm,
     };
     uiScaleSlider.onValueChange = [this]
     {
+        queueUiScalePreview();
         if (! uiScaleDragging) applyUiScaleChange();
     };
     addAndMakeVisible (uiScaleSlider);
@@ -329,7 +378,7 @@ AudioSettingsPanel::AudioSettingsPanel (device::DeviceManager& dm,
     uiScaleHint.setJustificationType (juce::Justification::centredLeft);
     uiScaleHint.setColour (juce::Label::textColourId, juce::Colour (0xff909094));
     uiScaleHint.setFont (juce::Font (juce::FontOptions (10.0f)));
-    uiScaleHint.setText ("Saved per-machine; takes effect immediately.",
+    uiScaleHint.setText ("Previews live; saved per-machine when released.",
                           juce::dontSendNotification);
     addAndMakeVisible (uiScaleHint);
 
@@ -712,7 +761,23 @@ void AudioSettingsPanel::applyUiScaleChange()
 {
     const float scale = (float) uiScaleSlider.getValue();
     appconfig::setUiScaleOverride (scale);
-    juce::Desktop::getInstance().setGlobalScaleFactor (scale);
+}
+
+void AudioSettingsPanel::queueUiScalePreview()
+{
+    pendingUiScale = (float) uiScaleSlider.getValue();
+    uiScalePreviewPending = true;
+    if (! isTimerRunning())
+        startTimer (50); // 20 Hz: visually live without a resize storm.
+}
+
+void AudioSettingsPanel::timerCallback()
+{
+    stopTimer();
+    if (! uiScalePreviewPending) return;
+
+    uiScalePreviewPending = false;
+    applyGlobalUiScale (*this, pendingUiScale);
 }
 
 void AudioSettingsPanel::applyRecordOffsetChange()
@@ -858,6 +923,15 @@ void AudioSettingsPanel::applyMulticoreChange()
 
 AudioSettingsPanel::~AudioSettingsPanel()
 {
+    stopTimer();
+    // A release or keyboard edit can queue the final 20 Hz preview and then
+    // close the modal before the timer fires. Apply that last value now so
+    // the persisted scale and the running UI cannot diverge until restart.
+    if (uiScalePreviewPending)
+    {
+        uiScalePreviewPending = false;
+        applyGlobalUiScale (*this, pendingUiScale);
+    }
     engine.removeChangeCallback (this);
     deviceManager.removeChangeListener (this);
 }

--- a/src/ui/AudioSettingsPanel.h
+++ b/src/ui/AudioSettingsPanel.h
@@ -4,6 +4,7 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <memory>
 #include <vector>
+#include "../foundation/MessageThread.h"
 #include "EmbeddedModal.h"
 #include "DuskComboBox.h"
 #include "DuskAudioDeviceSelector.h"
@@ -18,7 +19,8 @@ class Session;
 // materially affects USB audio on Linux - fractional periods cause
 // jitter; certain kernel+device combos distort at specific counts).
 // Also hosts a "Run Self-Test" button (SelfTestPanel).
-class AudioSettingsPanel final : public juce::Component
+class AudioSettingsPanel final : public juce::Component,
+                                 private dusk::Timer
 {
 public:
     AudioSettingsPanel (device::DeviceManager& dm,
@@ -111,6 +113,8 @@ private:
     juce::Slider uiScaleSlider;
     juce::Label  uiScaleHint;
     bool         uiScaleDragging = false;
+    float        pendingUiScale = 1.0f;
+    bool         uiScalePreviewPending = false;
 
     // Manual recording latency offset (samples), per-machine (AppConfig).
     // Subtracted from committed audio takes so a round-trip-delayed input
@@ -151,6 +155,8 @@ private:
     void applyOversamplingChange();
     void applyMulticoreChange();
     void applyUiScaleChange();
+    void queueUiScalePreview();
+    void timerCallback() override;
     void applyRecordOffsetChange();
     void applyRescan();
     void openSelfTest();

--- a/src/ui/BusComponent.cpp
+++ b/src/ui/BusComponent.cpp
@@ -529,22 +529,21 @@ BusComponent::BusComponent (Bus& b, Session& s, AudioEngine& e, int idx)
     // pan-control language is consistent across channels and buses.
     const auto panRed   = juce::Colour (0xffc04040);
 
-    // EQ section header - CompHeaderButton (LED + label pill) matches the
-    // COMP header below and the channel-strip EQ header. Left-click toggles
-    // enable; right-click opens the EQ section menu; double-click opens the
-    // editor. Fixed topology (no mode picker).
-    eqHeaderBtn = std::make_unique<CompHeaderButton> (
-        /*getEnabled*/ [this] { return bus.strip.eqEnabled.load (std::memory_order_relaxed); },
-        /*onToggle*/   [this]
+    // Split EQ header: status-light click toggles bypass, label click opens
+    // the editor, and a right-click anywhere opens the section menu.
+    eqHeaderBtn = std::make_unique<SplitModuleButton> ("EQ");
+    eqHeaderBtn->setAccentColour (eqGreen);
+    eqHeaderBtn->setCallbacks (
+        [this] { return ! bus.strip.eqEnabled.load (std::memory_order_relaxed); },
+        [this]
                         {
                             const bool now = ! bus.strip.eqEnabled.load (std::memory_order_relaxed);
                             bus.strip.eqEnabled.store (now, std::memory_order_release);
-                            if (eqHeaderBtn != nullptr) eqHeaderBtn->repaint();
+                            if (eqHeaderBtn != nullptr) eqHeaderBtn->refresh();
                         },
-        /*onPick*/       [this] { showEqSectionMenu(); },
-        /*onDoubleClick*/[this] { openEqEditorPopup(); });
-    eqHeaderBtn->setLabelText ("EQ");
-    eqHeaderBtn->setTooltip ("Left-click EQ on/off. Right-click for the EQ menu. Double-click to open the editor.");
+        [this] { openEqEditorPopup(); },
+        [this] { showEqSectionMenu(); });
+    eqHeaderBtn->setTooltip ("Click the status light to bypass/engage EQ; click EQ to open the editor; right-click for the EQ menu.");
     addAndMakeVisible (eqHeaderBtn.get());
 
     // Suffixes empty - same rationale as master: 38-px textbox can't fit
@@ -562,7 +561,7 @@ BusComponent::BusComponent (Bus& b, Session& s, AudioEngine& e, int idx)
     auto armBusEq = [this]
     {
         bus.strip.eqEnabled.store (true, std::memory_order_release);
-        if (eqHeaderBtn != nullptr) eqHeaderBtn->repaint();
+        if (eqHeaderBtn != nullptr) eqHeaderBtn->refresh();
     };
     eqLfGain .onValueChange = [this, armBusEq] { bus.strip.eqLfGainDb .store ((float) eqLfGain .getValue(), std::memory_order_relaxed); armBusEq(); };
     eqMidGain.onValueChange = [this, armBusEq] { bus.strip.eqMidGainDb.store ((float) eqMidGain.getValue(), std::memory_order_relaxed); armBusEq(); };
@@ -574,26 +573,26 @@ BusComponent::BusComponent (Bus& b, Session& s, AudioEngine& e, int idx)
     styleSmallLabel (eqHfLbl,  "H", eqGreen);
     addAndMakeVisible (eqLfLbl); addAndMakeVisible (eqMidLbl); addAndMakeVisible (eqHfLbl);
 
-    // Comp section. Shell now mirrors the channel-strip COMP visually:
-    //   - CompHeaderButton on top (single button, white text, green LED,
-    //     left-click toggles enable). No mode picker (bus comp is a
-    //     fixed SSL-style glue topology, not OPTO/FET/VCA).
+    // Comp section. The split header mirrors the channel-strip COMP and the
+    // processor remains a fixed SSL-style glue topology.
     //   - CompMeterStrip on the LEFT (handle + IN bar + dB scale + GR
     //     bar). Threshold drag writes bus.strip.compThreshDb (-60..0).
     //   - Knob grid on the RIGHT: RAT / ATK + REL / MAK across two rows.
     //     The standalone THR knob is gone - threshold is set via the
     //     triangle handle on the meter.
-    compHeaderBtn = std::make_unique<CompHeaderButton> (
-        /*getEnabled*/ [this] { return bus.strip.compEnabled.load (std::memory_order_relaxed); },
-        /*onToggle*/   [this]
+    compHeaderBtn = std::make_unique<SplitModuleButton> ("COMP");
+    compHeaderBtn->setAccentColour (compGold);
+    compHeaderBtn->setCallbacks (
+        [this] { return ! bus.strip.compEnabled.load (std::memory_order_relaxed); },
+        [this]
                         {
                             const bool now = ! bus.strip.compEnabled.load (std::memory_order_relaxed);
                             bus.strip.compEnabled.store (now, std::memory_order_release);
-                            if (compHeaderBtn != nullptr) compHeaderBtn->repaint();
+                            if (compHeaderBtn != nullptr) compHeaderBtn->refresh();
                         },
-        /*onPick*/       [this] { showCompSectionMenu(); },
-        /*onDoubleClick*/[this] { openCompEditorPopup(); });
-    compHeaderBtn->setTooltip ("Left-click comp on/off. Right-click for the COMP menu. Double-click to open the editor.");
+        [this] { openCompEditorPopup(); },
+        [this] { showCompSectionMenu(); });
+    compHeaderBtn->setTooltip ("Click the status light to bypass/engage compression; click COMP to open the editor; right-click for the COMP menu.");
     addAndMakeVisible (compHeaderBtn.get());
 
     CompMeterStrip::Source compSrc;
@@ -618,7 +617,7 @@ BusComponent::BusComponent (Bus& b, Session& s, AudioEngine& e, int idx)
     compSrc.autoEnable     = [this]
                               {
                                   bus.strip.compEnabled.store (true, std::memory_order_release);
-                                  if (compHeaderBtn != nullptr) compHeaderBtn->repaint();
+                                  if (compHeaderBtn != nullptr) compHeaderBtn->refresh();
                               };
     // Fader-side GR LED (matches channel-strip grammar): slim widget that
     // shows only the GR bar + threshold-drag handle, glued next to the
@@ -807,45 +806,30 @@ BusComponent::BusComponent (Bus& b, Session& s, AudioEngine& e, int idx)
     styleReadout (outputPeakLabel, juce::Colour (0xffd0d0d0));
     addAndMakeVisible (outputPeakLabel);
 
-    // Compact placeholder buttons (hidden until setCompactMode(true)).
-    // Same visual grammar as ChannelStripComponent's eq/comp compact
-    // pills so the bus + master strips read as the same compact form
-    // when the tape TIMELINE shrinks the strip.
-    auto styleCompactSectionBtn = [] (juce::TextButton& b, juce::Colour accent)
-    {
-        b.setColour (juce::TextButton::buttonColourId,   juce::Colour (0xff282830));
-        b.setColour (juce::TextButton::buttonOnColourId, accent.withMultipliedAlpha (0.85f));
-        b.setColour (juce::TextButton::textColourOffId,  accent.withMultipliedBrightness (0.8f));
-        b.setColour (juce::TextButton::textColourOnId,   juce::Colours::white);
-        b.setMouseClickGrabsKeyboardFocus (false);
-        b.setClickingTogglesState (false);
-    };
-    styleCompactSectionBtn (eqCompactButton,   juce::Colour (0xff5fc46f));
-    styleCompactSectionBtn (compCompactButton, juce::Colour (0xffe0c050));
-    // Identical grammar to the expanded EQ/COMP headers: left-click toggles the
-    // section on/off, right-click opens the section menu, double-click opens the
-    // editor. The illuminated background (driven by the 30 Hz refresh) reflects
-    // the enabled state.
-    eqCompactButton  .setTooltip ("Left-click EQ on/off. Right-click for the EQ menu. Double-click to open the editor.");
-    compCompactButton.setTooltip ("Left-click comp on/off. Right-click for the COMP menu. Double-click to open the editor.");
-    eqCompactButton  .onClick = [this]
-    {
-        const bool now = ! bus.strip.eqEnabled.load (std::memory_order_relaxed);
-        bus.strip.eqEnabled.store (now, std::memory_order_release);
-        // Mirror into the button's own toggle state so the pill text palette
-        // (textColourOnId vs Off) reflects the new state immediately, not 33 ms later.
-        eqCompactButton.setToggleState (now, juce::dontSendNotification);
-    };
-    eqCompactButton  .onRightClick  = [this] (const juce::MouseEvent&) { showEqSectionMenu(); };
-    eqCompactButton  .onDoubleClick = [this] { openEqEditorPopup(); };
-    compCompactButton.onClick = [this]
-    {
-        const bool now = ! bus.strip.compEnabled.load (std::memory_order_relaxed);
-        bus.strip.compEnabled.store (now, std::memory_order_release);
-        compCompactButton.setToggleState (now, juce::dontSendNotification);
-    };
-    compCompactButton.onRightClick  = [this] (const juce::MouseEvent&) { showCompSectionMenu(); };
-    compCompactButton.onDoubleClick = [this] { openCompEditorPopup(); };
+    // Compact split buttons use the same two primary hitboxes as the expanded
+    // headers, while retaining their section-specific accent colours.
+    eqCompactButton.setAccentColour (juce::Colour (0xff5fc46f));
+    compCompactButton.setAccentColour (juce::Colour (0xffe0c050));
+    eqCompactButton.setCallbacks (
+        [this] { return ! bus.strip.eqEnabled.load (std::memory_order_relaxed); },
+        [this]
+        {
+            const bool now = ! bus.strip.eqEnabled.load (std::memory_order_relaxed);
+            bus.strip.eqEnabled.store (now, std::memory_order_release);
+        },
+        [this] { openEqEditorPopup(); },
+        [this] { showEqSectionMenu(); });
+    compCompactButton.setCallbacks (
+        [this] { return ! bus.strip.compEnabled.load (std::memory_order_relaxed); },
+        [this]
+        {
+            const bool now = ! bus.strip.compEnabled.load (std::memory_order_relaxed);
+            bus.strip.compEnabled.store (now, std::memory_order_release);
+        },
+        [this] { openCompEditorPopup(); },
+        [this] { showCompSectionMenu(); });
+    eqCompactButton  .setTooltip ("Click the light to bypass/engage EQ; click EQ to open the editor; right-click for the EQ menu.");
+    compCompactButton.setTooltip ("Click the light to bypass/engage compression; click COMP to open the editor; right-click for the COMP menu.");
     addChildComponent (eqCompactButton);
     addChildComponent (compCompactButton);
 
@@ -1019,29 +1003,17 @@ void BusComponent::timerCallback()
     // refresh so all three strip types read the same way under TIMELINE.
     if (compactMode)
     {
-        const auto eqAccent   = juce::Colour (0xff5fc46f);
-        const auto compAccent = juce::Colour (0xffe0c050);
         const int eqOn   = bus.strip.eqEnabled  .load (std::memory_order_relaxed) ? 1 : 0;
         const int compOn = bus.strip.compEnabled.load (std::memory_order_relaxed) ? 1 : 0;
         if (eqOn != lastCompactEqOn)
         {
             lastCompactEqOn = eqOn;
-            // Track the atom (it can change via the popup editor) so the pill stays
-            // in sync regardless of how the section was toggled.
-            eqCompactButton.setToggleState (eqOn != 0, juce::dontSendNotification);
-            eqCompactButton.setColour (juce::TextButton::buttonColourId,
-                                         eqOn != 0 ? eqAccent.darker (0.55f)
-                                                    : juce::Colour (0xff282830));
-            eqCompactButton.repaint();
+            eqCompactButton.refresh();
         }
         if (compOn != lastCompactCompOn)
         {
             lastCompactCompOn = compOn;
-            compCompactButton.setToggleState (compOn != 0, juce::dontSendNotification);
-            compCompactButton.setColour (juce::TextButton::buttonColourId,
-                                           compOn != 0 ? compAccent.darker (0.55f)
-                                                        : juce::Colour (0xff282830));
-            compCompactButton.repaint();
+            compCompactButton.refresh();
         }
     }
 
@@ -1139,10 +1111,10 @@ void BusComponent::timerCallback()
         if (soloButton.getToggleState() != s)
             soloButton.setToggleState (s, juce::dontSendNotification);
     }
-    // EQ LED reads via CompHeaderButton's getEnabled lambda; nudge a
-    // repaint each tick so the LED reflects external atom changes (e.g.
-    // session reload, MIDI bindings) without a click.
-    if (eqHeaderBtn != nullptr) eqHeaderBtn->repaint();
+    // Refresh both split headers so external atom changes (session reload,
+    // editor actions, MIDI bindings) are reflected without a click.
+    if (eqHeaderBtn != nullptr) eqHeaderBtn->refresh();
+    if (compHeaderBtn != nullptr) compHeaderBtn->refresh();
 }
 
 void BusComponent::mouseDown (const juce::MouseEvent& e)
@@ -1641,8 +1613,8 @@ void BusComponent::resized()
 
     // Right-side stack - fader-side grammar matching the channel strip:
     //   [right pad] [GR LED (compMeter)] [gap] [level meter] [gap] [fader]
-    // Scale labels (+6 / +3 / 0 / ... / off) drawn by paint() to the LEFT
-    // of the fader track (same kSharedXOver math as ChannelStripComponent).
+    // Scale labels (+6 / +3 / 0 / ... / off) are drawn by paint() to the LEFT
+    // of the fader track.
     constexpr int kMeterW          = 14;   // 2 × ~6 px columns + 1 px gap (stereo LED)
     constexpr int kGrLedW          = 20;   // GR bar + threshold-drag handle
     constexpr int kMeterToGrGap    = 1;
@@ -1695,8 +1667,8 @@ void BusComponent::resized()
     constexpr int kFaderColW = 50;
     if (area.getWidth() > kFaderColW)
         area = area.removeFromRight (kFaderColW);
-    // Scale labels no longer use a dedicated carved column - they're drawn
-    // in paint() to the left of the fader track via kSharedXOver math.
+    // paint() positions the scale labels directly left of the fader track, so
+    // no column is carved out for them here.
     faderScaleArea = juce::Rectangle<int>();
     // grMeterArea was the old standalone GR bar; compMeter now owns the
     // GR display (placed beside the level meter below). Empty rect tells
@@ -1720,10 +1692,13 @@ void BusComponent::resized()
                             .withTrimmedBottom (kFaderValueH + 8);
     faderSlider.setBounds (sliderBounds);
 
+    // Share the bottom readout row with the output peak value, as channel
+    // strips do. Keeping the fader value here avoids the bus-group "0.0"
+    // floating one row above every other strip's readout.
     faderValueLabel.setBounds (sliderBounds.getX(),
-                                 sliderBounds.getBottom() + 6,
+                                 peakRow.getY(),
                                  sliderBounds.getWidth(),
-                                 kFaderValueH);
+                                 peakRow.getHeight());
 
     // Position the fader-side compMeter so its GR bar top (= compTop +
     // 10 px caption reserve) lines up with the level meter's "0" dB tick.
@@ -1814,7 +1789,7 @@ void BusComponent::resetEqSection()
     };
     reset (eqLfGain);  reset (eqMidGain);  reset (eqHfGain);
     bus.strip.eqEnabled.store (wasEnabled, std::memory_order_release);
-    if (eqHeaderBtn != nullptr) eqHeaderBtn->repaint();
+    if (eqHeaderBtn != nullptr) eqHeaderBtn->refresh();
 }
 
 void BusComponent::resetCompSection()
@@ -1828,6 +1803,6 @@ void BusComponent::resetCompSection()
     };
     reset (compRatio);  reset (compAttack);
     reset (compRelease); reset (compMakeup);
-    if (compHeaderBtn != nullptr) compHeaderBtn->repaint();
+    if (compHeaderBtn != nullptr) compHeaderBtn->refresh();
 }
 } // namespace duskstudio

--- a/src/ui/BusComponent.h
+++ b/src/ui/BusComponent.h
@@ -6,9 +6,8 @@
 #include "../session/Session.h"
 #include "AnalogVuMeter.h"
 #include "CompMeterStrip.h"
-#include "CompHeaderButton.h"
+#include "SplitModuleButton.h"
 #include "EmbeddedModal.h"
-#include "SectionPillButton.h"
 
 namespace duskstudio
 {
@@ -57,21 +56,18 @@ private:
     juce::Label nameLabel;
 
     // 3-band EQ controls (LF / MID / HF gains, fixed musical frequencies).
-    // Header is a CompHeaderButton (LED + label pill) so the EQ section
-    // shares its visual grammar with the COMP header above and with the
-    // channel-strip EQ header - single look across the desk.
-    std::unique_ptr<CompHeaderButton> eqHeaderBtn;
+    // Split EQ header shared with the channel and master strips.
+    std::unique_ptr<SplitModuleButton> eqHeaderBtn;
     juce::Slider     eqLfGain  { juce::Slider::RotaryHorizontalVerticalDrag, juce::Slider::TextBoxBelow };
     juce::Slider     eqMidGain { juce::Slider::RotaryHorizontalVerticalDrag, juce::Slider::TextBoxBelow };
     juce::Slider     eqHfGain  { juce::Slider::RotaryHorizontalVerticalDrag, juce::Slider::TextBoxBelow };
     juce::Label      eqLfLbl, eqMidLbl, eqHfLbl;
 
     // Bus compressor controls. Shell mirrors the channel-strip COMP
-    // section visually: a single CompHeaderButton on top, a CompMeterStrip
+    // section visually: a split module button on top, a CompMeterStrip
     // on the left, and the parameter knob grid on the right. The DSP
-    // underneath is still a fixed SSL-style glue topology - no mode
-    // picker, so the header button only toggles enable.
-    std::unique_ptr<CompHeaderButton> compHeaderBtn;
+    // underneath is still a fixed SSL-style glue topology - no mode picker.
+    std::unique_ptr<SplitModuleButton> compHeaderBtn;
     std::unique_ptr<CompMeterStrip>   compMeter;
     juce::Slider     compRatio   { juce::Slider::RotaryHorizontalVerticalDrag, juce::Slider::TextBoxBelow };
     juce::Slider     compAttack  { juce::Slider::RotaryHorizontalVerticalDrag, juce::Slider::TextBoxBelow };
@@ -122,12 +118,10 @@ private:
     // share one visual grammar.
     juce::Rectangle<int> eqArea;
     juce::Rectangle<int> compArea;
-    // Compact-mode section pills. Hidden when compactMode=false; visible (and the
-    // section knobs hidden) when true. Identical grammar to the expanded headers:
-    // left-click toggles enable, right-click opens the section menu, double-click
-    // opens the matching editor popup. Mirrors ChannelStripComponent's compact pills.
-    SectionPillButton eqCompactButton  { "EQ"   };
-    SectionPillButton compCompactButton { "COMP" };
+    // Compact split buttons. The left status hitbox toggles bypass, the right
+    // label opens the editor, and right-click anywhere opens the section menu.
+    SplitModuleButton eqCompactButton  { "EQ"   };
+    SplitModuleButton compCompactButton { "COMP" };
     // Compact-mode popups: clicking the placeholder button shows a
     // mini-editor mirroring the bus's EQ / COMP knobs so the user can
     // tweak without expanding the strip back to full mode.

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -93,14 +93,22 @@ void styleCompactKnob (juce::Slider& k, juce::Colour fill)
     k.setColour (juce::Slider::rotarySliderOutlineColourId, juce::Colour (0xff404048));
 }
 
+enum class ValueLabelDensity
+{
+    regular,
+    compactAtEightUp
+};
+
 void enableValueLabel (juce::Slider& k, const juce::String& suffix, int decimals,
-                       int width = 56, int height = 14)
+                       ValueLabelDensity density = ValueLabelDensity::regular)
 {
     // readOnly=false so single-click on the value text opens an inline
     // editor and the user can type a precise value. Background + outline
     // stay transparent so the value reads as a plain number against the
     // strip's tinted section bands rather than a boxed-in textbox.
-    k.setTextBoxStyle (juce::Slider::TextBoxBelow, false, width, height);
+    if (density == ValueLabelDensity::compactAtEightUp)
+        k.getProperties().set ("dusk_compactAtEightUp", true);
+    k.setTextBoxStyle (juce::Slider::TextBoxBelow, false, 56, 14);
     k.setTextValueSuffix (suffix);
     k.setNumDecimalPlacesToDisplay (decimals);
     k.setColour (juce::Slider::textBoxTextColourId,       juce::Colour (0xffd8d8d8));
@@ -138,18 +146,6 @@ inline juce::String formatBandGain (double db)
     return juce::String (db, 1);
 }
 } // namespace
-
-// Style helper for the EQ / COMP compact-mode placeholder buttons. They sit
-// in the slots the inline EQ + COMP sections occupy in normal mode and
-// open the corresponding editor as a popup when clicked. Hidden by default.
-static void styleCompactSectionButton (juce::TextButton& b, juce::Colour accent)
-{
-    b.setClickingTogglesState (false);
-    b.setColour (juce::TextButton::buttonColourId,   juce::Colour (0xff222226));
-    b.setColour (juce::TextButton::textColourOffId,  accent.brighter (0.3f));
-    b.setColour (juce::TextButton::textColourOnId,   accent.brighter (0.3f));
-    b.setVisible (false);
-}
 
 ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
                                                 PluginSlot& slot, AudioEngine& eng)
@@ -191,6 +187,19 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
     };
     addAndMakeVisible (nameLabel);
 
+    // Every frequency value box that can emit "k" notation needs the matching
+    // parser. The stock numeric-prefix parser reads "8k" as 8 Hz. Filters also
+    // accept their displayed OFF text and map it to the appropriate sentinel.
+    const auto parseFrequencyText = [] (const auto& raw, double offValue)
+    {
+        auto text = raw.trim().toLowerCase();
+        if (text == "off") return offValue;
+        if (text.endsWith ("hz")) text = text.dropLastCharacters (2).trimEnd();
+        const bool isKhz = text.endsWithChar ('k');
+        if (isKhz) text = text.dropLastCharacters (1);
+        return text.getDoubleValue() * (isKhz ? 1000.0 : 1.0);
+    };
+
     // Top filter section: HPF + LPF, white-faced (SSL 9000 J grammar).
     const auto filterWhite = juce::Colour (sslEqColors::kFilterWhite);
     hpfLabel.setText ("HPF", juce::dontSendNotification);
@@ -211,6 +220,10 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
     {
         if (v <= ChannelStripParams::kHpfOffHz + 0.5) return "OFF";
         return formatFrequency (v);
+    };
+    hpfKnob.valueFromTextFunction = [parseFrequencyText] (const auto& text)
+    {
+        return parseFrequencyText (text, ChannelStripParams::kHpfOffHz);
     };
     hpfKnob.setValue (track.strip.hpfFreq.load (std::memory_order_relaxed), juce::dontSendNotification);
     hpfKnob.onValueChange = [this] { onHpfKnobChanged(); };
@@ -235,6 +248,10 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
     {
         if (v >= ChannelStripParams::kLpfOffHz - 0.5) return "OFF";
         return formatFrequency (v);
+    };
+    lpfKnob.valueFromTextFunction = [parseFrequencyText] (const auto& text)
+    {
+        return parseFrequencyText (text, ChannelStripParams::kLpfOffHz);
     };
     lpfKnob.setValue (track.strip.lpfFreq.load (std::memory_order_relaxed), juce::dontSendNotification);
     lpfKnob.onValueChange = [this] { onLpfKnobChanged(); };
@@ -274,39 +291,36 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
     setupEqColumnLabel (eqQColumnLabel,    "Q");
 
     //  EQ region 
-    // Single EQ header button - unified section grammar. Left-click
-    // toggles eqEnabled; right-click opens the EQ section menu (type +
-    // reset + open editor); double-click opens the full EQ editor.
-    // Built-in green LED illuminates when engaged (auto-armed on first
-    // knob touch); text always white.
-    eqHeaderBtn = std::make_unique<CompHeaderButton> (
-        [this] { return track.strip.eqEnabled.load (std::memory_order_relaxed); },
+    // Split EQ header: the left status hitbox toggles bypass while the right
+    // label hitbox opens the editor. Right-click anywhere opens the EQ menu.
+    eqHeaderBtn = std::make_unique<SplitModuleButton> ("EQ");
+    eqHeaderBtn->setAccentColour (juce::Colour (fourKColors::kLfGreen));
+    eqHeaderBtn->setCallbacks (
+        [this] { return ! track.strip.eqEnabled.load (std::memory_order_relaxed); },
         [this]
         {
             const bool now = ! track.strip.eqEnabled.load (std::memory_order_relaxed);
             track.strip.eqEnabled.store (now, std::memory_order_release);
-            if (eqHeaderBtn != nullptr) eqHeaderBtn->repaint();
+            if (eqHeaderBtn != nullptr) eqHeaderBtn->refresh();
         },
-        [this] { showEqSectionMenu(); },
-        [this] { openEqEditorPopup(); });
-    eqHeaderBtn->setLabelText ("EQ");
-    eqHeaderBtn->setTooltip ("Left-click to enable / disable. Right-click for the EQ menu. Double-click to open the editor.");
-    eqHeaderBtn->setTitle ("EQ enable");
+        [this] { openEqEditorPopup(); },
+        [this] { showEqSectionMenu(); });
+    eqHeaderBtn->setTooltip ("Click the status light to bypass/engage EQ; click EQ to open the editor; right-click for the EQ menu.");
+    eqHeaderBtn->setAccessibilityTitle ("EQ enable");
     eqHeaderBtn->setHelpText ("Enables or disables the channel EQ section.");
     addAndMakeVisible (eqHeaderBtn.get());
 
     // COMP region
-    // Single COMP header button: left-click enables/disables, right-
-    // click opens the COMP section menu (mode + reset + open editor),
-    // double-click opens the full COMP editor. Shows "COMP" until the
-    // user picks a mode, then shows the mode name (OPTO/FET/VCA). Built-
-    // in green LED illuminates when the comp is engaged. Text white.
-    compModeButton = std::make_unique<CompHeaderButton> (
-        [this] { return track.strip.compEnabled.load (std::memory_order_relaxed); },
+    // COMP uses the same split grammar. The label continues to surface the
+    // selected OPTO/FET/VCA mode while remaining the editor hitbox.
+    compModeButton = std::make_unique<SplitModuleButton> ("COMP");
+    compModeButton->setAccentColour (juce::Colour (fourKColors::kCompGold));
+    compModeButton->setCallbacks (
+        [this] { return ! track.strip.compEnabled.load (std::memory_order_relaxed); },
         [this] { setCompEnabled (! track.strip.compEnabled.load (std::memory_order_relaxed)); },
-        [this] { showCompSectionMenu(); },
-        [this] { openCompEditorPopup(); });
-    compModeButton->setTooltip ("Left-click to enable / disable. Right-click for the COMP menu. Double-click to open the editor.");
+        [this] { openCompEditorPopup(); },
+        [this] { showCompSectionMenu(); });
+    compModeButton->setTooltip ("Click the status light to bypass/engage compression; click COMP to open the editor; right-click for the COMP menu.");
     addAndMakeVisible (compModeButton.get());
 
     refreshCompModeButtonState();
@@ -530,7 +544,10 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
         row.gain->setRange (ChannelStripParams::kBandGainMin, ChannelStripParams::kBandGainMax, 0.1);
         row.gain->setDoubleClickReturnValue (true, 0.0);
         row.gain->setTooltip (juce::String (spec.rowName) + " Gain (dB)");
-        enableValueLabel (*row.gain, "", 1);
+        // Exact fractional values such as -12.5 are wider than an EightUp
+        // cell. Preserve the number and use shrink-to-fit typography only at
+        // that density instead of ellipsising or rounding.
+        enableValueLabel (*row.gain, "", 1, ValueLabelDensity::compactAtEightUp);
         row.gain->textFromValueFunction = [] (double v) { return formatBandGain (v); };
         row.gain->setValue (spec.gainPtr (track.strip)->load (std::memory_order_relaxed),
                             juce::dontSendNotification);
@@ -559,11 +576,15 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
         row.freq->setSkewFactorFromMidPoint ((double) spec.freqDefault);
         row.freq->setDoubleClickReturnValue (true, spec.freqDefault);
         row.freq->setTooltip (juce::String (spec.rowName) + " Frequency (Hz)");
-        enableValueLabel (*row.freq, "", 0);
+        enableValueLabel (*row.freq, "", 0, ValueLabelDensity::compactAtEightUp);
         // textFromValueFunction must be set BEFORE setValue, otherwise the
         // initial text is rendered with the default formatter ("2000") and
         // doesn't get our "2.0k" notation until the user moves the knob.
         row.freq->textFromValueFunction = [] (double v) { return formatFrequency (v); };
+        row.freq->valueFromTextFunction = [parseFrequencyText] (const auto& text)
+        {
+            return parseFrequencyText (text, 0.0);
+        };
         row.freq->setValue (spec.freqPtr (track.strip)->load (std::memory_order_relaxed),
                             juce::dontSendNotification);
 
@@ -578,7 +599,7 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
             row.q->setSkewFactorFromMidPoint (1.0);  // Q midpoint at 1.0
             row.q->setDoubleClickReturnValue (true, 0.7);
             row.q->setTooltip (juce::String (spec.rowName) + " Q (bandwidth)");
-            enableValueLabel (*row.q, "", 1);
+            enableValueLabel (*row.q, "", 1, ValueLabelDensity::compactAtEightUp);
             row.q->setValue (spec.qPtr (track.strip)->load (std::memory_order_relaxed),
                               juce::dontSendNotification);
             {
@@ -792,6 +813,7 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
                                      juce::Colours::transparentBlack);
         faderValueLabel.setFont (juce::Font (juce::FontOptions (
             juce::Font::getDefaultMonospacedFontName(), 14.0f, juce::Font::bold)));
+        faderValueLabel.setMinimumHorizontalScale (0.75f);
         auto formatDb = [] (double db) -> juce::String
         {
             return (db <= -89.95) ? juce::String (juce::CharPointer_UTF8 ("\xe2\x88\x9e"))   /* ∞ = -inf dB / fully off */
@@ -1402,32 +1424,36 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
 
     // Compact-mode placeholder buttons. Hidden by default; setCompactMode(true)
     // makes them visible and hides the full inline EQ + COMP + AUX controls.
-    styleCompactSectionButton (eqCompactButton,   juce::Colour (fourKColors::kLfGreen));
-    styleCompactSectionButton (compCompactButton, juce::Colour (fourKColors::kCompGold));
-    styleCompactSectionButton (auxCompactButton,  juce::Colour (0xff9080c0));   // SEND violet
-    eqCompactButton  .setButtonText ("EQ");
-    compCompactButton.setButtonText ("COMP");
-    auxCompactButton .setButtonText ("AUX");
-    // Identical grammar to the expanded EQ/COMP headers: left-click toggles the
-    // section on/off, right-click opens the section menu, double-click opens the
-    // editor. The illuminated background (driven by the 30 Hz refresh) reflects
-    // the enabled state. AUX has no enable, so its left-click opens the editor.
-    eqCompactButton  .setTooltip ("Left-click EQ on/off. Right-click for the EQ menu. Double-click to open the editor.");
-    compCompactButton.setTooltip ("Left-click comp on/off. Right-click for the COMP menu. Double-click to open the editor.");
-    auxCompactButton .setTooltip ("Click to open the AUX sends panel. Right-click for the AUX menu.");
-    eqCompactButton  .onClick = [this]
-    {
-        track.strip.eqEnabled.store (! track.strip.eqEnabled.load (std::memory_order_relaxed),
-                                      std::memory_order_release);
-    };
-    eqCompactButton  .onRightClick   = [this] (const juce::MouseEvent&) { showEqSectionMenu(); };
-    eqCompactButton  .onDoubleClick  = [this] { openEqEditorPopup(); };
-    compCompactButton.onClick        = [this] { setCompEnabled (! track.strip.compEnabled.load (std::memory_order_relaxed)); };
-    compCompactButton.onRightClick   = [this] (const juce::MouseEvent&) { showCompSectionMenu(); };
-    compCompactButton.onDoubleClick  = [this] { openCompEditorPopup(); };
-    auxCompactButton .onClick        = [this] { openAuxEditorPopup(); };
-    auxCompactButton .onRightClick   = [this] (const juce::MouseEvent&) { showAuxSectionMenu(); };
-    auxCompactButton .onDoubleClick  = [this] { openAuxEditorPopup(); };
+    eqCompactButton  .setAccentColour (juce::Colour (fourKColors::kLfGreen));
+    compCompactButton.setAccentColour (juce::Colour (fourKColors::kCompGold));
+    auxCompactButton .setAccentColour (juce::Colour (0xff9080c0));   // SEND violet
+    eqCompactButton.setCallbacks (
+        [this] { return ! track.strip.eqEnabled.load (std::memory_order_relaxed); },
+        [this]
+        {
+            track.strip.eqEnabled.store (! track.strip.eqEnabled.load (std::memory_order_relaxed),
+                                          std::memory_order_release);
+        },
+        [this] { openEqEditorPopup(); },
+        [this] { showEqSectionMenu(); });
+    compCompactButton.setCallbacks (
+        [this] { return ! track.strip.compEnabled.load (std::memory_order_relaxed); },
+        [this] { setCompEnabled (! track.strip.compEnabled.load (std::memory_order_relaxed)); },
+        [this] { openCompEditorPopup(); },
+        [this] { showCompSectionMenu(); });
+    auxCompactButton.setCallbacks (
+        [this] { return track.strip.auxSendsBypassed.load (std::memory_order_relaxed); },
+        [this]
+        {
+            auto& bypassed = track.strip.auxSendsBypassed;
+            bypassed.store (! bypassed.load (std::memory_order_relaxed),
+                            std::memory_order_release);
+        },
+        [this] { openAuxEditorPopup(); },
+        [this] { showAuxSectionMenu(); });
+    eqCompactButton  .setTooltip ("Click the light to bypass/engage EQ; click EQ to open the editor; right-click for the EQ menu.");
+    compCompactButton.setTooltip ("Click the light to bypass/engage compression; click COMP to open the editor; right-click for the COMP menu.");
+    auxCompactButton .setTooltip ("Click the light to bypass/engage AUX sends; click AUX to open the sends editor; right-click for the AUX menu.");
     addChildComponent (eqCompactButton);    // hidden until compact mode flips on
     addChildComponent (compCompactButton);
     addChildComponent (auxCompactButton);
@@ -1446,7 +1472,7 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
     printButton .setTitle ("Track " + tn + " print effects on record");
     hpfKnob     .setTitle ("Track " + tn + " high-pass filter frequency");
     lpfKnob     .setTitle ("Track " + tn + " low-pass filter frequency");
-    if (eqHeaderBtn != nullptr) eqHeaderBtn->setTitle ("Track " + tn + " EQ enable / type");
+    if (eqHeaderBtn != nullptr) eqHeaderBtn->setAccessibilityTitle ("Track " + tn + " EQ enable / type");
     pluginSlotButton.setTitle ("Track " + tn + " insert slot");
     for (size_t i = 0; i < auxKnobs.size(); ++i)
         if (auxKnobs[i] != nullptr)
@@ -1669,6 +1695,31 @@ void ChannelStripComponent::setMixingMode (bool mixing)
         auxCompactButton.setVisible (false);
     }
 
+    resized();
+    repaint();
+}
+
+void ChannelStripComponent::setHorizontalDensity (consolelayout::HorizontalDensity density)
+{
+    if (horizontalDensity == density) return;
+    horizontalDensity = density;
+    const bool useCompactText = density == consolelayout::HorizontalDensity::EightUp;
+    const auto applyDensity = [useCompactText] (auto* slider)
+    {
+        if (slider == nullptr
+            || ! (bool) slider->getProperties().getWithDefault (
+                "dusk_compactAtEightUp", false))
+            return;
+
+        slider->getProperties().set ("dusk_compactValueText", useCompactText);
+        slider->lookAndFeelChanged();
+    };
+    for (auto& row : eqRows)
+    {
+        applyDensity (row.gain.get());
+        applyDensity (row.freq.get());
+        applyDensity (row.q.get());
+    }
     resized();
     repaint();
 }
@@ -4043,7 +4094,7 @@ void ChannelStripComponent::timerCallback()
         // Type cue now lives on the dedicated eqTypeChip mid-strip
         // (between HM and LM rows). Just repaint the header so its LED
         // tracks atom changes from external mutation paths.
-        eqHeaderBtn->repaint();
+        eqHeaderBtn->refresh();
     }
     if (insertBypassLed != nullptr)
         insertBypassLed->repaint();   // tracks bypass atom + slot load/unload
@@ -4084,34 +4135,13 @@ void ChannelStripComponent::timerCallback()
         syncKnob (vcaOutputKnob,   sp.compVcaOutput.load   (std::memory_order_relaxed));
     }
 
-    // TIMELINE-mode compact buttons get an on-air indicator so the user
-    // knows whether EQ / COMP is engaged without having to open the
-    // popup. Bullet character + brighter background when on.
+    // Keep split-button state visuals in sync with atom changes made by
+    // editors, automation, or MIDI rather than only by the last pointer click.
     if (compactMode)
     {
-        // Channel-strip EQ illuminates on eqEnabled alone - the same state the
-        // pill's left-click toggles and the expanded EQ header reflects. HPF is
-        // deliberately excluded: it has its own independent gate, and folding it
-        // in here left the pill stuck lit while HPF was engaged, so a click
-        // toggled eqEnabled with no visible change. Comp has a real on/off atom.
-        const auto& sp = track.strip;
-        const bool eqOn   = sp.eqEnabled.load (std::memory_order_relaxed);
-        const bool compOn = sp.compEnabled.load (std::memory_order_relaxed);
-
-        const auto eqAccent   = juce::Colour (fourKColors::kLfGreen);
-        const auto compAccent = juce::Colour (fourKColors::kCompGold);
-
-        // Text stays as the section name; the illuminated background
-        // (set below) is the on-state indicator. No leading bullet/dot.
-        if (eqCompactButton.getButtonText() != "EQ")
-            eqCompactButton.setButtonText ("EQ");
-        if (compCompactButton.getButtonText() != "COMP")
-            compCompactButton.setButtonText ("COMP");
-
-        eqCompactButton  .setColour (juce::TextButton::buttonColourId,
-                                       eqOn   ? eqAccent.darker (0.55f)   : juce::Colour (0xff222226));
-        compCompactButton.setColour (juce::TextButton::buttonColourId,
-                                       compOn ? compAccent.darker (0.55f) : juce::Colour (0xff222226));
+        eqCompactButton.refresh();
+        compCompactButton.refresh();
+        auxCompactButton.refresh();
     }
 
     // Detect bus-colour edits made via the aux strip's right-click menu and
@@ -5075,7 +5105,7 @@ void ChannelStripComponent::refreshCompModeButtonState()
     const char* names[] = { "OPTO", "FET", "VCA" };
     compModeButton->setLabelText (enabled ? juce::String ("COMP - ") + names[m]
                                           : juce::String ("COMP"));
-    compModeButton->repaint();   // refresh LED state too
+    compModeButton->refresh();   // refresh LED state too
 }
 
 void ChannelStripComponent::refreshCompKnobVisibility()
@@ -5134,7 +5164,7 @@ void ChannelStripComponent::showEqSectionMenu()
             {
                 case 1: case 2:
                     self->track.strip.eqBlackMode.store (chosen == 2, std::memory_order_relaxed);
-                    if (self->eqHeaderBtn != nullptr) self->eqHeaderBtn->repaint();
+                    if (self->eqHeaderBtn != nullptr) self->eqHeaderBtn->refresh();
                     break;
                 case 10: self->resetEqSection();    break;
                 case 11: self->openEqEditorPopup(); break;
@@ -5228,7 +5258,7 @@ void ChannelStripComponent::resetEqSection()
         if (row.q    != nullptr) reset (*row.q);
     }
     track.strip.eqEnabled.store (wasEnabled, std::memory_order_release);
-    if (eqHeaderBtn != nullptr) eqHeaderBtn->repaint();
+    if (eqHeaderBtn != nullptr) eqHeaderBtn->refresh();
 }
 
 void ChannelStripComponent::resetCompSection()
@@ -5521,19 +5551,14 @@ void ChannelStripComponent::paint (juce::Graphics& g)
         }
     }
 
-    // Track-3 fader scale labels - drawn here (not in the LookAndFeel)
-    // so they can extend into the strip area to the LEFT of the slider
-    // bounds. LookAndFeel only draws the ticks for this layout.
+    // Fader scale labels are drawn here (not in the LookAndFeel) so they can
+    // occupy the reserved gutter between the LEFT-side bus buttons and fader.
+    // LookAndFeel only draws the tick stubs for this layout.
     if (usesFaderThresholdLayout())
     {
         const auto& range = faderSlider.getNormalisableRange();
         const auto sliderB = faderSlider.getBounds().toFloat();
         const float trackCx = sliderB.getCentreX();
-        // trackW = jmin(4, sliderW*0.18) inside the LookAndFeel; mirror so
-        // labels sit just left of the tick stub.
-        const float trackW  = std::min (4.0f, sliderB.getWidth() * 0.18f);
-        const float trackLx = trackCx - trackW * 0.5f;
-
         for (const auto& t : kFaderTicks)
         {
             if (t.db < range.start - 0.01f || t.db > range.end + 0.01f) continue;
@@ -5550,8 +5575,6 @@ void ChannelStripComponent::paint (juce::Graphics& g)
             const juce::Font font (juce::FontOptions (isBottom ? 16.0f : 10.5f,
                                                       juce::Font::plain));
             g.setFont (font);
-            constexpr float kSharedXOver  = 24.0f;
-            const float labelRight = trackLx - kSharedXOver - 6.0f;
             const juce::String label = isBottom ? juce::String (juce::CharPointer_UTF8 ("\xe2\x88\x9e"))   /* ∞ = -inf dB / fully off */
                                                 : juce::String (t.label);
             // Visible glyph spans (baseline - ascent) to (baseline + descent).
@@ -5562,11 +5585,39 @@ void ChannelStripComponent::paint (juce::Graphics& g)
             const float ascent  = font.getAscent();
             const float descent = font.getDescent();
             const float baselineY = y + (ascent - descent) * 0.5f - 2.0f;
-            const float textW = juce::GlyphArrangement::getStringWidth (font, label);
+            // Fit the text inside the actual button-to-cap gutter. Right
+            // alignment keeps every label pinned beside the fader, while
+            // horizontal fitting makes a wider host font shrink instead of
+            // painting underneath the bus buttons.
+            const float labelLeft = busButtons.front() != nullptr
+                ? (float) busButtons.front()->getRight() + 2.0f
+                : sliderB.getX() - 20.0f;
+            const float labelRight = trackCx - 14.0f;
+            const float availableWidth = labelRight - labelLeft;
+            if (availableWidth < 8.0f)
+                continue;
+
+            juce::GlyphArrangement glyphs;
+            glyphs.addLineOfText (font, label, 0.0f, 0.0f);
+            const float naturalWidth = glyphs.getBoundingBox (0, -1, true).getWidth();
+            const auto fittedFont = naturalWidth > availableWidth
+                ? font.withHorizontalScale (jlimit (0.65f, 1.0f,
+                                                     availableWidth / naturalWidth))
+                : font;
+            g.setFont (fittedFont);
+            g.saveState();
+            const auto rounded = [] (float v) { return (int) std::lround (v); };
+            const auto labelClip = faderSlider.getBounds()
+                .withX (rounded (labelLeft))
+                .withY (rounded (baselineY - fittedFont.getAscent()))
+                .withWidth (std::max (1, rounded (availableWidth)))
+                .withHeight (std::max (1, rounded (fittedFont.getHeight())));
+            g.reduceClipRegion (labelClip);
             g.drawSingleLineText (label,
-                                    juce::roundToInt (labelRight - textW),
-                                    juce::roundToInt (baselineY),
-                                    juce::Justification::left);
+                                    rounded (labelRight),
+                                    rounded (baselineY),
+                                    juce::Justification::right);
+            g.restoreState();
         }
     }
 
@@ -5721,7 +5772,8 @@ void ChannelStripComponent::resized()
     constexpr int kColumnHeaderH  = 10;
     constexpr int kEqBandRowH     = kKnobBlockH;
     constexpr int kEqBandGap      = 2;
-    constexpr int kRowLabelW      = 28;
+    const int kRowLabelW = horizontalDensity == consolelayout::HorizontalDensity::EightUp
+                         ? 24 : 28;
     constexpr int kEqBandCount    = 4;
 
     eqArea = area.removeFromTop (kEqHeaderH + kEqHpfRowH + kFilterBandGap
@@ -5806,11 +5858,11 @@ void ChannelStripComponent::resized()
     // gets the full block height with no extra padding.
     constexpr int kCompBodyExtraH = 0;
     constexpr int kCompBodyH = 2 * kCompKnobRowH + kCompKnobGap + kCompBodyExtraH;
-    // Track-3 collapses every comp mode to a single-row body: FET/VCA
-    // pack 4 knobs side-by-side; OPTO packs GAIN + LIMIT side-by-side.
-    // Half the vertical space of the default 2-row layout.
-    const bool track3OneRowComp = usesFaderThresholdLayout();
-    const int effectiveCompBodyH = track3OneRowComp ? kCompKnobRowH : kCompBodyH;
+    // EightUp restores two rows so each FET/VCA control keeps a readable cell
+    // at the narrow channel width. Comfortable strips retain the shorter row.
+    const bool oneRowComp = usesFaderThresholdLayout()
+                         && horizontalDensity != consolelayout::HorizontalDensity::EightUp;
+    const int effectiveCompBodyH = oneRowComp ? kCompKnobRowH : kCompBodyH;
     compArea = area.removeFromTop (16 + 2 + effectiveCompBodyH + 4);
     {
         auto s = compArea.reduced (3, 2);
@@ -5854,7 +5906,7 @@ void ChannelStripComponent::resized()
 
         if (currentMode == 0)  // OPTO: GAIN knob top, LIMIT toggle bottom
         {
-            if (usesFaderThresholdLayout())
+            if (oneRowComp)
             {
                 // Track-3 OPTO single-row: GAIN cell on the LEFT half,
                 // LIMIT toggle vertically centred in the RIGHT half.
@@ -5884,7 +5936,7 @@ void ChannelStripComponent::resized()
         }
         else if (currentMode == 1)  // FET
         {
-            if (track3OneRowComp)
+            if (oneRowComp)
             {
                 // RAT / ATK / REL / MAK - matches the bus comp's single-row
                 // order so every comp in the mixer reads identically.
@@ -5909,7 +5961,7 @@ void ChannelStripComponent::resized()
         }
         else  // VCA
         {
-            if (track3OneRowComp)
+            if (oneRowComp)
             {
                 // RAT / ATK / REL / MAK - matches the bus comp's single-row
                 // order so every comp in the mixer reads identically.
@@ -6011,11 +6063,8 @@ void ChannelStripComponent::resized()
     // a vertical column to the left of the fader (laid out below).
 
     // Pan section is laid out together with the fader (see below) so
-    // the knob can be horizontally centered over the FADER COLUMN
-    // (busColumn + faderArea, excluding the right-side peak column),
-    // not over the strip itself. Centering over the strip puts the
-    // knob offset to the right of the visible fader because the peak
-    // column eats 31-37 px from the right edge.
+    // the knob can be horizontally centered over the stable fader column,
+    // independently of the meter stack and right-side bus column.
 
     auto buttons = area.removeFromBottom (20);
     const int btnW = buttons.getWidth() / 3;
@@ -6057,11 +6106,10 @@ void ChannelStripComponent::resized()
         && faderArea.getHeight() > kMaxFaderHeight + kPeakLabelH + 2)
         faderArea = faderArea.removeFromBottom (kMaxFaderHeight + kPeakLabelH + 2);
 
-    // Vertical bus-assign column. Lives on the LEFT of the fader by default
-    // (Tascam Model 2400 grammar - buttons under the engineer's left hand).
-    // At narrow strip widths it migrates to the RIGHT side, past the meter
-    // cluster, so it can't visually overlap the fader cap when the strip
-    // is squeezed below its design min width.
+    // Vertical bus-assign column. Keep it on the LEFT at every supported
+    // strip width, with the level meter and GR control fixed on the RIGHT.
+    // Both compact (timeline) and full-height modes pass through this same
+    // geometry so controls never swap sides at a scale or height breakpoint.
     constexpr int kBusColumnW   = 18;
     constexpr int kBusColumnGap = 3;
     constexpr int kBusButtonH   = 20;   // fixed height; evenly spaced across the 0->∞ scale
@@ -6071,61 +6119,63 @@ void ChannelStripComponent::resized()
     juce::Rectangle<int> faderCompMeterCol;
     if (usesFaderThresholdLayout())
     {
-        // Track-3 layout (right -> left): GR LED hugs the right side of
-        // the main level meter (1 px gap - reads as one continuous pair),
-        // both glued IMMEDIATELY to the right of the fader. compMeter
-        // internally flips its handle to the RIGHT (see setHandleOnRight)
-        // so the triangle points LEFT at the GR bar instead of poking
-        // into the meter column. kFaderLeftShift consumes empty space
-        // on the LEFT of the fader column so cap + PAN knob centre under
-        // the LIMIT button (which is centred on the strip), not biased
-        // left toward the bus-assign column.
+        // Stable layout (left -> right): bus assignments, centred fader,
+        // level meter, GR LED. compMeter keeps its handle on the RIGHT
+        // (see setHandleOnRight), matching the bus and master strips.
+        // Symmetric side reservations keep the pan, fader cap, tick labels,
+        // and numeric readout on the strip centreline without changing sides
+        // at a scale-factor breakpoint.
         constexpr int kGrLedW          = 20;   // GR bar + handle
         constexpr int kMeterToGrGap    = 1;
         constexpr int kFaderToMeterGap = 1;
-        constexpr int kRightPad        = 14;
-        constexpr int kFaderLeftShift  = 29;
+        // Three pixels inside either edge keeps the button and GR frames clear
+        // of the strip border while leaving the 116 px EightUp stereo layout
+        // enough room to retain a centred fader and readable scale labels.
+        constexpr int kOuterPad        = 3;
         constexpr int kFaderColMinReserve = 22;
 
-        // Wide-layout fader-column width prediction: bus on the LEFT, full
-        // leftShift, full right-side cluster carved from the right.
-        const int wideRightStack = kRightPad + kGrLedW + kMeterToGrGap
-                                  + kMeterWidth + kFaderToMeterGap;
-        const int faderColWideW  = faderArea.getWidth() - kBusColumnW
-                                  - kBusColumnGap - wideRightStack
-                                  - kFaderLeftShift;
-        const bool narrowMode = (faderColWideW < kFaderColMinReserve);
-
+        const auto fullArea = faderArea;
+        const int leftStackW = kOuterPad + kBusColumnW + kBusColumnGap;
+        const int rightStackW = kFaderToMeterGap + kMeterWidth
+                              + kMeterToGrGap + kGrLedW + kOuterPad;
+        const int symmetricSideW = std::max (leftStackW, rightStackW);
+        const bool canCentreWithoutOverlap = fullArea.getWidth()
+                                            >= symmetricSideW * 2
+                                             + kFaderColMinReserve;
         scaleColumn = juce::Rectangle<int>();
         grScaleArea = juce::Rectangle<int>();
-        if (narrowMode)
+        if (canCentreWithoutOverlap)
         {
-            // Bus migrates to the FAR RIGHT past the meter cluster; no
-            // leftShift needed since the fader column starts at the strip
-            // edge. Cap drifts slightly left of strip centre but can no
-            // longer overlap the bus buttons - the right-side stack is the
-            // ONLY thing carved from the strip, fader gets all remaining
-            // width.
-            faderArea.removeFromRight (kRightPad);
-            busColumn = faderArea.removeFromRight (kBusColumnW);
-            faderArea.removeFromRight (kBusColumnGap);
-            faderCompMeterCol = faderArea.removeFromRight (kGrLedW);
-            faderArea.removeFromRight (kMeterToGrGap);
-            meterColumn = faderArea.removeFromRight (kMeterWidth);
-            faderArea.removeFromRight (kFaderToMeterGap);
+            const int centredFaderW = std::max (
+                kFaderColMinReserve,
+                std::min (40, fullArea.getWidth() - symmetricSideW * 2));
+            const int centredFaderX = fullArea.getCentreX() - centredFaderW / 2;
+
+            faderArea = { centredFaderX, fullArea.getY(),
+                          centredFaderW, fullArea.getHeight() };
+            meterColumn = {
+                faderArea.getRight() + kFaderToMeterGap,
+                fullArea.getY(), kMeterWidth, fullArea.getHeight() };
+            faderCompMeterCol = {
+                meterColumn.getRight() + kMeterToGrGap,
+                fullArea.getY(), kGrLedW, fullArea.getHeight() };
+            busColumn = {
+                fullArea.getX() + kOuterPad,
+                fullArea.getY(), kBusColumnW, fullArea.getHeight() };
         }
         else
         {
-            // Wide path: bus on the LEFT, full leftShift centres the cap on
-            // strip centre under the strip-centred GAIN / LIMIT controls.
+            // Scripted/native resizes can bypass the normal application-width
+            // floor. Degrade without changing the established order: buses,
+            // remaining fader space, level meter, GR.
+            faderArea.removeFromLeft (kOuterPad);
             busColumn = faderArea.removeFromLeft (kBusColumnW);
             faderArea.removeFromLeft (kBusColumnGap);
-            faderArea.removeFromRight (kRightPad);
+            faderArea.removeFromRight (kOuterPad);
             faderCompMeterCol = faderArea.removeFromRight (kGrLedW);
             faderArea.removeFromRight (kMeterToGrGap);
             meterColumn = faderArea.removeFromRight (kMeterWidth);
             faderArea.removeFromRight (kFaderToMeterGap);
-            faderArea.removeFromLeft (kFaderLeftShift);
         }
     }
     else
@@ -6173,10 +6223,8 @@ void ChannelStripComponent::resized()
     // strip, so a header next to the fader would be misleading.
     threshMeterLabel.setVisible (false);
 
-    // Pan section pinned to the TOP of the fader column. Knob is
-    // centered on the fader's x-centre (faderArea after busColumn +
-    // peakColumn carve-outs) - NOT the strip centre - so it visually
-    // sits over the slider thumb's track.
+    // Pan section pinned to the TOP of the fader column. Knob is centered on
+    // the same fixed centreline as the slider thumb's track.
     constexpr int kPanKnobSize = 26;
     constexpr int kPanValueH   = 12;
     constexpr int kPanBlockH   = kPanKnobSize + kPanValueH + 2;
@@ -6224,40 +6272,37 @@ void ChannelStripComponent::resized()
         if (compactMode)
             sliderBounds = sliderBounds.withTrimmedBottom (kCompactFaderBottomTrim);
 
-        // Full-height strips align the fader value with the input peak
-        // readout (for example "0.8" and "-inf") in one bottom row. Compact
-        // strips retain the value slot immediately below the shorter fader.
-        const int kFaderValueH = 18;
-        if (compactMode)
-            faderValueLabel.setBounds (sliderBounds.getX(),
-                                          sliderBounds.getBottom() + 6,
-                                          sliderBounds.getWidth(),
-                                          kFaderValueH);
-        else
-            faderValueLabel.setBounds (sliderBounds.getX(),
-                                          peakRow.getY(),
-                                          sliderBounds.getWidth(),
-                                          peakRow.getHeight());
+        // Keep the fader value and input-peak readout (for example "0.0" and
+        // "-inf") on one shared bottom row in both full-height and timeline
+        // modes. Compact mode still reserves extra space below its shortened
+        // slider so the cap-at-min cannot collide with this row.
+        faderValueLabel.setBounds (sliderBounds.getX(),
+                                      peakRow.getY(),
+                                      sliderBounds.getWidth(),
+                                      peakRow.getHeight());
     }
     faderSlider.setBounds (sliderBounds);
 
-    // Bus buttons (1-4): span the fader scale from the "0" tick (top of #1) to
-    // the "off" tick (bottom of #4), dividing the range into four equal slots.
+    // Bus buttons (1-4): occupy a slightly tightened, vertically centred stack
+    // within the fader's 0-to-off range. This keeps them easy to scan without
+    // spreading four small controls over the entire fader height.
     // faderYForDb gives the exact tick Y for both the normal and threshold fader
     // layouts; anchoring to the meter column would miss it on strips that reserve
     // peak-label space below the meter.
     {
-        // Fixed-height buttons, evenly spaced: #1's top lines up with the "0"
-        // tick and #4's bottom with the "∞" tick. Distribute the TOPs linearly
-        // across [zeroY, offY - kBusButtonH]; the inter-button gap falls out as
-        // (span - kNumBuses*H)/(kNumBuses-1).
         const int zeroY = (int) std::lround (duskstudio::faderYForDb (faderSlider, 0.0f));
         const int offY  = (int) std::lround (duskstudio::faderYForDb (faderSlider, -90.0f));
         const int span  = std::max (ChannelStripParams::kNumBuses * kBusButtonH, offY - zeroY);
+        constexpr double kBusSpacingFactor = 0.85;
+        constexpr int kMaxBusButtonStep = 48;
+        const int naturalStep = (span - kBusButtonH) / (ChannelStripParams::kNumBuses - 1);
+        const int step = jlimit (kBusButtonH, kMaxBusButtonStep,
+                                 (int) std::lround (naturalStep * kBusSpacingFactor));
+        const int stackH = kBusButtonH + step * (ChannelStripParams::kNumBuses - 1);
+        const int stackTop = zeroY + std::max (0, (span - stackH) / 2);
         for (int i = 0; i < ChannelStripParams::kNumBuses; ++i)
         {
-            const int top = zeroY + (int) std::lround (
-                (double) (span - kBusButtonH) * i / (ChannelStripParams::kNumBuses - 1));
+            const int top = stackTop + step * i;
             busButtons[(size_t) i]->setBounds (busColumn.getX(), top, kBusColumnW, kBusButtonH);
         }
     }

--- a/src/ui/ChannelStripComponent.h
+++ b/src/ui/ChannelStripComponent.h
@@ -6,11 +6,11 @@
 #include <functional>
 #include <memory>
 #include "CompMeterStrip.h"
-#include "CompHeaderButton.h"
+#include "SplitModuleButton.h"
+#include "ConsoleLayout.h"
 #include "EmbeddedModal.h"
 #include "DuskComboBox.h"
 #include "NativeEditorOwner.h"
-#include "SectionPillButton.h"
 #include "../session/Session.h"
 #include "../foundation/MessageThread.h"
 
@@ -68,6 +68,8 @@ public:
     // Swaps the input/IN/ARM/PRINT row at the top for 4 AUX send knobs.
     void setMixingMode (bool mixing);
     bool isMixingMode() const noexcept { return mixingMode; }
+
+    void setHorizontalDensity (consolelayout::HorizontalDensity density);
 
 private:
     void timerCallback() override;
@@ -128,9 +130,9 @@ private:
     // Section-wide EQ type belongs in the header beside the EQ enable control.
     juce::TextButton eqTypeChip { "E" };
 
-    // Same grammar as the COMP header. Left = toggle eqEnabled. Right
-    // = section menu. Double-click = open editor. Label stays "EQ".
-    std::unique_ptr<CompHeaderButton> eqHeaderBtn;
+    // Split header: left status light toggles bypass, right label opens the
+    // editor, and right-click anywhere opens the section menu.
+    std::unique_ptr<SplitModuleButton> eqHeaderBtn;
     struct BandRow
     {
         std::unique_ptr<juce::Slider> gain;
@@ -141,12 +143,10 @@ private:
     };
     std::array<BandRow, 4> eqRows;
 
-    // Holds the union of all three modes' params; shows only the
-    // current mode. Illumination relies on LookAndFeel reading
-    // getToggleState - we do NOT setClickingTogglesState(true) (that
-    // would flip on every click and detach visual from compEnabled).
-    // onClick opens the mode menu; compEnabled mutated separately.
-    std::unique_ptr<CompHeaderButton> compModeButton;
+    // Holds the union of all three modes' params; shows only the current mode.
+    // The label includes that mode and opens the editor; the status light
+    // controls compEnabled.
+    std::unique_ptr<SplitModuleButton> compModeButton;
 
     // Opto (LA-2A): peak-red + gain + LIMIT.
     juce::Slider     optoPeakRedKnob { juce::Slider::RotaryHorizontalVerticalDrag, juce::Slider::NoTextBox };
@@ -303,8 +303,8 @@ private:
     // session-load mode change leaves every mode's knobs overlapping in
     // the comp section.
     int lastAppliedCompMode = -1;
-    // Unified section context menus (right-click on the EQ / COMP header or
-    // compact pill): character items + whole-section reset + open editor.
+    // Unified section context menus (right-click anywhere on the EQ / COMP / AUX
+    // split button): character items + whole-section reset + open editor.
     void showEqSectionMenu();
     void showCompSectionMenu();
     void showAuxSectionMenu();
@@ -423,9 +423,11 @@ public:
 private:
 
     bool compactMode = false;
-    SectionPillButton eqCompactButton   { "EQ" };
-    SectionPillButton compCompactButton { "COMP" };
-    SectionPillButton auxCompactButton  { "AUX" };
+    consolelayout::HorizontalDensity horizontalDensity =
+        consolelayout::HorizontalDensity::Comfortable;
+    SplitModuleButton eqCompactButton   { "EQ" };
+    SplitModuleButton compCompactButton { "COMP" };
+    SplitModuleButton auxCompactButton  { "AUX" };
     // EQ / COMP / AUX compact editors, each a centred EmbeddedModal (dim
     // backdrop, Esc / click-outside dismiss, transport-key forwarding, focus
     // restore all handled internally). Mutually exclusive - opening one closes

--- a/src/ui/ConsoleLayout.h
+++ b/src/ui/ConsoleLayout.h
@@ -8,22 +8,37 @@
 
 namespace duskstudio::consolelayout
 {
-constexpr int kMinChannelWidth = 154;
-constexpr int kMinBusWidth     = 172;
-constexpr int kMinMasterWidth  = 210;
-constexpr int kRefChannelWidth = 188;
-constexpr int kRefBusWidth     = 192;
-constexpr int kRefMasterWidth  = 260;
-constexpr int kStripGap        = 4;
-constexpr int kSectionGap      = 12;
-constexpr int kComponentInset  = 6;
-constexpr int kOuterPadding    = kComponentInset * 2;
-constexpr int kMainPadding     = 8;
-constexpr int kMaxScreenPages  = 8;
+constexpr int kMinChannelWidth       = 154;
+constexpr int kMinBusWidth           = 172;
+constexpr int kMinMasterWidth        = 210;
+constexpr int kEightUpChannelWidth   = 116;
+constexpr int kEightUpThresholdWidth = 1902;
+constexpr int kEightUpChannelCount   = SessionLayout::kBankSize;
+constexpr int kRefChannelWidth       = 188;
+constexpr int kRefBusWidth           = 192;
+constexpr int kRefMasterWidth        = 260;
+constexpr int kStripGap              = 4;
+constexpr int kSectionGap            = 12;
+constexpr int kComponentInset        = 6;
+constexpr int kOuterPadding          = kComponentInset * 2;
+constexpr int kMainPadding           = 8;
+constexpr int kMaxScreenPages        = 8;
 constexpr int kMinStride = (SessionLayout::kNumTracks + kMaxScreenPages - 1)
                          / kMaxScreenPages;
 constexpr int kMinPageButtonWidth = 32;
 constexpr int kMinPageButtonGap   = 2;
+
+enum class HorizontalDensity
+{
+    Comfortable,
+    EightUp
+};
+
+struct ChannelFit
+{
+    int channels = kMinStride;
+    HorizontalDensity density = HorizontalDensity::Comfortable;
+};
 
 constexpr int rightColumnWidth() noexcept
 {
@@ -32,6 +47,12 @@ constexpr int rightColumnWidth() noexcept
          + kSectionGap * 2
          + kMinMasterWidth;
 }
+
+static_assert (kEightUpThresholdWidth
+               == kEightUpChannelCount * kEightUpChannelWidth
+                + (kEightUpChannelCount - 1) * kStripGap
+                + rightColumnWidth()
+                + kOuterPadding);
 
 constexpr int fullFloorContentWidthForStride (int stride) noexcept
 {
@@ -115,9 +136,25 @@ inline int channelsThatFitForWidth (int componentWidth) noexcept
 {
     const int available = std::max (0, componentWidth - kOuterPadding - rightColumnWidth());
     const int perSlot = kMinChannelWidth + kStripGap;
-    if (available <= 0) return kMinStride;
-    const int fit = (available + kStripGap) / perSlot;
-    return std::clamp (fit, kMinStride, SessionLayout::kNumTracks);
+    const int comfortableFit = available > 0
+                             ? (available + kStripGap) / perSlot
+                             : kMinStride;
+    if (componentWidth >= kEightUpThresholdWidth
+        && comfortableFit < kEightUpChannelCount)
+        return kEightUpChannelCount;
+    return std::clamp (comfortableFit, kMinStride, SessionLayout::kNumTracks);
+}
+
+inline ChannelFit channelFitForWidth (int componentWidth) noexcept
+{
+    const int channels = channelsThatFitForWidth (componentWidth);
+    // At 2206 px the comfortable eight-strip floor becomes available and
+    // supersedes EightUp; below that, 1902..2205 px uses the 116 px tier.
+    const bool eightUp = componentWidth >= kEightUpThresholdWidth
+                      && channels == kEightUpChannelCount
+                      && componentWidth < fullFloorContentWidthForStride (kEightUpChannelCount);
+    return { channels, eightUp ? HorizontalDensity::EightUp
+                               : HorizontalDensity::Comfortable };
 }
 
 inline int screenPageCountForWidth (int componentWidth) noexcept
@@ -154,7 +191,6 @@ struct StripGeometry
     int contentRight     = kComponentInset;
     int busColumnLeft    = kComponentInset;
     int lastChannelRight = kComponentInset;
-
     bool channelsClearBus() const noexcept
     {
         return lastChannelRight + sectionGap <= busColumnLeft;
@@ -163,7 +199,8 @@ struct StripGeometry
 
 inline StripGeometry makeStripGeometry (int componentWidth,
                                         int budgetedChannels,
-                                        int visibleChannels) noexcept
+                                        int visibleChannels,
+                                        HorizontalDensity density = HorizontalDensity::Comfortable) noexcept
 {
     StripGeometry g;
     g.componentWidth = std::max (0, componentWidth);
@@ -186,7 +223,9 @@ inline StripGeometry makeStripGeometry (int componentWidth,
                                        / static_cast<double> (refTotal))
                        : 0.0;
 
-    g.channelWidth = std::max (kMinChannelWidth,
+    const int channelFloor = density == HorizontalDensity::EightUp
+                           ? kEightUpChannelWidth : kMinChannelWidth;
+    g.channelWidth = std::max (channelFloor,
                                static_cast<int> (std::lround (kRefChannelWidth * scale)));
     g.busWidth = std::max (kMinBusWidth,
                            static_cast<int> (std::lround (kRefBusWidth * scale)));
@@ -211,7 +250,7 @@ inline StripGeometry makeStripGeometry (int componentWidth,
     };
 
     // Normal fit: retain all control-size floors.
-    reduceRepeated (g.channelWidth, g.budgetedChannels, kMinChannelWidth);
+    reduceRepeated (g.channelWidth, g.budgetedChannels, channelFloor);
     reduceRepeated (g.busWidth, SessionLayout::kNumBuses, kMinBusWidth);
     reduceRepeated (g.masterWidth, 1, kMinMasterWidth);
 

--- a/src/ui/ConsoleView.cpp
+++ b/src/ui/ConsoleView.cpp
@@ -167,7 +167,8 @@ void ConsoleView::resized()
     // stride = channelsThatFit().
     showingAllTracks = (getWidth() >= allTracksContentWidth());
 
-    const int stride = bankStride();
+    const auto channelFit = consolelayout::channelFitForWidth (getWidth());
+    const int stride = channelFit.channels;
     // Re-derives the page against the new width and queues any surface move it
     // implies for the poll tick. Publishes nothing itself - a drag-resize
     // storing mcu.bank here would swallow a Bank Left/Right press.
@@ -199,13 +200,17 @@ void ConsoleView::resized()
     // refTotal would fit and skip the scale-down branch.
     const int widthRefChannels = showingAllTracks ? Session::kNumTracks : stride;
     const auto geometry = consolelayout::makeStripGeometry (
-        getWidth(), widthRefChannels, visibleChannels);
+        getWidth(), widthRefChannels, visibleChannels, channelFit.density);
     const int channelW = geometry.channelWidth;
     const int busW     = geometry.busWidth;
     const int masterW  = geometry.masterWidth;
 
     const int y = area.getY();
     const int h = area.getHeight();
+
+    for (auto& strip : strips)
+        if (strip != nullptr)
+            strip->setHorizontalDensity (channelFit.density);
 
     // Buses + master ANCHORED to the right edge. Channel strips fill
     // from the left up to `visibleChannels`; any leftover horizontal

--- a/src/ui/ConsoleView.h
+++ b/src/ui/ConsoleView.h
@@ -65,8 +65,9 @@ public:
     // Above this width we drop banking and show all 24 strips.
     int allTracksContentWidth() const;
 
-    // Strips that fit at kMinChannelWidth given current width. Buses +
-    // master always reserved. Capped at kNumTracks.
+    // Comfortable strips that fit at kMinChannelWidth, with the explicit
+    // EightUp override once its 116 px floor is available. Buses + master
+    // are always reserved. Capped at kNumTracks.
     int  channelsThatFit() const;
 
     // Lets the parent compute fit/numBanks for a width it's about to

--- a/src/ui/DuskMenuBar.h
+++ b/src/ui/DuskMenuBar.h
@@ -47,6 +47,11 @@ public:
 
     void resized() override { rebuildHits(); }
 
+    int getRequiredWidth() const noexcept
+    {
+        return hits.empty() ? 0 : hits.back().getRight();
+    }
+
     void mouseMove (const juce::MouseEvent& e) override
     {
         const int newHover = hitTest (e.getPosition());

--- a/src/ui/DuskStudioLookAndFeel.h
+++ b/src/ui/DuskStudioLookAndFeel.h
@@ -66,6 +66,19 @@ public:
     {
         return juce::Font (juce::FontOptions (16.0f));
     }
+
+    juce::Label* createSliderTextBox (juce::Slider& slider) override
+    {
+        auto* label = juce::LookAndFeel_V4::createSliderTextBox (slider);
+        if ((bool) slider.getProperties().getWithDefault (
+                "dusk_compactValueText", false))
+        {
+            label->setFont (juce::Font (juce::FontOptions (10.5f)));
+            label->setMinimumHorizontalScale (0.45f);
+        }
+        return label;
+    }
+
     juce::Font getPopupMenuFont() override
     {
         return juce::Font (juce::FontOptions (18.5f));
@@ -302,9 +315,11 @@ public:
         const auto range = slider.getNormalisableRange();
         const float padTopBot = 0.0f;   // bounds already inset
         const float trackH = bounds.getHeight() - padTopBot * 2.0f;
-        // Per-slider opt-in via "dusk_drawFaderScaleLabels" property -
-        // hardware-fader grammar: ticks extend further, dB drawn left of
-        // tick, "off" replaces "90" at the bottom.
+        // Per-slider opt-in via "dusk_drawFaderScaleLabels" property.
+        // The scale text is painted by the parent immediately to the left,
+        // so these hardware-style ticks extend right but stop short on the
+        // label side. Child sliders paint after their parent; symmetric long
+        // ticks would otherwise strike through the already-painted numbers.
         const bool drawScaleLabels = (bool) slider.getProperties()
             .getWithDefault ("dusk_drawFaderScaleLabels", false);
 
@@ -315,11 +330,13 @@ public:
             const float prop = (float) range.convertTo0to1 (t.db);
             const float tickY = bounds.getBottom() - padTopBot - prop * trackH;
             const bool isZero = (std::abs (t.db) < 0.01f);
-            const float xOver = drawScaleLabels ? (isZero ? 24.0f : 20.0f)
-                                                : (isZero ? 6.0f  : 3.0f);
+            const float leftOver = drawScaleLabels ? (isZero ? 4.0f : 3.0f)
+                                                   : (isZero ? 6.0f : 3.0f);
+            const float rightOver = drawScaleLabels ? (isZero ? 16.0f : 12.0f)
+                                                    : leftOver;
             g.setColour (isZero ? juce::Colour (0x90ffffff) : juce::Colour (0x40ffffff));
-            g.drawLine (trackRect.getX() - xOver, tickY,
-                         trackRect.getRight() + xOver, tickY,
+            g.drawLine (trackRect.getX() - leftOver, tickY,
+                         trackRect.getRight() + rightOver, tickY,
                          isZero ? 1.2f : 0.7f);
 
             // Labels not drawn here - strip is too narrow without

--- a/src/ui/EmbeddedModal.h
+++ b/src/ui/EmbeddedModal.h
@@ -297,6 +297,8 @@ public:
         const auto bounds = parent.getLocalBounds();
         const int w = std::max (1, body_->getWidth());
         const int h = std::max (1, body_->getHeight());
+        ownedPreferredBodyWidth = w;
+        ownedPreferredBodyHeight = h;
         const auto bodyBounds = bounds.withSizeKeepingCentre (
             std::min (w, bounds.getWidth()  - 16),
             std::min (h, bounds.getHeight() - 16));
@@ -461,6 +463,7 @@ public:
             userOnDismiss = {};
             userOnDismissOutside = {};
             borrowedHostResized = {};
+            ownedBodyScaleInvariant = false;
             return;
         }
 
@@ -551,6 +554,7 @@ public:
         userOnDismiss = {};
         userOnDismissOutside = {};
         borrowedHostResized = {};
+        ownedBodyScaleInvariant = false;
     }
 
     // Shutdown-only teardown. close() defers body destruction to the
@@ -593,6 +597,7 @@ public:
         userOnDismiss = {};
         userOnDismissOutside = {};
         borrowedHostResized = {};
+        ownedBodyScaleInvariant = false;
     }
 
     bool isOpen() const noexcept { return body_ != nullptr || borrowedBody_ != nullptr; }
@@ -635,6 +640,79 @@ public:
         // the old, smaller frame behind it.
         if (backdrop_ != nullptr)
             backdrop_->setBounds (body->getBounds().expanded (kBackdropMargin));
+    }
+
+    // Keep an owned modal at the physical size it had when opened while the
+    // app's global UI scale changes. This lets a settings panel remain a stable
+    // control surface while the DAW behind it previews each zoom value.
+    void setOwnedBodyScaleInvariant (bool invariant)
+    {
+        if (body_ == nullptr) return;
+        ownedBodyScaleInvariant = invariant;
+        ownedBodyReferenceGlobalScale = std::max (
+            0.01f, juce::Desktop::getInstance().getGlobalScaleFactor());
+        refitOwnedBodyToHost();
+    }
+
+    // Owning bodies such as the Audio Settings scrolling host have a preferred
+    // size but must shrink and re-centre when their host changes logical size.
+    // When physical-scale invariance is enabled, an inverse component transform
+    // cancels the app zoom for both the body and its frame.
+    void refitOwnedBodyToHost()
+    {
+        if (body_ == nullptr || host == nullptr) return;
+
+        const auto bounds = host->getLocalBounds();
+        const int preferredW = std::max (1, ownedPreferredBodyWidth);
+        const int preferredH = std::max (1, ownedPreferredBodyHeight);
+
+        if (ownedBodyScaleInvariant)
+        {
+            const float currentGlobalScale = std::max (
+                0.01f, juce::Desktop::getInstance().getGlobalScaleFactor());
+            const float inverseZoom = ownedBodyReferenceGlobalScale
+                                    / currentGlobalScale;
+            const float availableW = (float) std::max (1, bounds.getWidth()  - 16);
+            const float availableH = (float) std::max (1, bounds.getHeight() - 16);
+            const float fittedScale = std::min (
+                { inverseZoom, availableW / (float) preferredW,
+                               availableH / (float) preferredH });
+            const float visualW = (float) preferredW * fittedScale;
+            const float visualH = (float) preferredH * fittedScale;
+            const float visualX = (float) bounds.getCentreX() - visualW * 0.5f;
+            const float visualY = (float) bounds.getCentreY() - visualH * 0.5f;
+
+            body_->setBounds (0, 0, preferredW, preferredH);
+            body_->setTransform (juce::AffineTransform (
+                fittedScale, 0.0f, visualX,
+                0.0f, fittedScale, visualY));
+
+            if (backdrop_ != nullptr)
+            {
+                const int framedW = preferredW + kBackdropMargin * 2;
+                const int framedH = preferredH + kBackdropMargin * 2;
+                backdrop_->setBounds (0, 0, framedW, framedH);
+                backdrop_->setTransform (juce::AffineTransform (
+                    fittedScale, 0.0f, visualX - kBackdropMargin * fittedScale,
+                    0.0f, fittedScale, visualY - kBackdropMargin * fittedScale));
+            }
+            if (dim_ != nullptr)
+                dim_->setBounds (bounds);
+            return;
+        }
+
+        body_->setTransform ({});
+        if (backdrop_ != nullptr)
+            backdrop_->setTransform ({});
+        const auto bodyBounds = bounds.withSizeKeepingCentre (
+            std::min (preferredW, std::max (1, bounds.getWidth()  - 16)),
+            std::min (preferredH, std::max (1, bounds.getHeight() - 16)));
+
+        body_->setBounds (bodyBounds);
+        if (backdrop_ != nullptr)
+            backdrop_->setBounds (bodyBounds.expanded (kBackdropMargin));
+        if (dim_ != nullptr)
+            dim_->setBounds (bounds);
     }
 
 private:
@@ -775,6 +853,9 @@ private:
     std::unique_ptr<DimOverlay> dim_;
     std::unique_ptr<Backdrop> backdrop_;
     std::unique_ptr<juce::Component> body_;
+    int ownedPreferredBodyWidth = 1;
+    int ownedPreferredBodyHeight = 1;
+    float ownedBodyReferenceGlobalScale = 1.0f;
     juce::Component* borrowedBody_ = nullptr;
     std::function<void()> userOnDismiss;
     std::function<void()> userOnDismissOutside;
@@ -783,6 +864,7 @@ private:
     bool escapeDismisses = true;
     bool forwardShortcuts_ = true;
     bool listeningForOutsideClicks = false;
+    bool ownedBodyScaleInvariant = false;
 
     // Plugin editors (OOP / XEmbed / GL-rendering hosts especially) paint
     // above the modal in the native window's z-order regardless of toFront(),

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -571,7 +571,7 @@ MainComponent::MainComponent()
     if (! musicDir.exists()) musicDir = juce::File::getSpecialLocation (juce::File::userHomeDirectory);
     session.setSessionDirectory (musicDir.getChildFile ("Dusk Studio").getChildFile ("Untitled"));
 
-    // Top-of-window menu bar drives File / Settings actions. Replaces the
+    // Top-of-window menu bar drives File / View / Settings actions. Replaces the
     // old row of TextButtons (Audio settings... / Save / Save As... / etc).
     menuBar.setModel (this);
     addAndMakeVisible (menuBar);
@@ -1521,18 +1521,23 @@ bool MainComponent::keyPressed (const juce::KeyPress& key)
         }
     }
 
-    // Window: F11 toggles fullscreen. Walks up to the parent
-    // ResizableWindow because that's the layer that owns the OS window
-    // state, not MainComponent itself.
+    // Window: F11 and View > Full Screen share the same path.
     if (key == juce::KeyPress::F11Key)
-    {
-        if (auto* window = findParentComponentOfClass<juce::ResizableWindow>())
-        {
-            window->setFullScreen (! window->isFullScreen());
-            return true;
-        }
-    }
+        return toggleFullScreen();
 
+    return false;
+}
+
+bool MainComponent::toggleFullScreen()
+{
+    // MainComponent owns the menu and shortcuts, while the parent
+    // ResizableWindow owns the native OS state. Keeping the transition here
+    // gives View and F11 identical peer-recreation behaviour.
+    if (auto* window = findParentComponentOfClass<juce::ResizableWindow>())
+    {
+        window->setFullScreen (! window->isFullScreen());
+        return true;
+    }
     return false;
 }
 
@@ -1666,12 +1671,13 @@ void MainComponent::resized()
     auto area = getLocalBounds().reduced (8);
 
     // Top menu row. Grown to host the centered stage selector (RECORDING /
-    // MIXING / MASTERING / AUX). File / Settings menu on the left, system meters
+    // MIXING / MASTERING / AUX). File / View / Settings menus on the left, system meters
     // on the right; the stage selector and the session status text are placed
     // below, once the stage-tab width is known.
     constexpr int kMenuRowH = 32;
     const auto menuRow = area.removeFromTop (kMenuRowH);
-    menuBar.setBounds (menuRow.withWidth (200));
+    const int kMenuBarW = menuBar.getRequiredWidth();
+    menuBar.setBounds (menuRow.withWidth (kMenuBarW));
     if (systemStatusBar != nullptr)
         systemStatusBar->setBounds (menuRow.withTrimmedLeft (menuRow.getWidth() - 300));
     area.removeFromTop (4);
@@ -1735,7 +1741,7 @@ void MainComponent::resized()
     constexpr int kBankBtnH  = 26;
 
     // Stage selector lives in the TOP menu row, centered between the File /
-    // Settings menu and the system meters. The session status text fills the
+    // View / Settings menus and the system meters. The session status text fills the
     // gap to its left. (stageW / stageBlockW were computed above with the
     // transport metrics so the tabs follow the same compact breakpoint.)
     // stageCentreX is reused below to centre the bank / toolbar group directly
@@ -1743,7 +1749,7 @@ void MainComponent::resized()
     int stageCentreX = rowBounds.getCentreX();
     {
         const int menuStageY   = menuRow.getY() + (menuRow.getHeight() - kStageBtnH) / 2;
-        const int menuLeftPad  = menuRow.getX() + 200 + 12;            // past File / Settings
+        const int menuLeftPad  = menuRow.getX() + kMenuBarW + 12;      // past File / View / Settings
         const int menuRightPad = menuRow.getRight()
                                    - (systemStatusBar != nullptr ? 300 + 12 : 0);
         int stageX = menuRow.getX() + (menuRow.getWidth() - stageBlockW) / 2;
@@ -1945,6 +1951,12 @@ void MainComponent::resized()
         }
     }
    #endif
+
+    // A live UI-scale preview changes this component's logical dimensions
+    // while the native window keeps the same physical rectangle. Refit the
+    // settings host using its inverse transform so the modal remains visually
+    // stable while only the DAW behind it changes scale.
+    audioSettingsModal.refitOwnedBodyToHost();
 }
 
 void MainComponent::refreshSnapUi()
@@ -1988,7 +2000,10 @@ void MainComponent::showSnapResolutionMenu()
 void MainComponent::setTimelineVisible (bool show)
 {
     tapeStripExpanded = show;
-    if (tapeStrip    != nullptr) tapeStrip->setVisible (show);
+    const auto stage = engine.getStage();
+    const bool inFullscreenView = stage == AudioEngine::Stage::Mastering
+                               || stage == AudioEngine::Stage::Aux;
+    if (tapeStrip    != nullptr) tapeStrip->setVisible (show && ! inFullscreenView);
     if (consoleView  != nullptr) consoleView->setStripsCompactMode (show);
     if (transportBar != nullptr) transportBar->setTapeToggleVisualState (show);
     resized();
@@ -2060,6 +2075,7 @@ void MainComponent::openAudioSettings()
             self->startTimer (appconfig::getAutosaveIntervalSeconds() * 1000);
         }
     });
+    audioSettingsModal.setOwnedBodyScaleInvariant (true);
 }
 
 void MainComponent::openShortcuts()
@@ -4540,6 +4556,8 @@ enum MenuItemId
     // value, indexed off this base). Stays well above the file-action IDs
     // so future additions don't collide.
     kMenuFileTemplateBase = 1200,
+    kMenuViewFullScreen = 3001,
+    kMenuViewTimeline   = 3002,
     kMenuSettingsAudio = 2001,
     kMenuSettingsAbout = 2002,
     kMenuSettingsShortcuts = 2003,
@@ -4549,7 +4567,7 @@ enum MenuItemId
 
 juce::StringArray MainComponent::getMenuBarNames()
 {
-    return { "File", "Settings" };
+    return { "File", "View", "Settings" };
 }
 
 juce::PopupMenu MainComponent::getMenuForIndex (int topLevelMenuIndex,
@@ -4645,7 +4663,19 @@ juce::PopupMenu MainComponent::getMenuForIndex (int topLevelMenuIndex,
         addAccel (kMenuFileQuit, "Quit", 'Q',
                   juce::ModifierKeys::commandModifier);
     }
-    else if (topLevelMenuIndex == 1)   // Settings
+    else if (topLevelMenuIndex == 1)   // View
+    {
+        const auto* peer = getPeer();
+        const bool isFullScreen = peer != nullptr && peer->isFullScreen();
+        menu.addItem (kMenuViewFullScreen, "Full Screen", true, isFullScreen);
+        menu.addSeparator();
+        const auto stage = engine.getStage();
+        const bool timelineAvailable = stage != AudioEngine::Stage::Mastering
+                                    && stage != AudioEngine::Stage::Aux;
+        menu.addItem (kMenuViewTimeline, "Show Timeline",
+                      timelineAvailable, tapeStripExpanded);
+    }
+    else if (topLevelMenuIndex == 2)   // Settings
     {
         menu.addItem (kMenuSettingsAudio, "Settings...");
         menu.addItem (kMenuSettingsShortcuts, "Keyboard Shortcuts  (?)");
@@ -4755,6 +4785,8 @@ void MainComponent::menuItemSelected (int menuItemID, int /*topLevelMenuIndex*/)
             if (auto* app = juce::JUCEApplicationBase::getInstance())
                 app->systemRequestedQuit();
             break;
+        case kMenuViewFullScreen: toggleFullScreen(); break;
+        case kMenuViewTimeline: setTimelineVisible (! tapeStripExpanded); break;
         case kMenuSettingsAudio: openAudioSettings();   break;
         case kMenuSettingsShortcuts: openShortcuts();   break;
        #if DUSKSTUDIO_HAS_PATREON_CREDITS

--- a/src/ui/MainComponent.h
+++ b/src/ui/MainComponent.h
@@ -73,6 +73,7 @@ private:
     void openAudioSettings();
     void openBounceDialog();
     void openBounceStemsDialog();
+    bool toggleFullScreen();
     // Hardware inserts print dry offline; when the session has any, ask
     // whether to bounce in realtime instead. launch receives the choice.
     void askBounceRealtime (std::function<void (bool realtime)> launch);

--- a/src/ui/MasterStripComponent.cpp
+++ b/src/ui/MasterStripComponent.cpp
@@ -677,21 +677,21 @@ MasterStripComponent::MasterStripComponent (MasterBusParams& p,
     const auto pultecGold  = pultecBlack;   // legacy variable name; now black
     const auto compGold    = juce::Colour (0xff7da8c5);   // SSL G-bus comp powder blue (legacy var name)
 
-    // EQ header - shared CompHeaderButton pill (green LED + bold label).
-    // Left-click toggles; right-click opens the EQ section menu; double-
-    // click opens the editor (matches COMP / TAPE + channel + bus).
-    eqHeaderBtn = std::make_unique<CompHeaderButton> (
-        /*getEnabled*/ [this] { return params.eqEnabled.load (std::memory_order_relaxed); },
-        /*onToggle*/   [this]
+    // Split EQ header: the status hitbox toggles bypass and the label opens
+    // the editor. Right-clicking either side opens the section menu.
+    eqHeaderBtn = std::make_unique<SplitModuleButton> ("EQ");
+    eqHeaderBtn->setAccentColour (juce::Colour (0xff5fc46f));
+    eqHeaderBtn->setCallbacks (
+        [this] { return ! params.eqEnabled.load (std::memory_order_relaxed); },
+        [this]
                         {
                             const bool now = ! params.eqEnabled.load (std::memory_order_relaxed);
                             params.eqEnabled.store (now, std::memory_order_release);
-                            if (eqHeaderBtn != nullptr) eqHeaderBtn->repaint();
+                            if (eqHeaderBtn != nullptr) eqHeaderBtn->refresh();
                         },
-        /*onPick*/       [this] { showEqSectionMenu(); },
-        /*onDoubleClick*/[this] { openEqEditorPopup(); });
-    eqHeaderBtn->setLabelText ("EQ");
-    eqHeaderBtn->setTooltip ("Left-click EQ on/off. Right-click for the EQ menu. Double-click to open the editor.");
+        [this] { openEqEditorPopup(); },
+        [this] { showEqSectionMenu(); });
+    eqHeaderBtn->setTooltip ("Click the status light to bypass/engage EQ; click EQ to open the editor; right-click for the EQ menu.");
     addAndMakeVisible (eqHeaderBtn.get());
 
     // Suffixes intentionally empty - section labels already convey the
@@ -721,7 +721,7 @@ MasterStripComponent::MasterStripComponent (MasterBusParams& p,
     {
         params.eqEnabled.store (true, std::memory_order_release);
         // Repaint the header so the LED reflects the auto-armed state.
-        if (eqHeaderBtn != nullptr) eqHeaderBtn->repaint();
+        if (eqHeaderBtn != nullptr) eqHeaderBtn->refresh();
     };
     eqLfBoost   .onValueChange = [this, armMasterEq] { params.eqLfBoost     .store ((float) eqLfBoost   .getValue(), std::memory_order_relaxed); armMasterEq(); };
     eqLfAtten   .onValueChange = [this, armMasterEq] { params.eqLfAtten     .store ((float) eqLfAtten   .getValue(), std::memory_order_relaxed); armMasterEq(); };
@@ -821,24 +821,25 @@ MasterStripComponent::MasterStripComponent (MasterBusParams& p,
     addAndMakeVisible (eqHfBoostFreqLabel);
     addAndMakeVisible (eqHfAttenFreqLabel);
 
-    // Comp section. Same shell as bus + channel strips:
-    //   - CompHeaderButton (white text, green LED, left-click toggles
-    //     enable). No mode picker - fixed SSL-style glue topology.
+    // Comp section. The split header matches the bus + channel strips; the
+    // processor remains a fixed SSL-style glue topology.
     //   - CompMeterStrip on the LEFT (triangle-handle threshold, IN bar
     //     + dB scale + GR bar). Threshold drag writes compThreshDb.
     //   - Knob grid (RAT / MAK on top, ATK / REL on bottom) on the
     //     RIGHT. The standalone THR knob is gone.
-    compHeaderBtn = std::make_unique<CompHeaderButton> (
-        /*getEnabled*/ [this] { return params.compEnabled.load (std::memory_order_relaxed); },
-        /*onToggle*/   [this]
+    compHeaderBtn = std::make_unique<SplitModuleButton> ("COMP");
+    compHeaderBtn->setAccentColour (compGold);
+    compHeaderBtn->setCallbacks (
+        [this] { return ! params.compEnabled.load (std::memory_order_relaxed); },
+        [this]
                         {
                             const bool now = ! params.compEnabled.load (std::memory_order_relaxed);
                             params.compEnabled.store (now, std::memory_order_relaxed);
-                            if (compHeaderBtn != nullptr) compHeaderBtn->repaint();
+                            if (compHeaderBtn != nullptr) compHeaderBtn->refresh();
                         },
-        /*onPick*/       [this] { showCompSectionMenu(); },
-        /*onDoubleClick*/[this] { openCompEditorPopup(); });
-    compHeaderBtn->setTooltip ("Left-click comp on/off. Right-click for the COMP menu. Double-click to open the editor.");
+        [this] { openCompEditorPopup(); },
+        [this] { showCompSectionMenu(); });
+    compHeaderBtn->setTooltip ("Click the status light to bypass/engage compression; click COMP to open the editor; right-click for the COMP menu.");
     addAndMakeVisible (compHeaderBtn.get());
 
     CompMeterStrip::Source compSrc;
@@ -863,7 +864,7 @@ MasterStripComponent::MasterStripComponent (MasterBusParams& p,
     compSrc.autoEnable     = [this]
                               {
                                   params.compEnabled.store (true, std::memory_order_relaxed);
-                                  if (compHeaderBtn != nullptr) compHeaderBtn->repaint();
+                                  if (compHeaderBtn != nullptr) compHeaderBtn->refresh();
                               };
     // Fader-side GR LED (matches channel + bus grammar). Slim GR-only widget
     // with the threshold-drag handle on the right side, glued next to the
@@ -912,41 +913,30 @@ MasterStripComponent::MasterStripComponent (MasterBusParams& p,
     addAndMakeVisible (compRatio);    addAndMakeVisible (compAttack);
     addAndMakeVisible (compRelease);  addAndMakeVisible (compMakeup);
 
-    // Compact placeholder buttons (hidden until setCompactMode(true)).
-    auto styleCompactSectionBtn = [] (juce::TextButton& b, juce::Colour accent)
-    {
-        b.setColour (juce::TextButton::buttonColourId,   juce::Colour (0xff282830));
-        b.setColour (juce::TextButton::buttonOnColourId, accent.withMultipliedAlpha (0.85f));
-        b.setColour (juce::TextButton::textColourOffId,  accent.withMultipliedBrightness (0.8f));
-        b.setColour (juce::TextButton::textColourOnId,   juce::Colours::white);
-        b.setMouseClickGrabsKeyboardFocus (false);
-        b.setClickingTogglesState (false);
-    };
-    styleCompactSectionBtn (eqCompactButton,   juce::Colour (0xff5fc46f));
-    styleCompactSectionBtn (compCompactButton, juce::Colour (0xffe0c050));
-    eqCompactButton  .setTooltip ("Left-click EQ on/off. Right-click for the EQ menu. Double-click to open the editor.");
-    compCompactButton.setTooltip ("Left-click comp on/off. Right-click for the COMP menu. Double-click to open the editor.");
-    // Identical grammar to the expanded headers: left-click toggles, right-click
-    // opens the section menu, double-click opens the editor.
-    eqCompactButton.onClick = [this]
-    {
-        const bool now = ! params.eqEnabled.load (std::memory_order_relaxed);
-        params.eqEnabled.store (now, std::memory_order_release);
-        eqCompactButton.setToggleState (now, juce::dontSendNotification);
-    };
-    eqCompactButton.onRightClick  = [this] (const juce::MouseEvent&) { showEqSectionMenu(); };
-    eqCompactButton.onDoubleClick = [this] { openEqEditorPopup(); };
-    eqCompactButton.setToggleState (params.eqEnabled.load (std::memory_order_relaxed), juce::dontSendNotification);
-
-    compCompactButton.onClick = [this]
-    {
-        const bool now = ! params.compEnabled.load (std::memory_order_relaxed);
-        params.compEnabled.store (now, std::memory_order_relaxed);
-        compCompactButton.setToggleState (now, juce::dontSendNotification);
-    };
-    compCompactButton.onRightClick  = [this] (const juce::MouseEvent&) { showCompSectionMenu(); };
-    compCompactButton.onDoubleClick = [this] { openCompEditorPopup(); };
-    compCompactButton.setToggleState (params.compEnabled.load (std::memory_order_relaxed), juce::dontSendNotification);
+    // Compact buttons share the exact split hitboxes with the expanded
+    // headers and keep the established EQ/COMP accent colours.
+    eqCompactButton.setAccentColour (juce::Colour (0xff5fc46f));
+    compCompactButton.setAccentColour (juce::Colour (0xffe0c050));
+    eqCompactButton.setCallbacks (
+        [this] { return ! params.eqEnabled.load (std::memory_order_relaxed); },
+        [this]
+        {
+            const bool now = ! params.eqEnabled.load (std::memory_order_relaxed);
+            params.eqEnabled.store (now, std::memory_order_release);
+        },
+        [this] { openEqEditorPopup(); },
+        [this] { showEqSectionMenu(); });
+    compCompactButton.setCallbacks (
+        [this] { return ! params.compEnabled.load (std::memory_order_relaxed); },
+        [this]
+        {
+            const bool now = ! params.compEnabled.load (std::memory_order_relaxed);
+            params.compEnabled.store (now, std::memory_order_relaxed);
+        },
+        [this] { openCompEditorPopup(); },
+        [this] { showCompSectionMenu(); });
+    eqCompactButton  .setTooltip ("Click the light to bypass/engage EQ; click EQ to open the editor; right-click for the EQ menu.");
+    compCompactButton.setTooltip ("Click the light to bypass/engage compression; click COMP to open the editor; right-click for the COMP menu.");
     addChildComponent (eqCompactButton);
     addChildComponent (compCompactButton);
 
@@ -957,11 +947,9 @@ MasterStripComponent::MasterStripComponent (MasterBusParams& p,
     addAndMakeVisible (compRatLabel); addAndMakeVisible (compAtkLabel);
     addAndMakeVisible (compRelLabel); addAndMakeVisible (compMakLabel);
 
-    // TAPE pill (compact / tape-strip mode only) - identical grammar to the
-    // EQ / COMP compact pills and the regular-mode tapeHeaderBtn: left-click
-    // toggles tapeEnabled, right-click opens the section menu, double-click
-    // opens the editor. Lit state still reflects the tapeEnabled atom (synced
-    // from timerCallback) so the engine's auto-arm-on-edit shows up.
+    // TAPE pill (compact / tape-strip mode only) retains its existing grammar:
+    // left-click toggles tapeEnabled, right-click opens the section menu, and
+    // double-click opens the editor. Lit state reflects the tapeEnabled atom.
     {
         const auto tapeAccent = juce::Colour (0xffd0a060);
         tapeButton.setColour (juce::TextButton::buttonColourId,   juce::Colour (0xff282830));
@@ -973,8 +961,9 @@ MasterStripComponent::MasterStripComponent (MasterBusParams& p,
         tapeButton.setToggleState (params.tapeEnabled.load (std::memory_order_relaxed),
                                     juce::dontSendNotification);
         tapeButton.setTooltip ("Left-click tape on/off. Right-click for the TAPE menu. Double-click to open the editor.");
-        // Identical grammar to the expanded headers + the EQ/COMP pills: left-click
-        // toggles, right-click opens the section menu, double-click opens the editor.
+        // Tape carries toggle, menu and editor on one target, so it keeps the
+        // double-click gesture. EQ and COMP split the status light and the
+        // label into separate hitboxes instead.
         tapeButton.onClick = [this]
         {
             const bool now = ! params.tapeEnabled.load (std::memory_order_relaxed);
@@ -986,9 +975,9 @@ MasterStripComponent::MasterStripComponent (MasterBusParams& p,
         addAndMakeVisible (tapeButton);
     }
 
-    // Regular-mode TAPE header - CompHeaderButton (LED + label). Left-click
-    // toggles enable (matches the EQ / COMP headers); right-click opens the
-    // TAPE section menu; double-click opens the editor (tape has no inline
+    // Regular-mode TAPE header keeps its legacy CompHeaderButton grammar.
+    // Left-click toggles enable, right-click opens the TAPE section menu,
+    // and double-click opens the editor (tape has no inline
     // controls, so the popup is its only editor). The LED reflects
     // tapeEnabled. setCompactMode swaps visibility between this header and
     // the compact tapeButton pill above.
@@ -1141,30 +1130,17 @@ void MasterStripComponent::timerCallback()
     // section is engaged so TIMELINE users still see at-a-glance state.
     if (compactMode)
     {
-        const auto eqAccent   = juce::Colour (0xff5fc46f);
-        const auto compAccent = juce::Colour (0xffe0c050);
         const int eqOn   = params.eqEnabled  .load (std::memory_order_relaxed) ? 1 : 0;
         const int compOn = params.compEnabled.load (std::memory_order_relaxed) ? 1 : 0;
         if (eqOn != lastCompactEqOn)
         {
             lastCompactEqOn = eqOn;
-            // Track the atom, not the last click: EQ enable can change via the popup
-            // editor / MIDI without touching this button. The toggle state drives the
-            // lit (buttonOnColourId) appearance.
-            eqCompactButton.setToggleState (eqOn != 0, juce::dontSendNotification);
-            eqCompactButton.setColour (juce::TextButton::buttonColourId,
-                                         eqOn != 0 ? eqAccent.darker (0.55f)
-                                                    : juce::Colour (0xff282830));
-            eqCompactButton.repaint();
+            eqCompactButton.refresh();
         }
         if (compOn != lastCompactCompOn)
         {
             lastCompactCompOn = compOn;
-            compCompactButton.setToggleState (compOn != 0, juce::dontSendNotification);
-            compCompactButton.setColour (juce::TextButton::buttonColourId,
-                                           compOn != 0 ? compAccent.darker (0.55f)
-                                                        : juce::Colour (0xff282830));
-            compCompactButton.repaint();
+            compCompactButton.refresh();
         }
     }
 
@@ -1254,9 +1230,10 @@ void MasterStripComponent::timerCallback()
     }
     {
         const bool eqOn = params.eqEnabled.load (std::memory_order_relaxed);
-        if (eqHeaderBtn != nullptr) eqHeaderBtn->repaint();   // LED reflects atom
+        if (eqHeaderBtn != nullptr) eqHeaderBtn->refresh();   // LED reflects atom
         (void) eqOn;
     }
+    if (compHeaderBtn != nullptr) compHeaderBtn->refresh();
     {
         // TAPE pill state - sync toggle from atom so MIDI bind / future
         // automation reflects the lit state.
@@ -1808,8 +1785,8 @@ void MasterStripComponent::resized()
 
     // TAPE row - compact mode uses the pill-style tapeButton (click
     // opens editor, atom drives lit state); regular mode swaps in
-    // tapeHeaderBtn (CompHeaderButton with green LED, matches the EQ
-    // / COMP header grammar). Visibility set in setCompactMode.
+    // tapeHeaderBtn (legacy CompHeaderButton with a green LED).
+    // Visibility is set in setCompactMode.
     // Compact size matches the master EQ + COMP pills above
     // (20h × reduced(4,0)) so the three-pill stack reads as one
     // visual unit; non-compact tapeHeaderBtn keeps its taller native
@@ -1839,8 +1816,8 @@ void MasterStripComponent::resized()
 
     // Centred [fader | level meter | GR LED] cluster - fader-side grammar
     // matching channel + bus strips, but centred in the (wider) master strip
-    // instead of right-pinned. Scale labels drawn by paint() to the LEFT of
-    // the slider's track via kSharedXOver math. No separate carved column.
+    // instead of right-pinned. Scale labels are drawn by paint() to the LEFT
+    // of the slider's track, with no separate carved column.
     constexpr int kMeterW          = 16;
     constexpr int kGrLedW          = 20;
     constexpr int kMeterToGrGap    = 1;
@@ -2061,7 +2038,7 @@ void MasterStripComponent::resetEqSection()
     reset (eqHfBoostFreqKnob);
     reset (eqHfAttenFreqKnob);
     params.eqEnabled.store (wasEnabled, std::memory_order_release);
-    if (eqHeaderBtn != nullptr) eqHeaderBtn->repaint();
+    if (eqHeaderBtn != nullptr) eqHeaderBtn->refresh();
 }
 
 void MasterStripComponent::resetCompSection()
@@ -2075,6 +2052,6 @@ void MasterStripComponent::resetCompSection()
     };
     reset (compRatio);  reset (compAttack);
     reset (compRelease); reset (compMakeup);
-    if (compHeaderBtn != nullptr) compHeaderBtn->repaint();
+    if (compHeaderBtn != nullptr) compHeaderBtn->refresh();
 }
 } // namespace duskstudio

--- a/src/ui/MasterStripComponent.h
+++ b/src/ui/MasterStripComponent.h
@@ -9,6 +9,7 @@
 #include "DuskComboBox.h"
 #include "EmbeddedModal.h"
 #include "SectionPillButton.h"
+#include "SplitModuleButton.h"
 #include "../foundation/MessageThread.h"
 
 namespace duskstudio
@@ -47,9 +48,9 @@ private:
 
     // Pultec-style Tube EQ. Inline matches the popup editor so on-strip
     // dialling and modal-open dialling see the same controls.
-    // Header pill = shared CompHeaderButton (green LED + bold label).
-    // Single Pultec topology - no right-click mode picker.
-    std::unique_ptr<CompHeaderButton> eqHeaderBtn;
+    // Split header shared with the channel and bus strips. Single Pultec
+    // topology - no right-click mode picker.
+    std::unique_ptr<SplitModuleButton> eqHeaderBtn;
     juce::Slider     eqLfBoost   { juce::Slider::RotaryHorizontalVerticalDrag, juce::Slider::TextBoxBelow };
     juce::Slider     eqLfAtten   { juce::Slider::RotaryHorizontalVerticalDrag, juce::Slider::TextBoxBelow };
     juce::Slider     eqHfBoost   { juce::Slider::RotaryHorizontalVerticalDrag, juce::Slider::TextBoxBelow };
@@ -69,10 +70,10 @@ private:
     juce::Label      eqLfFreqLabel;
     juce::Label      eqHfBoostFreqLabel, eqHfAttenFreqLabel;
 
-    // Same shell as channel + bus strips: CompHeaderButton top,
+    // Same shell as channel + bus strips: split module button on top,
     // CompMeterStrip (triangle-handle threshold) left, knob grid right.
     // Fixed SSL-style glue topology - no mode picker.
-    std::unique_ptr<CompHeaderButton> compHeaderBtn;
+    std::unique_ptr<SplitModuleButton> compHeaderBtn;
     std::unique_ptr<CompMeterStrip>   compMeter;
     juce::Slider     compRatio     { juce::Slider::RotaryHorizontalVerticalDrag, juce::Slider::TextBoxBelow };
     juce::Slider     compAttack    { juce::Slider::RotaryHorizontalVerticalDrag, juce::Slider::TextBoxBelow };
@@ -86,9 +87,8 @@ private:
     // The lit state is driven by the tapeEnabled atom (synced from the 30 Hz
     // timer) so the panel's arm-on-touch is still reflected here.
     SectionPillButton tapeButton { "TAPE" };
-    // Expanded-mode header: shared CompHeaderButton (matches EQ/COMP
-    // grammar). Left toggles, right opens the section menu, double-click
-    // opens the tape panel.
+    // Expanded-mode TAPE header keeps the legacy grammar: left-click
+    // toggles, right-click opens the menu, and double-click opens the panel.
     std::unique_ptr<CompHeaderButton> tapeHeaderBtn;
     void openTapeMachineModal();
     std::unique_ptr<class DimOverlay> tapeMachineDim;
@@ -120,8 +120,8 @@ private:
     juce::Rectangle<int> eqArea;
     juce::Rectangle<int> compArea;
     juce::Rectangle<int> tapeArea;   // framed band behind the TAPE header (regular mode)
-    SectionPillButton eqCompactButton  { "EQ"   };
-    SectionPillButton compCompactButton { "COMP" };
+    SplitModuleButton eqCompactButton  { "EQ"   };
+    SplitModuleButton compCompactButton { "COMP" };
     EmbeddedModal eqEditorModal;
     EmbeddedModal compEditorModal;
     void openEqEditorPopup();

--- a/src/ui/NativeNotepadWindow.cpp
+++ b/src/ui/NativeNotepadWindow.cpp
@@ -29,6 +29,8 @@ namespace
 constexpr float kContentWidth = 760.0f;
 constexpr float kHeaderHeight = 62.0f;
 constexpr float kRibbonHeight = 62.0f;
+constexpr float kToolbarButtonLabelPadding = 18.0f;
+constexpr float kToolbarButtonMinWidth = 34.0f;
 
 // DejaVu Sans covers these ranges in the embedded fallback. Platform fonts can
 // contribute additional glyphs, but the editor never intentionally truncates
@@ -83,6 +85,25 @@ ImVec4 colour (unsigned int hex)
                    (hex & 0xff) / 255.0f);
 }
 
+float toolbarButtonWidth (const char* label)
+{
+    return std::max (kToolbarButtonMinWidth,
+                     ImGui::CalcTextSize (label, nullptr, true).x
+                         + kToolbarButtonLabelPadding);
+}
+
+int resizeMarkdownBuffer (ImGuiInputTextCallbackData* data)
+{
+    if (data == nullptr || data->EventFlag != ImGuiInputTextFlags_CallbackResize
+        || data->UserData == nullptr)
+        return 0;
+
+    auto& buffer = *static_cast<std::string*> (data->UserData);
+    buffer.resize (static_cast<std::size_t> (std::max (0, data->BufTextLen)));
+    data->Buf = buffer.data();
+    return 0;
+}
+
 } // namespace
 
 struct NativeNotepadWindow::Impl final : private dusk::Timer
@@ -111,6 +132,11 @@ struct NativeNotepadWindow::Impl final : private dusk::Timer
 
         bool onKeyboard (const DGL::Widget::KeyboardEvent& event) override
         {
+            // ImGui's multiline input treats Escape as "revert to activation",
+            // which can discard a complete Markdown-source editing pass. In
+            // source view Escape closes through the normal deferred save path.
+            if (owner.handleMarkdownEscape (event))
+                return true;
             if (owner.handleChordEntryNavigation (event))
                 return true;
             return DGL::ImGuiTopLevelWidget::onKeyboard (event);
@@ -209,6 +235,9 @@ struct NativeNotepadWindow::Impl final : private dusk::Timer
         document.setMarkdown (markdown);
         editor.reset ({ 0, 0 });
         editor.requestFocus();
+        markdownView = false;
+        markdownEntrySnapshot.reset();
+        markdownFocusRequested = false;
         closeRequested = false;
         closeWasPumped = false;
         hasSessionFile = sessionExists;
@@ -293,6 +322,15 @@ struct NativeNotepadWindow::Impl final : private dusk::Timer
     }
 
 private:
+    bool handleMarkdownEscape (const DGL::Widget::KeyboardEvent& event)
+    {
+        if (! markdownView || event.key != DGL::kKeyEscape)
+            return false;
+        if (event.press)
+            close();
+        return true;
+    }
+
     bool handleChordEntryNavigation (const DGL::Widget::KeyboardEvent& event)
     {
         if (! editor.chordEntryActive())
@@ -406,15 +444,39 @@ private:
         return editor.blockStyle();
     }
 
+    void setMarkdownView (bool shouldShowMarkdown)
+    {
+        if (markdownView == shouldShowMarkdown)
+            return;
+
+        if (shouldShowMarkdown)
+        {
+            editor.closeChordEntry();
+            markdownBuffer = document.markdown();
+            markdownEntrySnapshot = currentSnapshot();
+            history.breakRun();
+            markdownView = true;
+            markdownFocusRequested = true;
+            return;
+        }
+
+        const auto documentEnd = document.documentText().size();
+        if (markdownEntrySnapshot.has_value()
+            && markdownEntrySnapshot->markdown != document.markdown())
+            history.record (notepad::EditKind::structural,
+                            std::move (*markdownEntrySnapshot), documentEnd);
+        markdownEntrySnapshot.reset();
+        markdownView = false;
+        editor.reset ({ documentEnd, documentEnd });
+        editor.requestFocus();
+    }
+
     bool toolbarButton (const char* label, const char* tooltip, bool active = false,
                         ImFont* labelFont = nullptr)
     {
         // The atlas is built at the display scale, so a fixed width clips its
         // own label the moment the font grows. Measure what is about to be
         // drawn instead - in the label's own font, and past the "##" id tail.
-        constexpr float kLabelPadding = 18.0f;
-        constexpr float kMinButtonWidth = 34.0f;
-
         if (active)
         {
             ImGui::PushStyleColor (ImGuiCol_Button, colour (notepad::kStagePalette.rule));
@@ -423,9 +485,7 @@ private:
         }
         if (labelFont != nullptr)
             ImGui::PushFont (labelFont);
-        const auto width = std::max (kMinButtonWidth,
-                                     ImGui::CalcTextSize (label, nullptr, true).x
-                                         + kLabelPadding);
+        const auto width = toolbarButtonWidth (label);
         const bool clicked = ImGui::Button (label, ImVec2 (width, 32.0f));
         if (labelFont != nullptr)
             ImGui::PopFont();
@@ -444,6 +504,18 @@ private:
         return clicked;
     }
 
+    void drawSourceToggle()
+    {
+        // The ribbon is the only chrome that survives into source view, so it
+        // carries the way back out as well as the way in. Escape closes the
+        // notepad rather than returning to the chart.
+        if (toolbarButton ("Source", markdownView
+                                       ? "Return to the chord chart"
+                                       : "Edit the notepad.md text directly",
+                           markdownView))
+            setMarkdownView (! markdownView);
+    }
+
     void drawRibbon (float height)
     {
         ImGui::PushStyleVar (ImGuiStyleVar_ChildRounding, 0.0f);
@@ -453,6 +525,22 @@ private:
                            ImGuiChildFlags_AlwaysUseWindowPadding,
                            ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
 
+        // Source view replaces the chart with a plain text field, so the chart
+        // controls have nothing to act on while it is up.
+        if (! markdownView)
+        {
+            drawChartControls();
+            ImGui::SameLine (0.0f, 16.0f);
+        }
+        drawSourceToggle();
+
+        ImGui::EndChild();
+        ImGui::PopStyleColor();
+        ImGui::PopStyleVar (2);
+    }
+
+    void drawChartControls()
+    {
         ImGui::BeginDisabled (! history.canUndo());
         if (toolbarButton ("↶", "Undo the last edit (Ctrl+Z)", false))
             restoreHistory (false);
@@ -522,10 +610,6 @@ private:
             document.setSpelling (NotepadDocument::Spelling::flats);
 
         drawSectionMenu();
-
-        ImGui::EndChild();
-        ImGui::PopStyleColor();
-        ImGui::PopStyleVar (2);
     }
 
     void drawSectionMenu()
@@ -585,6 +669,56 @@ private:
         ImGui::PopStyleColor();
     }
 
+    void drawMarkdownEditor (float height)
+    {
+        ImGui::PushStyleColor (ImGuiCol_ChildBg, colour (notepad::kStagePalette.shell));
+        ImGui::PushStyleVar (ImGuiStyleVar_WindowPadding, ImVec2 (22.0f, 18.0f));
+        ImGui::BeginChild ("markdown-workspace", ImVec2 (0.0f, height),
+                           ImGuiChildFlags_AlwaysUseWindowPadding,
+                           ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
+
+        const auto available = ImGui::GetContentRegionAvail();
+        const float editorWidth = std::min (kContentWidth, std::max (0.0f, available.x));
+        ImGui::SetCursorPosX (ImGui::GetCursorPosX() + (available.x - editorWidth) * 0.5f);
+
+        if (editorWidth > 0.0f && available.y > 0.0f)
+        {
+            ImGui::PushStyleColor (ImGuiCol_FrameBg, colour (notepad::kStagePalette.stage));
+            ImGui::PushStyleColor (ImGuiCol_FrameBgHovered,
+                                   colour (notepad::kStagePalette.stage));
+            ImGui::PushStyleColor (ImGuiCol_FrameBgActive,
+                                   colour (notepad::kStagePalette.stage));
+            ImGui::PushStyleVar (ImGuiStyleVar_FramePadding, ImVec2 (34.0f, 26.0f));
+            if (monoFont != nullptr)
+                ImGui::PushFont (monoFont);
+            if (markdownFocusRequested)
+            {
+                ImGui::SetKeyboardFocusHere();
+                markdownFocusRequested = false;
+            }
+
+            const auto flags = ImGuiInputTextFlags_AllowTabInput
+                             | ImGuiInputTextFlags_CallbackResize;
+            if (ImGui::InputTextMultiline ("##markdown-source", markdownBuffer.data(),
+                                           markdownBuffer.capacity() + 1,
+                                           ImVec2 (editorWidth, available.y), flags,
+                                           resizeMarkdownBuffer, &markdownBuffer))
+            {
+                document.restoreMarkdown (markdownBuffer);
+                notifyTextChanged();
+            }
+
+            if (monoFont != nullptr)
+                ImGui::PopFont();
+            ImGui::PopStyleVar();
+            ImGui::PopStyleColor (3);
+        }
+
+        ImGui::EndChild();
+        ImGui::PopStyleVar();
+        ImGui::PopStyleColor();
+    }
+
     void draw (float width, float height)
     {
         auto& style = ImGui::GetStyle();
@@ -623,12 +757,6 @@ private:
         ImGui::TextUnformatted ("Lyrics and session notes");
         ImGui::PopStyleColor();
 
-        ImGui::SetCursorPos (ImVec2 (width - 90.0f, 16.0f));
-        if (ImGui::Button ("Done", ImVec2 (68.0f, 30.0f)))
-            close();
-        if (ImGui::IsItemHovered())
-            ImGui::SetTooltip ("Close the notepad; changes stay with this session");
-
         // The status bar is a line of text plus its own padding: sizing it by a
         // constant left it a few pixels short of a full line once the child
         // asked for that padding, and it clipped its own glyphs.
@@ -648,7 +776,10 @@ private:
         if (bands.chart > 0.0f)
         {
             ImGui::SetCursorPos (ImVec2 (0.0f, chartTop));
-            drawEditor (bands.chart);
+            if (markdownView)
+                drawMarkdownEditor (bands.chart);
+            else
+                drawEditor (bands.chart);
         }
 
         if (bands.status > 0.0f)
@@ -720,7 +851,11 @@ private:
     ImFont* boldItalicFont = nullptr;
     ImFont* monoFont = nullptr;
     std::optional<std::string> savedMarkdown;
+    std::optional<notepad::Snapshot> markdownEntrySnapshot;
+    std::string markdownBuffer;
     std::string savedAtLabel;
+    bool markdownView = false;
+    bool markdownFocusRequested = false;
     bool closeRequested = false;
     bool closeWasPumped = false;
     bool hasSessionFile = false;

--- a/src/ui/ScreenshotCapture.cpp
+++ b/src/ui/ScreenshotCapture.cpp
@@ -258,9 +258,9 @@ void MainComponent::captureScreenshots (const juce::File& outDir)
         snapshotComponent (consoleView->getBusComponent (0),   outDir, "np-05-bus-strip.png");
         snapshotComponent (consoleView->getMasterStripComponent(), outDir, "np-06-master-strip.png");
 
-        // Compact-mode strips: EQ / COMP (and TAPE / AUX) collapse into section
-        // pills that carry the same left-toggle / right-menu / double-click-editor
-        // grammar as the full headers. Capture channel, bus, and master compacted,
+        // Compact-mode strips: EQ / COMP / AUX collapse into split buttons;
+        // TAPE retains its existing section-pill grammar. Capture channel, bus,
+        // and master compacted,
         // then restore full mode so later shots aren't collapsed.
         consoleView->setStripsCompactMode (true);
         resized();

--- a/src/ui/SplitModuleButton.h
+++ b/src/ui/SplitModuleButton.h
@@ -1,0 +1,271 @@
+#pragma once
+
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <algorithm>
+#include <functional>
+#include <memory>
+
+namespace duskstudio
+{
+using SplitModuleTextButtonBase = juce::TextButton;
+
+class SplitModuleButton final : public juce::Component,
+                                public juce::SettableTooltipClient
+{
+public:
+    using StateCallback = std::function<bool()>;
+    using ActionCallback = std::function<void()>;
+
+    explicit SplitModuleButton (juce::String moduleLabel = {})
+        : indicatorButton (*this, true, false),
+          editorButton (*this, false, true),
+          label (std::move (moduleLabel))
+    {
+        addAndMakeVisible (indicatorButton);
+        addAndMakeVisible (editorButton);
+        setMouseCursor (juce::MouseCursor::PointingHandCursor);
+        Component::setTitle (label + " module");
+        setAccessibleLabels();
+
+        indicatorButton.onClick = [this]
+        {
+            const auto callback = toggleBypassFn;
+            if (callback) callback();
+        };
+        editorButton.onClick = [this]
+        {
+            const auto callback = openEditorFn;
+            if (callback) callback();
+        };
+    }
+
+    void setCallbacks (StateCallback getBypassed,
+                       ActionCallback toggleBypass,
+                       ActionCallback openEditor,
+                       ActionCallback openContextMenu)
+    {
+        isBypassedFn = std::move (getBypassed);
+        toggleBypassFn = std::move (toggleBypass);
+        openEditorFn = std::move (openEditor);
+        openContextMenuFn = std::move (openContextMenu);
+        refresh();
+    }
+
+    void setLabelText (juce::String newLabel)
+    {
+        if (label == newLabel) return;
+        label = std::move (newLabel);
+        if (! hasCustomAccessibilityTitle)
+            Component::setTitle (label + " module");
+        setAccessibleLabels();
+        repaint();
+    }
+
+    const juce::String& getLabelText() const noexcept { return label; }
+
+    void setAccessibilityTitle (const juce::String& newTitle)
+    {
+        hasCustomAccessibilityTitle = true;
+        Component::setTitle (newTitle);
+    }
+
+    // Pull externally-mutated model state into the accessibility-facing
+    // toggle before scheduling the visual update. Owners call this from
+    // their existing UI refresh timers.
+    void refresh()
+    {
+        syncIndicatorState();
+        repaint();
+    }
+
+    void setAccentColour (juce::Colour newAccent)
+    {
+        if (accent == newAccent) return;
+        accent = newAccent;
+        repaint();
+    }
+
+    void setTooltip (const juce::String& newTooltip) override
+    {
+        juce::SettableTooltipClient::setTooltip (newTooltip);
+        indicatorButton.setTooltip (newTooltip);
+        editorButton.setTooltip (newTooltip);
+    }
+
+    void paint (juce::Graphics& g) override
+    {
+        const auto bounds = getLocalBounds().toFloat().reduced (0.75f);
+        if (bounds.isEmpty()) return;
+
+        const bool bypassed = isBypassed();
+        const auto indicatorArea = indicatorButton.getBounds().toFloat();
+        const auto editorArea = editorButton.getBounds().toFloat();
+
+        g.setColour (juce::Colour (0xff202024).withAlpha (0.92f));
+        g.fillRoundedRectangle (bounds, 4.0f);
+
+        paintHitboxState (g, bounds, indicatorArea, indicatorButton);
+        paintHitboxState (g, bounds, editorArea, editorButton);
+
+        g.setColour (juce::Colour (0xff4a4a50).withAlpha (0.55f));
+        g.drawVerticalLine (indicatorButton.getRight(),
+                            bounds.getY() + 3.0f,
+                            bounds.getBottom() - 3.0f);
+
+        const float indicatorSize = std::clamp (
+            std::min (indicatorArea.getWidth() - 8.0f,
+                      indicatorArea.getHeight() - 6.0f),
+            5.0f, 9.0f);
+        const auto indicator = juce::Rectangle<float> (
+            indicatorSize, indicatorSize).withCentre (indicatorArea.getCentre());
+
+        g.setColour (juce::Colour (0xff09090b));
+        g.fillEllipse (indicator.expanded (1.0f));
+        if (bypassed)
+        {
+            g.setColour (juce::Colour (0xff29292e));
+            g.fillEllipse (indicator);
+            g.setColour (juce::Colour (0xff66666e));
+            g.drawEllipse (indicator.reduced (0.5f), 1.0f);
+        }
+        else
+        {
+            g.setColour (accent);
+            g.fillEllipse (indicator);
+            g.setColour (accent.brighter (0.8f).withAlpha (0.55f));
+            g.fillEllipse (indicator.reduced (indicatorSize * 0.32f)
+                                    .translated (-indicatorSize * 0.10f,
+                                                 -indicatorSize * 0.10f));
+        }
+
+        g.setColour (bypassed ? juce::Colour (0xff77777f)
+                              : juce::Colours::white);
+        g.setFont (juce::Font (juce::FontOptions (10.5f, juce::Font::bold)));
+        g.drawText (label, editorArea.reduced (3.0f, 0.0f),
+                    juce::Justification::centred, false);
+
+        g.setColour (juce::Colour (0xff55555c));
+        g.drawRoundedRectangle (bounds, 4.0f, 0.9f);
+    }
+
+    void resized() override
+    {
+        auto area = getLocalBounds();
+        const int indicatorWidth = std::max (
+            1, juce::roundToInt (static_cast<float> (area.getWidth()) * 0.20f));
+        indicatorButton.setBounds (area.removeFromLeft (indicatorWidth));
+        editorButton.setBounds (area);
+    }
+
+    std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override
+    {
+        return std::make_unique<juce::AccessibilityHandler> (
+            *this, juce::AccessibilityRole::group);
+    }
+
+private:
+    class HitboxButton final : public SplitModuleTextButtonBase
+    {
+    public:
+        HitboxButton (SplitModuleButton& ownerIn, bool isToggle, bool suppressRepeatedClicksIn)
+            : owner (ownerIn), suppressRepeatedClicks (suppressRepeatedClicksIn)
+        {
+            setClickingTogglesState (isToggle);
+            setMouseCursor (juce::MouseCursor::PointingHandCursor);
+            onStateChange = [this] { owner.repaint(); };
+        }
+
+        void paintButton (juce::Graphics&, bool, bool) override {}
+
+        void mouseDown (const juce::MouseEvent& e) override
+        {
+            if (e.mods.isPopupMenu())
+            {
+                owner.openContextMenu();
+                return;
+            }
+            if (suppressRepeatedClicks && e.getNumberOfClicks() != 1)
+                return;
+            SplitModuleTextButtonBase::mouseDown (e);
+        }
+
+        void mouseUp (const juce::MouseEvent& e) override
+        {
+            if (e.mods.isPopupMenu()
+                || (suppressRepeatedClicks && e.getNumberOfClicks() != 1))
+            {
+                setState (isMouseOver() ? buttonOver : buttonNormal);
+                return;
+            }
+            SplitModuleTextButtonBase::mouseUp (e);
+        }
+
+        void mouseDrag (const juce::MouseEvent& e) override
+        {
+            if (e.mods.isPopupMenu()
+                || (suppressRepeatedClicks && e.getNumberOfClicks() != 1))
+                return;
+            SplitModuleTextButtonBase::mouseDrag (e);
+        }
+
+    private:
+        SplitModuleButton& owner;
+        bool suppressRepeatedClicks = false;
+    };
+
+    bool isBypassed() const
+    {
+        return isBypassedFn ? isBypassedFn() : true;
+    }
+
+    void syncIndicatorState()
+    {
+        const bool engaged = ! isBypassed();
+        if (indicatorButton.getToggleState() != engaged)
+            indicatorButton.setToggleState (engaged, juce::dontSendNotification);
+    }
+
+    void openContextMenu()
+    {
+        const auto callback = openContextMenuFn;
+        if (callback) callback();
+    }
+
+    void setAccessibleLabels()
+    {
+        indicatorButton.setButtonText (label + " enabled");
+        indicatorButton.setTitle (label + " enabled");
+        indicatorButton.setHelpText ("Toggle " + label + " bypass");
+        editorButton.setButtonText ("Open " + label + " editor");
+        editorButton.setTitle ("Open " + label + " editor");
+        editorButton.setHelpText ("Open the " + label + " editor");
+    }
+
+    static void paintHitboxState (juce::Graphics& g,
+                                  juce::Rectangle<float> shell,
+                                  juce::Rectangle<float> area,
+                                  const HitboxButton& button)
+    {
+        float alpha = 0.0f;
+        if (button.isDown()) alpha = 0.18f;
+        else if (button.isOver()) alpha = 0.09f;
+        if (alpha <= 0.0f) return;
+
+        g.saveState();
+        g.reduceClipRegion (area.getSmallestIntegerContainer());
+        g.setColour (juce::Colours::white.withAlpha (alpha));
+        g.fillRoundedRectangle (shell, 4.0f);
+        g.restoreState();
+    }
+
+    HitboxButton indicatorButton;
+    HitboxButton editorButton;
+    StateCallback isBypassedFn;
+    ActionCallback toggleBypassFn;
+    ActionCallback openEditorFn;
+    ActionCallback openContextMenuFn;
+    juce::String label;
+    juce::Colour accent { 0xff60d060 };
+    bool hasCustomAccessibilityTitle = false;
+};
+} // namespace duskstudio

--- a/src/ui/WindowState.h
+++ b/src/ui/WindowState.h
@@ -4,15 +4,15 @@
 
 namespace duskstudio
 {
-// Window position / size / fullscreen-flag persistence. Stored at
+// Window position / size persistence. Stored at
 //   <userApplicationDataDirectory>/Dusk Studio/window-state.txt
 // - separate from session.json (session-portable) and recent.txt (per-user
 // session list) because window geometry is per-machine state.
 //
 // Internally we save the string returned by ResizableWindow's
-// getWindowStateAsString(), which encodes bounds + fullscreen flag in a
-// JUCE-native format that round-trips through restoreWindowStateFromString().
-// We don't roll our own XML - JUCE already gets this right.
+// getWindowStateAsString(), which encodes bounds and may include JUCE's
+// fullscreen prefix. MainWindow intentionally removes that prefix on restore
+// so every launch starts windowed while retaining the last windowed bounds.
 //
 // Validation: a restored rectangle is sanity-checked against connected
 // displays AFTER restore; if the window ends up entirely off-screen (the

--- a/tests/console_bank_mapping.cpp
+++ b/tests/console_bank_mapping.cpp
@@ -173,6 +173,66 @@ TEST_CASE ("Console layout: default width preserves the channel minimum",
     REQUIRE (consolelayout::screenPageCountForWidth (kDefaultConsoleWidth) == 8);
 }
 
+TEST_CASE ("Console layout: EightUp seats one hardware bank at the 1080p threshold",
+           "[console][layout]")
+{
+    constexpr int width = consolelayout::kEightUpThresholdWidth;
+    static_assert (width == 1902);
+    static_assert (consolelayout::kEightUpChannelWidth == 116);
+
+    const auto fit = consolelayout::channelFitForWidth (width);
+    REQUIRE (fit.channels == SessionLayout::kBankSize);
+    REQUIRE (fit.density == consolelayout::HorizontalDensity::EightUp);
+    REQUIRE (consolelayout::screenPageCountForWidth (width) == SessionLayout::kNumBanks);
+
+    const auto geometry = consolelayout::makeStripGeometry (
+        width, fit.channels, fit.channels, fit.density);
+    REQUIRE (geometry.channelWidth == consolelayout::kEightUpChannelWidth);
+    REQUIRE (geometry.busWidth == consolelayout::kMinBusWidth);
+    REQUIRE (geometry.masterWidth == consolelayout::kMinMasterWidth);
+    REQUIRE (geometry.stripGap == consolelayout::kStripGap);
+    REQUIRE (geometry.sectionGap == consolelayout::kSectionGap);
+    REQUIRE (geometry.channelsClearBus());
+    REQUIRE (geometry.lastChannelRight + geometry.sectionGap
+             == geometry.busColumnLeft);
+
+    // A maximized 1920 px MainComponent currently yields a 1904 px console.
+    // The two pixels above the exact floor stay as flex space before Bus 1.
+    constexpr int maximizedConsoleWidth = 1920 - 16;
+    const auto maximizedGeometry = consolelayout::makeStripGeometry (
+        maximizedConsoleWidth, fit.channels, fit.channels, fit.density);
+    REQUIRE (maximizedGeometry.channelWidth == consolelayout::kEightUpChannelWidth);
+    REQUIRE (maximizedGeometry.busWidth == consolelayout::kMinBusWidth);
+    REQUIRE (maximizedGeometry.masterWidth == consolelayout::kMinMasterWidth);
+    REQUIRE (maximizedGeometry.busColumnLeft
+             - maximizedGeometry.lastChannelRight
+             - maximizedGeometry.sectionGap == 2);
+
+    const std::pair<int, int> expected[] = { { 1, 8 }, { 9, 16 }, { 17, 24 } };
+    for (int page = 0; page < SessionLayout::kNumBanks; ++page)
+        REQUIRE (consolelayout::channelRangeForPage (page, width) == expected[page]);
+}
+
+TEST_CASE ("Console layout: EightUp is an isolated horizontal breakpoint",
+           "[console][layout]")
+{
+    const auto below = consolelayout::channelFitForWidth (
+        consolelayout::kEightUpThresholdWidth - 1);
+    REQUIRE (below.channels == 6);
+    REQUIRE (below.density == consolelayout::HorizontalDensity::Comfortable);
+
+    constexpr int comfortableEightWidth =
+        consolelayout::fullFloorContentWidthForStride (SessionLayout::kBankSize);
+    const auto comfortableEight = consolelayout::channelFitForWidth (comfortableEightWidth);
+    REQUIRE (comfortableEight.channels == SessionLayout::kBankSize);
+    REQUIRE (comfortableEight.density == consolelayout::HorizontalDensity::Comfortable);
+
+    constexpr int comfortableNineWidth =
+        consolelayout::fullFloorContentWidthForStride (SessionLayout::kBankSize + 1);
+    REQUIRE (consolelayout::channelsThatFitForWidth (comfortableNineWidth)
+             == SessionLayout::kBankSize + 1);
+}
+
 TEST_CASE ("Console layout: full-floor page width preserves every documented minimum",
            "[console][layout]")
 {
@@ -285,6 +345,17 @@ TEST_CASE ("Bank mapping: focused tracks cross three-strip page boundaries",
     REQUIRE (screenBankForTrack (20, 3, 8) == 6);
     REQUIRE (screenBankForTrack (21, 3, 8) == 7);
     REQUIRE (screenBankForTrack (23, 3, 8) == 7);
+}
+
+TEST_CASE ("Bank mapping: EightUp focus crosses hardware-bank boundaries",
+           "[console][bank]")
+{
+    constexpr int stride = SessionLayout::kBankSize;
+    constexpr int pages = SessionLayout::kNumBanks;
+    REQUIRE (screenBankForTrack (7,  stride, pages) == 0);
+    REQUIRE (screenBankForTrack (8,  stride, pages) == 1);
+    REQUIRE (screenBankForTrack (15, stride, pages) == 1);
+    REQUIRE (screenBankForTrack (16, stride, pages) == 2);
 }
 
 TEST_CASE ("Bank mapping: plain digits select exactly pages one through eight",

--- a/tests/session_format_version.cpp
+++ b/tests/session_format_version.cpp
@@ -25,7 +25,7 @@ void writeRaw (const juce::File& target, const juce::String& contents)
 } // namespace
 
 // Format-version contract:
-//   * Manual save writes "version": kFormatVersion (currently 5).
+//   * Manual save writes "version": kFormatVersion (currently 6).
 //   * Load rejects sessions whose version is HIGHER than the build's
 //     kFormatVersion — newer Dusk Studio can read older sessions (via the
 //     migrateSession switch) but older Dusk Studio must refuse newer ones
@@ -87,7 +87,7 @@ TEST_CASE ("SessionSerializer round-trip preserves version field",
     auto root = juce::JSON::parse (target);
     REQUIRE (root.isObject());
     REQUIRE (root.hasProperty ("version"));
-    REQUIRE ((int) root["version"] == 5);
+    REQUIRE ((int) root["version"] == 6);
 
     dir.deleteRecursively();
 }

--- a/tests/session_round_trip.cpp
+++ b/tests/session_round_trip.cpp
@@ -53,6 +53,7 @@ TEST_CASE ("SessionSerializer round-trip preserves transport + per-track state",
     t1.strip.hpfFreq.store (80.0f, std::memory_order_relaxed);
     t1.strip.lfGainDb.store (2.0f, std::memory_order_relaxed);
     t1.strip.insertBypassed.store (true, std::memory_order_relaxed);
+    t1.strip.auxSendsBypassed.store (true, std::memory_order_relaxed);
 
     auto& t2 = a.track (2);
     t2.name = "Vocal";
@@ -96,6 +97,8 @@ TEST_CASE ("SessionSerializer round-trip preserves transport + per-track state",
                   WithinAbs (2.0f, 1e-4f));
     REQUIRE (b.track (1).strip.insertBypassed.load (std::memory_order_relaxed));
     REQUIRE_FALSE (b.track (0).strip.insertBypassed.load (std::memory_order_relaxed));
+    REQUIRE (b.track (1).strip.auxSendsBypassed.load (std::memory_order_relaxed));
+    REQUIRE_FALSE (b.track (0).strip.auxSendsBypassed.load (std::memory_order_relaxed));
 
     REQUIRE (b.track (2).name == "Vocal");
     REQUIRE (b.track (2).mode.load (std::memory_order_relaxed) == (int) Track::Mode::Midi);

--- a/tests/session_schema_migration.cpp
+++ b/tests/session_schema_migration.cpp
@@ -80,12 +80,43 @@ TEST_CASE ("migrateSession advances a mock v1 root to the current schema",
     // version field must now match the current build's kFormatVersion.
     // We don't reach kFormatVersion symbolically from the test (it's
     // in an anonymous namespace inside the .cpp), so we check the
-    // Take provenance owns version 5; the original payload must survive every step.
+    // AUX-send bypass owns version 6; the original payload must survive every step.
     REQUIRE (root.is_object());
     REQUIRE (root.contains ("version"));
-    REQUIRE (root["version"].get<int>() == 5);
+    REQUIRE (root["version"].get<int>() == 6);
     REQUIRE (root.contains ("tempo"));
     REQUIRE (root["tempo"].get<double>() == 98.5);
+}
+
+TEST_CASE ("migrateSession stamps v5 AUX-send bypass data as v6",
+           "[session][serializer][migration][aux]")
+{
+    nlohmann::json root {
+        { "version", 5 },
+        { "tracks", nlohmann::json::array ({
+            { { "name", "Aux source" }, { "aux_sends_bypassed", true } }
+        }) }
+    };
+
+    auto migrated = root;
+    REQUIRE (duskstudio::migrateSession (migrated, 5));
+    REQUIRE (migrated["version"].get<int>() == 6);
+    REQUIRE (migrated["tracks"][0]["aux_sends_bypassed"].get<bool>());
+
+    const auto dir = makeTempMigrationDir();
+    const auto target = dir.getChildFile ("session.json");
+    writeRaw (target, root.dump());
+
+    duskstudio::Session session;
+    REQUIRE (duskstudio::SessionSerializer::load (session, target));
+    REQUIRE (session.track (0).strip.auxSendsBypassed.load (std::memory_order_relaxed));
+    REQUIRE (duskstudio::SessionSerializer::save (session, target));
+
+    const auto saved = nlohmann::json::parse (
+        target.loadFileAsString().toStdString(), nullptr, false);
+    REQUIRE (saved["version"].get<int>() == 6);
+    REQUIRE (saved["tracks"][0]["aux_sends_bypassed"].get<bool>());
+    dir.deleteRecursively();
 }
 
 TEST_CASE ("SessionSerializer loads a v1-tagged session file end-to-end",
@@ -111,12 +142,12 @@ TEST_CASE ("SessionSerializer loads a v1-tagged session file end-to-end",
     auto root = nlohmann::json::parse (target.loadFileAsString().toStdString(), nullptr, false);
     REQUIRE (root.is_object());
     REQUIRE (root.contains ("version"));
-    REQUIRE (root["version"].get<int>() == 5);
+    REQUIRE (root["version"].get<int>() == 6);
 
     dir.deleteRecursively();
 }
 
-TEST_CASE ("SessionSerializer migrates a v3 legacy plugin reference to a v5 save",
+TEST_CASE ("SessionSerializer migrates a v3 legacy plugin reference to a v6 save",
            "[session][serializer][migration][plugin-descriptor]")
 {
     using duskstudio::Session;
@@ -146,7 +177,7 @@ TEST_CASE ("SessionSerializer migrates a v3 legacy plugin reference to a v5 save
     const auto saved = nlohmann::json::parse (
         target.loadFileAsString().toStdString(), nullptr, false);
     REQUIRE (saved.is_object());
-    CHECK (saved["version"].get<int>() == 5);
+    CHECK (saved["version"].get<int>() == 6);
     CHECK (saved["tracks"][0]["plugin_desc_xml"].get<std::string>() == legacyXml);
     CHECK (saved["tracks"][0]["plugin_state"].get<std::string>()
            == "bGVnYWN5LXN0YXRl");
@@ -193,7 +224,7 @@ TEST_CASE ("SessionSerializer round-trips active and historical take provenance"
     REQUIRE (SessionSerializer::save (*source, target));
     const auto saved = nlohmann::json::parse (
         target.loadFileAsString().toStdString(), nullptr, false);
-    REQUIRE (saved["version"].get<int>() == 5);
+    REQUIRE (saved["version"].get<int>() == 6);
     const auto& savedAudio = saved["tracks"][0]["regions"][0];
     CHECK (savedAudio["take_provenance"]["captured_at_ms"].get<std::int64_t>() == 101);
     CHECK (savedAudio["take_provenance"]["loop_pass"].get<int>() == 2);
@@ -303,7 +334,7 @@ TEST_CASE ("SessionSerializer gives legacy v4 takes default provenance",
     REQUIRE (SessionSerializer::save (*clamped, target));
     const auto upgraded = nlohmann::json::parse (
         target.loadFileAsString().toStdString(), nullptr, false);
-    CHECK (upgraded["version"].get<int>() == 5);
+    CHECK (upgraded["version"].get<int>() == 6);
 
     dir.deleteRecursively();
 }

--- a/tests/session_track_shrink.cpp
+++ b/tests/session_track_shrink.cpp
@@ -87,6 +87,7 @@ TEST_CASE ("loading a session with fewer tracks blanks the surplus mixer state",
     ghost.strip.pan.store (0.75f);
     ghost.strip.mute.store (true);
     ghost.strip.busAssign[2].store (true);
+    ghost.strip.auxSendsBypassed.store (true);
     ghost.strip.auxSendDb[1].store (-12.0f);
     ghost.strip.auxSendPreFader[1].store (true);
     ghost.strip.hpfFreq.store (120.0f);
@@ -107,6 +108,7 @@ TEST_CASE ("loading a session with fewer tracks blanks the surplus mixer state",
     REQUIRE_THAT (t.strip.pan.load(), WithinAbs (0.0f, 1e-6f));
     REQUIRE_FALSE (t.strip.mute.load());
     REQUIRE_FALSE (t.strip.busAssign[2].load());
+    REQUIRE_FALSE (t.strip.auxSendsBypassed.load());
     REQUIRE_THAT (t.strip.auxSendDb[1].load(),
                   WithinAbs (ChannelStripParams::kAuxSendOffDb, 1e-6f));
     REQUIRE_FALSE (t.strip.auxSendPreFader[1].load());

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -61,7 +61,7 @@ src/ui/AnalogVuMeter.cpp	113
 src/ui/AnalogVuMeter.h	7
 src/ui/AudioRegionEditor.cpp	339
 src/ui/AudioRegionEditor.h	86
-src/ui/AudioSettingsPanel.cpp	96
+src/ui/AudioSettingsPanel.cpp	100
 src/ui/AudioSettingsPanel.h	39
 src/ui/AuxLaneComponent.cpp	168
 src/ui/AuxLaneComponent.h	28
@@ -102,12 +102,12 @@ src/ui/DuskFileBrowser.cpp	75
 src/ui/DuskFileBrowser.h	13
 src/ui/DuskLabelEditor.h	3
 src/ui/DuskMenuBar.h	29
-src/ui/DuskStudioLookAndFeel.h	119
+src/ui/DuskStudioLookAndFeel.h	124
 src/ui/EditCursors.cpp	58
 src/ui/EditCursors.h	7
 src/ui/EditModeToolbar.cpp	48
 src/ui/EditModeToolbar.h	10
-src/ui/EmbeddedModal.h	58
+src/ui/EmbeddedModal.h	62
 src/ui/FadeCurve.h	10
 src/ui/FreezeDialog.cpp	36
 src/ui/FreezeDialog.h	9
@@ -151,6 +151,7 @@ src/ui/SectionPillButton.h	7
 src/ui/SelfTestPanel.cpp	10
 src/ui/SelfTestPanel.h	7
 src/ui/ShortcutsPanel.h	37
+src/ui/SplitModuleButton.h	42
 src/ui/StartupDialog.cpp	104
 src/ui/StartupDialog.h	32
 src/ui/SteppedKnob.h	12


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a View menu with Full Screen and Show Timeline controls.
  * Added an EightUp layout for fitting more channel strips on wide displays.
  * Added live UI-scale previews with smoother resizing.
  * Added Markdown source editing to the notepad.
  * Added split controls for EQ, compressor, and AUX bypass, editing, and menus.
* **Bug Fixes**
  * AUX sends now mute correctly when bypassed and retain settings across cloning and sessions.
  * Applications now launch windowed while preserving prior windowed dimensions.
* **Documentation**
  * Updated the manual, README, and session-format documentation for these changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->