### PR TITLE
gui: align the app to the reconciled DAF revision (G0)

### DIFF
--- a/.github/actions/clone-dpf-stack/action.yml
+++ b/.github/actions/clone-dpf-stack/action.yml
@@ -13,6 +13,10 @@ description: >
   directory name still say DPF because every workflow names them; they move in
   the mechanical rename pass, not here.
 
+  Both revisions below are the tip of their repository's main. The Wayland
+  lifecycle work that used to live on an unmerged branch is reconciled into
+  that line, so a pin no longer depends on a branch surviving upstream.
+
 runs:
   using: composite
   steps:
@@ -20,9 +24,9 @@ runs:
       shell: bash
       env:
         DAF_REPO: https://github.com/dusk-audio/DAF.git
-        DAF_REV: f9fbc62af6fa7ce638a6f1e1482896c385a4955e
+        DAF_REV: 92c3d1a75450e8b8eaf963efe875f5742c7a1c84
         DAF_WIDGETS_REPO: https://github.com/dusk-audio/DAF-Widgets.git
-        DAF_WIDGETS_REV: 668de17f06abdeb98d5a4b62594bd634f8d1ac2e
+        DAF_WIDGETS_REV: 77daa2256582ef5e707b6fa8ca27bb757afd8de0
       run: |
         set -euo pipefail
         git init -q "${RUNNER_TEMP}/DPF"

--- a/.github/actions/clone-dpf-stack/action.yml
+++ b/.github/actions/clone-dpf-stack/action.yml
@@ -13,9 +13,11 @@ description: >
   directory name still say DPF because every workflow names them; they move in
   the mechanical rename pass, not here.
 
-  Both revisions below are the tip of their repository's main. The Wayland
-  lifecycle work that used to live on an unmerged branch is reconciled into
-  that line, so a pin no longer depends on a branch surviving upstream.
+  Both revisions below are the tip of their repository's main, so neither one
+  depends on a branch surviving upstream. The pugl submodule DAF carries still
+  does: its recorded revision sits on a branch in dusk-audio/pugl rather than
+  on that repository's main, and deleting the branch would strand the submodule
+  step below for every clone, this one included.
 
 runs:
   using: composite

--- a/BUILDING-LINUX.md
+++ b/BUILDING-LINUX.md
@@ -110,15 +110,26 @@ The session notepad is Dusk Studio's first native UI window: DAF/DGL for the Ope
 ```bash
 cd ~/projects
 git clone https://github.com/dusk-audio/DAF.git
-git -C DAF checkout f9fbc62af6fa7ce638a6f1e1482896c385a4955e
+git -C DAF checkout 92c3d1a75450e8b8eaf963efe875f5742c7a1c84
 git -C DAF submodule update --init
 git clone https://github.com/dusk-audio/DAF-Widgets.git
-git -C DAF-Widgets checkout 668de17f06abdeb98d5a4b62594bd634f8d1ac2e
+git -C DAF-Widgets checkout 77daa2256582ef5e707b6fa8ca27bb757afd8de0
 ```
 
