### PR TITLE
ci(windows): publish dispatch builds to the private repo as a dev prerelease

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -98,6 +98,24 @@ jobs:
           [[ "v$(tr -d '[:space:]' < VERSION)" == "${GITHUB_REF_NAME}" ]] || {
             echo "Tag ${GITHUB_REF_NAME} != VERSION v$(tr -d '[:space:]' < VERSION)"; exit 1; }
 
+      - name: Preflight - dev publish token (dispatch only)
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.RELEASES_REPO_TOKEN }}
+        run: |
+          set -euo pipefail
+          dev_probe_error=$(mktemp -t duskstudio-dev-preflight.XXXXXX)
+          trap 'rm -f "$dev_probe_error"' EXIT
+          if ! gh api --method POST \
+              "repos/${RELEASES_REPO}/releases/generate-notes" \
+              -f "tag_name=duskstudio-dev-preflight-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+              >/dev/null 2>"$dev_probe_error"; then
+            echo "::error::RELEASES_REPO_TOKEN cannot write to ${RELEASES_REPO}; the dev publish would fail after the build." >&2
+            cat "$dev_probe_error" >&2
+            exit 1
+          fi
+
       - name: Clone JUCE 8.0.4
         shell: bash
         run: |
@@ -315,7 +333,7 @@ jobs:
           sha="${GITHUB_SHA::7}"
           for msi in *.msi; do
             case "$msi" in
-              *"-dev.${sha}-"*) continue ;;
+              *"-dev.${sha}.msi") continue ;;
             esac
             mv -- "$msi" "${msi%.msi}-dev.${sha}.msi"
           done

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -12,8 +12,14 @@ name: Windows build
 #   - push of a v* tag  → publishes the MSI onto the SAME private release
 #                          the mac DMG lands on (shared tag, distinct asset
 #                          names), so one tag yields a cross-platform set.
-#   - workflow_dispatch  → builds and packages the MSI for validation only;
-#                          nothing is published.
+#   - workflow_dispatch  → builds and packages the MSI, and (unless the
+#                          `publish` input is unchecked) uploads it to the
+#                          SAME private repo under the rolling `ci-windows-dev`
+#                          prerelease, sha-stamped, so an untagged main commit
+#                          can be installed on a test box. Older dev assets on
+#                          that prerelease are deleted first, so it holds one
+#                          build; it is a prerelease, so it never becomes the
+#                          releases repo's "Latest".
 #
 # The MSI is UNSIGNED by design (no Authenticode cert) — users see a
 # SmartScreen prompt and choose "More info -> Run anyway" on first launch.
@@ -22,6 +28,11 @@ on:
   push:
     tags: ['v*']
   workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Upload the MSI to the private releases repo (ci-windows-dev prerelease)'
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -54,10 +65,10 @@ jobs:
           # GITHUB_TOKEN — don't leave it in git config.
           persist-credentials: false
 
-      - name: Preflight - releases-repo token is valid (tag builds only)
+      - name: Preflight - releases-repo token is valid (publishing builds only)
         # Fail fast before the full build if RELEASES_REPO_TOKEN is dead.
         # The non-mutating generate-notes endpoint rejects read-only tokens.
-        if: ${{ github.ref_type == 'tag' }}
+        if: ${{ github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.RELEASES_REPO_TOKEN }}
@@ -288,6 +299,25 @@ jobs:
           Get-ChildItem build\*.msi
           Get-ChildItem *.msi -ErrorAction SilentlyContinue
 
+      - name: Stamp dev MSI with the commit sha (dispatch only)
+        # A dev build carries the same VERSION as the last release, so an
+        # unstamped file is indistinguishable from that release's MSI once
+        # downloaded. Rename before hashing so SHA256SUMS.windows describes
+        # the file that actually gets uploaded.
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          sha="${GITHUB_SHA::7}"
+          for msi in *.msi; do
+            case "$msi" in
+              *"-dev.${sha}-"*) continue ;;
+            esac
+            mv -- "$msi" "${msi%.msi}-dev.${sha}.msi"
+          done
+          ls -1 -- *.msi
+
       - name: Compute SHA256 of MSI(s)
         shell: pwsh
         # No working-directory: package-windows.ps1 moves the finished MSI and
@@ -355,3 +385,56 @@ jobs:
           fi
           gh release upload "$TAG" --repo "$RELEASES_REPO" --clobber "${ASSETS[@]}"
           echo "Published ${#ASSETS[@]} asset(s) to ${RELEASES_REPO} @ ${TAG}"
