### PR TITLE
chore: move the sfizz submodule to its detached dusk-fizz home

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "external/sfizz"]
 	path = external/sfizz
-	url = https://github.com/dusk-audio/sfizz.git
+	url = https://github.com/dusk-audio/dusk-fizz.git
 	branch = dusk-studio
 [submodule "external/clap"]
 	path = external/clap

--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -166,12 +166,15 @@ Dusk Audio plugins (donor DSP cores)
     - TapeMachine  (full tape emulation)
     - shared/AnalogEmulation (TubeEmulation, TransformerEmulation, etc.)
 
-sfizz (SFZ / SoundFont sampler engine — powers the multisample instrument)
-  Version  : 1.2.3, submodule rev
-             31b23c260b43815c36af48afc504261726146a3a
+dusk-fizz (SFZ / SoundFont sampler engine — powers the multisample instrument)
+  Version  : 1.2.3 lineage, submodule rev
+             034c2af42c69bd5cfbc1249955b8760873bc111c
   License  : BSD-2-Clause (external/sfizz/LICENSE)
   Path     : external/sfizz/ (git submodule, built as a static library)
-  Upstream : https://github.com/sfztools/sfizz
+  Fork home: https://github.com/dusk-audio/dusk-fizz (Dusk-maintained hard
+             fork; the code keeps its upstream sfizz names and namespaces)
+  Upstream : https://github.com/sfztools/sfizz (archived by its owner
+             2026-06-21, read-only)
   Notes    : Built library-only — JACK / render / LV2 / VST3 / AU / demos /
              tests / devtools are all disabled, so their dependencies are not
              compiled in. The sub-components below ship vendored inside sfizz

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Channels 1-24 ───────────────→ 4 Aux Buses ─�
 
 - **DSP** is extracted from the Dusk Audio plugin suite (4K EQ, Multi-Comp FET/Opto/VCA, Multi-Q, TapeMachine, shared AnalogEmulation) so the mixer and the standalone plugins share a single DSP source of truth.
 - **Plugin host**: CLAP + VST3 + LV2 + AU on every channel strip; aux returns host reverb / delay. In-process by default; the **opt-in** out-of-process sandbox (`DUSKSTUDIO_USE_OOP_PLUGINS=1`) runs each plugin in a child via a per-platform IPC backend (Linux `memfd_create` + `futex`, macOS `shm_open` + `os_sync_wait_on_address`, Windows `CreateFileMapping` + `WaitOnAddress`) so a crashing plugin can't take the host down. Standard-host plugin *scanning* runs in that child; native CLAP and VST3 bundle scanning uses a child too, on its own gate, and falls back in-process when no child binary is present; native LV2 and AU discovery never loads plugin code. The macOS sandbox needs `os_sync_wait_on_address`, so it compiles in only at deployment target 14.4 or later: the released DMG targets macOS 11 and ships no child binary, so it hosts and scans everything in-process.
-- **Soundfonts**: `.sfz` and `.sf2` play through the built-in [sfizz](https://github.com/dusk-audio/sfizz) engine (SF2 → SFZ on load). No external synth required.
+- **Soundfonts**: `.sfz` and `.sf2` play through the built-in [dusk-fizz](https://github.com/dusk-audio/dusk-fizz) engine, our maintained hard fork of sfizz (SF2 → SFZ on load). No external synth required.
 
 ## Repository
 


### PR DESCRIPTION
Upstream sfztools/sfizz was archived by its owner on 2026-06-21 (read-only), which makes the dusk-audio fork a permanent hard fork with no upstream. Following the DAF precedent, it now lives as a detached repository - dusk-audio/dusk-fizz - with no fork banner and full history (default branch dusk-studio, tip 034c2af4 = exactly the rev this tree already pins).

- .gitmodules points at dusk-fizz; the submodule path, the built library, and the code's own sfizz names/namespaces are deliberately unchanged (the DAF lesson: rename the API surface only when divergence earns it, never as part of a repo move).
- The old dusk-audio/sfizz fork is archived in place, not deleted, so the submodule URL recorded in every older commit keeps resolving.
- README names the engine by its fork home; LICENSES records fork home + archived upstream, and catches up with the submodule rev PR #349 shipped (the provenance block still said the pre-#349 rev).

No source or build change; the gitlink is untouched. CI proves the new URL resolves at the pin.