### PR TITLE
gui: pass the GUI tower gate and publish the execution spec

### DIFF
--- a/.github/actions/clone-dpf-stack/action.yml
+++ b/.github/actions/clone-dpf-stack/action.yml
@@ -1,37 +1,42 @@
-name: Clone DPF stack (dusk-audio forks, pinned)
+name: Clone DAF stack (dusk-audio forks, pinned)
 description: >
-  Pinned DPF + DPF-Widgets checkouts into RUNNER_TEMP for the native notepad
-  UI. DPF/DGL + Dear ImGui back that UI, so the root configure hard-requires
+  Pinned DAF + DAF-Widgets checkouts into RUNNER_TEMP for the native notepad
+  UI. DAF/DGL + Dear ImGui back that UI, so the root configure hard-requires
   both checkouts. Pinned to Dusk-owned forks for the same reason JUCE is: a
   third-party rebase must not be able to break a build. The submodule pull
   brings in dgl/src/pugl-upstream from dusk-audio/pugl (the pinned rev's
   .gitmodules already points there). The pins below are the single source of
   truth for every workflow.
 
+  The framework was renamed from DPF to DAF (Dusk Audio Framework) and the
+  repositories moved with it. The checkout directories and this action's own
+  directory name still say DPF because every workflow names them; they move in
+  the mechanical rename pass, not here.
+
 runs:
   using: composite
   steps:
-    - name: Clone pinned DPF + DPF-Widgets
+    - name: Clone pinned DAF + DAF-Widgets
       shell: bash
       env:
-        DPF_REPO: https://github.com/dusk-audio/DPF.git
-        DPF_REV: f9fbc62af6fa7ce638a6f1e1482896c385a4955e
-        DPF_WIDGETS_REPO: https://github.com/dusk-audio/DPF-Widgets.git
-        DPF_WIDGETS_REV: 668de17f06abdeb98d5a4b62594bd634f8d1ac2e
+        DAF_REPO: https://github.com/dusk-audio/DAF.git
+        DAF_REV: f9fbc62af6fa7ce638a6f1e1482896c385a4955e
+        DAF_WIDGETS_REPO: https://github.com/dusk-audio/DAF-Widgets.git
+        DAF_WIDGETS_REV: 668de17f06abdeb98d5a4b62594bd634f8d1ac2e
       run: |
         set -euo pipefail
         git init -q "${RUNNER_TEMP}/DPF"
         cd "${RUNNER_TEMP}/DPF"
-        git remote add origin "${DPF_REPO}"
-        git fetch --depth 1 origin "${DPF_REV}"
-        git checkout -q "${DPF_REV}"
-        [[ "$(git rev-parse HEAD)" == "${DPF_REV}" ]] || {
-          echo "ERROR: DPF checkout $(git rev-parse HEAD) != pinned ${DPF_REV}" >&2; exit 1; }
+        git remote add origin "${DAF_REPO}"
+        git fetch --depth 1 origin "${DAF_REV}"
+        git checkout -q "${DAF_REV}"
+        [[ "$(git rev-parse HEAD)" == "${DAF_REV}" ]] || {
+          echo "ERROR: DAF checkout $(git rev-parse HEAD) != pinned ${DAF_REV}" >&2; exit 1; }
         git submodule update --init --depth 1
         git init -q "${RUNNER_TEMP}/DPF-Widgets"
         cd "${RUNNER_TEMP}/DPF-Widgets"
-        git remote add origin "${DPF_WIDGETS_REPO}"
-        git fetch --depth 1 origin "${DPF_WIDGETS_REV}"
-        git checkout -q "${DPF_WIDGETS_REV}"
-        [[ "$(git rev-parse HEAD)" == "${DPF_WIDGETS_REV}" ]] || {
-          echo "ERROR: DPF-Widgets checkout $(git rev-parse HEAD) != pinned ${DPF_WIDGETS_REV}" >&2; exit 1; }
+        git remote add origin "${DAF_WIDGETS_REPO}"
+        git fetch --depth 1 origin "${DAF_WIDGETS_REV}"
+        git checkout -q "${DAF_WIDGETS_REV}"
+        [[ "$(git rev-parse HEAD)" == "${DAF_WIDGETS_REV}" ]] || {
+          echo "ERROR: DAF-Widgets checkout $(git rev-parse HEAD) != pinned ${DAF_WIDGETS_REV}" >&2; exit 1; }

--- a/BUILDING-LINUX.md
+++ b/BUILDING-LINUX.md
@@ -59,11 +59,11 @@ Dusk Studio expects four sibling repositories alongside its own checkout:
 ├── dusk-studio/       (this repo)
 ├── JUCE-wayland/      (plugdata-team fork, branch: wayland-juce8)
 ├── plugins/           (Dusk Audio plugins, donor DSP)
-├── DPF/               (DISTRHO Plugin Framework — native notepad UI)
-└── DPF-Widgets/       (Dear ImGui layer for DPF)
+├── DAF/               (Dusk Audio Framework — native notepad UI)
+└── DAF-Widgets/       (Dear ImGui layer for DAF)
 ```
 
-CMake auto-discovers these. Override with `-DJUCE_PATH=...`, `-DDUSK_PLUGINS_PATH=...`, `-DDPF_PATH=...`, `-DDPF_WIDGETS_PATH=...` if you keep them elsewhere.
+CMake auto-discovers these. Override with `-DJUCE_PATH=...`, `-DDUSK_PLUGINS_PATH=...`, `-DDAF_PATH=...`, `-DDAF_WIDGETS_PATH=...` if you keep them elsewhere.
 
 ### Why the JUCE-wayland fork (Linux-only)
 
@@ -103,32 +103,32 @@ build and release workflows but is not on the donor repository's current
 
 If you also keep an upstream `JUCE/` sibling for cross-OS dev, CMake prefers `JUCE-wayland/` on Linux and falls back to `JUCE/` only if the fork isn't there.
 
-### The native notepad (DPF + Dear ImGui)
+### The native notepad (DAF + Dear ImGui)
 
-The session notepad is Dusk Studio's first native UI window: DPF/DGL for the OpenGL surface, DPF-Widgets for the Dear ImGui layer. Both come from Dusk-owned forks so an upstream rebase can't break a build.
+The session notepad is Dusk Studio's first native UI window: DAF/DGL for the OpenGL surface, DAF-Widgets for the Dear ImGui layer. Both come from Dusk-owned forks so an upstream rebase can't break a build.
 
 ```bash
 cd ~/projects
-git clone https://github.com/dusk-audio/DPF.git
-git -C DPF checkout f9fbc62af6fa7ce638a6f1e1482896c385a4955e
-git -C DPF submodule update --init
-git clone https://github.com/dusk-audio/DPF-Widgets.git
-git -C DPF-Widgets checkout 668de17f06abdeb98d5a4b62594bd634f8d1ac2e
+git clone https://github.com/dusk-audio/DAF.git
+git -C DAF checkout f9fbc62af6fa7ce638a6f1e1482896c385a4955e
+git -C DAF submodule update --init
+git clone https://github.com/dusk-audio/DAF-Widgets.git
+git -C DAF-Widgets checkout 668de17f06abdeb98d5a4b62594bd634f8d1ac2e
 ```
 
-Clone then check out the SHA, rather than cloning a branch: DPF's pin is the tip of `fix/wayland-review-findings`, which was never merged to that fork's `main`. (DPF-Widgets' pin happens to be its `main` tip today, but pin it the same way.) Neither branch may be deleted upstream — a plain clone would stop reaching the commit, and CI fetches the same SHAs. Both checkouts end up on a detached HEAD, which is what you want here. The submodule step is not optional either: DGL pulls its windowing layer from `dgl/src/pugl-upstream`.
+Clone then check out the SHA, rather than cloning a branch: DAF's pin is the tip of `fix/wayland-review-findings`, which was never merged to that fork's `main`. (DAF-Widgets' pin happens to be its `main` tip today, but pin it the same way.) Neither branch may be deleted upstream — a plain clone would stop reaching the commit, and CI fetches the same SHAs. Both checkouts end up on a detached HEAD, which is what you want here. The submodule step is not optional either: DGL pulls its windowing layer from `dgl/src/pugl-upstream`.
 
 The pins live in [.github/actions/clone-dpf-stack/action.yml](.github/actions/clone-dpf-stack/action.yml), which is the single source of truth for every workflow — read them from there if it ever disagrees with the commands above.
 
 Missing either checkout, `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` defaults to **OFF** and configure says so once, quietly:
 
 ```
--- Native notepad: DPF / DPF-Widgets not found - disabled
+-- Native notepad: DAF / DAF-Widgets not found - disabled
 ```
 
 The rest of the app builds and runs normally, but opening the notepad reports *"Notepad unavailable: built without the native notepad UI"*. Passing `-DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=ON` with a checkout missing turns that into a configure error instead of a silent downgrade.
 
-That OFF is sticky, because `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` is a **cached** CMake option — the one dependency here that a later reconfigure won't pick up on its own. Configure `build-linux/` before cloning DPF and cloning it afterwards changes nothing on the next configure, and the "not found" line stops printing too, so nothing hints that the notepad is still off. Either configure into a fresh build directory or force the cache, keeping the rest of the flags from [Configure + build](#configure--build) below:
+That OFF is sticky, because `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` is a **cached** CMake option — the one dependency here that a later reconfigure won't pick up on its own. Configure `build-linux/` before cloning DAF and cloning it afterwards changes nothing on the next configure, and the "not found" line stops printing too, so nothing hints that the notepad is still off. Either configure into a fresh build directory or force the cache, keeping the rest of the flags from [Configure + build](#configure--build) below:
 
 ```bash
 cmake -S . -B build-linux -G Ninja -DCMAKE_BUILD_TYPE=Release \
@@ -178,8 +178,8 @@ cmake --build build-linux-debug -j6
 cmake -S . -B build-linux \
   -DJUCE_PATH=/some/other/JUCE \
   -DDUSK_PLUGINS_PATH=/some/other/plugins \
-  -DDPF_PATH=/some/other/DPF \
-  -DDPF_WIDGETS_PATH=/some/other/DPF-Widgets
+  -DDAF_PATH=/some/other/DAF \
+  -DDAF_WIDGETS_PATH=/some/other/DAF-Widgets
 ```
 
 ## Tests

--- a/BUILDING-WINDOWS.md
+++ b/BUILDING-WINDOWS.md
@@ -16,7 +16,7 @@ This document is aimed at a developer with a Windows machine who has been handed
    vcpkg install --triplet x64-windows-static
    ```
 