-Clone then check out the SHA, rather than cloning a branch: DAF's pin is the tip of `fix/wayland-review-findings`, which was never merged to that fork's `main`. (DAF-Widgets' pin happens to be its `main` tip today, but pin it the same way.) Neither branch may be deleted upstream — a plain clone would stop reaching the commit, and CI fetches the same SHAs. Both checkouts end up on a detached HEAD, which is what you want here. The submodule step is not optional either: DGL pulls its windowing layer from `dgl/src/pugl-upstream`.
+Clone then check out the SHA, rather than building whatever `main` points at today: both pins are on their fork's `main`, but a branch tip moves and CI fetches these exact SHAs. Both checkouts end up on a detached HEAD, which is what you want here. The submodule step is not optional either: DGL pulls its windowing layer from `dgl/src/pugl-upstream`.
 
 The pins live in [.github/actions/clone-dpf-stack/action.yml](.github/actions/clone-dpf-stack/action.yml), which is the single source of truth for every workflow — read them from there if it ever disagrees with the commands above.
+
+#### Windowing backend
+
+DGL picks X11 or Wayland at configure time, and `-DDGL_BACKEND=` decides which: `auto` (the default) takes X11 whenever the X11 development files are installed and Wayland only when they are absent, `x11` and `wayland` ask for one and fail the configure if its development files are missing. Because one `dgl-opengl3` target serves every consumer in the tree, this is a property of the whole build directory: it is X11 or Wayland, not both.
+
+Leave it at `auto` for the app. The notepad is a native child window placed inside the JUCE main window, and Wayland has no window embedding — a `-DDGL_BACKEND=wayland` build of the app therefore refuses to open the notepad, reporting *Unable to embed session notepad with the current display backend*. The flag is there for the GUI tower's own build directories, which run standalone framework windows on a real Wayland session:
+
+```bash
+cmake -S . -B build-spike -G Ninja -DCMAKE_BUILD_TYPE=Release \
+  -DDUSKSTUDIO_BUILD_GUI_SPIKE=ON -DDGL_BACKEND=wayland
+```
 
 Missing either checkout, `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` defaults to **OFF** and configure says so once, quietly:
 

--- a/BUILDING-LINUX.md
+++ b/BUILDING-LINUX.md
@@ -120,17 +120,6 @@ Clone then check out the SHA, rather than building whatever `main` points at tod
 
 The pins live in [.github/actions/clone-dpf-stack/action.yml](.github/actions/clone-dpf-stack/action.yml), which is the single source of truth for every workflow — read them from there if it ever disagrees with the commands above.
 
-#### Windowing backend
-
-DGL picks X11 or Wayland at configure time, and `-DDGL_BACKEND=` decides which: `auto` (the default) takes X11 whenever the X11 development files are installed and Wayland only when they are absent, `x11` and `wayland` ask for one and fail the configure if its development files are missing. Because one `dgl-opengl3` target serves every consumer in the tree, this is a property of the whole build directory: it is X11 or Wayland, not both.
-
-Leave it at `auto` for the app. The notepad is a native child window placed inside the JUCE main window, and Wayland has no window embedding — a `-DDGL_BACKEND=wayland` build of the app therefore refuses to open the notepad, reporting *Unable to embed session notepad with the current display backend*. The flag is there for the GUI tower's own build directories, which run standalone framework windows on a real Wayland session:
-
-```bash
-cmake -S . -B build-spike -G Ninja -DCMAKE_BUILD_TYPE=Release \
-  -DDUSKSTUDIO_BUILD_GUI_SPIKE=ON -DDGL_BACKEND=wayland
-```
-
 Missing either checkout, `DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD` defaults to **OFF** and configure says so once, quietly:
 
 ```

--- a/BUILDING-LINUX.md
+++ b/BUILDING-LINUX.md
@@ -116,7 +116,7 @@ git clone https://github.com/dusk-audio/DAF-Widgets.git
 git -C DAF-Widgets checkout 77daa2256582ef5e707b6fa8ca27bb757afd8de0
 ```
 
-Clone then check out the SHA, rather than building whatever `main` points at today: both pins are on their fork's `main`, but a branch tip moves and CI fetches these exact SHAs. Both checkouts end up on a detached HEAD, which is what you want here. The submodule step is not optional either: DGL pulls its windowing layer from `dgl/src/pugl-upstream`.
+Clone then check out the SHA, rather than building whatever `main` points at today: both pins are on their fork's `main`, but a branch tip moves and CI fetches these exact SHAs. Both checkouts end up on a detached HEAD, which is what you want here. The submodule step is not optional either: DGL pulls its windowing layer from `dgl/src/pugl-upstream`. That submodule's recorded revision does still depend on a branch surviving in `dusk-audio/pugl`, unlike the two pins above: it is not on that repository's `main`.
 
 The pins live in [.github/actions/clone-dpf-stack/action.yml](.github/actions/clone-dpf-stack/action.yml), which is the single source of truth for every workflow — read them from there if it ever disagrees with the commands above.
 

--- a/BUILDING-LINUX.md
+++ b/BUILDING-LINUX.md
@@ -146,6 +146,17 @@ cmake -S . -B build-linux -G Ninja -DCMAKE_BUILD_TYPE=Release \
   -DDUSKSTUDIO_ENABLE_NATIVE_NOTEPAD=ON
 ```
 
+#### Windowing backend
+
+DGL picks X11 or Wayland at configure time, and `-DDGL_BACKEND=` decides which: `auto` (the default) takes X11 whenever the X11 development files are installed and Wayland only when they are absent, `x11` and `wayland` ask for one and fail the configure if its development files are missing. Because one `dgl-opengl3` target serves every consumer in the tree, this is a property of the whole build directory: it is X11 or Wayland, not both.
+
+Leave it at `auto` for the app. The notepad is a native child window placed inside the JUCE main window, and Wayland has no window embedding — a `-DDGL_BACKEND=wayland` build of the app therefore refuses to open the notepad, reporting *Unable to embed session notepad with the current display backend*. The flag is there for the GUI tower's own build directories, which run standalone framework windows on a real Wayland session:
+
+```bash
+cmake -S . -B build-spike -G Ninja -DCMAKE_BUILD_TYPE=Release \
+  -DDUSKSTUDIO_BUILD_GUI_SPIKE=ON -DDGL_BACKEND=wayland
+```
+
 ## Configure + build
 
 From the Dusk Studio directory:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,30 +497,11 @@ if(DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD)
     message(STATUS "Using DAF from: ${DUSKSTUDIO_DAF_SOURCE_DIR}")
     message(STATUS "Using DAF-Widgets from: ${DUSKSTUDIO_DAF_WIDGETS_SOURCE_DIR}")
 
-    # The namespace holding DGL's built-in font moved with the fork's DPF -> DAF rename.
-    # Read the spelling out of the checkout instead of guessing it from the path.
-    file(READ "${DUSKSTUDIO_DAF_SOURCE_DIR}/dgl/src/Resources.hpp" DUSKSTUDIO_DGL_RESOURCES_HPP)
-    if(DUSKSTUDIO_DGL_RESOURCES_HPP MATCHES "namespace[ \t]+daf_resources")
-        set(DUSKSTUDIO_DGL_RESOURCES_NS daf_resources)
-    else()
-        set(DUSKSTUDIO_DGL_RESOURCES_NS dpf_resources)
-    endif()
-    unset(DUSKSTUDIO_DGL_RESOURCES_HPP)
-
-    # The fork renamed its public surface from DPF to DAF (Dusk Audio Framework);
-    # the option names and the DGL helper function moved with it. Set and call
-    # both spellings so a checkout from either side of that rename configures.
-    set(DPF_LIBRARIES OFF CACHE BOOL "Build DPF's complete library set" FORCE)
-    set(DPF_EXAMPLES OFF CACHE BOOL "Build DPF examples" FORCE)
     set(DAF_LIBRARIES OFF CACHE BOOL "Build DAF's complete library set" FORCE)
     set(DAF_EXAMPLES OFF CACHE BOOL "Build DAF examples" FORCE)
     add_subdirectory("${DUSKSTUDIO_DAF_SOURCE_DIR}"
                      "${CMAKE_CURRENT_BINARY_DIR}/DAF" EXCLUDE_FROM_ALL)
-    if(COMMAND daf__add_dgl_opengl3)
-        daf__add_dgl_opengl3(TRUE FALSE FALSE)
-    else()
-        dpf__add_dgl_opengl3(TRUE FALSE FALSE)
-    endif()
+    daf__add_dgl_opengl3(TRUE FALSE FALSE)
     target_compile_options(dgl-opengl3 PRIVATE
         $<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-cpp;-Wno-stringop-overflow>
         $<$<COMPILE_LANG_AND_ID:CXX,Clang,AppleClang>:-Wno-cpp>)
@@ -534,8 +515,6 @@ if(DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD)
         "${DUSKSTUDIO_DAF_WIDGETS_SOURCE_DIR}/opengl/DearImGui.cpp")
     target_include_directories(dusk_notepad_ui PRIVATE
         "${DUSKSTUDIO_DAF_WIDGETS_SOURCE_DIR}/opengl")
-    target_compile_definitions(dusk_notepad_ui PRIVATE
-        DUSKSTUDIO_DGL_RESOURCES=${DUSKSTUDIO_DGL_RESOURCES_NS})
 
     if(MSVC)
         # Windows' GL header and opengl32 stop at OpenGL 1.1, and DAF-Widgets hands Dear
@@ -574,8 +553,6 @@ if(DUSKSTUDIO_ENABLE_NATIVE_NOTEPAD)
             "${DUSKSTUDIO_DAF_WIDGETS_SOURCE_DIR}/opengl/DearImGui.cpp")
         target_include_directories(dusk-gui-spike PRIVATE
             "${DUSKSTUDIO_DAF_WIDGETS_SOURCE_DIR}/opengl")
-        target_compile_definitions(dusk-gui-spike PRIVATE
-            DUSKSTUDIO_DGL_RESOURCES=${DUSKSTUDIO_DGL_RESOURCES_NS})
         if(MSVC)
             # Same GL 3.x loader the notepad needs, for the same reason: DAF-Widgets hands
             # Dear ImGui a custom loader that only carries those prototypes off Windows.

--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -269,14 +269,14 @@ pffft (FFT backend behind dusk::audio::Fft — spectrum analyser, DP alignment)
              FFTPACKv5 license text applies and is reproduced in full at the
              top of external/pffft/pffft.h.
 
-DPF / DGL (DISTRHO Plugin Framework graphics layer — backs the native notepad UI)
-  Version  : dusk-audio/DPF rev f9fbc62af6fa7ce638a6f1e1482896c385a4955e
-             (CI pin DPF_REV in .github/actions/clone-dpf-stack/action.yml)
+DAF / DGL (Dusk Audio Framework graphics layer — backs the native notepad UI)
+  Version  : dusk-audio/DAF rev 92c3d1a75450e8b8eaf963efe875f5742c7a1c84
+             (CI pin DAF_REV in .github/actions/clone-dpf-stack/action.yml)
   License  : ISC — Copyright (C) 2012-2025 Filipe Coelho <falktx@falktx.com>
-             (DPF/LICENSE)
-  Path     : not in tree — sibling checkout ../DPF, -DDPF_PATH=..., or
-             external/DPF. Only the DGL OpenGL3 subset is built
-             (dpf__add_dgl_opengl3); the resulting dgl-opengl3 static library
+             (DAF/LICENSE)
+  Path     : not in tree — sibling checkout ../DAF, -DDAF_PATH=..., or
+             external/DAF. Only the DGL OpenGL3 subset is built
+             (daf__add_dgl_opengl3); the resulting dgl-opengl3 static library
              is linked into the Dusk Studio binary. No plugin wrappers, no
              examples.
   Upstream : https://github.com/DISTRHO/DPF
@@ -289,13 +289,14 @@ DPF / DGL (DISTRHO Plugin Framework graphics layer — backs the native notepad 
                                Loftis / Harrison Consoles 2011-2012 and Robin
                                Gareus 2013 under the same ISC terms;
                                submodule dusk-audio/pugl rev
-                               5e2621d714ddf1cb0f86e852f8ba5dffe04aa3a3)
-                               On Linux without X11, dpf__add_dgl_opengl3
-                               selects DPF's vendored Wayland path instead.
-                               Its 12 Wayland-specific source/header files
+                               43d8e349c7ca7c4d76778a8c48b73226105bed14)
+                               On Linux without X11, or with
+                               -DDGL_BACKEND=wayland, daf__add_dgl_opengl3
+                               selects DAF's vendored Wayland path instead.
+                               Its 14 Wayland-specific source/header files
                                carry three additional ISC notice variants
-                               (David Robillard and DPF contributors) and four
-                               MIT protocol notice variants; all seven are
+                               (David Robillard and DAF contributors) and five
+                               MIT protocol notice variants; all eight are
                                reproduced below. The OpenGL3 target compiles
                                wayland_gl.c, not the unused wayland_cairo.c.
                - NanoVG        zlib  dgl/src/nanovg/LICENSE.txt
@@ -322,21 +323,21 @@ DPF / DGL (DISTRHO Plugin Framework graphics layer — backs the native notepad 
                                2013-2026 and 2008-2018 respectively; on the
                                include path for MSVC builds only)
 
-DPF-Widgets (DGL / Dear ImGui bridge — the notepad's immediate-mode UI layer)
-  Version  : dusk-audio/DPF-Widgets rev 668de17f06abdeb98d5a4b62594bd634f8d1ac2e
-             (CI pin DPF_WIDGETS_REV in .github/actions/clone-dpf-stack/action.yml)
+DAF-Widgets (DGL / Dear ImGui bridge — the notepad's immediate-mode UI layer)
+  Version  : dusk-audio/DAF-Widgets rev 77daa2256582ef5e707b6fa8ca27bb757afd8de0
+             (CI pin DAF_WIDGETS_REV in .github/actions/clone-dpf-stack/action.yml)
   License  : ISC — Copyright (C) 2012-2021 Filipe Coelho <falktx@falktx.com>
-             (DPF-Widgets/LICENSE)
-  Path     : not in tree — sibling checkout ../DPF-Widgets,
-             -DDPF_WIDGETS_PATH=..., or external/DPF-Widgets;
+             (DAF-Widgets/LICENSE)
+  Path     : not in tree — sibling checkout ../DAF-Widgets,
+             -DDAF_WIDGETS_PATH=..., or external/DAF-Widgets;
              opengl/DearImGui.cpp compiles into the dusk_notepad_ui library.
   Upstream : https://github.com/DISTRHO/DPF-Widgets
 
 Dear ImGui (immediate-mode GUI — notepad editor, toolbar, chord charts)
   Version  : 1.91.9b (IMGUI_VERSION in opengl/DearImGui/imgui.h)
   License  : MIT — Copyright (c) 2014-2025 Omar Cornut
-             (DPF-Widgets/opengl/DearImGui/LICENSE.txt)
-  Path     : vendored inside DPF-Widgets at opengl/DearImGui/; pulled into the
+             (DAF-Widgets/opengl/DearImGui/LICENSE.txt)
+  Path     : vendored inside DAF-Widgets at opengl/DearImGui/; pulled into the
              build as one translation unit by that repo's DearImGui.cpp.
   Upstream : https://github.com/ocornut/imgui
   Notes    : DearImGui.cpp also #includes three further projects into the same
@@ -350,7 +351,7 @@ Dear ImGui (immediate-mode GUI — notepad editor, toolbar, chord charts)
                                https://cmd.wtf)
                - ProggyClean.ttf  MIT  (Copyright (c) 2004, 2005 Tristan
                                Grimmer; notice at
-                               opengl/DearImGui/imgui_draw.cpp). DPF hands the
+                               opengl/DearImGui/imgui_draw.cpp). DAF hands the
                                notepad DejaVu Sans, but
                                IMGUI_DISABLE_DEFAULT_FONT stays commented out
                                in opengl/DearImGui/imconfig.h, so the
@@ -569,7 +570,7 @@ System shared libraries (Linux builds — linked dynamically, never bundled)
              audio backend, ALSA the fallback backend and the MIDI transport,
              X11 the plugin-editor embedding host, and GL the renderer the
              native notepad UI draws through. Three more arrive indirectly:
-             DPF's dgl-system-libs adds libdbus-1 when pkg-config finds it, and
+             DAF's dgl-system-libs adds libdbus-1 when pkg-config finds it, and
              JUCE's juce_graphics module declares freetype2 and fontconfig as
              Linux packages, so both land on the link line without either name
              appearing in this repo's CMakeLists.txt.
@@ -3787,8 +3788,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
 SOFTWARE.
 
 --------------------------------------------------------------------------------
-DPF / DGL — ISC
-LICENSE at dusk-audio/DPF rev f9fbc62af6fa7ce638a6f1e1482896c385a4955e
+DAF / DGL — ISC
+LICENSE at dusk-audio/DAF rev 92c3d1a75450e8b8eaf963efe875f5742c7a1c84
 --------------------------------------------------------------------------------
 
 Copyright (C) 2012-2025 Filipe Coelho <falktx@falktx.com>
@@ -3807,9 +3808,9 @@ PERFORMANCE OF THIS SOFTWARE.
 
 --------------------------------------------------------------------------------
 pugl — ISC
-dgl/src/pugl-upstream/COPYING at dusk-audio/DPF rev
-f9fbc62af6fa7ce638a6f1e1482896c385a4955e, pugl submodule rev
-5e2621d714ddf1cb0f86e852f8ba5dffe04aa3a3
+dgl/src/pugl-upstream/COPYING at dusk-audio/DAF rev
+92c3d1a75450e8b8eaf963efe875f5742c7a1c84, pugl submodule rev
+43d8e349c7ca7c4d76778a8c48b73226105bed14
 --------------------------------------------------------------------------------
 
 Copyright 2011-2022 David Robillard <d@drobilla.net>
@@ -3826,9 +3827,9 @@ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-DPF's dgl/src/pugl.cpp compiles common.c and internal.c, then the OpenGL and
+DAF's dgl/src/pugl.cpp compiles common.c and internal.c, then the OpenGL and
 stub source for the selected Linux, macOS, or Windows backend. Recursing their
-headers at pugl rev 5e2621d714ddf1cb0f86e852f8ba5dffe04aa3a3
+headers at pugl rev 43d8e349c7ca7c4d76778a8c48b73226105bed14
 produces the distinct source notices below. Every block ends with
 `SPDX-License-Identifier: ISC` and therefore uses the complete ISC permission
 and disclaimer immediately above.
@@ -3871,36 +3872,37 @@ win.c:
 Copyright 2012-2023 David Robillard <d@drobilla.net>
 
 --------------------------------------------------------------------------------
-DPF no-X11 Wayland OpenGL3 backend — ISC and MIT notices
-dgl/src/pugl.cpp HAVE_WAYLAND branch at dusk-audio/DPF rev
-f9fbc62af6fa7ce638a6f1e1482896c385a4955e
+DAF no-X11 Wayland OpenGL3 backend — ISC and MIT notices
+dgl/src/pugl.cpp HAVE_WAYLAND branch at dusk-audio/DAF rev
+92c3d1a75450e8b8eaf963efe875f5742c7a1c84
 --------------------------------------------------------------------------------
 
-dpf__add_dgl_opengl3 defines DGL_OPENGL, so a supported Linux build without
-X11 compiles wayland.c, wayland.h, wayland_stub.c and wayland_gl.c, but not
-wayland_cairo.c. pugl.cpp also directly includes all four generated protocol C
-files and their four client headers. These 12 Wayland-specific files carry
-exactly seven distinct notices: the three ISC source notices and four MIT
-protocol notices below. Each protocol C/header pair has byte-identical notice
-text after removal of its generated comment-container markers; both explicit
-paths are recorded with every block.
+daf__add_dgl_opengl3 defines DGL_OPENGL, so a supported Linux build without
+X11, or one configured with -DDGL_BACKEND=wayland, compiles wayland.c,
+wayland.h, wayland_stub.c and wayland_gl.c, but not wayland_cairo.c. pugl.cpp
+also directly includes all five generated protocol C files and their five
+client headers. These 14 Wayland-specific files carry exactly eight distinct
+notices: the three ISC source notices and five MIT protocol notices below.
+Each protocol C/header pair has byte-identical notice text after removal of
+its generated comment-container markers; both explicit paths are recorded
+with every block.
 
 dgl/src/pugl-extra/wayland.c and dgl/src/pugl-extra/wayland.h:
 
 Copyright 2012-2023 David Robillard <d@drobilla.net>
-Copyright 2025 DISTRHO Plugin Framework contributors
+Copyright 2025 Dusk Audio Framework contributors
 SPDX-License-Identifier: ISC
 
 dgl/src/pugl-extra/wayland_stub.c:
 
 Copyright 2012-2021 David Robillard <d@drobilla.net>
-Copyright 2025 DISTRHO Plugin Framework contributors
+Copyright 2025 Dusk Audio Framework contributors
 SPDX-License-Identifier: ISC
 
 dgl/src/pugl-extra/wayland_gl.c:
 
 Copyright 2012-2022 David Robillard <d@drobilla.net>
-Copyright 2025 DISTRHO Plugin Framework contributors
+Copyright 2025 Dusk Audio Framework contributors
 SPDX-License-Identifier: ISC
 
 The complete ISC permission and disclaimer for each of those three SPDX
@@ -4007,10 +4009,34 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
+dgl/src/pugl-extra/wayland-protocols/xdg-foreign-unstable-v2-protocol.c and
+dgl/src/pugl-extra/wayland-protocols/xdg-foreign-unstable-v2-client-protocol.h:
+
+Copyright © 2015-2016 Red Hat Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice (including the next
+paragraph) shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
 --------------------------------------------------------------------------------
 NanoVG — zlib license
-dgl/src/nanovg/LICENSE.txt at dusk-audio/DPF rev
-f9fbc62af6fa7ce638a6f1e1482896c385a4955e
+dgl/src/nanovg/LICENSE.txt at dusk-audio/DAF rev
+92c3d1a75450e8b8eaf963efe875f5742c7a1c84
 --------------------------------------------------------------------------------
 
 Copyright (c) 2013 Mikko Mononen memon@inside.org
@@ -4033,8 +4059,8 @@ misrepresented as being the original software.
 
 --------------------------------------------------------------------------------
 fontstash — zlib license
-Notice at the head of dgl/src/nanovg/fontstash.h at dusk-audio/DPF rev
-f9fbc62af6fa7ce638a6f1e1482896c385a4955e
+Notice at the head of dgl/src/nanovg/fontstash.h at dusk-audio/DAF rev
+92c3d1a75450e8b8eaf963efe875f5742c7a1c84
 --------------------------------------------------------------------------------
 
 Copyright (c) 2009-2013 Mikko Mononen memon@inside.org
@@ -4055,8 +4081,8 @@ freely, subject to the following restrictions:
 
 --------------------------------------------------------------------------------
 fontstash embedded UTF-8 decoder — MIT
-Notice at dgl/src/nanovg/fontstash.h:509-510 at dusk-audio/DPF rev
-f9fbc62af6fa7ce638a6f1e1482896c385a4955e. NanoVG.cpp compiles nanovg.c,
+Notice at dgl/src/nanovg/fontstash.h:509-510 at dusk-audio/DAF rev
+92c3d1a75450e8b8eaf963efe875f5742c7a1c84. NanoVG.cpp compiles nanovg.c,
 which includes fontstash.h. The compiled 2010 decoder variation carries these
 exact source lines:
 
@@ -4089,8 +4115,8 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 stb_truetype — MIT / public domain dual license
-Notice at the foot of dgl/src/nanovg/stb_truetype.h at dusk-audio/DPF rev
-f9fbc62af6fa7ce638a6f1e1482896c385a4955e
+Notice at the foot of dgl/src/nanovg/stb_truetype.h at dusk-audio/DAF rev
+92c3d1a75450e8b8eaf963efe875f5742c7a1c84
 --------------------------------------------------------------------------------
 
 ------------------------------------------------------------------------------
@@ -4135,8 +4161,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------------------
 stb_image — public-domain dedication and fallback permission
-License notice in dgl/src/nanovg/stb_image.h at dusk-audio/DPF rev
-f9fbc62af6fa7ce638a6f1e1482896c385a4955e
+License notice in dgl/src/nanovg/stb_image.h at dusk-audio/DAF rev
+92c3d1a75450e8b8eaf963efe875f5742c7a1c84
 --------------------------------------------------------------------------------
 
 This software is in the public domain. Where that dedication is not
@@ -4145,8 +4171,8 @@ distribute, and modify this file as you see fit.
 
 --------------------------------------------------------------------------------
 DejaVu Sans — Bitstream Vera Fonts License and Arev Fonts License
-dgl/src/resources/LICENSE-DejaVuSans.ttf.txt at dusk-audio/DPF rev
-f9fbc62af6fa7ce638a6f1e1482896c385a4955e
+dgl/src/resources/LICENSE-DejaVuSans.ttf.txt at dusk-audio/DAF rev
+92c3d1a75450e8b8eaf963efe875f5742c7a1c84
 --------------------------------------------------------------------------------
 
 Fonts are (c) Bitstream (see below). DejaVu changes are in public domain.
@@ -4250,7 +4276,7 @@ from Tavmjong Bah. For further information, contact: tavmjong @ free
 --------------------------------------------------------------------------------
 Khronos GL headers — MIT notices
 dgl/src/khronos/GL/glext.h and dgl/src/khronos/KHR/khrplatform.h at
-dusk-audio/DPF rev f9fbc62af6fa7ce638a6f1e1482896c385a4955e
+dusk-audio/DAF rev 92c3d1a75450e8b8eaf963efe875f5742c7a1c84
 --------------------------------------------------------------------------------
 
 glext.h carries this exact notice:
@@ -4282,9 +4308,9 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 
 --------------------------------------------------------------------------------
-DPF-Widgets — ISC
-LICENSE at dusk-audio/DPF-Widgets rev
-668de17f06abdeb98d5a4b62594bd634f8d1ac2e
+DAF-Widgets — ISC
+LICENSE at dusk-audio/DAF-Widgets rev
+77daa2256582ef5e707b6fa8ca27bb757afd8de0
 --------------------------------------------------------------------------------
 
 DISTRHO Plugin Framework (DPF)
@@ -4303,7 +4329,7 @@ CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 opengl/DearImGui.cpp carries this distinct complete source notice:
 
-Dear ImGui for DPF
+Dear ImGui for DAF
 Copyright (C) 2021 Jean Pierre Cimalando <jp-dev@inbox.ru>
 Copyright (C) 2021-2025 Filipe Coelho <falktx@falktx.com>
 
@@ -4321,7 +4347,7 @@ CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 The included opengl/DearImGui.hpp carries the same complete notice with the
 earlier Filipe Coelho range:
 
-Dear ImGui for DPF
+Dear ImGui for DAF
 Copyright (C) 2021 Jean Pierre Cimalando <jp-dev@inbox.ru>
 Copyright (C) 2021-2024 Filipe Coelho <falktx@falktx.com>
 
@@ -4338,8 +4364,8 @@ CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 --------------------------------------------------------------------------------
 Dear ImGui 1.91.9b — MIT
-opengl/DearImGui/LICENSE.txt at dusk-audio/DPF-Widgets rev
-668de17f06abdeb98d5a4b62594bd634f8d1ac2e
+opengl/DearImGui/LICENSE.txt at dusk-audio/DAF-Widgets rev
+77daa2256582ef5e707b6fa8ca27bb757afd8de0
 --------------------------------------------------------------------------------
 
 The MIT License (MIT)
@@ -4366,8 +4392,8 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 imgui-knobs — MIT
-opengl/DearImGuiKnobs/LICENSE at dusk-audio/DPF-Widgets rev
-668de17f06abdeb98d5a4b62594bd634f8d1ac2e
+opengl/DearImGuiKnobs/LICENSE at dusk-audio/DAF-Widgets rev
+77daa2256582ef5e707b6fa8ca27bb757afd8de0
 --------------------------------------------------------------------------------
 
 MIT License
@@ -4394,8 +4420,8 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 imgui_toggle — ISC-style permission grant
-opengl/DearImGuiToggle/LICENSE at dusk-audio/DPF-Widgets rev
-668de17f06abdeb98d5a4b62594bd634f8d1ac2e
+opengl/DearImGuiToggle/LICENSE at dusk-audio/DAF-Widgets rev
+77daa2256582ef5e707b6fa8ca27bb757afd8de0
 --------------------------------------------------------------------------------
 
 Copyright © 2022 nitz — chris marc dailey https://cmd.wtf
@@ -4418,7 +4444,7 @@ LICENSE at bluescan/proggyfonts rev
 stream expands to 41,208 bytes. Its Adler-32 is 0x48f962f7 and its SHA-256 is
 527d2a443ce051f93f7e77b855609722b8cb220a9f104b4aa037be5c90b71324; all three
 values match that revision's ProggyClean.ttf byte for byte at
-dusk-audio/DPF-Widgets rev 668de17f06abdeb98d5a4b62594bd634f8d1ac2e.
+dusk-audio/DAF-Widgets rev 77daa2256582ef5e707b6fa8ca27bb757afd8de0.
 --------------------------------------------------------------------------------
 
 MIT License

--- a/docs/dejuce-gui-plan.md
+++ b/docs/dejuce-gui-plan.md
@@ -50,9 +50,11 @@ Dusk plug-ins follow. Both descend from `a9b033c2`.
 | Pinned branch `f9fbc62a` | 3 | `Window::setEmbeddedOffset`, the Wayland lifecycle and scaling fixes, the pugl mirror pointer |
 | `main` | 31 | The DPF to DAF rename, a second round of Wayland lifetime fixes, AU and CLAP fixes, CI hardening, the pugl mirror pointer |
 
-The pugl submodule is pinned to `5e2621d7` on **both** sides, so the Wayland
-backend's own history is not divergent. All divergence is in the framework
-repository itself.
+Before the reconciliation the pugl submodule was pinned to `5e2621d7` on
+**both** sides, so the Wayland backend's own history was not divergent; all
+divergence was in the framework repository itself. (`43d8e349`, the landed pin
+recorded in §1, is where the `dusk/302-app-contract` work later moved the
+submodule.)
 
 **Nothing on the pinned branch is superseded by main, and nothing on main is
 superseded by the branch.** They are two independent rounds of work on the same

--- a/docs/dejuce-gui-plan.md
+++ b/docs/dejuce-gui-plan.md
@@ -29,11 +29,20 @@ accessibility bridge in §3. None of them is a research problem.
 
 ## 1. Framework revision reconciliation
 
+**Landed.** The framework side is merged and the app is on it: `dusk-audio/DAF`
+`main` is `92c3d1a7` — the reconciled Wayland revision plus the
+application-contract fixes — with its pugl submodule at `43d8e349`, and
+`dusk-audio/DAF-Widgets` `main` is `77daa22`. G0 moved `DAF_REV` and
+`DAF_WIDGETS_REV` onto both. One action is left and it is Marc's: **delete the
+branch `fix/wayland-review-findings` in `dusk-audio/DAF`**, so no third line can
+accumulate. The rest of this section is the record of what was reconciled and
+why.
+
 ### 1.1 Where the two lines stand
 
-The app pins `DAF_REV=f9fbc62a` (`.github/actions/clone-dpf-stack/action.yml`),
-which is the tip of the framework branch `fix/wayland-review-findings`. That
-commit is **not** an ancestor of the framework's `main`, which is the line the
+The app pinned `DAF_REV=f9fbc62a` (`.github/actions/clone-dpf-stack/action.yml`),
+the tip of the framework branch `fix/wayland-review-findings`. That commit is
+**not** an ancestor of the framework's `main`, which is the line the
 Dusk plug-ins follow. Both descend from `a9b033c2`.
 
 | | Commits since `a9b033c2` | Carries |
@@ -68,10 +77,9 @@ window to scale 1 for its whole life and the matching `onPuglConfigure` hook
 that propagates a live scale change never runs. Main is missing both halves of
 that mechanism.
 
-### 1.2 The proposed reconciled revision
+### 1.2 The reconciled revision
 
-Prepared and validated locally; the push and merge are Marc's. Three commits on
-top of `main`:
+Merged as three commits on top of `main`:
 
 1. Cherry-pick `f9fbc62a` (`setEmbeddedOffset`). Applies cleanly except for the
    two `DISTRHO_SAFE_ASSERT_RETURN` uses, which become `DAF_SAFE_ASSERT_RETURN`.
@@ -91,17 +99,15 @@ top of `main`:
      explains why.
 3. A new commit adding `DGL_BACKEND` (§1.4).
 
-Validated on this box: `dusk_notepad_ui` and the whole `DuskStudio` target build
-clean against the result, and the spike runs on it. The prepared branch is
-`dusk/301-reconcile` in the framework clone at `/home/marc/projects/DAF`; it has
-never been pushed, so it has to be recreated or transplanted before the PR.
+`dusk_notepad_ui` and the whole `DuskStudio` target build clean against the
+result, and the spike runs on it.
 
-Stacked on top of it is `dusk/302-app-contract`, four commits closing §3 rows 5,
-6 and 8 and the framework half of §4.1 (issue #302). One of those commits only
-moves the pugl submodule, whose own two commits are on `dusk/302-app-contract`
-in `dusk-audio/pugl`. The ImGui bridge half of §4.1 and the fix for §4.4 are on
-`dusk/302-app-contract` in `dusk-audio/DAF-Widgets`. All three branches are
-local and validated here; §1.5 gives the order they have to be pushed in.
+Stacked on top of it was `dusk/302-app-contract`, four commits closing §3 rows
+5, 6 and 8 and the framework half of §4.1 (issue #302). One of those commits
+only moves the pugl submodule, whose own two commits merged in
+`dusk-audio/pugl`. The ImGui bridge half of §4.1 and the fix for §4.4 came the
+same way in `dusk-audio/DAF-Widgets`. Everything named here is now on the
+respective `main`.
 
 ### 1.3 What the app has to change to consume `main`
 
@@ -113,50 +119,61 @@ The rename is not cosmetic at the build interface. Three things move:
 | `dpf__add_dgl_opengl3()` | `daf__add_dgl_opengl3()` | root `CMakeLists.txt` |
 | `namespace dpf_resources` | `namespace daf_resources` | `src/ui/NativeNotepadWindow.cpp` |
 
-Commit `39d19a6` on this branch makes all three accept either spelling, so the
-tree configures against the current pin and against the reconciled revision.
-When the pin moves, that dual handling collapses to the DAF spelling and the
-`DUSKSTUDIO_DGL_RESOURCES` macro goes away; it exists only to span the two live
-revisions.
+Commit `39d19a6` made all three accept either spelling so the tree configured
+against both live revisions. G0 retired that: the build speaks only DAF and the
+`DUSKSTUDIO_DGL_RESOURCES` macro is gone. `DPF_PATH` / `DPF_WIDGETS_PATH` and
+the `../DPF` search rungs stay until the mechanical rename pass (§7), because
+the workflows still name them.
 
-### 1.4 The backend is chosen by accident today
+### 1.4 Choosing the backend
 
 `daf__add_dgl_system_libs` selects X11 whenever the X11 development files are
-installed, and Wayland only when they are absent. There is no way to ask for
-Wayland. On a dual-stack developer box or CI image the failure is silent: the
+installed, and Wayland only when they are absent. Before `DGL_BACKEND` there was
+no way to ask for Wayland. On a dual-stack box or CI image that is silent: the
 build succeeds and the app runs, just against XWayland — which is precisely what
 the zero-XWayland policy for Dusk-owned surfaces forbids.
 
-Proposed commit 3 adds `DGL_BACKEND` with values `auto` (the old behaviour, and
-still the default), `x11` and `wayland`, and fails the configure when the
-requested backend's libraries are missing. Linux app and CI configures then pass
-`-DDGL_BACKEND=wayland` explicitly.
+Commit 3 added `DGL_BACKEND` with values `auto` (the old behaviour, and still
+the default), `x11` and `wayland`, and fails the configure when the requested
+backend's libraries are missing.
 
 Note the consequence for build layout: **the backend is a per-configure choice**,
 because one `dgl-opengl3` target serves every consumer in the tree. A build
 directory is X11 or Wayland, not both. The spike therefore lives in its own
 build directory rather than beside the app.
 
-### 1.5 Proposal to Marc
+**The app's own configures cannot take `wayland` yet, and G0 did not give it to
+them.** The vehicle every phase up to G5 uses is a framework child window placed
+inside the JUCE main window, and Wayland has no window embedding: pugl says so
+(`wayland.c`, "Wayland has no window embedding, ignoring parent"),
+`puglSetWindowPosition` answers `PUGL_UNSUPPORTED` there, and
+`NativeNotepadWindow` deliberately refuses the backend rather than let the
+notepad escape into a separate top-level. A `-DDGL_BACKEND=wayland` app build
+therefore ships a notepad that cannot open, which G0 is not allowed to do. The
+flag belongs to the spike's build directory today; the app's Linux configures
+take it at G5, in the same change that stops embedding and gives the shell its
+own decorations. `BUILDING-LINUX.md` documents the rule.
 
-- Push and merge in this order, because each step is what makes the next one
-  build:
-  1. `dusk/302-app-contract` in `dusk-audio/pugl`, or the submodule pointer the
-     DAF branch carries dangles for every clone including CI.
-  2. `dusk/301-reconcile` in `dusk-audio/DAF` (the three commits above), then the
-     `dusk/302-app-contract` branch stacked on it.
-  3. `dusk/302-app-contract` in `dusk-audio/DAF-Widgets`, which needs DAF's new
-     widget focus callback to compile.
-- Re-pin `DAF_REV` in `.github/actions/clone-dpf-stack/action.yml` to the merge
-  commit; that action is the single source of truth for every workflow, and it
-  already clones from `https://github.com/dusk-audio/DAF.git`.
-- Re-pin `DAF_WIDGETS_REV` to `main` of `dusk-audio/DAF-Widgets`, which is two
-  commits ahead of the current pin and carries the matching rename, plus the
-  bridge work above once it merges. There is no divergence there.
-- Delete the branch `fix/wayland-review-findings` once merged, so no third line
-  can accumulate.
-- Retire the dual-spelling handling in the app's `CMakeLists.txt` and
-  `NativeNotepadWindow.cpp` in the same PR that moves the pin.
+### 1.5 What was agreed, and what is left
+
+Done, in this order, because each step is what made the next one build:
+
+1. `dusk/302-app-contract` in `dusk-audio/pugl`, or the submodule pointer the
+   DAF branch carries would dangle for every clone including CI.
+2. `dusk/301-reconcile` in `dusk-audio/DAF` (the three commits above), then the
+   `dusk/302-app-contract` branch stacked on it.
+3. `dusk/302-app-contract` in `dusk-audio/DAF-Widgets`, which needs DAF's widget
+   focus callback to compile.
+4. `DAF_REV` and `DAF_WIDGETS_REV` re-pinned in
+   `.github/actions/clone-dpf-stack/action.yml`, the single source of truth for
+   every workflow, and the dual-spelling handling retired from the app's
+   `CMakeLists.txt` and `NativeNotepadWindow.cpp` in the same change.
+5. `LICENSES.txt` regenerated against the new revisions: both provenance stamps,
+   the pugl submodule rev, and the Wayland notice inventory, which gained the
+   xdg-foreign-unstable-v2 protocol pair.
+
+Left, and it is Marc's: **delete the branch `fix/wayland-review-findings` in
+`dusk-audio/DAF`**, so no third line can accumulate.
 
 ## 2. What the gate spike measured
 
@@ -397,15 +414,19 @@ Each phase ends with the app shipping.
 
 ### G0 — Framework alignment
 
-No user-visible change. Land §1: reconcile the framework revision, move
-`DAF_REV` and `DAF_WIDGETS_REV`, pass `-DDGL_BACKEND=wayland` on Linux app and
-CI configures, drop the dual-spelling handling.
+**Landed.** No user-visible change. `DAF_REV` and `DAF_WIDGETS_REV` moved to the
+reconciled revisions (§1), the dual-spelling handling is gone, `LICENSES.txt`
+carries the new provenance, and the spike's two validation commits are in the
+tree. `DGL_BACKEND` is documented in `BUILDING-LINUX.md` but **not** passed on
+any app configure: §1.4 says why, and G5 is where the app takes it.
 
-Owns: `CMakeLists.txt`, `.github/actions/clone-dpf-stack/action.yml`, the
-Linux workflows, `src/ui/NativeNotepadWindow.cpp`. Take the leftover mechanical
-renames in §7 here too if they are cheap.
-Gate movement: none. Verify: full build, ctest, notepad opens under Xvfb and
-under headless `mutter`.
+Owned: `CMakeLists.txt`, `.github/actions/clone-dpf-stack/action.yml`,
+`src/ui/NativeNotepadWindow.cpp`, `LICENSES.txt`, `BUILDING-LINUX.md`. The
+leftover mechanical renames in §7 stayed out: the checkout directories and
+`-DDPF_PATH` flags are named by 16 references across 8 workflow files, which is
+a pass of its own.
+Gate movement: none. Verified: full build, 787 tests, notepad opens under Xvfb,
+spike selftest 9 of 9 under headless `mutter`.
 
 ### G1 — Widget kit and theme
 
@@ -551,19 +572,20 @@ preferred CMake variables (`DAF_PATH`, `DAF_WIDGETS_PATH`), the sibling
 auto-detect (`../DAF` and `../DAF-Widgets` are tried first), the CI action's
 clone URLs and pin variables, and the contributor build instructions.
 
+Moved with the G0 pin, because a stale provenance record is a defect rather than
+a naming preference: `LICENSES.txt` now reads `dusk-audio/DAF rev <sha>`, and
+the `dpf__add_dgl_opengl3` and `dpf_resources` fallbacks are gone.
+
 Still mechanical, and deliberately left for a pass of its own rather than
-smuggled into a tower — do it in G0 if it is cheap, otherwise as a standalone PR:
+smuggled into a tower:
 
 - `.github/actions/clone-dpf-stack/` is still the action's directory name, and
   its `RUNNER_TEMP/DPF` checkout directories and the `-DDPF_PATH=` flags in the
   workflows still use the old spelling. All three are named by 16 references
   across 8 workflow files, which is why they did not move here.
-- `LICENSES.txt` records provenance as `dusk-audio/DPF rev <sha>`. It is
-  hand-maintained release-audit surface and has to be regenerated when the pin
-  moves anyway, so the repo name moves with the pin, not before it.
-- The `DPF_PATH` / `DPF_WIDGETS_PATH` fallbacks in the app's CMake, and the
-  `dpf__add_dgl_opengl3` and `dpf_resources` fallbacks, retire when the pin
-  lands on the reconciled revision (§1.5).
+- The `DPF_PATH` / `DPF_WIDGETS_PATH` variables and the `../DPF` search rungs in
+  the app's CMake stay until those workflow flags move, since they are what the
+  flags land on.
 
 Deliberately left saying DPF: the shipped changelog entries and the per-release
 handoff documents, which are records of what was true at a revision rather than

--- a/src/ui/NativeNotepadWindow.cpp
+++ b/src/ui/NativeNotepadWindow.cpp
@@ -27,12 +27,6 @@
 # include "src/Resources.hpp"
 #endif
 
-// The framework fork renamed this namespace along with the rest of its public surface; the
-// configure reads the spelling out of the checkout so both sides of that rename compile.
-#ifndef DUSKSTUDIO_DGL_RESOURCES
-# define DUSKSTUDIO_DGL_RESOURCES dpf_resources
-#endif
-
 #include <algorithm>
 #include <cmath>
 #include <cstdarg>
@@ -246,8 +240,8 @@ struct NativeNotepadWindow::Impl final : private dusk::Timer
 
         io.Fonts->Clear();
         bodyFont = io.Fonts->AddFontFromMemoryTTF (
-            (void*) DUSKSTUDIO_DGL_RESOURCES::dejavusans_ttf,
-            DUSKSTUDIO_DGL_RESOURCES::dejavusans_ttf_size,
+            (void*) daf_resources::dejavusans_ttf,
+            daf_resources::dejavusans_ttf_size,
             size, &embeddedConfig, kDocumentGlyphRanges);
 
         boldFont = addPlatformFont (*io.Fonts, {

--- a/tools/gui-spike/ChannelStripView.h
+++ b/tools/gui-spike/ChannelStripView.h
@@ -43,6 +43,9 @@ public:
     void setEditingName (bool yes) noexcept { editingName = yes; }
     bool isEditingName() const noexcept { return editingName; }
 
+    // The shell hides the pointer for the duration of a knob drag, the way the JUCE strip does.
+    bool isDragging() const noexcept { return ! activeDrag.empty(); }
+
     // Read by the shell's overlay, so a run reports what the strip actually cost.
     int lastWidgetCount = 0;
 

--- a/tools/gui-spike/GuiSpikeMain.cpp
+++ b/tools/gui-spike/GuiSpikeMain.cpp
@@ -123,6 +123,9 @@ public:
     const std::string& rendererName() const noexcept { return renderer; }
     int lastVertices() const noexcept { return vertices; }
 
+    // What a file dialog opened through xdg-desktop-portal would be parented to.
+    std::string portalHandle() const { return Window::getPortalParentHandle(); }
+
 protected:
     // pugl has no screenshot hook, so the spike takes its own: the base onDisplay has
     // finished submitting the frame and the buffer has not been swapped yet, which is the
@@ -591,6 +594,7 @@ int main (int argc, char* argv[])
                  window.pointerEvents, window.keyEvents, window.textEvents,
                  window.focusInEvents, window.focusOutEvents);
     std::printf ("[spike] cursor changes accepted by the backend: %d\n", window.cursorCalls);
+    std::printf ("[spike] portal parent handle: \"%s\"\n", window.portalHandle().c_str());
 
     int failures = 0;
     for (const auto& line : window.selftestLog)

--- a/tools/gui-spike/GuiSpikeMain.cpp
+++ b/tools/gui-spike/GuiSpikeMain.cpp
@@ -15,10 +15,6 @@
 # include "src/Resources.hpp"
 #endif
 
-#ifndef DUSKSTUDIO_DGL_RESOURCES
-# define DUSKSTUDIO_DGL_RESOURCES dpf_resources
-#endif
-
 #include <algorithm>
 #include <chrono>
 #include <cmath>
@@ -417,8 +413,8 @@ private:
         auto add = [&] (float size)
         {
             return io.Fonts->AddFontFromMemoryTTF (
-                const_cast<void*> (static_cast<const void*> (DUSKSTUDIO_DGL_RESOURCES::dejavusans_ttf)),
-                DUSKSTUDIO_DGL_RESOURCES::dejavusans_ttf_size, size * scale, &cfg, ranges);
+                const_cast<void*> (static_cast<const void*> (daf_resources::dejavusans_ttf)),
+                daf_resources::dejavusans_ttf_size, size * scale, &cfg, ranges);
         };
 
         // One face per design size rather than one scaled face: the strip's 8 pt column

--- a/tools/gui-spike/GuiSpikeMain.cpp
+++ b/tools/gui-spike/GuiSpikeMain.cpp
@@ -21,6 +21,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <string>
+#include <utility>
 #include <vector>
 
 #if defined (__unix__)
@@ -107,9 +108,6 @@ public:
         }
 
         buildFonts (scale);
