### PR TITLE
docs(release): bill UI scaling in the 0.13.0 notes; real package contact

### DIFF
--- a/.github/actions/apt-deps/action.yml
+++ b/.github/actions/apt-deps/action.yml
@@ -1,0 +1,34 @@
+name: Install apt packages
+description: >
+  apt-get update + install with the Azure apt mirror bypassed, bounded
+  fetch timeouts, and a retry loop. azure.archive.ubuntu.com serves the
+  hosted runners and a sick mirror node stalls a job for hours; talking
+  to archive.ubuntu.com directly and capping every fetch turns that into
+  a fast, retried failure instead.
+inputs:
+  packages:
+    description: Space-separated apt package list
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: apt-get with mirror bypass and retries
+      shell: bash
+      run: |
+        sudo find /etc/apt/ -type f \( -name "*.list" -o -name "*.sources" \) \
+          -exec sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' {} +
+        printf '%s\n' \
+          'Acquire::Retries "3";' \
+          'Acquire::http::Timeout "30";' \
+          'Acquire::https::Timeout "30";' \
+          | sudo tee /etc/apt/apt.conf.d/99dusk-ci >/dev/null
+        for i in 1 2 3; do
+          if sudo apt-get update && \
+             sudo apt-get install -y --no-install-recommends ${{ inputs.packages }}; then
+            exit 0
+          fi
+          echo "apt attempt $i failed; retrying in 20s"
+          sleep 20
+        done
+        echo "apt failed after 3 attempts"
+        exit 1

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -50,18 +50,18 @@ jobs:
           persist-credentials: false
 
       - name: Install Linux build deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential cmake ninja-build pkg-config ccache \
-            libasound2-dev libjack-jackd2-dev libmp3lame-dev libsndfile1-dev libsodium-dev \
-            libpipewire-0.3-dev \
-            liblilv-dev libsuil-dev lv2-dev \
-            ladspa-sdk \
-            libcurl4-openssl-dev libfreetype-dev libfontconfig1-dev \
-            libx11-dev libxcomposite-dev libxcursor-dev libxext-dev \
-            libxinerama-dev libxrandr-dev libxrender-dev libxss-dev \
-            libwebkit2gtk-4.0-dev libgl1-mesa-dev libglu1-mesa-dev xvfb \
+        uses: ./.github/actions/apt-deps
+        with:
+          packages: >-
+            build-essential cmake ninja-build pkg-config ccache
+            libasound2-dev libjack-jackd2-dev libmp3lame-dev libsndfile1-dev libsodium-dev
+            libpipewire-0.3-dev
+            liblilv-dev libsuil-dev lv2-dev
+            ladspa-sdk
+            libcurl4-openssl-dev libfreetype-dev libfontconfig1-dev
+            libx11-dev libxcomposite-dev libxcursor-dev libxext-dev
+            libxinerama-dev libxrandr-dev libxrender-dev libxss-dev
+            libwebkit2gtk-4.0-dev libgl1-mesa-dev libglu1-mesa-dev xvfb
             libwayland-dev libxkbcommon-dev libdecor-0-dev
 
       - name: Cache ccache objects

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -86,29 +86,31 @@ jobs:
           [[ "v$(tr -d '[:space:]' < VERSION)" == "${GITHUB_REF_NAME}" ]] || {
             echo "Tag ${GITHUB_REF_NAME} != VERSION v$(tr -d '[:space:]' < VERSION)"; exit 1; }
 
-      - name: Install Linux build deps + packaging tools
+      - name: Swap the aarch64 apt mirror
         # The aarch64 arm pulls from ports.ubuntu.com, which is often unreachable
         # from GitHub's ARM runners on both IPv6 and IPv4; swap it for the MIT
         # mirror and force IPv4 (arm only, so the amd64 arm keeps its stock apt
         # sources and network behavior). Mirrors raspberry-pi-build.yml.
+        if: matrix.arch == 'aarch64'
         run: |
