### PR TITLE
ci: bound every apt call with timeout(1) and switch mirrors on failure

### DIFF
--- a/.github/actions/apt-deps/action.yml
+++ b/.github/actions/apt-deps/action.yml
@@ -17,4 +17,13 @@ runs:
   steps:
     - name: apt-get with timeouts, retries, and mirror switching
       shell: bash
-      run: '"${GITHUB_ACTION_PATH}/apt_install.sh" ${{ inputs.packages }}'
+      # The list reaches the shell through the environment, not through
+      # expression interpolation: a value spliced into the run body becomes
+      # shell syntax, so a metacharacter in it would execute. Word splitting
+      # on the unquoted expansion is what turns the list into arguments, and
+      # set -f keeps a package name from globbing against the workspace.
+      env:
+        PACKAGES: ${{ inputs.packages }}
+      run: |
+        set -f
+        "${GITHUB_ACTION_PATH}/apt_install.sh" $PACKAGES

--- a/.github/actions/apt-deps/action.yml
+++ b/.github/actions/apt-deps/action.yml
@@ -1,10 +1,13 @@
 name: Install apt packages
 description: >
-  apt-get update + install with the Azure apt mirror bypassed, bounded
-  fetch timeouts, and a retry loop. azure.archive.ubuntu.com serves the
-  hosted runners and a sick mirror node stalls a job for hours; talking
-  to archive.ubuntu.com directly and capping every fetch turns that into
-  a fast, retried failure instead.
+  Hardened apt-get update + install: timeout(1) around every apt
+  invocation (Acquire timeouts alone cannot stop a byte-dribbling mirror,
+  which is how a "retried" install still sat stuck for 70+ minutes),
+  three attempts, and an automatic mirror switch after the first failure.
+  x86 runners flip azure.archive.ubuntu.com <-> archive.ubuntu.com; arm64
+  runners are normalized onto mirrors.mit.edu with ports.ubuntu.com as
+  the fallback, with IPv4 forced. Logic lives in apt_install.sh next to
+  this file.
 inputs:
   packages:
     description: Space-separated apt package list
@@ -12,23 +15,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: apt-get with mirror bypass and retries
+    - name: apt-get with timeouts, retries, and mirror switching
       shell: bash
-      run: |
-        sudo find /etc/apt/ -type f \( -name "*.list" -o -name "*.sources" \) \
-          -exec sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' {} +
-        printf '%s\n' \
-          'Acquire::Retries "3";' \
-          'Acquire::http::Timeout "30";' \
-          'Acquire::https::Timeout "30";' \
-          | sudo tee /etc/apt/apt.conf.d/99dusk-ci >/dev/null
-        for i in 1 2 3; do
-          if sudo apt-get update && \
-             sudo apt-get install -y --no-install-recommends ${{ inputs.packages }}; then
-            exit 0
-          fi
-          echo "apt attempt $i failed; retrying in 20s"
-          sleep 20
-        done
-        echo "apt failed after 3 attempts"
-        exit 1
+      run: '"${GITHUB_ACTION_PATH}/apt_install.sh" ${{ inputs.packages }}'

--- a/.github/actions/apt-deps/apt_install.sh
+++ b/.github/actions/apt-deps/apt_install.sh
@@ -162,9 +162,13 @@ for i in $(seq 1 "$ATTEMPTS"); do
     if attempt; then
         # apt exiting 0 is not proof; verify the packages are present so a
         # miss fails here with a clear message, not three steps later.
+        # dpkg -s alone would not be proof either: it succeeds for a package
+        # left in config-files state, which has no headers or binaries. Only
+        # the installed status counts.
         missing=()
         for pkg in ${packages+"${packages[@]}"}; do