-        reportGraphics();
-
-        done();
     }
 
     ~SpikeWindow() override
@@ -131,6 +129,11 @@ protected:
     // only point where a readback is the frame the compositor is about to show.
     void onDisplay() override
     {
+        // The widget kit releases the scoped graphics context at the end of its constructor,
+        // so the first frame is the earliest point where GL can be asked what it is.
+        if (renderer.empty())
+            reportGraphics();
+
         DGL::ImGuiStandaloneWindow::onDisplay();
 
         if (options.capturePath.empty() || frames != options.captureFrame)
@@ -172,6 +175,12 @@ protected:
 
     bool onCharacterInput (const DGL::Widget::CharacterInputEvent& e) override
     { ++textEvents; return DGL::ImGuiStandaloneWindow::onCharacterInput (e); }
+
+    void onFocusChanged (const DGL::Widget::FocusEvent& e) override
+    {
+        if (e.focus) ++focusInEvents; else ++focusOutEvents;
+        DGL::ImGuiStandaloneWindow::onFocusChanged (e);
+    }
 
     void onImGuiDisplay() override
     {
@@ -233,11 +242,24 @@ protected:
 
         vertices = dl->VtxBuffer.Size;
 
+        // Hide the pointer for the length of a knob drag, the idiom every DAW knob uses.
+        bool dragging = false;
+        for (const auto& v : views)
+            dragging = dragging || v.isDragging();
+
+        if (dragging != pointerHidden)
+        {
+            pointerHidden = dragging;
+            // Both bases carry a setCursor, so the window's has to be named.
+            cursorCalls += Window::setCursor (dragging ? DGL::kMouseCursorNone
+                                                       : DGL::kMouseCursorArrow) ? 1 : 0;
+        }
+
         // Keyboard: the shell owns the shortcuts a view would not, so a key press proves it
         // reaches the application and not only the focused text field.
         // Not gated on io.WantCaptureKeyboard: the widgets library forces keyboard nav on,
-        // which pins that flag true, and the ImGui bridge never reports window focus, so it
-        // says nothing about whether the application may take the key.
+        // which pins that flag true, so it says nothing about whether the application may
+        // take the key.
         if (! views[0].isEditingName() && ! ImGui::IsAnyItemActive())
         {
             auto& p = *strips[0];
@@ -253,9 +275,15 @@ protected:
                 application.quit();
         }
 
-        if (firstResult.openInsertMenu || (options.demo == 2 && frames == 30))
+        // A popup id is derived from the id stack of the window that is current when it is
+        // opened, so both halves have to happen inside this window: the selftest runs before
+        // the console is begun and can only ask for a popup, never open one itself.
+        if (firstResult.openInsertMenu || std::exchange (requestInsertMenu, false)
+            || (options.demo == 2 && frames == 30))
             ImGui::OpenPopup ("##insertMenu");
-        if (ImGui::BeginPopup ("##insertMenu"))
+
+        insertMenuUp = ImGui::BeginPopup ("##insertMenu");
+        if (insertMenuUp)
         {
             ImGui::TextDisabled ("Insert slot");
             ImGui::Separator();
@@ -266,9 +294,10 @@ protected:
             ImGui::EndPopup();
         }
 
-        if (firstResult.openIoModal || (options.demo == 1 && frames == 30))
+        if (firstResult.openIoModal || std::exchange (requestIoModal, false)
+            || (options.demo == 1 && frames == 30))
             ImGui::OpenPopup ("Channel input");
-        drawIoModal (w, h, scale);
+        ioModalUp = drawIoModal (w, h, scale);
 
         drawHud (w, scale);
 
@@ -279,6 +308,7 @@ protected:
 
 public:
     int pointerEvents = 0, keyEvents = 0, textEvents = 0;
+    int focusInEvents = 0, focusOutEvents = 0, cursorCalls = 0;
     std::vector<std::string> selftestLog;
 
 private:
@@ -330,8 +360,8 @@ private:
                                                  && p.name.find ('Z') != std::string::npos); break;
 
             case 64: io.AddMousePosEvent (2.0f, 2.0f); io.AddMouseButtonEvent (0, false); break;
-            case 66: ImGui::OpenPopup ("Channel input"); break;
-            case 70: note ("modal is open", ImGui::IsPopupOpen ("Channel input")); break;
+            case 66: requestIoModal = true; break;
+            case 70: note ("modal is open", ioModalUp); break;
             // What has to hold for an embedded modal: the strip underneath stops taking
             // the pointer while it is up.
             case 72: io.AddMousePosEvent (hfGain.x, hfGain.y); break;
@@ -341,21 +371,30 @@ private:
             case 80: note ("modal blocks the strip underneath",
                            std::fabs (p.hfGainDb.load() - selftestBefore) < 0.01f); break;
 
-            case 84: ImGui::OpenPopup ("##insertMenu"); break;
-            case 88: note ("context menu is open", ImGui::IsPopupOpen ("##insertMenu")); break;
-            case 92: application.quit(); break;
+            case 84: requestInsertMenu = true; break;
+            case 88: note ("context menu is open", insertMenuUp); break;
+
+            // A key held while the window loses the focus must not stay down. The compositor
+            // this runs under has no seat, so the focus change is delivered through the
+            // framework's own callback rather than through a real one.
+            case 90: io.AddKeyEvent (ImGuiKey_M, true); break;
+            case 92: keyWasHeld = ImGui::IsKeyDown (ImGuiKey_M);
+                     onFocusChanged (DGL::Widget::FocusEvent()); break;
+            case 94: note ("focus loss clears a held key",
+                           keyWasHeld && ! ImGui::IsKeyDown (ImGuiKey_M)); break;
+            case 96: application.quit(); break;
             default: break;
         }
     }
 
