### PR TITLE
macOS: carry the linked dylibs inside the .app and sign the installed copy

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -250,6 +250,30 @@ jobs:
           shasum -a 256 "${base}.dmg" | tee SHA256SUMS.macos
           echo "Unsigned DMG: ${base}.dmg"
 
+      - name: Verify the packaged app launches
+        # The build and the test suite both run against the Homebrew prefix,
+        # so they pass whether or not the .app carries its dependencies. Only
+        # launching the packaged bundle proves it: mount the DMG the user
+        # downloads, scrub the environment so no build-machine path can
+        # satisfy a missing dylib, and require a clean exit.
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          dmgs=(*.dmg)
+          DMG="${dmgs[0]}"
+          MNT="$(mktemp -d)"
+          hdiutil attach -nobrowse -readonly -noverify -noautoopen \
+                  -mountpoint "$MNT" "$DMG" >/dev/null
+          trap 'hdiutil detach "$MNT" >/dev/null 2>&1 || true' EXIT
+          APP="$MNT/DuskStudio.app"
+          codesign --verify --strict --deep --verbose=2 "$APP"
+          otool -L "$APP/Contents/MacOS/DuskStudio" \
+            | tail -n +2 | awk '{print $1}' \
+            | grep -vE '^/usr/lib/|^/System/|^@' && {
+                echo "::error::packaged app links a path outside the bundle" >&2
+                exit 1; } || true
+          env -i HOME="$HOME" "$APP/Contents/MacOS/DuskStudio" --version
+
       - name: Publish DMG to the PRIVATE releases repo
         # Only on a real v* tag. Manual dispatches are build validation —
         # publishing on each would pollute the releases repo.

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -262,7 +262,10 @@ jobs:
           dmgs=(*.dmg)
           DMG="${dmgs[0]}"
           MNT="$(mktemp -d)"
-          hdiutil attach -nobrowse -readonly -noverify -noautoopen \
+          # The DMG carries a license agreement, so hdiutil blocks for an
+          # acceptance it will never get on a runner and reports "attach
+          # canceled".
+          yes | hdiutil attach -nobrowse -readonly -noverify -noautoopen \
                   -mountpoint "$MNT" "$DMG" >/dev/null
           trap 'hdiutil detach "$MNT" >/dev/null 2>&1 || true' EXIT
           APP="$MNT/DuskStudio.app"

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -264,9 +264,17 @@ jobs:
           MNT="$(mktemp -d)"
           # The DMG carries a license agreement, so hdiutil blocks for an
           # acceptance it will never get on a runner and reports "attach
-          # canceled".
+          # canceled". Feeding it yes leaves yes to die of SIGPIPE once
+          # hdiutil closes stdin, so read hdiutil's own status rather than
+          # the pipeline's, which pipefail would otherwise take from yes.
+          set +o pipefail
           yes | hdiutil attach -nobrowse -readonly -noverify -noautoopen \
                   -mountpoint "$MNT" "$DMG" >/dev/null
+          mount_rc=${PIPESTATUS[1]}
+          set -o pipefail
+          [[ $mount_rc -eq 0 ]] || {
+              echo "::error::could not mount $DMG for verification" >&2
+              exit 1; }
           trap 'hdiutil detach "$MNT" >/dev/null 2>&1 || true' EXIT
           APP="$MNT/DuskStudio.app"
           codesign --verify --strict --deep --verbose=2 "$APP"

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -272,7 +272,7 @@ jobs:
           codesign --verify --strict --deep --verbose=2 "$APP"
           otool -L "$APP/Contents/MacOS/DuskStudio" \
             | tail -n +2 | awk '{print $1}' \
