### PR TITLE
fix: preserve LV2 generations without resyncing shared state

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 874 Catch2 test cases across 172 test source files. Linux
+The C++ suite declares 875 Catch2 test cases across 172 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 874 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 875 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/lv2/Lv2Instance.cpp
+++ b/src/engine/lv2/Lv2Instance.cpp
@@ -917,11 +917,12 @@ bool Lv2Instance::saveState (std::vector<uint8_t>& out) const
     // as cur/ below; without a directory, file-writing plugins keep only their
     // in-memory state (the pre-file-state behaviour, fine for effects).
     std::error_code ec;
-    const auto next = statepaths::prepareNextGeneration (impl->stateDir, ec);
+    const auto transaction = statepaths::prepareNextGeneration (impl->stateDir, ec);
     // Never report a successful blob-only save for a slot configured with
     // file-backed state: that would silently stop carrying its external files
     // after a staging or recovery failure.
-    if (next.empty()) return false;
+    if (transaction.next.empty()) return false;
+    const auto& next = transaction.next;
 
     // A restored plugin refers to files in cur/. Lilv must consider that the
     // scratch generation so it preserves their bytes in the stable copy store,
@@ -975,7 +976,7 @@ bool Lv2Instance::saveState (std::vector<uint8_t>& out) const
     // Only now that both the plugin snapshot and Turtle serialization succeeded
     // may the fresh files replace cur/. Until this point a restored plugin's
     // absolute cur/ paths remain valid throughout the save.
