### PR TITLE
ci: unclutter the pugl pin sentence

### DIFF
--- a/.github/actions/clone-dpf-stack/action.yml
+++ b/.github/actions/clone-dpf-stack/action.yml
@@ -14,7 +14,7 @@ description: >
   the mechanical rename pass, not here.
 
   Both revisions below are the tip of their repository's main, so neither one
-  depends on a branch surviving upstream. The pugl submodule DAF carries still
+  depends on a branch surviving upstream. The pugl submodule in DAF still
   does: its recorded revision sits on a branch in dusk-audio/pugl rather than
   on that repository's main, and deleting the branch would strand the submodule
   step below for every clone, this one included.


### PR DESCRIPTION
Comment-only, one line: "The pugl submodule DAF carries still does" read as a garden path; "The pugl submodule in DAF still does" says the same thing without the stumble. The sentence is the one warning protecting the branch-held pugl pin, so it should read cleanly.