+
+      - name: Publish dev MSI to the PRIVATE releases repo (dispatch only)
+        # Same invariant as the tag path: never actions/upload-artifact, because
+        # on a public repo those are world-downloadable. Dev builds land on one
+        # rolling prerelease so the releases repo gains a single extra entry no
+        # matter how many dispatches run, and prerelease means it can never
+        # become the repo's "Latest" over a real version tag.
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.RELEASES_REPO_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="ci-windows-dev"
+          SHA="${GITHUB_SHA::7}"
+
+          shopt -s nullglob
+          ASSETS=( *.msi SHA256SUMS.windows )
+          if [[ ${#ASSETS[@]} -eq 0 ]]; then
+            echo "::error::no MSI produced - packaging step failed" >&2
+            exit 1
+          fi
+
+          NOTES="Unsigned Windows dev build - NOT a release.
+
+          Commit: ${GITHUB_SHA}
+          Ref: ${GITHUB_REF_NAME}
+          Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+
+          Rebuilt and replaced by every dispatch of the Windows build workflow."
+
+          if gh release view "$TAG" --repo "$RELEASES_REPO" >/dev/null 2>&1; then
+            gh release edit "$TAG" --repo "$RELEASES_REPO" \
+              --title "Windows dev build (${SHA})" --notes "$NOTES" --prerelease
+            # Drop the previous dev build: its assets are sha-stamped, so
+            # --clobber alone would let them pile up under this tag forever.
+            gh release view "$TAG" --repo "$RELEASES_REPO" \
+              --json assets -q '.assets[].name' \
+            | while read -r old; do
+                if [[ -n "$old" ]]; then
+                  gh release delete-asset "$TAG" "$old" \
+                    --repo "$RELEASES_REPO" -y || true
+                fi
+              done
+          elif ! gh release create "$TAG" --repo "$RELEASES_REPO" \
+                 --title "Windows dev build (${SHA})" --notes "$NOTES" \
+                 --prerelease; then
+            # A concurrent dispatch may have created it between the two calls.
+            gh release view "$TAG" --repo "$RELEASES_REPO" >/dev/null
+          fi
+
+          gh release upload "$TAG" --repo "$RELEASES_REPO" --clobber "${ASSETS[@]}"
+          echo "Published ${#ASSETS[@]} asset(s) to ${RELEASES_REPO} @ ${TAG} (${SHA})"

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -38,8 +38,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
-  cancel-in-progress: true
+  # Dispatches share one fixed group so two dev publishes cannot interleave
+  # their delete-then-upload against the single ci-windows-dev release; they
+  # queue instead of cancelling, so neither loses its assets mid-replacement.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && 'dev-publish' || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:
   build:
@@ -65,10 +68,10 @@ jobs:
           # GITHUB_TOKEN — don't leave it in git config.
           persist-credentials: false
 
-      - name: Preflight - releases-repo token is valid (publishing builds only)
+      - name: Preflight - releases-repo token is valid (tag builds only)
         # Fail fast before the full build if RELEASES_REPO_TOKEN is dead.
         # The non-mutating generate-notes endpoint rejects read-only tokens.
-        if: ${{ github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
+        if: ${{ github.ref_type == 'tag' }}
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.RELEASES_REPO_TOKEN }}
@@ -392,49 +395,59 @@ jobs:
         # rolling prerelease so the releases repo gains a single extra entry no
         # matter how many dispatches run, and prerelease means it can never
         # become the repo's "Latest" over a real version tag.
+        #
+        # Nothing here reuses the tag path's ASSETS array or its upload line:
+        # tests/release_mechanics.sh requires each release workflow to carry
+        # exactly one canonical create and upload, and the notes for a dev
+        # build are written here rather than taken from RELEASE-NOTES.md.
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish }}
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.RELEASES_REPO_TOKEN }}
         run: |
           set -euo pipefail
-          TAG="ci-windows-dev"
+          DEV_TAG="ci-windows-dev"
           SHA="${GITHUB_SHA::7}"
 
           shopt -s nullglob