-    if (! statepaths::commitNextGeneration (impl->stateDir, ec))
+    if (! statepaths::commitNextGeneration (transaction, ec))
     {
         // commitNextGeneration may have moved cur aside before the publish or
         // rollback failed. Preserve the complete staged generation as recovery

--- a/src/engine/lv2/Lv2StatePaths.h
+++ b/src/engine/lv2/Lv2StatePaths.h
@@ -1,14 +1,18 @@
 #pragma once
 
+#include <algorithm>
 #include <array>
+#include <cstdint>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
+#include <map>
 #include <set>
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <utility>
 #include <vector>
 
 #if defined(__linux__) || defined(__APPLE__)
@@ -27,6 +31,34 @@ namespace duskstudio::lv2::statepaths
 {
 inline constexpr const char* kReadyMarkerName = ".ready";
 inline constexpr const char* kStateFileName = "state.ttl";
+
+struct SharedStoreEntry
+{
+    std::filesystem::file_type type = std::filesystem::file_type::none;
+    std::uintmax_t size = 0;
+    std::filesystem::file_time_type writeTime {};
+    std::filesystem::path symlinkTarget;
+
+    bool operator== (const SharedStoreEntry& other) const noexcept
+    {
+        return type == other.type && size == other.size
+            && writeTime == other.writeTime && symlinkTarget == other.symlinkTarget;
+    }
+};
+
+struct SharedStoreSnapshot
+{
+    bool rootExisted = false;
+    std::map<std::filesystem::path, SharedStoreEntry> entries;
+};
+
+struct GenerationTransaction
+{
+    std::filesystem::path stateDir;
+    std::filesystem::path next;
+    SharedStoreSnapshot copyBefore;
+    SharedStoreSnapshot linkBefore;
+};
 
 // Resolve symlinked existing prefixes while preserving a state-directory
 // suffix that has not been created yet. On macOS this also normalizes the
@@ -77,6 +109,164 @@ inline void syncTreeBestEffort (const std::filesystem::path& root) noexcept
         it.increment (ec);
     }
     syncPathBestEffort (root);
+}
+
+// Lilv treats copy/ and link/ as immutable shared stores: a changed scratch
+// file gets a new revision name, and a new external path gets a new link. Keep
+// the identities present before a save so commit can make only additions
+// durable instead of opening and fsyncing every older sample on every autosave.
+inline SharedStoreSnapshot snapshotSharedStore (
+    const std::filesystem::path& root)
+{
+    SharedStoreSnapshot snapshot;
+    std::error_code ec;
+    const auto rootStatus = std::filesystem::symlink_status (root, ec);
+    if (ec || rootStatus.type() == std::filesystem::file_type::not_found)
+        return snapshot;
+
+    snapshot.rootExisted = true;
+    if (! std::filesystem::is_directory (rootStatus)) return snapshot;
+
+    std::filesystem::recursive_directory_iterator it (
+        root, std::filesystem::directory_options::skip_permission_denied, ec);
+    const std::filesystem::recursive_directory_iterator end;
+    while (! ec && it != end)
+    {
+        const auto path = it->path();
+        const auto status = it->symlink_status (ec);
+        if (ec) break;
+
+        SharedStoreEntry entry;
+        entry.type = status.type();
+        if (std::filesystem::is_regular_file (status))
+        {
+            entry.size = it->file_size (ec);
+            if (ec) break;
+            entry.writeTime = it->last_write_time (ec);
+            if (ec) break;
+        }
+        else if (std::filesystem::is_symlink (status))
+        {
+            entry.symlinkTarget = std::filesystem::read_symlink (path, ec);
+            if (ec) break;
+        }
+        snapshot.entries.emplace (path.lexically_relative (root), std::move (entry));
+        it.increment (ec);
+    }
+    return snapshot;
+}
+
+struct SharedStoreSyncPlan
+{
+    std::vector<std::filesystem::path> files;
+    std::vector<std::filesystem::path> directories;
+};
+
+inline SharedStoreSyncPlan planSharedStoreSync (
+    const std::filesystem::path& root, const SharedStoreSnapshot& before)
+{
+    SharedStoreSyncPlan plan;
+    std::set<std::filesystem::path> changedDirectories;
+    std::error_code ec;
+    const auto rootStatus = std::filesystem::symlink_status (root, ec);
+    if (ec || rootStatus.type() == std::filesystem::file_type::not_found)
+    {
+        if (before.rootExisted) plan.directories.push_back (root.parent_path());
+        return plan;
+    }
+
+    if (! before.rootExisted)
+    {
+        changedDirectories.insert (root);
+        changedDirectories.insert (root.parent_path());
+    }
+    if (! std::filesystem::is_directory (rootStatus))
+    {
+        plan.directories.assign (changedDirectories.begin(), changedDirectories.end());
+        return plan;
+    }
+
+    const auto rememberParents = [&] (const std::filesystem::path& path)
+    {
+        auto parent = path.parent_path();
+        while (! parent.empty())
+        {
+            changedDirectories.insert (parent);
+            if (parent == root) break;
+            parent = parent.parent_path();
+        }
+    };
+
+    std::set<std::filesystem::path> seen;
+    std::filesystem::recursive_directory_iterator it (
+        root, std::filesystem::directory_options::skip_permission_denied, ec);
+    const std::filesystem::recursive_directory_iterator end;
+    while (! ec && it != end)
+    {
+        const auto path = it->path();
+        const auto relative = path.lexically_relative (root);
+        seen.insert (relative);
+        const auto status = it->symlink_status (ec);
+        if (ec) break;
+
+        SharedStoreEntry current;
+        current.type = status.type();
+        if (std::filesystem::is_regular_file (status))
+        {
+            current.size = it->file_size (ec);
+            if (ec) break;
+            current.writeTime = it->last_write_time (ec);
+            if (ec) break;
+        }
+        else if (std::filesystem::is_symlink (status))
+        {
+            current.symlinkTarget = std::filesystem::read_symlink (path, ec);
+            if (ec) break;
+        }
+
+        const auto previous = before.entries.find (relative);
+        if (previous == before.entries.end() || ! (previous->second == current))
+        {
+            if (std::filesystem::is_regular_file (status))
+                plan.files.push_back (path);
+            else if (std::filesystem::is_directory (status))
+                changedDirectories.insert (path);
+            rememberParents (path);
+        }
+        it.increment (ec);
+    }
+
+    // A removed entry changes its former parent directory even though there is
+    // no surviving path to visit after the transaction.
+    for (const auto& [relative, entry] : before.entries)
+    {
+        (void) entry;
+        if (seen.find (relative) == seen.end()) rememberParents (root / relative);
+    }
+
+    plan.directories.assign (changedDirectories.begin(), changedDirectories.end());
+    const auto depth = [] (const std::filesystem::path& path)
+    {
+        return std::distance (path.begin(), path.end());
+    };
+    std::sort (plan.directories.begin(), plan.directories.end(),
+               [&] (const auto& a, const auto& b)
+               {
+                   const auto aDepth = depth (a);
+                   const auto bDepth = depth (b);
+                   return aDepth != bDepth ? aDepth > bDepth : a < b;
+               });
+    return plan;
+}
+
+inline void syncSharedStoreChangesBestEffort (
+    const std::filesystem::path& root, const SharedStoreSnapshot& before)
+{
+    const auto plan = planSharedStoreSync (root, before);
+    for (const auto& file : plan.files) syncPathBestEffort (file);
+    // Deepest first: persist each new directory's contents before its name in
+    // the parent, then finally persist a newly-created shared-store root.
+    for (const auto& directory : plan.directories) syncPathBestEffort (directory);
 }
 
 inline bool generationIsReady (const std::filesystem::path& generation)
