### PR TITLE
chore: repin DAF for the CLAP resize-hint notification

### DIFF
--- a/.github/actions/clone-daf-stack/action.yml
+++ b/.github/actions/clone-daf-stack/action.yml
@@ -13,7 +13,7 @@ runs:
       shell: bash
       env:
         DAF_REPO: https://github.com/dusk-audio/DAF.git
-        DAF_REV: dfc50729f7a7d31dc0e0740c863bf88dee71c7c2
+        DAF_REV: 2f573d68d79218d2f9e048e47d99e424ca7958c6
         PUGL_REV: 43d8e349c7ca7c4d76778a8c48b73226105bed14
         DAF_WIDGETS_REPO: https://github.com/dusk-audio/DAF-Widgets.git
         DAF_WIDGETS_REV: 1c09e1ef29f92ae7feb200bac8febdf814cf5e4a

--- a/docs/MAINTAINER-GUIDE.md
+++ b/docs/MAINTAINER-GUIDE.md
@@ -306,7 +306,7 @@ CMake auto-detects four external repos at configure time, on top of three git su
 cd /path/to/dusk-studio
 
 git clone https://github.com/dusk-audio/DAF.git ../DAF
-git -C ../DAF checkout dfc50729f7a7d31dc0e0740c863bf88dee71c7c2
+git -C ../DAF checkout 2f573d68d79218d2f9e048e47d99e424ca7958c6
 git -C ../DAF submodule update --init     # dgl/src/pugl-upstream
 
 git clone https://github.com/dusk-audio/DAF-Widgets.git ../DAF-Widgets


### PR DESCRIPTION
Picks up dusk-audio/DAF#20, which calls resize_hints_changed when a UI's geometry constraints change at runtime rather than only at creation.

The 0.13 handoff script keeps its own DAF_REV: that pin set reproduces the milestone build and is not meant to track main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled DAF repository revision used by automated setup workflows.
  * Synchronized maintainer setup instructions with the updated revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->