-    void drawIoModal (float w, float h, float scale)
+    bool drawIoModal (float w, float h, float scale)
     {
         ImGui::SetNextWindowPos (ImVec2 (w * 0.5f, h * 0.5f), ImGuiCond_Always, ImVec2 (0.5f, 0.5f));
         ImGui::SetNextWindowSize (ImVec2 (290.0f * scale, 0.0f));
 
         if (! ImGui::BeginPopupModal ("Channel input", nullptr,
                                       ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove))
-            return;
+            return false;
 
         static const char* modes[] = { "Mono", "Stereo", "MIDI" };
         static const char* ins[]   = { "In 1", "In 2", "In 3", "In 4" };
@@ -368,6 +407,7 @@ private:
             ImGui::CloseCurrentPopup();
 
         ImGui::EndPopup();
+        return true;
     }
 
     void drawHud (float w, float scale)
@@ -449,10 +489,14 @@ private:
     std::string renderer;
     std::string menuChoice;
     int modeIndex = 0, inputIndex = 0, inputRIndex = 1;
+    bool requestIoModal = false, requestInsertMenu = false;
+    bool ioModalUp = false, insertMenuUp = false;
+    bool pointerHidden = false;
 
     bool measuring = true;
     int selftestStep = 0;
     float selftestBefore = 0.0f;
