### PR TITLE
0.13.2: restore native plugin state on session reopen (#355) and unwedge the plugin scan (#347)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,23 @@ canonical source.
   time, and those are gone. Opening a session now hands each plugin its
   settings as it loads, so a session carrying several heavy plugins can take
   a little longer to open, with a brief silence while that happens.
+- **A plugin that hangs while being scanned no longer takes the scan with it.**
+  Scanning probes each plugin in a separate process so a bad one cannot crash
+  Dusk Studio, and gives it 30 seconds before declaring it stuck. That deadline
+  could never fire: the code waiting for the child process to say something did
+  not come back until the child said it, so a plugin blocking on a licence or
+  authorisation dialog it cannot show during discovery held the scan open
+  indefinitely. A watchdog now enforces the deadline and ends the plugin so the
+  scan moves on, for CLAP and VST3 bundles read by Dusk Studio's own hosts as
+  well as for the standard host, which had the same fault. A plugin that
+  finishes just as the clock runs out is no longer quarantined for it.
+- **The plugin scan can be stopped.** The progress window has a **Cancel**
+  button, and Esc does the same: the scan stops at the plugin being probed and
+  skips it rather than quarantining it. Plugins found before the stop stay in
+  the picker, though a CLAP or VST3 pass through Dusk Studio's own hosts is
+  discarded rather than recorded half-finished, so run the scan again when you
+  want a complete list. Before this the window could not be dismissed at all,
+  so a scan that went wrong left no way into the rest of the application.
 
 ## [0.13.1] - 2026-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to Dusk Studio. Format loosely follows
 back-filled from `git log`; once tags exist this file is the
 canonical source.
 
+## [0.13.2] - Unreleased
+
+### Fixed
+
+- **Plugin settings are restored again when a session is reopened.** Every
+  plugin loaded through Dusk Studio's own CLAP, LV2, VST3, Audio Unit and
+  multisample hosts came back at its default settings after a save, a quit and
+  a reopen, no matter which format it was. The settings were written to
+  `session.json` correctly all along; the code that read them back used a
+  different, incompatible text encoding to the one that wrote them, so it saw
+  nothing and left the plugin untouched. Plugins hosted through the application
+  framework were never affected. Sessions saved by an earlier release carry
+  usable settings and recover them on this one, in either of the two forms
+  earlier releases wrote, with one exception:
+  a session that was reopened under the fault and then saved again had its
+  stored settings overwritten with the defaults that were on screen at the
+  time, and those are gone. Opening a session now hands each plugin its
+  settings as it loads, so a session carrying several heavy plugins can take
+  a little longer to open, with a brief silence while that happens.
+
 ## [0.13.1] - 2026-08-24
 
 A packaging and Windows-safety fix release. The 0.13.0 macOS disk image could

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1517,7 +1517,7 @@ There is no VST2 support. See *Native plugin hosting (Linux, macOS, and Windows)
 
 ## Scanning
 
-Dusk Studio does not automatically scan plugins on first launch. Open any plugin picker (right-click any channel insert slot → **+ Plugin**, or the aux lane plugin slot) and click **Scan plugins**. Scanning takes 10–30 seconds for a large collection.
+Dusk Studio does not automatically scan plugins on first launch. Open any plugin picker (right-click any channel insert slot → **+ Plugin**, or the aux lane plugin slot) and click **Scan plugins**. Scanning takes 10–30 seconds for a large collection and runs behind a progress window naming the plugin being probed, so the app stays responsive rather than appearing to hang. Click **Cancel** there, or press Esc, to stop early. The plugin being probed is skipped and plugins already added stay in the picker, but a CLAP or VST3 pass through Dusk Studio's own hosts is abandoned rather than recorded half-finished, so its earlier results stand until you run **Scan plugins** again. The LV2 and Audio Unit passes read manifests rather than plugin code and finish on their own once started.
 
 Plugin scan results are cached in:
 
@@ -1527,7 +1527,9 @@ Plugin scan results are cached in:
 
 The native hosts keep their own sidecar caches next to it (`clap-cache.json` and `vst3-native-cache.json` on every OS, `lv2-native-cache.json` on Linux and macOS, `au-native-cache.json` on macOS), rebuilt by the same **Scan plugins** button. Existing XML sidecars are used as a fallback whenever the matching JSON cache cannot be loaded, including when it is absent, malformed, or unusable; subsequent scans write JSON. The native LV2 scan reads only the bundles' manifests, and the native AU scan reads the macOS Audio Component registry metadata; neither scan instantiates plugin code, so a broken plugin cannot crash that scan and is simply skipped (or reported when you try to load it).
 
-To re-scan on every launch, enable **Settings → General → Scan plugins on startup**. The startup scan runs in the background behind a progress window (it shows the plugin currently being scanned and a progress bar), so the app stays responsive instead of appearing to hang while a large collection is scanned.
+To re-scan on every launch, enable **Settings → General → Scan plugins on startup**. It uses the same progress window, cancels the same way, and reports what it found to the session log rather than to an alert.
+
+A plugin that never finishes being probed — most often one waiting on a licence or authorisation dialog it cannot show during a scan — is given 30 seconds and then ended, so the scan moves on to the next one. A standard-host plugin is quarantined at that point and skipped by every later scan; the alert at the end of a **Scan plugins** run says how many are quarantined and which file to delete to probe them again. CLAP and VST3 bundles read by Dusk Studio's own hosts are only skipped, and are probed again on the next scan.
 
 ## Loading a plugin
 
@@ -2354,8 +2356,8 @@ Two variants:
 ### Plugin scan complete
 
 - **When**: The scanner finishes (startup-auto or manual).
-- **Text**: title "Plugin scan complete", body "1 new plugin added." (singular) or "N new plugins added." (plural).
-- **Buttons**: none — the dialog holds briefly, then closes itself.
+- **Text**: title "Plugin scan complete", body "1 new plugin added." (singular) or "N new plugins added." (plural). A cancelled scan titles "Plugin scan cancelled" and reports what it added before you stopped it.
+- **Buttons**: **Cancel** while scanning, then none — the dialog holds briefly, then closes itself.
 
 ### Plugin slot labels (inline, not a dialog)
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 767 Catch2 test cases across 154 test source files. Linux
+The C++ suite declares 776 Catch2 test cases across 156 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 767 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 776 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 776 Catch2 test cases across 156 test source files. Linux
+The C++ suite declares 777 Catch2 test cases across 156 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 776 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 777 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -218,7 +218,7 @@ static std::vector<uint8_t> decodeBase64Blob (const juce::String& s, const char*
     // 0.13.1 migrated Audio Unit and soundfont slots onto their native keys
     // without transcoding, so a session it converted holds the JUCE form here.
     if (blob.empty())
-        blob = decodeLegacyStateBase64 (s);
+        blob = decodeLegacyStateBase64 (s.toStdString());
 
     if (blob.empty())
     {
@@ -260,7 +260,9 @@ static void migrateLegacyAuSlot (
 
     // Writes nativeState only on success, so a legacy blob that cannot be read
     // leaves the slot exactly as it was.
-    if (! transcodeLegacyStateBase64 (legacyState, nativeState)) return;
+    std::string transcoded;
+    if (! transcodeLegacyStateBase64 (legacyState.toStdString(), transcoded)) return;
+    nativeState = transcoded;
 
     nativeIdentifier = id.toString();
     descriptor.reset();
@@ -294,8 +296,10 @@ static void migrateLegacyMultisampleTrack (Track& track, PluginManager& manager)
 
     // See migrateLegacyAuSlot: an unreadable blob aborts the migration with the
     // legacy pair untouched rather than moving a slot whose state is lost.
-    if (! transcodeLegacyStateBase64 (track.pluginStateBase64,
-                                      track.nativeMultisampleStateBase64)) return;
+    std::string transcoded;
+    if (! transcodeLegacyStateBase64 (track.pluginStateBase64.toStdString(),
+                                      transcoded)) return;
+    track.nativeMultisampleStateBase64 = transcoded;
 
     track.nativeMultisamplePath = descriptor->location;
     track.pluginDescriptor.reset();

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -11,6 +11,8 @@
 #include "CompModeMap.h"
 #include "../session/RegionEditActions.h"
 #include "DeviceFallbackMessage.h"
+#include "LegacyStateBase64.h"
+#include "../foundation/Base64.h"
 #include "../foundation/MessageThread.h"
 #if DUSKSTUDIO_HAS_NATIVE_AU
  #include "au/AuBundle.h"
@@ -204,15 +206,28 @@ static std::filesystem::path lv2StateDirFor (Session& session, const juce::Strin
 #if DUSKSTUDIO_HAS_NATIVE_CLAP || DUSKSTUDIO_HAS_NATIVE_LV2 || DUSKSTUDIO_HAS_NATIVE_VST3 \
     || DUSKSTUDIO_HAS_NATIVE_AU || DUSKSTUDIO_HAS_MULTISAMPLE
 // Session-carried native plugin state blob (base64) -> bytes. Empty on any
-// decode failure - callers treat "no state" and "bad state" the same.
-static std::vector<uint8_t> decodeBase64Blob (const juce::String& s)
+// decode failure - callers treat "no state" and "bad state" the same, so an
+// unreadable blob is otherwise indistinguishable from a plugin that saved
+// nothing. Say so once, or a corrupted session restores defaults with no trace.
+static std::vector<uint8_t> decodeBase64Blob (const juce::String& s, const char* slotKind)
 {
-    std::vector<uint8_t> blob;
-    if (s.isEmpty()) return blob;
-    juce::MemoryBlock mb;
-    if (mb.fromBase64Encoding (s) && mb.getSize() > 0)
-        blob.assign (static_cast<const uint8_t*> (mb.getData()),
-                     static_cast<const uint8_t*> (mb.getData()) + mb.getSize());
+    if (s.isEmpty()) return {};
+
+    auto blob = dusk::base64::decode (s.toRawUTF8(), s.getNumBytesAsUTF8());
+
+    // 0.13.1 migrated Audio Unit and soundfont slots onto their native keys
+    // without transcoding, so a session it converted holds the JUCE form here.
+    if (blob.empty())
+        blob = decodeLegacyStateBase64 (s);
+
+    if (blob.empty())
+    {
+        std::fprintf (stderr,
+                      "[Dusk Studio/session] %s state is unreadable (%d chars); "
+                      "restoring the slot at its defaults\n",
+                      slotKind, s.length());
+        std::fflush (stderr);
+    }
     return blob;
 }
 #endif
@@ -243,8 +258,11 @@ static void migrateLegacyAuSlot (
     au::ComponentId id;
     if (! au::ComponentId::parse (candidate->location, id)) return;
 
+    // Writes nativeState only on success, so a legacy blob that cannot be read
+    // leaves the slot exactly as it was.
+    if (! transcodeLegacyStateBase64 (legacyState, nativeState)) return;
+
     nativeIdentifier = id.toString();
-    nativeState = legacyState;
     descriptor.reset();
     legacyXml.clear();
     legacyState.clear();
@@ -274,8 +292,12 @@ static void migrateLegacyMultisampleTrack (Track& track, PluginManager& manager)
     // wiping it here would destroy the blob on the next save and restore nothing.
     if (descriptor->location.empty()) return;
 
-    track.nativeMultisamplePath        = descriptor->location;
-    track.nativeMultisampleStateBase64 = track.pluginStateBase64;
+    // See migrateLegacyAuSlot: an unreadable blob aborts the migration with the
+    // legacy pair untouched rather than moving a slot whose state is lost.
+    if (! transcodeLegacyStateBase64 (track.pluginStateBase64,
+                                      track.nativeMultisampleStateBase64)) return;
+
+    track.nativeMultisamplePath = descriptor->location;
     track.pluginDescriptor.reset();
     track.pluginLegacyDescriptionXml.clear();
     track.pluginStateBase64.clear();
@@ -2032,7 +2054,7 @@ void AudioEngine::consumePluginStateAfterLoad()
             slot.unload();
             strip.insertMode.store (ChannelStrip::kInsertPlugin, std::memory_order_release);
 
-            auto blob = decodeBase64Blob (track.nativeClapStateBase64);
+            auto blob = decodeBase64Blob (track.nativeClapStateBase64, "track CLAP");
 
             const juce::File clapFile (track.nativeClapPath);
             if (strip.isPrepared())
@@ -2072,7 +2094,7 @@ void AudioEngine::consumePluginStateAfterLoad()
             slot.unload();
             strip.insertMode.store (ChannelStrip::kInsertPlugin, std::memory_order_release);
 
-            auto blob = decodeBase64Blob (track.nativeLv2StateBase64);
+            auto blob = decodeBase64Blob (track.nativeLv2StateBase64, "track LV2");
 
             const juce::File lv2File (track.nativeLv2Path);
             if (strip.isPrepared())
@@ -2114,7 +2136,7 @@ void AudioEngine::consumePluginStateAfterLoad()
             slot.unload();
             strip.insertMode.store (ChannelStrip::kInsertPlugin, std::memory_order_release);
 
-            auto blob = decodeBase64Blob (track.nativeVst3StateBase64);
+            auto blob = decodeBase64Blob (track.nativeVst3StateBase64, "track VST3");
 
             const juce::File vst3File (track.nativeVst3Path);
             if (strip.isPrepared())
@@ -2149,7 +2171,7 @@ void AudioEngine::consumePluginStateAfterLoad()
         {
             slot.unload();
             strip.insertMode.store (ChannelStrip::kInsertPlugin, std::memory_order_release);
-            auto blob = decodeBase64Blob (track.nativeAuStateBase64);
+            auto blob = decodeBase64Blob (track.nativeAuStateBase64, "track Audio Unit");
             if (strip.isPrepared())
             {
                 suspendProcessing();
@@ -2184,7 +2206,7 @@ void AudioEngine::consumePluginStateAfterLoad()
             slot.unload();
             strip.insertMode.store (ChannelStrip::kInsertPlugin, std::memory_order_release);
 
-            auto blob = decodeBase64Blob (track.nativeMultisampleStateBase64);
+            auto blob = decodeBase64Blob (track.nativeMultisampleStateBase64, "track multisample");
 
             const juce::File soundfont (track.nativeMultisamplePath);
             if (strip.isPrepared())
@@ -2317,7 +2339,7 @@ void AudioEngine::consumePluginStateAfterLoad()
                 slot.unload();   // ensure no JUCE plugin lingers in this slot
                 strip.insertMode[(size_t) s].store (AuxLaneStrip::kInsertPlugin, std::memory_order_release);
 
-                auto blob = decodeBase64Blob (lane.nativeClapStateBase64[(size_t) s]);
+                auto blob = decodeBase64Blob (lane.nativeClapStateBase64[(size_t) s], "aux CLAP");
 
                 const juce::File clapFile (lane.nativeClapPath[(size_t) s]);
                 if (strip.isPrepared())
@@ -2355,7 +2377,7 @@ void AudioEngine::consumePluginStateAfterLoad()
                 slot.unload();
                 strip.insertMode[(size_t) s].store (AuxLaneStrip::kInsertPlugin, std::memory_order_release);
 
-                auto blob = decodeBase64Blob (lane.nativeLv2StateBase64[(size_t) s]);
+                auto blob = decodeBase64Blob (lane.nativeLv2StateBase64[(size_t) s], "aux LV2");
 
                 const juce::File lv2File (lane.nativeLv2Path[(size_t) s]);
                 if (strip.isPrepared())
@@ -2400,7 +2422,7 @@ void AudioEngine::consumePluginStateAfterLoad()
                 slot.unload();
                 strip.insertMode[(size_t) s].store (AuxLaneStrip::kInsertPlugin, std::memory_order_release);
 
-                auto blob = decodeBase64Blob (lane.nativeVst3StateBase64[(size_t) s]);
+                auto blob = decodeBase64Blob (lane.nativeVst3StateBase64[(size_t) s], "aux VST3");
 
                 const juce::File vst3File (lane.nativeVst3Path[(size_t) s]);
                 if (strip.isPrepared())
@@ -2437,7 +2459,7 @@ void AudioEngine::consumePluginStateAfterLoad()
                 slot.unload();
                 strip.insertMode[(size_t) s].store (
                     AuxLaneStrip::kInsertPlugin, std::memory_order_release);
-                auto blob = decodeBase64Blob (lane.nativeAuStateBase64[(size_t) s]);
+                auto blob = decodeBase64Blob (lane.nativeAuStateBase64[(size_t) s], "aux Audio Unit");
                 const auto identifier = lane.nativeAuIdentifier[(size_t) s];
                 if (strip.isPrepared())
                 {

--- a/src/engine/LegacyStateBase64.h
+++ b/src/engine/LegacyStateBase64.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace duskstudio
+{
+// Slots that used to be hosted through the JUCE plugin path stored their state
+// in JUCE's MemoryBlock encoding; the native keys those slots migrate onto are
+// RFC 4648. The two decoders reject each other's output outright, so the string
+// has to be transcoded on the way across.
+//
+// False means the legacy string held something that could not be read back. The
+// caller must then abandon the migration and leave the legacy pair untouched:
+// moving a slot whose state is dropped en route restores it at its defaults, and
+// the next save writes those defaults over the only surviving copy.
+inline bool transcodeLegacyStateBase64 (const juce::String& legacy, juce::String& out)
+{
+    if (legacy.isEmpty()) { out.clear(); return true; }
+
+    juce::MemoryBlock decoded;
+    if (! decoded.fromBase64Encoding (legacy)) return false;
+
+    // A plugin that saved nothing encodes as "0.", which reads back as zero
+    // bytes. That is a successful read of an empty state, not a failure - and
+    // failing here would strand the slot's identity along with it.
+    out = decoded.getSize() == 0
+              ? juce::String()
+              : juce::Base64::toBase64 (decoded.getData(), decoded.getSize());
+    return true;
+}
+
+// 0.13.1 ran the migrations above by copying the string across rather than
+// transcoding it, so a session it converted carries the MemoryBlock form on a
+// native key. Reading one back is unambiguous: that form always contains a '.',
+// which never appears in RFC 4648 output. Empty on anything else.
+inline std::vector<std::uint8_t> decodeLegacyStateBase64 (const juce::String& s)
+{
+    std::vector<std::uint8_t> blob;
+
+    juce::MemoryBlock decoded;
+    if (! decoded.fromBase64Encoding (s) || decoded.getSize() == 0)
+        return blob;
+
+    const auto* bytes = static_cast<const std::uint8_t*> (decoded.getData());
+    blob.assign (bytes, bytes + decoded.getSize());
+    return blob;
+}
+} // namespace duskstudio

--- a/src/engine/LegacyStateBase64.h
+++ b/src/engine/LegacyStateBase64.h
@@ -1,12 +1,75 @@
 #pragma once
 
-#include <juce_core/juce_core.h>
+#include "../foundation/Base64.h"
 
+#include <cstddef>
 #include <cstdint>
+#include <string>
 #include <vector>
 
 namespace duskstudio
 {
+namespace detail
+{
+// JUCE MemoryBlock's private base64 alphabet: index 0 is '.', then the rest in
+// an order that matches nothing in RFC 4648. Kept verbatim so blobs written by
+// the JUCE plugin path keep reading back after the de-JUCE swap.
+inline int legacySextet (char c) noexcept
+{
+    static constexpr char table[] =
+        ".ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+";
+    for (int i = 0; i < 64; ++i)
+        if (table[i] == c) return i;
+    return -1;
+}
+
+// Decode of the MemoryBlock form, mirroring JUCE's MemoryBlock fromBase64Encoding
+// bit for bit: a decimal byte count, a '.', then 6-bit groups laid down LSB-first
+// into a zero-filled buffer of exactly that count. Characters outside the
+// alphabet are skipped without advancing the bit cursor, bits past the declared
+// size are dropped, and a shorter-than-declared payload leaves the tail zeroed,
+// all exactly as the JUCE reader behaved. False only when there is no '.' at
+// all (not this encoding), or when the declared count is beyond what the
+// payload could ever have carried, which the real encoder cannot produce.
+inline bool decodeLegacyBlob (const std::string& s, std::vector<std::uint8_t>& out)
+{
+    out.clear();
+
+    const std::size_t dot = s.find ('.');
+    if (dot == std::string::npos) return false;
+
+    std::size_t numBytes = 0;
+    for (std::size_t i = 0; i < dot; ++i)
+    {
+        const char c = s[i];
+        if (c < '0' || c > '9') break;          // getIntValue semantics: digits, then stop
+        numBytes = numBytes * 10 + (std::size_t) (c - '0');
+        if (numBytes > (std::size_t) 1 << 30) return false;
+    }
+
+    // The encoder writes ceil(bytes * 8 / 6) payload characters, so a count the
+    // payload cannot fill is corruption, not a state to allocate.
+    const std::size_t dataChars = s.size() - dot - 1;
+    if (numBytes > (dataChars * 6) / 8 + 8) return false;
+
+    out.assign (numBytes, 0);
+    std::size_t pos = 0;
+    for (std::size_t i = dot + 1; i < s.size(); ++i)
+    {
+        const int v = legacySextet (s[i]);
+        if (v < 0) continue;
+        for (int k = 0; k < 6; ++k)
+        {
+            const std::size_t bit = pos + (std::size_t) k;
+            if ((bit >> 3) >= out.size()) break;
+            out[bit >> 3] = (std::uint8_t) (out[bit >> 3] | (((v >> k) & 1) << (bit & 7)));
+        }
+        pos += 6;
+    }
+    return true;
+}
+} // namespace detail
+
 // Slots that used to be hosted through the JUCE plugin path stored their state
 // in JUCE's MemoryBlock encoding; the native keys those slots migrate onto are
 // RFC 4648. The two decoders reject each other's output outright, so the string
@@ -16,19 +79,18 @@ namespace duskstudio
 // caller must then abandon the migration and leave the legacy pair untouched:
 // moving a slot whose state is dropped en route restores it at its defaults, and
 // the next save writes those defaults over the only surviving copy.
-inline bool transcodeLegacyStateBase64 (const juce::String& legacy, juce::String& out)
+inline bool transcodeLegacyStateBase64 (const std::string& legacy, std::string& out)
 {
-    if (legacy.isEmpty()) { out.clear(); return true; }
+    if (legacy.empty()) { out.clear(); return true; }
 
-    juce::MemoryBlock decoded;
-    if (! decoded.fromBase64Encoding (legacy)) return false;
+    std::vector<std::uint8_t> decoded;
+    if (! detail::decodeLegacyBlob (legacy, decoded)) return false;
 
     // A plugin that saved nothing encodes as "0.", which reads back as zero
     // bytes. That is a successful read of an empty state, not a failure - and
     // failing here would strand the slot's identity along with it.
-    out = decoded.getSize() == 0
-              ? juce::String()
-              : juce::Base64::toBase64 (decoded.getData(), decoded.getSize());
+    out = decoded.empty() ? std::string()
+                          : dusk::base64::encode (decoded.data(), decoded.size());
     return true;
 }
 
@@ -36,16 +98,11 @@ inline bool transcodeLegacyStateBase64 (const juce::String& legacy, juce::String
 // transcoding it, so a session it converted carries the MemoryBlock form on a
 // native key. Reading one back is unambiguous: that form always contains a '.',
 // which never appears in RFC 4648 output. Empty on anything else.
-inline std::vector<std::uint8_t> decodeLegacyStateBase64 (const juce::String& s)
+inline std::vector<std::uint8_t> decodeLegacyStateBase64 (const std::string& s)
 {
     std::vector<std::uint8_t> blob;
-
-    juce::MemoryBlock decoded;
-    if (! decoded.fromBase64Encoding (s) || decoded.getSize() == 0)
-        return blob;
-
-    const auto* bytes = static_cast<const std::uint8_t*> (decoded.getData());
-    blob.assign (bytes, bytes + decoded.getSize());
+    if (! detail::decodeLegacyBlob (s, blob))
+        blob.clear();
     return blob;
 }
 } // namespace duskstudio

--- a/src/engine/PluginManager.cpp
+++ b/src/engine/PluginManager.cpp
@@ -22,7 +22,12 @@
   #include "au/AuScanner.h"
 #endif
 
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <map>
+#include <mutex>
+#include <thread>
 
 namespace duskstudio
 {
@@ -157,6 +162,158 @@ namespace
 // A plugin can take a few seconds to instantiate on a cold cache; give a
 // generous ceiling and treat anything past it as a hang.
 constexpr int kScanTimeoutMs = 30000;
+
+// Bounded so a child that chatters instead of finishing cannot grow the parent
+// without limit for the whole timeout.
+constexpr size_t kMaxScanOutputBytes = 8 * 1024 * 1024;
+
+struct SandboxedScan
+{
+    enum class Verdict
+    {
+        Completed,      // child produced a payload; trust it
+        Cancelled,      // user stopped the scan; the file is untouched, not at fault
+        Failed,         // crash, hang, or a flood of output
+        Unsupervised    // no watchdog, so the scan was never safe to start
+    };
+
+    Verdict     verdict  = Verdict::Failed;
+    bool        timedOut = false;         // picks the log line; never the verdict
+    bool        tooMuchOutput = false;
+    std::string payload;
+};
+
+// Drive one already-started sandboxed child to a verdict.
+//
+// readProcessOutput does not return until it has filled its buffer or the child
+// exits, so a deadline polled from this thread never fires against a plugin
+// sitting on a license dialog and writing nothing. A watchdog enforces the
+// deadline and the cancel flag instead - ending the child is what releases the
+// read - and re-issues the kill every tick, because a killed child frees the
+// reader only once the pipe reaches EOF.
+//
+// isRunning() reaps the child and the pid becomes reusable the moment it does,
+// so the reader publishes reading=false inside the same lock that gates every
+// kill. Without that interlock a late kill lands on an unrelated process.
+SandboxedScan driveSandboxedScan (juce::ChildProcess& proc, const std::atomic<bool>* abort)
+{
+    SandboxedScan result;
+
+    juce::MemoryOutputStream captured;
+    char buf[8192];
+
+    std::mutex              watchMutex;
+    std::condition_variable watchDone;
+    bool reading   = true;   // all three guarded by watchMutex
+    bool cancelled = false;
+    bool expired   = false;
+
+    std::thread watchdog;
+    try
+    {
+        watchdog = std::thread ([&]
+        {
+            // Wrap-safe elapsed check: unsigned subtraction is correct across a
+            // single getMillisecondCounter() wrap (every ~49 days of uptime), so
+            // compare the interval rather than an absolute deadline.
+            const std::uint32_t startMs = juce::Time::getMillisecondCounter();
+            std::unique_lock<std::mutex> lock (watchMutex);
+
+            while (! watchDone.wait_for (lock, std::chrono::milliseconds (25),
+                                         [&reading] { return ! reading; }))
+            {
+                if (abort != nullptr && abort->load (std::memory_order_relaxed))
+                    cancelled = true;
+                else if (juce::Time::getMillisecondCounter() - startMs
+                             >= (std::uint32_t) kScanTimeoutMs)
+                    expired = true;
+                else
+                    continue;
+
+                proc.kill();   // TerminateProcess on Windows - unblocks a modal dialog
+            }
+        });
+    }
+    catch (const std::system_error& e)
+    {
+        // Without a watchdog the read below can block forever. Refuse the file
+        // rather than wedge the whole scan on it.
+        proc.kill();
+        proc.waitForProcessToFinish (200);
+        std::fprintf (stderr, "[Dusk Studio/scan] could not start the scan watchdog: %s\n",
+                      e.what());
+        std::fflush (stderr);
+        result.verdict = SandboxedScan::Verdict::Unsupervised;
+        return result;
+    }
+
+    {
+        // A joinable std::thread destructor terminates the process, so every way
+        // out of the loop below - including a throw - has to pass through here.
+        struct Joiner
+        {
+            ~Joiner()
+            {
+                { std::lock_guard<std::mutex> lock (mutex); reading = false; }
+                done.notify_one();
+                thread.join();
+            }
+
+            std::thread&             thread;
+            std::mutex&              mutex;
+            std::condition_variable& done;
+            bool&                    reading;
+        } joiner { watchdog, watchMutex, watchDone, reading };
+
+        for (;;)
+        {
+            const int n = proc.readProcessOutput (buf, (int) sizeof buf);
+            if (n > 0)
+            {
+                captured.write (buf, (size_t) n);
+                if (captured.getDataSize() < kMaxScanOutputBytes) continue;
+
+                {
+                    // Under the lock like every other kill, so the watchdog
+                    // cannot also be killing while this one runs.
+                    std::lock_guard<std::mutex> lock (watchMutex);
+                    reading = false;
+                    proc.kill();
+                }
+                result.tooMuchOutput = true;
+                break;
+            }
+
+            bool finished = false;
+            {
+                std::lock_guard<std::mutex> lock (watchMutex);
+                if (! proc.isRunning()) { reading = false; finished = true; }
+            }
+            if (! finished) { juce::Thread::sleep (5); continue; }
+
+            int extra;
+            while ((extra = proc.readProcessOutput (buf, (int) sizeof buf)) > 0)
+                captured.write (buf, (size_t) extra);
+            break;
+        }
+    }
+
+    if (result.tooMuchOutput || cancelled || expired)
+        proc.waitForProcessToFinish (200);   // reap: kill() never waitpid()s
+
+    result.timedOut = expired;
+    result.payload  = scanproto::extractPayload (captured.toString().toStdString());
+
+    // A payload carries both sentinels, so having one proves the child finished
+    // the scan. That outranks everything the watchdog saw: a deadline that
+    // expired while the child was already exiting, or a flood that arrived
+    // alongside a good answer, would otherwise blacklist a plugin that scanned
+    // fine. timedOut and tooMuchOutput only pick the log line.
+    if (! result.payload.empty()) result.verdict = SandboxedScan::Verdict::Completed;
+    else if (cancelled)           result.verdict = SandboxedScan::Verdict::Cancelled;
+    else                          result.verdict = SandboxedScan::Verdict::Failed;
+    return result;
+}
 } // namespace
 #endif
 
@@ -213,70 +370,39 @@ public:
             return true;
         }
 
-        juce::MemoryOutputStream captured;
-        char buf[8192];
-        // Wrap-safe elapsed check: unsigned subtraction is correct across a
-        // single getMillisecondCounter() wrap (every ~49 days of uptime), so
-        // compare the interval rather than an absolute deadline.
-        const std::uint32_t startMs = juce::Time::getMillisecondCounter();
-        bool aborted  = false;
-        bool timedOut = false;
+        const auto scan = driveSandboxedScan (proc, abort);
 
-        for (;;)
+        if (scan.verdict == SandboxedScan::Verdict::Unsupervised)
         {
-            const int n = proc.readProcessOutput (buf, (int) sizeof buf);
-            if (n > 0) { captured.write (buf, (size_t) n); continue; }
-
-            if (! proc.isRunning())
-            {
-                int extra;
-                while ((extra = proc.readProcessOutput (buf, (int) sizeof buf)) > 0)
-                    captured.write (buf, (size_t) extra);
-                break;
-            }
-
-            // Cancel / app-shutdown: kill the child immediately rather than
-            // waiting out its timeout. Not a crash, so don't blacklist.
-            if (abort != nullptr && abort->load (std::memory_order_relaxed))
-            {
-                proc.kill();
-                proc.waitForProcessToFinish (200);  // reap: kill() SIGKILLs but never waitpid()s
-                aborted = true;
-                break;
-            }
-
-            if (juce::Time::getMillisecondCounter() - startMs >= (std::uint32_t) kScanTimeoutMs)
-            {
-                proc.kill();                         // TerminateProcess on Windows - unblocks a modal dialog
-                proc.waitForProcessToFinish (200);   // reap the SIGKILLed child, no zombie
-                timedOut = true;
-                break;
-            }
-            juce::Thread::sleep (5);
+            // Same rule as a missing host binary: skip, don't scan in-process,
+            // don't blacklist.
+            noteSandboxUnavailable (fileOrIdentifier);
+            return true;
         }
 
-        // Abort tears the whole scan down; leave the in-flight file UNSCANNED
-        // (return true) rather than blacklisting a plugin the user cancelled on.
-        if (aborted) return true;
+        // Cancel tears the whole scan down; leave the in-flight file UNSCANNED
+        // (return true) rather than blacklisting a plugin the user stopped on.
+        if (scan.verdict == SandboxedScan::Verdict::Cancelled) return true;
 
-        const auto payload = scanproto::extractPayload (captured.toString().toStdString());
-
-        if (timedOut || payload.empty())
+        if (scan.verdict == SandboxedScan::Verdict::Failed)
         {
-            // A hang (timed out) or a crash (child died with no clean payload):
-            // quarantine so the next scan skips it instead of re-hanging /
-            // re-crashing. A hung scan is most often a plugin blocking on a
-            // license / authorization dialog it cannot show during discovery.
+            // A hang, a crash, or a flood of output: quarantine so the next scan
+            // skips it instead of re-hanging / re-crashing. A hung scan is most
+            // often a plugin blocking on a license / authorization dialog it
+            // cannot show during discovery.
             knownList.addToBlacklist (fileOrIdentifier);
-            std::fprintf (stderr, timedOut
-                ? "[Dusk Studio/scan] quarantined \"%s\": timed out (possible license dialog)\n"
-                : "[Dusk Studio/scan] quarantined \"%s\": scan crashed (no payload)\n",
+            std::fprintf (stderr,
+                scan.tooMuchOutput
+                    ? "[Dusk Studio/scan] quarantined \"%s\": flooded the scan output\n"
+                : scan.timedOut
+                    ? "[Dusk Studio/scan] quarantined \"%s\": timed out (possible license dialog)\n"
+                    : "[Dusk Studio/scan] quarantined \"%s\": scan crashed (no payload)\n",
                 fileOrIdentifier.toRawUTF8());
             std::fflush (stderr);
             return false;
         }
 
-        const auto parsed = scanproto::parsePayload (payload);
+        const auto parsed = scanproto::parsePayload (scan.payload);
         if (! parsed.has_value())
         {
             knownList.addToBlacklist (fileOrIdentifier);
@@ -536,13 +662,15 @@ int PluginManager::scanInstalledPlugins (
     const bool blacklistGrew = knownPluginList.getBlacklistedFiles().size() != blacklistBefore;
     if (added > 0 || pruned > 0 || blacklistGrew) saveCache();
 
-    if (! aborting)
-    {
-        scanClapPlugins();        // CLAP isn't a juce format - scan it alongside the JUCE pass
-        scanLv2Plugins();         // native-LV2 rows are separate from JUCE's LV2 format
-        scanVst3NativePlugins();  // native-VST3 rows are separate from JUCE's VST3 format
-        scanAuPlugins();          // native-AU rows come from the macOS component registry
-    }
+    // Each phase is re-gated on the live flag, not the one sampled before the
+    // JUCE pass: a cancel raised during the CLAP phase has to stop the VST3 one
+    // too, or Cancel stays inert for the rest of the native scan.
+    const auto cancelled = [abort] { return abort != nullptr && abort->load (std::memory_order_relaxed); };
+
+    if (! aborting && ! cancelled()) scanClapPlugins (abort);        // CLAP isn't a juce format - scan it alongside the JUCE pass
+    if (! aborting && ! cancelled()) scanLv2Plugins();               // native-LV2 rows are separate from JUCE's LV2 format
+    if (! aborting && ! cancelled()) scanVst3NativePlugins (abort);  // native-VST3 rows are separate from JUCE's VST3 format
+    if (! aborting && ! cancelled()) scanAuPlugins();                // native-AU rows come from the macOS component registry
     return added;
 }
 
@@ -552,83 +680,95 @@ int PluginManager::scanInstalledPlugins (
 // couldn't spawn (caller falls back in-process); a spawned child that crashes
 // or times out yields no payload and the bundle is skipped - re-probed next
 // scan, but never fatal.
-bool PluginManager::scanNativeBundleSandboxed (const char* format, const juce::File& bundle,
-                                               std::vector<PluginDescriptor>& into) const
+PluginManager::NativeScanOutcome PluginManager::scanNativeBundleSandboxed (
+    const char* format, const juce::File& bundle,
+    std::vector<PluginDescriptor>& into, const std::atomic<bool>* abort) const
 {
     const juce::File hostExe (getHostExecutablePath());
     if (hostExe == juce::File() || ! hostExe.existsAsFile())
-        return false;
+        return NativeScanOutcome::NoSandbox;
 
     juce::ChildProcess proc;
     const juce::StringArray args { hostExe.getFullPathName(), "--scan-native",
                                    format, bundle.getFullPathName() };
     if (! proc.start (args, juce::ChildProcess::wantStdOut))
-        return false;
+        return NativeScanOutcome::NoSandbox;
 
-    juce::MemoryOutputStream captured;
-    char buf[8192];
-    const std::uint32_t startMs = juce::Time::getMillisecondCounter();
-    for (;;)
+    const auto scan = driveSandboxedScan (proc, abort);
+
+    // A child DID run and was killed unsupervised, so the bundle's factory may
+    // have executed already. Falling back in-process would run it again with no
+    // isolation at all - skip instead, and re-probe on the next scan.
+    if (scan.verdict == SandboxedScan::Verdict::Unsupervised)
+        return NativeScanOutcome::Handled;
+
+    if (scan.verdict == SandboxedScan::Verdict::Cancelled)
+        return NativeScanOutcome::Cancelled;
+
+    if (scan.verdict == SandboxedScan::Verdict::Failed)
     {
-        const int n = proc.readProcessOutput (buf, (int) sizeof buf);
-        if (n > 0) { captured.write (buf, (size_t) n); continue; }
-        if (! proc.isRunning())
-        {
-            int extra;
-            while ((extra = proc.readProcessOutput (buf, (int) sizeof buf)) > 0)
-                captured.write (buf, (size_t) extra);
-            break;
-        }
-        if (juce::Time::getMillisecondCounter() - startMs >= (std::uint32_t) kScanTimeoutMs)
-        {
-            proc.kill();
-            proc.waitForProcessToFinish (200);   // reap the SIGKILLed child, no zombie
-            break;
-        }
-        juce::Thread::sleep (5);
+        // Crash / hang / flood - handled (skip the bundle) so the caller doesn't
+        // re-execute the failing code in-process. Native scans have no
+        // quarantine store of their own; the bundle is re-probed next scan.
+        std::fprintf (stderr,
+            scan.tooMuchOutput
+                ? "[Dusk Studio/scan] native %s bundle skipped (flooded the scan output): %s\n"
+            : scan.timedOut
+                ? "[Dusk Studio/scan] native %s bundle skipped (timed out): %s\n"
+                : "[Dusk Studio/scan] native %s bundle skipped (child failed): %s\n",
+            format, bundle.getFullPathName().toRawUTF8());
+        std::fflush (stderr);
+        return NativeScanOutcome::Handled;
     }
 
-    const auto payload = scanproto::extractPayload (captured.toString().toStdString());
-    if (payload.empty())
-    {
-        // Crash / hang / no sentinels - treat as handled (skip the bundle) so the
-        // caller doesn't re-execute the crashing code in-process.
-        std::fprintf (stderr, "[Dusk Studio/scan] native %s bundle skipped (child failed): %s\n",
-                      format, bundle.getFullPathName().toRawUTF8());
-        return true;
-    }
-    auto found = scanproto::parsePayload (payload);
+    auto found = scanproto::parsePayload (scan.payload);
     if (! found.has_value())
     {
         std::fprintf (stderr,
                       "[Dusk Studio/scan] native %s bundle skipped (malformed child payload): %s\n",
                       format, bundle.getFullPathName().toRawUTF8());
-        return true;
+        std::fflush (stderr);
+        return NativeScanOutcome::Handled;
     }
     into.insert (into.end(), std::make_move_iterator (found->begin()),
                  std::make_move_iterator (found->end()));
-    return true;
+    return NativeScanOutcome::Handled;
 }
 #endif
 
-void PluginManager::scanClapPlugins()
+void PluginManager::scanClapPlugins (const std::atomic<bool>* abort)
 {
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
     // Discover OUTSIDE the lock (executes every bundle's factory - slow), swap
     // in under it. The cache write also stays outside so a picker open on the
     // message thread can't stall behind this thread's file I/O.
     std::vector<PluginDescriptor> fresh;
+    bool cancelled = false;
     for (const auto& path : clap::ClapScanner::findClapFiles (clap::ClapScanner::defaultSearchPaths()))
     {
+        // Between bundles as well as inside one, or a cancel would still have to
+        // wait out every remaining bundle in this phase.
+        if (abort != nullptr && abort->load (std::memory_order_relaxed)) { cancelled = true; break; }
+
         const juce::File file (juce::String::fromUTF8 (path.u8string().c_str()));
-        if (! scanNativeBundleSandboxed ("clap", file, fresh))
+        const auto outcome = scanNativeBundleSandboxed ("clap", file, fresh, abort);
+        if (outcome == NativeScanOutcome::Cancelled) { cancelled = true; break; }
+        if (outcome == NativeScanOutcome::NoSandbox)
             nativescan::appendClapRows (path, fresh);   // no sandbox available - in-process
     }
+
+    // `fresh` REPLACES the previous results, so publishing a run that stopped
+    // early would drop every bundle after the stop from the picker and from the
+    // cache on disk. Keep what the last complete scan found instead.
+    if (cancelled) return;
+
     {
         const juce::ScopedLock sl (nativeDescriptionsLock);
         clapDescriptions.swap (fresh);
     }
     saveNativeCache (clapDescriptions, "clap-cache.json");
+#else
+    (void) abort;
 #endif
 }
 
@@ -771,21 +911,32 @@ std::vector<PluginDescriptor> PluginManager::getLv2InstrumentDescriptions() cons
     return filterByInstrumentFlag (lv2Descriptions, true);
 }
 
-void PluginManager::scanVst3NativePlugins()
+void PluginManager::scanVst3NativePlugins (const std::atomic<bool>* abort)
 {
 #if DUSKSTUDIO_HAS_NATIVE_VST3
     std::vector<PluginDescriptor> fresh;
+    bool cancelled = false;
     for (const auto& path : vst3::Vst3Scanner::findVst3Bundles (vst3::Vst3Scanner::defaultSearchPaths()))
     {
+        // See scanClapPlugins: a cancel must not wait out the remaining bundles,
+        // and a phase that stopped early must not replace the cached results.
+        if (abort != nullptr && abort->load (std::memory_order_relaxed)) { cancelled = true; break; }
+
         const juce::File file (juce::String::fromUTF8 (path.u8string().c_str()));
-        if (! scanNativeBundleSandboxed ("vst3", file, fresh))
+        const auto outcome = scanNativeBundleSandboxed ("vst3", file, fresh, abort);
+        if (outcome == NativeScanOutcome::Cancelled) { cancelled = true; break; }
+        if (outcome == NativeScanOutcome::NoSandbox)
             nativescan::appendVst3Rows (path, fresh);   // no sandbox available - in-process
     }
+    if (cancelled) return;
+
     {
         const juce::ScopedLock sl (nativeDescriptionsLock);
         vst3NativeDescriptions.swap (fresh);
     }
     saveNativeCache (vst3NativeDescriptions, "vst3-native-cache.json");
+#else
+    (void) abort;
 #endif
 }
 

--- a/src/engine/PluginManager.h
+++ b/src/engine/PluginManager.h
@@ -41,7 +41,7 @@ public:
 
     std::vector<PluginDescriptor> getClapEffectDescriptions() const;
     std::vector<PluginDescriptor> getClapInstrumentDescriptions() const;
-    void scanClapPlugins();
+    void scanClapPlugins (const std::atomic<bool>* abort = nullptr);
 
     std::vector<PluginDescriptor> getLv2EffectDescriptions() const;
     std::vector<PluginDescriptor> getLv2InstrumentDescriptions() const;
@@ -49,7 +49,7 @@ public:
 
     std::vector<PluginDescriptor> getVst3NativeEffectDescriptions() const;
     std::vector<PluginDescriptor> getVst3NativeInstrumentDescriptions() const;
-    void scanVst3NativePlugins();
+    void scanVst3NativePlugins (const std::atomic<bool>* abort = nullptr);
 
     std::vector<PluginDescriptor> getAuEffectDescriptions() const;
     std::vector<PluginDescriptor> getAuInstrumentDescriptions() const;
@@ -116,8 +116,17 @@ private:
 
     juce::File nativeCacheFile (const char* fileName) const;
 #if DUSKSTUDIO_HAS_NATIVE_CLAP || DUSKSTUDIO_HAS_NATIVE_VST3
-    bool scanNativeBundleSandboxed (const char* format, const juce::File& bundle,
-                                    std::vector<PluginDescriptor>& into) const;
+    // What one sandboxed native-bundle scan settled.
+    enum class NativeScanOutcome
+    {
+        Handled,     // the child settled it; do NOT re-run the bundle in-process
+        NoSandbox,   // no usable child was started; the caller falls back in-process
+        Cancelled    // user stopped the scan; abandon the phase without caching it
+    };
+
+    NativeScanOutcome scanNativeBundleSandboxed (const char* format, const juce::File& bundle,
+                                                 std::vector<PluginDescriptor>& into,
+                                                 const std::atomic<bool>* abort) const;
 #endif
     void loadNativeCache (std::vector<PluginDescriptor>& into,
                           const char* jsonFileName, const char* legacyXmlFileName,

--- a/src/engine/clap/ClapInstance.cpp
+++ b/src/engine/clap/ClapInstance.cpp
@@ -289,7 +289,21 @@ bool ClapInstance::loadState (const std::vector<uint8_t>& in)
         if (n > 0) { std::memcpy (buffer, c->data + c->pos, n); c->pos += n; }
         return (int64_t) n;   // 0 = EOF
     };
-    return st->load (plugin, &is);
+    if (! st->load (plugin, &is)) return false;
+
+    // Restored state can select a mode with different lookahead (linear phase,
+    // oversampling), so the value cached at activate() no longer describes the
+    // plugin. Re-read it or the host compensates by the wrong amount.
+    // clap_plugin_latency.get is [main-thread & active].
+    if (active)
+    {
+        if (const auto* lat = static_cast<const clap_plugin_latency_t*> (
+                plugin->get_extension (plugin, CLAP_EXT_LATENCY));
+            lat != nullptr && lat->get != nullptr)
+            latencySamples = (int) lat->get (plugin);
+    }
+
+    return true;
 }
 
 bool ClapInstance::getParamValue (clap_id id, double& out) const

--- a/src/foundation/Base64.h
+++ b/src/foundation/Base64.h
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
 #include <vector>
 
 // RFC 4648 base64 decoding. JUCE's MemoryBlock base64 pair is a DIFFERENT format
@@ -54,6 +55,51 @@ inline std::vector<std::uint8_t> decode (const char* utf8, std::size_t length)
             bits -= 8;
             out.push_back ((std::uint8_t) ((accumulator >> bits) & 0xffu));
         }
+    }
+    return out;
+}
+
+// Canonical RFC 4648 encoding, '=' padding included: byte-for-byte what JUCE's
+// Base64 helper emitted, so state strings written before the de-JUCE swap
+// compare equal to ones written after it.
+inline std::string encode (const std::uint8_t* data, std::size_t length)
+{
+    static constexpr char alphabet[] =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    std::string out;
+    if (data == nullptr || length == 0) return out;
+    out.reserve (((length + 2) / 3) * 4);
+
+    std::size_t i = 0;
+    for (; i + 3 <= length; i += 3)
+    {
+        const std::uint32_t v = ((std::uint32_t) data[i] << 16)
+                              | ((std::uint32_t) data[i + 1] << 8)
+                              | (std::uint32_t) data[i + 2];
+        out.push_back (alphabet[(v >> 18) & 63]);
+        out.push_back (alphabet[(v >> 12) & 63]);
+        out.push_back (alphabet[(v >> 6) & 63]);
+        out.push_back (alphabet[v & 63]);
+    }
+
+    const std::size_t rem = length - i;
+    if (rem == 1)
+    {
+        const std::uint32_t v = (std::uint32_t) data[i] << 16;
+        out.push_back (alphabet[(v >> 18) & 63]);
+        out.push_back (alphabet[(v >> 12) & 63]);
+        out.push_back ('=');
+        out.push_back ('=');
+    }
+    else if (rem == 2)
+    {
+        const std::uint32_t v = ((std::uint32_t) data[i] << 16)
+                              | ((std::uint32_t) data[i + 1] << 8);
+        out.push_back (alphabet[(v >> 18) & 63]);
+        out.push_back (alphabet[(v >> 12) & 63]);
+        out.push_back (alphabet[(v >> 6) & 63]);
+        out.push_back ('=');
     }
     return out;
 }

--- a/src/foundation/Base64.h
+++ b/src/foundation/Base64.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+// RFC 4648 base64 decoding. JUCE's MemoryBlock base64 pair is a DIFFERENT format
+// despite the name - it prefixes a decimal byte count and uses a private alphabet
+// - so the two must never be mixed.
+//
+// Lenient about canonical form, because the job is recovering bytes rather than
+// validating: up to two trailing '=' are dropped without checking the group
+// needed them, and bits left over in the final group are discarded. Rejection is
+// reserved for input that cannot yield bytes at all - a character outside the
+// alphabet, or a length whose last group holds a single character.
+namespace dusk::base64
+{
+inline int sextet (char c) noexcept
+{
+    if (c >= 'A' && c <= 'Z') return c - 'A';
+    if (c >= 'a' && c <= 'z') return c - 'a' + 26;
+    if (c >= '0' && c <= '9') return c - '0' + 52;
+    if (c == '+') return 62;
+    if (c == '/') return 63;
+    return -1;
+}
+
+inline std::vector<std::uint8_t> decode (const char* utf8, std::size_t length)
+{
+    std::vector<std::uint8_t> out;
+    if (utf8 == nullptr) return out;
+
+    std::size_t numChars = length;
+    for (int pad = 0; pad < 2 && numChars > 0 && utf8[numChars - 1] == '='; ++pad)
+        --numChars;
+
+    // A four-char group carries 1..3 bytes, so a remainder of one char is a
+    // truncated blob rather than an unpadded one.
+    if (numChars % 4 == 1) return out;
+
+    out.reserve ((numChars / 4) * 3 + 2);
+
+    std::uint32_t accumulator = 0;
+    int bits = 0;
+    for (std::size_t i = 0; i < numChars; ++i)
+    {
+        const int value = sextet (utf8[i]);
+        if (value < 0) { out.clear(); return out; }
+
+        accumulator = (accumulator << 6) | (std::uint32_t) value;
+        bits += 6;
+        if (bits >= 8)
+        {
+            bits -= 8;
+            out.push_back ((std::uint8_t) ((accumulator >> bits) & 0xffu));
+        }
+    }
+    return out;
+}
+} // namespace dusk::base64

--- a/src/session/RegionEditActions.cpp
+++ b/src/session/RegionEditActions.cpp
@@ -4,6 +4,7 @@
 #include "../engine/Transport.h"
 #include "../engine/audiofile/FileReader.h"
 #include "../engine/audiofile/FileWriter.h"
+#include "../foundation/Base64.h"
 #include "../foundation/Decibels.h"
 
 #include <algorithm>
@@ -483,12 +484,7 @@ namespace
 #if DUSKSTUDIO_HAS_NATIVE_AU
 std::vector<uint8_t> decodeCarriedState (const juce::String& base64)
 {
-    std::vector<uint8_t> out;
-    juce::MemoryBlock blob;
-    if (blob.fromBase64Encoding (base64) && blob.getSize() > 0)
-        out.assign (static_cast<const uint8_t*> (blob.getData()),
-                    static_cast<const uint8_t*> (blob.getData()) + blob.getSize());
-    return out;
+    return dusk::base64::decode (base64.toRawUTF8(), base64.getNumBytesAsUTF8());
 }
 #endif
 

--- a/src/session/RegionEditActions.cpp
+++ b/src/session/RegionEditActions.cpp
@@ -1,5 +1,6 @@
 #include "RegionEditActions.h"
 #include "../engine/AudioEngine.h"
+#include "../engine/LegacyStateBase64.h"
 #include "../engine/PlaybackEngine.h"
 #include "../engine/Transport.h"
 #include "../engine/audiofile/FileReader.h"
@@ -484,7 +485,15 @@ namespace
 #if DUSKSTUDIO_HAS_NATIVE_AU
 std::vector<uint8_t> decodeCarriedState (const juce::String& base64)
 {
-    return dusk::base64::decode (base64.toRawUTF8(), base64.getNumBytesAsUTF8());
+    auto blob = dusk::base64::decode (base64.toRawUTF8(), base64.getNumBytesAsUTF8());
+
+    // Same fallback as AudioEngine's decodeBase64Blob: a 0.13.1-migrated slot
+    // carries the JUCE MemoryBlock form on the native key, which RFC 4648
+    // rejects outright. Dropping it here would clone the slot empty and let the
+    // next save write defaults over the only surviving copy.
+    if (blob.empty())
+        blob = duskstudio::decodeLegacyStateBase64 (base64.toStdString());
+    return blob;
 }
 #endif
 

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -1648,7 +1648,7 @@ void MainComponent::maybeStartStartupPluginScan()
         std::fflush (stderr);
 
         auto& mgr = self->engine.getPluginManager();
-        auto body = std::make_unique<PluginScanModal> (mgr, [safe] (int added)
+        auto body = std::make_unique<PluginScanModal> (mgr, [safe] (int added, bool cancelled)
         {
             auto* s = safe.getComponent();
             if (s == nullptr) return;
@@ -1657,8 +1657,8 @@ void MainComponent::maybeStartStartupPluginScan()
             const int total = m.getEffectDescriptions().size()
                             + m.getInstrumentDescriptions().size();
             std::fprintf (stderr,
-                          "[Dusk Studio] Scan-on-startup: added %d new plugins (%d total).\n",
-                          added, total);
+                          "[Dusk Studio] Scan-on-startup: %s, added %d new plugins (%d total).\n",
+                          cancelled ? "cancelled" : "finished", added, total);
             if (const int skipped = m.getLastScanSandboxSkips(); skipped > 0)
                 std::fprintf (stderr,
                               "[Dusk Studio] Scan-on-startup: sandbox unavailable - %d plugin(s) left unscanned.\n",
@@ -1666,11 +1666,14 @@ void MainComponent::maybeStartStartupPluginScan()
             std::fflush (stderr);
         });
 
-        // Locked modal (no click-outside / Esc dismiss): it closes itself when
-        // the scan completes.
-        self->scanModal.show (*self, std::move (body), /*onDismiss*/ {},
+        // No click-outside dismiss; the modal closes itself when the scan
+        // completes. Esc cancels rather than dismissing: tearing the modal down
+        // mid-scan would join the worker on the message thread.
+        auto* scan = body.get();
+        self->scanModal.show (*self, std::move (body),
+                              /*onDismiss*/ [scan] { scan->requestCancel(); },
                               /*dismissOnClickOutside*/ false,
-                              /*dismissOnEscape*/ false);
+                              /*dismissOnEscape*/ true);
     });
 }
 

--- a/src/ui/PluginPickerHelpers.cpp
+++ b/src/ui/PluginPickerHelpers.cpp
@@ -194,7 +194,7 @@ void runScanModal (PluginManager& manager, juce::Component* parent,
 
     auto body = std::make_unique<PluginScanModal> (manager,
         [&modal, &manager, safeHost, onAlertDismiss = std::move (onAlertDismiss)]
-        (int added) mutable
+        (int added, bool cancelled) mutable
         {
             modal.close();
 
@@ -202,6 +202,11 @@ void runScanModal (PluginManager& manager, juce::Component* parent,
                 "Added %d plugin%s to the picker. (Total known: %d)",
                 added, added == 1 ? "" : "s",
                 manager.getPluginCount());
+
+            if (cancelled)
+                message = "You stopped the scan. " + message
+                        + "\n\nThe rest of your collection was not scanned; "
+                          "run Scan plugins again to finish.";
 
             // On a shipped build this warning means the install lost its child
             // executable, so name the path that was looked for.
@@ -224,14 +229,17 @@ void runScanModal (PluginManager& manager, juce::Component* parent,
                         << manager.getCacheFile().getFullPathName();
 
             if (auto* h = safeHost.getComponent())
-                showDuskAlert (*h, "Plugin scan complete", std::move (message),
-                                  std::move (onAlertDismiss));
+                showDuskAlert (*h, cancelled ? "Plugin scan cancelled" : "Plugin scan complete",
+                                  std::move (message), std::move (onAlertDismiss));
             else if (onAlertDismiss)
                 onAlertDismiss();
         });
 
-    modal.show (*host, std::move (body), /*onDismiss*/ {},
-                /*dismissOnClickOutside*/ false, /*dismissOnEscape*/ false);
+    // Esc cancels rather than dismissing: tearing the modal down mid-scan would
+    // join the worker on the message thread. The scan unwinds and closes itself.
+    auto* scan = body.get();
+    modal.show (*host, std::move (body), /*onDismiss*/ [scan] { scan->requestCancel(); },
+                /*dismissOnClickOutside*/ false, /*dismissOnEscape*/ true);
 }
 
 namespace

--- a/src/ui/PluginScanModal.cpp
+++ b/src/ui/PluginScanModal.cpp
@@ -5,12 +5,12 @@
 namespace duskstudio
 {
 PluginScanModal::PluginScanModal (PluginManager& mgr,
-                                  std::function<void (int)> onFinishedIn)
+                                  std::function<void (int, bool)> onFinishedIn)
     : manager (mgr),
       onFinished (std::move (onFinishedIn)),
       progressBar (progressValue)
 {
-    setSize (420, 150);
+    setSize (420, 190);
 
     titleLabel.setText ("Scanning plugins...", juce::dontSendNotification);
     titleLabel.setFont (juce::Font (juce::FontOptions (16.0f, juce::Font::bold)));
@@ -26,6 +26,11 @@ PluginScanModal::PluginScanModal (PluginManager& mgr,
     progressBar.setColour (juce::ProgressBar::backgroundColourId, juce::Colour (0xff101012));
     progressBar.setColour (juce::ProgressBar::foregroundColourId, juce::Colour (0xff5fa8ff));
     addAndMakeVisible (progressBar);
+
+    cancelButton.setColour (juce::TextButton::buttonColourId, juce::Colour (0xff202024));
+    cancelButton.setColour (juce::TextButton::textColourOffId, juce::Colour (0xffd0d0d0));
+    cancelButton.onClick = [this] { requestCancel(); };
+    addAndMakeVisible (cancelButton);
 
     startedAtMs = juce::Time::getMillisecondCounter();
     std::fprintf (stderr, "[Dusk Studio] PluginScanModal: created, starting worker thread\n");
@@ -56,6 +61,24 @@ PluginScanModal::~PluginScanModal()
         worker->stopThread (5000);
         worker.reset();
     }
+}
+
+void PluginScanModal::requestCancel()
+{
+    // Don't relabel a scan that already finished. completeShown covers a result
+    // that is on screen; scanDone covers the ticks between the worker returning
+    // and the timer noticing. A cancel landing in the few instructions before
+    // the worker publishes scanDone still marks the result cancelled - that
+    // changes the wording only, never what was scanned.
+    if (completeShown || scanDone.load (std::memory_order_acquire)) return;
+    if (aborting.exchange (true)) return;
+
+    // The scanner's watchdog polls the flag, so the plugin being probed is ended
+    // within a tick instead of sitting out the rest of its timeout.
+    worker->signalThreadShouldExit();
+
+    cancelButton.setEnabled (false);
+    titleLabel.setText ("Cancelling scan...", juce::dontSendNotification);
 }
 
 void PluginScanModal::Worker::run()
@@ -104,10 +127,13 @@ void PluginScanModal::timerCallback()
         completeAtMs  = juce::Time::getMillisecondCounter();
 
         const int added = addedCount.load (std::memory_order_relaxed);
-        titleLabel.setText ("Plugin scan complete", juce::dontSendNotification);
+        const bool cancelled = aborting.load (std::memory_order_relaxed);
+        titleLabel.setText (cancelled ? "Plugin scan cancelled" : "Plugin scan complete",
+                            juce::dontSendNotification);
         statusLabel.setText (juce::String (added) + " new plugin"
                                  + (added == 1 ? "" : "s") + " added.",
                              juce::dontSendNotification);
+        cancelButton.setVisible (false);
         progressValue = 1.0;
         progressBar.repaint();
     }
@@ -125,14 +151,16 @@ void PluginScanModal::timerCallback()
         // lambda never touches `this`.
         if (onFinished)
             dusk::callAsync (
-                [cb = onFinished, count = addedCount.load (std::memory_order_relaxed)]
-                { cb (count); });
+                [cb = onFinished, count = addedCount.load (std::memory_order_relaxed),
+                 cancelled = aborting.load (std::memory_order_relaxed)]
+                { cb (count, cancelled); });
     }
 }
 
 void PluginScanModal::resized()
 {
     auto area = getLocalBounds().reduced (20);
+    cancelButton.setBounds (area.removeFromBottom (30).removeFromRight (90));
     titleLabel.setBounds (area.removeFromTop (26));
     area.removeFromTop (10);
     progressBar.setBounds (area.removeFromTop (22));

--- a/src/ui/PluginScanModal.h
+++ b/src/ui/PluginScanModal.h
@@ -16,18 +16,25 @@ class PluginManager;
 // doesn't look like a frozen app. Mirrors BounceDialog's worker-thread +
 // Timer pattern.
 //
-// Lifetime: handed to an EmbeddedModal (the caller keeps the modal alive).
-// When the scan finishes, the Timer fires onFinished(addedCount) so the caller
-// can close the modal + surface a result. The destructor signals the worker to
-// abort mid-file (via the atomic the scanner polls between child-process reads)
-// and joins it, so quitting the app mid-scan doesn't hang on a slow plugin.
+// Lifetime: handed to an EmbeddedModal (the caller keeps the modal alive). When
+// the scan finishes, the Timer fires onFinished so the caller can close the
+// modal + surface a result. The destructor raises the same abort flag the
+// scanner's watchdog polls and then joins the worker, so quitting the app
+// mid-scan doesn't hang on a slow plugin.
 class PluginScanModal final : public juce::Component,
                               private dusk::Timer
 {
 public:
+    // onFinished reports what the scan added and whether the user stopped it,
+    // so the caller can word its follow-up as a partial result.
     PluginScanModal (PluginManager& manager,
-                     std::function<void (int addedCount)> onFinished);
+                     std::function<void (int addedCount, bool cancelled)> onFinished);
     ~PluginScanModal() override;
+
+    // Stop probing and let the scan unwind on its own; the modal then closes
+    // through the normal completion path with whatever was found so far.
+    // Message thread only. Idempotent, and a no-op once the scan has finished.
+    void requestCancel();
 
     void resized() override;
     void paint (juce::Graphics&) override;
@@ -44,7 +51,7 @@ private:
     };
 
     PluginManager&                       manager;
-    std::function<void (int)>            onFinished;
+    std::function<void (int, bool)>      onFinished;
 
     std::atomic<bool>  aborting   { false };
     std::atomic<bool>  scanDone   { false };
@@ -56,6 +63,7 @@ private:
 
     juce::Label        titleLabel;
     juce::Label        statusLabel;
+    juce::TextButton   cancelButton { "Cancel" };
     // Declared BEFORE progressBar: the ProgressBar ctor binds a double& to
     // this, and members construct in declaration order - so it must be live
     // (initialised) before progressBar's ctor runs.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,6 +55,8 @@ add_executable(dusk-studio-tests
     fade_curve_path.cpp
     file_importer_audio.cpp
     hardware_insert.cpp
+    base64_decode.cpp
+    legacy_state_base64.cpp
     session_round_trip.cpp
     session_tape_migration.cpp
     session_freeze_roundtrip.cpp

--- a/tests/base64_decode.cpp
+++ b/tests/base64_decode.cpp
@@ -1,0 +1,83 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "foundation/Base64.h"
+
+#include <juce_core/juce_core.h>
+
+#include <string>
+#include <vector>
+
+namespace
+{
+std::vector<std::uint8_t> decode (const std::string& s)
+{
+    return dusk::base64::decode (s.data(), s.size());
+}
+
+std::vector<std::uint8_t> bytesOf (const std::string& s)
+{
+    return { s.begin(), s.end() };
+}
+} // namespace
+
+// Native plugin state is written with juce::Base64::toBase64 (RFC 4648) and read
+// back through dusk::base64::decode. These were once mismatched: the reader used
+// juce::MemoryBlock::fromBase64Encoding, a size-prefixed private format that
+// rejects every RFC string, so every CLAP / LV2 / VST3 / AU / multisample slot
+// silently restored to its default state.
+TEST_CASE ("dusk::base64 decodes what juce::Base64 encodes", "[base64][foundation]")
+{
+    juce::Random random (0x5eed);
+
+    for (int size : { 1, 2, 3, 4, 7, 64, 201, 1024, 8702 })
+    {
+        std::vector<std::uint8_t> original ((size_t) size);
+        for (auto& byte : original)
+            byte = (std::uint8_t) random.nextInt (256);
+
+        const auto encoded = juce::Base64::toBase64 (original.data(), original.size());
+        REQUIRE (decode (encoded.toStdString()) == original);
+    }
+}
+
+TEST_CASE ("dusk::base64 matches the RFC 4648 vectors", "[base64][foundation]")
+{
+    REQUIRE (decode ("").empty());
+    REQUIRE (decode ("Zg==")     == bytesOf ("f"));
+    REQUIRE (decode ("Zm8=")     == bytesOf ("fo"));
+    REQUIRE (decode ("Zm9v")     == bytesOf ("foo"));
+    REQUIRE (decode ("Zm9vYg==") == bytesOf ("foob"));
+    REQUIRE (decode ("Zm9vYmE=") == bytesOf ("fooba"));
+    REQUIRE (decode ("Zm9vYmFy") == bytesOf ("foobar"));
+
+    // The real session payloads use the full alphabet including + and /.
+    REQUIRE (decode ("+/8=") == std::vector<std::uint8_t> { 0xfb, 0xff });
+}
+
+TEST_CASE ("dusk::base64 accepts missing padding", "[base64][foundation]")
+{
+    REQUIRE (decode ("Zg")     == bytesOf ("f"));
+    REQUIRE (decode ("Zm8")    == bytesOf ("fo"));
+    REQUIRE (decode ("Zm9vYg") == bytesOf ("foob"));
+}
+
+// The bug this whole header exists to prevent: a JUCE MemoryBlock string must
+// never decode as if it were RFC 4648.
+TEST_CASE ("dusk::base64 rejects the JUCE MemoryBlock encoding", "[base64][foundation]")
+{
+    REQUIRE (decode ("12.ABC").empty());
+
+    const std::string payload = "CLAPSTATEblob";
+    const juce::MemoryBlock block (payload.data(), payload.size());
+    REQUIRE (decode (block.toBase64Encoding().toStdString()).empty());
+}
+
+TEST_CASE ("dusk::base64 rejects malformed input", "[base64][foundation]")
+{
+    REQUIRE (decode ("!!!!").empty());
+    REQUIRE (decode ("Zm9v YmFy").empty());       // embedded whitespace
+    REQUIRE (decode ("Zm9v\nYmFy").empty());      // wrapped lines
+    REQUIRE (decode ("QQ==QQ==").empty());        // padding mid-string
+    REQUIRE (decode ("Zm9vYmFyZ").empty());       // group of one carries no byte
+    REQUIRE (dusk::base64::decode (nullptr, 8).empty());
+}

--- a/tests/legacy_state_base64.cpp
+++ b/tests/legacy_state_base64.cpp
@@ -1,0 +1,81 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/LegacyStateBase64.h"
+#include "foundation/Base64.h"
+
+#include <juce_core/juce_core.h>
+
+#include <cstdint>
+#include <vector>
+
+using duskstudio::decodeLegacyStateBase64;
+using duskstudio::transcodeLegacyStateBase64;
+
+namespace
+{
+std::vector<std::uint8_t> decode (const juce::String& s)
+{
+    return dusk::base64::decode (s.toRawUTF8(), s.getNumBytesAsUTF8());
+}
+} // namespace
+
+// The AU and multisample migrations move a slot from the JUCE plugin path onto a
+// native key. Both encodings are base64 by name only, so a straight copy hands
+// the native restore something it cannot read: the slot comes back at its
+// defaults and the next save writes those defaults over the last good copy.
+TEST_CASE ("legacy state transcodes onto the native keys", "[session][migration]")
+{
+    const std::vector<std::uint8_t> original { 0x00, 0x11, 0xfe, 0xff, 0x7f, 0x80, 0x2b, 0x2f, 0x41 };
+    const auto legacy = juce::MemoryBlock (original.data(), original.size()).toBase64Encoding();
+
+    juce::String migrated;
+    REQUIRE (transcodeLegacyStateBase64 (legacy, migrated));
+    REQUIRE (migrated != legacy);
+    REQUIRE (decode (migrated) == original);
+}
+
+TEST_CASE ("legacy state transcode reports unreadable input", "[session][migration]")
+{
+    juce::String migrated { "untouched" };
+
+    // No '.' byte-count prefix: not the legacy encoding at all. Migrating on a
+    // false return would strand the only copy of the user's settings.
+    REQUIRE_FALSE (transcodeLegacyStateBase64 ("Zm9vYmFy", migrated));
+    REQUIRE_FALSE (transcodeLegacyStateBase64 ("not a blob", migrated));
+    REQUIRE (migrated == "untouched");
+
+    // An empty legacy slot has nothing to lose and migrates cleanly.
+    REQUIRE (transcodeLegacyStateBase64 ({}, migrated));
+    REQUIRE (migrated.isEmpty());
+}
+
+// A plugin that saved no state at all encodes as "0.". Reading that as a failure
+// would abandon the migration, leaving a DuskMultisample slot on a JUCE format
+// that no longer exists - the soundfont would simply never load.
+TEST_CASE ("legacy state transcode accepts an empty saved state", "[session][migration]")
+{
+    const auto legacy = juce::MemoryBlock().toBase64Encoding();
+    REQUIRE (legacy == "0.");
+
+    juce::String migrated { "untouched" };
+    REQUIRE (transcodeLegacyStateBase64 (legacy, migrated));
+    REQUIRE (migrated.isEmpty());
+}
+
+// 0.13.1 copied the legacy string onto the native key instead of transcoding it,
+// and its reader took it. A session it converted, then never re-saved with the
+// slot loaded, still holds that form; reading only RFC 4648 would reset it.
+TEST_CASE ("0.13.1-migrated state still decodes", "[session][migration]")
+{
+    const std::vector<std::uint8_t> original { 0x7f, 0x00, 0xc3, 0x2a, 0xff };
+    const auto carried = juce::MemoryBlock (original.data(), original.size()).toBase64Encoding();
+
+    REQUIRE (decode (carried).empty());                    // not RFC 4648
+    REQUIRE (decodeLegacyStateBase64 (carried) == original);
+
+    // The fallback must not claim RFC 4648 strings: it needs the '.' byte-count
+    // prefix, which base64 output never contains.
+    REQUIRE (decodeLegacyStateBase64 (
+                 juce::Base64::toBase64 (original.data(), original.size())).empty());
+    REQUIRE (decodeLegacyStateBase64 ({}).empty());
+}

--- a/tests/legacy_state_base64.cpp
+++ b/tests/legacy_state_base64.cpp
@@ -6,6 +6,7 @@
 #include <juce_core/juce_core.h>
 
 #include <cstdint>
+#include <string>
 #include <vector>
 
 using duskstudio::decodeLegacyStateBase64;
@@ -13,9 +14,9 @@ using duskstudio::transcodeLegacyStateBase64;
 
 namespace
 {
-std::vector<std::uint8_t> decode (const juce::String& s)
+std::vector<std::uint8_t> decode (const std::string& s)
 {
-    return dusk::base64::decode (s.toRawUTF8(), s.getNumBytesAsUTF8());
+    return dusk::base64::decode (s.data(), s.size());
 }
 } // namespace
 
@@ -26,17 +27,23 @@ std::vector<std::uint8_t> decode (const juce::String& s)
 TEST_CASE ("legacy state transcodes onto the native keys", "[session][migration]")
 {
     const std::vector<std::uint8_t> original { 0x00, 0x11, 0xfe, 0xff, 0x7f, 0x80, 0x2b, 0x2f, 0x41 };
-    const auto legacy = juce::MemoryBlock (original.data(), original.size()).toBase64Encoding();
+    const auto legacy = juce::MemoryBlock (original.data(), original.size())
+                            .toBase64Encoding().toStdString();
 
-    juce::String migrated;
+    std::string migrated;
     REQUIRE (transcodeLegacyStateBase64 (legacy, migrated));
     REQUIRE (migrated != legacy);
     REQUIRE (decode (migrated) == original);
+
+    // The transcoded form must be byte-identical to what juce::Base64 used to
+    // write, so sessions saved before and after the de-JUCE swap compare equal.
+    REQUIRE (migrated
+             == juce::Base64::toBase64 (original.data(), original.size()).toStdString());
 }
 
 TEST_CASE ("legacy state transcode reports unreadable input", "[session][migration]")
 {
-    juce::String migrated { "untouched" };
+    std::string migrated { "untouched" };
 
     // No '.' byte-count prefix: not the legacy encoding at all. Migrating on a
     // false return would strand the only copy of the user's settings.
@@ -46,7 +53,7 @@ TEST_CASE ("legacy state transcode reports unreadable input", "[session][migrati
 
     // An empty legacy slot has nothing to lose and migrates cleanly.
     REQUIRE (transcodeLegacyStateBase64 ({}, migrated));
-    REQUIRE (migrated.isEmpty());
+    REQUIRE (migrated.empty());
 }
 
 // A plugin that saved no state at all encodes as "0.". Reading that as a failure
@@ -54,12 +61,12 @@ TEST_CASE ("legacy state transcode reports unreadable input", "[session][migrati
 // that no longer exists - the soundfont would simply never load.
 TEST_CASE ("legacy state transcode accepts an empty saved state", "[session][migration]")
 {
-    const auto legacy = juce::MemoryBlock().toBase64Encoding();
+    const auto legacy = juce::MemoryBlock().toBase64Encoding().toStdString();
     REQUIRE (legacy == "0.");
 
-    juce::String migrated { "untouched" };
+    std::string migrated { "untouched" };
     REQUIRE (transcodeLegacyStateBase64 (legacy, migrated));
-    REQUIRE (migrated.isEmpty());
+    REQUIRE (migrated.empty());
 }
 
 // 0.13.1 copied the legacy string onto the native key instead of transcoding it,
@@ -68,7 +75,8 @@ TEST_CASE ("legacy state transcode accepts an empty saved state", "[session][mig
 TEST_CASE ("0.13.1-migrated state still decodes", "[session][migration]")
 {
     const std::vector<std::uint8_t> original { 0x7f, 0x00, 0xc3, 0x2a, 0xff };
-    const auto carried = juce::MemoryBlock (original.data(), original.size()).toBase64Encoding();
+    const auto carried = juce::MemoryBlock (original.data(), original.size())
+                             .toBase64Encoding().toStdString();
 
     REQUIRE (decode (carried).empty());                    // not RFC 4648
     REQUIRE (decodeLegacyStateBase64 (carried) == original);
@@ -76,6 +84,28 @@ TEST_CASE ("0.13.1-migrated state still decodes", "[session][migration]")
     // The fallback must not claim RFC 4648 strings: it needs the '.' byte-count
     // prefix, which base64 output never contains.
     REQUIRE (decodeLegacyStateBase64 (
-                 juce::Base64::toBase64 (original.data(), original.size())).empty());
+                 juce::Base64::toBase64 (original.data(), original.size()).toStdString())
+                 .empty());
     REQUIRE (decodeLegacyStateBase64 ({}).empty());
+}
+
+// The decoder no longer calls into JUCE, so its bit-order agreement with
+// juce::MemoryBlock is an implementation promise rather than a shared code
+// path. Sweep every payload length across a few group alignments so a
+// bit-cursor mistake at any 6-bit boundary fails loudly here instead of
+// silently corrupting a restored plugin state.
+TEST_CASE ("legacy decode matches juce::MemoryBlock across lengths", "[session][migration]")
+{
+    for (int n = 0; n <= 32; ++n)
+    {
+        std::vector<std::uint8_t> original;
+        original.reserve ((size_t) n);
+        for (int i = 0; i < n; ++i)
+            original.push_back ((std::uint8_t) (i * 37 + n * 11 + 3));
+
+        const auto legacy = juce::MemoryBlock (original.data(), original.size())
+                                .toBase64Encoding().toStdString();
+
+        REQUIRE (decodeLegacyStateBase64 (legacy) == original);
+    }
 }

--- a/tests/session_round_trip.cpp
+++ b/tests/session_round_trip.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
+#include "foundation/Base64.h"
 #include "session/Session.h"
 #include "session/SessionSerializer.h"
 
@@ -178,18 +179,27 @@ TEST_CASE ("SessionSerializer round-trips an aux native-CLAP slot", "[session][s
     const auto dir = makeTempSessionDir();
     const auto target = dir.getChildFile ("session.json");
 
+    // Encoded the way AudioEngine::publishPluginStateForSave writes it, so the
+    // stored string is checked against the decoder the restore path uses instead
+    // of only against itself.
+    const std::vector<std::uint8_t> state { 0x00, 0x01, 0xfe, 0xff, 0x7f, 0x80, 0x2b, 0x2f };
+    const auto encoded = juce::Base64::toBase64 (state.data(), state.size());
+
     Session a;
     auto& lane = a.auxLane (1);
     lane.nativeClapPath[0]        = "/home/user/.clap/DuskVerb.clap";
     lane.nativeClapPluginId[0]    = "com.dusk.duskverb";
-    lane.nativeClapStateBase64[0] = "Q0xBUFNUQVRFYmxvYg==";
+    lane.nativeClapStateBase64[0] = encoded;
     REQUIRE (SessionSerializer::save (a, target));
 
     Session b;
     REQUIRE (SessionSerializer::load (b, target));
     REQUIRE (b.auxLane (1).nativeClapPath[0]        == "/home/user/.clap/DuskVerb.clap");
     REQUIRE (b.auxLane (1).nativeClapPluginId[0]    == "com.dusk.duskverb");
-    REQUIRE (b.auxLane (1).nativeClapStateBase64[0] == "Q0xBUFNUQVRFYmxvYg==");
+
+    const auto& stored = b.auxLane (1).nativeClapStateBase64[0];
+    REQUIRE (stored == encoded);
+    REQUIRE (dusk::base64::decode (stored.toRawUTF8(), stored.getNumBytesAsUTF8()) == state);
 
     // A lane with no native CLAP stays empty (keys omitted on write).
     REQUIRE (b.auxLane (0).nativeClapPath[0].isEmpty());

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -7,7 +7,7 @@ src/dsp/ChannelStrip.h	32
 src/dsp/MasterBus.cpp	3
 src/dsp/MasterBus.h	7
 src/dsp/MasteringChain.h	5
-src/engine/AudioEngine.cpp	140
+src/engine/AudioEngine.cpp	139
 src/engine/AudioEngine.h	18
 src/engine/AudioPipelineSelfTest.cpp	23
 src/engine/BounceEngine.cpp	47
@@ -20,6 +20,7 @@ src/engine/DuskStudioPlayHead.h	4
 src/engine/FileImporter.cpp	20
 src/engine/FileImporter.h	4
 src/engine/JuceCompat.h	5
+src/engine/LegacyStateBase64.h	8
 src/engine/MasteringPlayer.cpp	3
 src/engine/MasteringPlayer.h	8
 src/engine/PlaybackEngine.cpp	6
@@ -50,7 +51,7 @@ src/session/MarkerEditActions.h	4
 src/session/MidiBindings.cpp	47
 src/session/MidiBindings.h	10
 src/session/ParamEditAction.h	2
-src/session/RegionEditActions.cpp	36
+src/session/RegionEditActions.cpp	35
 src/session/RegionEditActions.h	16
 src/session/Session.cpp	10
 src/session/Session.h	76

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -25,7 +25,7 @@ src/engine/MasteringPlayer.cpp	3
 src/engine/MasteringPlayer.h	8
 src/engine/PlaybackEngine.cpp	6
 src/engine/PlaybackEngine.h	4
-src/engine/PluginManager.cpp	112
+src/engine/PluginManager.cpp	109
 src/engine/PluginManager.h	29
 src/engine/PluginSlot.cpp	73
 src/engine/PluginSlot.h	42
@@ -145,8 +145,8 @@ src/ui/PluginPickerHelpers.cpp	135
 src/ui/PluginPickerHelpers.h	23
 src/ui/PluginPickerPanel.cpp	70
 src/ui/PluginPickerPanel.h	13
-src/ui/PluginScanModal.cpp	28
-src/ui/PluginScanModal.h	10
+src/ui/PluginScanModal.cpp	33
+src/ui/PluginScanModal.h	11
 src/ui/ScreenshotCapture.cpp	31
 src/ui/SectionPillButton.h	7
 src/ui/SelfTestPanel.cpp	10

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -20,7 +20,6 @@ src/engine/DuskStudioPlayHead.h	4
 src/engine/FileImporter.cpp	20
 src/engine/FileImporter.h	4
 src/engine/JuceCompat.h	5
-src/engine/LegacyStateBase64.h	8
 src/engine/MasteringPlayer.cpp	3
 src/engine/MasteringPlayer.h	8
 src/engine/PlaybackEngine.cpp	6


### PR DESCRIPTION
Fixes #355 and #347 for the 0.13.2 point release, cut from the v0.13.1 tag. Targets release/0.13 because main has moved on to de-JUCE work that must not ship in 0.13.x.

## #355 - plugin state never restored

Native-host plugin state was written to session.json with juce::Base64 (RFC 4648) and read back with juce::MemoryBlock::fromBase64Encoding, a size-prefixed private format that rejects every RFC string. The decode failed 100% of the time, so loadState was never called for any CLAP, LV2, VST3, AU or multisample slot, on tracks and aux lanes alike. The state on disk was valid all along.

- New src/foundation/Base64.h provides a JUCE-free RFC 4648 decoder; the two readers now use it. Encoders untouched. The JUCE-hosted PluginSlot path uses the MemoryBlock pair on both sides and is untouched.
- The 0.13.1 AU/multisample migrations copied MemoryBlock-encoded strings onto native keys verbatim. Those now transcode at migration time (src/engine/LegacyStateBase64.h), and the reader falls back to the MemoryBlock form so sessions 0.13.1 already migrated still restore. The fallback is unambiguous: that form always contains a '.', which RFC output never does.
- ClapInstance re-reads CLAP_EXT_LATENCY after loadState so PDC tracks a state-dependent latency (VST3 signals kLatencyChanged, LV2 has a latency port, AU is polled; CLAP was the gap).
- An unreadable blob now logs one stderr line instead of silently restoring defaults.

Verified end to end on Linux: mutated a parameter inside a real session's CLAP state blob, reopened, saved - the mutated value came back from the live plugin instance, which is only possible through decode -> loadState -> saveState. LV2 and VST3 slots load and round-trip; missing plugins degrade to the existing missing-plugin report.

## #347 - plugin scan wedges with no way out

The out-of-process scanner already had a 30s timeout, a blacklist and a dead-man's pedal, but ChildProcess::readProcessOutput blocks until the buffer fills or the child exits, so the deadline could never fire against a plugin sitting on a license dialog (Ujam and friends). The scan modal also had no cancel of any kind.

- A watchdog thread now owns every kill (abort or 30s deadline); killing the child is what releases the blocked read. Reap and kill are interlocked under one mutex so a kill can never land on a reaped (reusable) pid. A complete payload outranks the deadline, so a plugin that finished at 29.9s cannot be quarantined by the race.
- The same fix is shared with the native CLAP/VST3 bundle scan, which had an identical blocking-read loop and no abort at all (reproduced: a hanging .vst3 wedged dusk-studio-plugin-host --scan-native indefinitely).
- The scan modal gets a Cancel button and Esc support at both call sites. Cancel skips the in-flight plugin without blacklisting it and stops the remaining phases promptly; a cancelled manual scan says so in the completion alert instead of claiming success.
- Scan output is capped at 8 MB so a chattering child cannot grow the parent unboundedly.

Verified on Linux with a fabricated plugin that blocks in its loader: the JUCE phase quarantines it at 30s, the native VST3 phase (which previously hung forever) times out and skips it at 30s, the scan completes, and Esc mid-scan unwinds within a second or two.

Verified on the Windows 11 VM with the ci-windows-dev MSI built from this branch (7d128f8): silent install clean; a hand-built VST3 DLL that blocks in its entry point is quarantined by the JUCE phase at 30s and timeout-skipped by the native VST3 phase at 30s (TerminateProcess releases the blocked read as designed); the scan completes and the app stays healthy; clicking Cancel during the native-phase hang closes the modal within seconds and the startup log reports the scan as cancelled.

## juce-gate allowlist

--update recorded three decreases (AudioEngine.cpp 140 -> 139, RegionEditActions.cpp 36 -> 35, PluginManager.cpp 112 -> 109). Three hand edits need justifying:

- src/engine/LegacyStateBase64.h (new, 8): must call JUCE's own MemoryBlock base64 pair - reimplementing its bit-packing inside a data-preservation path is not a risk worth taking in a point release, and isolating it in a header is what made it unit-testable.
- src/ui/PluginScanModal.cpp 28 -> 33, .h 10 -> 11: the Cancel button is a juce::TextButton styled exactly as BounceDialog and FreezeDialog style theirs. There is no Dusk button class and the GUI tower has no seam yet.

## Known limitations (deliberate)

- A scan child whose grandchild inherits the pipe write end and survives the kill can still block the reader; no clean fix without fd-level access.
- LV2 and AU native discovery read manifests/registry only, cannot hang, and take no abort; cancel gates between phases.
- A cancelled native CLAP/VST3 pass is abandoned, not committed half-finished (committing a partial run would delete the missing rows from the picker and cache).
- LV2 file-backed state cur/prev rotation vs restored absolute paths is deferred to #357.

## Tests

764 ctest cases pass (9 new: RFC decoder round-trip/vectors/rejections, legacy transcode incl. the "0." empty-state form, 0.13.1-migrated fallback, session round-trip now decoding what it stores). Xvfb integration selftest 15/15. The migration helpers themselves are file-static in AudioEngine.cpp and stay untested directly; the transcode/fallback logic they call is what the new unit tests pin.

## Branch provenance

Cut clean from the v0.13.1 tag: the two fix commits plus the review follow-up (hand-reimplemented MemoryBlock base64 so the legacy compatibility header no longer pulls in JUCE, and the clone-path legacy fallback). Deliberately does NOT contain main — main's de-JUCE / GUI-tower work must not ship in a 0.13.x point release. Verified: `git merge-base --is-ancestor origin/main HEAD` is false. The same fix content lands on main separately via #358.

Built and verified against the v0.13.1 sibling pins (donor 69f04318, DPF f9fbc62, DPF-Widgets 668de17): app builds clean, 765 ctest cases pass, JUCE gate 180 files / 9207 uses, Xvfb integration selftest 15/15.