-          if [ "${{ matrix.arch }}" = "aarch64" ]; then
-            sudo find /etc/apt/ -type f \( -name "*.list" -o -name "*.sources" \) \
-              -exec sed -i 's|ports.ubuntu.com|mirrors.mit.edu|g' {} +
-            echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4 >/dev/null
-          fi
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential cmake ninja-build pkg-config \
-            libasound2-dev libjack-jackd2-dev libmp3lame-dev libsndfile1-dev libsodium-dev \
-            libpipewire-0.3-dev \
-            liblilv-dev libsuil-dev lv2-dev \
-            ladspa-sdk \
-            libcurl4-openssl-dev libfreetype-dev libfontconfig1-dev \
-            libx11-dev libxcomposite-dev libxcursor-dev libxext-dev \
-            libxinerama-dev libxrandr-dev libxrender-dev libxss-dev \
-            libwebkit2gtk-4.0-dev libgl1-mesa-dev libglu1-mesa-dev \
-            libwayland-dev libxkbcommon-dev libdecor-0-dev \
+          sudo find /etc/apt/ -type f \( -name "*.list" -o -name "*.sources" \) \
+            -exec sed -i 's|ports.ubuntu.com|mirrors.mit.edu|g' {} +
+          echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4 >/dev/null
+
+      - name: Install Linux build deps + packaging tools
+        uses: ./.github/actions/apt-deps
+        with:
+          packages: >-
+            build-essential cmake ninja-build pkg-config
+            libasound2-dev libjack-jackd2-dev libmp3lame-dev libsndfile1-dev libsodium-dev
+            libpipewire-0.3-dev
+            liblilv-dev libsuil-dev lv2-dev
+            ladspa-sdk
+            libcurl4-openssl-dev libfreetype-dev libfontconfig1-dev
+            libx11-dev libxcomposite-dev libxcursor-dev libxext-dev
+            libxinerama-dev libxrandr-dev libxrender-dev libxss-dev
+            libwebkit2gtk-4.0-dev libgl1-mesa-dev libglu1-mesa-dev
+            libwayland-dev libxkbcommon-dev libdecor-0-dev
             xz-utils
 
       - name: Clone JUCE (Dusk-owned Wayland mirror, pinned)

--- a/.github/workflows/linux-sanitizer.yml
+++ b/.github/workflows/linux-sanitizer.yml
@@ -65,19 +65,19 @@ jobs:
         # units pull in juce_gui_basics for jassert helpers and the
         # initialiser path touches X11. Cheap to keep, prevents flaky
         # startup failures on a future test that does need a display.
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential cmake ninja-build pkg-config ccache \
-            llvm \
-            libasound2-dev libjack-jackd2-dev libmp3lame-dev libsndfile1-dev libsodium-dev \
-            libpipewire-0.3-dev \
-            liblilv-dev libsuil-dev lv2-dev \
-            ladspa-sdk \
-            libcurl4-openssl-dev libfreetype-dev libfontconfig1-dev \
-            libx11-dev libxcomposite-dev libxcursor-dev libxext-dev \
-            libxinerama-dev libxrandr-dev libxrender-dev libxss-dev \
-            libwebkit2gtk-4.0-dev libgl1-mesa-dev libglu1-mesa-dev xvfb \
+        uses: ./.github/actions/apt-deps
+        with:
+          packages: >-
+            build-essential cmake ninja-build pkg-config ccache
+            llvm
+            libasound2-dev libjack-jackd2-dev libmp3lame-dev libsndfile1-dev libsodium-dev
+            libpipewire-0.3-dev
+            liblilv-dev libsuil-dev lv2-dev
+            ladspa-sdk
+            libcurl4-openssl-dev libfreetype-dev libfontconfig1-dev
+            libx11-dev libxcomposite-dev libxcursor-dev libxext-dev
+            libxinerama-dev libxrandr-dev libxrender-dev libxss-dev
+            libwebkit2gtk-4.0-dev libgl1-mesa-dev libglu1-mesa-dev xvfb
             libwayland-dev libxkbcommon-dev libdecor-0-dev
 
       - name: Cache ccache objects

--- a/.github/workflows/manual-pdf.yml
+++ b/.github/workflows/manual-pdf.yml
@@ -84,15 +84,15 @@ jobs:
         # fancyvrb, booktabs). fonts-dejavu supplies the "DejaVu Sans Mono"
         # monofont build-pdf.sh requests. perl is preinstalled on the runner
         # (build-pdf.sh uses it to strip em dashes).
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            pandoc \
-            texlive-xetex \
-            texlive-fonts-recommended \
-            texlive-latex-recommended \
-            texlive-latex-extra \
-            lmodern \
+        uses: ./.github/actions/apt-deps
+        with:
+          packages: >-
+            pandoc
+            texlive-xetex
+            texlive-fonts-recommended
+            texlive-latex-recommended
+            texlive-latex-extra
+            lmodern
             fonts-dejavu
 
       - name: Render MANUAL.pdf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@ The first release cut from the main line since 0.12 branched. Linux gets a
 native PipeWire backend and MIDI hot-plug; macOS gets Dusk Studio's own plugin
 hosts for all four formats, Audio Units included. Stems render in a single
 pass, a new realtime bounce prints hardware inserts wet instead of dry, loop
-recording keeps every pass as its own take, and every session now carries a
-notepad with a chord chart. Underneath, the audio device layer, MIDI, audio
-file I/O and the FFT stopped going through the application framework and
-became Dusk Studio's own.
+recording keeps every pass as its own take, every session now carries a
+notepad with a chord chart, and the whole interface zooms from half to double
+size. Underneath, the audio device layer, MIDI, audio file I/O and the FFT
+stopped going through the application framework and became Dusk Studio's own.
 
 The 0.12.7 fix wave was written on the 0.12 line but never released; those
 fixes are ported here and are listed below rather than under a 0.12.7 heading.