+    bool keyWasHeld = false;
     int frames = 0;
     int vertices = 0;
     std::chrono::steady_clock::time_point lastFrame {};
@@ -543,8 +587,10 @@ int main (int argc, char* argv[])
                  cpu, 100.0 * cpu / std::max (1.0e-6, wall),
                  window.lastVertices(), opts.strips);
     std::printf ("[spike] renderer=%s\n", window.rendererName().c_str());
-    std::printf ("[spike] input events: pointer=%d key=%d text=%d\n",
-                 window.pointerEvents, window.keyEvents, window.textEvents);
+    std::printf ("[spike] input events: pointer=%d key=%d text=%d focusIn=%d focusOut=%d\n",
+                 window.pointerEvents, window.keyEvents, window.textEvents,
+                 window.focusInEvents, window.focusOutEvents);
+    std::printf ("[spike] cursor changes accepted by the backend: %d\n", window.cursorCalls);
 
     int failures = 0;
     for (const auto& line : window.selftestLog)

--- a/tools/gui-spike/GuiSpikeMain.cpp
+++ b/tools/gui-spike/GuiSpikeMain.cpp
@@ -280,8 +280,13 @@ protected:
 
         // A popup id is derived from the id stack of the window that is current when it is
         // opened, so both halves have to happen inside this window: the selftest runs before
