### PR TITLE
Refuse LV2 state paths that escape the session state directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 873 Catch2 test cases across 172 test source files. Linux
+The C++ suite declares 874 Catch2 test cases across 172 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 873 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 874 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 869 Catch2 test cases across 172 test source files. Linux
+The C++ suite declares 873 Catch2 test cases across 172 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 869 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 873 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/lv2/Lv2Instance.cpp
+++ b/src/engine/lv2/Lv2Instance.cpp
@@ -117,7 +117,11 @@ struct Lv2Instance::Impl
     {
         if (abstractPath == nullptr) return nullptr;
         auto* self = static_cast<Impl*> (handle);
-        return ::strdup (statepaths::toAbsolute (self->stateDir, abstractPath).c_str());
+        const auto absolute = statepaths::toAbsolute (self->stateDir, abstractPath);
+        // A refused blob value must not fall through as the relative string it
+        // came in as: the plugin would resolve it against the process working
+        // directory and read a file outside the session entirely.
+        return absolute.empty() ? nullptr : ::strdup (absolute.c_str());
     }
     static char* abstractPathCb (LV2_State_Map_Path_Handle handle, const char* absolutePath)
     {

--- a/src/engine/lv2/Lv2StatePaths.h
+++ b/src/engine/lv2/Lv2StatePaths.h
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <set>
 #include <string>
 #include <string_view>
@@ -559,47 +560,42 @@ inline bool prepareContainedPath (const std::filesystem::path& cur,
     std::filesystem::create_directories (cur, ec);
     if (ec) return false;
 
-    std::vector<std::filesystem::path> parts (relative.begin(), relative.end());
-    if (parts.empty())
-    {
-        ec = std::make_error_code (std::errc::invalid_argument);
-        return false;
-    }
-
 #if defined(__linux__) || defined(__APPLE__)
     // Each level is created and reopened relative to the previous descriptor
     // with O_NOFOLLOW, so a symlink swapped in between the check and the
-    // creation fails the open rather than redirecting it.
+    // creation fails the open rather than redirecting it. Opening cur the same
+    // way is what rejects a state root that is itself a link.
     const auto fail = [&ec] { ec = std::error_code (errno, std::generic_category()); };
 
     int dir = ::open (cur.c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
     if (dir < 0) { fail(); return false; }
 
     bool ok = true;
-    for (size_t i = 0; i + 1 < parts.size(); ++i)
+    for (auto part = relative.begin(); part != relative.end(); ++part)
     {
-        if (::mkdirat (dir, parts[i].c_str(), 0777) != 0 && errno != EEXIST)
+        if (std::next (part) == relative.end())
+        {
+            struct stat leaf {};
+            if (::fstatat (dir, part->c_str(), &leaf, AT_SYMLINK_NOFOLLOW) == 0
+                && S_ISLNK (leaf.st_mode))
+            {
+                ec = std::make_error_code (std::errc::too_many_symbolic_link_levels);
+                ok = false;
+            }
+            break;
+        }
+
+        if (::mkdirat (dir, part->c_str(), 0777) != 0 && errno != EEXIST)
         {
             fail();
             ok = false;
             break;
         }
-        const int child = ::openat (dir, parts[i].c_str(),
+        const int child = ::openat (dir, part->c_str(),
                                     O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
         if (child < 0) { fail(); ok = false; break; }
         ::close (dir);
         dir = child;
-    }
-
-    if (ok)
-    {
-        struct stat leaf {};
-        if (::fstatat (dir, parts.back().c_str(), &leaf, AT_SYMLINK_NOFOLLOW) == 0
-            && S_ISLNK (leaf.st_mode))
-        {
-            ec = std::make_error_code (std::errc::too_many_symbolic_link_levels);
-            ok = false;
-        }
     }
 
     ::close (dir);
@@ -610,15 +606,24 @@ inline bool prepareContainedPath (const std::filesystem::path& cur,
     // is_symlink also catches a Windows junction, which reports its own
     // file_type and would slip past a symlink-only test.
     using FileType = std::filesystem::file_type;
-    auto walk = cur;
-    for (size_t i = 0; i < parts.size(); ++i)
+
+    // create_directories leaves an existing link alone, so cur has to be shown
+    // to be a real directory before anything is built underneath it.
+    if (std::filesystem::symlink_status (cur, ec).type() != FileType::directory)
     {
-        walk /= parts[i];
+        ec = std::make_error_code (std::errc::too_many_symbolic_link_levels);
+        return false;
+    }
+
+    auto walk = cur;
+    for (auto part = relative.begin(); part != relative.end(); ++part)
+    {
+        walk /= *part;
         const auto type = std::filesystem::symlink_status (walk, ec).type();
         if (ec && ec != std::errc::no_such_file_or_directory) return false;
         ec.clear();
 
-        const bool isLeaf = i + 1 == parts.size();
+        const bool isLeaf = std::next (part) == relative.end();
         // A plugin may reuse a directory or file it made earlier; anything else
         // that already occupies the name is a reparse point or worse.
         if (type != FileType::not_found && type != FileType::directory

--- a/src/engine/lv2/Lv2StatePaths.h
+++ b/src/engine/lv2/Lv2StatePaths.h
@@ -11,7 +11,9 @@
 #include <vector>
 
 #if defined(__linux__) || defined(__APPLE__)
+ #include <cerrno>
  #include <fcntl.h>
+ #include <sys/stat.h>
  #include <unistd.h>
 #endif
 
@@ -504,24 +506,135 @@ inline bool commitNextGeneration (const std::filesystem::path& stateDir,
     return publishReadyNext (stateDir, ec);
 }
 
+// How far down the resolved path canonical containment may be enforced. A
+// generation's entries are symlinks into <dir>/copy for files the plugin wrote
+// and into <dir>/link for files it only referenced, and a link-store entry
+// points straight at the user's original file outside the session - resolving
+// the leaf would reject an ordinary external sample. Only real directories sit
+// above it, so a symlink there is never something lilv wrote.
+inline bool parentsResolveInsideStateDirectory (
+    const std::filesystem::path& stateDir, const std::filesystem::path& resolved)
+{
+    std::error_code ec;
+    const auto canonicalRoot = std::filesystem::weakly_canonical (stateDir, ec);
+    const auto root = ec ? stateDir.lexically_normal() : canonicalRoot;
+    ec.clear();
+    const auto parents = std::filesystem::weakly_canonical (resolved.parent_path(), ec);
+    return ! ec && isWithin (root, parents);
+}
+
 // Restore side: an abstract path from a state blob resolves against <dir>/cur.
 // Already-absolute abstract paths (and an empty stateDir) pass through. A blob
-// with "../" segments that would escape cur/ is refused (passed through
-// unresolved) rather than mapped to a file outside the state directory.
+// value that escapes the state directory - lexically through "../" segments, or
+// through a symlinked directory planted in its prefix - yields an empty string.
+// Handing the unresolved value back instead would leave the plugin resolving it
+// against the process working directory, which is both outside the session and
+// dependent on where the application was launched from.
 inline std::string toAbsolute (const std::filesystem::path& stateDir,
                                const std::string& abstractPath)
 {
     const auto abstract = std::filesystem::u8path (abstractPath);
-    if (stateDir.empty() || abstract.empty()
-        || abstract == std::filesystem::path (".") || abstract.is_absolute())
-        return abstractPath;
-    const auto cur      = stateDir / "cur";
+    if (stateDir.empty() || abstract.is_absolute()) return abstractPath;
+    if (abstract.empty() || abstract == std::filesystem::path (".")) return {};
+
+    const auto cur      = (stateDir / "cur").lexically_normal();
     const auto resolved = (cur / abstract).lexically_normal();
-    const auto rel      = resolved.lexically_relative (cur);
-    if (rel.empty() || rel == std::filesystem::path (".")
-        || *rel.begin() == std::filesystem::path (".."))
-        return abstractPath;
+    if (! isWithin (cur, resolved)) return {};
+    if (! parentsResolveInsideStateDirectory (stateDir, resolved)) return {};
     return resolved.u8string();
+}
+
+// Create the leading directories of a cur/-relative request without ever
+// traversing a symlink, and refuse a leaf that already exists as one. Lexical
+// containment alone is not enough: a symlink left in the state tree by a
+// crafted session (or by a plugin that wrote one itself) redirects an
+// in-root-looking write anywhere on the filesystem. Refusing a symlinked leaf
+// costs nothing legitimate - lilv's own leaf symlinks point into the shared
+// copy/link stores, and writing through one would corrupt the file every other
+// generation references.
+inline bool prepareContainedPath (const std::filesystem::path& cur,
+                                  const std::filesystem::path& relative,
+                                  std::error_code& ec)
+{
+    std::filesystem::create_directories (cur, ec);
+    if (ec) return false;
+
+    std::vector<std::filesystem::path> parts (relative.begin(), relative.end());
+    if (parts.empty())
+    {
+        ec = std::make_error_code (std::errc::invalid_argument);
+        return false;
+    }
+
+#if defined(__linux__) || defined(__APPLE__)
+    // Each level is created and reopened relative to the previous descriptor
+    // with O_NOFOLLOW, so a symlink swapped in between the check and the
+    // creation fails the open rather than redirecting it.
+    const auto fail = [&ec] { ec = std::error_code (errno, std::generic_category()); };
+
+    int dir = ::open (cur.c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    if (dir < 0) { fail(); return false; }
+
+    bool ok = true;
+    for (size_t i = 0; i + 1 < parts.size(); ++i)
+    {
+        if (::mkdirat (dir, parts[i].c_str(), 0777) != 0 && errno != EEXIST)
+        {
+            fail();
+            ok = false;
+            break;
+        }
+        const int child = ::openat (dir, parts[i].c_str(),
+                                    O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+        if (child < 0) { fail(); ok = false; break; }
+        ::close (dir);
+        dir = child;
+    }
+
+    if (ok)
+    {
+        struct stat leaf {};
+        if (::fstatat (dir, parts.back().c_str(), &leaf, AT_SYMLINK_NOFOLLOW) == 0
+            && S_ISLNK (leaf.st_mode))
+        {
+            ec = std::make_error_code (std::errc::too_many_symbolic_link_levels);
+            ok = false;
+        }
+    }
+
+    ::close (dir);
+    return ok;
+#else
+    // No openat equivalent here, so the walk is check-then-create and only as
+    // race-resistant as the platform makes it. Testing the type rather than
+    // is_symlink also catches a Windows junction, which reports its own
+    // file_type and would slip past a symlink-only test.
+    using FileType = std::filesystem::file_type;
+    auto walk = cur;
+    for (size_t i = 0; i < parts.size(); ++i)
+    {
+        walk /= parts[i];
+        const auto type = std::filesystem::symlink_status (walk, ec).type();
+        if (ec && ec != std::errc::no_such_file_or_directory) return false;
+        ec.clear();
+
+        const bool isLeaf = i + 1 == parts.size();
+        // A plugin may reuse a directory or file it made earlier; anything else
+        // that already occupies the name is a reparse point or worse.
+        if (type != FileType::not_found && type != FileType::directory
+            && ! (isLeaf && type == FileType::regular))
+        {
+            ec = std::make_error_code (std::errc::too_many_symbolic_link_levels);
+            return false;
+        }
+        if (isLeaf) break;
+
+        std::filesystem::create_directory (walk, ec);
+        if (ec && ! std::filesystem::is_directory (walk)) return false;
+        ec.clear();
+    }
+    return true;
+#endif
 }
 
 // Restore-side state:makePath. The plugin may create the returned file, so
@@ -547,8 +660,9 @@ inline std::filesystem::path makeRestorePath (
         return {};
     }
 
-    std::filesystem::create_directories (resolved.parent_path(), ec);
-    return ec ? std::filesystem::path {} : resolved;
+    if (! prepareContainedPath (cur, resolved.lexically_relative (cur), ec))
+        return {};
+    return resolved;
 }
 
 // Save side: an absolute path lilv hands us becomes a cur/-relative abstract

--- a/tests/lv2_state_paths.cpp
+++ b/tests/lv2_state_paths.cpp
@@ -206,6 +206,26 @@ TEST_CASE ("LV2 state paths: restore makePath refuses a symlinked parent",
     REQUIRE_FALSE (stdfs::exists (outside / "deeper"));
 }
 
+TEST_CASE ("LV2 state paths: restore makePath refuses a symlinked cur",
+           "[lv2][state][regression][issue-393]")
+{
+    TempDirectory temp ("dusk-lv2-state-generation-");
+    const auto stateDir = temp.path() / "state";
+    const auto outside = temp.path() / "outside";
+    stdfs::create_directories (stateDir);
+    stdfs::create_directories (outside);
+    stdfs::create_directory_symlink (outside, stateDir / "cur");
+
+    std::error_code ec;
+    REQUIRE (makeRestorePath (stateDir, "payload.txt", ec).empty());
+    REQUIRE (ec);
+    REQUIRE_FALSE (stdfs::exists (outside / "payload.txt"));
+
+    REQUIRE (makeRestorePath (stateDir, "nested/payload.txt", ec).empty());
+    REQUIRE (ec);
+    REQUIRE_FALSE (stdfs::exists (outside / "nested"));
+}
+
 TEST_CASE ("LV2 state paths: restore makePath refuses a symlinked leaf",
            "[lv2][state][regression][issue-393]")
 {

--- a/tests/lv2_state_paths.cpp
+++ b/tests/lv2_state_paths.cpp
@@ -104,9 +104,12 @@ TEST_CASE ("LV2 state paths: refuse escaping abstract paths",
         REQUIRE (toAbsolute (dir, traversal).empty());
 
     // A valid in-root path still maps, and an absolute one still passes through.
+    // Build the absolute case from current_path: a leading separator alone is
+    // not an absolute path on Windows, where the root name carries the drive.
     REQUIRE (stdfs::path (toAbsolute (dir, "samples/kick.wav"))
              == cur / "samples" / "kick.wav");
-    REQUIRE (toAbsolute (dir, "/etc/passwd") == "/etc/passwd");
+    const auto external = (stdfs::current_path() / "shared" / "ir.wav").u8string();
+    REQUIRE (toAbsolute (dir, external) == external);
 
     // Backslashes are a separator on Windows and an ordinary filename character
     // elsewhere, so assert the invariant that holds on both: whatever comes

--- a/tests/lv2_state_paths.cpp
+++ b/tests/lv2_state_paths.cpp
@@ -51,10 +51,12 @@ TEST_CASE ("LV2 state paths: abstract resolves under cur/", "[lv2][state]")
     // An already-absolute abstract path is left untouched.
     const auto abs = (stdfs::current_path() / "shared" / "ir.wav").u8string();
     REQUIRE (toAbsolute (dir, abs) == abs);
+    // Anything that does not name a file under cur/ is refused outright rather
+    // than handed back for the plugin to resolve against its own directory.
     REQUIRE (toAbsolute (dir, "").empty());
-    REQUIRE (toAbsolute (dir, ".") == ".");
-    REQUIRE (toAbsolute (dir, "./") == "./");
-    REQUIRE (toAbsolute (dir, "samples/..") == "samples/..");
+    REQUIRE (toAbsolute (dir, ".").empty());
+    REQUIRE (toAbsolute (dir, "./").empty());
+    REQUIRE (toAbsolute (dir, "samples/..").empty());
 }
 
 TEST_CASE ("LV2 state paths: absolute under cur/ becomes relative", "[lv2][state]")
@@ -89,12 +91,77 @@ TEST_CASE ("LV2 state paths: canonical state root handles a symlink alias",
 }
 #endif
 
-TEST_CASE ("LV2 state paths: refuse escaping abstract paths", "[lv2][state]")
+TEST_CASE ("LV2 state paths: refuse escaping abstract paths",
+           "[lv2][state][regression][issue-392]")
 {
     const stdfs::path dir = "/session/state/lv2/track01";
-    // A blob that tries to climb out of cur/ is handed back unresolved.
-    REQUIRE (toAbsolute (dir, "../../secret.wav") == "../../secret.wav");
+    const auto cur = (dir / "cur").lexically_normal();
+
+    // A blob that climbs out of cur/ resolves to nothing. Returning the input
+    // would leave the plugin resolving it against the working directory.
+    for (const auto* traversal : { "../../secret.wav", "..", "../",
+                                   "samples/../../secret.wav", "a/b/../../../etc/passwd" })
+        REQUIRE (toAbsolute (dir, traversal).empty());
+
+    // A valid in-root path still maps, and an absolute one still passes through.
+    REQUIRE (stdfs::path (toAbsolute (dir, "samples/kick.wav"))
+             == cur / "samples" / "kick.wav");
+    REQUIRE (toAbsolute (dir, "/etc/passwd") == "/etc/passwd");
+
+    // Backslashes are a separator on Windows and an ordinary filename character
+    // elsewhere, so assert the invariant that holds on both: whatever comes
+    // back is either a refusal or a path under cur/.
+    for (const auto* mixed : { "..\\..\\secret.wav", "samples\\..\\..\\secret.wav",
+                               "samples\\kick.wav" })
+    {
+        const auto mapped = toAbsolute (dir, mixed);
+        if (! mapped.empty()) REQUIRE (isWithin (cur, stdfs::path (mapped)));
+    }
 }
+
+#if defined(__linux__) || defined(__APPLE__)
+TEST_CASE ("LV2 state paths: refuse abstract paths that escape through a directory symlink",
+           "[lv2][state][regression][issue-392]")
+{
+    TempDirectory temp ("dusk-lv2-state-generation-");
+    const auto stateDir = temp.path() / "state";
+    const auto outside = temp.path() / "outside";
+    stdfs::create_directories (stateDir / "cur");
+    stdfs::create_directories (outside / "deeper");
+    writeText (outside / "secret.txt", "secret");
+    stdfs::create_directory_symlink (outside, stateDir / "cur" / "escape");
+
+    REQUIRE (toAbsolute (stateDir, "escape/secret.txt").empty());
+    REQUIRE (toAbsolute (stateDir, "escape/deeper/secret.txt").empty());
+}
+
+TEST_CASE ("LV2 state paths: abstract paths follow lilv's copy and link stores",
+           "[lv2][state][regression][issue-392]")
+{
+    // lilv keeps one copy of a file the plugin wrote under <dir>/copy and
+    // symlinks each generation at it. A file the plugin only referenced is
+    // linked from <dir>/link straight at the user's original, which lives
+    // outside the session on purpose. Both must still map.
+    TempDirectory temp ("dusk-lv2-state-generation-");
+    const auto stateDir = temp.path() / "state";
+    const auto userSamples = temp.path() / "Music";
+    stdfs::create_directories (stateDir / "cur");
+    stdfs::create_directories (stateDir / "link");
+    writeText (stateDir / "copy" / "bank.sfz", "<region>");
+    writeText (userSamples / "kick.wav", "RIFF");
+    stdfs::create_symlink (stdfs::path ("..") / "copy" / "bank.sfz",
+                           stateDir / "cur" / "bank.sfz");
+    stdfs::create_symlink (userSamples / "kick.wav", stateDir / "link" / "kick.wav");
+    stdfs::create_symlink (stdfs::path ("..") / "link" / "kick.wav",
+                           stateDir / "cur" / "kick.wav");
+
+    REQUIRE (stdfs::path (toAbsolute (stateDir, "bank.sfz"))
+             == stateDir / "cur" / "bank.sfz");
+    REQUIRE (stdfs::path (toAbsolute (stateDir, "kick.wav"))
+             == stateDir / "cur" / "kick.wav");
+    REQUIRE (readText (toAbsolute (stateDir, "kick.wav")) == "RIFF");
+}
+#endif
 
 TEST_CASE ("LV2 state paths: restore makePath stays under cur/", "[lv2][state]")
 {
@@ -116,6 +183,54 @@ TEST_CASE ("LV2 state paths: restore makePath stays under cur/", "[lv2][state]")
     REQUIRE (makeRestorePath (temp.path(), absolute, ec).empty());
     REQUIRE (ec == std::errc::invalid_argument);
 }
+
+#if defined(__linux__) || defined(__APPLE__)
+TEST_CASE ("LV2 state paths: restore makePath refuses a symlinked parent",
+           "[lv2][state][regression][issue-393]")
+{
+    TempDirectory temp ("dusk-lv2-state-generation-");
+    const auto stateDir = temp.path() / "state";
+    const auto outside = temp.path() / "outside";
+    stdfs::create_directories (stateDir / "cur");
+    stdfs::create_directories (outside);
+    stdfs::create_directory_symlink (outside, stateDir / "cur" / "escape");
+
+    std::error_code ec;
+    REQUIRE (makeRestorePath (stateDir, "escape/payload.txt", ec).empty());
+    REQUIRE (ec);
+    REQUIRE_FALSE (stdfs::exists (outside / "payload.txt"));
+
+    // Nested under the symlink is refused on the same descriptor walk.
+    REQUIRE (makeRestorePath (stateDir, "escape/deeper/payload.txt", ec).empty());
+    REQUIRE (ec);
+    REQUIRE_FALSE (stdfs::exists (outside / "deeper"));
+}
+
+TEST_CASE ("LV2 state paths: restore makePath refuses a symlinked leaf",
+           "[lv2][state][regression][issue-393]")
+{
+    TempDirectory temp ("dusk-lv2-state-generation-");
+    const auto stateDir = temp.path() / "state";
+    const auto outside = temp.path() / "outside";
+    stdfs::create_directories (stateDir / "cur" / "restore");
+    stdfs::create_directories (outside);
+    writeText (outside / "target.txt", "original");
+    stdfs::create_symlink (outside / "target.txt",
+                           stateDir / "cur" / "restore" / "payload.txt");
+
+    std::error_code ec;
+    REQUIRE (makeRestorePath (stateDir, "restore/payload.txt", ec).empty());
+    REQUIRE (ec);
+    REQUIRE (readText (outside / "target.txt") == "original");
+
+    // A real file at the same leaf is a normal rewrite and stays allowed.
+    stdfs::remove (stateDir / "cur" / "restore" / "payload.txt");
+    writeText (stateDir / "cur" / "restore" / "payload.txt", "kept");
+    REQUIRE (makeRestorePath (stateDir, "restore/payload.txt", ec)
+             == stateDir / "cur" / "restore" / "payload.txt");
+    REQUIRE_FALSE (ec);
+}
+#endif
 
 TEST_CASE ("LV2 state paths: abstract<->absolute round-trips under cur/", "[lv2][state]")
 {


### PR DESCRIPTION
Fixes #392. Fixes #393.

## #392 restore paths fell through as process-relative

`toAbsolute` detected a blob value that climbed out of `cur/` and then handed the value straight back. The value is still relative, so the plugin resolved it against the process working directory. What it read depended on where the app was launched from, and a later save could copy those bytes into the session state store.

It now returns an empty string and `absolutePathCb` returns null. A refusal leaves no usable path behind, which is the only outcome that actually closes this.

Note that null is not a documented return for `state:mapPath` `absolute_path`, so a plugin that skips the null check will crash on a crafted session. Taking that over the arbitrary read: it matches what `makePathCb` already does today, and only a corrupt or crafted session reaches it. Our own `toAbstract` never emits a traversal.

## #393 makePath could write through a symlink

`makeRestorePath` checked containment lexically and then called `create_directories`, which follows symlinks. A symlink left in the state tree redirected an in-root-looking write anywhere on disk.

Parents are now created and reopened one level at a time relative to the previous descriptor with `O_NOFOLLOW`, so a symlink swapped in between the check and the create fails the open instead of redirecting it. An existing symlink at the leaf is refused rather than written through, which also stops a plugin rewriting the user's own file through one of lilv's link-store entries.

The non-POSIX fallback tests `symlink_status().type()` rather than `is_symlink`, because the MS STL reports a directory junction as `file_type::junction` and a symlink-only test misses it.

## Why the read side stops at the parent directories

Containment on the restore-read side is enforced on the parent directories, not the leaf, and that is deliberate. lilv's link store symlinks straight at the user's original file outside the session, which is the whole point of a link dir. Canonicalising the leaf would reject any externally referenced sample and break sfz restore. Only real directories sit above the leaf, so a symlink there is never something lilv wrote and only ever redirects a read. A test pins both the copy store and the link store so this cannot regress quietly.

The write side keeps the strict no-symlink-anywhere rule.

## Verification

- 861/861 ctest, app and test builds clean, juce-gate unchanged at 164 files / 8256 uses
- Reverted the fix and re-ran: 5 of the new tests fail without it and pass with it
- README test count 869 to 873, which `release-mechanics-contract` enforces

No MANUAL.md change. A healthy session sees no behaviour difference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LV2 state handling to reject invalid, empty, escaping, and symlink-based paths.
  * Prevented invalid relative paths from being passed to plugins.
  * Added safer restore-path handling for symlinked directories and files.

* **Tests**
  * Expanded coverage for path traversal, symlink safety, and valid state-file behavior.

* **Documentation**
  * Updated the documented C++ test count from 873 to 874.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->