@@ -450,18 +640,24 @@ inline bool recoverGeneration (const std::filesystem::path& stateDir,
 // file-backed plugin can keep absolute paths into cur while lilv copies those
 // files into the fresh generation; rotating cur before asking the plugin for
 // its state makes those paths stale during serialization.
-inline std::filesystem::path prepareNextGeneration (
+inline GenerationTransaction prepareNextGeneration (
     const std::filesystem::path& stateDir, std::error_code& ec)
 {
+    GenerationTransaction transaction;
     ec.clear();
     if (stateDir.empty()) return {};
     if (! recoverGeneration (stateDir, {}, ec)) return {};
+    transaction.stateDir = stateDir;
+    transaction.copyBefore = snapshotSharedStore (stateDir / "copy");
+    transaction.linkBefore = snapshotSharedStore (stateDir / "link");
     const auto next = stateDir / "next";
 
     std::filesystem::remove_all (next, ec);
     if (ec) return {};
     std::filesystem::create_directories (next, ec);
-    return ec ? std::filesystem::path {} : next;
+    if (ec) return {};
+    transaction.next = next;
+    return transaction;
 }
 
 inline void discardNextGeneration (const std::filesystem::path& stateDir) noexcept
@@ -474,13 +670,19 @@ inline void discardNextGeneration (const std::filesystem::path& stateDir) noexce
 // Publish a successfully serialized next/ generation. cur remains the active
 // generation until this commit point. If publishing next fails after cur was
 // moved aside, restore cur before returning so the carried state stays usable.
-inline bool commitNextGeneration (const std::filesystem::path& stateDir,
+inline bool commitNextGeneration (const GenerationTransaction& transaction,
                                   std::error_code& ec)
 {
     ec.clear();
+    const auto& stateDir = transaction.stateDir;
     if (stateDir.empty()) return false;
 
     const auto next = stateDir / "next";
+    if (transaction.next != next)
+    {
+        ec = std::make_error_code (std::errc::invalid_argument);
+        return false;
+    }
     if (! std::filesystem::is_directory (next, ec) || ec)
         return false;
 
@@ -488,8 +690,8 @@ inline bool commitNextGeneration (const std::filesystem::path& stateDir,
     // it. Recovery can then distinguish publish interruption from an incomplete
     // staging write.
     syncTreeBestEffort (next);
-    syncTreeBestEffort (stateDir / "copy");
-    syncTreeBestEffort (stateDir / "link");
+    syncSharedStoreChangesBestEffort (stateDir / "copy", transaction.copyBefore);
+    syncSharedStoreChangesBestEffort (stateDir / "link", transaction.linkBefore);
     {
         std::ofstream marker (next / kReadyMarkerName,
                               std::ios::binary | std::ios::trunc);

--- a/tests/lv2_state_paths.cpp
+++ b/tests/lv2_state_paths.cpp
@@ -10,6 +10,7 @@
 #include <filesystem>
 #include <fstream>
 #include <stdexcept>
+#include <string>
 
 using namespace duskstudio::lv2::statepaths;
 namespace stdfs = std::filesystem;
@@ -272,7 +273,8 @@ TEST_CASE ("LV2 file-backed save stages before rotating cur",
     writeText (curSample, "generation one");
 
     std::error_code ec;
-    const auto next = prepareNextGeneration (temp.path(), ec);
+    const auto transaction = prepareNextGeneration (temp.path(), ec);
+    const auto& next = transaction.next;
     REQUIRE_FALSE (ec);
     REQUIRE (next == temp.path() / "next");
 
@@ -282,7 +284,7 @@ TEST_CASE ("LV2 file-backed save stages before rotating cur",
     REQUIRE (readText (curSample) == "generation one");
 
     writeText (next / "samples" / "voice.wav", "generation two");
-    REQUIRE (commitNextGeneration (temp.path(), ec));
+    REQUIRE (commitNextGeneration (transaction, ec));
     REQUIRE_FALSE (ec);
     REQUIRE (readText (temp.path() / "cur" / "samples" / "voice.wav")
              == "generation two");
@@ -298,14 +300,53 @@ TEST_CASE ("LV2 file-backed save stages before rotating cur",
     REQUIRE (readText (restored) == "generation two");
 
     // A second successful save retains exactly one fallback generation.
-    const auto third = prepareNextGeneration (temp.path(), ec);
+    const auto thirdTransaction = prepareNextGeneration (temp.path(), ec);
+    const auto& third = thirdTransaction.next;
     REQUIRE_FALSE (ec);
     writeText (third / "samples" / "voice.wav", "generation three");
-    REQUIRE (commitNextGeneration (temp.path(), ec));
+    REQUIRE (commitNextGeneration (thirdTransaction, ec));
     REQUIRE (readText (temp.path() / "cur" / "samples" / "voice.wav")
              == "generation three");
     REQUIRE (readText (temp.path() / "prev" / "samples" / "voice.wav")
              == "generation two");
+}
+
+TEST_CASE ("LV2 shared-store durability ignores pre-existing immutable files",
+           "[lv2][state][regression][issue-395]")
+{
+    TempDirectory temp ("dusk-lv2-state-generation-");
+    const auto copy = temp.path() / "copy";
+    const auto old = copy / "banks";
+    stdfs::create_directories (old);
+
+    // Model a sampler's established shared store with enough entries that
+    // opening and fsyncing each one would dominate an autosave. File contents
+    // stay tiny so the regression itself remains fast and deterministic.
+    constexpr int oldFileCount = 2048;
+    for (int i = 0; i < oldFileCount; ++i)
+        writeText (old / ("sample-" + std::to_string (i) + ".bin"), "old");
+
+    const auto before = snapshotSharedStore (copy);
+    REQUIRE (before.rootExisted);
+    REQUIRE (before.entries.size() == (size_t) oldFileCount + 1);
+
+    const auto fresh = copy / "new-bank" / "manifest.bin";
+    const auto modified = old / "sample-17.bin";
+    writeText (fresh, "new");
+    writeText (modified, "modified-payload");
+    const auto plan = planSharedStoreSync (copy, before);
+
+    // The durability work is proportional to this transaction, not the size
+    // of the shared store. No older sample path may be opened by the sync pass.
+    REQUIRE (plan.files.size() == 2);
+    REQUIRE (std::find (plan.files.begin(), plan.files.end(), fresh) != plan.files.end());
+    REQUIRE (std::find (plan.files.begin(), plan.files.end(), modified) != plan.files.end());
+    REQUIRE (plan.directories.size() == 3);
+    REQUIRE (std::find (plan.directories.begin(), plan.directories.end(),
+                        fresh.parent_path()) != plan.directories.end());
+    REQUIRE (std::find (plan.directories.begin(), plan.directories.end(), old)
+             != plan.directories.end());
+    REQUIRE (plan.directories.back() == copy);
 }
 
 TEST_CASE ("LV2 staging recovers only a complete next generation",
@@ -315,7 +356,8 @@ TEST_CASE ("LV2 staging recovers only a complete next generation",
     writeText (temp.path() / "next" / "state.bin", "incomplete");
 
     std::error_code ec;
-    const auto fresh = prepareNextGeneration (temp.path(), ec);
+    const auto freshTransaction = prepareNextGeneration (temp.path(), ec);
+    const auto& fresh = freshTransaction.next;
     REQUIRE_FALSE (ec);
     REQUIRE (fresh == temp.path() / "next");
     REQUIRE_FALSE (stdfs::exists (fresh / "state.bin"));
@@ -324,7 +366,8 @@ TEST_CASE ("LV2 staging recovers only a complete next generation",
     // could rename next/ to cur/. The next save promotes the complete state.
     writeText (fresh / "state.bin", "recoverable");
     writeText (fresh / kReadyMarkerName, "ready\n");
-    const auto afterRecovery = prepareNextGeneration (temp.path(), ec);
+    const auto recoveryTransaction = prepareNextGeneration (temp.path(), ec);
+    const auto& afterRecovery = recoveryTransaction.next;
     REQUIRE_FALSE (ec);
     REQUIRE (afterRecovery == temp.path() / "next");
     REQUIRE (readText (temp.path() / "cur" / "state.bin") == "recoverable");
@@ -333,7 +376,8 @@ TEST_CASE ("LV2 staging recovers only a complete next generation",
     TempDirectory fallback ("dusk-lv2-state-generation-");
     writeText (fallback.path() / "prev" / "state.bin", "previous");
     writeText (fallback.path() / "next" / "state.bin", "incomplete");
-    const auto afterFallback = prepareNextGeneration (fallback.path(), ec);
+    const auto fallbackTransaction = prepareNextGeneration (fallback.path(), ec);
+    const auto& afterFallback = fallbackTransaction.next;
     REQUIRE_FALSE (ec);
     REQUIRE (readText (fallback.path() / "cur" / "state.bin") == "previous");
     REQUIRE_FALSE (stdfs::exists (afterFallback / "state.bin"));
@@ -361,7 +405,8 @@ TEST_CASE ("LV2 failed file-backed save leaves cur and prev untouched",
     writeText (temp.path() / "prev" / "state.bin", "previous");
 
     std::error_code ec;
-    const auto next = prepareNextGeneration (temp.path(), ec);
+    const auto transaction = prepareNextGeneration (temp.path(), ec);
+    const auto& next = transaction.next;
     REQUIRE_FALSE (ec);
     writeText (next / "state.bin", "incomplete");
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved LV2 state saving by synchronizing only files that have changed, reducing unnecessary processing when many existing state files are present.
  * Enhanced state-generation handling for more reliable save and commit operations.

* **Tests**
  * Added coverage for shared state synchronization, including scenarios with large numbers of pre-existing files.

* **Documentation**
  * Updated the documented Catch2 test count from 874 to 875.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->