### PR TITLE
Link libsodium statically in the Linux release build

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -224,6 +224,34 @@ jobs:
             exit 1
           fi
 
+      - name: Build static libsodium (pinned)
+        # The distro package is the right dependency for a distro build, but
+        # its soname is the distro's: jammy carries libsodium.so.23 and any
+        # distro on 1.0.19+ carries .so.26, so a tarball linked against the
+        # apt library fails in the loader everywhere but Ubuntu. Link the
+        # audited source instead, matching what Windows and macOS already do.
+        env:
+          SODIUM_VERSION: 1.0.22
+          SODIUM_SHA256: adbdd8f16149e81ac6078a03aca6fc03b592b89ef7b5ed83841c086191be3349
+        run: |
+          set -euo pipefail
+          archive="${RUNNER_TEMP}/libsodium-${SODIUM_VERSION}.tar.gz"
+          source_dir="${RUNNER_TEMP}/libsodium-source"
+          prefix="${RUNNER_TEMP}/libsodium"
+          curl --fail --location --retry 3 \
+            --output "${archive}" \
+            "https://download.libsodium.org/libsodium/releases/libsodium-${SODIUM_VERSION}.tar.gz"
+          echo "${SODIUM_SHA256}  ${archive}" | sha256sum --check
+          mkdir -p "${source_dir}"
+          tar -xzf "${archive}" -C "${source_dir}" --strip-components=1
+          cd "${source_dir}"
+          # Position-independent, because it is linked into a PIE executable.
+          ./configure \
+            --prefix="${prefix}" --disable-shared --enable-static --with-pic
+          # Keep this small autotools build aligned with the three-core runner.
+          make -j3 check
+          make install
+
       - name: Configure (Release)
         run: |
           cmake -S . -B build-linux -G Ninja \
@@ -231,18 +259,36 @@ jobs:
             -DDUSKSTUDIO_SKIP_FORK_CHECK=ON \
             -DDUSKSTUDIO_REQUIRE_NATIVE_LV2=ON \
             -DDUSKSTUDIO_REQUIRE_PIPEWIRE=ON \
+            -DDUSKSTUDIO_SODIUM_ROOT="${RUNNER_TEMP}/libsodium" \
             -DJUCE_PATH="${RUNNER_TEMP}/JUCE-wayland" \
             -DDUSK_PLUGINS_PATH="${RUNNER_TEMP}/plugins-main" \
             -DDPF_PATH="${RUNNER_TEMP}/DPF" \
             -DDPF_WIDGETS_PATH="${RUNNER_TEMP}/DPF-Widgets"
 
+      - name: Verify the static libsodium archive was selected
+        run: |
+          grep -Eq '^DUSKSTUDIO_SODIUM_STATIC_LIBRARY:FILEPATH=.*/libsodium\.a$' \
+            build-linux/CMakeCache.txt || {
+            echo "::error::Linux release configure did not select static libsodium" >&2
+            exit 1; }
+
       - name: Build (Release)
         run: cmake --build build-linux -j6
 
-      - name: Verify libsodium runtime linkage
+      - name: Verify libsodium is not a runtime dependency
+        # libsodium-dev is installed, so a regression in the CMake selection
+        # would silently link the shared library and produce a tarball that
+        # only starts on Ubuntu.
         run: |
-          readelf -d build-linux/DuskStudio_artefacts/Release/DuskStudio \
-            | grep -Eq '\(NEEDED\).*libsodium\.so\.'
+          set -euo pipefail
+          linked=0
+          while IFS= read -r -d '' bin; do
+            if readelf -d "$bin" 2>/dev/null | grep -qE '\(NEEDED\).*libsodium'; then
+              echo "::error::${bin} links libsodium at runtime; the tarball would not start off Ubuntu" >&2
+              linked=1
+            fi
+          done < <(find build-linux/DuskStudio_artefacts -type f -executable -print0)
+          [ "$linked" -eq 0 ]
 
       - name: Build + run tests (release gate)
         # No artifact ships unless the full Catch2 suite passes.
@@ -253,6 +299,7 @@ jobs:
             -DDUSKSTUDIO_SKIP_FORK_CHECK=ON \
             -DDUSKSTUDIO_REQUIRE_NATIVE_LV2=ON \
             -DDUSKSTUDIO_REQUIRE_PIPEWIRE=ON \
+            -DDUSKSTUDIO_SODIUM_ROOT="${RUNNER_TEMP}/libsodium" \
             -DJUCE_PATH="${RUNNER_TEMP}/JUCE-wayland" \
             -DDUSK_PLUGINS_PATH="${RUNNER_TEMP}/plugins-main" \
             -DDPF_PATH="${RUNNER_TEMP}/DPF" \

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -281,13 +281,24 @@ jobs:
         # only starts on Ubuntu.
         run: |
           set -euo pipefail