-        // the console is begun and can only ask for a popup, never open one itself.
-        if (firstResult.openInsertMenu || std::exchange (requestInsertMenu, false)
+        // the console is begun and can only ask for a popup, never open one itself. Both
+        // requests are taken here rather than inside the conditions below, which would leave
+        // one of them set whenever the strip asks for the same popup on the same frame.
+        const bool insertMenuRequested = std::exchange (requestInsertMenu, false);
+        const bool ioModalRequested = std::exchange (requestIoModal, false);
+
+        if (firstResult.openInsertMenu || insertMenuRequested
             || (options.demo == 2 && frames == 30))
             ImGui::OpenPopup ("##insertMenu");
 
@@ -297,7 +302,7 @@ protected:
             ImGui::EndPopup();
         }
 
-        if (firstResult.openIoModal || std::exchange (requestIoModal, false)
+        if (firstResult.openIoModal || ioModalRequested
             || (options.demo == 1 && frames == 30))
             ImGui::OpenPopup ("Channel input");
         ioModalUp = drawIoModal (w, h, scale);


### PR DESCRIPTION
The GUI tower's G0 phase from docs/dejuce-gui-plan.md: move the app onto the reconciled DAF framework revision now that the four framework PRs (pugl 1, DAF 15/16, DAF-Widgets 1) are merged.

- Repin: DAF_REV 92c3d1a7 (DAF main tip), DAF_WIDGETS_REV 77daa22 (DAF-Widgets main tip). Both are branch-held pins: DAF's pugl submodule records 43d8e349, held only by branches in dusk-audio/pugl - the action and BUILDING-LINUX now say those branches must survive until pugl's own line absorbs them.
- Retire the DPF/DAF API dual-spelling: the pin only speaks DAF, so the configure probes, the DUSKSTUDIO_DGL_RESOURCES macro, and the dpf__ fallback call go; NativeNotepadWindow names daf_resources directly. DPF_PATH/DPF_WIDGETS_PATH acceptance and the ../DPF search rungs stay until the mechanical rename pass moves the workflows.
- LICENSES.txt provenance regenerated for the pin (DAF names/revs, the xdg-foreign-unstable-v2 addition: 14 files / 8 notices; quoted notices verified against the actual files).
- Deliberate: no -DDGL_BACKEND=wayland in CI or releases. pugl's Wayland backend cannot embed and the notepad refuses that backend by design (src/ui/NativeNotepadWindow.cpp:371), so a wayland-backend release would ship a notepad that cannot open, invisibly to CI. The flag is documented in BUILDING-LINUX.md; the flip belongs to G5, the first Dusk-owned top-level.
- The GUI gate spike gains the framework-fix validation (focus, hidden cursor, portal handle) folded from the 302 work; still OFF by default, no target in the shipping build.
- Spec updated: reconciliation and G0 recorded as landed; remaining G0 action is deleting fix/wayland-review-findings in dusk-audio/DAF after this merges.

Verification: full build at the pins with zero new warnings; notepad opens under Xvfb; ctest 787/787; juce-gate unchanged at 178 files / 9050 uses; spike selftest 9/9 under a private headless compositor, including the focus and portal-handle cases; independent second review pass fixed two doc findings before push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved GUI interaction feedback, including cursor visibility during knob dragging and focus-change handling.
  * Added diagnostics for graphics initialization and native window embedding.
  * Enhanced GUI self-tests to verify modal dialogs, context menus, and focus behavior.

* **Documentation**
  * Updated Linux build instructions with framework revisions and X11/Wayland backend guidance.
  * Updated licensing and framework attribution information.
  * Recorded completed framework integration work and verification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->