@@ -31,8 +31,9 @@ fixes are ported here and are listed below rather than under a 0.12.7 heading.
   sheet while keeping your own accidental spelling. Sections are markers such
   as `[Chorus]` on their own line. Notes save atomically beside the session as
   a plain `notepad.md` using ChordPro brackets, so the file opens in any
-  chord-sheet app and follows the session through Save As. Typing in the
-  notepad never triggers a transport shortcut.
+  chord-sheet app and follows the session through Save As. A toolbar button
+  flips the page to its Markdown source and back without losing unsaved
+  edits. Typing in the notepad never triggers a transport shortcut.
 - **Native PipeWire audio backend (Linux).** Dusk Studio now speaks
   libpipewire directly instead of borrowing a JACK compatibility layer.
   PipeWire sinks, sources and duplex nodes list as devices of their own,
@@ -65,6 +66,12 @@ fixes are ported here and are listed below rather than under a 0.12.7 heading.
   from the measured loop, and the latency ping works with the transport
   stopped. Mono hardware inserts gain their own I/O format (single send,
   single return) instead of being modelled as a half-empty pair.
+- **UI scale control.** A slider in the audio settings panel zooms the whole
+  interface, 0.50x to 2.00x on top of the OS display scaling. The interface
+  rescales live as the slider moves, and the value is remembered per machine
+  rather than per session. A denser console layout fits a full bank of eight
+  strips plus the buses and master on a 1080p display.
+- **View menu.** Full Screen (F11) and a Show Timeline toggle.
 - **New folder button in the file browser.** Available on every save and
   directory-pick flow; creating a folder navigates into it.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1547,7 +1547,7 @@ set(CPACK_PACKAGE_VENDOR            "Dusk Audio")
 set(CPACK_PACKAGE_VERSION           "${DUSKSTUDIO_VERSION}")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Portastudio-style 24-channel DAW")
 set(CPACK_PACKAGE_HOMEPAGE_URL      "https://github.com/dusk-audio/dusk-studio")
-set(CPACK_PACKAGE_CONTACT           "Dusk Audio <support@duskaudio.example>")
+set(CPACK_PACKAGE_CONTACT           "Dusk Audio <marc@duskaudio.com>")
 set(CPACK_RESOURCE_FILE_LICENSE     "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
 set(CPACK_PACKAGE_INSTALL_DIRECTORY "Dusk Studio")
 

--- a/packaging/DuskStudio.appdata.xml
+++ b/packaging/DuskStudio.appdata.xml
@@ -32,7 +32,7 @@
     <!-- scripts/bump-version.sh prepends new <release> entries here. -->
     <release version="0.13.0" date="2026-08-16">
       <description>
-        <p>Adds the session notepad, native PipeWire and macOS plugin hosting, MIDI hot-plug, loop take stacking, realtime hardware bounce, and a broad set of session, recording, audio-device, and plug-in fixes.</p>
+        <p>Adds the session notepad, a UI scale control, native PipeWire and macOS plugin hosting, MIDI hot-plug, loop take stacking, realtime hardware bounce, and a broad set of session, recording, audio-device, and plug-in fixes.</p>
       </description>
     </release>
     <release version="0.12.6" date="2026-07-25">

--- a/packaging/RELEASE-NOTES.md
+++ b/packaging/RELEASE-NOTES.md
@@ -1,5 +1,5 @@
 <!-- summary-start -->
-Adds the session notepad, native PipeWire and macOS plugin hosting, MIDI hot-plug, loop take stacking, realtime hardware bounce, and a broad set of session, recording, audio-device, and plug-in fixes.
+Adds the session notepad, a UI scale control, native PipeWire and macOS plugin hosting, MIDI hot-plug, loop take stacking, realtime hardware bounce, and a broad set of session, recording, audio-device, and plug-in fixes.
 <!-- summary-end -->
 
 ### Downloads


### PR DESCRIPTION
Completes the 0.13.0 release notes now that #315 is merged.

- CHANGELOG 0.13.0: adds the UI scale control entry (live rescale, 0.50x-2.00x, eight-strip 1080p fit), a View menu bullet, and the notepad Markdown source view; intro sentence mentions the interface zoom.
- packaging/RELEASE-NOTES.md and DuskStudio.appdata.xml: summary sentence now names the UI scale control.
- CMakeLists.txt: CPACK_PACKAGE_CONTACT set to the real address (last hand-edit item from #178).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live interface scaling from 0.5× to 2×, with settings saved per machine.
  * Added a denser console layout and a View menu with fullscreen and timeline controls.
  * Added a session notepad with Markdown source viewing while preserving unsaved edits.
  * Added native PipeWire and macOS plug-in hosting, MIDI hot-plug support, and realtime hardware bounce.
  * Loop recording now preserves each pass as a separate take.

* **Bug Fixes**
  * Improved session, recording, audio-device, and plug-in behavior.
  * Typing in the session notepad no longer triggers transport shortcuts.

* **Documentation**
  * Updated release documentation with the latest features and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->