+          # Both guards below exist because every failure mode of this check is
+          # a silent pass: no readelf and no scanned files each leave the
+          # counter at zero, which reads as success.
+          command -v readelf >/dev/null || {
+            echo "::error::readelf is unavailable, so runtime linkage cannot be verified" >&2
+            exit 1; }
+          scanned=0
           linked=0
           while IFS= read -r -d '' bin; do
+            scanned=$((scanned + 1))
             if readelf -d "$bin" 2>/dev/null | grep -qE '\(NEEDED\).*libsodium'; then
               echo "::error::${bin} links libsodium at runtime; the tarball would not start off Ubuntu" >&2
               linked=1
             fi
           done < <(find build-linux/DuskStudio_artefacts -type f -executable -print0)
+          [ "$scanned" -gt 0 ] || {
+            echo "::error::no executables under build-linux/DuskStudio_artefacts to verify" >&2
+            exit 1; }
           [ "$linked" -eq 0 ]
 
       - name: Build + run tests (release gate)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -636,12 +636,16 @@ target_sources(DuskStudio PRIVATE
 target_link_libraries(DuskStudio PRIVATE dusk_sndfile)
 
 # Signed SFZ catalogs use detached Ed25519 signatures. Windows consumes the
-# static vcpkg manifest prefix, Linux uses the distro library, and macOS links
-# a deployment-target-matched static archive so the app has no extra dylib.
+# static vcpkg manifest prefix and macOS links a deployment-target-matched
+# static archive, so neither ships an extra library. A Linux build resolves the
+# distro library by default, which is what a distro package wants; the portable
+# tarball cannot, because a binary linked against one distro's soname does not
+# start on any other. The release workflow supplies DUSKSTUDIO_SODIUM_ROOT to
+# get the same static archive the other two platforms already use.
 add_library(dusk_sodium INTERFACE)
 set(DUSKSTUDIO_SODIUM_ROOT "" CACHE PATH
     "Optional libsodium installation prefix for Dusk Studio")
-if(APPLE)
+if(APPLE OR (UNIX AND DUSKSTUDIO_SODIUM_ROOT))
     find_path(DUSKSTUDIO_SODIUM_INCLUDE_DIR sodium.h
         HINTS "${DUSKSTUDIO_SODIUM_ROOT}"
         PATH_SUFFIXES include)
@@ -650,8 +654,8 @@ if(APPLE)
         PATH_SUFFIXES lib lib64)
     if(NOT (DUSKSTUDIO_SODIUM_INCLUDE_DIR AND DUSKSTUDIO_SODIUM_STATIC_LIBRARY))
         message(FATAL_ERROR
-            "Static libsodium is required for signed SFZ catalogs on macOS. "
-            "Build it for the app's deployment target and set "
+            "Static libsodium is required for signed SFZ catalogs here. "
+            "Build it for the target platform and set "
             "DUSKSTUDIO_SODIUM_ROOT to its installation prefix.")
     endif()
     target_include_directories(dusk_sodium SYSTEM INTERFACE

--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -461,13 +461,14 @@ libsodium (signed SFZ catalog authentication — required on every platform)
              dusk_sodium interface target.
   Notes    : The app uses detached Ed25519 verification and canonical base64
              helpers only; no private signing key is distributed. Linux CI,
-             sanitizer, release, and Raspberry Pi builds install
-             libsodium-dev and link the distro shared object. Debian package
-             runtime dependency discovery is handled by dpkg-shlibdeps. RPM
-             packages rely on rpmbuild's automatic ELF requirements under
-             CPack. The portable tarball does not copy system shared libraries,
-             so its host must provide libsodium like the other documented
-             desktop/runtime libraries.
+             sanitizer, and Raspberry Pi builds install libsodium-dev and link
+             the distro shared object. The Linux release build instead links a
+             static archive built from the pinned source below, because a
+             binary carrying one distro's soname does not start on any other.
+             Debian package runtime dependency discovery is handled by
+             dpkg-shlibdeps. RPM packages rely on rpmbuild's automatic ELF
+             requirements under CPack. The portable tarball therefore carries
+             its libsodium in the executable and needs none from the host.
              On macOS and Windows the same fail-closed discovery contract
              requires the platform build to supply compatible headers and a
              library. The current upstream audit reference is release 1.0.22,

--- a/packaging/README-linux.txt
+++ b/packaging/README-linux.txt
@@ -35,8 +35,8 @@ A normal desktop Linux (X11 or Wayland). Audio runs over PipeWire/JACK
 (preferred) or ALSA. The PipeWire client library is linked in, so
 libpipewire-0.3-0 must be present even if you only use ALSA. On a minimal
 system, install the usual desktop libraries (X11, freetype, fontconfig, alsa)
-if the binary reports a missing library. Signed SFZ catalog authentication also
-requires libsodium.so.23; on Ubuntu 22.04, install the libsodium23 package.
+if the binary reports a missing library. Signed SFZ catalog authentication
+needs nothing from the host; libsodium is compiled into the binary.
 
 
 LICENSE


### PR DESCRIPTION
Closes #322.

The portable Linux tarballs carried a `NEEDED` entry for `libsodium.so.23`, Ubuntu 22.04's soname, and bundled nothing. Any distro on libsodium 1.0.19 or newer provides `libsodium.so.26`, so on openSUSE, Fedora and Arch the binary died in the dynamic loader before `main`. Both architectures, and neither binary carries an `RPATH`, so no bundled copy could have been found either.

No CI job caught it because every Linux workflow runs on `ubuntu-22.04`, the one distro where the soname resolves.

## Approach

Windows and macOS already link a static libsodium; Linux was the only platform that did not. `CMakeLists.txt:638` described that split as deliberate, and for a distro package it is right. It is wrong for a portable tarball.

- `CMakeLists.txt` widens the existing static-archive branch from `if(APPLE)` to `if(APPLE OR (UNIX AND DUSKSTUDIO_SODIUM_ROOT))`. A source build with `libsodium-dev` and no root set is unchanged, which is what distro packaging wants. Windows is untouched twice over: it passes no `DUSKSTUDIO_SODIUM_ROOT`, and `UNIX` is false there.
- `linux-release.yml` builds the same pinned, SHA-256-checked libsodium 1.0.22 that `macos-release.yml` already builds, for both matrix legs, and passes the prefix to the app and test configures.

Rejected: bundling `libsodium.so.23` with an `$ORIGIN` RPATH. It ships a third-party shared object, adds an RPATH to a binary that has none, and leaves a pinned 1.0.18 in the payload to track for CVEs.

The tradeoff worth naming: a static libsodium means a CVE needs a Dusk Studio rebuild rather than arriving through the distro. That burden already exists on macOS and Windows, and it is the lesser cost against a binary that does not start at all.

## The check was backwards

`Verify libsodium runtime linkage` asserted that `libsodium.so.` **was** a `NEEDED` entry, so it passed on precisely the arrangement that shipped broken. It came in with #255 with no stated rationale and reads as a "did it link at all" smoke test from when dynamic was the only Linux path.

It now asserts the absence, across every executable under the artefacts tree rather than one hardcoded path, and the configure step is separately checked for having selected the archive. `libsodium-dev` stays installed on the runner on purpose: the assertion then proves the static archive won with a shared library present, which is a stronger test of the CMake selection than removing it would be.

## Docs corrected in the same pass

- `LICENSES.txt:465` said Linux release builds "link the distro shared object".
- `packaging/README-linux.txt:37` told users to install `libsodium23`. That one ships inside the tarball.

The pinned SHA matches the audit reference already recorded in `LICENSES.txt` (1.0.22, `adbdd8f1...`), so there is no new supply-chain entry.

## Verification

The workflow cannot run outside a tag, so the CMake block was extracted into a fixture and driven directly:

| Check | Result |
|---|---|
| Linux with `DUSKSTUDIO_SODIUM_ROOT` selects `libsodium.a`, and the CI `CMakeCache` grep matches it | pass |
| Linux without a root still resolves the distro `.so`, source builds unchanged | pass |
| Assertion loop against a dynamically linked binary | exits 1 with the error |
| Assertion loop against a statically linked binary | exits 0 |

Not covered locally, and first exercised on the tag run: the libsodium autotools build has never run on `ubuntu-22.04-arm`, and `--with-pic` is new here (macOS does not need it, a Linux PIE does).

## Release impact

`v0.13.0` is published but unannounced, with 2 and 3 downloads on the Linux assets. The tag moves to this commit and the tarballs are rebuilt. The consolidated `SHA256SUMS` must be regenerated afterwards, since both Linux hashes change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Linux release packages now include libsodium directly, eliminating the need for a separately installed runtime library.
  * Signed SFZ catalog authentication works without additional host dependencies.
* **Bug Fixes**
  * Release validation now confirms the packaged application is self-contained and does not depend on an external libsodium library.
* **Documentation**
  * Updated Linux requirements to remove the previously required libsodium package and runtime library installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->