### PR TITLE
chore(release): set the 0.13.0 date to the actual release day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Dusk Studio. Format loosely follows
 back-filled from `git log`; once tags exist this file is the
 canonical source.
 
-## [0.13.0] - 2026-08-16
+## [0.13.0] - 2026-08-19
 
 The first release cut from the main line since 0.12 branched. Linux gets a
 native PipeWire backend and MIDI hot-plug; macOS gets Dusk Studio's own plugin

--- a/packaging/DuskStudio.appdata.xml
+++ b/packaging/DuskStudio.appdata.xml
@@ -30,7 +30,7 @@
   <content_rating type="oars-1.1"/>
   <releases>
     <!-- scripts/bump-version.sh prepends new <release> entries here. -->
-    <release version="0.13.0" date="2026-08-16">
+    <release version="0.13.0" date="2026-08-19">
       <description>
         <p>Adds the session notepad, a UI scale control, native PipeWire and macOS plugin hosting, MIDI hot-plug, loop take stacking, realtime hardware bounce, and a broad set of session, recording, audio-device, and plug-in fixes.</p>
       </description>


### PR DESCRIPTION
CHANGELOG and appdata dated 2026-08-19 to match the planned release day; both previously carried the metadata-landing date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the 0.13.0 release date to August 19, 2026 in the changelog and application metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->