### PR TITLE
Hosting H5c: native CLAP/VST3 on Windows

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -207,7 +207,13 @@ jobs:
             -DDPF_WIDGETS_PATH="${RT_UNIX}/DPF-Widgets" \
             -DASIOSDK_PATH="${ASIOSDK_PATH}" \
             -DCMAKE_PREFIX_PATH="${VCPKG_PREFIX}" \
-            -DDUSKSTUDIO_ENABLE_LTO=ON
+            -DDUSKSTUDIO_ENABLE_LTO=ON \
+            -DDUSKSTUDIO_NATIVE_CLAP=ON \
+            -DDUSKSTUDIO_NATIVE_VST3=ON
+          for option in DUSKSTUDIO_NATIVE_CLAP DUSKSTUDIO_NATIVE_VST3; do
+            grep -q "^${option}:BOOL=ON$" build/CMakeCache.txt || {
+              echo "::error::${option} was not enabled in the app configure" >&2; exit 1; }
+          done
 
       - name: Build (Release)
         shell: bash
@@ -232,7 +238,13 @@ jobs:
             -DDPF_PATH="${RT_UNIX}/DPF" \
             -DDPF_WIDGETS_PATH="${RT_UNIX}/DPF-Widgets" \
             -DASIOSDK_PATH="${ASIOSDK_PATH}" \
-            -DCMAKE_PREFIX_PATH="${VCPKG_PREFIX}"
+            -DCMAKE_PREFIX_PATH="${VCPKG_PREFIX}" \
+            -DDUSKSTUDIO_NATIVE_CLAP=ON \
+            -DDUSKSTUDIO_NATIVE_VST3=ON
+          for option in DUSKSTUDIO_NATIVE_CLAP DUSKSTUDIO_NATIVE_VST3; do
+            grep -q "^${option}:BOOL=ON$" build-tests/CMakeCache.txt || {
+              echo "::error::${option} was not enabled in the test configure" >&2; exit 1; }
+          done
           cmake --build build-tests --config Release --target dusk-studio-tests -j4
           ctest --test-dir build-tests --output-on-failure -C Release -E "FileImporter"
 

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -131,7 +131,13 @@ jobs:
             -DDPF_PATH="${RT_UNIX}/DPF" \
             -DDPF_WIDGETS_PATH="${RT_UNIX}/DPF-Widgets" \
             -DASIOSDK_PATH="${ASIOSDK_PATH}" \
-            -DCMAKE_PREFIX_PATH="${VCPKG_PREFIX}"
+            -DCMAKE_PREFIX_PATH="${VCPKG_PREFIX}" \
+            -DDUSKSTUDIO_NATIVE_CLAP=ON \
+            -DDUSKSTUDIO_NATIVE_VST3=ON
+          for option in DUSKSTUDIO_NATIVE_CLAP DUSKSTUDIO_NATIVE_VST3; do
+            grep -q "^${option}:BOOL=ON$" build-tests/CMakeCache.txt || {
+              echo "::error::${option} was not enabled in the test configure" >&2; exit 1; }
+          done
 
       - name: Build test binary
         # Build only the test target. The Catch2 binary depends on

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,10 +24,11 @@ if(APPLE)
     enable_language(OBJCXX)
 endif()
 
-# Native CLAP host (src/engine/clap/) is available on Linux and macOS. Default
-# ON there, OFF elsewhere; it can be forced off to test the feature-gated path.
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR APPLE)
-    option(DUSKSTUDIO_NATIVE_CLAP "Build the native CLAP plugin host (Linux/macOS)" ON)
+# Native CLAP host (src/engine/clap/) is available on Linux, macOS, and
+# Windows. Default ON there, OFF elsewhere; it can be forced off to test the
+# feature-gated path.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR APPLE OR WIN32)
+    option(DUSKSTUDIO_NATIVE_CLAP "Build the native CLAP plugin host (Linux/macOS/Windows)" ON)
 else()
     set(DUSKSTUDIO_NATIVE_CLAP OFF)
 endif()
@@ -115,15 +116,15 @@ endif()
 # Native VST3 host — Steinberg SDK hosting subset from the Dusk-owned mirror
 # (external/vst3sdk submodule, tag dusk-vst3sdk-v1; see DUSK-MIRROR.md there).
 # GPL-3.0 arm of the SDK's dual license — see LICENSES.txt.
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR APPLE)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR APPLE OR WIN32)
     set(DUSKSTUDIO_VST3_SDK_PRESENT OFF)
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/vst3sdk/pluginterfaces/base/funknown.cpp")
         set(DUSKSTUDIO_VST3_SDK_PRESENT ON)
     endif()
-    if(APPLE)
+    if(APPLE OR WIN32)
         # Same rule as the LV2 gate above: default follows the submodule, an
         # explicit request without it is fatal.
-        option(DUSKSTUDIO_NATIVE_VST3 "Build the native VST3 plugin host (Linux/macOS)"
+        option(DUSKSTUDIO_NATIVE_VST3 "Build the native VST3 plugin host (Linux/macOS/Windows)"
                ${DUSKSTUDIO_VST3_SDK_PRESENT})
         if(DUSKSTUDIO_NATIVE_VST3 AND NOT DUSKSTUDIO_VST3_SDK_PRESENT)
             message(FATAL_ERROR
@@ -134,7 +135,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR APPLE)
                            "(git submodule update --init external/vst3sdk)")
         endif()
     elseif(DUSKSTUDIO_VST3_SDK_PRESENT)
