### PR TITLE
ci: retire the widget-kit branch caveat now the pin is on main

### DIFF
--- a/.github/actions/clone-dpf-stack/action.yml
+++ b/.github/actions/clone-dpf-stack/action.yml
@@ -13,13 +13,11 @@ description: >
   directory name still say DPF because every workflow names them; they move in
   the mechanical rename pass, not here.
 
-  DAF_REV is the tip of its repository's main. Two pins below are not, and both
-  therefore depend on a branch surviving upstream: DAF_WIDGETS_REV names the tip
-  of the widget-kit branch and has to be moved to the commit that lands on that
-  repository's main before this merges, and the pugl submodule DAF carries has
-  its recorded revision on a branch in dusk-audio/pugl rather than on that
-  repository's main. Deleting either branch strands every workflow that runs
-  this action, because they all clone through it.
+  Both revisions below are the tip of their repository's main, so neither one
+  depends on a branch surviving upstream. The pugl submodule DAF carries still
+  does: its recorded revision sits on a branch in dusk-audio/pugl rather than
+  on that repository's main, and deleting the branch would strand the submodule
+  step below for every clone, this one included.
 
 runs:
   using: composite


### PR DESCRIPTION
Comment-only. The G1 repin moved DAF_WIDGETS_REV onto the DAF-Widgets merge commit but left the caveat paragraph above it claiming the pin was still branch-held. Both halves of that claim are now false, and a reader who notices is likely to dismiss the half that still matters: the pugl submodule's recorded revision remains on a branch in dusk-audio/pugl, and deleting that branch strands the submodule step for every clone of this action. The paragraph now states exactly that and nothing more.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that DAF and DAF-Widgets revisions follow their repositories’ `main` branches.
  * Documented that the embedded pugl component continues to track a branch in its upstream repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->