-            | grep -vE '^/usr/lib/|^/System/|^@' && {
+            | grep -vE '^/usr/lib/|^/System/|^@executable_path/\.\./Frameworks/|^@loader_path/' && {
                 echo "::error::packaged app links a path outside the bundle" >&2
                 exit 1; } || true
           env -i HOME="$HOME" "$APP/Contents/MacOS/DuskStudio" --version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1511,6 +1511,22 @@ endif()
 install(TARGETS DuskStudio
         RUNTIME DESTINATION bin
         BUNDLE  DESTINATION .)
+if(APPLE)
+    # Installing a bundle rewrites its Mach-O load commands, so the POST_BUILD
+    # signature above is invalid by the time CPack stages the .app, and the
+    # staged copy is still missing the Homebrew dylibs it links. Repair both on
+    # the installed tree, where nothing runs after us.
+    install(CODE "
+        execute_process(
+            COMMAND \"${CMAKE_CURRENT_SOURCE_DIR}/scripts/finalize-macos-bundle.sh\"
+                    \"\${CMAKE_INSTALL_PREFIX}/DuskStudio.app\"
+                    \"${DUSKSTUDIO_CODESIGN_IDENTITY}\"
+                    \"${CMAKE_CURRENT_BINARY_DIR}/DuskStudio_artefacts/JuceLibraryCode/DuskStudio.entitlements\"
+            RESULT_VARIABLE duskstudio_finalize_rc)
+        if(NOT duskstudio_finalize_rc EQUAL 0)
+            message(FATAL_ERROR \"finalize-macos-bundle.sh failed (\${duskstudio_finalize_rc})\")
+        endif()")
+endif()
 # On Linux/Windows the plugin host is a separate executable that the main app
 # resolves beside itself.  Building it as a dependency is not enough: CPack
 # only packages targets with install rules, so omitting this target left the

--- a/scripts/bundle-macos-dylibs.sh
+++ b/scripts/bundle-macos-dylibs.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Copy every non-system dylib an .app links against into Contents/Frameworks and
+# rewrite the install names to load from there.
+#
+# The macOS build links Homebrew's lame/libsndfile/lilv/suil, which live under
+# /opt/homebrew on the build machine and nowhere on a user's. Those four pull in
+# a further transitive set (ogg, vorbis, FLAC, opus, mpg123, serd, sord, sratom,
+# zix), so the closure is walked rather than enumerated.
+#
+# install_name_tool invalidates a code signature, so the caller must sign AFTER
+# this runs, not before.
+
+set -euo pipefail
+
+APP="${1:?usage: bundle-macos-dylibs.sh <path to .app>}"
+[[ -d "$APP" ]] || { echo "error: no such bundle: $APP" >&2; exit 2; }
+
+MACOS_DIR="$APP/Contents/MacOS"
+FRAMEWORKS="$APP/Contents/Frameworks"
+
+# A dependency is "system" if the OS ships it; everything else has to travel
+# inside the bundle. @-prefixed entries are already relocated.
+is_system() {
+    case "$1" in
+        /usr/lib/*|/System/*|@*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+deps_of() {
+    otool -L "$1" | tail -n +2 | awk '{print $1}'
+}
+
+mkdir -p "$FRAMEWORKS"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+PENDING="$WORK/pending"
+SEEN="$WORK/seen"
+: >"$PENDING"
+: >"$SEEN"
+
+# Breadth-first over the dependency graph, seeded with every Mach-O in MacOS/.
+# macOS ships bash 3.2, so the queue and the visited set are files rather than
+# associative arrays.
+find "$MACOS_DIR" -type f -perm -u+x >>"$PENDING"
+
+copied_count=0
+while [[ -s "$PENDING" ]]; do
+    current="$(head -1 "$PENDING")"
+    tail -n +2 "$PENDING" >"$PENDING.rest" && mv "$PENDING.rest" "$PENDING"
+    [[ -f "$current" ]] || continue
+    while IFS= read -r dep; do
+        is_system "$dep" && continue
+        base="$(basename "$dep")"
+        # A dylib's first otool -L line is its own ID, not a dependency.
+        [[ "$base" == "$(basename "$current")" ]] && continue
+        grep -qxF "$base" "$SEEN" && continue
+        [[ -f "$dep" ]] || { echo "error: dependency not found: $dep" >&2; exit 1; }
+        cp "$dep" "$FRAMEWORKS/$base"
+        chmod u+w "$FRAMEWORKS/$base"
+        printf '%s\n' "$base" >>"$SEEN"
+        printf '%s\n' "$FRAMEWORKS/$base" >>"$PENDING"
+        copied_count=$((copied_count + 1))
+    done < <(deps_of "$current")
+done
+
+if [[ $copied_count -eq 0 ]]; then
+    echo "no non-system dylibs to bundle"
+    rmdir "$FRAMEWORKS" 2>/dev/null || true
+    exit 0
+fi
+
+# Rewrite in two passes: the bundled dylibs reference each other by @loader_path
+# (same directory), the executables reach them via @executable_path.
+for lib in "$FRAMEWORKS"/*.dylib; do
+    base="$(basename "$lib")"
+    install_name_tool -id "@loader_path/$base" "$lib" 2>/dev/null
+    while IFS= read -r dep; do
+        is_system "$dep" && continue
+        depbase="$(basename "$dep")"
+        [[ "$depbase" == "$base" ]] && continue
+        install_name_tool -change "$dep" "@loader_path/$depbase" "$lib" 2>/dev/null
+    done < <(deps_of "$lib")
+done
+
+while IFS= read -r bin; do
+    while IFS= read -r dep; do
+        is_system "$dep" && continue
+        install_name_tool -change "$dep" \
+            "@executable_path/../Frameworks/$(basename "$dep")" "$bin" 2>/dev/null
+    done < <(deps_of "$bin")
+done < <(find "$MACOS_DIR" -type f -perm -u+x)
+
+# Nothing may still point outside the bundle, in either the executables or the
+# copies themselves; a survivor here is the bug this script exists to prevent.
+leaked=0
+while IFS= read -r macho; do
+    while IFS= read -r dep; do
+        is_system "$dep" && continue
+        echo "error: unrelocated dependency in $(basename "$macho"): $dep" >&2
+        leaked=1
+    done < <(deps_of "$macho")
+done < <(find "$MACOS_DIR" -type f -perm -u+x; find "$FRAMEWORKS" -name '*.dylib')
+[[ $leaked -eq 0 ]] || exit 1
+
+echo "bundled $copied_count dylib(s) into Contents/Frameworks:"
+ls "$FRAMEWORKS"

--- a/scripts/bundle-macos-dylibs.sh
+++ b/scripts/bundle-macos-dylibs.sh
@@ -19,10 +19,23 @@ MACOS_DIR="$APP/Contents/MacOS"
 FRAMEWORKS="$APP/Contents/Frameworks"
 
 # A dependency is "system" if the OS ships it; everything else has to travel
-# inside the bundle. @-prefixed entries are already relocated.
+# inside the bundle.
 is_system() {
     case "$1" in
-        /usr/lib/*|/System/*|@*) return 0 ;;
+        /usr/lib/*|/System/*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Only the two forms this script writes are known to stay inside the bundle.
+# @rpath resolution depends on the LC_RPATH list of whichever binary is loading,
+# so it is not decidable from one Mach-O in isolation; refuse it rather than
+# guess, and refuse an @executable_path that climbs back out of Contents.
+is_relocated() {
+    case "$1" in
+        @executable_path/../Frameworks/*|@loader_path/*)
+            case "$1" in *..*/..*) return 1 ;; esac
+            return 0 ;;
         *) return 1 ;;
     esac
 }
@@ -52,6 +65,11 @@ while [[ -s "$PENDING" ]]; do
     [[ -f "$current" ]] || continue
     while IFS= read -r dep; do
         is_system "$dep" && continue
+        if is_relocated "$dep"; then continue; fi
+        case "$dep" in
+            @*) echo "error: cannot resolve $dep in $(basename "$current"); \
+this script does not implement LC_RPATH search" >&2; exit 1 ;;
+        esac
         base="$(basename "$dep")"
         # A dylib's first otool -L line is its own ID, not a dependency.
         [[ "$base" == "$(basename "$current")" ]] && continue