-        option(DUSKSTUDIO_NATIVE_VST3 "Build the native VST3 plugin host (Linux/macOS)" ON)
+        option(DUSKSTUDIO_NATIVE_VST3 "Build the native VST3 plugin host (Linux/macOS/Windows)" ON)
     else()
         set(DUSKSTUDIO_NATIVE_VST3 OFF)
         message(STATUS "Native VST3 host: external/vst3sdk submodule missing - disabled "
@@ -919,6 +920,8 @@ if(DUSKSTUDIO_NATIVE_CLAP)
         target_sources(DuskStudio PRIVATE src/engine/clap/ClapEditor_Mac.mm)
     elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         target_sources(DuskStudio PRIVATE src/engine/clap/ClapEditor.cpp)
+    elseif(WIN32)
+        target_sources(DuskStudio PRIVATE src/engine/clap/ClapEditor_Win.cpp)
     endif()
     target_compile_definitions(DuskStudio PRIVATE DUSKSTUDIO_HAS_NATIVE_CLAP=1)
 endif()
@@ -991,6 +994,10 @@ if(DUSKSTUDIO_NATIVE_VST3)
         target_sources(dusk-vst3-hosting PRIVATE
             ${VST3SDK_DIR}/public.sdk/source/common/threadchecker_linux.cpp
             ${VST3SDK_DIR}/public.sdk/source/vst/hosting/module_linux.cpp)
+    elseif(WIN32)
+        target_sources(dusk-vst3-hosting PRIVATE
+            ${VST3SDK_DIR}/public.sdk/source/common/threadchecker_win32.cpp
+            ${VST3SDK_DIR}/public.sdk/source/vst/hosting/module_win32.cpp)
     endif()
     target_include_directories(dusk-vst3-hosting SYSTEM PUBLIC ${VST3SDK_DIR})
     target_compile_definitions(dusk-vst3-hosting PUBLIC
@@ -1010,6 +1017,8 @@ if(DUSKSTUDIO_NATIVE_VST3)
         target_sources(DuskStudio PRIVATE src/engine/vst3/Vst3Editor_Mac.mm)
     elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         target_sources(DuskStudio PRIVATE src/engine/vst3/Vst3Editor.cpp)
+    elseif(WIN32)
+        target_sources(DuskStudio PRIVATE src/engine/vst3/Vst3Editor_Win.cpp)
     endif()
     target_link_libraries(DuskStudio PRIVATE dusk-vst3-hosting)
     target_compile_definitions(DuskStudio PRIVATE DUSKSTUDIO_HAS_NATIVE_VST3=1)

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1500,7 +1500,7 @@ Dusk Studio scans and hosts:
 - **AU** on macOS only, through Dusk Studio's native Audio Unit host — effects and instruments.
 - **Native multi-sampler** (`.sfz`, `.sf2`, and ARIA `.bank.xml` files via the built-in sfizz engine — SF2 is converted to SFZ on load, while a bank manifest opens its first program) on all platforms.
 
-There is no VST2 support. See *Native plugin hosting (Linux and macOS)* below for what the native hosts change.
+There is no VST2 support. See *Native plugin hosting (Linux, macOS, and Windows)* below for what the native hosts change.
 
 ## Scanning
 
@@ -1542,7 +1542,7 @@ Click the loaded plugin's slot to open its editor. The editor appears as a centr
 
 This holds on all platforms, including the macOS out-of-process sandbox. Rather than reparenting the sandbox child's native window into the main window (cross-process NSView embedding, which Dusk Studio deliberately does not use), macOS hosts the editor **in-process** against a lightweight "shell" instance of the plugin while the plugin's DSP keeps running in the sandbox child; knob moves are mirrored between the shell editor and the running child in both directions. If the plugin cannot be instantiated in-process for editing (its file has moved, or it refuses a second instance), the editor falls back to a floating window owned by the sandbox child — that fallback window is not dimmed by other modals and is closed from its own controls.
 
-## Native plugin hosting (Linux and macOS)
+## Native plugin hosting (Linux, macOS, and Windows)
 
 CLAP and VST3 plugins — effects and instruments — are hosted by Dusk Studio's own plugin hosts on Linux, macOS, and Windows; LV2 is on Linux and macOS. Audio Units use the native host on macOS too. The native hosts own the format lifecycle and editor embedding directly; on Linux this also sidesteps the standard layer's UI breakage on Wayland desktops.
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -30,7 +30,7 @@ Dusk Studio includes:
 - Four mix buses, each with a 3-band EQ and console-style bus compressor.
 - A master bus with tape saturation, a tube program EQ, bus compressor, and mono-sum check.
 - A dedicated mastering stage with 5-band digital EQ, multiband compressor, brick-wall limiter, and BS.1770 loudness metering.
-- VST3, LV2, AU, and CLAP plugin hosting, with optional out-of-process sandboxing for crash isolation. On Linux and macOS, CLAP, LV2 and VST3 — effects and instruments — run through Dusk Studio's own native hosts; Audio Units do too on macOS.
+- VST3, LV2, AU, and CLAP plugin hosting, with optional out-of-process sandboxing for crash isolation. CLAP and VST3 — effects and instruments — run through Dusk Studio's own native hosts on Linux, macOS, and Windows; LV2 does on Linux and macOS, and Audio Units do on macOS.
 - External hardware insert per channel and per aux, with automatic latency measurement.
 - A multi-sampler that plays `.sfz` files and `.sf2` SoundFonts on MIDI tracks, both through the built-in sfizz engine (SF2 files are converted to SFZ on load — no external synth required).
 - MIDI Clock and MIDI Time Code chase and emit.
@@ -1494,9 +1494,9 @@ A few rules:
 
 Dusk Studio scans and hosts:
 
-- **VST3** on Linux, macOS, and Windows. On Linux and macOS, effects AND instruments load through Dusk Studio's own native VST3 host (rows tagged **VST3-Native**); Windows uses the standard host.
+- **VST3** on Linux, macOS, and Windows. Effects AND instruments load through Dusk Studio's own native VST3 host (rows tagged **VST3-Native**) on all three.
 - **LV2** on Linux and macOS. Effects and instruments load through Dusk Studio's own native LV2 host (rows tagged **LV2-Native**). If a plugin update adds new instruments, run **Scan plugins** for them to appear.
-- **CLAP** on Linux and macOS, through the native host — effects and instruments.
+- **CLAP** on Linux, macOS, and Windows, through the native host — effects and instruments.
 - **AU** on macOS only, through Dusk Studio's native Audio Unit host — effects and instruments.
 - **Native multi-sampler** (`.sfz`, `.sf2`, and ARIA `.bank.xml` files via the built-in sfizz engine — SF2 is converted to SFZ on load, while a bank manifest opens its first program) on all platforms.
 
@@ -1512,7 +1512,7 @@ Plugin scan results are cached in:
 - macOS: `~/Library/Application Support/Dusk Studio/plugin-cache.xml`
 - Windows: `%APPDATA%\Dusk Studio\plugin-cache.xml`
 
-On Linux and macOS the native hosts keep their own sidecar caches next to it (`clap-cache.json`, `lv2-native-cache.json`, `vst3-native-cache.json`, plus `au-native-cache.json` on macOS), rebuilt by the same **Scan plugins** button. Existing XML sidecars are used as a fallback whenever the matching JSON cache cannot be loaded, including when it is absent, malformed, or unusable; subsequent scans write JSON. The native LV2 scan reads only the bundles' manifests, and the native AU scan reads the macOS Audio Component registry metadata; neither scan instantiates plugin code, so a broken plugin cannot crash that scan and is simply skipped (or reported when you try to load it).
+The native hosts keep their own sidecar caches next to it (`clap-cache.json` and `vst3-native-cache.json` on every OS, `lv2-native-cache.json` on Linux and macOS, `au-native-cache.json` on macOS), rebuilt by the same **Scan plugins** button. Existing XML sidecars are used as a fallback whenever the matching JSON cache cannot be loaded, including when it is absent, malformed, or unusable; subsequent scans write JSON. The native LV2 scan reads only the bundles' manifests, and the native AU scan reads the macOS Audio Component registry metadata; neither scan instantiates plugin code, so a broken plugin cannot crash that scan and is simply skipped (or reported when you try to load it).
 
 To re-scan on every launch, enable **Settings → General → Scan plugins on startup**. The startup scan runs in the background behind a progress window (it shows the plugin currently being scanned and a progress bar), so the app stays responsive instead of appearing to hang while a large collection is scanned.
 
@@ -1525,7 +1525,7 @@ In the **plugin picker** modal:
 - Each row shows the plugin name and its format (VST3 / LV2 / AudioUnit / CLAP / LV2-Native / VST3-Native).
 - Click a row to load and dismiss.
 
-On Linux and macOS, both the effect and instrument pickers list LV2 and VST3 plugins as **LV2-Native** / **VST3-Native** rows — the same plugins, hosted by Dusk Studio's native hosts instead of the standard one. On macOS, Audio Units appear once as native **AudioUnit** rows. There are no duplicate standard-host rows for these formats.
+Both the effect and instrument pickers list VST3 plugins as **VST3-Native** rows on every OS, and LV2 plugins as **LV2-Native** rows on Linux and macOS — the same plugins, hosted by Dusk Studio's native hosts instead of the standard one. On macOS, Audio Units appear once as native **AudioUnit** rows. There are no duplicate standard-host rows for these formats.
 
 The picker filters by intent: only effect plugins appear when you're loading onto a channel insert or aux lane; only instruments appear when you're loading onto a MIDI track.
 
@@ -1544,7 +1544,7 @@ This holds on all platforms, including the macOS out-of-process sandbox. Rather 
 
 ## Native plugin hosting (Linux and macOS)
 
-On Linux and macOS, CLAP, LV2, and VST3 plugins — effects and instruments — are hosted by Dusk Studio's own plugin hosts rather than the standard hosting layer. Audio Units use the native host on macOS too. The native hosts own the format lifecycle and editor embedding directly; on Linux this also sidesteps the standard layer's UI breakage on Wayland desktops.
+CLAP and VST3 plugins — effects and instruments — are hosted by Dusk Studio's own plugin hosts on Linux, macOS, and Windows; LV2 is on Linux and macOS. Audio Units use the native host on macOS too. The native hosts own the format lifecycle and editor embedding directly; on Linux this also sidesteps the standard layer's UI breakage on Wayland desktops.
 
 In practice the differences are small:
 
@@ -1568,7 +1568,7 @@ OOP is supported on:
 - **Windows**: always.
 - **macOS**: requires macOS 14.4 or later. The plugin **editor** is hosted in-process via a shell instance and embeds as a centred modal like the other platforms — see *Opening the editor* above.
 
-Plugins run **in-process by default** — it gives the most responsive plugin editors and the lowest CPU cost. To run third-party binary plugins in the OOP sandbox instead, launch with `DUSKSTUDIO_USE_OOP_PLUGINS=1`; a plugin that crashes or hangs then takes down only the host child, not Dusk Studio. The switch reaches standard-host rows only. Native rows — **CLAP**, **LV2-Native**, and **VST3-Native** on Linux and macOS, plus **AudioUnit** on macOS — always run in-process and ignore it, as *Native plugin hosting* above says. If the `dusk-studio-plugin-host` binary is missing the loader falls back to in-process automatically. Standard-host plugin **scanning** runs in the sandboxed child, so a plugin that crashes while being probed is blacklisted instead of crashing the app; native scanning follows the format-specific rules described under *Scanning*. (Dusk Studio's own bundled plugins always run in-process.)
+Plugins run **in-process by default** — it gives the most responsive plugin editors and the lowest CPU cost. To run third-party binary plugins in the OOP sandbox instead, launch with `DUSKSTUDIO_USE_OOP_PLUGINS=1`; a plugin that crashes or hangs then takes down only the host child, not Dusk Studio. The switch reaches standard-host rows only. Native rows — **CLAP** and **VST3-Native** on every OS, **LV2-Native** on Linux and macOS, plus **AudioUnit** on macOS — always run in-process and ignore it, as *Native plugin hosting* above says. If the `dusk-studio-plugin-host` binary is missing the loader falls back to in-process automatically. Standard-host plugin **scanning** runs in the sandboxed child, so a plugin that crashes while being probed is blacklisted instead of crashing the app; native scanning follows the format-specific rules described under *Scanning*. (Dusk Studio's own bundled plugins always run in-process.)
 
 When a plugin crashes in OOP mode:
 
@@ -1737,7 +1737,7 @@ In addition to MCU support, any control in Dusk Studio can be bound to a MIDI CC
 
 The binding is captured and immediately active. The next time that CC arrives, the control responds.
 
-**Plugin parameters**: right-click a loaded insert slot and choose **MIDI Learn last-touched parameter**. Move the target knob in the plugin's own editor first, then trigger your controller — the binding targets whichever parameter you touched last. This works for standard-host plugins and for every native host on Linux and macOS (CLAP, LV2-Native, VST3-Native, and AudioUnit on macOS), including LV2 plugins whose parameters are atom "patch" properties (JUCE-built LV2s, notably).
+**Plugin parameters**: right-click a loaded insert slot and choose **MIDI Learn last-touched parameter**. Move the target knob in the plugin's own editor first, then trigger your controller — the binding targets whichever parameter you touched last. This works for standard-host plugins and for every native host (CLAP and VST3-Native on every OS, LV2-Native on Linux and macOS, and AudioUnit on macOS), including LV2 plugins whose parameters are atom "patch" properties (JUCE-built LV2s, notably).
 
 ## Trigger types
 

--- a/docs/dejuce-hosting-h5-platform.md
+++ b/docs/dejuce-hosting-h5-platform.md
@@ -1,11 +1,11 @@
 # Hosting tower H5 — native platform ports + AU (executable spec)
 
-Status: **H5a.0-H5a.2 MERGED AS PR #120 AT `2a8135d`; H5a.3 MERGED AS PR
-#121 AT `12efe0d`; H5a.4-H5a.6 MERGED AS PR #122 AT `084196c`. H5a IS
-COMPLETE; MACOS BENCH SIGN-OFF REMAINS OWED. H5b IMPLEMENTATION AND LOCAL
-VERIFICATION ARE COMPLETE ON `dejuce/hosting-h5b`; DRAFT PR #154 IS OPEN AND
-MACOS CI IS GREEN. STOCK APPLE AU EFFECT + INSTRUMENT FULL-APP BENCH SIGN-OFF
-REMAINS OWED.** H4 is merged as PR #119 at `3c5c901`. The H5
+Status: **H5a MERGED (PRs #120/#121/#122). H5b MERGED (PR #154). H5c IS IN
+PROGRESS ON `dejuce/hosting-h5c`: WINDOWS CLAP/VST3 CORE, CHILD-HWND EDITORS,
+CMAKE GATES, AND WINDOWS CI ENABLEMENT ARE COMMITTED LOCALLY; WINDOWS CI AND
+BENCH SIGN-OFF REMAIN OWED. MACOS BENCH SIGN-OFF (H5a) AND STOCK APPLE AU
+EFFECT + INSTRUMENT BENCH SIGN-OFF (H5b) REMAIN OWED.** H4 is merged as PR
+#119 at `3c5c901`. The H5
 scout verified the live source/CMake/CI surface from that baseline. Windows
 LV2 is deferred. H5 is three sequential PRs: H5a macOS CLAP/LV2/VST3, H5b
 macOS AU, H5c Windows CLAP/VST3. No H5 branch is pushed without Marc's word.
@@ -380,7 +380,7 @@ H5 is complete only when:
 
 ## Resume phrase
 
-"Hosting H5b, spec docs/dejuce-hosting-h5-platform.md — on
-dejuce/hosting-h5b, monitor draft PR #154, fix macOS CI or review findings,
-and record the stock Apple AU effect + instrument bench sign-off; do not
-start H5c until H5b merges."
+"Hosting H5c, spec docs/dejuce-hosting-h5-platform.md — on
+dejuce/hosting-h5c, review the local commits, get Marc's word to push and
+open the PR, drive Windows CI green, and record the Windows CLAP/VST3
+bench sign-off (editor DPI, resize/reopen, state, latency, ASIO playback)."

--- a/docs/dejuce-hosting-h5-platform.md
+++ b/docs/dejuce-hosting-h5-platform.md
@@ -1,10 +1,12 @@
 # Hosting tower H5 — native platform ports + AU (executable spec)
 
-Status: **H5a MERGED (PRs #120/#121/#122). H5b MERGED (PR #154). H5c IS IN
-PROGRESS ON `dejuce/hosting-h5c`: WINDOWS CLAP/VST3 CORE, CHILD-HWND EDITORS,
-CMAKE GATES, AND WINDOWS CI ENABLEMENT ARE COMMITTED LOCALLY; WINDOWS CI AND
-BENCH SIGN-OFF REMAIN OWED. MACOS BENCH SIGN-OFF (H5a) AND STOCK APPLE AU
-EFFECT + INSTRUMENT BENCH SIGN-OFF (H5b) REMAIN OWED.** H4 is merged as PR
+Status: **H5a MERGED (PRs #120/#121/#122). H5b MERGED (PR #154). H5c IS OPEN
+AS PR #317 ON `dejuce/hosting-h5c`: WINDOWS CLAP/VST3 CORE, CHILD-HWND
+EDITORS, CMAKE GATES, AND WINDOWS CI ENABLEMENT ARE PUSHED, ALL PR CHECKS ARE
+GREEN, AND A DISPATCHED `windows-build.yml` RUN COMPILED AND PACKAGED THE
+WINDOWS APP INCLUDING BOTH EDITOR UNITS. WINDOWS BENCH SIGN-OFF REMAINS OWED.
+MACOS BENCH SIGN-OFF (H5a) AND STOCK APPLE AU EFFECT + INSTRUMENT BENCH
+SIGN-OFF (H5b) REMAIN OWED.** H4 is merged as PR
 #119 at `3c5c901`. The H5
 scout verified the live source/CMake/CI surface from that baseline. Windows
 LV2 is deferred. H5 is three sequential PRs: H5a macOS CLAP/LV2/VST3, H5b
@@ -380,7 +382,7 @@ H5 is complete only when:
 
 ## Resume phrase
 
-"Hosting H5c, spec docs/dejuce-hosting-h5-platform.md — on
-dejuce/hosting-h5c, review the local commits, get Marc's word to push and
-open the PR, drive Windows CI green, and record the Windows CLAP/VST3
-bench sign-off (editor DPI, resize/reopen, state, latency, ASIO playback)."
+"Hosting H5c, spec docs/dejuce-hosting-h5-platform.md — PR #317 is open with
+green checks; record the Windows CLAP/VST3 bench sign-off (editor DPI,
+resize/reopen, state, latency, ASIO playback), then get Marc's word to merge
+and start H6."

--- a/src/engine/clap/ClapBundle.cpp
+++ b/src/engine/clap/ClapBundle.cpp
@@ -1,11 +1,14 @@
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
+
 #include "ClapBundle.h"
 
 #include <clap/clap.h>
 
-#if defined(_WIN32)
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#else
+#if ! defined(_WIN32)
 #include <dlfcn.h>
 #endif
 

--- a/src/engine/clap/ClapBundle.cpp
+++ b/src/engine/clap/ClapBundle.cpp
@@ -2,7 +2,12 @@
 
 #include <clap/clap.h>
 
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#else
 #include <dlfcn.h>
+#endif
 
 #if defined(__APPLE__)
 #include <CoreFoundation/CoreFoundation.h>
@@ -13,6 +18,52 @@
 
 namespace duskstudio::clap
 {
+#if defined(_WIN32)
+namespace
+{
+// Identity and error text stay UTF-8; only the loader call itself goes UTF-16.
+std::wstring widenUtf8 (const std::string& utf8)
+{
+    if (utf8.empty()) return {};
+    const int n = ::MultiByteToWideChar (CP_UTF8, 0, utf8.data(),
+                                         (int) utf8.size(), nullptr, 0);
+    if (n <= 0) return {};
+    std::wstring wide ((size_t) n, L'\0');
+    ::MultiByteToWideChar (CP_UTF8, 0, utf8.data(), (int) utf8.size(),
+                           wide.data(), n);
+    return wide;
+}
+
+std::string lastErrorUtf8()
+{
+    const DWORD code = ::GetLastError();
+    wchar_t* buffer = nullptr;
+    const DWORD len = ::FormatMessageW (
+        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM
+            | FORMAT_MESSAGE_IGNORE_INSERTS,
+        nullptr, code, 0, reinterpret_cast<wchar_t*> (&buffer), 0, nullptr);
+    std::string text = "error " + std::to_string (code);
+    if (len > 0 && buffer != nullptr)
+    {
+        const int n = ::WideCharToMultiByte (CP_UTF8, 0, buffer, (int) len,
+                                             nullptr, 0, nullptr, nullptr);
+        if (n > 0)
+        {
+            std::string message ((size_t) n, '\0');
+            ::WideCharToMultiByte (CP_UTF8, 0, buffer, (int) len,
+                                   message.data(), n, nullptr, nullptr);
+            while (! message.empty()
+                   && (message.back() == '\n' || message.back() == '\r'
+                       || message.back() == '\0'))
+                message.pop_back();
+            if (! message.empty()) text += ": " + message;
+        }
+        ::LocalFree (buffer);
+    }
+    return text;
+}
+} // namespace
+#endif
 #if defined(__APPLE__)
 namespace
 {
@@ -85,6 +136,24 @@ bool ClapBundle::load (const std::string& path, std::string& errorOut)
     unload();
     bundlePath = path;
 
+#if defined(_WIN32)
+    // A Windows .clap is a renamed DLL. The scanner and session store absolute
+    // paths, which LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR requires; it lets the
+    // plugin's own directory resolve its dependent DLLs.
+    handle = ::LoadLibraryExW (widenUtf8 (path).c_str(), nullptr,
+                               LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR
+                                   | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+    if (handle == nullptr)
+    {
+        errorOut = "LoadLibrary failed: " + lastErrorUtf8();
+        bundlePath.clear();
+        return false;
+    }
+
+    // A .clap exports `const clap_plugin_entry_t clap_entry`.
+    entry = reinterpret_cast<const ::clap_plugin_entry*> (
+        ::GetProcAddress (static_cast<HMODULE> (handle), "clap_entry"));
+#else
 #if defined(__APPLE__)
     std::string executablePath;
     if (! resolveBundleExecutable (path, executablePath, errorOut))
@@ -110,6 +179,7 @@ bool ClapBundle::load (const std::string& path, std::string& errorOut)
 
     // A .clap exports `const clap_plugin_entry_t clap_entry`.
     entry = reinterpret_cast<const ::clap_plugin_entry*> (dlsym (handle, "clap_entry"));
+#endif
     if (entry == nullptr)              { errorOut = "no clap_entry symbol";        unload(); return false; }
     if (! clap_version_is_compatible (entry->clap_version))
                                        { errorOut = "incompatible CLAP version";   unload(); return false; }
@@ -155,7 +225,11 @@ void ClapBundle::unload()
     entry = nullptr;
     if (handle != nullptr)
     {
+#if defined(_WIN32)
+        ::FreeLibrary (static_cast<HMODULE> (handle));
+#else
         dlclose (handle);
+#endif
         handle = nullptr;
     }
     bundlePath.clear();

--- a/src/engine/clap/ClapBundle.h
+++ b/src/engine/clap/ClapBundle.h
@@ -48,7 +48,7 @@ public:
     const std::string&              getPath()    const noexcept { return bundlePath; }
 
 private:
-    void* handle = nullptr;                          // dlopen handle
+    void* handle = nullptr;                          // dlopen handle / HMODULE
     const ::clap_plugin_entry*   entry   = nullptr;
     bool  initialised = false;                       // entry->init() succeeded
     const ::clap_plugin_factory* factory = nullptr;

--- a/src/engine/clap/ClapEditor.h
+++ b/src/engine/clap/ClapEditor.h
@@ -10,8 +10,9 @@
 namespace duskstudio::clap
 {
 // Native embedded editor for a CLAP plugin. The platform translation unit owns
-// an X11 child window on Linux or an NSView child container on macOS. Drives the
-// plugin's fd/timer event pump through ClapHost on the message thread.
+// an X11 child window on Linux, an NSView child container on macOS, or a child
+// HWND on Windows. Drives the plugin's event pump through ClapHost on the
+// message thread.
 //
 // Platform headers do not leak through this boundary. Native parent handles are
 // opaque pointers, so the API also remains safe on pointer-width Windows handles.

--- a/src/engine/clap/ClapEditor.h
+++ b/src/engine/clap/ClapEditor.h
@@ -35,6 +35,22 @@ public:
     bool embed (void* parentHandle, int x, int y, int w, int h, std::string& errorOut);
 
     void setBounds (int x, int y, int w, int h);
+
+    // Tell the GUI the host's logical->physical factor. A HiDPI-aware plugin
+    // reports its size in physical pixels only once it knows the scale, so the
+    // cached preferred size is re-read when it takes. CLAP fixes the macOS
+    // scale at 1, so only the Win32 embed calls this.
+    void setContentScale (double scale) noexcept
+    {
+        if (! created || plugin == nullptr || gui == nullptr) return;
+        if (gui->set_scale == nullptr || scale <= 0.0) return;
+        if (! gui->set_scale (plugin, scale)) return;
+
+        uint32_t w = 0, h = 0;
+        if (gui->get_size != nullptr && gui->get_size (plugin, &w, &h) && w > 0 && h > 0)
+        { prefW = (int) w; prefH = (int) h; }
+    }
+
     void reveal();
     void hide();
 

--- a/src/engine/clap/ClapEditor_Win.cpp
+++ b/src/engine/clap/ClapEditor_Win.cpp
@@ -1,0 +1,262 @@
+#include "ClapEditor.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include <algorithm>
+
+namespace duskstudio::clap
+{
+namespace
+{
+HWND containerHwnd (std::uintptr_t handle) noexcept
+{
+    return reinterpret_cast<HWND> (handle);
+}
+
+// One process-wide class for every CLAP container window. The plugin parents
+// its own HWND inside ours, so our window procedure never needs more than
+// default handling.
+const wchar_t* containerClass()
+{
+    static const wchar_t* name = [] {
+        WNDCLASSEXW wc {};
+        wc.cbSize        = sizeof (wc);
+        wc.style         = CS_DBLCLKS;
+        wc.lpfnWndProc   = &DefWindowProcW;
+        wc.hInstance     = ::GetModuleHandleW (nullptr);
+        wc.hCursor       = ::LoadCursorW (nullptr, IDC_ARROW);
+        wc.lpszClassName = L"DuskClapEditorContainer";
+        ::RegisterClassExW (&wc);
+        return wc.lpszClassName;
+    }();
+    return name;
+}
+} // namespace
+
+ClapEditor::~ClapEditor() { close(); }
+
+bool ClapEditor::open (const ::clap_plugin* p, ClapHost& host, std::string& errorOut)
+{
+    if (p == nullptr) { errorOut = "null plugin"; return false; }
+
+    gui = static_cast<const clap_plugin_gui_t*> (p->get_extension (p, CLAP_EXT_GUI));
+    if (gui == nullptr) { errorOut = "plugin has no gui extension"; return false; }
+    if (gui->is_api_supported == nullptr
+        || ! gui->is_api_supported (p, CLAP_WINDOW_API_WIN32, false))
+    { errorOut = "plugin has no embedded-Win32 GUI"; gui = nullptr; return false; }
+    if (gui->create == nullptr || ! gui->create (p, CLAP_WINDOW_API_WIN32, false))
+    { errorOut = "gui create() failed"; gui = nullptr; return false; }
+
+    plugin  = p;
+    hostPtr = &host;
+    host.setPlugin (p);
+    host.setCallbacks (this);
+    created = true;
+
+    resizable = (gui->can_resize != nullptr) && gui->can_resize (p);
+
+    uint32_t w = 0, h = 0;
+    if (gui->get_size != nullptr && gui->get_size (p, &w, &h))
+    { prefW = (int) w; prefH = (int) h; }
+    return true;
+}
+
+bool ClapEditor::embed (void* parentHandle, int x, int y, int w, int h,
+                        std::string& errorOut)
+{
+    if (! created) { errorOut = "gui not created"; return false; }
+    if (parentHandle == nullptr) { errorOut = "null parent window"; return false; }
+
+    auto* parent = static_cast<HWND> (parentHandle);
+    const int ww = w > 0 ? w : (prefW > 0 ? prefW : 400);
+    const int hh = h > 0 ? h : (prefH > 0 ? prefH : 300);
+
+    // Created hidden; reveal() shows it once the wrapper has final bounds.
+    HWND container = ::CreateWindowExW (
+        0, containerClass(), L"", WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS,
+        x, y, ww, hh, parent, nullptr, ::GetModuleHandleW (nullptr), nullptr);
+    if (container == nullptr)
+    { errorOut = "could not create Win32 container window"; return false; }
+
+    platformContext = parent;
+    containerHandle = reinterpret_cast<std::uintptr_t> (container);
+
+    clap_window_t win {};
+    win.api   = CLAP_WINDOW_API_WIN32;
+    win.win32 = container;
+    if (gui->set_parent == nullptr || ! gui->set_parent (plugin, &win))
+    { errorOut = "gui set_parent() failed"; close(); return false; }
+
+    if (resizable && gui->set_size != nullptr)
+        gui->set_size (plugin, (uint32_t) ww, (uint32_t) hh);
+    if (gui->show != nullptr && ! gui->show (plugin))
+    { errorOut = "gui show() failed"; close(); return false; }
+
+    embedded = true;
+    return true;
+}
+
+void ClapEditor::setBounds (int x, int y, int w, int h)
+{
+    HWND container = containerHwnd (containerHandle);
+    if (container == nullptr) return;
+
+    const int ww = std::max (1, w);
+    const int hh = std::max (1, h);
+    ::SetWindowPos (container, nullptr, x, y, ww, hh,
+                    SWP_NOZORDER | SWP_NOACTIVATE);
+    if (resizable && gui != nullptr && gui->set_size != nullptr && w > 0 && h > 0)
+        gui->set_size (plugin, (uint32_t) w, (uint32_t) h);
+}
+
+bool ClapEditor::getRootRelativePosition (void*, int&, int&) const
+{
+    return false;
+}
+
+bool ClapEditor::getActualGeometry (int&, int&, int&, int&) const
+{
+    return false;
+}
+
+void ClapEditor::reveal()
+{
+    HWND container = containerHwnd (containerHandle);
+    if (container == nullptr || mapped) return;
+    ::ShowWindow (container, SW_SHOWNA);
+    mapped = true;
+}
+
+void ClapEditor::hide()
+{
+    HWND container = containerHwnd (containerHandle);
+    if (container == nullptr || ! mapped) return;
+    ::ShowWindow (container, SW_HIDE);
+    mapped = false;
+}
+
+void ClapEditor::quiesce() noexcept
+{
+    if (HWND container = containerHwnd (containerHandle); container != nullptr && mapped)
+        ::ShowWindow (container, SW_HIDE);
+    mapped = false;
+}
+
+void ClapEditor::abandonPluginAndContainer() noexcept
+{
+    abandonPlugin();
+    // The plugin is already disposed but its window class may still own child
+    // windows under our container. DestroyWindow would dispatch WM_DESTROY
+    // through window procedures in a DLL that can be unloaded by now, so the
+    // container is dropped, not destroyed; the parent peer's teardown reaps it.
+    platformContext = nullptr;
+    containerHandle = 0;
+    mapped          = false;
+}
+
+void ClapEditor::close()
+{
+    // Leak path: the plugin GUI stays created (it hangs in gui->destroy) and
+    // keeps its child windows under our container, so the container HWND is
+    // leaked with it; the peer's own destruction tears the window tree down
+    // while the leaked GUI is still a valid message target.
+    if (leakOnClose && created)
+    {
+        if (hostPtr != nullptr)
+        {
+            hostPtr->markGuiLeaked();
+            hostPtr->setCallbacks (nullptr);
+            hostPtr = nullptr;
+        }
+        platformContext = nullptr;
+        containerHandle = 0;
+        gui = nullptr;
+        plugin = nullptr;
+        created = embedded = mapped = false;
+        return;
+    }
+
+    if (plugin != nullptr && gui != nullptr)
+    {
+        if (gui->hide != nullptr)    gui->hide (plugin);
+        if (gui->destroy != nullptr) gui->destroy (plugin);
+    }
+    if (hostPtr != nullptr) { hostPtr->setCallbacks (nullptr); hostPtr = nullptr; }
+
+    if (HWND container = containerHwnd (containerHandle); container != nullptr)
+        ::DestroyWindow (container);
+    platformContext = nullptr;
+    containerHandle = 0;
+    gui = nullptr;
+    plugin = nullptr;
+    created = embedded = mapped = false;
+}
+
+void ClapEditor::drainPendingCallbacks()
+{
+    if (pendingClosed.exchange (false))
+    {
+        if (pendingClosedWasDestroyed.load())
+        {
+            if (plugin != nullptr && gui != nullptr && gui->destroy != nullptr)
+                gui->destroy (plugin);
+            gui = nullptr;
+            created = embedded = false;
+            hide();
+        }
+        if (onClosed) onClosed();
+        pendingResize.exchange (false);
+        pendingShow.exchange (false);
+        pendingHide.exchange (false);
+        return;
+    }
+
+    if (pendingResize.exchange (false))
+    {
+        const int w = pendingW.load (std::memory_order_relaxed);
+        const int h = pendingH.load (std::memory_order_relaxed);
+        prefW = w; prefH = h;
+        if (HWND container = containerHwnd (containerHandle); container != nullptr)
+            ::SetWindowPos (container, nullptr, 0, 0,
+                            std::max (1, w), std::max (1, h),
+                            SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
+        if (onResize) onResize (w, h);
+    }
+
+    if (pendingShow.exchange (false)) reveal();
+    if (pendingHide.exchange (false)) hide();
+}
+
+void ClapEditor::pump (double elapsedMs)
+{
+    drainPendingCallbacks();
+    if (hostPtr != nullptr) hostPtr->pumpGui (elapsedMs);
+}
+
+bool ClapEditor::onRequestResize (uint32_t w, uint32_t h)
+{
+    pendingW.store ((int) w, std::memory_order_relaxed);
+    pendingH.store ((int) h, std::memory_order_relaxed);
+    pendingResize.store (true, std::memory_order_release);
+    return true;
+}
+
+bool ClapEditor::onRequestShow()
+{
+    pendingShow.store (true, std::memory_order_release);
+    return true;
+}
+
+bool ClapEditor::onRequestHide()
+{
+    pendingHide.store (true, std::memory_order_release);
+    return true;
+}
+
+void ClapEditor::onGuiClosed (bool wasDestroyed)
+{
+    pendingClosedWasDestroyed.store (wasDestroyed, std::memory_order_relaxed);
+    pendingClosed.store (true, std::memory_order_release);
+}
+} // namespace duskstudio::clap

--- a/src/engine/clap/ClapEditor_Win.cpp
+++ b/src/engine/clap/ClapEditor_Win.cpp
@@ -1,7 +1,10 @@
-#include "ClapEditor.h"
-
+// Ahead of every include: whichever header reaches windows.h first must see
+// these, or its min/max macros eat std::max at the call sites below.
 #define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <windows.h>
+
+#include "ClapEditor.h"
 
 #include <algorithm>
 
@@ -25,7 +28,9 @@ const wchar_t* containerClass()
         wc.style         = CS_DBLCLKS;
         wc.lpfnWndProc   = &DefWindowProcW;
         wc.hInstance     = ::GetModuleHandleW (nullptr);
-        wc.hCursor       = ::LoadCursorW (nullptr, IDC_ARROW);
+        // IDC_ARROW is an integer-resource pseudo-pointer, and without UNICODE
+        // defined it expands to the ANSI form; the W call needs it re-cast.
+        wc.hCursor       = ::LoadCursorW (nullptr, reinterpret_cast<LPCWSTR> (IDC_ARROW));
         wc.lpszClassName = L"DuskClapEditorContainer";
         ::RegisterClassExW (&wc);
         return wc.lpszClassName;

--- a/src/engine/clap/ClapHost.cpp
+++ b/src/engine/clap/ClapHost.cpp
@@ -5,7 +5,9 @@
 #include <cstdio>
 #include <cstring>
 
+#if ! defined(_WIN32)
 #include <poll.h>
+#endif
 
 namespace duskstudio::clap
 {
@@ -35,9 +37,11 @@ ClapHost::ClapHost()
     guiExt.request_hide         = &ClapHost::requestHide;
     guiExt.closed               = &ClapHost::guiClosed;
 
+#if ! defined(_WIN32)
     fdExt.register_fd   = &ClapHost::registerFd;
     fdExt.modify_fd     = &ClapHost::modifyFd;
     fdExt.unregister_fd = &ClapHost::unregisterFd;
+#endif
 
     timerExt.register_timer   = &ClapHost::registerTimer;
     timerExt.unregister_timer = &ClapHost::unregisterTimer;
@@ -49,7 +53,9 @@ const void* ClapHost::getExtension (const clap_host_t* h, const char* id) noexce
     if (std::strcmp (id, CLAP_EXT_LOG)               == 0) return &s.logExt;
     if (std::strcmp (id, CLAP_EXT_THREAD_CHECK)      == 0) return &s.threadCheckExt;
     if (std::strcmp (id, CLAP_EXT_GUI)               == 0) return &s.guiExt;
+#if ! defined(_WIN32)
     if (std::strcmp (id, CLAP_EXT_POSIX_FD_SUPPORT)  == 0) return &s.fdExt;
+#endif
     if (std::strcmp (id, CLAP_EXT_TIMER_SUPPORT)     == 0) return &s.timerExt;
     return nullptr;
 }
@@ -95,6 +101,7 @@ void ClapHost::guiClosed (const clap_host_t* h, bool wasDestroyed) noexcept
     if (auto* c = self (h).callbacks.load (std::memory_order_acquire)) c->onGuiClosed (wasDestroyed);
 }
 
+#if ! defined(_WIN32)
 // posix-fd
 bool ClapHost::registerFd (const clap_host_t* h, int fd, clap_posix_fd_flags_t flags) noexcept
 {
@@ -118,6 +125,7 @@ bool ClapHost::unregisterFd (const clap_host_t* h, int fd) noexcept
     v.erase (std::remove_if (v.begin(), v.end(), [fd] (const RegFd& r) { return r.fd == fd; }), v.end());
     return v.size() != n;
 }
+#endif
 
 // timer
 bool ClapHost::registerTimer (const clap_host_t* h, uint32_t periodMs, clap_id* idOut) noexcept
@@ -151,6 +159,7 @@ void ClapHost::pumpGui (double elapsedMs)
         && plugin->on_main_thread != nullptr)
         plugin->on_main_thread (plugin);
 
+#if ! defined(_WIN32)
     if (! fds.empty())
     {
         if (const auto* fdSup = static_cast<const clap_plugin_posix_fd_support_t*> (
@@ -188,6 +197,7 @@ void ClapHost::pumpGui (double elapsedMs)
                 }
         }
     }
+#endif
 
     if (! timers.empty())
     {

--- a/src/engine/clap/ClapHost.h
+++ b/src/engine/clap/ClapHost.h
@@ -12,9 +12,10 @@
 namespace duskstudio::clap
 {
 // Minimal CLAP host: owns a clap_host_t and the host extensions an embedded-GUI
-// audio host needs - log, thread-check, gui, posix-fd-support, timer-support.
-// One per plugin instance. The plugin's editor runs its own X11 event loop and
-// asks us to pump its fd + timers; pumpGui() does that from the message thread.
+// audio host needs - log, thread-check, gui, timer-support, and posix-fd-support
+// everywhere but Windows (the extension must not exist there). One per plugin
+// instance. The plugin's embedded editor asks us to pump its fds + timers;
+// pumpGui() does that from the message thread.
 // See docs/native-clap-host-plan.md.
 class ClapHost
 {
@@ -63,8 +64,9 @@ public:
     void markGuiLeaked() noexcept    { guiLeaked = true; }
     bool isGuiLeaked() const noexcept { return guiLeaked; }
 
-    // Message thread: poll the plugin's registered fds (level-triggered) and fire
-    // its registered timers, so the embedded GUI processes its X11 events + repaints.
+    // Message thread: poll the plugin's registered fds (level-triggered, POSIX
+    // platforms) and fire its registered timers, so the embedded GUI processes
+    // its events + repaints.
     void pumpGui (double elapsedMs);
 
 private:
@@ -79,10 +81,12 @@ private:
     static bool requestShow (const clap_host_t*) noexcept;
     static bool requestHide (const clap_host_t*) noexcept;
     static void guiClosed (const clap_host_t*, bool) noexcept;
-    // posix-fd
+#if ! defined(_WIN32)
+    // posix-fd: never advertised on Windows, so nothing fd-shaped compiles there.
     static bool registerFd   (const clap_host_t*, int, clap_posix_fd_flags_t) noexcept;
     static bool modifyFd     (const clap_host_t*, int, clap_posix_fd_flags_t) noexcept;
     static bool unregisterFd (const clap_host_t*, int) noexcept;
+#endif
     // timer
     static bool registerTimer   (const clap_host_t*, uint32_t, clap_id*) noexcept;
     static bool unregisterTimer (const clap_host_t*, clap_id) noexcept;
@@ -94,16 +98,20 @@ private:
     clap_host_log_t              logExt {};
     clap_host_thread_check_t     threadCheckExt {};
     clap_host_gui_t              guiExt {};
+#if ! defined(_WIN32)
     clap_host_posix_fd_support_t fdExt {};
+#endif
     clap_host_timer_support_t    timerExt {};
 
     const clap_plugin*       plugin = nullptr;
     std::atomic<Callbacks*>  callbacks { nullptr };
     bool                     guiLeaked = false;
 
+#if ! defined(_WIN32)
     struct RegFd    { int fd; clap_posix_fd_flags_t flags; };
-    struct RegTimer { clap_id id; uint32_t periodMs; double accumMs; };
     std::vector<RegFd>    fds;
+#endif
+    struct RegTimer { clap_id id; uint32_t periodMs; double accumMs; };
     std::vector<RegTimer> timers;
     clap_id nextTimerId = 1;
     std::atomic<bool> callbackRequested { false };   // request_callback -> on_main_thread, drained in pumpGui

--- a/src/engine/clap/ClapScanner.cpp
+++ b/src/engine/clap/ClapScanner.cpp
@@ -21,9 +21,24 @@ std::vector<stdfs::path> ClapScanner::defaultSearchPaths()
         dirs.push_back (d);
     };
 
-    // $CLAP_PATH overrides / extends the defaults (':'-separated, like $PATH).
-    if (const char* env = std::getenv ("CLAP_PATH"))
-        for (const auto& tok : dusk::text::split (env, ':'))
+    // $CLAP_PATH overrides / extends the defaults, separated like $PATH
+    // (':' on POSIX, ';' on Windows).
+#if defined(_WIN32)
+    constexpr char kListSep = ';';
+    // _wgetenv, not getenv: the value carries user-profile paths, which the
+    // ANSI environment mangles for non-ASCII user names. ';' is one byte in
+    // UTF-8, so splitting after the conversion is safe.
+    const std::string envStorage = [] {
+        const wchar_t* w = ::_wgetenv (L"CLAP_PATH");
+        return w != nullptr ? stdfs::path (w).u8string() : std::string();
+    }();
+    const char* env = envStorage.empty() ? nullptr : envStorage.c_str();
+#else
+    constexpr char kListSep = ':';
+    const char* env = std::getenv ("CLAP_PATH");
+#endif
+    if (env != nullptr)
+        for (const auto& tok : dusk::text::split (env, kListSep))
         {
             const auto trimmed = dusk::text::trim (tok);
             if (! trimmed.empty()) add (stdfs::u8path (trimmed));
@@ -32,6 +47,12 @@ std::vector<stdfs::path> ClapScanner::defaultSearchPaths()
 #if defined(__APPLE__)
     add (dusk::fs::userHomeDir() / "Library/Audio/Plug-Ins/CLAP");
     add ("/Library/Audio/Plug-Ins/CLAP");
+#elif defined(_WIN32)
+    // CLAP's documented Windows install dirs (clap/entry.h).
+    if (const wchar_t* common = ::_wgetenv (L"COMMONPROGRAMFILES"))
+        add (stdfs::path (common) / L"CLAP");
+    if (const wchar_t* local = ::_wgetenv (L"LOCALAPPDATA"))
+        add (stdfs::path (local) / L"Programs" / L"Common" / L"CLAP");
 #else
     add (dusk::fs::userHomeDir() / ".clap");
     add ("/usr/lib/clap");

--- a/src/engine/clap/ClapScanner.cpp
+++ b/src/engine/clap/ClapScanner.cpp
@@ -48,11 +48,12 @@ std::vector<stdfs::path> ClapScanner::defaultSearchPaths()
     add (dusk::fs::userHomeDir() / "Library/Audio/Plug-Ins/CLAP");
     add ("/Library/Audio/Plug-Ins/CLAP");
 #elif defined(_WIN32)
-    // CLAP's documented Windows install dirs (clap/entry.h).
-    if (const wchar_t* common = ::_wgetenv (L"COMMONPROGRAMFILES"))
-        add (stdfs::path (common) / L"CLAP");
+    // CLAP's documented Windows install dirs (clap/entry.h), user-scoped first
+    // to match every other platform's ordering.
     if (const wchar_t* local = ::_wgetenv (L"LOCALAPPDATA"))
         add (stdfs::path (local) / L"Programs" / L"Common" / L"CLAP");
+    if (const wchar_t* common = ::_wgetenv (L"COMMONPROGRAMFILES"))
+        add (stdfs::path (common) / L"CLAP");
 #else
     add (dusk::fs::userHomeDir() / ".clap");
     add ("/usr/lib/clap");

--- a/src/engine/vst3/Vst3Editor.h
+++ b/src/engine/vst3/Vst3Editor.h
@@ -10,8 +10,9 @@ namespace duskstudio::vst3
 class Vst3Instance;
 
 // Native editor embed for a VST3 plugin view. The platform translation unit
-// owns an X11 child window on Linux or an NSView child container on macOS.
-// open() discovers/creates the view; embed() attaches it to the native child.
+// owns an X11 child window on Linux, an NSView child container on macOS, or a
+// child HWND on Windows. open() discovers/creates the view; embed() attaches
+// it to the native child.
 //
 // The frame is wired at open() - BEFORE attached() - so the view can reach the
 // IPlugFrame while attaching. On Linux it can also query the IRunLoop. Resize
@@ -36,8 +37,8 @@ public:
     // Create a native child container under parentHandle at (x,y,w,h) and
     // attach the view into it. Visibility afterwards is platform-specific: the
     // X11 host window is mapped here (toolkit editors can refuse to realise
-    // into an unmapped parent), while the Cocoa container stays hidden until
-    // reveal(). reveal()/hide() are idempotent on both.
+    // into an unmapped parent), while the Cocoa and Win32 containers stay
+    // hidden until reveal(). reveal()/hide() are idempotent everywhere.
     bool embed (std::uintptr_t parentHandle, int x, int y, int w, int h,
                 std::string& errorOut);
 

--- a/src/engine/vst3/Vst3Editor_Win.cpp
+++ b/src/engine/vst3/Vst3Editor_Win.cpp
@@ -1,0 +1,265 @@
+#include "Vst3Editor.h"
+#include "Vst3HostContext.h"
+#include "Vst3Instance.h"
+
+#include <pluginterfaces/gui/iplugview.h>
+#include <pluginterfaces/gui/iplugviewcontentscalesupport.h>
+#include <pluginterfaces/vst/ivsteditcontroller.h>
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include <algorithm>
+
+namespace duskstudio::vst3
+{
+using namespace Steinberg;
+
+namespace
+{
+// One process-wide class for every VST3 container window. The plugin attaches
+// its own HWND inside ours, so our window procedure never needs more than
+// default handling.
+const wchar_t* containerClass()
+{
+    static const wchar_t* name = [] {
+        WNDCLASSEXW wc {};
+        wc.cbSize        = sizeof (wc);
+        wc.style         = CS_DBLCLKS;
+        wc.lpfnWndProc   = &DefWindowProcW;
+        wc.hInstance     = ::GetModuleHandleW (nullptr);
+        wc.hCursor       = ::LoadCursorW (nullptr, IDC_ARROW);
+        wc.lpszClassName = L"DuskVst3EditorContainer";
+        ::RegisterClassExW (&wc);
+        return wc.lpszClassName;
+    }();
+    return name;
+}
+} // namespace
+
+struct Vst3Editor::Impl
+{
+    Vst3Editor*      owner    = nullptr;
+    Vst3Instance*    instance = nullptr;
+    Vst3HostContext* host     = nullptr;
+
+    IPtr<IPlugView> view;
+    HWND container = nullptr;
+
+    int   prefW = 0, prefH = 0;
+    int   lastW = 0, lastH = 0;
+    float contentScale = 0.0f;
+    bool  embedded = false, visible = false;
+
+    void confirmSize (int w, int h)
+    {
+        if (! view || (w == lastW && h == lastH)) return;
+        lastW = w;
+        lastH = h;
+        ViewRect size (0, 0, w, h);
+        view->onSize (&size);
+    }
+
+    void applyContentScale()
+    {
+        if (! view || contentScale <= 0.0f) return;
+        FUnknownPtr<IPlugViewContentScaleSupport> scale (view);
+        if (scale)
+            scale->setContentScaleFactor (contentScale);
+    }
+
+    bool onResizeView (int w, int h)
+    {
+        if (w <= 0 || h <= 0 || ! view) return false;
+        prefW = w;
+        prefH = h;
+
+        if (container != nullptr)
+            ::SetWindowPos (container, nullptr, 0, 0, w, h,
+                            SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
+
+        if (owner->onResize)
+            owner->onResize (w, h);
+
+        confirmSize (w, h);
+        return true;
+    }
+};
+
+Vst3Editor::Vst3Editor() : impl (std::make_unique<Impl>()) { impl->owner = this; }
+Vst3Editor::~Vst3Editor() { close(); }
+
+int  Vst3Editor::preferredWidth()  const noexcept { return impl->prefW; }
+int  Vst3Editor::preferredHeight() const noexcept { return impl->prefH; }
+bool Vst3Editor::isOpen()     const noexcept { return impl->view != nullptr; }
+bool Vst3Editor::isEmbedded() const noexcept { return impl->embedded; }
+
+bool Vst3Editor::open (Vst3Instance& inst, std::string& errorOut)
+{
+    if (impl->view) return true;
+
+    auto* controller = static_cast<Vst::IEditController*> (inst.editController());
+    if (controller == nullptr) { errorOut = "plugin has no edit controller"; return false; }
+
+    impl->view = owned (controller->createView (Vst::ViewType::kEditor));
+    if (! impl->view) { errorOut = "plugin has no editor view"; return false; }
+
+    if (impl->view->isPlatformTypeSupported (kPlatformTypeHWND) != kResultTrue)
+    {
+        errorOut = "editor does not support HWND embedding";
+        impl->view = nullptr;
+        return false;
+    }
+
+    impl->instance = &inst;
+    impl->host = &inst.getHost();
+    inst.setResizeViewHandler ([self = impl.get()] (int w, int h)
+                               { return self->onResizeView (w, h); });
+    impl->view->setFrame (static_cast<IPlugFrame*> (impl->host->plugFrame()));
+
+    ViewRect size {};
+    if (impl->view->getSize (&size) == kResultOk)
+    {
+        impl->prefW = size.getWidth();
+        impl->prefH = size.getHeight();
+    }
+    return true;
+}
+
+bool Vst3Editor::embed (std::uintptr_t parentHandle, int x, int y, int w, int h,
+                        std::string& errorOut)
+{
+    if (! impl->view) { errorOut = "no view open"; return false; }
+    if (impl->embedded) return true;
+    if (parentHandle == 0) { errorOut = "null parent window"; return false; }
+
+    auto* parent = reinterpret_cast<HWND> (parentHandle);
+    const int ww = w > 0 ? w : (impl->prefW > 0 ? impl->prefW : 480);
+    const int hh = h > 0 ? h : (impl->prefH > 0 ? impl->prefH : 320);
+
+    // Created hidden; reveal() shows it once the wrapper has final bounds.
+    impl->container = ::CreateWindowExW (
+        0, containerClass(), L"", WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS,
+        x, y, ww, hh, parent, nullptr, ::GetModuleHandleW (nullptr), nullptr);
+    if (impl->container == nullptr)
+    {
+        errorOut = "could not create Win32 container window";
+        return false;
+    }
+
+    // The scale must reach the view before attached(): a HiDPI-aware plugin
+    // sizes its window from the last scale it was told.
+    impl->applyContentScale();
+
+    if (impl->view->attached (impl->container, kPlatformTypeHWND) != kResultOk)
+    {
+        errorOut = "IPlugView::attached failed";
+        close();
+        return false;
+    }
+
+    ViewRect size {};
+    if (impl->view->getSize (&size) == kResultOk
+        && size.getWidth() > 0 && size.getHeight() > 0)
+    {
+        impl->prefW = size.getWidth();
+        impl->prefH = size.getHeight();
+    }
+
+    impl->embedded = true;
+    return true;
+}
+
+void Vst3Editor::setBounds (int x, int y, int w, int h)
+{
+    if (impl->container == nullptr) return;
+    const int ww = std::max (1, w);
+    const int hh = std::max (1, h);
+    ::SetWindowPos (impl->container, nullptr, x, y, ww, hh,
+                    SWP_NOZORDER | SWP_NOACTIVATE);
+    if (impl->embedded)
+        impl->confirmSize (ww, hh);
+}
+
+void Vst3Editor::setContentScale (float scale)
+{
+    impl->contentScale = scale;
+    impl->applyContentScale();
+}
+
+void Vst3Editor::reveal()
+{
+    if (impl->container == nullptr || impl->visible) return;
+    ::ShowWindow (impl->container, SW_SHOWNA);
+    impl->visible = true;
+}
+
+void Vst3Editor::hide()
+{
+    if (impl->container == nullptr || ! impl->visible) return;
+    ::ShowWindow (impl->container, SW_HIDE);
+    impl->visible = false;
+}
+
+void Vst3Editor::quiesce() noexcept
+{
+    if (impl->container != nullptr && impl->visible)
+        ::ShowWindow (impl->container, SW_HIDE);
+    impl->visible = false;
+}
+
+void Vst3Editor::abandonPlugin() noexcept
+{
+    (void) impl->view.take();
+    impl->instance = nullptr;
+    impl->host     = nullptr;
+    impl->embedded = false;
+}
+
+void Vst3Editor::abandonPluginAndContainer() noexcept
+{
+    abandonPlugin();
+    // The instance is already disposed but its view class may still own child
+    // windows under our container. DestroyWindow would dispatch WM_DESTROY
+    // through window procedures in a module that can be unloaded by now, so
+    // the container is dropped, not destroyed; the parent peer's teardown
+    // reaps it.
+    impl->container = nullptr;
+    impl->visible   = false;
+}
+
+void Vst3Editor::close()
+{
+    if (impl->view)
+    {
+        if (impl->embedded)
+            impl->view->removed();
+        impl->view->setFrame (nullptr);
+        impl->view = nullptr;
+    }
+    if (impl->instance != nullptr)
+    {
+        impl->instance->setResizeViewHandler (nullptr);
+        impl->instance = nullptr;
+    }
+    impl->host = nullptr;
+
+    if (impl->container != nullptr)
+    {
+        ::DestroyWindow (impl->container);
+        impl->container = nullptr;
+    }
+
+    impl->embedded = impl->visible = false;
+    impl->prefW = impl->prefH = impl->lastW = impl->lastH = 0;
+}
+
+bool Vst3Editor::getRootRelativePosition (std::uintptr_t, int&, int&) const { return false; }
+bool Vst3Editor::getActualGeometry (int&, int&, int&, int&) const { return false; }
+
+void Vst3Editor::pump (double elapsedMs)
+{
+    if (impl->host != nullptr)
+        impl->host->pump (elapsedMs);
+}
+} // namespace duskstudio::vst3

--- a/src/engine/vst3/Vst3Editor_Win.cpp
+++ b/src/engine/vst3/Vst3Editor_Win.cpp
@@ -1,3 +1,9 @@
+// Ahead of every include: whichever header reaches windows.h first must see
+// these, or its min/max macros eat std::max at the call sites below.
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+
 #include "Vst3Editor.h"
 #include "Vst3HostContext.h"
 #include "Vst3Instance.h"
@@ -5,9 +11,6 @@
 #include <pluginterfaces/gui/iplugview.h>
 #include <pluginterfaces/gui/iplugviewcontentscalesupport.h>
 #include <pluginterfaces/vst/ivsteditcontroller.h>
-
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
 
 #include <algorithm>
 
@@ -28,7 +31,9 @@ const wchar_t* containerClass()
         wc.style         = CS_DBLCLKS;
         wc.lpfnWndProc   = &DefWindowProcW;
         wc.hInstance     = ::GetModuleHandleW (nullptr);
-        wc.hCursor       = ::LoadCursorW (nullptr, IDC_ARROW);
+        // IDC_ARROW is an integer-resource pseudo-pointer, and without UNICODE
+        // defined it expands to the ANSI form; the W call needs it re-cast.
+        wc.hCursor       = ::LoadCursorW (nullptr, reinterpret_cast<LPCWSTR> (IDC_ARROW));
         wc.lpszClassName = L"DuskVst3EditorContainer";
         ::RegisterClassExW (&wc);
         return wc.lpszClassName;

--- a/src/engine/vst3/Vst3Scanner.cpp
+++ b/src/engine/vst3/Vst3Scanner.cpp
@@ -21,9 +21,24 @@ std::vector<stdfs::path> Vst3Scanner::defaultSearchPaths()
         dirs.push_back (d);
     };
 
-    // $VST3_PATH overrides / extends the defaults (':'-separated, like $PATH).
-    if (const char* env = std::getenv ("VST3_PATH"))
-        for (const auto& tok : dusk::text::split (env, ':'))
+    // $VST3_PATH overrides / extends the defaults, separated like $PATH
+    // (':' on POSIX, ';' on Windows).
+#if defined(_WIN32)
+    constexpr char kListSep = ';';
+    // _wgetenv, not getenv: the value carries user-profile paths, which the
+    // ANSI environment mangles for non-ASCII user names. ';' is one byte in
+    // UTF-8, so splitting after the conversion is safe.
+    const std::string envStorage = [] {
+        const wchar_t* w = ::_wgetenv (L"VST3_PATH");
+        return w != nullptr ? stdfs::path (w).u8string() : std::string();
+    }();
+    const char* env = envStorage.empty() ? nullptr : envStorage.c_str();
+#else
+    constexpr char kListSep = ':';
+    const char* env = std::getenv ("VST3_PATH");
+#endif
+    if (env != nullptr)
+        for (const auto& tok : dusk::text::split (env, kListSep))
         {
             const auto trimmed = dusk::text::trim (tok);
             if (! trimmed.empty()) add (stdfs::u8path (trimmed));
@@ -32,6 +47,12 @@ std::vector<stdfs::path> Vst3Scanner::defaultSearchPaths()
 #if defined(__APPLE__)
     add (dusk::fs::userHomeDir() / "Library/Audio/Plug-Ins/VST3");
     add ("/Library/Audio/Plug-Ins/VST3");
+#elif defined(_WIN32)
+    // The VST3 spec's Windows install dirs.
+    if (const wchar_t* local = ::_wgetenv (L"LOCALAPPDATA"))
+        add (stdfs::path (local) / L"Programs" / L"Common" / L"VST3");
+    if (const wchar_t* common = ::_wgetenv (L"COMMONPROGRAMFILES"))
+        add (stdfs::path (common) / L"VST3");
 #else
     add (dusk::fs::userHomeDir() / ".vst3");
     add ("/usr/lib/vst3");

--- a/src/ui/ClapPluginEditorComponent.cpp
+++ b/src/ui/ClapPluginEditorComponent.cpp
@@ -127,6 +127,13 @@ void ClapPluginEditorComponent::tryEmbed()
     auto* parent = peerNativeHandle();
     if (parent == nullptr) return;
 
+#if defined(_WIN32)
+    // The container HWND is sized in physical pixels via embedscale, so the GUI
+    // must be told the same combined factor (platform DPI x app UI zoom) before
+    // it parents itself and reports a size.
+    editor.setContentScale (embedscale::factor (*this));
+#endif
+
     const auto area = editorBoundsInPeer();
     std::string err;
     embedding = true;

--- a/src/ui/Vst3PluginEditorComponent.cpp
+++ b/src/ui/Vst3PluginEditorComponent.cpp
@@ -104,6 +104,10 @@ void Vst3PluginEditorComponent::tryEmbed()
 #if defined(__linux__)
     if (auto* peer = getPeer())
         editor.setContentScale ((float) peer->getPlatformScaleFactor());
+#elif defined(_WIN32)
+    // The child HWND is sized in physical pixels via embedscale, so the view
+    // must be told the same combined factor (platform DPI x app UI zoom).
+    editor.setContentScale ((float) embedscale::factor (*this));
 #endif
 
     const auto area = editorBoundsInPeer();

--- a/tests/clap_bundle_load.cpp
+++ b/tests/clap_bundle_load.cpp
@@ -8,13 +8,19 @@
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
-#include <dlfcn.h>
 #include <filesystem>
 #include <fstream>
 #include <stdexcept>
 #include <string>
-#include <unistd.h>
 #include <vector>
+
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#include <unistd.h>
+#endif
 
 #if defined(__APPLE__)
 #include <mach-o/dyld.h>
@@ -74,6 +80,19 @@ TEST_CASE ("ClapBundle fails gracefully on a missing bundle", "[clap][bundle]")
 
 TEST_CASE ("ClapBundle rejects a real shared object that is not a CLAP bundle", "[clap][bundle]")
 {
+#if defined(_WIN32)
+    // kernel32.dll loads fine but has no clap_entry, exercising the
+    // post-LoadLibrary rejection path.
+    wchar_t systemDir[MAX_PATH] {};
+    REQUIRE (::GetSystemDirectoryW (systemDir, MAX_PATH) > 0);
+    const auto library = std::filesystem::path (systemDir) / L"kernel32.dll";
+
+    duskstudio::clap::ClapBundle b;
+    std::string err;
+    REQUIRE_FALSE (b.load (library.u8string(), err));
+    REQUIRE_FALSE (b.isLoaded());
+    REQUIRE (err == "no clap_entry symbol");
+#else
     // A valid shared object that dlopens fine but has no clap_entry exercises the
     // post-dlopen rejection path. Resolve the host libc portably (its soname differs
     // across libc / OS) via dladdr instead of hardcoding libc.so.6.
@@ -89,6 +108,7 @@ TEST_CASE ("ClapBundle rejects a real shared object that is not a CLAP bundle", 
     REQUIRE_FALSE (b.isLoaded());
     REQUIRE_FALSE (err.empty());
     INFO ("rejection reason: " << err);
+#endif
 }
 
 #if defined(__APPLE__)

--- a/tests/clap_scanner.cpp
+++ b/tests/clap_scanner.cpp
@@ -14,13 +14,27 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+
+#if defined(_WIN32)
+#include <process.h>
+#else
 #include <unistd.h>
+#endif
 
 using duskstudio::clap::ClapScanner;
 
 namespace
 {
 namespace stdfs = std::filesystem;
+
+long currentPid() noexcept
+{
+#if defined(_WIN32)
+    return (long) ::_getpid();
+#else
+    return (long) ::getpid();
+#endif
+}
 
 class TempDirectory
 {
@@ -31,7 +45,7 @@ public:
         // steady_clock reads can land on the same tick.
         const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
         value = stdfs::temp_directory_path()
-                / (std::string (prefix) + std::to_string (getpid()) + "_" + std::to_string (unique));
+                / (std::string (prefix) + std::to_string (currentPid()) + "_" + std::to_string (unique));
         std::error_code ec;
         if (! stdfs::create_directories (value, ec) || ec)
             throw std::runtime_error ("could not create test directory: " + ec.message());

--- a/tests/clap_scanner.cpp
+++ b/tests/clap_scanner.cpp
@@ -63,6 +63,19 @@ private:
     stdfs::path value;
 };
 
+// setenv/unsetenv are POSIX; MSVC only ships _putenv_s, where an empty value
+// is the removal form. The scanner reads CLAP_PATH through _wgetenv on
+// Windows, and _putenv_s updates the same block _wgetenv sees.
+bool setEnvironment (const std::string& name, const char* value) noexcept
+{
+#if defined(_WIN32)
+    return ::_putenv_s (name.c_str(), value != nullptr ? value : "") == 0;
+#else
+    return value != nullptr ? ::setenv (name.c_str(), value, 1) == 0
+                            : ::unsetenv (name.c_str()) == 0;
+#endif
+}
+
 class ScopedEnvironment
 {
 public:
@@ -71,16 +84,13 @@ public:
     {
         if (const char* current = std::getenv (variable))
             previous = current;
-        if (setenv (name.c_str(), value.c_str(), 1) != 0)
+        if (! setEnvironment (name, value.c_str()))
             throw std::runtime_error ("could not set test environment variable");
     }
 
     ~ScopedEnvironment()
     {
-        if (previous.has_value())
-            setenv (name.c_str(), previous->c_str(), 1);
-        else
-            unsetenv (name.c_str());
+        setEnvironment (name, previous.has_value() ? previous->c_str() : nullptr);
     }
 
 private:

--- a/tests/clap_scanner.cpp
+++ b/tests/clap_scanner.cpp
@@ -119,6 +119,8 @@ TEST_CASE ("ClapScanner keeps CLAP_PATH ahead of platform defaults", "[clap][sca
     const auto home = temp.path() / "home";
 #if defined(__APPLE__)
     const auto userDefault = home / "Library/Audio/Plug-Ins/CLAP";
+#elif defined(_WIN32)
+    const auto userDefault = home / "Programs" / "Common" / "CLAP";
 #else
     const auto userDefault = home / ".clap";
 #endif
@@ -129,7 +131,12 @@ TEST_CASE ("ClapScanner keeps CLAP_PATH ahead of platform defaults", "[clap][sca
     REQUIRE (stdfs::create_directories (userDefault, ec));
     REQUIRE_FALSE (ec);
 
+#if defined(_WIN32)
+    // The Windows user default hangs off LOCALAPPDATA, not the profile dir.
+    ScopedEnvironment scopedHome ("LOCALAPPDATA", home.u8string());
+#else
     ScopedEnvironment scopedHome ("HOME", home.u8string());
+#endif
     ScopedEnvironment scopedClapPath ("CLAP_PATH", overridePath.u8string());
     const auto paths = ClapScanner::defaultSearchPaths();
     REQUIRE (paths.size() >= 2);

--- a/tests/vst3_scanner.cpp
+++ b/tests/vst3_scanner.cpp
@@ -105,6 +105,8 @@ TEST_CASE ("Vst3Scanner keeps VST3_PATH ahead of platform defaults", "[vst3][sca
     const auto home = temp.path() / "home";
 #if defined(__APPLE__)
     const auto userDefault = home / "Library/Audio/Plug-Ins/VST3";
+#elif defined(_WIN32)
+    const auto userDefault = home / "Programs" / "Common" / "VST3";
 #else
     const auto userDefault = home / ".vst3";
 #endif
@@ -116,7 +118,8 @@ TEST_CASE ("Vst3Scanner keeps VST3_PATH ahead of platform defaults", "[vst3][sca
     REQUIRE_FALSE (ec);
 
 #if defined(_WIN32)
-    ScopedEnvironment scopedHome ("USERPROFILE", home.u8string());
+    // The Windows user default hangs off LOCALAPPDATA, not the profile dir.
+    ScopedEnvironment scopedHome ("LOCALAPPDATA", home.u8string());
 #else
     ScopedEnvironment scopedHome ("HOME", home.u8string());
 #endif


### PR DESCRIPTION
Closes #293 (bench sign-off items remain owed after CI).

- CLAP: LoadLibraryExW loader with UTF-16 paths and UTF-8 identity/errors, Windows install dirs with a ';' list separator, posix-fd-support absent on Windows (neither compiled nor advertised).
- VST3: SDK module_win32/threadchecker_win32 selection; Windows install dirs.
- Editors: child-HWND containers for both formats (CLAP_WINDOW_API_WIN32 / kPlatformTypeHWND), created hidden until reveal, content scale (platform DPI x UI zoom) delivered before attach.
- Windows LV2 stays off.
- Both Windows workflows configure with the native hosts ON and assert the cache values.
- CLAP loader/scanner tests drop POSIX-only includes; Windows rejection path covered via kernel32.dll.

Linux/macOS behavior unchanged: macOS app build clean, 729/729 tests pass locally, juce-gate count identical to main.

Held as draft until v0.13.0 is tagged; merge is 0.14 scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added native CLAP and VST3 hosting on Windows.
  - Windows plugin editors now support embedded interfaces, resizing, visibility, scaling, and lifecycle handling.
  - Added Windows plugin discovery using standard user and shared installation locations.
  - Added Unicode path support for Windows plugin loading and scanning.

- **Bug Fixes**
  - Improved Windows compatibility for plugin loading, editor embedding, and search paths.
  - Updated platform-specific handling for CLAP and VST3 plugins.

- **Documentation**
  - Updated the manual to reflect native CLAP and VST3 support across Windows, macOS, and Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->