-            dpkg -s "$pkg" >/dev/null 2>&1 || missing+=("$pkg")
+            [ "$(dpkg-query -W -f='${db:Status-Status}' "$pkg" 2>/dev/null)" = installed ] \
+                || missing+=("$pkg")
         done
         if [ ${#missing[@]} -eq 0 ]; then
             exit 0

--- a/.github/actions/apt-deps/apt_install.sh
+++ b/.github/actions/apt-deps/apt_install.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# One hardened apt front end for every workflow in this repo. Ported from
+# dusk-audio-plugins .github/scripts/apt_install.sh, where its two defences
+# were earned the hard way:
+#
+#   STALL. An unreachable or byte-dribbling mirror does not fail apt, it
+#   hangs it. Acquire::http::Timeout only bounds socket inactivity; a mirror
+#   trickling bytes never trips it, so a retry loop alone never gets its
+#   second attempt (run 32272023755 sat in apt-get for 70+ minutes with
+#   retries "enabled"). Hence timeout(1) around every apt invocation.
+#
+#   MIRROR PINNING. azure.archive.ubuntu.com and archive.ubuntu.com take
+#   turns being the sick one; the arm64 ports archive adds ports.ubuntu.com
+#   (under-resourced) vs mirrors.mit.edu. Pinning EITHER side is the bug, so
+#   after the first failed attempt this script switches to the other mirror
+#   in the machine's family and keeps going.
+#
+# Families:
+#   x86 runners:  azure.archive.ubuntu.com <-> archive.ubuntu.com
+#   arm64 runners (ports): mirrors.mit.edu <-> ports.ubuntu.com
+#     ports.ubuntu.com is regularly unreachable from GitHub's ARM runners on
+#     both stacks, so MIT is normalized to primary up front (preserving the
+#     old raspberry-pi-build behaviour) and IPv4 is forced, which that
+#     workflow had established as necessary.
+#
+# Usage:
+#   apt_install.sh pkg [pkg...]   update, then install those packages
+#   apt_install.sh --update-only  refresh the lists only
+set -uo pipefail
+
+ATTEMPTS="${APT_ATTEMPTS:-3}"
+UPDATE_TIMEOUT="${APT_UPDATE_TIMEOUT:-120}"
+INSTALL_TIMEOUT="${APT_INSTALL_TIMEOUT:-300}"
+RETRY_SLEEP="${APT_RETRY_SLEEP:-10}"
+APT_OPTS=(-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30)
+
+# A typo'd override must fail loudly, not turn the installer into a no-op
+# that exits 0 having installed nothing (seq on a non-number runs the loop
+# body zero times).
+require_positive_int() {
+    case "$2" in
+        '' | *[!0-9]* ) ;;
+        * ) [ "$2" -gt 0 ] && return 0 ;;
+    esac
+    echo "::error::$1 must be a positive integer, got '$2'" >&2
+    exit 2
+}
+require_positive_int APT_ATTEMPTS        "$ATTEMPTS"
+require_positive_int APT_UPDATE_TIMEOUT  "$UPDATE_TIMEOUT"
+require_positive_int APT_INSTALL_TIMEOUT "$INSTALL_TIMEOUT"
+case "$RETRY_SLEEP" in
+    '' | *[!0-9]* )
+        echo "::error::APT_RETRY_SLEEP must be a non-negative integer, got '$RETRY_SLEEP'" >&2
+        exit 2 ;;
+esac
+
+AZURE_MIRROR="http://azure.archive.ubuntu.com/ubuntu"
+STOCK_MIRROR="http://archive.ubuntu.com/ubuntu"
+MIT_PORTS="http://mirrors.mit.edu/ubuntu-ports"
+STOCK_PORTS="http://ports.ubuntu.com/ubuntu-ports"
+
+if [ "$(id -u)" -eq 0 ]; then
+    SUDO=()
+else
+    SUDO=(sudo)
+fi
+
+update_only=0
+if [ "${1:-}" = "--update-only" ]; then
+    update_only=1
+    shift
+fi
+packages=("$@")
+
+if [ "$update_only" -eq 0 ] && [ ${#packages[@]} -eq 0 ]; then
+    echo "apt_install: no packages given" >&2
+    exit 2
+fi
+
+# Both list formats: 24.04 images ship deb822 .sources files and no
+# sources.list.
+mirror_files() {
+    local f
+    for f in /etc/apt/sources.list \
+             /etc/apt/sources.list.d/*.list \
+             /etc/apt/sources.list.d/*.sources; do
+        [ -f "$f" ] && printf '%s\n' "$f"
+    done
+}
+
+sources_match() {
+    local f
+    while read -r f; do
+        grep -q "$1" "$f" 2>/dev/null && return 0
+    done < <(mirror_files)
+    return 1
+}
+
+rewrite_sources() {
+    local from="$1" to="$2"
+    mirror_files | while read -r f; do
+        "${SUDO[@]}" sed -i -e "s|${from}|${to}|g" "$f" || true
+    done
+}
+
+mirror_family() {
+    if sources_match "ports\.ubuntu\.com" || sources_match "mirrors\.mit\.edu/ubuntu-ports"; then
+        echo ports
+    else
+        echo archive
+    fi
+}
+
+if [ "$(mirror_family)" = "ports" ]; then
+    # arm64: normalize everything (azure.ports included) onto MIT up front and
+    # force IPv4, matching what raspberry-pi-build.yml had proven necessary.
+    rewrite_sources "http://azure.ports.ubuntu.com/ubuntu-ports" "$MIT_PORTS"
+    rewrite_sources "$STOCK_PORTS" "$MIT_PORTS"
+    echo 'Acquire::ForceIPv4 "true";' | "${SUDO[@]}" tee /etc/apt/apt.conf.d/99force-ipv4 >/dev/null
+fi
+
+current_mirror() {
+    if [ "$(mirror_family)" = "ports" ]; then
+        if sources_match "mirrors\.mit\.edu"; then echo mit; else echo stock; fi
+    else
+        if sources_match "azure\."; then echo azure; else echo stock; fi
+    fi
+}
+
+# Move to whichever mirror we are NOT on, within this machine's family.
+# Called once, after the first failure.
+switch_mirror() {
+    local to
+    if [ "$(mirror_family)" = "ports" ]; then
+        if [ "$(current_mirror)" = "mit" ]; then
+            to="$STOCK_PORTS"; rewrite_sources "$MIT_PORTS" "$to"
+        else
+            to="$MIT_PORTS"; rewrite_sources "$STOCK_PORTS" "$to"
+        fi
+    else
+        if [ "$(current_mirror)" = "azure" ]; then
+            to="$STOCK_MIRROR"; rewrite_sources "$AZURE_MIRROR" "$to"
+        else
+            to="$AZURE_MIRROR"; rewrite_sources "$STOCK_MIRROR" "$to"
+        fi
+        # security.ubuntu.com is a separate host that stalls independently.
+        rewrite_sources "http://security.ubuntu.com/ubuntu" "$to"
+    fi
+    echo "::notice::apt switching mirror to ${to}"
+}
+
+attempt() {
+    "${SUDO[@]}" timeout "$UPDATE_TIMEOUT" apt-get update "${APT_OPTS[@]}" || return 1
+    [ "$update_only" -eq 1 ] && return 0
+    "${SUDO[@]}" timeout "$INSTALL_TIMEOUT" env DEBIAN_FRONTEND=noninteractive \
+        apt-get install -y --no-install-recommends "${APT_OPTS[@]}" "${packages[@]}"
+}
+
+for i in $(seq 1 "$ATTEMPTS"); do
+    if attempt; then
+        # apt exiting 0 is not proof; verify the packages are present so a
+        # miss fails here with a clear message, not three steps later.
+        missing=()
+        for pkg in ${packages+"${packages[@]}"}; do
+            dpkg -s "$pkg" >/dev/null 2>&1 || missing+=("$pkg")
+        done
+        if [ ${#missing[@]} -eq 0 ]; then
+            exit 0
+        fi
+        echo "::warning::apt reported success but these are missing: ${missing[*]}"
+    fi
+
+    if [ "$i" -eq "$ATTEMPTS" ]; then
+        echo "::error::apt failed after ${ATTEMPTS} attempts (mirror: $(current_mirror))"
+        exit 1
+    fi
+
+    echo "::warning::apt attempt ${i} failed or timed out; retrying in ${RETRY_SLEEP}s"
+    [ "$i" -eq 1 ] && switch_mirror
+    sleep "$RETRY_SLEEP"
+done

--- a/.github/actions/apt-deps/apt_install.sh
+++ b/.github/actions/apt-deps/apt_install.sh
@@ -79,13 +79,17 @@ if [ "$update_only" -eq 0 ] && [ ${#packages[@]} -eq 0 ]; then
     exit 2
 fi
 
-# Both list formats: 24.04 images ship deb822 .sources files and no
-# sources.list.
+# Every place a mirror host can hide. 24.04 images ship deb822 .sources files
+# and no sources.list. Current hosted images go further and put the host in a
+# mirrorlist, leaving the list files pointing at file:/etc/apt/apt-mirrors.txt;
+# miss that file and the mirror reads as unknown, so a switch rewrites nothing
+# and lands back on the sick host it was already using.
 mirror_files() {
     local f
     for f in /etc/apt/sources.list \
              /etc/apt/sources.list.d/*.list \
-             /etc/apt/sources.list.d/*.sources; do
+             /etc/apt/sources.list.d/*.sources \
+             /etc/apt/apt-mirrors.txt; do
         [ -f "$f" ] && printf '%s\n' "$f"
     done
 }

--- a/.github/workflows/raspberry-pi-build.yml
+++ b/.github/workflows/raspberry-pi-build.yml
@@ -44,30 +44,24 @@ jobs:
           persist-credentials: false
 
       - name: Install Linux build deps
-        # ports.ubuntu.com (the arm64 archive) is under-resourced and regularly
-        # unreachable from GitHub's ARM runners on both IPv6 and IPv4, redding
-        # the build on an otherwise-clean commit. Swap it for a high-bandwidth
-        # mirror (MIT), force IPv4, and retry so a mirror hiccup doesn't fail CI.
-        run: |
-          sudo find /etc/apt/ -type f \( -name "*.list" -o -name "*.sources" \) \
-            -exec sed -i 's|ports.ubuntu.com|mirrors.mit.edu|g' {} +
-          echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4 >/dev/null
-          ok=0
-          for i in 1 2 3; do
-            sudo apt-get update && sudo apt-get install -y --no-install-recommends \
-              build-essential cmake ninja-build pkg-config ccache \
-              libasound2-dev libjack-jackd2-dev libmp3lame-dev libsndfile1-dev libsodium-dev \
-              libpipewire-0.3-dev \
-              liblilv-dev libsuil-dev lv2-dev \
-              ladspa-sdk \
-              libcurl4-openssl-dev libfreetype-dev libfontconfig1-dev \
-              libx11-dev libxcomposite-dev libxcursor-dev libxext-dev \
-              libxinerama-dev libxrandr-dev libxrender-dev libxss-dev \
-              libwebkit2gtk-4.0-dev libgl1-mesa-dev libglu1-mesa-dev xvfb \
-              libwayland-dev libxkbcommon-dev libdecor-0-dev && { ok=1; break; }
-            echo "apt attempt $i failed; retrying in 20s"; sleep 20
-          done
-          [ "$ok" = 1 ] || { echo "apt failed after 3 attempts"; exit 1; }
+        # The shared apt-deps action normalizes arm64 runners onto the MIT
+        # ports mirror with IPv4 forced (ports.ubuntu.com is under-resourced
+        # and regularly unreachable from GitHub's ARM runners), bounds every
+        # apt call with timeout(1), and falls back to the other mirror on
+        # failure, so a sick mirror is a fast retried failure, never a stall.
+        uses: ./.github/actions/apt-deps
+        with:
+          packages: >-
+            build-essential cmake ninja-build pkg-config ccache
+            libasound2-dev libjack-jackd2-dev libmp3lame-dev libsndfile1-dev libsodium-dev
+            libpipewire-0.3-dev
+            liblilv-dev libsuil-dev lv2-dev
+            ladspa-sdk
+            libcurl4-openssl-dev libfreetype-dev libfontconfig1-dev
+            libx11-dev libxcomposite-dev libxcursor-dev libxext-dev
+            libxinerama-dev libxrandr-dev libxrender-dev libxss-dev
+            libwebkit2gtk-4.0-dev libgl1-mesa-dev libglu1-mesa-dev xvfb
+            libwayland-dev libxkbcommon-dev libdecor-0-dev
 
       - name: Cache ccache objects
         uses: actions/cache@v6


### PR DESCRIPTION
Run 32272023755 ("Catch2 tests (TSan)") sat in "Install Linux build deps" for 70+ minutes before being cancelled, despite the action advertising "mirror bypass and retries". Two defects:

1. **No `timeout(1)`**: `Acquire::http::Timeout` only bounds socket inactivity. A mirror that dribbles bytes hangs `apt-get` forever, so the retry loop never gets its second attempt. Every apt invocation is now wrapped in `timeout(1)` (120 s update / 300 s install, three attempts), so the worst case is minutes, never the job timeout.
2. **Permanent mirror pinning**: the action pinned `archive.ubuntu.com`; azure and archive take turns being the sick one (both directions observed within one day on the plugins repo). The installer now switches to the other mirror in the machine's family after the first failed attempt: `azure.archive.ubuntu.com <-> archive.ubuntu.com` on x86, `mirrors.mit.edu <-> ports.ubuntu.com` on arm64 (normalized onto MIT primary with IPv4 forced, preserving the raspberry-pi workflow's proven behaviour).

The logic is ported from dusk-audio-plugins' hardened `apt_install.sh` (dusk-audio-plugins#191 plus its fleet-wide follow-up dusk-audio-plugins#196) and lives in `.github/actions/apt-deps/apt_install.sh`; the action is now a thin wrapper. `raspberry-pi-build.yml` drops its own inline untimeouted retry loop and uses the shared action. Also added: dpkg presence verification after installs, so a silent miss fails at the install step with a clear message.

Verified with actionlint (the single remaining finding, `linux-release.yml:282` SC2206, is pre-existing), YAML parse, and `bash -n` on the script. No raw `apt-get` remains in any workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package installation reliability during Raspberry Pi builds.
  * Added automatic mirror switching, IPv4 handling, retries, and operation timeouts.
  * Added support for ARM-specific package mirrors and common APT source formats.
  * Improved validation and error reporting for failed or missing package installations.

* **Maintenance**
  * Centralized dependency installation behavior for more consistent build workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->