### PR TITLE
dejuce: port the windowed-sinc import resampler off JUCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 795 Catch2 test cases across 161 test source files. Linux
+The C++ suite declares 799 Catch2 test cases across 162 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 795 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 799 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/AudioPipelineSelfTest.cpp
+++ b/src/engine/AudioPipelineSelfTest.cpp
@@ -551,7 +551,7 @@ namespace
 // Goertzel sliding magnitude estimator. Returns the linear amplitude of a
 // single discrete frequency component in the input buffer. O(N) per
 // frequency; we only probe a handful so this is cheap compared to a full
-// FFT and avoids the juce::dsp::FFT plumbing.
+// FFT and needs no FFT plumbing of its own.
 float goertzelMagnitude (const float* x, int n, double freqHz, double sr)
 {
     if (n <= 0 || sr <= 0.0) return 0.0f;

--- a/src/engine/FileImporter.cpp
+++ b/src/engine/FileImporter.cpp
@@ -5,7 +5,7 @@
 #include "audiofile/FileWriter.h"
 #include "midi/MidiFileReader.h"
 #include "../foundation/PlanarBuffer.h"
-#include <juce_audio_basics/juce_audio_basics.h>
+#include "../foundation/WindowedSincInterpolator.h"
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -285,11 +285,11 @@ AudioImportResult importAudio (const AudioImportRequest& req)
         // interpolators consumed.
         const double ratio = srcSampleRate / sessionSr;
         const int needIn   = (int) std::ceil ((double) kGrain * ratio)
-                               + (int) juce::WindowedSincInterpolator::getBaseLatency() + 8;
+                               + (int) dusk::audio::WindowedSincInterpolator::getBaseLatency() + 8;
         dusk::audio::PlanarBuffer confChunk, carry;
         confChunk.setSize (req.targetChannels, kGrain);
         carry.setSize     (req.targetChannels, needIn + kGrain);
-        std::array<juce::WindowedSincInterpolator, 2> interp;
+        std::array<dusk::audio::WindowedSincInterpolator, 2> interp;
         for (auto& i : interp) i.reset();
 
         // The sinc kernel delays its output by getBaseLatency() INPUT samples;
@@ -298,7 +298,7 @@ AudioImportResult importAudio (const AudioImportRequest& req)
         // amount). Discard the equivalent output-domain prefix; EOF zero-pad
         // above supplies the extra input the tail needs.
         std::int64_t discard = (std::int64_t) std::llround (
-            (double) juce::WindowedSincInterpolator::getBaseLatency() / ratio);
+            (double) dusk::audio::WindowedSincInterpolator::getBaseLatency() / ratio);
 
         int         carryLen = 0;
         std::int64_t srcPos   = 0;