-   Manifest mode rejects per-package arguments: `vcpkg install libsndfile:x64-windows-static` errors out while `vcpkg.json` is present. Your vcpkg clone must also already contain the baseline commit, because vcpkg resolves it locally and will not fetch it; clones updated on or after 2026-08-01 have it, so `git pull` in the vcpkg clone first if yours is older. The packages land in `vcpkg_installed\x64-windows-static` under the checkout, so add `-DCMAKE_PREFIX_PATH=<repo-root>/vcpkg_installed/x64-windows-static` to the configure line, forward slashes as with the DPF paths below.
+   Manifest mode rejects per-package arguments: `vcpkg install libsndfile:x64-windows-static` errors out while `vcpkg.json` is present. Your vcpkg clone must also already contain the baseline commit, because vcpkg resolves it locally and will not fetch it; clones updated on or after 2026-08-01 have it, so `git pull` in the vcpkg clone first if yours is older. The packages land in `vcpkg_installed\x64-windows-static` under the checkout, so add `-DCMAKE_PREFIX_PATH=<repo-root>/vcpkg_installed/x64-windows-static` to the configure line, forward slashes as with the DAF paths below.
 4. **Steinberg ASIO SDK** — effectively required for the Visual Studio flow in this document, despite reading like an extra. A multi-config generator with Release among its configurations fails the configure without it ([CMakeLists.txt:694-701](CMakeLists.txt#L694-L701) and [:728-735](CMakeLists.txt#L728-L735)), which is exactly what `-G "Visual Studio 17 2022"` gives you: a shipping Windows binary must not silently come out WASAPI-only. Download from https://www.steinberg.net/asiosdk, accept the EULA, unzip somewhere stable, then pass `-DASIOSDK_PATH=C:/path/to/asiosdk` (its `common/` must contain `iasiodrv.h`). To skip the download on a first dev build, pass `-DDUSKSTUDIO_REQUIRE_ASIO=OFF` instead and accept WASAPI only.
 
 ## Repository layout
@@ -28,11 +28,11 @@ C:\dev\
 ├── dusk-studio\       (this repo)
 ├── JUCE\              (JUCE 8.0.x, the framework)
 ├── plugins\           (Dusk Audio plugins, donor DSP)
-├── DPF\               (DISTRHO Plugin Framework — native notepad UI)
-└── DPF-Widgets\       (Dear ImGui layer for DPF)
+├── DAF\               (Dusk Audio Framework — native notepad UI)
+└── DAF-Widgets\       (Dear ImGui layer for DAF)
 ```
 
-CMake auto-discovers these. If you put them elsewhere, pass `-DJUCE_PATH=...`, `-DDUSK_PLUGINS_PATH=...`, `-DDPF_PATH=...`, and `-DDPF_WIDGETS_PATH=...` at configure time.
+CMake auto-discovers these. If you put them elsewhere, pass `-DJUCE_PATH=...`, `-DDUSK_PLUGINS_PATH=...`, `-DDAF_PATH=...`, and `-DDAF_WIDGETS_PATH=...` at configure time.
 
 ### Clone everything
 
@@ -59,32 +59,32 @@ When that pin moves, update every workflow and this guide together.
 
 The Dusk Studio repo's own directory name (`dusk-studio\`) doesn't matter to the build, so rename it if you prefer.
 
-### The native notepad (DPF + Dear ImGui)
+### The native notepad (DAF + Dear ImGui)
 
-The session notepad is a native window built on DPF/DGL plus the Dear ImGui layer from DPF-Widgets, rather than a JUCE component. Both come from Dusk-owned forks pinned to the revisions CI builds:
+The session notepad is a native window built on DAF/DGL plus the Dear ImGui layer from DAF-Widgets, rather than a JUCE component. Both come from Dusk-owned forks pinned to the revisions CI builds:
 
 ```cmd
 cd C:\dev
-git clone https://github.com/dusk-audio/DPF.git
-git -C DPF checkout f9fbc62af6fa7ce638a6f1e1482896c385a4955e
-git -C DPF submodule update --init
-git clone https://github.com/dusk-audio/DPF-Widgets.git
-git -C DPF-Widgets checkout 668de17f06abdeb98d5a4b62594bd634f8d1ac2e
+git clone https://github.com/dusk-audio/DAF.git
+git -C DAF checkout f9fbc62af6fa7ce638a6f1e1482896c385a4955e
+git -C DAF submodule update --init
+git clone https://github.com/dusk-audio/DAF-Widgets.git
+git -C DAF-Widgets checkout 668de17f06abdeb98d5a4b62594bd634f8d1ac2e
 ```
 
-Clone then check out the SHA, rather than cloning a branch: DPF's pin is the tip of `fix/wayland-review-findings`, which was never merged to that fork's `main`. (DPF-Widgets' pin happens to be its `main` tip today, but pin it the same way.) Neither branch may be deleted upstream — a plain clone would stop reaching the commit, and CI fetches the same SHAs. The submodule step is not optional either: DGL pulls its windowing layer from `dgl/src/pugl-upstream`. The pins live in [.github/actions/clone-dpf-stack/action.yml](.github/actions/clone-dpf-stack/action.yml), the single source of truth for every workflow.
+Clone then check out the SHA, rather than cloning a branch: DAF's pin is the tip of `fix/wayland-review-findings`, which was never merged to that fork's `main`. (DAF-Widgets' pin happens to be its `main` tip today, but pin it the same way.) Neither branch may be deleted upstream — a plain clone would stop reaching the commit, and CI fetches the same SHAs. The submodule step is not optional either: DGL pulls its windowing layer from `dgl/src/pugl-upstream`. The pins live in [.github/actions/clone-dpf-stack/action.yml](.github/actions/clone-dpf-stack/action.yml), the single source of truth for every workflow.
 
 Missing either checkout, `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` defaults to **OFF** and configure says so once, quietly:
 
 ```
--- Native notepad: DPF / DPF-Widgets not found - disabled
+-- Native notepad: DAF / DAF-Widgets not found - disabled
 ```
 
 The build otherwise completes as normal, but opening the notepad reports *"Notepad unavailable: built without the native notepad UI"*. Passing `-DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=ON` with a checkout missing makes it a configure error instead.
 
-That OFF is sticky, because `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` is a **cached** CMake option — the one dependency here a later reconfigure won't pick up on its own. Configure `build\` before cloning DPF and cloning it afterwards changes nothing on the next configure, and the "not found" line stops printing too. Either configure into a fresh build directory or add `-DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=ON` to the configure command below.
+That OFF is sticky, because `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` is a **cached** CMake option — the one dependency here a later reconfigure won't pick up on its own. Configure `build\` before cloning DAF and cloning it afterwards changes nothing on the next configure, and the "not found" line stops printing too. Either configure into a fresh build directory or add `-DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=ON` to the configure command below.
 
-If you override the paths explicitly, give DPF **forward slashes** — `-DDPF_PATH=C:/dev/DPF`. DPF's own CMake re-parses the value, and backslashes come through as invalid escapes.
+If you override the paths explicitly, give DAF **forward slashes** — `-DDAF_PATH=C:/dev/DAF`. DAF's own CMake re-parses the value, and backslashes come through as invalid escapes.
 
 ## Configure + build
 
@@ -158,8 +158,8 @@ In VS, right-click the **DuskStudio** project → **Set as Startup Project** →
 cmake -S . -B build ^
   -DJUCE_PATH=C:/some/other/JUCE ^
   -DDUSK_PLUGINS_PATH=C:/some/other/plugins ^
-  -DDPF_PATH=C:/some/other/DPF ^
-  -DDPF_WIDGETS_PATH=C:/some/other/DPF-Widgets ^
+  -DDAF_PATH=C:/some/other/DAF ^
+  -DDAF_WIDGETS_PATH=C:/some/other/DAF-Widgets ^
   -G "Visual Studio 17 2022" -A x64
 ```
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -555,6 +555,12 @@ if(DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD)
             "${DUSKSTUDIO_DPF_WIDGETS_SOURCE_DIR}/opengl")
         target_compile_definitions(dusk-gui-spike PRIVATE
             DUSKSTUDIO_DGL_RESOURCES=${DUSKSTUDIO_DGL_RESOURCES_NS})
+        if(MSVC)
+            # Same GL 3.x loader the notepad needs, for the same reason: DPF-Widgets hands
+            # Dear ImGui a custom loader that only carries those prototypes off Windows.
+            target_sources(dusk-gui-spike PRIVATE src/ui/ImGuiGlLoaderWin32.cpp)
+            target_include_directories(dusk-gui-spike PRIVATE src/ui)
+        endif()
         target_link_libraries(dusk-gui-spike PRIVATE
             dgl-opengl3
             dgl-opengl3-definitions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -540,6 +540,30 @@ if(DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD)
     target_link_libraries(DuskStudio PRIVATE dusk_notepad_ui)
     target_compile_definitions(DuskStudio PRIVATE DUSKSTUDIO_HAS_NATIVE_NOTEPAD=1)
 
+    # Gate spike for the GUI tower: a standalone framework application window rendering one
+    # channel strip, used to measure frame cost and prove the shell. It ships with nothing,
+    # links no part of the app, and stays off unless asked for. Configure a separate build
+    # directory for it, since the windowing backend is a per-configure choice: use
+    # -DDGL_BACKEND=wayland there to keep a dual-stack box off XWayland.
+    option(DUSKSTUDIO_BUILD_GUI_SPIKE "Build the non-shipping GUI tower gate spike" OFF)
+    if(DUSKSTUDIO_BUILD_GUI_SPIKE)
+        add_executable(dusk-gui-spike
+            tools/gui-spike/GuiSpikeMain.cpp
+            tools/gui-spike/ChannelStripView.cpp
+            "${DUSKSTUDIO_DPF_WIDGETS_SOURCE_DIR}/opengl/DearImGui.cpp")
+        target_include_directories(dusk-gui-spike PRIVATE
+            "${DUSKSTUDIO_DPF_WIDGETS_SOURCE_DIR}/opengl")
+        target_compile_definitions(dusk-gui-spike PRIVATE
+            DUSKSTUDIO_DGL_RESOURCES=${DUSKSTUDIO_DGL_RESOURCES_NS})
+        target_link_libraries(dusk-gui-spike PRIVATE
+            dgl-opengl3
+            dgl-opengl3-definitions
+            dgl-system-libs-definitions)
+        target_compile_features(dusk-gui-spike PRIVATE cxx_std_17)
+        set_target_properties(dusk-gui-spike PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/gui-spike")
+    endif()
+
     if(WIN32)
         # The system OpenGL path can be GDI Generic 1.1 on VMs and over Remote
         # Desktop. The MSI puts Mesa beside DuskStudio.exe, and Main.cpp selects

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -393,31 +393,74 @@ else()
         "the plugins repo to ../plugins (sibling directory).")
 endif()
 
+# Resolves a framework checkout into <outVar>, or leaves it empty when none is
+# present. EXPLICIT names -D variables in preference order; the first one set
+# wins, and if what it points at is not a checkout that is a hard error rather
+# than a silent fall back to a sibling. SEARCH names directories relative to the
+# source tree, tried in order. MARKER is the file that identifies a checkout.
+function(duskstudio_resolve_framework_dir outVar)
+    cmake_parse_arguments(ARG "" "MARKER;LABEL" "EXPLICIT;SEARCH" ${ARGN})
+
+    foreach(pathVar IN LISTS ARG_EXPLICIT)
+        if(DEFINED ${pathVar})
+            if(NOT EXISTS "${${pathVar}}/${ARG_MARKER}")
+                message(FATAL_ERROR
+                    "${pathVar}=${${pathVar}} has no ${ARG_MARKER} - it is not a "
+                    "${ARG_LABEL} checkout.")
+            endif()
+            set(${outVar} "${${pathVar}}" PARENT_SCOPE)
+            return()
+        endif()
+    endforeach()
+
+    foreach(candidate IN LISTS ARG_SEARCH)
+        if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${candidate}/${ARG_MARKER}")
+            set(${outVar} "${CMAKE_CURRENT_SOURCE_DIR}/${candidate}" PARENT_SCOPE)
+            return()
+        endif()
+    endforeach()
+
+    set(${outVar} "" PARENT_SCOPE)
+endfunction()
+
 # Native first-party UI surface for the session notepad. The editor is built on
-# the same DPF/DGL + Dear ImGui stack selected for the final GUI tower, so the
+# the same DAF/DGL + Dear ImGui stack selected for the final GUI tower, so the
 # feature does not add another JUCE widget that would need to be ported later.
-# During development, explicit paths win over sibling checkouts; the external/
-# fallbacks are the eventual pinned release dependencies.
+#
+# The framework is Dusk's own hard fork, renamed from DPF to DAF (Dusk Audio
+# Framework). DAF_PATH and DAF_WIDGETS_PATH are the spellings to use; the DPF
+# ones still resolve, and retire once every checkout and CI image has moved.
+#
+# Resolution order per checkout: an explicit path wins, then a sibling clone,
+# then the vendored external/ copy, and at each rung the DAF name is tried
+# before the DPF one. An explicit path that is not a checkout is a hard error
+# rather than a silent fall-through to a sibling.
+duskstudio_resolve_framework_dir(DUSKSTUDIO_DAF_SOURCE_DIR
+    MARKER   CMakeLists.txt
+    LABEL    DAF
+    EXPLICIT DAF_PATH DPF_PATH
+    SEARCH   ../DAF ../DPF external/DAF external/DPF)
+duskstudio_resolve_framework_dir(DUSKSTUDIO_DAF_WIDGETS_SOURCE_DIR
+    MARKER   opengl/DearImGui.hpp
+    LABEL    DAF-Widgets
+    EXPLICIT DAF_WIDGETS_PATH DPF_WIDGETS_PATH
+    SEARCH   ../DAF-Widgets ../DPF-Widgets external/DAF-Widgets external/DPF-Widgets)
+
 # OFF drops the notepad window (DUSKSTUDIO_HAS_NATIVE_NOTEPAD guards its call
-# sites) so a configure without the DPF checkouts - a test-only tree, say - is
-# still possible. The default follows the checkouts, same as the native LV2
-# host follows its dev libs: a machine without DPF still configures, while an
+# sites) so a configure without the framework checkouts - a test-only tree, say
+# - is still possible. The default follows the checkouts, same as the native LV2
+# host follows its dev libs: a machine without them still configures, while an
 # EXPLICIT -DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=ON with them missing (what CI
-# effectively exercises by passing DPF_PATH) stays a configure error.
+# effectively exercises by passing DAF_PATH) stays a configure error.
 set(DUSKSTUDIO_NOTEPAD_DEPS_FOUND OFF)
-if((DEFINED DPF_PATH
-    OR EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../DPF/CMakeLists.txt"
-    OR EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/DPF/CMakeLists.txt")
-   AND (DEFINED DPF_WIDGETS_PATH
-    OR EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../DPF-Widgets/opengl/DearImGui.hpp"
-    OR EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/DPF-Widgets/opengl/DearImGui.hpp"))
+if(DUSKSTUDIO_DAF_SOURCE_DIR AND DUSKSTUDIO_DAF_WIDGETS_SOURCE_DIR)
     set(DUSKSTUDIO_NOTEPAD_DEPS_FOUND ON)
 endif()
 option(DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD
-       "Build the native DPF/DGL + Dear ImGui session notepad window"
+       "Build the native DAF/DGL + Dear ImGui session notepad window"
        ${DUSKSTUDIO_NOTEPAD_DEPS_FOUND})
 if(NOT DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD AND NOT DUSKSTUDIO_NOTEPAD_DEPS_FOUND)
-    message(STATUS "Native notepad: DPF / DPF-Widgets not found - disabled")
+    message(STATUS "Native notepad: DAF / DAF-Widgets not found - disabled")
 endif()
 
 if(WIN32)
@@ -437,48 +480,26 @@ if(WIN32)
 endif()
 
 if(DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD)
-    if(DEFINED DPF_PATH)
-        if(NOT EXISTS "${DPF_PATH}/CMakeLists.txt")
-            message(FATAL_ERROR
-                "DPF_PATH=${DPF_PATH} has no CMakeLists.txt - it is not a DPF checkout.")
-        endif()
-        set(DUSKSTUDIO_DPF_SOURCE_DIR "${DPF_PATH}")
-    elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../DPF/CMakeLists.txt")
-        set(DUSKSTUDIO_DPF_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../DPF")
-    elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/DPF/CMakeLists.txt")
-        set(DUSKSTUDIO_DPF_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/DPF")
-    else()
+    if(NOT DUSKSTUDIO_DAF_SOURCE_DIR)
         message(FATAL_ERROR
-            "DPF is required for the native notepad UI. Set -DDPF_PATH=/path/to/DPF, "
-            "clone it to ../DPF, initialise external/DPF, or configure with "
+            "DAF is required for the native notepad UI. Set -DDAF_PATH=/path/to/DAF, "
+            "clone it to ../DAF, initialise external/DAF, or configure with "
+            "-DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=OFF.")
+    endif()
+    if(NOT DUSKSTUDIO_DAF_WIDGETS_SOURCE_DIR)
+        message(FATAL_ERROR
+            "DAF-Widgets is required for the native notepad UI. Set "
+            "-DDAF_WIDGETS_PATH=/path/to/DAF-Widgets, clone it to ../DAF-Widgets, "
+            "initialise external/DAF-Widgets, or configure with "
             "-DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=OFF.")
     endif()
 
-    if(DEFINED DPF_WIDGETS_PATH)
-        if(NOT EXISTS "${DPF_WIDGETS_PATH}/opengl/DearImGui.hpp")
-            message(FATAL_ERROR
-                "DPF_WIDGETS_PATH=${DPF_WIDGETS_PATH} has no opengl/DearImGui.hpp - "
-                "it is not a DPF-Widgets checkout.")
-        endif()
-        set(DUSKSTUDIO_DPF_WIDGETS_SOURCE_DIR "${DPF_WIDGETS_PATH}")
-    elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../DPF-Widgets/opengl/DearImGui.hpp")
-        set(DUSKSTUDIO_DPF_WIDGETS_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../DPF-Widgets")
-    elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/DPF-Widgets/opengl/DearImGui.hpp")
-        set(DUSKSTUDIO_DPF_WIDGETS_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/DPF-Widgets")
-    else()
-        message(FATAL_ERROR
-            "DPF-Widgets is required for the native notepad UI. Set "
-            "-DDPF_WIDGETS_PATH=/path/to/DPF-Widgets, clone it to ../DPF-Widgets, "
-            "initialise external/DPF-Widgets, or configure with "
-            "-DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=OFF.")
-    endif()
-
-    message(STATUS "Using DPF from: ${DUSKSTUDIO_DPF_SOURCE_DIR}")
-    message(STATUS "Using DPF-Widgets from: ${DUSKSTUDIO_DPF_WIDGETS_SOURCE_DIR}")
+    message(STATUS "Using DAF from: ${DUSKSTUDIO_DAF_SOURCE_DIR}")
+    message(STATUS "Using DAF-Widgets from: ${DUSKSTUDIO_DAF_WIDGETS_SOURCE_DIR}")
 
     # The namespace holding DGL's built-in font moved with the fork's DPF -> DAF rename.
     # Read the spelling out of the checkout instead of guessing it from the path.
-    file(READ "${DUSKSTUDIO_DPF_SOURCE_DIR}/dgl/src/Resources.hpp" DUSKSTUDIO_DGL_RESOURCES_HPP)
+    file(READ "${DUSKSTUDIO_DAF_SOURCE_DIR}/dgl/src/Resources.hpp" DUSKSTUDIO_DGL_RESOURCES_HPP)
     if(DUSKSTUDIO_DGL_RESOURCES_HPP MATCHES "namespace[ \t]+daf_resources")
         set(DUSKSTUDIO_DGL_RESOURCES_NS daf_resources)
     else()
@@ -493,8 +514,8 @@ if(DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD)
     set(DPF_EXAMPLES OFF CACHE BOOL "Build DPF examples" FORCE)
     set(DAF_LIBRARIES OFF CACHE BOOL "Build DAF's complete library set" FORCE)
     set(DAF_EXAMPLES OFF CACHE BOOL "Build DAF examples" FORCE)
-    add_subdirectory("${DUSKSTUDIO_DPF_SOURCE_DIR}"
-                     "${CMAKE_CURRENT_BINARY_DIR}/DPF" EXCLUDE_FROM_ALL)
+    add_subdirectory("${DUSKSTUDIO_DAF_SOURCE_DIR}"
+                     "${CMAKE_CURRENT_BINARY_DIR}/DAF" EXCLUDE_FROM_ALL)
     if(COMMAND daf__add_dgl_opengl3)
         daf__add_dgl_opengl3(TRUE FALSE FALSE)
     else()
@@ -510,14 +531,14 @@ if(DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD)
         src/ui/NotepadEditorCore.cpp
         src/ui/NotepadEditor.cpp
         src/ui/NativeNotepadWindow.cpp
-        "${DUSKSTUDIO_DPF_WIDGETS_SOURCE_DIR}/opengl/DearImGui.cpp")
+        "${DUSKSTUDIO_DAF_WIDGETS_SOURCE_DIR}/opengl/DearImGui.cpp")
     target_include_directories(dusk_notepad_ui PRIVATE
-        "${DUSKSTUDIO_DPF_WIDGETS_SOURCE_DIR}/opengl")
+        "${DUSKSTUDIO_DAF_WIDGETS_SOURCE_DIR}/opengl")
     target_compile_definitions(dusk_notepad_ui PRIVATE
         DUSKSTUDIO_DGL_RESOURCES=${DUSKSTUDIO_DGL_RESOURCES_NS})
 
     if(MSVC)
-        # Windows' GL header and opengl32 stop at OpenGL 1.1, and DPF-Widgets hands Dear
+        # Windows' GL header and opengl32 stop at OpenGL 1.1, and DAF-Widgets hands Dear
         # ImGui's OpenGL3 backend a "custom loader" (DGL's OpenGL.hpp) that carries GL 3.x
         # prototypes on Linux and macOS only - so DearImGui.cpp does not compile here at
         # all. Force-include a loader that resolves those entry points through
@@ -527,7 +548,7 @@ if(DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD)
         target_sources(dusk_notepad_ui PRIVATE src/ui/ImGuiGlLoaderWin32.cpp)
         target_include_directories(dusk_notepad_ui PRIVATE src/ui)
         set_source_files_properties(
-            "${DUSKSTUDIO_DPF_WIDGETS_SOURCE_DIR}/opengl/DearImGui.cpp"
+            "${DUSKSTUDIO_DAF_WIDGETS_SOURCE_DIR}/opengl/DearImGui.cpp"
             PROPERTIES COMPILE_OPTIONS "/FIImGuiGlLoaderWin32.h")
     endif()
 
@@ -550,13 +571,13 @@ if(DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD)
         add_executable(dusk-gui-spike
             tools/gui-spike/GuiSpikeMain.cpp
             tools/gui-spike/ChannelStripView.cpp
-            "${DUSKSTUDIO_DPF_WIDGETS_SOURCE_DIR}/opengl/DearImGui.cpp")
+            "${DUSKSTUDIO_DAF_WIDGETS_SOURCE_DIR}/opengl/DearImGui.cpp")
         target_include_directories(dusk-gui-spike PRIVATE
-            "${DUSKSTUDIO_DPF_WIDGETS_SOURCE_DIR}/opengl")
+            "${DUSKSTUDIO_DAF_WIDGETS_SOURCE_DIR}/opengl")
         target_compile_definitions(dusk-gui-spike PRIVATE
             DUSKSTUDIO_DGL_RESOURCES=${DUSKSTUDIO_DGL_RESOURCES_NS})
         if(MSVC)
-            # Same GL 3.x loader the notepad needs, for the same reason: DPF-Widgets hands
+            # Same GL 3.x loader the notepad needs, for the same reason: DAF-Widgets hands
             # Dear ImGui a custom loader that only carries those prototypes off Windows.
             target_sources(dusk-gui-spike PRIVATE src/ui/ImGuiGlLoaderWin32.cpp)
             target_include_directories(dusk-gui-spike PRIVATE src/ui)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -476,11 +476,30 @@ if(DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD)
     message(STATUS "Using DPF from: ${DUSKSTUDIO_DPF_SOURCE_DIR}")
     message(STATUS "Using DPF-Widgets from: ${DUSKSTUDIO_DPF_WIDGETS_SOURCE_DIR}")
 
+    # The namespace holding DGL's built-in font moved with the fork's DPF -> DAF rename.
+    # Read the spelling out of the checkout instead of guessing it from the path.
+    file(READ "${DUSKSTUDIO_DPF_SOURCE_DIR}/dgl/src/Resources.hpp" DUSKSTUDIO_DGL_RESOURCES_HPP)
+    if(DUSKSTUDIO_DGL_RESOURCES_HPP MATCHES "namespace[ \t]+daf_resources")
+        set(DUSKSTUDIO_DGL_RESOURCES_NS daf_resources)
+    else()
+        set(DUSKSTUDIO_DGL_RESOURCES_NS dpf_resources)
+    endif()
+    unset(DUSKSTUDIO_DGL_RESOURCES_HPP)
+
+    # The fork renamed its public surface from DPF to DAF (Dusk Audio Framework);
+    # the option names and the DGL helper function moved with it. Set and call
+    # both spellings so a checkout from either side of that rename configures.
     set(DPF_LIBRARIES OFF CACHE BOOL "Build DPF's complete library set" FORCE)
     set(DPF_EXAMPLES OFF CACHE BOOL "Build DPF examples" FORCE)
+    set(DAF_LIBRARIES OFF CACHE BOOL "Build DAF's complete library set" FORCE)
+    set(DAF_EXAMPLES OFF CACHE BOOL "Build DAF examples" FORCE)
     add_subdirectory("${DUSKSTUDIO_DPF_SOURCE_DIR}"
                      "${CMAKE_CURRENT_BINARY_DIR}/DPF" EXCLUDE_FROM_ALL)
-    dpf__add_dgl_opengl3(TRUE FALSE FALSE)
+    if(COMMAND daf__add_dgl_opengl3)
+        daf__add_dgl_opengl3(TRUE FALSE FALSE)
+    else()
+        dpf__add_dgl_opengl3(TRUE FALSE FALSE)
+    endif()
     target_compile_options(dgl-opengl3 PRIVATE
         $<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-cpp;-Wno-stringop-overflow>
         $<$<COMPILE_LANG_AND_ID:CXX,Clang,AppleClang>:-Wno-cpp>)
@@ -494,6 +513,8 @@ if(DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD)
         "${DUSKSTUDIO_DPF_WIDGETS_SOURCE_DIR}/opengl/DearImGui.cpp")
     target_include_directories(dusk_notepad_ui PRIVATE
         "${DUSKSTUDIO_DPF_WIDGETS_SOURCE_DIR}/opengl")
+    target_compile_definitions(dusk_notepad_ui PRIVATE
+        DUSKSTUDIO_DGL_RESOURCES=${DUSKSTUDIO_DGL_RESOURCES_NS})
 
     if(MSVC)
         # Windows' GL header and opengl32 stop at OpenGL 1.1, and DPF-Widgets hands Dear

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ LAME. The Linux and Windows guides list the exact package or manifest setup.
 |----------|-----|
 | Linux | [BUILDING-LINUX.md](BUILDING-LINUX.md) |
 | Windows | [BUILDING-WINDOWS.md](BUILDING-WINDOWS.md) |
-| macOS | Mirror of Linux flow; upstream JUCE 8.0.4, sibling `plugins`, the same pinned DPF stack, and static libsodium supplied through `DUSKSTUDIO_SODIUM_ROOT`. Built and tested per push on `macos-14` (Apple Silicon Sonoma) - see [.github/workflows/macos-build.yml](.github/workflows/macos-build.yml). |
+| macOS | Mirror of Linux flow; upstream JUCE 8.0.4, sibling `plugins`, the same pinned DAF stack, and static libsodium supplied through `DUSKSTUDIO_SODIUM_ROOT`. Built and tested per push on `macos-14` (Apple Silicon Sonoma) - see [.github/workflows/macos-build.yml](.github/workflows/macos-build.yml). |
 | Linux tarball packaging | [packaging/README.md](packaging/README.md) |
 | End-user manual / troubleshooting | [MANUAL.md](MANUAL.md) |
 

--- a/docs/MAINTAINER-GUIDE.md
+++ b/docs/MAINTAINER-GUIDE.md
@@ -44,7 +44,7 @@ cmake --build build -j6
 ./build/DuskStudio_artefacts/Release/DuskStudio
 ```
 
-JUCE, the Dusk plugins repo, and the DPF stack behind the native notepad are auto-discovered from sibling directories (`../JUCE` / `../JUCE-wayland`, `../plugins`, `../DPF`, `../DPF-Widgets`). See Part 5 for what happens when discovery fails — it will, eventually, and the error messages are not always obvious.
+JUCE, the Dusk plugins repo, and the DAF stack behind the native notepad are auto-discovered from sibling directories (`../JUCE` / `../JUCE-wayland`, `../plugins`, `../DAF`, `../DAF-Widgets`). See Part 5 for what happens when discovery fails — it will, eventually, and the error messages are not always obvious.
 
 **Checkpoint:** the app launches, you can create a track, arm it, and play a click.
 
@@ -300,20 +300,20 @@ CMake auto-detects four external repos at configure time, on top of three git su
 
 - **JUCE:** `-DJUCE_PATH=…` wins; else on Linux it prefers `../JUCE-wayland` (a plugdata-team fork with ~5 local commits Dusk Studio depends on — XEmbed, X11-on-Wayland fix, peer-creation latch), falling back to `../JUCE`; on macOS it uses `../JUCE` (upstream). The upstream-vs-fork API difference (`addDefaultFormatsToManager`) is hidden behind [src/engine/JuceCompat.h](../src/engine/JuceCompat.h) — call `duskstudio::juce_compat::addDefaultFormats(fm)` and never sprinkle `#ifdef __linux__` at call sites.
 - **Dusk plugins:** `-DDUSK_PLUGINS_PATH=…` wins; else `../plugins`, and that is the whole list. Check out the `DONOR_REV` shared by the build and release workflows: the required framework-free compressor core is not on the donor repository's current `main`. Build at any other revision and you build against that revision's DSP and layout. Missing entirely, configure only *warns*: you get a recorder with no EQ, comp, or tape rather than a failed build, so read the configure output.
-- **DPF + DPF-Widgets** (the native notepad UI): `-DDPF_PATH=…` / `-DDPF_WIDGETS_PATH=…` win; else `../DPF` and `../DPF-Widgets`, else the `external/` fallbacks, which are placeholders for the eventual release pinning and are not populated today. The two checks are ANDed, so missing *either* one quietly defaults `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` to OFF, announced by one easy-to-miss STATUS line (`Native notepad: DPF / DPF-Widgets not found - disabled`); at runtime the notepad then reports *"Notepad unavailable: built without the native notepad UI"*. Forcing `-DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=ON` without them is a configure error rather than a silent downgrade. Clone the Dusk-owned forks at the revisions CI pins — [.github/actions/clone-dpf-stack/action.yml](../.github/actions/clone-dpf-stack/action.yml) is the single source of truth for those pins:
+- **DAF + DAF-Widgets** (the native notepad UI): `-DDAF_PATH=…` / `-DDAF_WIDGETS_PATH=…` win (the older `-DDPF_PATH=…` / `-DDPF_WIDGETS_PATH=…` still resolve, and retire once every checkout and CI image has moved); else `../DAF` and `../DAF-Widgets`, then `../DPF` and `../DPF-Widgets`, else the `external/` fallbacks, which are placeholders for the eventual release pinning and are not populated today. The two checks are ANDed, so missing *either* one quietly defaults `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` to OFF, announced by one easy-to-miss STATUS line (`Native notepad: DAF / DAF-Widgets not found - disabled`); at runtime the notepad then reports *"Notepad unavailable: built without the native notepad UI"*. Forcing `-DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=ON` without them is a configure error rather than a silent downgrade. Clone the Dusk-owned forks at the revisions CI pins — [.github/actions/clone-dpf-stack/action.yml](../.github/actions/clone-dpf-stack/action.yml) is the single source of truth for those pins:
 
 ```bash
 cd /path/to/dusk-studio
 
-git clone https://github.com/dusk-audio/DPF.git ../DPF
-git -C ../DPF checkout f9fbc62af6fa7ce638a6f1e1482896c385a4955e
-git -C ../DPF submodule update --init     # dgl/src/pugl-upstream
+git clone https://github.com/dusk-audio/DAF.git ../DAF
+git -C ../DAF checkout f9fbc62af6fa7ce638a6f1e1482896c385a4955e
+git -C ../DAF submodule update --init     # dgl/src/pugl-upstream
 
-git clone https://github.com/dusk-audio/DPF-Widgets.git ../DPF-Widgets
-git -C ../DPF-Widgets checkout 668de17f06abdeb98d5a4b62594bd634f8d1ac2e
+git clone https://github.com/dusk-audio/DAF-Widgets.git ../DAF-Widgets
+git -C ../DAF-Widgets checkout 668de17f06abdeb98d5a4b62594bd634f8d1ac2e
 ```
 
-Clone then check out the SHA rather than cloning a branch: DPF's pin is the tip of `fix/wayland-review-findings`, never merged to that fork's `main` (DPF-Widgets' pin is its `main` tip today, but treat it the same). Neither branch may be deleted upstream, or both these commands and CI's fetch-by-SHA stop resolving.
+Clone then check out the SHA rather than cloning a branch: DAF's pin is the tip of `fix/wayland-review-findings`, never merged to that fork's `main` (DAF-Widgets' pin is its `main` tip today, but treat it the same). Neither branch may be deleted upstream, or both these commands and CI's fetch-by-SHA stop resolving.
 
 `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` is a cached `option()`, which makes the OFF sticky in a nasty way: configure a build dir before the checkouts exist, add them later, and re-running CMake in that same dir leaves the notepad off — and the STATUS line above no longer prints, because its guard also requires the deps to be missing. Use a fresh build dir after cloning, or pass `-DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=ON` to overwrite the cache entry.
 
@@ -601,7 +601,7 @@ manual checks that the script cannot cover:
   accidentals display correctly.
 - Extract both Linux tarballs and smoke each binary only on its matching
   architecture, under a private Xvfb display with `WAYLAND_DISPLAY` unset.
-  Never let a release binary touch the live Wayland session. DPF/DGL windows
+  Never let a release binary touch the live Wayland session. DAF/DGL windows
   that require GLX belong in the hardware pass.
 - Inspect the tarball, DMG, and MSI payloads. Each must be Dusk-only, with no
   `JUCE-*` paths, and each must contain the complete

--- a/docs/dejuce-campaign.md
+++ b/docs/dejuce-campaign.md
@@ -152,8 +152,11 @@ reimplemented.
    **Gate passed (#301, 2026-08-24): GO.** Spike, measurements, backend gap
    audit, framework revision reconciliation and phases G0-G6 in
    [dejuce-gui-plan.md](dejuce-gui-plan.md) — read that first, this entry is
-   the summary it supersedes. The fork stack is now named DAF (Dusk Audio
-   Framework); repos, CMake variables and paths still say DPF.
+   the summary it supersedes. The fork stack is now DAF (Dusk Audio Framework):
+   the repos are `dusk-audio/DAF` and `dusk-audio/DAF-Widgets`, all future work
+   is on DAF, and the shared ImGui widget kit lives in DAF-Widgets rather than
+   the plugins repo's `shared-dpf/ui`. What still says DPF is listed in that
+   spec's Naming section.
 
 Done since the last queue edit: events remainder (PR #112, zero gate
 movement by design), FFT (branch dejuce/fft — DpAligner + MasteringEqEditor

--- a/docs/dejuce-campaign.md
+++ b/docs/dejuce-campaign.md
@@ -149,6 +149,11 @@ reimplemented.
    event loop = rewrite of MessageThread.cpp, call sites already converged
    by the events-remainder tower, PR #112. ~120 files, 50%+ of total
    effort, multi-release. Unlinks everything else, `juce_core` last.
+   **Gate passed (#301, 2026-08-24): GO.** Spike, measurements, backend gap
+   audit, framework revision reconciliation and phases G0-G6 in
+   [dejuce-gui-plan.md](dejuce-gui-plan.md) — read that first, this entry is
+   the summary it supersedes. The fork stack is now named DAF (Dusk Audio
+   Framework); repos, CMake variables and paths still say DPF.
 
 Done since the last queue edit: events remainder (PR #112, zero gate
 movement by design), FFT (branch dejuce/fft — DpAligner + MasteringEqEditor

--- a/docs/dejuce-gui-plan.md
+++ b/docs/dejuce-gui-plan.md
@@ -29,7 +29,7 @@ and the accessibility bridge in §4. None of them is a research problem.
 
 ### 1.1 Where the two lines stand
 
-The app pins `DPF_REV=f9fbc62a` (`.github/actions/clone-dpf-stack/action.yml`),
+The app pins `DAF_REV=f9fbc62a` (`.github/actions/clone-dpf-stack/action.yml`),
 which is the tip of the framework branch `fix/wayland-review-findings`. That
 commit is **not** an ancestor of the framework's `main`, which is the line the
 Dusk plug-ins follow. Both descend from `a9b033c2`.
@@ -91,7 +91,7 @@ top of `main`:
 
 Validated on this box: `dusk_notepad_ui` and the whole `DuskStudio` target build
 clean against the result, and the spike runs on it. The prepared branch is
-`dusk/301-reconcile` in the framework clone at `/home/marc/projects/DPF`; it has
+`dusk/301-reconcile` in the framework clone at `/home/marc/projects/DAF`; it has
 never been pushed, so it has to be recreated or transplanted before the PR.
 
 ### 1.3 What the app has to change to consume `main`
@@ -130,10 +130,12 @@ build directory rather than beside the app.
 
 ### 1.5 Proposal to Marc
 
-- Merge the three commits above into the framework `main`, as one reviewed PR.
-- Re-pin `DPF_REV` in `.github/actions/clone-dpf-stack/action.yml` to the merge
-  commit; that action is the single source of truth for every workflow.
-- Re-pin `DPF_WIDGETS_REV` to the widgets repository's `main`, which is two
+- Merge the three commits above into `main` of `dusk-audio/DAF`, as one reviewed
+  PR.
+- Re-pin `DAF_REV` in `.github/actions/clone-dpf-stack/action.yml` to the merge
+  commit; that action is the single source of truth for every workflow, and it
+  already clones from `https://github.com/dusk-audio/DAF.git`.
+- Re-pin `DAF_WIDGETS_REV` to `main` of `dusk-audio/DAF-Widgets`, which is two
   commits ahead of the current pin and carries the matching rename. There is no
   divergence there.
 - Delete the branch `fix/wayland-review-findings` once merged, so no third line
@@ -149,7 +151,7 @@ Zero JUCE, links no part of the app.
 ```
 cmake -S . -B build-spike -G Ninja -DCMAKE_BUILD_TYPE=Release \
       -DDUSKSTUDIO_BUILD_GUI_SPIKE=ON -DDGL_BACKEND=wayland \
-      -DJUCE_PATH=... -DDUSK_PLUGINS_PATH=... -DDPF_PATH=... -DDPF_WIDGETS_PATH=...
+      -DJUCE_PATH=... -DDUSK_PLUGINS_PATH=... -DDAF_PATH=... -DDAF_WIDGETS_PATH=...
 cmake --build build-spike --target dusk-gui-spike -j6
 
 tools/gui-spike/headless-compositor.sh &
@@ -349,28 +351,38 @@ Each phase ends with the app shipping.
 ### G0 — Framework alignment
 
 No user-visible change. Land §1: reconcile the framework revision, move
-`DPF_REV` and `DPF_WIDGETS_REV`, pass `-DDGL_BACKEND=wayland` on Linux app and
+`DAF_REV` and `DAF_WIDGETS_REV`, pass `-DDGL_BACKEND=wayland` on Linux app and
 CI configures, drop the dual-spelling handling.
 
 Owns: `CMakeLists.txt`, `.github/actions/clone-dpf-stack/action.yml`, the
-Linux workflows, `src/ui/NativeNotepadWindow.cpp`.
+Linux workflows, `src/ui/NativeNotepadWindow.cpp`. Take the leftover mechanical
+renames in §7 here too if they are cheap.
 Gate movement: none. Verify: full build, ctest, notepad opens under Xvfb and
 under headless `mutter`.
 
 ### G1 — Widget kit and theme
 
-No user-visible change. Promote the spike's drawing layer into a real module the
-app and the first-party plugin UIs share: theme tokens from
-`DuskStudioLookAndFeel`, the SSL knob, the fader, the segmented meter, the GR
-strip, the module pill, buttons, the value bubble and the text field. Settle the
+No user-visible change. Promote the spike's drawing layer into a real module in
+DAF-Widgets that the app and the first-party plug-in UIs both consume: theme
+tokens from `DuskStudioLookAndFeel`, the SSL knob, the fader, the segmented
+meter, the GR strip, the module pill, buttons, the value bubble and the text
+field. Settle the
 shortcut routing rule (§4.2), the glyph strategy (§4.3), and the draw-list
 caching from §2.2 here, before anything depends on them. Fix §4.1 and §4.4 in
 the framework.
 
-New files, all JUCE-free: `src/ui/imgui/DuskTheme.h`, `DuskWidgets.{h,cpp}`,
-`DuskImGuiHost.{h,cpp}` (the embedded-window lifecycle lifted out of
-`NativeNotepadWindow`). Reconcile with the plug-ins repo's
-`shared-dpf/ui/DuskImGuiWidgets.hpp` rather than forking a second knob.
+New app-side files, all JUCE-free: `src/ui/imgui/DuskImGuiHost.{h,cpp}`, the
+embedded-window lifecycle lifted out of `NativeNotepadWindow`.
+
+**The shared widget kit's home is `dusk-audio/DAF-Widgets`, not the plug-ins
+repo** (Marc, 2026-08-24). The knob, fader, meter, module pill and theme tokens
+go there, beside the Dear ImGui layer they build on, and both Dusk Studio and the
+plug-ins consume them from that one place. The plug-ins repo's
+`shared-dpf/ui/DuskImGuiWidgets.hpp` is the previous home: anything in it worth
+keeping migrates into DAF-Widgets, and it is not extended in place. Do not fork a
+second knob in `src/ui/`, and do not add to `shared-dpf/ui/` — a widget that only
+Dusk Studio needs still belongs in DAF-Widgets if a plug-in could ever want it.
+
 Gate movement: none. Verify: golden-image tests against captured frames, plus
 `NativeNotepadWindow` rebased onto `DuskImGuiHost` as the first consumer.
 
@@ -476,13 +488,30 @@ Owed to Marc's bench, and not inferable from this gate:
 
 ## 7. Naming
 
-Marc renamed the fork stack to **DAF, the Dusk Audio Framework**, on
-2026-08-24. It is a naming decision only. The GitHub repositories, the CMake
-variables (`DPF_PATH`, `DPF_WIDGETS_PATH`, `DPF_REV`), the CI action directory
-and the app's own identifiers still say DPF, and this plan deliberately leaves
-them alone: renaming them is a mechanical pass that should happen on its own,
-not smuggled into a tower. Prose in this document and in tower PRs says DAF; code
-and paths say DPF until that pass lands.
+The fork stack is **DAF, the Dusk Audio Framework**. The rename is real, not
+prospective: `dusk-audio/DPF` is now `dusk-audio/DAF` and `dusk-audio/DPF-Widgets`
+is now `dusk-audio/DAF-Widgets`, the old URLs redirect, and the framework's `main`
+already renamed its own public surface. **All future development is on DAF**; a
+DPF spelling anywhere in this tree is transitional, not a second supported name.
+
+Already moved: the repositories themselves, the framework's public API, the app's
+preferred CMake variables (`DAF_PATH`, `DAF_WIDGETS_PATH`), the sibling
+auto-detect (`../DAF` and `../DAF-Widgets` are tried first), the CI action's
+clone URLs and pin variables, and the contributor build instructions.
+
+Still mechanical, and deliberately left for a pass of its own rather than
+smuggled into a tower — do it in G0 if it is cheap, otherwise as a standalone PR:
+
+- `.github/actions/clone-dpf-stack/` is still the action's directory name, and
+  its `RUNNER_TEMP/DPF` checkout directories and the `-DDPF_PATH=` flags in the
+  workflows still use the old spelling. All three are named by 16 references
+  across 8 workflow files, which is why they did not move here.
+- `LICENSES.txt` records provenance as `dusk-audio/DPF rev <sha>`. It is
+  hand-maintained release-audit surface and has to be regenerated when the pin
+  moves anyway, so the repo name moves with the pin, not before it.
+- The `DPF_PATH` / `DPF_WIDGETS_PATH` fallbacks in the app's CMake, and the
+  `dpf__add_dgl_opengl3` and `dpf_resources` fallbacks, retire when the pin
+  lands on the reconciled revision (§1.5).
 
 ## 8. Resume phrase
 

--- a/docs/dejuce-gui-plan.md
+++ b/docs/dejuce-gui-plan.md
@@ -90,7 +90,9 @@ top of `main`:
 3. A new commit adding `DGL_BACKEND` (§1.4).
 
 Validated on this box: `dusk_notepad_ui` and the whole `DuskStudio` target build
-clean against the result, and the spike runs on it.
+clean against the result, and the spike runs on it. The prepared branch is
+`dusk/301-reconcile` in the framework clone at `/home/marc/projects/DPF`; it has
+never been pushed, so it has to be recreated or transplanted before the PR.
 
 ### 1.3 What the app has to change to consume `main`
 
@@ -200,15 +202,15 @@ Three levers, in the order they should be tried:
    segments each because `ImDrawList` has no radial gradient; a small
    pre-rendered dome texture tinted per band would collapse it to four vertices.
 
-Lever 3 alone is worth measuring first: at 39 widgets per strip, the knobs are
-the bulk of the 25,690 vertices.
+Lever 3 alone is worth measuring first: a strip carries 21 knobs at roughly 600
+vertices each, so the domes are about half of its 25,690.
 
 ### 2.3 Everything else the spike exercised
 
 | Property | Result |
 |---|---|
 | Native Wayland, no X11 in the loop | Confirmed. Links `wayland-client`/`-egl`/`-cursor`; `DGL_BACKEND=wayland` reports "Wayland (requested)" |
-| Resize | 20 programmatic resizes over 12 s at 8 strips: 60 fps held, worst frame 23.3 ms, no stall or crash |
+| Resize | 19 programmatic resizes over 12 s at 8 strips: 60 fps held, worst frame 23.3 ms, no stall or crash |
 | Scale | Rendering at an application scale of 2.0 reflows correctly and costs the same 5.0% |
 | Renderer and context lifetime | Four full window create/destroy cycles then a measured run: renderer identical each time, no leak, no failed realize |
 | Knob drag, wheel, double-click reset | Pass |
@@ -457,6 +459,11 @@ Owed to Marc's bench, and not inferable from this gate:
 - **Decoration behaviour on GNOME.** Row 13 above is read from the source; confirm on
   the desktop before committing to CSD.
 - **Second GPU / Intel path.** All numbers are from the discrete Vega M.
+- **macOS and Windows compiles of the spike.** Only Linux was available. The
+  spike has no platform code beyond a `getrusage` block that compiles out
+  elsewhere, and its CMake carries the same MSVC GL 3.x loader the notepad
+  needs, but neither has been built. If the shell's portability is in question
+  before G5, build `dusk-gui-spike` on both.
 - **The accessibility decision** (§3, row 9), which is Marc's call and gates G3.
 
 ## 7. Naming

--- a/docs/dejuce-gui-plan.md
+++ b/docs/dejuce-gui-plan.md
@@ -151,7 +151,15 @@ cmake -S . -B build-spike -G Ninja -DCMAKE_BUILD_TYPE=Release \
       -DDUSKSTUDIO_BUILD_GUI_SPIKE=ON -DDGL_BACKEND=wayland \
       -DJUCE_PATH=... -DDUSK_PLUGINS_PATH=... -DDPF_PATH=... -DDPF_WIDGETS_PATH=...
 cmake --build build-spike --target dusk-gui-spike -j6
+
+tools/gui-spike/headless-compositor.sh &
+XDG_RUNTIME_DIR=/tmp/dusk-headless WAYLAND_DISPLAY=dusk-headless \
+  env -u DISPLAY ./build-spike/gui-spike/dusk-gui-spike --seconds 10 --strips 24
 ```
+
+`headless-compositor.sh` starts a `mutter` with its own runtime directory, dbus
+session and display name. Nothing Dusk-owned goes on the live session's socket:
+a crash in one of these surfaces takes the desktop with it.
 
 It draws the strip from `ChannelStripComponent::resized()`'s real geometry, with
 the colours, fonts, knob dome, fader cap and segmented meter ported from
@@ -441,9 +449,9 @@ Per phase, non-negotiable:
   generalise it.
 - A live-Wayland pass on Marc's desktop for every view the phase touches. The
   standing rule that the app binary only runs under Xvfb applies to the JUCE
-  build; a framework-native build has to be run on a real compositor, and the
-  private headless `mutter` recipe in `tools/gui-spike/` is the safe way to do
-  that from an agent session.
+  build; a framework-native build has to be run on a real compositor, and
+  `tools/gui-spike/headless-compositor.sh` is the safe way to do that from an
+  agent session.
 
 Owed to Marc's bench, and not inferable from this gate:
 

--- a/docs/dejuce-gui-plan.md
+++ b/docs/dejuce-gui-plan.md
@@ -1,0 +1,477 @@
+# De-JUCE — GUI tower (campaign plan)
+
+The last tower. It removes `src/ui/` as a JUCE surface and, with it, every
+remaining JUCE module. This document is the execution spec: the gate evidence,
+the framework revision to build on, the backend gaps that have to be closed, the
+phase order, and what each phase must prove before it lands.
+
+Gate issue: #301. Campaign map: [dejuce-campaign.md](dejuce-campaign.md).
+
+## Recommendation: GO
+
+The locked direction holds. A native Wayland application window driven by the
+Dusk Audio Framework's DGL/pugl stack, rendering a real Dusk Studio channel
+strip in Dear ImGui, runs at a locked 60 Hz with p50 16.5 ms and a worst frame
+of 19.9 ms, costs 4.7% of one core for one strip, survives repeated window
+teardown and recreation without losing its renderer, and reproduces the current
+look closely enough that the theme port reads as a port rather than a redesign.
+A full bank of eight strips holds 60 Hz at 18.3% of a core, and all twenty-four
+console strips hold it at 45.6%. Nothing in the spike argued for a different
+framework, and the two defects it did surface (window focus is never delivered
+to the ImGui layer, and window decorations are absent under GNOME) are bounded
+work inside a framework the project already owns, not reasons to change course.
+
+The GO is conditional on three things being treated as tower work rather than
+discovered late: the focus/decoration gaps in §4, the frame-cost ceiling in §2,
+and the accessibility bridge in §4. None of them is a research problem.
+
+## 1. Framework revision reconciliation
+
+### 1.1 Where the two lines stand
+
+The app pins `DPF_REV=f9fbc62a` (`.github/actions/clone-dpf-stack/action.yml`),
+which is the tip of the framework branch `fix/wayland-review-findings`. That
+commit is **not** an ancestor of the framework's `main`, which is the line the
+Dusk plug-ins follow. Both descend from `a9b033c2`.
+
+| | Commits since `a9b033c2` | Carries |
+|---|---|---|
+| Pinned branch `f9fbc62a` | 3 | `Window::setEmbeddedOffset`, the Wayland lifecycle and scaling fixes, the pugl mirror pointer |
+| `main` | 31 | The DPF to DAF rename, a second round of Wayland lifetime fixes, AU and CLAP fixes, CI hardening, the pugl mirror pointer |
+
+The pugl submodule is pinned to `5e2621d7` on **both** sides, so the Wayland
+backend's own history is not divergent. All divergence is in the framework
+repository itself.
+
+**Nothing on the pinned branch is superseded by main, and nothing on main is
+superseded by the branch.** They are two independent rounds of work on the same
+files:
+
+- `213336ad` (branch, "point the pugl submodule at the dusk-audio mirror") has an
+  exact equivalent on main in `d8e5bc69` ("take pugl from our own fork"). The
+  resulting `.gitmodules` is byte-identical. Nothing to carry.
+- `f9fbc62a` (`Window::setEmbeddedOffset`) is **absent from main**. The notepad
+  refuses to open without it, so main cannot be adopted as-is.
+- `7b33d9f6` ("Fix Wayland lifecycle and scaling issues") is **absent from
+  main**. Main's `36a7347a` is a different fix set on the same file (unclaimed
+  clipboard offers, per-view timer purge on destroy, sub-`BTN_LEFT` button
+  codes, 64-bit shm pool sizing, `_GNU_SOURCE`), not a rework of it.
+
+There is exactly one place where the two sides made **contradictory** decisions:
+`getDesktopScaleFactor()` on Wayland. Main returns `1.0` with a comment arguing
+it is harmless; the branch returns the `0.0` "unknown" sentinel. The branch is
+the later decision and it is the correct one — `Window::PrivateData` derives
+`followsPuglScaleFactor` from `d_isZero(scale)`, so returning `1.0` pins the
+window to scale 1 for its whole life and the matching `onPuglConfigure` hook
+that propagates a live scale change never runs. Main is missing both halves of
+that mechanism.
+
+### 1.2 The proposed reconciled revision
+
+Prepared and validated locally; the push and merge are Marc's. Three commits on
+top of `main`:
+
+1. Cherry-pick `f9fbc62a` (`setEmbeddedOffset`). Applies cleanly except for the
+   two `DISTRHO_SAFE_ASSERT_RETURN` uses, which become `DAF_SAFE_ASSERT_RETURN`.
+2. Cherry-pick `7b33d9f6` (Wayland lifecycle and scaling). Five conflict hunks,
+   all mechanical once the intent is clear:
+   - `wayland.c`, timer removal: both sides added a `puglWaylandRemoveViewTimers`.
+     Take the branch's pair (`puglWaylandRemoveTimer` + the view sweep), because
+     the helper is also used by the branch's `puglStopTimer`, and wrap it in the
+     `PUGL_WAYLAND_HAVE_TIMERFD` guard main added. Drop the branch's duplicate
+     unguarded call in `puglFreeViewInternals`.
+   - `wayland.c`, timer dispatch: take the branch side, which adds
+     `impl->timers[i].fd != timer.fd` to the staleness check. Strict superset.
+   - `WindowPrivateData.cpp`: take the branch's `HAVE_WAYLAND` scale-follow block
+     in `onPuglConfigure`, keeping main's `DAF_TEST_WINDOW_CPP` spelling.
+   - `DafUI.cpp` and `README.wayland`: take the branch's `0.0` sentinel and its
+     prose, under DAF naming. This is the one semantic call in the set; §1.1
+     explains why.
+3. A new commit adding `DGL_BACKEND` (§1.4).
+
+Validated on this box: `dusk_notepad_ui` and the whole `DuskStudio` target build
+clean against the result, and the spike runs on it.
+
+### 1.3 What the app has to change to consume `main`
+
+The rename is not cosmetic at the build interface. Three things move:
+
+| Was | Is | Where it bites |
+|---|---|---|
+| `DPF_LIBRARIES` / `DPF_EXAMPLES` | `DAF_LIBRARIES` / `DAF_EXAMPLES` | root `CMakeLists.txt` |
+| `dpf__add_dgl_opengl3()` | `daf__add_dgl_opengl3()` | root `CMakeLists.txt` |
+| `namespace dpf_resources` | `namespace daf_resources` | `src/ui/NativeNotepadWindow.cpp` |
+
+Commit `39d19a6` on this branch makes all three accept either spelling, so the
+tree configures against the current pin and against the reconciled revision.
+When the pin moves, that dual handling collapses to the DAF spelling and the
+`DUSKSTUDIO_DGL_RESOURCES` macro goes away; it exists only to span the two live
+revisions.
+
+### 1.4 The backend is chosen by accident today
+
+`daf__add_dgl_system_libs` selects X11 whenever the X11 development files are
+installed, and Wayland only when they are absent. There is no way to ask for
+Wayland. On a dual-stack developer box or CI image the failure is silent: the
+build succeeds and the app runs, just against XWayland — which is precisely what
+the zero-XWayland policy for Dusk-owned surfaces forbids.
+
+Proposed commit 3 adds `DGL_BACKEND` with values `auto` (the old behaviour, and
+still the default), `x11` and `wayland`, and fails the configure when the
+requested backend's libraries are missing. Linux app and CI configures then pass
+`-DDGL_BACKEND=wayland` explicitly.
+
+Note the consequence for build layout: **the backend is a per-configure choice**,
+because one `dgl-opengl3` target serves every consumer in the tree. A build
+directory is X11 or Wayland, not both. The spike therefore lives in its own
+build directory rather than beside the app.
+
+### 1.5 Proposal to Marc
+
+- Merge the three commits above into the framework `main`, as one reviewed PR.
+- Re-pin `DPF_REV` in `.github/actions/clone-dpf-stack/action.yml` to the merge
+  commit; that action is the single source of truth for every workflow.
+- Re-pin `DPF_WIDGETS_REV` to the widgets repository's `main`, which is two
+  commits ahead of the current pin and carries the matching rename. There is no
+  divergence there.
+- Delete the branch `fix/wayland-review-findings` once merged, so no third line
+  can accumulate.
+- Retire the dual-spelling handling in the app's `CMakeLists.txt` and
+  `NativeNotepadWindow.cpp` in the same PR that moves the pin.
+
+## 2. What the gate spike measured
+
+Source: `tools/gui-spike/`. Off by default behind `DUSKSTUDIO_BUILD_GUI_SPIKE`.
+Zero JUCE, links no part of the app.
+
+```
+cmake -S . -B build-spike -G Ninja -DCMAKE_BUILD_TYPE=Release \
+      -DDUSKSTUDIO_BUILD_GUI_SPIKE=ON -DDGL_BACKEND=wayland \
+      -DJUCE_PATH=... -DDUSK_PLUGINS_PATH=... -DDPF_PATH=... -DDPF_WIDGETS_PATH=...
+cmake --build build-spike --target dusk-gui-spike -j6
+```
+
+It draws the strip from `ChannelStripComponent::resized()`'s real geometry, with
+the colours, fonts, knob dome, fader cap and segmented meter ported from
+`DuskStudioLookAndFeel`, against stub parameters at the shipping ranges and
+meters fed by a 30 Hz source thread with the UI-side ballistics the shipping
+timer callback applies.
+
+### 2.1 Environment
+
+Every number below is from a **private headless `mutter` 48.4** session
+(`--headless --no-x11 --virtual-monitor 1920x1080`, its own `XDG_RUNTIME_DIR`,
+its own dbus session, its own Wayland display name), never the live desktop.
+GL is **hardware**, not llvmpipe: `AMD Radeon RX Vega M GH (radeonsi, vegam,
+Mesa 24.3.3)`, GL 4.6 compatibility profile.
+
+Headless is not the same as the desktop. It has no seat, so no real pointer or
+keyboard events arrive; it does not run the desktop's compositing or effects;
+and its idea of output scale is fixed. **The live-desktop pass is Marc's bench
+and is owed** (§6).
+
+### 2.2 Frame pacing and cost
+
+Ten second runs, present-to-present measured at the top of each ImGui frame.
+The frame rate is capped at 60 by the framework's idle callback, so the number
+that carries information is CPU, not fps.
+
+| Strips | fps | p50 | p95 | worst | CPU (one core) | verts/frame |
+|---|---|---|---|---|---|---|
+| 1 | 60.0 | 16.53 ms | 19.49 ms | 19.85 ms | 4.7% | 25,690 |
+| 8 (one bank) | 59.9 | 15.91 ms | 18.76 ms | 26.16 ms | 18.3% | 205,492 |
+| 24 (full console) | 59.8 | 16.90 ms | 17.66 ms | 33.78 ms | 45.6% | 606,096 |
+
+Read the CPU column as the tower's central engineering constraint. Cost is
+linear in strips because immediate mode rebuilds every vertex every frame,
+whereas the JUCE strip today repaints only `inputMeterArea` on its 30 Hz tick.
+**45.6% of a core for a static console is not shippable as-is** on the machines
+Dusk Studio targets, and it is a headroom problem, not a frame-rate one: the
+budget is being spent whether or not anything moved.
+
+Three levers, in the order they should be tried:
+
+1. Cache the draw list for strips whose parameters did not change and only
+   rebuild the meter rectangles. ImGui supports this through a retained
+   `ImDrawList` per strip; the meters are a handful of rectangles.
+2. Drop the redraw rate to 30 Hz for strips that are not under the pointer.
+   Meters are already a 30 Hz signal; only the control being dragged needs 60.
+3. Reduce vertex count in the knob dome. It is 12 concentric circles at 32
+   segments each because `ImDrawList` has no radial gradient; a small
+   pre-rendered dome texture tinted per band would collapse it to four vertices.
+
+Lever 3 alone is worth measuring first: at 39 widgets per strip, the knobs are
+the bulk of the 25,690 vertices.
+
+### 2.3 Everything else the spike exercised
+
+| Property | Result |
+|---|---|
+| Native Wayland, no X11 in the loop | Confirmed. Links `wayland-client`/`-egl`/`-cursor`; `DGL_BACKEND=wayland` reports "Wayland (requested)" |
+| Resize | 20 programmatic resizes over 12 s at 8 strips: 60 fps held, worst frame 23.3 ms, no stall or crash |
+| Scale | Rendering at an application scale of 2.0 reflows correctly and costs the same 5.0% |
+| Renderer and context lifetime | Four full window create/destroy cycles then a measured run: renderer identical each time, no leak, no failed realize |
+| Knob drag, wheel, double-click reset | Pass |
+| Text entry on the strip name | Pass (`InputText`, commit on Enter) |
+| Shell keyboard shortcut | Pass |
+| Modal opens and dims | Pass |
+| Context menu opens | Pass |
+| Modal blocks the strip underneath | **Fail** — see §4.1 |
+
+The interaction results come from `--selftest`, which injects at the ImGui event
+queue. A headless compositor has no seat, so the run reports
+`pointer=0 key=0 text=0` through the real path: the spike proves the widget
+layer, and deliberately proves nothing about pugl's seat handling.
+
+## 3. Framework gap audit for an application
+
+Audited against `dgl/src/pugl-extra/wayland.c` and the DGL sources on the
+reconciled revision. "Plugin UI" needs are already met; this is the delta for a
+desktop application.
+
+| # | Capability | Status | Reference |
+|---|---|---|---|
+| 1 | IME / text input | Partial | `wayland.c:1430`, `:2970` |
+| 2 | Drag and drop | Absent (offers actively declined) | `wayland.c:1909` |
+| 3 | Multiple top-level windows | Present | `wayland.c:186`, `wayland.h:151` |
+| 4 | Transient parent / modal | Partial (parent yes, modal no) | `wayland.c:3070`, `:3813` |
+| 5 | Portal parenting (xdg-foreign) | Absent | no protocol vendored |
+| 6 | Keyboard focus | Partial (pugl emits, DGL drops) | `wayland.c:1555`, `:3851` |
+| 7 | Clipboard | Partial (text only, no primary) | `wayland.c:4093`, `:4109` |
+| 8 | Cursors | Partial (10 shapes, no hide, no custom) | `wayland.c:2519`, `:2568` |
+| 9 | Accessibility | Absent (nothing in the tree) | — |
+| 10 | Headless automation | Absent in the backend | `wayland.c:2911` |
+| 11 | HiDPI / fractional scaling | Present | `wayland.c:312`, `:355` |
+| 12 | Timers and event loop | Present, real blocking wait with timeout | `wayland.c:3454`, `:3612` |
+| 13 | Window decorations | Partial, and the worst gap | `wayland.c:3193` |
+| 14 | EGL context | Present, survives close/reopen | `wayland_gl.c:61`, `:146` |
+
+Detail on the ones that change the plan:
+
+- **Decorations (13).** Server-side only: the backend asks for
+  `SERVER_SIDE` and the configure listener is a stub whose own comment says an
+  answer of `CLIENT_SIDE` leaves the window undecorated. GNOME has never
+  implemented `xdg-decoration`, so on Marc's own desktop the manager is NULL and
+  that branch never runs. Worse, `xdg_toplevel.move`, `.resize` and
+  `.show_window_menu` appear nowhere in the backend. Net result on GNOME: a
+  borderless window with no titlebar, no close or maximise control, no
+  drag-to-move and no resize borders. **This blocks the shell flip (G5) and
+  nothing before it.** It needs either client-side decorations drawn in ImGui —
+  which the portastudio aesthetic arguably wants anyway — or hit-tested edges
+  wired to `xdg_toplevel.move`/`.resize`. Prefer CSD: it is one place, it is
+  themeable, and it removes the compositor dependency entirely.
+- **Focus (6).** pugl dispatches `PUGL_FOCUS_IN`/`OUT`, but DGL has no focus
+  callback on `Widget` and never surfaces them, and the widgets library's ImGui
+  bridge never calls `io.AddFocusEvent()`. §4.1 covers the consequences.
+- **Cursors (8).** There is no hidden-cursor path and no custom cursor image.
+  The hide-pointer-and-warp idiom that every DAW knob drag uses is therefore
+  unavailable. Add a `PUGL_CURSOR_NONE` shape; it is a one-line
+  `wl_pointer_set_cursor(..., NULL, ...)` in the backend.
+- **Portal parenting (5).** Every file chooser opened through
+  xdg-desktop-portal will be unparented, so it can appear behind the main window
+  or on another workspace. Needed by G2, which is where the first file dialog
+  moves.
+- **Accessibility (9).** Nothing exists, in either the framework or ImGui, and
+  `src/ui/` already carries JUCE accessibility labelling that would regress
+  silently. This needs a deliberate decision from Marc before G3, not after:
+  either an AT-SPI bridge fed from the ImGui widget kit, or a written,
+  documented decision to drop screen-reader support in the native UI.
+- **Headless automation (10).** The backend hard-fails without a compositor and
+  has no screenshot hook. This is workable and already solved twice over: run
+  under a private headless `mutter` as this gate did, and let the application
+  read its own frame back (the spike's `--capture` does `glReadPixels` after the
+  base `onDisplay` and before the swap). The existing Xvfb screenshot harness
+  has to move to that model with the tower.
+
+## 4. Defects the spike found
+
+### 4.1 Window focus never reaches the ImGui layer
+
+`DGL::Widget` has no focus callback and the widgets library's `DearImGui.cpp`
+never calls `io.AddFocusEvent()`, so ImGui always believes the window is
+unfocused. Three consequences, all observed:
+
+- ImGui's modal never takes navigation focus, so its input blocking does not
+  engage. The spike's modal dims the console correctly and still lets a drag
+  reach a knob behind it. The `EmbeddedModal` seam depends on that blocking.
+- `Escape` does not close a popup, because that routing runs through navigation.
+- Key state is never cleared on focus loss, so a modifier held while switching
+  windows stays down.
+
+Fix in the framework, not the app: surface pugl's `PUGL_FOCUS_IN`/`OUT` as a DGL
+widget callback and have the ImGui bridge forward it. Owner: G1.
+
+### 4.2 `WantCaptureKeyboard` is not a usable gate
+
+`DearImGui.cpp` unconditionally sets `ImGuiConfigFlags_NavEnableKeyboard`, which
+pins `io.WantCaptureKeyboard` true once navigation is active. Combined with
+§4.1 it says nothing about whether the application may take a key. A DAW's
+global shortcut layer needs its own routing rule — the spike uses "no text field
+open and no item active" — and the tower should settle that rule once, in the
+widget kit, rather than per view.
+
+### 4.3 The font atlas is a fixed glyph set
+
+ImGui bakes glyphs at atlas build time. The default range is Latin, which
+silently dropped the fader's infinity mark; the JUCE UI gets it free from the
+system font. Every non-Latin mark the UI uses has to be declared. Track name
+entry is worse: a user typing in any non-Latin script gets nothing. Decide in
+G1 whether to bake a wide range, or to load glyphs on demand.
+
+### 4.4 `ImGuiWidget<StandaloneWindow>` does not call `done()`
+
+`StandaloneWindow` documents that `done()` must be called at the end of the
+constructor to release the scoped graphics context. The widgets library's
+standalone specialisation does not, so the final subclass has to. Either fix it
+upstream or write it down; the spike calls `done()` itself.
+
+## 5. Phases
+
+`src/ui/` is **119 files carrying 7,675 of the tree's 9,055 JUCE uses** (85%),
+across roughly 54,000 lines of `.cpp`. It cannot land in one PR. The
+incremental vehicle is the pattern the notepad already ships: a framework child
+window embedded over the JUCE main window through the native parent handle and
+`Window::setEmbeddedOffset`, with the JUCE side reduced to a placeholder. That
+is why `setEmbeddedOffset` must survive the reconciliation.
+
+Each phase ends with the app shipping.
+
+### G0 — Framework alignment
+
+No user-visible change. Land §1: reconcile the framework revision, move
+`DPF_REV` and `DPF_WIDGETS_REV`, pass `-DDGL_BACKEND=wayland` on Linux app and
+CI configures, drop the dual-spelling handling.
+
+Owns: `CMakeLists.txt`, `.github/actions/clone-dpf-stack/action.yml`, the
+Linux workflows, `src/ui/NativeNotepadWindow.cpp`.
+Gate movement: none. Verify: full build, ctest, notepad opens under Xvfb and
+under headless `mutter`.
+
+### G1 — Widget kit and theme
+
+No user-visible change. Promote the spike's drawing layer into a real module the
+app and the first-party plugin UIs share: theme tokens from
+`DuskStudioLookAndFeel`, the SSL knob, the fader, the segmented meter, the GR
+strip, the module pill, buttons, the value bubble and the text field. Settle the
+shortcut routing rule (§4.2), the glyph strategy (§4.3), and the draw-list
+caching from §2.2 here, before anything depends on them. Fix §4.1 and §4.4 in
+the framework.
+
+New files, all JUCE-free: `src/ui/imgui/DuskTheme.h`, `DuskWidgets.{h,cpp}`,
+`DuskImGuiHost.{h,cpp}` (the embedded-window lifecycle lifted out of
+`NativeNotepadWindow`). Reconcile with the plug-ins repo's
+`shared-dpf/ui/DuskImGuiWidgets.hpp` rather than forking a second knob.
+Gate movement: none. Verify: golden-image tests against captured frames, plus
+`NativeNotepadWindow` rebased onto `DuskImGuiHost` as the first consumer.
+
+### G2 — Dialogs and panels
+
+First shipping phase. Move the self-contained modal family, one file per commit,
+each becoming an embedded framework window: `AudioSettingsPanel`,
+`StartupDialog`, `ChannelCompEditor`, `MasteringEqEditor`,
+`MasteringLimiterEditor`, `VirtualKeyboardComponent`. Re-point the
+`EmbeddedModal`, `DuskComboBox` and `showContextMenu` seams at ImGui
+implementations. Needs portal parenting (§3, row 5) for the first file dialog.
+
+Owns: roughly 12 files, ~6,000 lines. Gate: those files leave the allowlist.
+Verify: each panel captured headlessly and diffed against its JUCE screenshot;
+ctest; live-Wayland pass per panel.
+
+### G3 — The console
+
+The largest and riskiest phase, and the one the spike measured.
+`ChannelStripComponent` (6,340 lines), `MasterStripComponent`, `BusComponent`,
+`AuxLaneComponent`, `ConsoleView`, `AnalogVuMeter`, `CompMeterStrip`,
+`SplitModuleButton` become one embedded framework window covering the console
+area. Do not start it until §2.2's caching work is landed and measured at 24
+strips.
+
+Owns: roughly 15 files, ~16,000 lines. Verify: 24-strip CPU under the budget
+agreed in G1; golden images per strip variant including the compact and 8-up
+density tiers; the automation, take and metering paths exercised live.
+
+### G4 — The arrangement
+
+`TapeStrip`, `AudioRegionEditor`, `PianoRollComponent`, `TransportBar`,
+`MasteringView` and their helpers. Mechanically similar to G3 but with real
+scrolling, selection and drag semantics, so drag and drop (§3, row 2) is decided
+here.
+
+Owns: roughly 20 files, ~15,000 lines.
+
+### G5 — The shell flip
+
+`MainComponent` stops being a `juce::Component` and the top-level window becomes
+a framework window. Client-side decorations (§3, row 13) land here, because this is
+the first Dusk-owned top-level. Third-party plugin editors move to their own
+XWayland child windows, which is already the design. `juce_gui_extra`,
+`juce_gui_basics` and `juce_graphics` unlink.
+
+Owns: `MainComponent.{h,cpp}` (6,000 lines), `DuskStudioApp.{h,cpp}`,
+`ScreenshotCapture`, the screenshot harness.
+
+### G6 — Residue
+
+What is left once no UI is JUCE: `MessageThread.cpp` rewritten on the pugl
+world's timers and event loop, `juce_data_structures`, `AudioThumbnail` off
+`juce_audio_utils`, and the last `juce::String`/`File`/`Colour` holdouts in
+`src/session` and `src/engine` that were anchored by UI types.
+
+Module unlink order, each step its own commit so a bisect lands on one module:
+
+```
+juce_gui_extra -> juce_gui_basics -> juce_graphics
+  -> juce_audio_utils -> juce_audio_formats
+  -> juce_data_structures -> juce_events -> juce_core
+```
+
+`juce_core` last, as the campaign requires.
+
+## 6. Verification and bench debts
+
+Per phase, non-negotiable:
+
+- Full app build, zero new warnings; `dusk-studio-tests` green.
+- `tools/juce-gate.sh` passes, and every file the phase claims is gone from
+  `tools/juce-allowlist.txt`. Files leave and never rejoin.
+- Golden-image capture under headless `mutter`, diffed against the JUCE render of
+  the same view. The spike's `--capture` shows the mechanism; G1 should
+  generalise it.
+- A live-Wayland pass on Marc's desktop for every view the phase touches. The
+  standing rule that the app binary only runs under Xvfb applies to the JUCE
+  build; a framework-native build has to be run on a real compositor, and the
+  private headless `mutter` recipe in `tools/gui-spike/` is the safe way to do
+  that from an agent session.
+
+Owed to Marc's bench, and not inferable from this gate:
+
+- **Live-desktop frame pacing.** Every number in §2 is headless. Compositing,
+  vsync to a real output, fractional scaling and a loaded desktop are not
+  represented.
+- **Real input.** The headless compositor has no seat, so pointer, keyboard,
+  scroll, text and cursor behaviour reached the application zero times. Drag
+  feel, wheel resolution, double-click timing and modifier handling are all
+  unverified through the real path.
+- **HiDPI from the compositor.** The scale test drove an application-level
+  factor. `wp_fractional_scale_v1` negotiation with a real output is untested.
+- **Decoration behaviour on GNOME.** Row 13 above is read from the source; confirm on
+  the desktop before committing to CSD.
+- **Second GPU / Intel path.** All numbers are from the discrete Vega M.
+- **The accessibility decision** (§3, row 9), which is Marc's call and gates G3.
+
+## 7. Naming
+
+Marc renamed the fork stack to **DAF, the Dusk Audio Framework**, on
+2026-08-24. It is a naming decision only. The GitHub repositories, the CMake
+variables (`DPF_PATH`, `DPF_WIDGETS_PATH`, `DPF_REV`), the CI action directory
+and the app's own identifiers still say DPF, and this plan deliberately leaves
+them alone: renaming them is a mechanical pass that should happen on its own,
+not smuggled into a tower. Prose in this document and in tower PRs says DAF; code
+and paths say DPF until that pass lands.
+
+## 8. Resume phrase
+
+"GUI tower, phase G<n>" — read this file, then
+[dejuce-campaign.md](dejuce-campaign.md) for the ritual. The gate evidence is
+§2, the framework work is §1 and §4, and the phase you are on owns exactly the
+files listed under it.

--- a/docs/dejuce-gui-plan.md
+++ b/docs/dejuce-gui-plan.md
@@ -513,6 +513,10 @@ smuggled into a tower — do it in G0 if it is cheap, otherwise as a standalone 
   `dpf__add_dgl_opengl3` and `dpf_resources` fallbacks, retire when the pin
   lands on the reconciled revision (§1.5).
 
+Deliberately left saying DPF: the shipped changelog entries and the per-release
+handoff documents, which are records of what was true at a revision rather than
+instructions for today.
+
 ## 8. Resume phrase
 
 "GUI tower, phase G<n>" — read this file, then

--- a/src/ui/NativeNotepadWindow.cpp
+++ b/src/ui/NativeNotepadWindow.cpp
@@ -27,6 +27,12 @@
 # include "src/Resources.hpp"
 #endif
 
+// The framework fork renamed this namespace along with the rest of its public surface; the
+// configure reads the spelling out of the checkout so both sides of that rename compile.
+#ifndef DUSKSTUDIO_DGL_RESOURCES
+# define DUSKSTUDIO_DGL_RESOURCES dpf_resources
+#endif
+
 #include <algorithm>
 #include <cmath>
 #include <cstdarg>
@@ -240,8 +246,8 @@ struct NativeNotepadWindow::Impl final : private dusk::Timer
 
         io.Fonts->Clear();
         bodyFont = io.Fonts->AddFontFromMemoryTTF (
-            (void*) dpf_resources::dejavusans_ttf,
-            dpf_resources::dejavusans_ttf_size,
+            (void*) DUSKSTUDIO_DGL_RESOURCES::dejavusans_ttf,
+            DUSKSTUDIO_DGL_RESOURCES::dejavusans_ttf_size,
             size, &embeddedConfig, kDocumentGlyphRanges);
 
         boldFont = addPlatformFont (*io.Fonts, {

--- a/tools/gui-spike/ChannelStripView.cpp
+++ b/tools/gui-spike/ChannelStripView.cpp
@@ -532,7 +532,6 @@ StripFrameResult ChannelStripView::draw (ImDrawList& dl, ImVec2 origin, float wi
     ctx.activeDrag = &activeDrag;
     ctx.dragStartValue = &dragStartValue;
 
-    const int startVtx = dl.VtxBuffer.Size;
     auto s = [scale] (float v) { return v * scale; };
     char buf[32];
 
@@ -914,7 +913,6 @@ StripFrameResult ChannelStripView::draw (ImDrawList& dl, ImVec2 origin, float wi
         }
     }
 
-    lastVertexCount = dl.VtxBuffer.Size - startVtx;
     lastWidgetCount = ctx.widgets;
     return result;
 }

--- a/tools/gui-spike/ChannelStripView.cpp
+++ b/tools/gui-spike/ChannelStripView.cpp
@@ -1,0 +1,922 @@
+#include "ChannelStripView.h"
+#include "StripTheme.h"
+
+#include <DearImGui/imgui_internal.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+
+namespace duskspike
+{
+namespace
+{
+
+constexpr float kRotaryStart = -2.35619449f;
+constexpr float kRotaryEnd   =  2.35619449f;
+
+ImU32 col (std::uint32_t argb, float alpha = 1.0f)
+{
+    const int a = static_cast<int> (((argb >> 24) & 0xff) * alpha);
+    return IM_COL32 ((argb >> 16) & 0xff, (argb >> 8) & 0xff, argb & 0xff, a);
+}
+
+// JUCE's Colour::brighter / ::darker, so the knob dome and the cap satin land on the same
+// shades the LookAndFeel produces rather than something merely similar.
+std::uint32_t brighter (std::uint32_t argb, float amount)
+{
+    const float k = 1.0f / (1.0f + amount);
+    auto ch = [k] (int c) { return 255 - static_cast<int> ((255 - c) * k); };
+    return (argb & 0xff000000u)
+         | (static_cast<std::uint32_t> (ch ((argb >> 16) & 0xff)) << 16)
+         | (static_cast<std::uint32_t> (ch ((argb >> 8) & 0xff)) << 8)
+         |  static_cast<std::uint32_t> (ch (argb & 0xff));
+}
+
+std::uint32_t darker (std::uint32_t argb, float amount)
+{
+    const float k = 1.0f / (1.0f + amount);
+    auto ch = [k] (int c) { return static_cast<int> (c * k); };
+    return (argb & 0xff000000u)
+         | (static_cast<std::uint32_t> (ch ((argb >> 16) & 0xff)) << 16)
+         | (static_cast<std::uint32_t> (ch ((argb >> 8) & 0xff)) << 8)
+         |  static_cast<std::uint32_t> (ch (argb & 0xff));
+}
+
+std::uint32_t lerpArgb (std::uint32_t a, std::uint32_t b, float t)
+{
+    auto ch = [a, b, t] (int shift)
+    {
+        const float x = static_cast<float> ((a >> shift) & 0xff);
+        const float y = static_cast<float> ((b >> shift) & 0xff);
+        return static_cast<std::uint32_t> (x + (y - x) * t) & 0xffu;
+    };
+    return 0xff000000u | (ch (16) << 16) | (ch (8) << 8) | ch (0);
+}
+
+enum class Align { left, centre, right };
+
+void text (ImDrawList& dl, ImFont* font, float size, ImVec2 at, float width,
+           std::uint32_t colour, const char* str, Align align = Align::centre)
+{
+    if (font == nullptr || str == nullptr || *str == 0)
+        return;
+
+    const ImVec2 extent = font->CalcTextSizeA (size, FLT_MAX, 0.0f, str);
+    float x = at.x;
+    if (align == Align::centre) x = at.x + (width - extent.x) * 0.5f;
+    else if (align == Align::right) x = at.x + width - extent.x;
+
+    dl.AddText (font, size, ImVec2 (std::round (x), std::round (at.y)), col (colour), str);
+}
+
+void panel (ImDrawList& dl, ImVec2 tl, ImVec2 br, std::uint32_t fill,
+            std::uint32_t border, float borderAlpha, float radius, float thickness)
+{
+    dl.AddRectFilled (tl, br, col (fill), radius);
+    dl.AddRect (tl, br, col (border, borderAlpha), radius, 0, thickness);
+}
+
+// The dome from DuskStudioLookAndFeel::drawSslKnob. ImDrawList has no radial gradient, so
+// the body is a stack of concentric circles marching toward the highlight point; twelve
+// steps is where the banding stops being visible at these radii.
+void drawSslKnob (ImDrawList& dl, ImVec2 centre, float radius, float norm,
+                  std::uint32_t fill)
+{
+    const float r = radius - 2.0f;
+    if (r <= 1.0f)
+        return;
+
+    const float bodyR = r * 0.94f;
+    const float angle = kRotaryStart + norm * (kRotaryEnd - kRotaryStart);
+
+    for (int i = 0; i < 11; ++i)
+    {
+        const float t = kRotaryStart + (kRotaryEnd - kRotaryStart) * (i / 10.0f);
+        const float dotR = r * 0.965f;
+        const ImVec2 p (centre.x + std::sin (t) * dotR, centre.y - std::cos (t) * dotR);
+        dl.AddCircleFilled (p, std::max (0.9f, r * 0.06f), col (theme::kKnobDot), 8);
+    }
+
+    dl.AddCircleFilled (ImVec2 (centre.x, centre.y + bodyR * 0.25f), bodyR + 3.0f,
+                        IM_COL32 (0, 0, 0, 40), 24);
+
+    const std::uint32_t hi = brighter (fill, 0.20f);
+    const std::uint32_t lo = darker (fill, 0.40f);
+    const ImVec2 hiCentre (centre.x - bodyR * 0.45f, centre.y - bodyR * 0.50f);
+
+    constexpr int kSteps = 12;
+    for (int i = 0; i < kSteps; ++i)
+    {
+        const float t = i / static_cast<float> (kSteps - 1);
+        const float ringR = bodyR * (1.0f - t * 0.92f);
+        const ImVec2 c (centre.x + (hiCentre.x - centre.x) * t,
+                        centre.y + (hiCentre.y - centre.y) * t);
+        dl.AddCircleFilled (c, ringR, col (lerpArgb (lo, hi, t)), 32);
+    }
+
+    dl.AddEllipseFilled (ImVec2 (centre.x, centre.y - bodyR * 0.60f),
+                         ImVec2 (bodyR * 0.70f, bodyR * 0.27f),
+                         IM_COL32 (255, 255, 255, 0x24), 0.0f, 20);
+
+    dl.AddCircle (centre, bodyR, col (theme::kKnobRim), 32, 1.0f);
+
+    const ImVec2 dir (std::sin (angle), -std::cos (angle));
+    dl.AddLine (ImVec2 (centre.x + dir.x * bodyR * 0.82f, centre.y + dir.y * bodyR * 0.82f),
+                ImVec2 (centre.x + dir.x * bodyR, centre.y + dir.y * bodyR),
+                IM_COL32 (0x0c, 0x0c, 0x0e, 255), std::max (2.4f, r * 0.13f));
+    dl.AddLine (ImVec2 (centre.x + dir.x * bodyR * 0.16f, centre.y + dir.y * bodyR * 0.16f),
+                ImVec2 (centre.x + dir.x * bodyR * 0.76f, centre.y + dir.y * bodyR * 0.76f),
+                IM_COL32 (255, 255, 255, 255), std::max (2.0f, r * 0.10f));
+}
+
+void formatFreq (char* out, std::size_t n, float hz)
+{
+    if (hz >= 1000.0f)
+    {
+        const float k = hz / 1000.0f;
+        if (k >= 10.0f) std::snprintf (out, n, "%.0fk", k);
+        else            std::snprintf (out, n, "%.1fk", k);
+    }
+    else
+    {
+        std::snprintf (out, n, "%.0f", hz);
+    }
+}
+
+void formatGain (char* out, std::size_t n, float db)
+{
+    if (std::fabs (db - std::round (db)) < 0.05f) std::snprintf (out, n, "%+.0f", db);
+    else                                          std::snprintf (out, n, "%+.1f", db);
+}
+
+} // namespace
+
+// --------------------------------------------------------------------------------------
+
+namespace
+{
+
+struct Ctx
+{
+    ImDrawList* dl = nullptr;
+    float scale = 1.0f;
+    const StripFonts* fonts = nullptr;
+    std::string* activeDrag = nullptr;
+    float* dragStartValue = nullptr;
+    int widgets = 0;
+
+    float s (float v) const noexcept { return v * scale; }
+};
+
+bool hitArea (const char* id, ImVec2 tl, ImVec2 br)
+{
+    ImGui::SetCursorScreenPos (tl);
+    ImGui::InvisibleButton (id, ImVec2 (std::max (1.0f, br.x - tl.x),
+                                        std::max (1.0f, br.y - tl.y)));
+    return ImGui::IsItemHovered();
+}
+
+// One knob: hit area, vertical drag with a shift-fine modifier, wheel, double-click reset,
+// the dome, its caption and its value readout. Returns true while it owns the mouse.
+bool knob (Ctx& ctx, const char* id, ImVec2 centre, float radius,
+           std::atomic<float>& value, const Range& range, float defaultValue,
+           std::uint32_t fill, const char* caption, const char* valueText,
+           std::uint32_t outline = theme::kKnobOutline)
+{
+    ++ctx.widgets;
+
+    const ImVec2 tl (centre.x - radius, centre.y - radius);
+    const ImVec2 br (centre.x + radius, centre.y + radius);
+    hitArea (id, tl, br);
+
+    float v = value.load (std::memory_order_relaxed);
+    bool owned = false;
+
+    if (ImGui::IsItemActive() && ImGui::IsMouseDragging (ImGuiMouseButton_Left, 0.0f))
+    {
+        if (*ctx.activeDrag != id)
+        {
+            *ctx.activeDrag = id;
+            *ctx.dragStartValue = v;
+        }
+
+        const float travel = ctx.s (140.0f);
+        const float fine = ImGui::GetIO().KeyShift ? 0.25f : 1.0f;
+        const float dy = ImGui::GetMouseDragDelta (ImGuiMouseButton_Left, 0.0f).y;
+        const float n = range.toNorm (*ctx.dragStartValue) - (dy / travel) * fine;
+        v = range.fromNorm (n);
+        value.store (v, std::memory_order_relaxed);
+        owned = true;
+    }
+    else if (*ctx.activeDrag == id && ! ImGui::IsItemActive())
+    {
+        ctx.activeDrag->clear();
+    }
+
+    if (ImGui::IsItemHovered() && ImGui::GetIO().MouseWheel != 0.0f)
+    {
+        const float n = range.toNorm (v) + ImGui::GetIO().MouseWheel * 0.02f;
+        value.store (range.fromNorm (n), std::memory_order_relaxed);
+    }
+
+    if (ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked (ImGuiMouseButton_Left))
+        value.store (defaultValue, std::memory_order_relaxed);
+
+    drawSslKnob (*ctx.dl, centre, radius, range.toNorm (value.load (std::memory_order_relaxed)), fill);
+
+    if (outline != theme::kKnobOutline)
+        ctx.dl->AddCircle (centre, radius - 1.0f, col (outline), 32, ctx.s (1.4f));
+
+    if (caption != nullptr)
+        text (*ctx.dl, ctx.fonts->label, ctx.s (9.0f),
+              ImVec2 (centre.x - ctx.s (24.0f), centre.y - radius - ctx.s (11.0f)),
+              ctx.s (48.0f), theme::kTextDim, caption);
+
+    if (valueText != nullptr)
+        text (*ctx.dl, ctx.fonts->label, ctx.s (10.5f),
+              ImVec2 (centre.x - ctx.s (28.0f), centre.y + radius + ctx.s (1.0f)),
+              ctx.s (56.0f), theme::kTextValue, valueText);
+
+    return owned;
+}
+
+bool textButton (Ctx& ctx, const char* id, ImVec2 tl, ImVec2 br, const char* label,
+                 bool on, std::uint32_t offFill, std::uint32_t onFill,
+                 std::uint32_t offText, std::uint32_t onText, float fontSize)
+{
+    ++ctx.widgets;
+    const bool hovered = hitArea (id, tl, br);
+    const bool clicked = ImGui::IsItemHovered() && ImGui::IsMouseReleased (ImGuiMouseButton_Left);
+
+    ctx.dl->AddRectFilled (tl, br, col (on ? onFill : offFill), ctx.s (2.0f));
+    if (hovered)
+        ctx.dl->AddRectFilled (tl, br, IM_COL32 (255, 255, 255, ImGui::IsItemActive() ? 30 : 16),
+                               ctx.s (2.0f));
+    ctx.dl->AddRect (tl, br, col (theme::kKnobOutline, 0.55f), ctx.s (2.0f), 0, ctx.s (0.8f));
+
+    const float h = br.y - tl.y;
+    text (*ctx.dl, ctx.fonts->pill, ctx.s (fontSize),
+          ImVec2 (tl.x, tl.y + (h - ctx.s (fontSize)) * 0.5f - ctx.s (1.0f)),
+          br.x - tl.x, on ? onText : offText, label);
+
+    return clicked;
+}
+
+// The EQ / COMP / AUX header pill: an LED hitbox on the left fifth toggles the section,
+// the label hitbox opens its menu. Only the toggle half is wired in the spike.
+bool splitModuleButton (Ctx& ctx, const char* id, ImVec2 tl, ImVec2 br,
+                        const char* label, std::atomic<bool>& engaged,
+                        std::uint32_t accent)
+{
+    ++ctx.widgets;
+    const bool on = engaged.load (std::memory_order_relaxed);
+    const float w = br.x - tl.x;
+    const float h = br.y - tl.y;
+
+    const bool hovered = hitArea (id, tl, br);
+    bool toggled = false;
+    if (hovered && ImGui::IsMouseReleased (ImGuiMouseButton_Left))
+    {
+        engaged.store (! on, std::memory_order_relaxed);
+        toggled = true;
+    }
+
+    ctx.dl->AddRectFilled (tl, br, col (theme::kShellFill, 0.92f), ctx.s (4.0f));
+    ctx.dl->AddRect (tl, br, col (theme::kShellBorder), ctx.s (4.0f), 0, ctx.s (0.9f));
+    if (hovered)
+        ctx.dl->AddRectFilled (tl, br, IM_COL32 (255, 255, 255, ImGui::IsItemActive() ? 46 : 23),
+                               ctx.s (4.0f));
+
+    const float dividerX = tl.x + w * 0.20f;
+    ctx.dl->AddLine (ImVec2 (dividerX, tl.y + ctx.s (2.0f)), ImVec2 (dividerX, br.y - ctx.s (2.0f)),
+                     col (theme::kShellDivider, 0.55f), ctx.s (1.0f));
+
+    const float ledR = std::min (std::max (std::min (w - ctx.s (8.0f), h - ctx.s (6.0f)),
+                                           ctx.s (5.0f)), ctx.s (9.0f)) * 0.5f;
+    const ImVec2 ledC (tl.x + w * 0.10f, tl.y + h * 0.5f);
+    ctx.dl->AddCircleFilled (ledC, ledR + ctx.s (1.0f), col (theme::kLedRingDark), 16);
+    ctx.dl->AddCircleFilled (ledC, ledR, col (on ? accent : theme::kLedOffFill), 16);
+    if (on)
+        ctx.dl->AddCircleFilled (ImVec2 (ledC.x, ledC.y - ledR * 0.3f), ledR * 0.45f,
+                                 col (brighter (accent, 0.8f), 0.55f), 12);
+
+    text (*ctx.dl, ctx.fonts->pill, ctx.s (10.5f),
+          ImVec2 (dividerX, tl.y + (h - ctx.s (10.5f)) * 0.5f - ctx.s (1.0f)),
+          br.x - dividerX, on ? theme::kTextBright : theme::kLabelBypassed, label);
+
+    return toggled;
+}
+
+std::uint32_t meterColourForDb (float db)
+{
+    if (db >= 5.0f)  return theme::kLedRed;
+    if (db >= -5.0f) return theme::kLedYellow;
+    return theme::kLedGreen;
+}
+
+// Segmented LED bar with hard zone boundaries at -5 and +5 dB, mapped through the fader's
+// skewed range so 0 dB lines up with the fader's 0 tick.
+void drawMeter (Ctx& ctx, ImVec2 tl, ImVec2 br, float displayedDb, float peakDb)
+{
+    const auto& range = StripParams::faderRange();
+    const float h = br.y - tl.y;
+
+    auto yForDb = [&] (float db)
+    {
+        return br.y - h * range.toNorm (std::clamp (db, -90.0f, 6.0f));
+    };
+
+    ctx.dl->AddRectFilled (tl, br, col (theme::kMeterBack), ctx.s (1.5f));
+
+    const float fillTop = yForDb (displayedDb);
+    if (fillTop < br.y - 0.5f)
+    {
+        const std::uint32_t tip = meterColourForDb (displayedDb);
+        ctx.dl->AddRectFilled (ImVec2 (tl.x - ctx.s (1.5f), fillTop - ctx.s (1.5f)),
+                               ImVec2 (br.x + ctx.s (1.5f), br.y + ctx.s (1.5f)),
+                               col (tip, 0.20f), ctx.s (2.0f));
+
+        const float yellowTop = yForDb (5.0f);
+        const float greenTop  = yForDb (-5.0f);
+
+        auto band = [&] (float top, float bottom, std::uint32_t c)
+        {
+            const float a = std::max (top, fillTop);
+            if (a < bottom - 0.25f)
+                ctx.dl->AddRectFilled (ImVec2 (tl.x, a), ImVec2 (br.x, bottom), col (c));
+        };
+
+        band (tl.y, yellowTop, theme::kLedRed);
+        band (yellowTop, greenTop, theme::kLedYellow);
+        band (greenTop, br.y, theme::kLedGreen);
+    }
+
+    if (peakDb > -99.0f)
+    {
+        const float py = yForDb (peakDb);
+        ctx.dl->AddRectFilled (ImVec2 (tl.x, py - ctx.s (0.7f)),
+                               ImVec2 (br.x, py + ctx.s (0.7f)),
+                               col (peakDb >= 5.0f ? theme::kPeakTickHot : theme::kPeakTick));
+    }
+
+    const int segments = std::clamp (static_cast<int> (h / ctx.s (3.5f)), 8, 30);
+    for (int i = 1; i < segments; ++i)
+    {
+        const float y = tl.y + h * (i / static_cast<float> (segments));
+        ctx.dl->AddRectFilled (ImVec2 (tl.x + ctx.s (1.0f), y),
+                               ImVec2 (br.x - ctx.s (1.0f), y + ctx.s (0.8f)),
+                               col (theme::kMeterSegment));
+    }
+
+    ctx.dl->AddRect (tl, br, col (theme::kMeterBorder), ctx.s (1.5f), 0, ctx.s (0.5f));
+}
+
+// The slim GR column beside the fader: 24 one-dB segments filling downward, plus the
+// draggable threshold triangle that stands in for the missing threshold knob.
+void drawGrStrip (Ctx& ctx, ImVec2 tl, ImVec2 br, float grDb,
+                  std::atomic<float>& thresholdDb, const char* id)
+{
+    ++ctx.widgets;
+    constexpr float kFloor = -24.0f;
+    const float h = br.y - tl.y;
+    const float barR = br.x - ctx.s (8.0f);
+
+    ctx.dl->AddRectFilled (tl, ImVec2 (barR, br.y), col (theme::kGrBack), ctx.s (2.0f));
+
+    const float frac = std::clamp (-grDb / -kFloor, 0.0f, 1.0f);
+    if (frac > 0.001f)
+    {
+        const float bottom = tl.y + h * frac;
+        for (int i = 0; i < 24; ++i)
+        {
+            const float a = tl.y + h * (i / 24.0f);
+            const float b = tl.y + h * ((i + 1) / 24.0f) - ctx.s (0.6f);
+            if (a >= bottom)
+                break;
+            ctx.dl->AddRectFilled (ImVec2 (tl.x + ctx.s (1.0f), a),
+                                   ImVec2 (barR - ctx.s (1.0f), std::min (b, bottom)),
+                                   col (lerpArgb (brighter (theme::kCompGold, 0.25f),
+                                                  brighter (theme::kHfRed, 0.10f), i / 23.0f)));
+        }
+    }
+
+    ctx.dl->AddRect (tl, ImVec2 (barR, br.y), col (theme::kMeterBorder), ctx.s (2.0f), 0, ctx.s (0.5f));
+
+    const auto& range = StripParams::faderRange();
+    const float thr = thresholdDb.load (std::memory_order_relaxed);
+    const float ty = br.y - h * range.toNorm (std::clamp (thr, -90.0f, 6.0f));
+
+    hitArea (id, ImVec2 (barR, ty - ctx.s (7.0f)), ImVec2 (br.x, ty + ctx.s (7.0f)));
+    if (ImGui::IsItemActive() && ImGui::IsMouseDragging (ImGuiMouseButton_Left, 0.0f))
+    {
+        const float n = std::clamp ((br.y - ImGui::GetIO().MousePos.y) / h, 0.0f, 1.0f);
+        thresholdDb.store (std::clamp (range.fromNorm (n), -60.0f, 0.0f), std::memory_order_relaxed);
+    }
+
+    const float tw = ctx.s (10.0f);
+    ctx.dl->AddTriangleFilled (ImVec2 (br.x, ty - tw * 0.6f), ImVec2 (br.x, ty + tw * 0.6f),
+                               ImVec2 (barR + ctx.s (1.0f), ty),
+                               col (ImGui::IsItemHovered() ? brighter (theme::kCompGold, 0.4f)
+                                                           : theme::kCompGold));
+}
+
+// The vertical fader: track, asymmetric ticks, the brushed cap, and the dB scale the strip
+// paints in the left gutter.
+void drawFader (Ctx& ctx, ImVec2 tl, ImVec2 br, float labelLeft,
+                std::atomic<float>& faderDb, const char* id)
+{
+    ++ctx.widgets;
+    const auto& range = StripParams::faderRange();
+    const float pad = ctx.s (layout::kFaderTrackPad);
+    const float trackTop = tl.y + pad;
+    const float trackBottom = br.y - pad;
+    const float trackH = trackBottom - trackTop;
+    const float cx = (tl.x + br.x) * 0.5f;
+
+    hitArea (id, tl, br);
+    if (ImGui::IsItemActive() && ImGui::IsMouseDown (ImGuiMouseButton_Left))
+    {
+        const float n = std::clamp ((trackBottom - ImGui::GetIO().MousePos.y) / trackH, 0.0f, 1.0f);
+        faderDb.store (range.fromNorm (n), std::memory_order_relaxed);
+    }
+    if (ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked (ImGuiMouseButton_Left))
+        faderDb.store (0.0f, std::memory_order_relaxed);
+
+    const float db = faderDb.load (std::memory_order_relaxed);
+    const float pos = trackBottom - trackH * range.toNorm (db);
+
+    const float trackW = std::min (ctx.s (4.0f), (br.x - tl.x) * 0.18f);
+    ctx.dl->AddRectFilled (ImVec2 (cx - trackW * 0.5f, trackTop),
+                           ImVec2 (cx + trackW * 0.5f, trackBottom),
+                           col (theme::kTrackFill), trackW * 0.5f);
+    ctx.dl->AddRectFilledMultiColor (ImVec2 (cx - trackW * 0.5f, trackTop),
+                                     ImVec2 (cx + trackW * 0.5f, trackTop + ctx.s (6.0f)),
+                                     IM_COL32 (0, 0, 0, 128), IM_COL32 (0, 0, 0, 128),
+                                     IM_COL32 (0, 0, 0, 0), IM_COL32 (0, 0, 0, 0));
+    ctx.dl->AddRect (ImVec2 (cx - trackW * 0.5f, trackTop),
+                     ImVec2 (cx + trackW * 0.5f, trackBottom),
+                     col (theme::kStripBorder), trackW * 0.5f, 0, ctx.s (0.6f));
+
+    for (const auto& tick : kFaderTicks)
+    {
+        const float y = trackBottom - trackH * range.toNorm (tick.db);
+        const bool isZero = tick.db == 0.0f;
+        const float leftOver = isZero ? ctx.s (4.0f) : ctx.s (3.0f);
+        const float rightOver = isZero ? ctx.s (16.0f) : ctx.s (12.0f);
+
+        ctx.dl->AddLine (ImVec2 (cx - trackW * 0.5f - leftOver, y),
+                         ImVec2 (cx + trackW * 0.5f + rightOver, y),
+                         IM_COL32 (255, 255, 255, isZero ? 0x90 : 0x40),
+                         isZero ? ctx.s (1.2f) : ctx.s (0.7f));
+
+        const bool isInf = tick.db <= -90.0f;
+        const float size = ctx.s (isInf ? 16.0f : 10.5f);
+        text (*ctx.dl, ctx.fonts->band, size,
+              ImVec2 (labelLeft, y - size * (isInf ? 0.75f : 0.55f)),
+              cx - ctx.s (layout::kFaderCapW) * 0.5f - labelLeft - ctx.s (3.0f),
+              isZero ? theme::kTextBright : 0xffb8b8c0, tick.label, Align::right);
+    }
+
+    const float capW = std::min (br.x - tl.x - ctx.s (6.0f), ctx.s (layout::kFaderCapW));
+    const float capH = ctx.s (layout::kFaderCapH);
+    const ImVec2 capTL (cx - capW * 0.5f, pos - capH * 0.5f);
+    const ImVec2 capBR (cx + capW * 0.5f, pos + capH * 0.5f);
+
+    ctx.dl->AddRectFilled (ImVec2 (capTL.x - ctx.s (2.0f), capTL.y + ctx.s (2.0f)),
+                           ImVec2 (capBR.x + ctx.s (2.0f), capBR.y + ctx.s (4.0f)),
+                           IM_COL32 (0, 0, 0, 140), ctx.s (4.0f));
+
+    const float bands[] = { 0.0f, 0.30f, 0.50f, 0.70f, 1.0f };
+    const std::uint32_t stops[] = { theme::kCapTop, 0xffcfc8b8, theme::kCapMid, 0xffcfc8b8, theme::kCapBottom };
+    for (int i = 0; i < 4; ++i)
+    {
+        ctx.dl->AddRectFilledMultiColor (ImVec2 (capTL.x, capTL.y + capH * bands[i]),
+                                         ImVec2 (capBR.x, capTL.y + capH * bands[i + 1]),
+                                         col (stops[i]), col (stops[i]),
+                                         col (stops[i + 1]), col (stops[i + 1]));
+    }
+
+    ctx.dl->AddLine (ImVec2 (capTL.x, capTL.y + ctx.s (1.0f)), ImVec2 (capBR.x, capTL.y + ctx.s (1.0f)),
+                     IM_COL32 (255, 255, 255, 0x70), ctx.s (1.0f));
+    ctx.dl->AddLine (ImVec2 (capTL.x, capBR.y - ctx.s (2.0f)), ImVec2 (capBR.x, capBR.y - ctx.s (2.0f)),
+                     IM_COL32 (0, 0, 0, 0x40), ctx.s (1.0f));
+    ctx.dl->AddRect (capTL, capBR, col (theme::kCapRim), ctx.s (2.5f), 0, ctx.s (1.0f));
+
+    for (int i = -1; i <= 1; ++i)
+    {
+        const float gy = pos + ctx.s (4.0f) * static_cast<float> (i);
+        ctx.dl->AddRectFilled (ImVec2 (capTL.x + ctx.s (3.0f), gy),
+                               ImVec2 (capBR.x - ctx.s (3.0f), gy + ctx.s (1.6f)),
+                               col (theme::kCapGroove));
+        ctx.dl->AddLine (ImVec2 (capTL.x + ctx.s (3.0f), gy + ctx.s (2.4f)),
+                         ImVec2 (capBR.x - ctx.s (3.0f), gy + ctx.s (2.4f)),
+                         IM_COL32 (255, 255, 255, 0x35), ctx.s (0.9f));
+    }
+}
+
+} // namespace
+
+// --------------------------------------------------------------------------------------
+
+StripFrameResult ChannelStripView::draw (ImDrawList& dl, ImVec2 origin, float width,
+                                         float height, float scale, StripParams& params,
+                                         const StripFonts& fonts)
+{
+    StripFrameResult result;
+
+    Ctx ctx;
+    ctx.dl = &dl;
+    ctx.scale = scale;
+    ctx.fonts = &fonts;
+    ctx.activeDrag = &activeDrag;
+    ctx.dragStartValue = &dragStartValue;
+
+    const int startVtx = dl.VtxBuffer.Size;
+    auto s = [scale] (float v) { return v * scale; };
+    char buf[32];
+
+    panel (dl, origin, ImVec2 (origin.x + width, origin.y + height),
+           theme::kStripFill, theme::kStripBorder, 1.0f, s (4.0f), s (1.0f));
+
+    dl.AddRectFilled (ImVec2 (origin.x + s (1.5f), origin.y + s (1.5f)),
+                      ImVec2 (origin.x + width - s (1.5f), origin.y + s (5.5f)),
+                      col (theme::kTrackColour, 0.85f), s (2.0f));
+
+    const float left = origin.x + s (layout::kOuterInset);
+    const float right = origin.x + width - s (layout::kOuterInset);
+    const float innerW = right - left;
+    float y = origin.y + s (layout::kOuterInset) + s (layout::kTopPad);
+
+    // Name: double-click swaps the label for a text field, the one place the strip needs
+    // real keyboard text entry.
+    {
+        const ImVec2 tl (left, y), br (right, y + s (layout::kNameH));
+        if (editingName)
+        {
+            ImGui::SetCursorScreenPos (ImVec2 (tl.x, tl.y));
+            ImGui::PushItemWidth (br.x - tl.x);
+            ImGui::PushStyleColor (ImGuiCol_FrameBg, ImGui::ColorConvertU32ToFloat4 (col (theme::kButtonOff)));
+            if (ImGui::InputText ("##name", nameBuffer, sizeof nameBuffer,
+                                  ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_AutoSelectAll))
+            {
+                params.name = nameBuffer;
+                editingName = false;
+            }
+            if (ImGui::IsItemDeactivated())
+            {
+                params.name = nameBuffer;
+                editingName = false;
+            }
+            ImGui::SetKeyboardFocusHere (-1);
+            ImGui::PopStyleColor();
+            ImGui::PopItemWidth();
+        }
+        else
+        {
+            hitArea ("##nameLabel", tl, br);
+            if (ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked (ImGuiMouseButton_Left))
+            {
+                std::snprintf (nameBuffer, sizeof nameBuffer, "%s", params.name.c_str());
+                editingName = true;
+            }
+            text (dl, fonts.name, s (13.0f), ImVec2 (tl.x, tl.y + s (3.0f)), innerW,
+                  theme::kTextBright, params.name.c_str());
+        }
+        y = br.y + s (2.0f);
+    }
+
+    if (textButton (ctx, "##io", ImVec2 (left, y), ImVec2 (right, y + s (layout::kIoButtonH)),
+                    "MONO  IN 1", false, theme::kButtonPanel, theme::kButtonPanel,
+                    theme::kIoText, theme::kIoText, 10.0f))
+        result.openIoModal = true;
+    y += s (layout::kIoButtonH) + s (3.0f);
+
+    {
+        const float w3 = innerW / 3.0f;
+        const float h = s (layout::kRowH);
+        struct { const char* id; const char* label; std::atomic<bool>* flag;
+                 std::uint32_t on; std::uint32_t offText; std::uint32_t onText; } row[] = {
+            { "##in",    "IN",    &params.inputMonitor, theme::kPanCyan, 0xff708090, theme::kOnText },
+            { "##arm",   "ARM",   &params.recordArmed,  theme::kArmOn,   theme::kArmOffText, theme::kTextBright },
+            { "##print", "PRINT", &params.printEffects, theme::kPrintOn, 0xff8a7060, theme::kOnText },
+        };
+        for (int i = 0; i < 3; ++i)
+        {
+            const ImVec2 tl (left + w3 * i + s (1.0f), y + s (1.0f));
+            const ImVec2 br (left + w3 * (i + 1) - s (1.0f), y + h - s (1.0f));
+            const bool on = row[i].flag->load (std::memory_order_relaxed);
+            if (textButton (ctx, row[i].id, tl, br, row[i].label, on, theme::kButtonOff,
+                            row[i].on, row[i].offText, row[i].onText, 9.5f))
+                row[i].flag->store (! on, std::memory_order_relaxed);
+        }
+        y += h;
+    }
+
+    {
+        const ImVec2 tl (left + s (3.0f), y), br (right - s (3.0f), y + s (layout::kRowH));
+        textButton (ctx, "##insert", tl, br, "Baroness", false, theme::kButtonPanel,
+                    theme::kButtonPanel, theme::kInsertText, theme::kInsertText, 10.0f);
+        if (ImGui::IsItemHovered() && ImGui::IsMouseReleased (ImGuiMouseButton_Right))
+        {
+            result.openInsertMenu = true;
+            result.insertMenuAt = ImGui::GetIO().MousePos;
+        }
+        dl.AddCircleFilled (ImVec2 (tl.x + s (8.0f), (tl.y + br.y) * 0.5f), s (4.0f),
+                            col (0xff60d060), 16);
+        y = br.y + s (2.0f);
+    }
+
+    // EQ
+    {
+        const float h = s (layout::kEqPanelH);
+        panel (dl, ImVec2 (left, y), ImVec2 (right, y + h), theme::kEqFill,
+               theme::kEqAccent, 0.40f, s (3.0f), s (0.8f));
+
+        const float px = left + s (3.0f);
+        const float pw = innerW - s (6.0f);
+        float py = y;
+
+        const ImVec2 chipTL (px + pw - s (28.0f), py + s (1.0f));
+        const ImVec2 chipBR (px + pw - s (1.0f), py + s (layout::kEqHeaderH) - s (1.0f));
+        const bool black = params.eqBlackMode.load (std::memory_order_relaxed);
+        if (textButton (ctx, "##eqtype", chipTL, chipBR, black ? "G" : "E", black,
+                        0xff5a3a20, theme::kButtonOff, theme::kTextBright, theme::kTextBright, 10.0f))
+            params.eqBlackMode.store (! black, std::memory_order_relaxed);
+
+        splitModuleButton (ctx, "##eqhdr", ImVec2 (px, py),
+                           ImVec2 (chipTL.x - s (2.0f), py + s (layout::kEqHeaderH)),
+                           "EQ", params.eqEnabled, theme::kLfGreen);
+        py += s (layout::kEqHeaderH);
+
+        const float halfW = pw * 0.5f;
+        text (dl, fonts.band, s (12.0f), ImVec2 (px, py), halfW, theme::kTextDim, "HPF");
+        text (dl, fonts.band, s (12.0f), ImVec2 (px + halfW, py), halfW, theme::kTextDim, "LPF");
+        py += s (layout::kFilterLabelH);
+
+        const float kr = s (layout::kKnobSize) * 0.5f;
+        formatFreq (buf, sizeof buf, params.hpfFreq.load (std::memory_order_relaxed));
+        knob (ctx, "##hpf", ImVec2 (px + halfW * 0.5f, py + kr), kr, params.hpfFreq,
+              StripParams::hpfRange(), 20.0f, theme::kFilterWhite, nullptr, buf);
+        formatFreq (buf, sizeof buf, params.lpfFreq.load (std::memory_order_relaxed));
+        knob (ctx, "##lpf", ImVec2 (px + halfW * 1.5f, py + kr), kr, params.lpfFreq,
+              StripParams::lpfRange(), 20000.0f, theme::kFilterWhite, nullptr, buf);
+        py += s (layout::kKnobBlockH);
+
+        dl.AddLine (ImVec2 (px, py + s (2.5f)), ImVec2 (px + pw, py + s (2.5f)),
+                    col (theme::kEqAccent, 0.18f), s (1.0f));
+        py += s (layout::kFilterBandGap);
+
+        const float colW = (pw - s (layout::kRowLabelW)) / 3.0f;
+        const char* heads[] = { "GAIN", "FREQ", "Q" };
+        for (int i = 0; i < 3; ++i)
+            text (dl, fonts.small, s (8.0f), ImVec2 (px + s (layout::kRowLabelW) + colW * i, py),
+                  colW, theme::kTextDim, heads[i]);
+        py += s (layout::kColumnHeaderH);
+
+        struct Band { const char* label; std::atomic<float>* gain; std::atomic<float>* freq;
+                      std::atomic<float>* q; const Range* freqRange; float freqDefault;
+                      std::uint32_t colour; };
+        const Band bands[] = {
+            { "HF", &params.hfGainDb, &params.hfFreq, nullptr, &StripParams::hfFreqRange(), 8000.0f, theme::kHfRed },
+            { "HM", &params.hmGainDb, &params.hmFreq, &params.hmQ, &StripParams::hmFreqRange(), 2000.0f, theme::kHmGreen },
+            { "LM", &params.lmGainDb, &params.lmFreq, &params.lmQ, &StripParams::lmFreqRange(), 600.0f, theme::kLmBlue },
+            { "LF", &params.lfGainDb, &params.lfFreq, nullptr, &StripParams::lfFreqRange(), 100.0f, theme::kLfGraphite },
+        };
+
+        for (int b = 0; b < 4; ++b)
+        {
+            const float rowY = py + (s (layout::kEqBandRowH) + s (layout::kEqBandGap)) * b;
+            text (dl, fonts.band, s (12.0f), ImVec2 (px, rowY + s (7.0f)),
+                  s (layout::kRowLabelW), bands[b].colour, bands[b].label);
+
+            const float cy = rowY + kr;
+            char id[24];
+
+            formatGain (buf, sizeof buf, bands[b].gain->load (std::memory_order_relaxed));
+            std::snprintf (id, sizeof id, "##g%d", b);
+            knob (ctx, id, ImVec2 (px + s (layout::kRowLabelW) + colW * 0.5f, cy), kr,
+                  *bands[b].gain, StripParams::gainRange(), 0.0f, bands[b].colour, nullptr, buf);
+
+            formatFreq (buf, sizeof buf, bands[b].freq->load (std::memory_order_relaxed));
+            std::snprintf (id, sizeof id, "##f%d", b);
+            knob (ctx, id, ImVec2 (px + s (layout::kRowLabelW) + colW * 1.5f, cy), kr,
+                  *bands[b].freq, *bands[b].freqRange, bands[b].freqDefault, bands[b].colour, nullptr, buf);
+
+            if (bands[b].q != nullptr)
+            {
+                std::snprintf (buf, sizeof buf, "%.2f", bands[b].q->load (std::memory_order_relaxed));
+                std::snprintf (id, sizeof id, "##q%d", b);
+                knob (ctx, id, ImVec2 (px + s (layout::kRowLabelW) + colW * 2.5f, cy), kr,
+                      *bands[b].q, StripParams::qRange(), 0.7f, bands[b].colour, nullptr, buf);
+            }
+        }
+
+        y += h + s (3.0f);
+    }
+
+    // COMP
+    {
+        const float h = s (layout::kCompPanelH);
+        panel (dl, ImVec2 (left, y), ImVec2 (right, y + h), theme::kCompFill,
+               theme::kCompGold, 0.40f, s (3.0f), s (0.8f));
+
+        const float px = left + s (3.0f);
+        const float pw = innerW - s (6.0f);
+        splitModuleButton (ctx, "##comphdr", ImVec2 (px, y + s (2.0f)),
+                           ImVec2 (px + pw, y + s (18.0f)), "COMP",
+                           params.compEnabled, theme::kCompGold);
+
+        const float bodyY = y + s (20.0f);
+        const float colW = pw / 4.0f;
+        const float kr = s (layout::kCompKnobSize) * 0.5f;
+
+        struct Cell { const char* id; const char* label; std::atomic<float>* value;
+                      const Range* range; float def; const char* fmt; };
+        const Cell cells[] = {
+            { "##rat", "RAT", &params.compFetRatioIndex, nullptr, 0.0f, nullptr },
+            { "##atk", "ATK", &params.compFetAttack,  &StripParams::atkRange(), 0.2f,   "%.2f" },
+            { "##rel", "REL", &params.compFetRelease, &StripParams::relRange(), 400.0f, "%.0f" },
+            { "##mak", "MAK", &params.compFetOutput,  &StripParams::makRange(), 0.0f,   "%+.1f" },
+        };
+        static const Range ratioRange { 0.0f, 4.0f, 1.0f };
+        static const char* kRatios[] = { "4:1", "8:1", "12:1", "20:1", "All" };
+
+        for (int i = 0; i < 4; ++i)
+        {
+            const float cx = px + colW * (i + 0.5f);
+            text (dl, fonts.label, s (9.0f), ImVec2 (cx - colW * 0.5f, bodyY), colW,
+                  0xffb07050, cells[i].label);
+
+            if (cells[i].range == nullptr)
+            {
+                const int idx = std::clamp (static_cast<int> (std::lround (
+                    cells[i].value->load (std::memory_order_relaxed))), 0, 4);
+                knob (ctx, cells[i].id, ImVec2 (cx, bodyY + s (layout::kCompKnobLabelH) + kr), kr,
+                      *cells[i].value, ratioRange, 0.0f, theme::kCompGold, nullptr, kRatios[idx]);
+            }
+            else
+            {
+                std::snprintf (buf, sizeof buf, cells[i].fmt,
+                               cells[i].value->load (std::memory_order_relaxed));
+                knob (ctx, cells[i].id, ImVec2 (cx, bodyY + s (layout::kCompKnobLabelH) + kr), kr,
+                      *cells[i].value, *cells[i].range, cells[i].def, theme::kCompGold, nullptr, buf);
+            }
+        }
+
+        y += h + s (6.0f);
+    }
+
+    // AUX sends
+    {
+        const float h = s (layout::kAuxPanelH);
+        panel (dl, ImVec2 (left, y), ImVec2 (right, y + h), theme::kSendFill,
+               theme::kSendPurple, 0.40f, s (3.0f), s (0.8f));
+
+        const float px = left + s (3.0f);
+        const float pw = innerW - s (6.0f);
+        const float colW = pw / 4.0f;
+        const float kr = s (layout::kAuxKnobSize) * 0.5f;
+        const char* names[] = { "REV", "DLY", "CUE", "FX" };
+
+        for (int i = 0; i < 4; ++i)
+        {
+            const float cx = px + colW * (i + 0.5f);
+            text (dl, fonts.small, s (8.5f), ImVec2 (cx - colW * 0.5f, y + s (3.0f)), colW,
+                  theme::kSendPurple, names[i]);
+
+            const float knobY = y + s (3.0f + 11.0f + 1.0f) + (i % 2 == 0 ? 0.0f : s (layout::kAuxStaggerY));
+            const float db = params.auxSendDb[i].load (std::memory_order_relaxed);
+            if (db <= StripParams::kAuxSendOffDb + 0.5f) std::snprintf (buf, sizeof buf, "-");
+            else                                         std::snprintf (buf, sizeof buf, "%.0f", db);
+
+            char id[16];
+            std::snprintf (id, sizeof id, "##aux%d", i);
+            knob (ctx, id, ImVec2 (cx, knobY + kr), kr, params.auxSendDb[i],
+                  StripParams::auxRange(), StripParams::kAuxSendOffDb, theme::kAuxFill[i],
+                  nullptr, buf,
+                  params.auxSendPreFader[i].load (std::memory_order_relaxed)
+                      ? theme::kAuxPreOutline : theme::kKnobOutline);
+        }
+
+        y += h + s (3.0f);
+    }
+
+    // Fader column: pan on top, then bus buttons / fader / meter / GR side by side.
+    {
+        const float bottomBlock = s (layout::kPeakLabelH + 2.0f + layout::kAutoH + 4.0f + layout::kMsRowH);
+        const float colBottom = origin.y + height - s (layout::kOuterInset) - bottomBlock;
+        const float cx = (left + right) * 0.5f;
+
+        const float panTop = y;
+        text (dl, fonts.pill, s (10.5f), ImVec2 (cx - s (28.0f), panTop), s (56.0f),
+              theme::kTextDim, "PAN");
+        const float pan = params.pan.load (std::memory_order_relaxed);
+        if (std::fabs (pan) < 0.005f)      std::snprintf (buf, sizeof buf, "C");
+        else if (pan < 0.0f)               std::snprintf (buf, sizeof buf, "L%.0f", -pan * 100.0f);
+        else                               std::snprintf (buf, sizeof buf, "R%.0f", pan * 100.0f);
+        knob (ctx, "##pan", ImVec2 (cx, panTop + s (layout::kPanLabelH) + s (13.0f)),
+              s (layout::kPanKnobSize) * 0.5f, params.pan, StripParams::panRange(), 0.0f,
+              theme::kPanRed, nullptr, buf);
+
+        const float faderTop = panTop + s (layout::kPanLabelH + layout::kPanBlockH + layout::kPanFaderGap);
+        const float faderW = std::clamp (innerW - s (74.0f), s (22.0f), s (40.0f));
+
+        drawFader (ctx, ImVec2 (cx - faderW * 0.5f, faderTop),
+                   ImVec2 (cx + faderW * 0.5f, colBottom),
+                   left + s (layout::kBusColumnW) + s (6.0f), params.faderDb, "##fader");
+
+        // Meters share the fader's top and bottom trim so 0 dB is on the same scan line.
+        const float meterTop = faderTop + s (layout::kFaderTrackPad);
+        const float meterBottom = colBottom - s (layout::kFaderTrackPad);
+        const float meterX = cx + faderW * 0.5f + s (1.0f);
+
+        inputMeter.tick (params.meterInputDb.load (std::memory_order_relaxed),
+                         ImGui::GetIO().Framerate > 1.0f ? ImGui::GetIO().Framerate / 30.0f : 2.0f);
+        drawMeter (ctx, ImVec2 (meterX, meterTop),
+                   ImVec2 (meterX + s (layout::kMeterWidth), meterBottom),
+                   inputMeter.displayed, inputMeter.peakHold);
+
+        const float grX = meterX + s (layout::kMeterWidth) + s (1.0f);
+        const float gr = params.meterGrDb.load (std::memory_order_relaxed);
+        if (gr < displayedGrDb) displayedGrDb = gr;
+        else                    displayedGrDb += (gr - displayedGrDb) * 0.18f;
+        drawGrStrip (ctx, ImVec2 (grX, meterTop), ImVec2 (grX + s (layout::kGrLedW), meterBottom),
+                     displayedGrDb, params.compFetThresholdDb, "##thr");
+
+        // Bus buttons track the fader's 0 dB and -inf marks, as in the shipping layout.
+        {
+            const auto& range = StripParams::faderRange();
+            const float trackTop = faderTop + s (layout::kFaderTrackPad);
+            const float trackH = (colBottom - s (layout::kFaderTrackPad)) - trackTop;
+            const float zeroY = trackTop + trackH * (1.0f - range.toNorm (0.0f));
+            const float offY  = trackTop + trackH;
+            const float bh = s (layout::kBusButtonH);
+            const float span = std::max (4.0f * bh, offY - zeroY);
+            const int step = static_cast<int> (std::clamp (std::lround ((span - bh) / 3.0f * 0.85),
+                                                           static_cast<long> (bh),
+                                                           static_cast<long> (s (48.0f))));
+            const float stackTop = zeroY + std::max (0.0f, (span - (bh + step * 3)) * 0.5f);
+            const std::uint32_t busColours[] = { 0xff5a8ad0, 0xffe0c050, 0xff60c060, 0xffc06888 };
+
+            for (int i = 0; i < 4; ++i)
+            {
+                const ImVec2 tl (left + s (3.0f), stackTop + step * i);
+                const ImVec2 br (tl.x + s (layout::kBusColumnW), tl.y + bh);
+                char id[16];
+                std::snprintf (id, sizeof id, "##bus%d", i);
+                std::snprintf (buf, sizeof buf, "%d", i + 1);
+                const bool on = params.busAssign[i].load (std::memory_order_relaxed);
+                if (textButton (ctx, id, tl, br, buf, on, theme::kButtonOff, busColours[i],
+                                brighter (busColours[i], 0.15f), theme::kOnText, 10.0f))
+                    params.busAssign[i].store (! on, std::memory_order_relaxed);
+            }
+        }
+
+        y = colBottom;
+    }
+
+    // Readouts, automation mode, mute / solo / phase.
+    {
+        const float db = params.faderDb.load (std::memory_order_relaxed);
+        if (db <= -89.95f) std::snprintf (buf, sizeof buf, "\xe2\x88\x9e");
+        else               std::snprintf (buf, sizeof buf, "%.1f", db);
+        text (dl, fonts.monoBig, s (14.0f), ImVec2 (left, y + s (2.0f)), innerW * 0.55f,
+              theme::kTextValue, buf, Align::centre);
+
+        const float peak = inputMeter.peakHold;
+        std::snprintf (buf, sizeof buf, "%.1f", peak);
+        const std::uint32_t peakCol = peak >= -3.0f ? 0xffff5050
+                                    : (peak >= -12.0f ? 0xffe0c050 : theme::kTextValue);
+        text (dl, fonts.mono, s (11.0f), ImVec2 (left + innerW * 0.55f, y + s (4.0f)),
+              innerW * 0.45f, peakCol, buf, Align::right);
+        y += s (layout::kPeakLabelH + 2.0f);
+
+        textButton (ctx, "##auto", ImVec2 (left + s (1.0f), y),
+                    ImVec2 (right - s (1.0f), y + s (layout::kAutoH)), "AUTO: READ", true,
+                    theme::kButtonOff, 0xff20603a, 0xff707074, 0xffd0e8d0, 9.5f);
+        y += s (layout::kAutoH + 4.0f);
+
+        const float w3 = innerW / 3.0f;
+        struct { const char* id; const char* label; std::atomic<bool>* flag; std::uint32_t on; } msp[] = {
+            { "##mute",  "M", &params.mute,        theme::kMuteOn },
+            { "##solo",  "S", &params.solo,        theme::kSoloOn },
+            { "##phase", "\xc3\x98", &params.phaseInvert, theme::kPhaseOn },
+        };
+        for (int i = 0; i < 3; ++i)
+        {
+            const ImVec2 tl (left + w3 * i + s (1.0f), y + s (1.0f));
+            const ImVec2 br (left + w3 * (i + 1) - s (1.0f), y + s (layout::kMsRowH) - s (1.0f));
+            const bool on = msp[i].flag->load (std::memory_order_relaxed);
+            if (textButton (ctx, msp[i].id, tl, br, msp[i].label, on, theme::kButtonOff,
+                            msp[i].on, theme::kTextDim, theme::kOnText, 11.0f))
+                msp[i].flag->store (! on, std::memory_order_relaxed);
+        }
+    }
+
+    lastVertexCount = dl.VtxBuffer.Size - startVtx;
+    lastWidgetCount = ctx.widgets;
+    return result;
+}
+
+} // namespace duskspike

--- a/tools/gui-spike/ChannelStripView.h
+++ b/tools/gui-spike/ChannelStripView.h
@@ -43,18 +43,15 @@ public:
     void setEditingName (bool yes) noexcept { editingName = yes; }
     bool isEditingName() const noexcept { return editingName; }
 
-    // Frame counters, so the shell can report what the strip actually cost.
-    int lastVertexCount = 0;
+    // Read by the shell's overlay, so a run reports what the strip actually cost.
     int lastWidgetCount = 0;
 
 private:
     MeterBallistics inputMeter;
-    MeterBallistics inputMeterR;
     float displayedGrDb = 0.0f;
 
     std::string activeDrag;
     float dragStartValue = 0.0f;
-    float dragStartY = 0.0f;
     bool editingName = false;
     char nameBuffer[64] = {};
 };

--- a/tools/gui-spike/ChannelStripView.h
+++ b/tools/gui-spike/ChannelStripView.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "StripModel.h"
+
+#include <DearImGui.hpp>
+
+#include <string>
+
+namespace duskspike
+{
+
+struct StripFonts
+{
+    ImFont* small   = nullptr;  // 8 pt column headers
+    ImFont* label   = nullptr;  // 9 pt knob labels
+    ImFont* pill    = nullptr;  // 10.5 pt module headers
+    ImFont* band    = nullptr;  // 12 pt band / filter labels
+    ImFont* name    = nullptr;  // 13 pt strip name
+    ImFont* mono    = nullptr;  // 11 pt numeric readouts
+    ImFont* monoBig = nullptr;  // 14 pt fader readout
+};
+
+// Which interaction the frame just asked for, so the shell can drive the pieces that
+// belong to the application rather than the strip.
+struct StripFrameResult
+{
+    bool openIoModal      = false;
+    bool openInsertMenu   = false;
+    ImVec2 insertMenuAt {};
+};
+
+class ChannelStripView
+{
+public:
+    StripFrameResult draw (ImDrawList& dl,
+                           ImVec2 origin,
+                           float width,
+                           float height,
+                           float scale,
+                           StripParams& params,
+                           const StripFonts& fonts);
+
+    void setEditingName (bool yes) noexcept { editingName = yes; }
+    bool isEditingName() const noexcept { return editingName; }
+
+    // Frame counters, so the shell can report what the strip actually cost.
+    int lastVertexCount = 0;
+    int lastWidgetCount = 0;
+
+private:
+    MeterBallistics inputMeter;
+    MeterBallistics inputMeterR;
+    float displayedGrDb = 0.0f;
+
+    std::string activeDrag;
+    float dragStartValue = 0.0f;
+    float dragStartY = 0.0f;
+    bool editingName = false;
+    char nameBuffer[64] = {};
+};
+
+} // namespace duskspike

--- a/tools/gui-spike/GuiSpikeMain.cpp
+++ b/tools/gui-spike/GuiSpikeMain.cpp
@@ -1,0 +1,562 @@
+// Non-shipping gate spike for the GUI tower (issue #301). It puts one Dusk Studio channel
+// strip on a native application window driven by the Dusk Audio Framework's DGL/pugl stack
+// and Dear ImGui, with no JUCE anywhere in the target, and reports what a 60 Hz frame of it
+// costs. It is a measuring instrument, not a step toward the shipping UI.
+
+#include "ChannelStripView.h"
+#include "StripModel.h"
+#include "StripTheme.h"
+
+#include <Application.hpp>
+#include <OpenGL.hpp>
+#include <DearImGui.hpp>
+#include <DearImGui/imgui_internal.h>
+#ifndef DGL_NO_SHARED_RESOURCES
+# include "src/Resources.hpp"
+#endif
+
+#ifndef DUSKSTUDIO_DGL_RESOURCES
+# define DUSKSTUDIO_DGL_RESOURCES dpf_resources
+#endif
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+#if defined (__unix__)
+# include <sys/resource.h>
+#endif
+
+namespace
+{
+
+struct Options
+{
+    double seconds = 0.0;      // 0 runs until the window is closed
+    int    strips = 1;
+    int    reopen = 0;         // window close/reopen cycles before measuring
+    double scaleOverride = 0.0;
+    int    width = 0;
+    int    height = 0;
+    bool   resizeSweep = false;
+    bool   quiet = false;
+    std::string capturePath;
+    int    captureFrame = 60;
+    bool   selftest = false;
+    int    demo = 0;           // 1 opens the modal, 2 opens the insert menu
+};
+
+double cpuSeconds()
+{
+#if defined (__unix__)
+    rusage ru {};
+    getrusage (RUSAGE_SELF, &ru);
+    return static_cast<double> (ru.ru_utime.tv_sec + ru.ru_stime.tv_sec)
+         + 1.0e-6 * static_cast<double> (ru.ru_utime.tv_usec + ru.ru_stime.tv_usec);
+#else
+    return 0.0;
+#endif
+}
+
+double percentile (std::vector<double>& v, double p)
+{
+    if (v.empty())
+        return 0.0;
+    std::sort (v.begin(), v.end());
+    const auto i = std::min (v.size() - 1,
+                             static_cast<std::size_t> (p * static_cast<double> (v.size() - 1)));
+    return v[i];
+}
+
+const char* glStr (unsigned int name)
+{
+    const auto* const s = reinterpret_cast<const char*> (glGetString (name));
+    return s != nullptr ? s : "(null)";
+}
+
+} // namespace
+
+class SpikeWindow final : public DGL::ImGuiStandaloneWindow
+{
+public:
+    SpikeWindow (DGL::Application& app, const Options& opts)
+        : DGL::ImGuiStandaloneWindow (app, 13.0f), application (app), options (opts)
+    {
+        setTitle ("Dusk Studio GUI gate spike");
+        setResizable (true);
+
+        const float scale = static_cast<float> (options.scaleOverride > 0.0
+                                                ? options.scaleOverride : getScaleFactor());
+        const int w = options.width > 0 ? options.width
+                    : static_cast<int> ((duskspike::layout::kStripWidth + 24.0f)
+                                        * static_cast<float> (options.strips) * scale);
+        const int h = options.height > 0 ? options.height
+                    : static_cast<int> ((duskspike::layout::kMinStripHeight + 20.0f) * scale);
+        setSize (static_cast<uint> (w), static_cast<uint> (h));
+
+        strips.resize (static_cast<std::size_t> (std::max (1, options.strips)));
+        views.resize (strips.size());
+        for (std::size_t i = 0; i < strips.size(); ++i)
+        {
+            strips[i].reset (new duskspike::StripParams());
+            char name[32];
+            std::snprintf (name, sizeof name, "TRK %02d", static_cast<int> (i) + 1);
+            strips[i]->name = name;
+            sources.emplace_back (new duskspike::StubMeterSource (*strips[i]));
+            sources.back()->start();
+        }
+
+        buildFonts (scale);
+        reportGraphics();
+
+        done();
+    }
+
+    ~SpikeWindow() override
+    {
+        for (auto& s : sources)
+            s->stop();
+    }
+
+    void beginMeasuring() { measuring = true; frameDeltas.clear(); }
+
+    const std::vector<double>& deltas() const noexcept { return frameDeltas; }
+    int framesDrawn() const noexcept { return frames; }
+    const std::string& rendererName() const noexcept { return renderer; }
+    int lastVertices() const noexcept { return vertices; }
+
+protected:
+    // pugl has no screenshot hook, so the spike takes its own: the base onDisplay has
+    // finished submitting the frame and the buffer has not been swapped yet, which is the
+    // only point where a readback is the frame the compositor is about to show.
+    void onDisplay() override
+    {
+        DGL::ImGuiStandaloneWindow::onDisplay();
+
+        if (options.capturePath.empty() || frames != options.captureFrame)
+            return;
+
+        const int w = static_cast<int> (getWidth());
+        const int h = static_cast<int> (getHeight());
+        std::vector<unsigned char> pixels (static_cast<std::size_t> (w) * h * 3);
+
+        glFinish();
+        glPixelStorei (GL_PACK_ALIGNMENT, 1);
+        glReadPixels (0, 0, w, h, GL_RGB, GL_UNSIGNED_BYTE, pixels.data());
+
+        if (FILE* const f = std::fopen (options.capturePath.c_str(), "wb"))
+        {
+            std::fprintf (f, "P6\n%d %d\n255\n", w, h);
+            for (int row = h - 1; row >= 0; --row)
+                std::fwrite (pixels.data() + static_cast<std::size_t> (row) * w * 3, 1,
+                             static_cast<std::size_t> (w) * 3, f);
+            std::fclose (f);
+            std::printf ("[spike] captured frame %d to %s (%dx%d)\n",
+                         frames, options.capturePath.c_str(), w, h);
+        }
+    }
+
+    // Counted so a run can say whether the compositor delivered any input at all, rather
+    // than leaving "input works" to be inferred from the code compiling.
+    bool onMouse (const DGL::Widget::MouseEvent& e) override
+    { ++pointerEvents; return DGL::ImGuiStandaloneWindow::onMouse (e); }
+
+    bool onMotion (const DGL::Widget::MotionEvent& e) override
+    { ++pointerEvents; return DGL::ImGuiStandaloneWindow::onMotion (e); }
+
+    bool onScroll (const DGL::Widget::ScrollEvent& e) override
+    { ++pointerEvents; return DGL::ImGuiStandaloneWindow::onScroll (e); }
+
+    bool onKeyboard (const DGL::Widget::KeyboardEvent& e) override
+    { ++keyEvents; return DGL::ImGuiStandaloneWindow::onKeyboard (e); }
+
+    bool onCharacterInput (const DGL::Widget::CharacterInputEvent& e) override
+    { ++textEvents; return DGL::ImGuiStandaloneWindow::onCharacterInput (e); }
+
+    void onImGuiDisplay() override
+    {
+        if (options.selftest)
+            driveSelftest();
+
+        const auto now = std::chrono::steady_clock::now();
+        if (frames > 0 && measuring)
+            frameDeltas.push_back (std::chrono::duration<double, std::milli> (now - lastFrame).count());
+        lastFrame = now;
+        ++frames;
+
+        if (options.seconds > 0.0)
+        {
+            if (frames == 1)
+                startedAt = now;
+            else if (std::chrono::duration<double> (now - startedAt).count() >= options.seconds)
+                application.quit();
+        }
+
+        const float scale = static_cast<float> (options.scaleOverride > 0.0
+                                                ? options.scaleOverride : getScaleFactor());
+        const float w = static_cast<float> (getWidth());
+        const float h = static_cast<float> (getHeight());
+
+        if (options.resizeSweep && (frames % 30) == 0 && frames < 600)
+        {
+            const uint sweep = static_cast<uint> (600 + (frames / 30) % 8 * 40);
+            setSize (sweep, static_cast<uint> (h));
+        }
+
+        ImGui::SetNextWindowPos (ImVec2 (0.0f, 0.0f));
+        ImGui::SetNextWindowSize (ImVec2 (w, h));
+        ImGui::PushStyleVar (ImGuiStyleVar_WindowPadding, ImVec2 (0.0f, 0.0f));
+        ImGui::PushStyleVar (ImGuiStyleVar_WindowBorderSize, 0.0f);
+        ImGui::PushStyleColor (ImGuiCol_WindowBg,
+                               ImGui::ColorConvertU32ToFloat4 (IM_COL32 (0x12, 0x12, 0x14, 255)));
+        ImGui::Begin ("##console", nullptr,
+                      ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize
+                      | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar
+                      | ImGuiWindowFlags_NoBringToFrontOnFocus);
+
+        auto* const dl = ImGui::GetWindowDrawList();
+
+        const float stripW = duskspike::layout::kStripWidth * scale;
+        const float gap = 4.0f * scale;
+        const float stripH = std::max (duskspike::layout::kMinStripHeight * scale, h - 12.0f * scale);
+        float x = 6.0f * scale;
+
+        duskspike::StripFrameResult firstResult;
+        for (std::size_t i = 0; i < views.size(); ++i)
+        {
+            const auto r = views[i].draw (*dl, ImVec2 (x, 6.0f * scale), stripW, stripH,
+                                          scale, *strips[i], fonts);
+            if (i == 0)
+                firstResult = r;
+            x += stripW + gap;
+        }
+
+        vertices = dl->VtxBuffer.Size;
+
+        // Keyboard: the shell owns the shortcuts a view would not, so a key press proves it
+        // reaches the application and not only the focused text field.
+        // Not gated on io.WantCaptureKeyboard: the widgets library forces keyboard nav on,
+        // which pins that flag true, and the ImGui bridge never reports window focus, so it
+        // says nothing about whether the application may take the key.
+        if (! views[0].isEditingName() && ! ImGui::IsAnyItemActive())
+        {
+            auto& p = *strips[0];
+            if (ImGui::IsKeyPressed (ImGuiKey_M, false))
+                p.mute.store (! p.mute.load(), std::memory_order_relaxed);
+            if (ImGui::IsKeyPressed (ImGuiKey_S, false))
+                p.solo.store (! p.solo.load(), std::memory_order_relaxed);
+            if (ImGui::IsKeyPressed (ImGuiKey_UpArrow, true))
+                p.faderDb.store (std::min (6.0f, p.faderDb.load() + 0.5f), std::memory_order_relaxed);
+            if (ImGui::IsKeyPressed (ImGuiKey_DownArrow, true))
+                p.faderDb.store (std::max (-90.0f, p.faderDb.load() - 0.5f), std::memory_order_relaxed);
+            if (ImGui::IsKeyPressed (ImGuiKey_Escape, false) && options.seconds <= 0.0)
+                application.quit();
+        }
+
+        if (firstResult.openInsertMenu || (options.demo == 2 && frames == 30))
+            ImGui::OpenPopup ("##insertMenu");
+        if (ImGui::BeginPopup ("##insertMenu"))
+        {
+            ImGui::TextDisabled ("Insert slot");
+            ImGui::Separator();
+            const char* items[] = { "Baroness", "Langevin", "Tape Machine", "Clear slot" };
+            for (const auto* item : items)
+                if (ImGui::MenuItem (item))
+                    menuChoice = item;
+            ImGui::EndPopup();
+        }
+
+        if (firstResult.openIoModal || (options.demo == 1 && frames == 30))
+            ImGui::OpenPopup ("Channel input");
+        drawIoModal (w, h, scale);
+
+        drawHud (w, scale);
+
+        ImGui::End();
+        ImGui::PopStyleColor();
+        ImGui::PopStyleVar (2);
+    }
+
+public:
+    int pointerEvents = 0, keyEvents = 0, textEvents = 0;
+    std::vector<std::string> selftestLog;
+
+private:
+    // A headless compositor has no seat, so nothing arrives through the Wayland input path.
+    // This injects at the ImGui event queue instead: it proves the widget layer reacts, and
+    // deliberately proves nothing about pugl's seat handling, which is bench work.
+    void driveSelftest()
+    {
+        auto& io = ImGui::GetIO();
+        auto& p = *strips[0];
+        const float scale = static_cast<float> (options.scaleOverride > 0.0
+                                                ? options.scaleOverride : getScaleFactor());
+        auto note = [this] (const char* what, bool ok)
+        { selftestLog.emplace_back (std::string (ok ? "pass  " : "FAIL  ") + what); };
+
+        // HF gain knob, centre of the first EQ band row's GAIN column.
+        const ImVec2 hfGain (6.0f * scale + (4.0f + 3.0f + 28.0f + (182.0f - 34.0f) / 6.0f) * scale,
+                             6.0f * scale + (4.0f + 6.0f + 20.0f + 2.0f + 18.0f + 3.0f + 18.0f
+                                             + 18.0f + 2.0f + 16.0f + 10.0f + 40.0f + 5.0f
+                                             + 10.0f + 13.0f) * scale);
+
+        switch (selftestStep++)
+        {
+            case 10: io.AddMousePosEvent (hfGain.x, hfGain.y); break;
+            case 12: selftestBefore = p.hfGainDb.load(); io.AddMouseButtonEvent (0, true); break;
+            case 14: io.AddMousePosEvent (hfGain.x, hfGain.y - 40.0f * scale); break;
+            case 16: io.AddMouseButtonEvent (0, false); break;
+            case 18: note ("knob drag changes value", p.hfGainDb.load() > selftestBefore + 0.5f); break;
+
+            case 22: io.AddMouseWheelEvent (0.0f, 3.0f); break;
+            case 24: note ("knob wheel changes value", p.hfGainDb.load() != selftestBefore); break;
+
+            case 28: io.AddMousePosEvent (hfGain.x, hfGain.y); break;
+            case 30: io.AddMouseButtonEvent (0, true); break;
+            case 31: io.AddMouseButtonEvent (0, false); break;
+            case 32: io.AddMouseButtonEvent (0, true); break;
+            case 33: io.AddMouseButtonEvent (0, false); break;
+            case 36: note ("knob double-click resets", std::fabs (p.hfGainDb.load()) < 0.01f); break;
+
+            case 40: io.AddKeyEvent (ImGuiKey_M, true); break;
+            case 41: io.AddKeyEvent (ImGuiKey_M, false); break;
+            case 44: note ("shell keyboard shortcut", p.mute.load()); break;
+
+            case 48: views[0].setEditingName (true); break;
+            case 52: io.AddInputCharacter ('Z'); break;
+            case 56: io.AddKeyEvent (ImGuiKey_Enter, true); break;
+            case 57: io.AddKeyEvent (ImGuiKey_Enter, false); break;
+            case 62: note ("text entry commits", ! views[0].isEditingName()
+                                                 && p.name.find ('Z') != std::string::npos); break;
+
+            case 64: io.AddMousePosEvent (2.0f, 2.0f); io.AddMouseButtonEvent (0, false); break;
+            case 66: ImGui::OpenPopup ("Channel input"); break;
+            case 70: note ("modal is open", ImGui::IsPopupOpen ("Channel input")); break;
+            // What has to hold for an embedded modal: the strip underneath stops taking
+            // the pointer while it is up.
+            case 72: io.AddMousePosEvent (hfGain.x, hfGain.y); break;
+            case 74: selftestBefore = p.hfGainDb.load(); io.AddMouseButtonEvent (0, true); break;
+            case 76: io.AddMousePosEvent (hfGain.x, hfGain.y - 40.0f * scale); break;
+            case 78: io.AddMouseButtonEvent (0, false); break;
+            case 80: note ("modal blocks the strip underneath",
+                           std::fabs (p.hfGainDb.load() - selftestBefore) < 0.01f); break;
+
+            case 84: ImGui::OpenPopup ("##insertMenu"); break;
+            case 88: note ("context menu is open", ImGui::IsPopupOpen ("##insertMenu")); break;
+            case 92: application.quit(); break;
+            default: break;
+        }
+    }
+
+    void drawIoModal (float w, float h, float scale)
+    {
+        ImGui::SetNextWindowPos (ImVec2 (w * 0.5f, h * 0.5f), ImGuiCond_Always, ImVec2 (0.5f, 0.5f));
+        ImGui::SetNextWindowSize (ImVec2 (290.0f * scale, 0.0f));
+
+        if (! ImGui::BeginPopupModal ("Channel input", nullptr,
+                                      ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove))
+            return;
+
+        static const char* modes[] = { "Mono", "Stereo", "MIDI" };
+        static const char* ins[]   = { "In 1", "In 2", "In 3", "In 4" };
+        ImGui::Combo ("Mode", &modeIndex, modes, IM_ARRAYSIZE (modes));
+        ImGui::Combo ("Input L", &inputIndex, ins, IM_ARRAYSIZE (ins));
+        ImGui::Combo ("Input R", &inputRIndex, ins, IM_ARRAYSIZE (ins));
+        ImGui::Separator();
+        if (ImGui::Button ("Close", ImVec2 (120.0f * scale, 0.0f))
+            || ImGui::IsKeyPressed (ImGuiKey_Escape, false))
+            ImGui::CloseCurrentPopup();
+
+        ImGui::EndPopup();
+    }
+
+    void drawHud (float w, float scale)
+    {
+        if (options.quiet || w < 420.0f * scale)
+            return;
+
+        char line[256];
+        std::snprintf (line, sizeof line, "%.1f fps   %d verts   %d widgets   scale %.2f   %s",
+                       static_cast<double> (ImGui::GetIO().Framerate),
+                       vertices, views[0].lastWidgetCount, static_cast<double> (scale),
+                       menuChoice.empty() ? "" : menuChoice.c_str());
+
+        auto* const dl = ImGui::GetWindowDrawList();
+        const ImVec2 at (w - 380.0f * scale, 6.0f * scale);
+        dl->AddRectFilled (at, ImVec2 (w - 6.0f * scale, at.y + 18.0f * scale),
+                           IM_COL32 (0, 0, 0, 160), 3.0f);
+        dl->AddText (fonts.mono, 11.0f * scale, ImVec2 (at.x + 6.0f * scale, at.y + 3.0f * scale),
+                     IM_COL32 (0xc0, 0xc0, 0xc8, 255), line);
+    }
+
+    void buildFonts (float scale)
+    {
+        auto& io = ImGui::GetIO();
+        io.Fonts->Clear();
+
+        ImFontConfig cfg;
+        cfg.FontDataOwnedByAtlas = false;
+        cfg.OversampleH = 2;
+        cfg.OversampleV = 2;
+        cfg.PixelSnapH = false;
+
+        // ImGui bakes a fixed glyph set. The default range is Latin only, which silently
+        // drops the fader's infinity mark - a glyph the JUCE strip gets for free from the
+        // system font. Every non-Latin mark the UI uses has to be declared here.
+        static const ImWchar ranges[] = {
+            0x0020, 0x024f,   // Latin and its supplements
+            0x2000, 0x22ff,   // punctuation, arrows, maths (infinity lives here)
+            0x2500, 0x25ff,   // box drawing and geometric shapes
+            0
+        };
+
+        auto add = [&] (float size)
+        {
+            return io.Fonts->AddFontFromMemoryTTF (
+                const_cast<void*> (static_cast<const void*> (DUSKSTUDIO_DGL_RESOURCES::dejavusans_ttf)),
+                DUSKSTUDIO_DGL_RESOURCES::dejavusans_ttf_size, size * scale, &cfg, ranges);
+        };
+
+        // One face per design size rather than one scaled face: the strip's 8 pt column
+        // headers are unreadable if they are a scaled 13 pt atlas entry.
+        fonts.small   = add (8.0f);
+        fonts.label   = add (9.0f);
+        fonts.pill    = add (10.5f);
+        fonts.band    = add (12.0f);
+        fonts.name    = add (13.0f);
+        fonts.mono    = add (11.0f);
+        fonts.monoBig = add (14.0f);
+        io.FontDefault = fonts.band;
+        io.Fonts->Build();
+    }
+
+    void reportGraphics()
+    {
+        renderer = glStr (GL_RENDERER);
+        if (! options.quiet)
+            std::printf ("[spike] GL vendor=%s renderer=%s version=%s\n",
+                         glStr (GL_VENDOR), renderer.c_str(), glStr (GL_VERSION));
+    }
+
+    DGL::Application& application;
+    Options options;
+
+    std::vector<std::unique_ptr<duskspike::StripParams>> strips;
+    std::vector<std::unique_ptr<duskspike::StubMeterSource>> sources;
+    std::vector<duskspike::ChannelStripView> views;
+    duskspike::StripFonts fonts;
+
+    std::string renderer;
+    std::string menuChoice;
+    int modeIndex = 0, inputIndex = 0, inputRIndex = 1;
+
+    bool measuring = true;
+    int selftestStep = 0;
+    float selftestBefore = 0.0f;
+    int frames = 0;
+    int vertices = 0;
+    std::chrono::steady_clock::time_point lastFrame {};
+    std::chrono::steady_clock::time_point startedAt {};
+    std::vector<double> frameDeltas;
+};
+
+int main (int argc, char* argv[])
+{
+    Options opts;
+
+    for (int i = 1; i < argc; ++i)
+    {
+        const std::string a = argv[i];
+        auto next = [&] () -> const char* { return i + 1 < argc ? argv[++i] : "0"; };
+
+        if      (a == "--seconds") opts.seconds = std::atof (next());
+        else if (a == "--strips")  opts.strips = std::atoi (next());
+        else if (a == "--reopen")  opts.reopen = std::atoi (next());
+        else if (a == "--scale")   opts.scaleOverride = std::atof (next());
+        else if (a == "--width")   opts.width = std::atoi (next());
+        else if (a == "--height")  opts.height = std::atoi (next());
+        else if (a == "--resize-sweep") opts.resizeSweep = true;
+        else if (a == "--quiet")   opts.quiet = true;
+        else if (a == "--capture") opts.capturePath = next();
+        else if (a == "--capture-frame") opts.captureFrame = std::atoi (next());
+        else if (a == "--selftest") opts.selftest = true;
+        else if (a == "--demo")    opts.demo = std::atoi (next());
+        else if (a == "--help")
+        {
+            std::printf ("usage: dusk-gui-spike [--seconds N] [--strips N] [--reopen N]\n"
+                         "                      [--scale F] [--width N] [--height N]\n"
+                         "                      [--resize-sweep] [--quiet]\n"
+                         "                      [--capture FILE.ppm] [--capture-frame N]\n"
+                         "                      [--selftest] [--demo 1|2]\n");
+            return 0;
+        }
+    }
+
+    DGL::Application app (true);
+    app.setClassName ("dusk-studio-gui-spike");
+
+    // Renderer and context lifetime: build and tear the whole window down a few times
+    // before the measured run, so a leaked EGL display or a stale surface shows up as a
+    // failure here rather than in the shipping app months later.
+    for (int i = 0; i < opts.reopen; ++i)
+    {
+        Options warm = opts;
+        warm.seconds = 0.35;
+        warm.quiet = true;
+        SpikeWindow w (app, warm);
+        w.show();
+        app.exec (4);
+        std::printf ("[spike] reopen cycle %d: %d frames, renderer=%s\n",
+                     i + 1, w.framesDrawn(), w.rendererName().c_str());
+    }
+
+    SpikeWindow window (app, opts);
+    window.show();
+
+    const double cpuBefore = cpuSeconds();
+    const auto wallBefore = std::chrono::steady_clock::now();
+
+    window.beginMeasuring();
+    app.exec (4);
+
+    const double wall = std::chrono::duration<double> (
+        std::chrono::steady_clock::now() - wallBefore).count();
+    const double cpu = cpuSeconds() - cpuBefore;
+
+    auto d = window.deltas();
+    if (d.empty())
+    {
+        std::printf ("[spike] no frames drawn\n");
+        return 1;
+    }
+
+    const double p50 = percentile (d, 0.50);
+    const double p95 = percentile (d, 0.95);
+    const double worst = d.back();
+    double sum = 0.0;
+    for (const double v : d) sum += v;
+
+    std::printf ("[spike] frames=%zu wall=%.2fs mean=%.3fms p50=%.3fms p95=%.3fms worst=%.3fms\n",
+                 d.size(), wall, sum / static_cast<double> (d.size()), p50, p95, worst);
+    std::printf ("[spike] effective fps=%.1f  cpu=%.2fs (%.1f%% of one core)  verts/frame=%d  strips=%d\n",
+                 static_cast<double> (d.size()) / std::max (1.0e-6, wall),
+                 cpu, 100.0 * cpu / std::max (1.0e-6, wall),
+                 window.lastVertices(), opts.strips);
+    std::printf ("[spike] renderer=%s\n", window.rendererName().c_str());
+    std::printf ("[spike] input events: pointer=%d key=%d text=%d\n",
+                 window.pointerEvents, window.keyEvents, window.textEvents);
+
+    int failures = 0;
+    for (const auto& line : window.selftestLog)
+    {
+        std::printf ("[spike] selftest %s\n", line.c_str());
+        if (line.rfind ("FAIL", 0) == 0)
+            ++failures;
+    }
+
+    return failures == 0 ? 0 : 2;
+}

--- a/tools/gui-spike/StripModel.h
+++ b/tools/gui-spike/StripModel.h
@@ -59,7 +59,6 @@ struct StripParams
 
     std::array<std::atomic<bool>, 4> busAssign {};
 
-    std::atomic<bool>  hpfEnabled { false };
     std::atomic<float> hpfFreq { 20.0f };
     std::atomic<float> lpfFreq { 20000.0f };
     std::atomic<bool>  eqEnabled   { true };
@@ -70,24 +69,18 @@ struct StripParams
     std::atomic<float> lfGainDb { 3.0f };  std::atomic<float> lfFreq { 100.0f };
 
     std::atomic<bool>  compEnabled { true };
-    std::atomic<int>   compMode    { 1 };
     std::atomic<float> compFetRatioIndex { 0.0f };
     std::atomic<float> compFetAttack  { 0.2f };
     std::atomic<float> compFetRelease { 400.0f };
     std::atomic<float> compFetOutput  { 0.0f };
     std::atomic<float> compFetThresholdDb { -14.0f };
-    std::atomic<float> compOptoGain { 50.0f };
-    std::atomic<bool>  compOptoLimit { false };
 
-    std::atomic<bool>  auxSendsBypassed { false };
     std::array<std::atomic<float>, 4> auxSendDb { { { -12.0f }, { -100.0f }, { -24.0f }, { -100.0f } } };
     std::array<std::atomic<bool>, 4>  auxSendPreFader {};
 
     // Written by the stub source thread, read by the frame. Same contract as the engine's
     // meter atomics: dBFS, absolute per-block peak, no ballistics on the writer side.
     std::atomic<float> meterInputDb { -100.0f };
-    std::atomic<float> meterInputRDb { -100.0f };
-    std::atomic<float> meterOutLDb { -100.0f };
     std::atomic<float> meterGrDb   { 0.0f };
 
     static constexpr float kAuxSendOffDb = -100.0f;
@@ -143,8 +136,6 @@ public:
                 const float db   = 20.0f * std::log10 (std::max (1.0e-5f, lin));
 
                 params.meterInputDb.store (db, std::memory_order_relaxed);
-                params.meterInputRDb.store (db - 2.5f, std::memory_order_relaxed);
-                params.meterOutLDb.store (db - 1.0f, std::memory_order_relaxed);
 
                 const float over = db - params.compFetThresholdDb.load (std::memory_order_relaxed);
                 params.meterGrDb.store (over > 0.0f ? -over * 0.6f : 0.0f, std::memory_order_relaxed);

--- a/tools/gui-spike/StripModel.h
+++ b/tools/gui-spike/StripModel.h
@@ -1,0 +1,200 @@
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <string>
+#include <thread>
+
+namespace duskspike
+{
+
+// A skewed range with the same shape as the one the strip's sliders use, so a knob
+// sweep in the spike lands on the same value it would land on in the app.
+struct Range
+{
+    float start = 0.0f;
+    float end   = 1.0f;
+    float skew  = 1.0f;
+
+    static Range withMidPoint (float s, float e, float mid) noexcept
+    {
+        Range r { s, e, 1.0f };
+        const float t = (mid - s) / (e - s);
+        if (t > 0.0f && t < 1.0f)
+            r.skew = std::log (0.5f) / std::log (t);
+        return r;
+    }
+
+    float toNorm (float v) const noexcept
+    {
+        const float t = (v - start) / (end - start);
+        const float c = t < 0.0f ? 0.0f : (t > 1.0f ? 1.0f : t);
+        return skew == 1.0f ? c : std::pow (c, skew);
+    }
+
+    float fromNorm (float n) const noexcept
+    {
+        const float c = n < 0.0f ? 0.0f : (n > 1.0f ? 1.0f : n);
+        const float t = skew == 1.0f ? c : std::pow (c, 1.0f / skew);
+        return start + (end - start) * t;
+    }
+};
+
+// The shipping parameters are plain atomics on ChannelStripParams; the spike mirrors the
+// subset the strip draws, at the same ranges and defaults, so the knob feel is comparable.
+struct StripParams
+{
+    std::string name = "KICK IN";
+
+    std::atomic<float> faderDb { 0.0f };
+    std::atomic<float> pan     { 0.0f };
+    std::atomic<bool>  mute    { false };
+    std::atomic<bool>  solo    { false };
+    std::atomic<bool>  phaseInvert { false };
+    std::atomic<bool>  inputMonitor { false };
+    std::atomic<bool>  recordArmed  { true };
+    std::atomic<bool>  printEffects { false };
+
+    std::array<std::atomic<bool>, 4> busAssign {};
+
+    std::atomic<bool>  hpfEnabled { false };
+    std::atomic<float> hpfFreq { 20.0f };
+    std::atomic<float> lpfFreq { 20000.0f };
+    std::atomic<bool>  eqEnabled   { true };
+    std::atomic<bool>  eqBlackMode { false };
+    std::atomic<float> hfGainDb { 2.5f };  std::atomic<float> hfFreq { 8000.0f };
+    std::atomic<float> hmGainDb { -1.5f }; std::atomic<float> hmFreq { 2000.0f }; std::atomic<float> hmQ { 0.7f };
+    std::atomic<float> lmGainDb { 0.0f };  std::atomic<float> lmFreq { 600.0f };  std::atomic<float> lmQ { 1.4f };
+    std::atomic<float> lfGainDb { 3.0f };  std::atomic<float> lfFreq { 100.0f };
+
+    std::atomic<bool>  compEnabled { true };
+    std::atomic<int>   compMode    { 1 };
+    std::atomic<float> compFetRatioIndex { 0.0f };
+    std::atomic<float> compFetAttack  { 0.2f };
+    std::atomic<float> compFetRelease { 400.0f };
+    std::atomic<float> compFetOutput  { 0.0f };
+    std::atomic<float> compFetThresholdDb { -14.0f };
+    std::atomic<float> compOptoGain { 50.0f };
+    std::atomic<bool>  compOptoLimit { false };
+
+    std::atomic<bool>  auxSendsBypassed { false };
+    std::array<std::atomic<float>, 4> auxSendDb { { { -12.0f }, { -100.0f }, { -24.0f }, { -100.0f } } };
+    std::array<std::atomic<bool>, 4>  auxSendPreFader {};
+
+    // Written by the stub source thread, read by the frame. Same contract as the engine's
+    // meter atomics: dBFS, absolute per-block peak, no ballistics on the writer side.
+    std::atomic<float> meterInputDb { -100.0f };
+    std::atomic<float> meterInputRDb { -100.0f };
+    std::atomic<float> meterOutLDb { -100.0f };
+    std::atomic<float> meterGrDb   { 0.0f };
+
+    static constexpr float kAuxSendOffDb = -100.0f;
+
+    static const Range& faderRange()  { static const Range r = Range::withMidPoint (-90.0f, 6.0f, -12.0f); return r; }
+    static const Range& hpfRange()    { static const Range r = Range::withMidPoint (20.0f, 300.0f, 80.0f); return r; }
+    static const Range& lpfRange()    { static const Range r = Range::withMidPoint (3000.0f, 20000.0f, 8000.0f); return r; }
+    static const Range& hfFreqRange() { static const Range r = Range::withMidPoint (1000.0f, 20000.0f, 8000.0f); return r; }
+    static const Range& hmFreqRange() { static const Range r = Range::withMidPoint (600.0f, 13000.0f, 2000.0f); return r; }
+    static const Range& lmFreqRange() { static const Range r = Range::withMidPoint (100.0f, 4000.0f, 600.0f); return r; }
+    static const Range& lfFreqRange() { static const Range r = Range::withMidPoint (20.0f, 400.0f, 100.0f); return r; }
+    static const Range& qRange()      { static const Range r = Range::withMidPoint (0.4f, 4.0f, 1.0f); return r; }
+    static const Range& gainRange()   { static const Range r { -15.0f, 15.0f, 1.0f }; return r; }
+    static const Range& atkRange()    { static const Range r = Range::withMidPoint (0.02f, 80.0f, 0.5f); return r; }
+    static const Range& relRange()    { static const Range r = Range::withMidPoint (50.0f, 1100.0f, 300.0f); return r; }
+    static const Range& makRange()    { static const Range r { -20.0f, 20.0f, 1.0f }; return r; }
+    static const Range& auxRange()    { static const Range r = Range::withMidPoint (-60.0f, 6.0f, -12.0f); return r; }
+    static const Range& panRange()    { static const Range r { -1.0f, 1.0f, 1.0f }; return r; }
+};
+
+// Stands in for the audio thread: a detached 30 Hz writer, which is the rate the UI polls
+// meters at today. Its only job is to make the meters move like real programme material so
+// the frame cost of the meter path is measured rather than guessed.
+class StubMeterSource
+{
+public:
+    explicit StubMeterSource (StripParams& p) : params (p) {}
+
+    ~StubMeterSource() { stop(); }
+
+    void start()
+    {
+        if (running.exchange (true))
+            return;
+
+        thread = std::thread ([this]
+        {
+            using clock = std::chrono::steady_clock;
+            auto next = clock::now();
+            float phase = 0.0f;
+
+            while (running.load (std::memory_order_relaxed))
+            {
+                next += std::chrono::microseconds (33333);
+                phase += 0.0333f;
+
+                // A kick-ish envelope at 100 bpm plus a low bed, so the bar spends time in
+                // all three meter zones and the peak-hold tick has something to hold.
+                const float beat = std::fmod (phase * (100.0f / 60.0f), 1.0f);
+                const float hit  = std::exp (-beat * 9.0f);
+                const float bed  = 0.06f + 0.03f * std::sin (phase * 2.1f);
+                const float lin  = std::min (1.4f, hit * 0.95f + bed);
+                const float db   = 20.0f * std::log10 (std::max (1.0e-5f, lin));
+
+                params.meterInputDb.store (db, std::memory_order_relaxed);
+                params.meterInputRDb.store (db - 2.5f, std::memory_order_relaxed);
+                params.meterOutLDb.store (db - 1.0f, std::memory_order_relaxed);
+
+                const float over = db - params.compFetThresholdDb.load (std::memory_order_relaxed);
+                params.meterGrDb.store (over > 0.0f ? -over * 0.6f : 0.0f, std::memory_order_relaxed);
+
+                std::this_thread::sleep_until (next);
+            }
+        });
+    }
+
+    void stop()
+    {
+        if (running.exchange (false) && thread.joinable())
+            thread.join();
+    }
+
+private:
+    StripParams& params;
+    std::atomic<bool> running { false };
+    std::thread thread;
+};
+
+// The ballistics the shipping strip applies in its 30 Hz timer callback, kept on the UI
+// side and driven per frame so the spike shows the same needle behaviour at 60 Hz.
+struct MeterBallistics
+{
+    float displayed = -100.0f;
+    float peakHold  = -100.0f;
+    int   peakHoldFrames = 0;
+
+    void tick (float incoming, float framesPerUiTick)
+    {
+        const float decay = 1.0f - std::pow (1.0f - 0.15f, 1.0f / framesPerUiTick);
+
+        if (incoming > displayed) displayed = incoming;
+        else                      displayed += (incoming - displayed) * decay;
+
+        if (incoming >= peakHold)
+        {
+            peakHold = incoming;
+            peakHoldFrames = static_cast<int> (18.0f * framesPerUiTick);
+        }
+        else if (peakHoldFrames > 0)
+        {
+            --peakHoldFrames;
+        }
+        else
+        {
+            peakHold = std::max (-100.0f, peakHold - 1.5f / framesPerUiTick);
+        }
+    }
+};
+
+} // namespace duskspike

--- a/tools/gui-spike/StripTheme.h
+++ b/tools/gui-spike/StripTheme.h
@@ -1,0 +1,152 @@
+#pragma once
+
+#include <cstdint>
+
+namespace duskspike
+{
+namespace theme
+{
+
+// ARGB literals lifted from DuskStudioLookAndFeel.h and ChannelStripComponent::paint(),
+// converted to ImGui's ABGR at use through col().
+constexpr std::uint32_t kStripFill      = 0xff1a1a1c;
+constexpr std::uint32_t kStripBorder    = 0xff2a2a2e;
+constexpr std::uint32_t kConsoleBack    = 0xff121214;
+constexpr std::uint32_t kFocusRing      = 0xffd0a050;
+
+constexpr std::uint32_t kEqFill         = 0xff1f231e;
+constexpr std::uint32_t kEqAccent       = 0xff80c090;
+constexpr std::uint32_t kCompFill       = 0xff241f1c;
+constexpr std::uint32_t kCompGold       = 0xffd09060;
+constexpr std::uint32_t kSendFill       = 0xff1f1d24;
+constexpr std::uint32_t kSendPurple     = 0xff9080c0;
+
+constexpr std::uint32_t kHfRed          = 0xffc44444;
+constexpr std::uint32_t kHmGreen        = 0xff5fa55f;
+constexpr std::uint32_t kLmBlue         = 0xff5878b0;
+constexpr std::uint32_t kLfGraphite     = 0xff5a5a62;
+constexpr std::uint32_t kFilterWhite    = 0xffe0e0e4;
+constexpr std::uint32_t kLfGreen        = 0xff5c9a5c;
+constexpr std::uint32_t kPanRed         = 0xffc04040;
+constexpr std::uint32_t kPanCyan        = 0xff70b8c0;
+
+constexpr std::uint32_t kAuxFill[4]     = { 0xff5a8ad0, 0xff9080c0, 0xffe0c050, 0xff60c060 };
+constexpr std::uint32_t kAuxPreOutline  = 0xffffc060;
+constexpr std::uint32_t kKnobOutline    = 0xff404048;
+
+constexpr std::uint32_t kButtonOff      = 0xff202024;
+constexpr std::uint32_t kButtonPanel    = 0xff222226;
+constexpr std::uint32_t kTextDim        = 0xff8e9298;
+constexpr std::uint32_t kTextValue      = 0xffd8d8d8;
+constexpr std::uint32_t kTextBright     = 0xffffffff;
+constexpr std::uint32_t kArmOn          = 0xffd03030;
+constexpr std::uint32_t kArmOffText     = 0xffd06060;
+constexpr std::uint32_t kMuteOn         = 0xffff4500;
+constexpr std::uint32_t kSoloOn         = 0xffcccc00;
+constexpr std::uint32_t kPhaseOn        = 0xff70c0d0;
+constexpr std::uint32_t kPrintOn        = 0xffd09060;
+constexpr std::uint32_t kInsertText     = 0xff9080c0;
+constexpr std::uint32_t kIoText         = 0xffa0a8b8;
+constexpr std::uint32_t kOnText         = 0xff121214;
+
+constexpr std::uint32_t kShellFill      = 0xff202024;
+constexpr std::uint32_t kShellBorder    = 0xff55555c;
+constexpr std::uint32_t kShellDivider   = 0xff4a4a50;
+constexpr std::uint32_t kLedRingDark    = 0xff09090b;
+constexpr std::uint32_t kLedOffFill     = 0xff29292e;
+constexpr std::uint32_t kLedOffRing     = 0xff66666e;
+constexpr std::uint32_t kLabelBypassed  = 0xff77777f;
+
+constexpr std::uint32_t kLedGreen       = 0xff20d040;
+constexpr std::uint32_t kLedYellow      = 0xfff0e020;
+constexpr std::uint32_t kLedRed         = 0xffff2020;
+constexpr std::uint32_t kMeterBack      = 0xff060608;
+constexpr std::uint32_t kMeterBorder    = 0xff2a2a30;
+constexpr std::uint32_t kMeterSegment   = 0xff020203;
+constexpr std::uint32_t kPeakTick       = 0xfff0f0f0;
+constexpr std::uint32_t kPeakTickHot    = 0xffff8080;
+
+constexpr std::uint32_t kTrackFill      = 0xff0a0a0c;
+constexpr std::uint32_t kCapTop         = 0xffe2dccb;
+constexpr std::uint32_t kCapMid         = 0xff9d958a;
+constexpr std::uint32_t kCapBottom      = 0xffb8b0a0;
+constexpr std::uint32_t kCapGroove      = 0xff202018;
+constexpr std::uint32_t kCapRim         = 0xff0a0a0a;
+constexpr std::uint32_t kKnobDot        = 0xffc8c8d2;
+constexpr std::uint32_t kKnobRim        = 0xff0b0b0d;
+
+constexpr std::uint32_t kGrBack         = 0xff141418;
+constexpr std::uint32_t kTrackColour    = 0xffc06848;
+
+} // namespace theme
+
+// Layout constants, all in design pixels at scale 1.0, mirroring
+// ChannelStripComponent::resized() and ConsoleLayout.h.
+namespace layout
+{
+constexpr float kStripWidth      = 188.0f;
+constexpr float kOuterInset      = 4.0f;
+constexpr float kTopPad          = 6.0f;
+constexpr float kNameH           = 20.0f;
+constexpr float kIoButtonH       = 18.0f;
+constexpr float kRowH            = 18.0f;
+
+constexpr float kKnobSize        = 26.0f;
+constexpr float kValueLabelH     = 12.0f;
+constexpr float kKnobBlockH      = kKnobSize + kValueLabelH + 2.0f;
+constexpr float kEqHeaderH       = 16.0f;
+constexpr float kFilterLabelH    = 10.0f;
+constexpr float kEqHpfRowH       = kFilterLabelH + kKnobBlockH;
+constexpr float kFilterBandGap   = 5.0f;
+constexpr float kColumnHeaderH   = 10.0f;
+constexpr float kEqBandRowH      = kKnobBlockH;
+constexpr float kEqBandGap       = 2.0f;
+constexpr float kRowLabelW       = 28.0f;
+constexpr int   kEqBandCount     = 4;
+constexpr float kEqPanelH        = kEqHeaderH + kEqHpfRowH + kFilterBandGap + kColumnHeaderH
+                                   + kEqBandCount * kEqBandRowH + (kEqBandCount - 1) * kEqBandGap;
+
+constexpr float kCompKnobSize    = 24.0f;
+constexpr float kCompKnobBlockH  = kCompKnobSize + kValueLabelH + 2.0f;
+constexpr float kCompKnobLabelH  = 10.0f;
+constexpr float kCompKnobRowH    = kCompKnobLabelH + kCompKnobBlockH;
+constexpr float kCompPanelH      = 16.0f + 2.0f + kCompKnobRowH + 4.0f;
+
+constexpr float kAuxKnobSize     = 24.0f;
+constexpr float kAuxStaggerY     = 10.0f;
+constexpr float kAuxValueH       = 10.0f;
+constexpr float kAuxBlockH       = kAuxStaggerY + kAuxKnobSize + 2.0f + kAuxValueH;
+constexpr float kAuxPanelH       = 3.0f + 11.0f + 1.0f + kAuxBlockH;
+
+constexpr float kPanKnobSize     = 26.0f;
+constexpr float kPanBlockH       = kPanKnobSize + kValueLabelH + 2.0f;
+constexpr float kPanLabelH       = 11.0f;
+constexpr float kPanBlockW       = 56.0f;
+constexpr float kPanFaderGap     = 4.0f;
+
+constexpr float kPeakLabelH      = 18.0f;
+constexpr float kAutoH           = 16.0f;
+constexpr float kMsRowH          = 20.0f;
+
+constexpr float kMeterWidth      = 12.0f;
+constexpr float kBusColumnW      = 18.0f;
+constexpr float kBusButtonH      = 20.0f;
+constexpr float kGrLedW          = 20.0f;
+constexpr float kFaderTrackPad   = 18.0f;
+constexpr float kFaderCapH       = 36.0f;
+constexpr float kFaderCapW       = 20.0f;
+
+// Fixed height above and below the fader column, from the resized() walk.
+constexpr float kAboveFader      = 481.0f;
+constexpr float kBelowFader      = 66.0f;
+constexpr float kMinStripHeight  = 820.0f;
+}
+
+struct FaderTick { float db; const char* label; };
+
+inline constexpr FaderTick kFaderTicks[] = {
+    {   6.0f, "+6" }, {  3.0f, "+3" }, { 0.0f, "0" }, { -3.0f, "3" }, { -6.0f, "6" },
+    { -12.0f, "12" }, { -24.0f, "24" }, { -40.0f, "40" }, { -90.0f, "\xe2\x88\x9e" }
+};
+
+} // namespace duskspike

--- a/tools/gui-spike/headless-compositor.sh
+++ b/tools/gui-spike/headless-compositor.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Private headless Wayland compositor for running the GUI spike, or any future
+# framework-native Dusk surface, without touching the live desktop session.
+#
+# The live session must never host these windows: a crash in a Dusk-owned surface takes
+# the session with it. This starts a mutter of its own with its own runtime directory,
+# its own dbus session and its own Wayland display name, so a client can only reach it
+# by being pointed at it explicitly.
+#
+#   tools/gui-spike/headless-compositor.sh &
+#   XDG_RUNTIME_DIR=/tmp/dusk-headless WAYLAND_DISPLAY=dusk-headless \
+#     env -u DISPLAY ./build-spike/gui-spike/dusk-gui-spike --seconds 10
+#
+# The runtime directory is short on purpose: a wayland socket path cannot exceed 108
+# bytes, which a build or scratch directory easily does.
+set -euo pipefail
+
+RUNTIME_DIR="${DUSK_HEADLESS_RUNTIME_DIR:-/tmp/dusk-headless}"
+DISPLAY_NAME="${DUSK_HEADLESS_DISPLAY:-dusk-headless}"
+MONITOR="${DUSK_HEADLESS_MONITOR:-1920x1080}"
+
+if ! command -v mutter >/dev/null; then
+    echo "mutter is not installed; a nested compositor (weston, cage) would also work" >&2
+    exit 1
+fi
+
+mkdir -p "$RUNTIME_DIR"
+chmod 700 "$RUNTIME_DIR"
+
+export XDG_RUNTIME_DIR="$RUNTIME_DIR"
+unset WAYLAND_DISPLAY DISPLAY DBUS_SESSION_BUS_ADDRESS
+
+exec dbus-run-session -- mutter --headless --no-x11 \
+    --wayland-display="$DISPLAY_NAME" --virtual-monitor "$MONITOR"


### PR DESCRIPTION
Closes #301.

## What

The GUI tower's gate: a working spike, measurements, a framework gap audit, the DAF revision reconciliation, and the execution spec the tower runs on.

- docs/dejuce-gui-plan.md - the deliverable. GO recommendation (conditional on the focus/decoration gaps, the frame-cost ceiling, and the accessibility decision being planned tower work), phases G0-G6 with file ownership and module-unlink order, verification and bench debts per phase.
- tools/gui-spike/ - a non-shipping DAF application shell rendering a faithful channel strip (SSL knob domes, fader, segmented meter, EQ/COMP/AUX panels) in Dear ImGui at 60 Hz, native Wayland, behind DUSKSTUDIO_BUILD_GUI_SPIKE (OFF by default; the shipping build has no spike target). Includes an input selftest and a frame/CPU measurement mode, plus tools/gui-spike/headless-compositor.sh for running any framework-native surface under a private headless mutter instead of the live session.
- Measurements (headless mutter, hardware GL): 60 Hz held at 1/8/24 strips at 4.7%/18.3%/45.6% of one core. The CPU column is the tower's engineering constraint; three reduction levers are specced and G3 is gated on them.
- Gap audit of the DAF Wayland backend against application needs, with file references: worst gaps are window decorations on GNOME (blocks G5, spec recommends client-side decorations) and focus never reaching the ImGui layer (modal blocking inert, Escape dead, sticky keys - fix specced for the framework in G1).
- Framework revision reconciliation: the pinned f9fbc62 branch and DAF main are two independent fix sets with one genuine contradiction (desktop scale sentinel; the branch is correct). A validated three-commit reconciliation (setEmbeddedOffset + Wayland lifecycle fixes + a new DGL_BACKEND=auto|x11|wayland option, because today X11 dev headers silently decide the backend) is prepared locally as dusk/301-reconcile and proposed in the spec - pushing it to dusk-audio/DAF and repinning is G0.
- DAF adoption per the rename: DAF_PATH/DAF_WIDGETS_PATH preferred (DPF spellings resolve through the transition), ../DAF siblings auto-detected first, the CI composite clones dusk-audio/DAF + DAF-Widgets at the unchanged pins, build docs updated, and the spec records that the shared ImGui widget kit's home is DAF-Widgets - shared-dpf/ui migrates across and is not extended. The action's directory name and the workflows' DPF_PATH flags stay for the mechanical rename pass (16 references across 8 workflow files), listed in the spec.
- The dual-spelling configure handling (namespace daf_resources vs dpf_resources, daf__/dpf__add_dgl_opengl3) spans the current pin and the reconciled revision; it retires when the pin moves.

## Verification

- Shipping build: zero new warnings; DUSKSTUDIO_BUILD_GUI_SPIKE=OFF confirmed with no spike references in the generated build; native notepad resolves and builds against the DAF paths.
- ctest 787/787 after rebasing onto the #344 merge; juce-gate passes at 178 files / 9050 uses, unmoved by this PR (the spike is JUCE-free and lives outside src/).
- Spike selftest: 7/8 (the failing case is the modal-blocking defect the spec documents in section 4.1 - a framework fix owned by G1).

## Owed to Marc's bench

Every measurement is headless and seatless: live-desktop frame pacing, real input feel, compositor fractional scaling, GNOME decoration behaviour, the Intel GPU path, and macOS/Windows compiles of the spike. The accessibility decision (AT-SPI bridge vs a documented drop) gates G3.