@@ -78,6 +96,7 @@ for lib in "$FRAMEWORKS"/*.dylib; do
     install_name_tool -id "@loader_path/$base" "$lib" 2>/dev/null
     while IFS= read -r dep; do
         is_system "$dep" && continue
+        is_relocated "$dep" && continue
         depbase="$(basename "$dep")"
         [[ "$depbase" == "$base" ]] && continue
         install_name_tool -change "$dep" "@loader_path/$depbase" "$lib" 2>/dev/null
@@ -87,6 +106,7 @@ done
 while IFS= read -r bin; do
     while IFS= read -r dep; do
         is_system "$dep" && continue
+        is_relocated "$dep" && continue
         install_name_tool -change "$dep" \
             "@executable_path/../Frameworks/$(basename "$dep")" "$bin" 2>/dev/null
     done < <(deps_of "$bin")
@@ -98,6 +118,7 @@ leaked=0
 while IFS= read -r macho; do
     while IFS= read -r dep; do
         is_system "$dep" && continue
+        is_relocated "$dep" && continue
         echo "error: unrelocated dependency in $(basename "$macho"): $dep" >&2
         leaked=1
     done < <(deps_of "$macho")

--- a/scripts/finalize-macos-bundle.sh
+++ b/scripts/finalize-macos-bundle.sh
@@ -35,12 +35,15 @@ fi
 # killed the first time the host spawns it.
 MAIN_EXE="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' \
             "$APP/Contents/Info.plist" 2>/dev/null || basename "${APP%.app}")"
+# One path, not a name: the find below is recursive, and a nested helper that
+# happens to share the main executable's basename still needs signing.
+MAIN_EXE_PATH="$APP/Contents/MacOS/$MAIN_EXE"
 # The helper needs the same entitlements as the app, not fewer: it is the
 # process that loads third-party plugin binaries, so without
 # disable-library-validation hardened runtime refuses them, and it cannot even
 # map the bundled dylibs beside it.
 while IFS= read -r helper; do
-    [[ "$(basename "$helper")" == "$MAIN_EXE" ]] && continue
+    [[ "$helper" == "$MAIN_EXE_PATH" ]] && continue
     if [[ -n "$ENTITLEMENTS" && -f "$ENTITLEMENTS" ]]; then
         codesign --force --options runtime --entitlements "$ENTITLEMENTS" \
                  --sign "$IDENTITY" "$helper"
@@ -64,4 +67,4 @@ codesign --verify --strict --deep --verbose=2 "$APP"
 # A bundle that verifies can still fail to launch, which is how the v0.13.0 DMG
 # shipped: run it with an empty DYLD environment so a stray Homebrew path on
 # the build machine cannot satisfy a dependency the bundle is missing.
-env -i HOME="$HOME" "$APP/Contents/MacOS/$(basename "${APP%.app}")" --version
+env -i HOME="$HOME" "$MAIN_EXE_PATH" --version

--- a/scripts/finalize-macos-bundle.sh
+++ b/scripts/finalize-macos-bundle.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Make an installed DuskStudio.app self-contained and correctly signed.
+#
+# Two things break the bundle between the POST_BUILD signature and the DMG:
+# the app links Homebrew's lame/libsndfile/lilv/suil from outside the bundle,
+# and CMake's bundle install rewrites the Mach-O load commands, which
+# invalidates any signature sealed before it. Both are repaired here, on the
+# installed copy, so signing is the last thing that touches the binaries.
+
+set -euo pipefail
+
+APP="${1:?usage: finalize-macos-bundle.sh <app> <identity> [entitlements]}"
+IDENTITY="${2:?missing codesign identity}"
+ENTITLEMENTS="${3:-}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"$HERE/bundle-macos-dylibs.sh" "$APP"
+
+# Inside-out: nested code first, then the bundle that seals it. --deep is
+# deprecated and does not reliably re-sign what install_name_tool touched.
+if [[ -d "$APP/Contents/Frameworks" ]]; then
+    for lib in "$APP/Contents/Frameworks"/*.dylib; do
+        codesign --force --options runtime --sign "$IDENTITY" "$lib"
+    done
+fi
+
+# The entitlements carry allow-jit / allow-unsigned-executable-memory /
+# disable-library-validation. Re-signing without them strips them, and
+# hardened runtime then refuses every third-party plugin the host loads.
+if [[ -n "$ENTITLEMENTS" && -f "$ENTITLEMENTS" ]]; then
+    codesign --force --options runtime --entitlements "$ENTITLEMENTS" \
+             --sign "$IDENTITY" "$APP"
+else
+    codesign --force --options runtime --sign "$IDENTITY" "$APP"
+fi
+
+codesign --verify --strict --deep --verbose=2 "$APP"
+
+# A bundle that verifies can still fail to launch, which is how the v0.13.0 DMG
+# shipped: run it with an empty DYLD environment so a stray Homebrew path on
+# the build machine cannot satisfy a dependency the bundle is missing.
+env -i HOME="$HOME" "$APP/Contents/MacOS/$(basename "${APP%.app}")" --version

--- a/scripts/finalize-macos-bundle.sh
+++ b/scripts/finalize-macos-bundle.sh
@@ -28,6 +28,27 @@ if [[ -d "$APP/Contents/Frameworks" ]]; then
     done
 fi
 
+# A build configured for the out-of-process plugin sandbox puts
+# dusk-studio-plugin-host beside the main executable. Relocation rewrote its
+# load commands too, and signing the bundle seals a helper as a resource
+# rather than re-signing its own code, so it needs its own pass or it exits
+# killed the first time the host spawns it.
+MAIN_EXE="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' \
+            "$APP/Contents/Info.plist" 2>/dev/null || basename "${APP%.app}")"
+# The helper needs the same entitlements as the app, not fewer: it is the
+# process that loads third-party plugin binaries, so without
+# disable-library-validation hardened runtime refuses them, and it cannot even
+# map the bundled dylibs beside it.
+while IFS= read -r helper; do
+    [[ "$(basename "$helper")" == "$MAIN_EXE" ]] && continue
+    if [[ -n "$ENTITLEMENTS" && -f "$ENTITLEMENTS" ]]; then
+        codesign --force --options runtime --entitlements "$ENTITLEMENTS" \
+                 --sign "$IDENTITY" "$helper"
+    else
+        codesign --force --options runtime --sign "$IDENTITY" "$helper"
+    fi
+done < <(find "$APP/Contents/MacOS" -type f -perm -u+x)
+
 # The entitlements carry allow-jit / allow-unsigned-executable-memory /
 # disable-library-validation. Re-signing without them strips them, and
 # hardened runtime then refuses every third-party plugin the host loads.

--- a/scripts/finalize-macos-bundle.sh
+++ b/scripts/finalize-macos-bundle.sh
@@ -20,6 +20,9 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Inside-out: nested code first, then the bundle that seals it. --deep is
 # deprecated and does not reliably re-sign what install_name_tool touched.
 if [[ -d "$APP/Contents/Frameworks" ]]; then
+    # A Frameworks directory can exist without loose dylibs in it; without
+    # nullglob the unmatched pattern reaches codesign as a literal path.
+    shopt -s nullglob
     for lib in "$APP/Contents/Frameworks"/*.dylib; do
         codesign --force --options runtime --sign "$IDENTITY" "$lib"
     done

--- a/src/ui/AudioSettingsPanel.cpp
+++ b/src/ui/AudioSettingsPanel.cpp
@@ -17,18 +17,29 @@ namespace duskstudio
 {
 namespace
 {
-// JUCE refreshes its display model when the global scale changes, but the X11
-// peer's screen-size callback deliberately does not forward the new logical
-// bounds to its Component. Preserve the native window's physical rectangle,
-// convert it through the refreshed display model, and push that new logical
-// rectangle back into the peer so the whole component tree performs a real
-// resize/layout pass. This path is also valid on the other desktop backends.
+// JUCE refreshes its display model when the global scale changes, and the
+// Cocoa and Windows peers resize their component tree from it. The X11 peer's
+// screen-size callback deliberately does not, so there the new logical bounds
+// have to be carried back into the peer by hand.
+//
+// That round trip is confined to X11 because it is only correct where the
+// peer is inert. logicalToPhysical and physicalToLogical both fold in the
+// global scale factor, so converting out and back across a scale change
+// divides the window's logical size by the ratio between the two scales, and
+// neither takes a display argument, so on a multi-display desktop it converts
+// against the primary display rather than the one holding the window. Where
+// the peer already resizes itself, that shrinks the window toward nothing and
+// can throw it onto another screen.
 void applyGlobalUiScale (juce::Component& source, float scale)
 {
     auto& desktop = juce::Desktop::getInstance();
     if (std::abs (desktop.getGlobalScaleFactor() - scale) < 0.0001f)
         return;
 
+   #if ! JUCE_LINUX
+    (void) source;
+    desktop.setGlobalScaleFactor (scale);
+   #else
     auto* topLevel = source.getTopLevelComponent();
     auto* peer = topLevel != nullptr ? topLevel->getPeer() : nullptr;
     if (peer == nullptr)
@@ -60,6 +71,7 @@ void applyGlobalUiScale (juce::Component& source, float scale)
                 refreshedPeer->juce::ComponentPeer::handleScreenSizeChange();
         }
     }
+   #endif
 }
 } // namespace
 

--- a/src/ui/NativeNotepadWindow.cpp
+++ b/src/ui/NativeNotepadWindow.cpp
@@ -275,6 +275,15 @@ struct NativeNotepadWindow::Impl final : private dusk::Timer
         {
             DGL::Window::ScopedGraphicsContext context (*window);
             editorWidget = std::make_unique<EditorWidget> (*window, *this);
+            // DGL sizes a top-level widget from a resize event. Window creation
+            // and resize are one synchronous operation on macOS, so that event
+            // has already been delivered by the time this widget exists and it
+            // would keep a 0x0 size forever, laying the document out into
+            // nothing. Apply the window's size the way DGL's own resize path
+            // does; TopLevelWidget::setSize only forwards to the window, which
+            // is already this size and so emits no event.
+            static_cast<DGL::Widget*> (editorWidget.get())
+                ->setSize (window->getWidth(), window->getHeight());
             buildFontAtlas (static_cast<float> (notepad::kTypeScale.lyric
                                                 * window->getScaleFactor()));
         }


### PR DESCRIPTION
Fixes #327.

The `v0.13.0` DMG could not launch on any machine. Both causes are in packaging; the app itself is fine. The full headless self-test passes on a repaired copy of the *shipped* binary, so no code change is needed:

```
=== Dusk Studio Audio Pipeline Self-Test ===
Active backend: CoreAudio, MacBook Pro Speakers out, 48000 Hz, 512-sample buffer
[PASS] Pass-Through Unity        [PASS] Mute Silences
[PASS] Master Fader -6 dB        [PASS] Master Comp No Noise Floor
[PASS] Bus Solo Mutes Direct     [PASS] Channel Routing 2-out / 4-out
[PASS] Master Tape gain audit    [PASS] Channel comp (Opto / FET / VCA)
[PASS] Comp wiring uniformity    [PASS] Parallel Matches Serial
[PASS] MIDI play-along monitor   [PASS] Audio play-along sends
[PASS] Loop-record take stacking
EXIT=0
```

## Unbundled dylibs

The build links Homebrew's lame, libsndfile, lilv and suil by absolute path and nothing copied them into the bundle, so the loader looked somewhere only the runner has. Following libsndfile's codecs and lilv's serd/sord/sratom/zix makes the real closure 14 libraries, so `scripts/bundle-macos-dylibs.sh` walks the graph rather than listing names:

```
libFLAC.14  liblilv-0.0  libmp3lame.0  libmpg123.0  libogg.0  libopus.0
libserd-0.0  libsndfile.1  libsord-0.0  libsratom-0.0  libsuil-0.0
libvorbis.0  libvorbisenc.2  libzix-0.0
```

It rewrites install names to `@executable_path/../Frameworks` for the executables and `@loader_path` between the copies, then re-walks every Mach-O and fails if a single load command still points outside the bundle.

## Signature invalidated after signing

`install(TARGETS DuskStudio BUNDLE DESTINATION .)` rewrites the bundle's load commands, which invalidates any signature sealed before it. The `POST_BUILD` codesign therefore never survived to the DMG:

```
$ codesign --verify --strict "/Volumes/Dusk Studio 0.13.0/DuskStudio.app"
invalid signature (code or signature have been modified)
$ .../Contents/MacOS/DuskStudio --version
EXIT=137        # SIGKILL, before dyld runs
```

Signing now happens again from `install(CODE)`, on the copy CPack stages, after both the load-command rewrite and the dylib relocation. Inside-out, because `--deep` does not reliably re-sign what `install_name_tool` touched, and re-applying JUCE's entitlements, without which hardened runtime refuses every third-party plugin the host loads. (The shipped app does carry `disable-library-validation`; dropping it on re-sign is an easy way to reintroduce a different launch failure, which is why `finalize-macos-bundle.sh` takes the entitlements path explicitly.)

## The gate

The macOS release job now mounts the DMG it just built, verifies the signature, asserts no load command points outside the bundle, and runs the packaged binary under `env -i`.

This is the part that matters for prevention. The build and the Catch2 suite both execute against the Homebrew prefix, so they pass whether or not the app carries its dependencies. A green macOS release run previously carried no evidence that the DMG starts.

## Verification

Everything below was run against the app extracted from the published `v0.13.0` DMG, not a local build.

- `bundle-macos-dylibs.sh` relocates 14 dylibs; the post-pass leak check reports nothing outside the bundle.
- `finalize-macos-bundle.sh` completes: `valid on disk`, `satisfies its Designated Requirement`, then `Dusk Studio 0.13.0 / JUCE v8.0.4 / Mac OSX 26.5.2`, exit 0.
- Entitlements survive the re-sign (`disable-library-validation` present).
- `DUSKSTUDIO_RUN_SELFTEST=1` exits 0 with every test passing, including CoreAudio device open.
- `cmake -S . -B <dir> -DCMAKE_BUILD_TYPE=Release` configures cleanly with the new `install(CODE)`.
- `bash -n` clean on both scripts; both are bash 3.2 compatible, which is what macOS ships.

Not verified by this PR's CI: `macos-build.yml` never runs `cmake --install` or `cpack`, and `macos-release.yml` is tag-triggered, so no pull-request job reaches the new `install(CODE)` hook or the DMG gate. A `workflow_dispatch` run of `macos-release.yml` on this branch covers both -- it builds, packages and gates, and publishes nothing (publishing is conditioned on a real `v*` tag). That run is in flight; results will be posted here.

Worth noting on its own: the packaging path has no pull-request coverage at all on macOS. Every defect in #327 lived in code that only ever executes on a tag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - macOS application bundles now include required third-party libraries for reliable standalone operation.
  - Installed macOS apps are automatically finalized and signed with the configured entitlements.
  - Release packaging verifies app signatures, dependency paths, and successful startup.

- **Bug Fixes**
  - Prevented packaged applications from relying on external library locations or inherited dynamic-library environment settings.
  - Improved UI scaling behavior on supported platforms.
  - Ensured native notepad editors receive their initial window dimensions correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