--- a/src/foundation/WindowedSincInterpolator.h
+++ b/src/foundation/WindowedSincInterpolator.h
@@ -1,0 +1,161 @@
+#pragma once
+
+#include <cmath>
+
+// Stateful windowed-sinc resampler, the algorithm JUCE's
+// WindowedSincInterpolator implements: a 200-sample history ring is fed one
+// input sample per whole step of the read position, and each output sample is
+// 201 taps of a Hann-windowed sinc kernel, read from a shared lookup table at
+// the fractional position. History carries across process() calls, so a stream
+// is resampled block by block; reset() drops it at a discontinuity (seek, new
+// file). Algorithmic latency is 100 input samples.
+//
+// The table is built once, on the first construction, and process() itself
+// neither allocates nor locks. 201 taps per output sample is still an offline
+// cost - this is the import and conform resampler, not one for a block
+// callback. One instance per channel; sharing one smears their histories.
+namespace dusk::audio
+{
+namespace detail
+{
+// The kernel JUCE ships as a 10001-entry float literal, generated here rather
+// than copied. Hann-windowed sinc over 100 zero crossings, sampled 99 steps
+// per crossing while the reader below steps 100 - so the kernel comes back 1%
+// narrower than it was built, and the last taps run off the end of the window
+// into the zero tail. Both belong to this filter's response rather than being
+// slips to correct: the table exists to match JUCE's output sample for sample.
+struct WindowedSincTable
+{
+    static constexpr int kCrossings             = 100;
+    static constexpr int kBuildStepsPerCrossing = 99;
+    static constexpr int kWindowEnd             = kCrossings * kBuildStepsPerCrossing;
+    // One past the furthest entry the reader's 100-steps-per-crossing indexing
+    // can reach, so its trailing lookups land on the zero tail, not past it.
+    static constexpr int kSize                  = 10001;
+
+    WindowedSincTable() noexcept
+    {
+        constexpr double pi = 3.14159265358979323846;
+        values[0] = 1.0f;
+        for (int i = 1; i <= kWindowEnd; ++i)
+        {
+            const double x    = (double) i / (double) kBuildStepsPerCrossing;
+            const double sinc = std::sin (pi * x) / (pi * x);
+            const double hann = 0.5 * (1.0 + std::cos (pi * x / (double) kCrossings));
+            values[(size_t) i] = (float) (sinc * hann);
+        }
+    }
+
+    float values[kSize] {};
+};
+
+inline const float* windowedSincTable() noexcept
+{
+    static const WindowedSincTable table;
+    return table.values;
+}
+} // namespace detail
+
+class WindowedSincInterpolator
+{
+public:
+    WindowedSincInterpolator() noexcept : table (detail::windowedSincTable()) {}
+
+    // Latency of the interpolation itself, in input samples. Divide by the
+    // speed ratio for the latency a resampling pass actually shows.
+    static constexpr float getBaseLatency() noexcept { return (float) kCrossings; }
+
+    void reset() noexcept
+    {
+        for (auto& sample : history)
+            sample = 0.0f;
+        writeIndex   = 0;
+        subSamplePos = 1.0;
+    }
+
+    // Produces `numOutputSamples` from `input`, consuming `speedRatio` input
+    // samples per output sample, and returns how many were actually consumed.
+    // The carried fractional position can pull in up to two samples beyond
+    // speedRatio * numOutputSamples, so size `input` with that headroom.
+    int process (double speedRatio,
+                 const float* input,
+                 float* output,
+                 int numOutputSamples) noexcept
+    {
+        int numUsed = 0;
+        double pos = subSamplePos;
+
+        for (int i = 0; i < numOutputSamples; ++i)
+        {
+            while (pos >= 1.0)
+            {
+                history[(size_t) writeIndex] = input[numUsed++];
+                if (++writeIndex == kHistorySize)
+                    writeIndex = 0;
+                pos -= 1.0;
+            }
+
+            output[i] = valueAtOffset ((float) pos);
+            pos += speedRatio;
+        }
+
+        subSamplePos = pos;
+        return numUsed;
+    }
+
+private:
+    static constexpr int kCrossings            = 100;
+    static constexpr int kHistorySize          = kCrossings * 2;
+    static constexpr int kReadStepsPerCrossing = 100;
+
+    // Taps run from -kCrossings to +kCrossings around the read position, so the
+    // kernel is sampled at whole-sample spacing and only the position of the
+    // first tap has to be looked up: every later tap moves a whole crossing
+    // through the table, mirroring at the sign change. The tap that lands
+    // exactly on the read position needs no special case, because the table
+    // opens at exactly 1.0f.
+    float valueAtOffset (float offset) const noexcept
+    {
+        float result           = 0.0f;
+        int   samplePosition   = writeIndex;
+        float firstFrac        = 0.0f;
+        float lastSincPosition = -1.0f;
+        int   index            = 0;
+        int   sign             = -1;
+
+        for (int i = -kCrossings; i <= kCrossings; ++i)
+        {
+            const float sincPosition = (1.0f - offset) + (float) i;
+
+            if (i == -kCrossings || (sincPosition >= 0.0f && lastSincPosition < 0.0f))
+            {
+                const float indexFloat   = std::abs (sincPosition) * (float) kReadStepsPerCrossing;
+                const float indexFloored = std::floor (indexFloat);
+                index     = (int) indexFloored;
+                firstFrac = indexFloat - indexFloored;
+                sign      = sincPosition < 0.0f ? -1 : 1;
+            }
+
+            if (sincPosition < (float) kCrossings && sincPosition > -(float) kCrossings)
+            {
+                const float lower = table[index];
+                const float upper = table[index + 1];
+                result += history[(size_t) samplePosition] * (lower + firstFrac * (upper - lower));
+            }
+
+            if (++samplePosition == kHistorySize)
+                samplePosition = 0;
+
+            lastSincPosition = sincPosition;
+            index += kReadStepsPerCrossing * sign;
+        }
+
+        return result;
+    }
+
+    const float* table;
+    float        history[kHistorySize] {};
+    int          writeIndex   = 0;
+    double       subSamplePos = 1.0;
+};
+} // namespace dusk::audio

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -198,6 +198,7 @@ target_sources(dusk-studio-tests PRIVATE
     foundation_int_delay_line.cpp
     foundation_spsc_index_fifo.cpp
     foundation_lagrange_interpolator.cpp
+    foundation_windowed_sinc_interpolator.cpp
     foundation_midi_buffer.cpp
     foundation_midi_note_name.cpp
     foundation_planar_buffer.cpp

--- a/tests/foundation_windowed_sinc_interpolator.cpp
+++ b/tests/foundation_windowed_sinc_interpolator.cpp
@@ -1,0 +1,137 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <juce_audio_basics/juce_audio_basics.h>
+
+#include "foundation/WindowedSincInterpolator.h"
+
+#include <cmath>
+#include <vector>
+
+using Catch::Matchers::WithinAbs;
+
+// The generated kernel is bit-identical to the table JUCE ships wherever the
+// two agree on sin/cos to the last double bit - on glibc every assertion below
+// holds at a tolerance of exactly zero. The 1e-6 the tests actually use is
+// headroom for a platform libm that rounds a handful of table entries the
+// other way, not slack for algorithmic drift.
+
+namespace
+{
+std::vector<float> makeSource (int numSamples)
+{
+    std::vector<float> source ((size_t) numSamples);
+    for (int i = 0; i < numSamples; ++i)
+    {
+        const double t = (double) i;
+        source[(size_t) i] = (float) (0.7 * std::sin (0.031 * t)
+                                      + 0.2 * std::sin (0.47 * t + 1.1)
+                                      + 0.05 * std::sin (1.9 * t));
+    }
+    return source;
+}
+} // namespace
+
+TEST_CASE ("dusk::audio::WindowedSincInterpolator tracks the JUCE resampler across blocks",
+           "[foundation][audio]")
+{
+    constexpr int kBlock = 128;
+    constexpr int kBlocks = 12;
+
+    // The ratios a file import actually asks for (source rate / session rate),
+    // plus two that never land on a repeating fraction.
+    for (const double ratio : { 44100.0 / 48000.0, 48000.0 / 44100.0, 96000.0 / 48000.0,
+                                48000.0 / 96000.0, 88200.0 / 48000.0, 1.0,
+                                1.0009765625, 1.2345678 })
+    {
+        const int needed = (int) std::ceil ((double) (kBlock * kBlocks) * ratio) + 16;
+        const auto source = makeSource (needed);
+
+        dusk::audio::WindowedSincInterpolator dut;
+        juce::WindowedSincInterpolator        reference;
+
+        std::vector<float> dutOut ((size_t) kBlock);
+        std::vector<float> refOut ((size_t) kBlock);
+        int dutRead = 0, refRead = 0;
+
+        for (int block = 0; block < kBlocks; ++block)
+        {
+            const int dutUsed = dut.process (ratio, source.data() + dutRead,
+                                             dutOut.data(), kBlock);
+            const int refUsed = reference.process (ratio, source.data() + refRead,
+                                                  refOut.data(), kBlock);
+
+            REQUIRE (dutUsed == refUsed);
+            dutRead += dutUsed;
+            refRead += refUsed;
+
+            for (int i = 0; i < kBlock; ++i)
+                REQUIRE_THAT (dutOut[(size_t) i], WithinAbs (refOut[(size_t) i], 1.0e-6));
+        }
+    }
+}
+
+TEST_CASE ("dusk::audio::WindowedSincInterpolator reset clears history like the JUCE resampler",
+           "[foundation][audio]")
+{
+    constexpr int kBlock = 256;
+    const auto source = makeSource (2048);
+
+    dusk::audio::WindowedSincInterpolator dut;
+    juce::WindowedSincInterpolator        reference;
+
+    std::vector<float> dutOut ((size_t) kBlock);
+    std::vector<float> refOut ((size_t) kBlock);
+
+    dut.process (0.8, source.data(), dutOut.data(), kBlock);
+    reference.process (0.8, source.data(), refOut.data(), kBlock);
+
+    dut.reset();
+    reference.reset();
+
+    const int dutUsed = dut.process (0.8, source.data() + 1024, dutOut.data(), kBlock);
+    const int refUsed = reference.process (0.8, source.data() + 1024, refOut.data(), kBlock);
+
+    REQUIRE (dutUsed == refUsed);
+    for (int i = 0; i < kBlock; ++i)
+        REQUIRE_THAT (dutOut[(size_t) i], WithinAbs (refOut[(size_t) i], 1.0e-6));
+}
+
+TEST_CASE ("dusk::audio::WindowedSincInterpolator is silent for silent input",
+           "[foundation][audio]")
+{
+    constexpr int kBlock = 96;
+    const std::vector<float> silence (1024, 0.0f);
+    std::vector<float> out ((size_t) kBlock, 1.0f);
+
+    dusk::audio::WindowedSincInterpolator dut;
+    int read = 0;
+    for (int block = 0; block < 4; ++block)
+    {
+        read += dut.process (1.3, silence.data() + read, out.data(), kBlock);
+        for (int i = 0; i < kBlock; ++i)
+            REQUIRE_THAT (out[(size_t) i], WithinAbs (0.0f, 0.0f));
+    }
+}
+
+TEST_CASE ("dusk::audio::WindowedSincInterpolator delays by its base latency",
+           "[foundation][audio]")
+{
+    REQUIRE_THAT (dusk::audio::WindowedSincInterpolator::getBaseLatency(),
+                  WithinAbs (juce::WindowedSincInterpolator::getBaseLatency(), 0.0));
+
+    constexpr int kCount = 512;
+    const auto latency = (int) dusk::audio::WindowedSincInterpolator::getBaseLatency();
+
+    std::vector<float> impulse ((size_t) kCount, 0.0f);
+    impulse[0] = 1.0f;
+    std::vector<float> out ((size_t) kCount);
+
+    dusk::audio::WindowedSincInterpolator dut;
+    REQUIRE (dut.process (1.0, impulse.data(), out.data(), kCount) == kCount);
+
+    REQUIRE_THAT (out[(size_t) latency], WithinAbs (1.0f, 1.0e-6));
+    for (int i = 0; i < kCount; ++i)
+        if (i != latency)
+            REQUIRE (std::abs (out[(size_t) i]) < 0.02f);
+}

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -7,7 +7,7 @@ src/dsp/ChannelStrip.h	29
 src/dsp/MasteringChain.h	4
 src/engine/AudioEngine.cpp	86
 src/engine/AudioEngine.h	15
-src/engine/AudioPipelineSelfTest.cpp	23
+src/engine/AudioPipelineSelfTest.cpp	22
 src/engine/BounceEngine.cpp	44
 src/engine/BounceEngine.h	18
 src/engine/DpAligner.cpp	3

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -15,7 +15,7 @@ src/engine/DpAligner.h	3
 src/engine/DpImporter.cpp	41
 src/engine/DpImporter.h	6
 src/engine/DuskStudioPlayHead.h	4
-src/engine/FileImporter.cpp	9
+src/engine/FileImporter.cpp	5
 src/engine/FileImporter.h	4
 src/engine/JuceCompat.h	5
 src/engine/MasteringPlayer.cpp	2


### PR DESCRIPTION
Advances #300. With this, every non-hosting juce_audio_basics/juce_dsp primitive in src/ is gone; what remains on #300 rides with other tickets (see below).

## What

- src/foundation/WindowedSincInterpolator.h replaces JUCE's WindowedSincInterpolator in FileImporter (all three sites, including the getBaseLatency carry sizing). The 10001-entry kernel is generated, not copied: 9959/10001 entries are bit-identical to JUCE's shipped literals and the 42 differences are libm noise at sinc zero crossings (worst delta 9.6e-18). JUCE's two kernel quirks - the table is built at 99 steps per crossing but read back at 100, and the trailing taps run into the zero tail - are reproduced deliberately and documented in the header; they are part of the filter response the A/B holds against.
- FileImporter.cpp drops its juce_audio_basics include.
- One pre-existing comment in AudioPipelineSelfTest.cpp reworded to stop spelling out the gate-tripping token; allowlist ratcheted.

## Verification

- A/B vs juce::WindowedSincInterpolator: bit-exact on glibc/x86-64 across 44.1<->48k, 96<->48k, 88.2->48k, unity, and two non-repeating fractional ratios, 12 blocks each, plus reset parity, silence, and an impulse pinning the 100-sample base latency. Tests commit at 1e-6 purely as headroom for another platform's libm rounding a table entry the other way.
- juce-gate: 9055 -> 9050 uses (178 files); no allowlist additions or raises.
- ctest 787/787; Xvfb self-test 15/15; app build zero new warnings.

## Not in this PR, established while trying

Unlinking juce_dsp from the app target fails at link with 42 undefined references from the vendored donor multicomp.cpp (juce::dsp::Oversampling / IIR::Coefficients explicit instantiations live in juce_dsp.cpp, which only compiles while the module is linked). The donor uses juce::dsp 147+ times, so the unlink belongs to the donor DSP port (#294/#295), not to hosting (#297) as previously assumed. The AudioRegionEditor.h ordering include rides along with that. Nothing from the attempt is committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a project-owned windowed-sinc resampler for high-quality audio sample-rate conversion.
  * Improved resampling with persistent state, reset support, and low-latency block processing.

* **Bug Fixes**
  * Updated audio file importing to use the project’s resampling implementation.

* **Tests**
  * Added comprehensive coverage for resampling accuracy, latency, reset behavior, silence, and impulse response.

* **Documentation**
  * Updated the documented C++ test totals and clarified an audio self-test comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->