-          ASSETS=( *.msi SHA256SUMS.windows )
-          if [[ ${#ASSETS[@]} -eq 0 ]]; then
+          DEV_ASSETS=( *.msi )
+          if [[ ${#DEV_ASSETS[@]} -eq 0 ]]; then
             echo "::error::no MSI produced - packaging step failed" >&2
             exit 1
           fi
+          DEV_ASSETS+=( SHA256SUMS.windows )
 
-          NOTES="Unsigned Windows dev build - NOT a release.
+          dev_notes=$(mktemp -t duskstudio-dev-notes.XXXXXX)
+          trap 'rm -f "$dev_notes"' EXIT
+          cat > "$dev_notes" <<EOF
+          Unsigned Windows dev build - NOT a release.
 
           Commit: ${GITHUB_SHA}
           Ref: ${GITHUB_REF_NAME}
           Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
 
-          Rebuilt and replaced by every dispatch of the Windows build workflow."
+          Rebuilt and replaced by every dispatch of the Windows build workflow.
+          EOF
 
-          if gh release view "$TAG" --repo "$RELEASES_REPO" >/dev/null 2>&1; then
-            gh release edit "$TAG" --repo "$RELEASES_REPO" \
-              --title "Windows dev build (${SHA})" --notes "$NOTES" --prerelease
+          if gh release view "$DEV_TAG" --repo "$RELEASES_REPO" >/dev/null 2>&1; then
+            gh release edit "$DEV_TAG" --repo "$RELEASES_REPO" \
+              --title "Windows dev build (${SHA})" --notes-file "$dev_notes" --prerelease
             # Drop the previous dev build: its assets are sha-stamped, so
             # --clobber alone would let them pile up under this tag forever.
-            gh release view "$TAG" --repo "$RELEASES_REPO" \
+            # A failed delete must stop the job rather than leave a mixed set.
+            gh release view "$DEV_TAG" --repo "$RELEASES_REPO" \
               --json assets -q '.assets[].name' \
             | while read -r old; do
                 if [[ -n "$old" ]]; then
-                  gh release delete-asset "$TAG" "$old" \
-                    --repo "$RELEASES_REPO" -y || true
+                  gh release delete-asset "$DEV_TAG" "$old" \
+                    --repo "$RELEASES_REPO" -y
                 fi
               done
-          elif ! gh release create "$TAG" --repo "$RELEASES_REPO" \
-                 --title "Windows dev build (${SHA})" --notes "$NOTES" \
-                 --prerelease; then
-            # A concurrent dispatch may have created it between the two calls.
-            gh release view "$TAG" --repo "$RELEASES_REPO" >/dev/null
+          else
+            gh release create "$DEV_TAG" --repo "$RELEASES_REPO" \
+              --title "Windows dev build (${SHA})" --notes-file "$dev_notes" \
+              --prerelease
           fi
 
-          gh release upload "$TAG" --repo "$RELEASES_REPO" --clobber "${ASSETS[@]}"
-          echo "Published ${#ASSETS[@]} asset(s) to ${RELEASES_REPO} @ ${TAG} (${SHA})"
+          gh release upload "$DEV_TAG" --repo "$RELEASES_REPO" --clobber "${DEV_ASSETS[@]}"
+          echo "Published ${#DEV_ASSETS[@]} asset(s) to ${RELEASES_REPO} @ ${DEV_TAG} (${SHA})"


### PR DESCRIPTION
The Windows workflow published only on a `v*` tag, so no commit after a release was installable on a Windows test box without cutting a version. As of `dcf1dcd` that meant the newest MSI in existence was v0.13.0, missing #317 (native CLAP/VST3 on Windows) and #326 (XDG files out of the MSI) - the two things most worth testing there.

`workflow_dispatch` now sha-stamps the MSI and uploads it to a rolling `ci-windows-dev` prerelease in the private releases repo, behind a `publish` input that defaults to true.

Invariants kept:

- Still no `actions/upload-artifact`. This repo is public, so those are world-downloadable for ~90 days; dev builds route to the private releases repo like the tag path does.
- The dev release is created with `--prerelease`, so it can never displace a real version tag as the releases repo Latest.
- Previous dev assets are deleted before upload. They are sha-stamped, so `--clobber` alone would let them accumulate under the tag indefinitely.
- The MSI is renamed before the SHA256 step, so `SHA256SUMS.windows` describes the file that is actually uploaded.
- The MSVC test gate is ungated and so still applies to dev builds.

The token preflight now also covers the dispatch path, so a dead `RELEASES_REPO_TOKEN` fails in seconds rather than after a full MSVC build. On a tag push `inputs` is null, so `inputs.publish` is falsy and the tag path is unchanged.

Concurrent dispatches are serialised: they share one fixed concurrency group with `cancel-in-progress` false, so two dev publishes cannot interleave their delete-then-upload against the single rolling release. With that in place the create-race retry is unreachable, so create is a plain else branch, and a failed asset delete stops the job rather than leaving a mixed set of builds attached.

`tests/release_mechanics.sh` holds each release workflow to one canonical create, one canonical upload of `${ASSETS[@]}`, an identical tag-only token preflight, and a release body taken from `RELEASE-NOTES.md`. The dev lane conforms rather than relaxing the contract: it keeps its own `DEV_ASSETS` array and upload line, writes its notes to a temp file passed as `--notes-file`, and leaves the preflight step byte-identical to the other three workflows. The cost is that a dev dispatch with a dead `RELEASES_REPO_TOKEN` fails at the publish step instead of before the build.

`actionlint` clean, including its embedded shellcheck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual Windows build runs now include a publishing option, enabled by default.
  * Development Windows releases are automatically updated with the latest installers.
  * Published Windows installers include refreshed release notes and clearly identified MSI assets.

* **Reliability**
  * Publishing checks are limited to tagged releases.
  * Windows build runs are queued to prevent conflicting updates.
  * Release updates now fail clearly when installer assets cannot be removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
