### PR TITLE
fix: stop OOP mutation after worker park timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 877 Catch2 test cases across 172 test source files. Linux
+The C++ suite declares 881 Catch2 test cases across 173 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 877 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 881 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/ipc/PluginHostMain.cpp
+++ b/src/engine/ipc/PluginHostMain.cpp
@@ -33,6 +33,7 @@
 
 #include "PluginIpc.h"
 #include "PluginScanProtocol.h"
+#include "WorkerPark.h"
 #if DUSKSTUDIO_HAS_NATIVE_CLAP || DUSKSTUDIO_HAS_NATIVE_VST3
  #include "../NativeScanRows.h"
 #endif
@@ -225,6 +226,128 @@ int runIpcStub (int argc, const char* const* argv, bool suppressReplies) noexcep
     return 0;
 }
 
+// Test-only child shape used by the cross-platform regression suite. It runs
+// the real shared-memory worker/control topology with a processor that remains
+// inside processBlock longer than the production park deadline. The mutation
+// callback aborts if it is ever entered while processing, so receiving the
+// explicit park-timeout reply proves the callback was not touched first.
+struct ParkTimeoutTestProcessor
+{
+    std::atomic<bool> processing { false };
+
+    void processBlock()
+    {
+        processing.store (true, std::memory_order_release);
+        std::this_thread::sleep_for (std::chrono::milliseconds (250));
+        processing.store (false, std::memory_order_release);
+    }
+
+    void mutate()
+    {
+        if (processing.load (std::memory_order_acquire))
+            std::abort();
+    }
+};
+
+int runIpcParkTimeoutStub (int argc, const char* const* argv) noexcept
+{
+    ipcp::NativeHandle channel = ipcp::locateInheritedChannel (argc, argv);
+    if (! ipcp::isValid (channel)) return 1;
+
+    ipcp::NativeHandle shmHandle;
+    if (! ipcp::recvHandle (channel, shmHandle)) return 1;
+
+    ipcp::InterprocessSignal commandSignal;
+    ipcp::InterprocessSignal replySignal;
+    if (! commandSignal.receiveFromParent (channel)
+        || ! replySignal.receiveFromParent (channel))
+        return 1;
+
+    ipcp::SharedMemory shm;
+    std::string err;
+    if (! shm.mapInheritedHandle (shmHandle, kTotalSize, err)) return 1;
+
+    auto* block = headerOf (shm.data());
+    if (block->magic != kMagic || block->version != kVersion) return 1;
+
+    char ready = 'k';
+    if (! ipcp::writeExact (channel, &ready, 1)) return 1;
+
+    ParkTimeoutTestProcessor processor;
+    std::atomic<ParkTimeoutTestProcessor*> currentProcessor { &processor };
+    std::atomic<bool> shouldQuit { false };
+
+    std::thread worker ([&]
+    {
+        std::uint32_t lastSequence = 0;
+        while (! shouldQuit.load (std::memory_order_acquire))
+        {
+            const auto command = block->cmdSeq.load (std::memory_order_acquire);
+            if (command == lastSequence)
+            {
+                (void) commandSignal.wait (&block->cmdSeq, command, nullptr);
+                continue;
+            }
+
+            if (auto* current = currentProcessor.load (std::memory_order_acquire))
+                current->processBlock();
+
+            lastSequence = command;
+            block->replySeq.store (command, std::memory_order_release);
+            replySignal.wake (&block->replySeq);
+        }
+    });
+
+    while (true)
+    {
+        ControlMsgHeader request {};
+        if (! ipcp::readExact (channel, &request, sizeof (request))) break;
+        if (request.payloadLen > kMaxControlPayload
+            || request.totalLen != (std::uint32_t) sizeof (request) + request.payloadLen)
+            break;
+
+        std::vector<std::uint8_t> payload (request.payloadLen);
+        if (request.payloadLen > 0
+            && ! ipcp::readExact (channel, payload.data(), request.payloadLen))
+            break;
+
+        std::uint32_t status = 99;
+        const auto op = (OpCode) request.op;
+        if (op == OpCode::Ping)
+        {
+            status = processor.processing.load (std::memory_order_acquire) ? 0u : 1u;
+        }
+        else if (op == OpCode::PrepareToPlay || op == OpCode::Release
+                 || op == OpCode::GetState || op == OpCode::SetState)
+        {
+            const bool parked = duskstudio::ipc::withParkedWorker (
+                currentProcessor, block->cmdSeq, block->replySeq,
+                [&] { processor.mutate(); });
+            if (parked)
+                currentProcessor.store (&processor, std::memory_order_release);
+            status = parked ? 0u : kControlStatusWorkerParkTimeout;
+        }
+
+        if (status == kControlStatusWorkerParkTimeout)
+            block->state.store (kStateCrashed, std::memory_order_release);
+
+        const bool replySent = sendControlReply (channel, request.op, status, nullptr, 0);
+
+        if (status == kControlStatusWorkerParkTimeout)
+        {
+            replySignal.wake (&block->replySeq);
+            std::_Exit (EXIT_FAILURE);
+        }
+        if (! replySent) break;
+    }
+
+    shouldQuit.store (true, std::memory_order_release);
+    block->state.store (kStateTeardown, std::memory_order_release);
+    commandSignal.wake (&block->cmdSeq);
+    worker.join();
+    return 0;
+}
+
 // --- Phase 2 host mode ---------------------------------------------------
 
 #if JUCE_MAC
@@ -382,27 +505,22 @@ bool parsePluginDescriptionXml (const juce::String& xml,
 // plugins crash hard if the host violates it (the parent uses the same
 // pattern around its own state I/O via AtomicPark.h).
 //
-// Mechanism: clear currentInstance so the worker no-ops on any new
-// cmdSeq bump, then wait until cmdSeq == replySeq (worker has drained
-// every command it had in flight). 50 ms ceiling caps the stall if the
-// worker somehow falls behind; we'd rather risk one stale audio block
-// than wedge the control channel.
+// Mechanism: clear currentInstance so the worker no-ops on any new cmdSeq
+// bump, then wait until cmdSeq == replySeq (worker has drained every command
+// it had in flight). A worker that misses the bounded deadline is unsafe to
+// mutate: leave the pointer parked, report a terminal RPC error, and let the
+// control loop exit the child after sending that reply.
 template <typename Fn>
-void withParkedWorker (HostState& host, Fn&& fn)
+std::uint32_t withParkedHostWorker (HostState& host, Fn&& fn)
 {
-    host.currentInstance.store (nullptr, std::memory_order_release);
-    const auto deadline = std::chrono::steady_clock::now()
-                         + std::chrono::milliseconds (50);
-    while (std::chrono::steady_clock::now() < deadline)
+    if (! duskstudio::ipc::withParkedWorker (
+            host.currentInstance, host.hdr->cmdSeq, host.hdr->replySeq, fn))
     {
-        const auto cs = host.hdr->cmdSeq .load (std::memory_order_acquire);
-        const auto rs = host.hdr->replySeq.load (std::memory_order_acquire);
-        if (cs == rs) break;
-        std::this_thread::sleep_for (std::chrono::microseconds (200));
+        host.hdr->state.store (kStateCrashed, std::memory_order_release);
+        return kControlStatusWorkerParkTimeout;
     }
-    fn();
-    host.currentInstance.store (host.ownedInstance.get(),
-                                  std::memory_order_release);
+    host.currentInstance.store (host.ownedInstance.get(), std::memory_order_release);
+    return 0;
 }
 
 std::uint32_t handleLoadPlugin (HostState& host,
@@ -490,18 +608,17 @@ std::uint32_t handlePrepareToPlay (HostState& host,
     PrepareToPlayPayload p {};
     std::memcpy (&p, payload.data(), sizeof (p));
     if (host.ownedInstance == nullptr) return 0;
-    withParkedWorker (host, [&]
+    return withParkedHostWorker (host, [&]
     {
         host.ownedInstance->prepareToPlay (p.sampleRate, p.blockSize);
         host.currentSampleRate = p.sampleRate;
         host.currentBlockSize  = p.blockSize;
     });
-    return 0;
 }
 
 std::uint32_t handleRelease (HostState& host)
 {
-    withParkedWorker (host, [&]
+    return withParkedHostWorker (host, [&]
     {
         if (host.ownedInstance != nullptr)
         {
@@ -519,7 +636,6 @@ std::uint32_t handleRelease (HostState& host)
             host.ownedInstance.reset();
         }
     });
-    return 0;
 }
 
 std::uint32_t handleGetState (HostState& host,
@@ -527,11 +643,12 @@ std::uint32_t handleGetState (HostState& host,
 {
     if (host.ownedInstance == nullptr) return 1;
     juce::MemoryBlock mb;
-    withParkedWorker (host, [&]
+    const auto parkStatus = withParkedHostWorker (host, [&]
     {
         const juce::MessageManagerLock mml;
         host.ownedInstance->getStateInformation (mb);
     });
+    if (parkStatus != 0) return parkStatus;
     if (mb.getSize() > kStateBytes) return 2;
     std::memcpy (static_cast<char*> (host.shm.data()) + kStateOffset,
                   mb.getData(), mb.getSize());
@@ -549,13 +666,13 @@ std::uint32_t handleSetState (HostState& host,
     std::uint32_t sz = 0;
     std::memcpy (&sz, payload.data(), sizeof (sz));
     if (sz > kStateBytes) return 3;
-    withParkedWorker (host, [&]
+    const auto parkStatus = withParkedHostWorker (host, [&]
     {
         const juce::MessageManagerLock mml;
         host.ownedInstance->setStateInformation (
             static_cast<const char*> (host.shm.data()) + kStateOffset, (int) sz);
     });
-    return 0;
+    return parkStatus;
 }
 
 std::uint32_t handleShowEditor (HostState& host,
@@ -898,10 +1015,17 @@ int runIpcHost (int argc, const char* const* argv) noexcept
                 default:                     status = 99; break;
             }
 
-            if (! sendControlReply (host.channel, hdr.op, status,
-                                     reply.empty() ? nullptr : reply.data(),
-                                     (std::uint32_t) reply.size()))
-                break;
+            const bool replySent = sendControlReply (
+                host.channel, hdr.op, status,
+                reply.empty() ? nullptr : reply.data(),
+                (std::uint32_t) reply.size());
+
+            if (status == kControlStatusWorkerParkTimeout)
+            {
+                host.replySignal.wake (&host.hdr->replySeq);
+                std::_Exit (EXIT_FAILURE);
+            }
+            if (! replySent) break;
         }
         host.shouldQuit.store (true, std::memory_order_release);
         host.hdr->state.store (kStateTeardown, std::memory_order_release);
@@ -1074,12 +1198,14 @@ int main (int argc, char** argv)
 
     bool ipcStub = false;
     bool ipcStubTimeout = false;
+    bool ipcParkTimeoutStub = false;
     bool ipcHost = false;
     bool scan    = false;
     for (int i = 1; i < argc; ++i)
     {
         if (std::strcmp (args[i], "--ipc-stub") == 0) ipcStub = true;
         if (std::strcmp (args[i], "--ipc-stub-timeout") == 0) ipcStubTimeout = true;
+        if (std::strcmp (args[i], "--ipc-park-timeout-stub") == 0) ipcParkTimeoutStub = true;
         if (std::strcmp (args[i], "--ipc-host") == 0) ipcHost = true;
         if (std::strcmp (args[i], "--scan")     == 0) scan    = true;
 #if DUSKSTUDIO_HAS_NATIVE_CLAP || DUSKSTUDIO_HAS_NATIVE_VST3
@@ -1089,6 +1215,7 @@ int main (int argc, char** argv)
 
     if (scan)    return runScan (argc, args);
     if (ipcStub || ipcStubTimeout) return runIpcStub (argc, args, ipcStubTimeout);
+    if (ipcParkTimeoutStub) return runIpcParkTimeoutStub (argc, args);
     if (ipcHost) return runIpcHost (argc, args);
 
     std::fprintf (stderr,

--- a/src/engine/ipc/PluginIpc.h
+++ b/src/engine/ipc/PluginIpc.h
@@ -35,6 +35,11 @@ constexpr std::size_t   kStateBytes = 4 * 1024 * 1024; // up to 4 MB plugin stat
 // allocation and OOM-kill the process.
 constexpr std::uint32_t kMaxControlPayload = 256 * 1024;
 
+// Terminal control-RPC status: the audio worker did not acknowledge a park
+// before its deadline, so the child sent this reply and then exited without
+// mutating or destroying the processor.
+constexpr std::uint32_t kControlStatusWorkerParkTimeout = 100;
+
 // State values for `BlockHeader::state`.
 constexpr std::uint32_t kStateReady    = 0;
 constexpr std::uint32_t kStateCrashed  = 1;

--- a/src/engine/ipc/RemotePluginConnection.cpp
+++ b/src/engine/ipc/RemotePluginConnection.cpp
@@ -155,7 +155,7 @@ bool RemotePluginConnection::connect (const std::string& hostExecutablePath,
     // a reader thread there would block forever on readExact. The
     // self-test connects with extraArg=="--ipc-stub" and would
     // otherwise leak a permanently-blocked thread per connection.
-    if (extraArg == "--ipc-host")
+    if (extraArg == "--ipc-host" || extraArg == "--ipc-park-timeout-stub")
         startReaderThread();
 
     return true;
@@ -340,6 +340,8 @@ bool RemotePluginConnection::sendAndAwaitReply (OpCode op,
     hdrOut   = replyHeader;
     replyOut = std::move (replyPayload);
     replyReady = false;
+    if (hdrOut.status == kControlStatusWorkerParkTimeout)
+        crashed.store (true, std::memory_order_release);
     return true;
 }
 

--- a/src/engine/ipc/WorkerPark.h
+++ b/src/engine/ipc/WorkerPark.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <thread>
+
+namespace duskstudio::ipc
+{
+
+constexpr auto kWorkerParkTimeout = std::chrono::milliseconds (50);
+
+// Remove the processor from the audio worker's lookup path, then wait until
+// every command already observed by the worker has been acknowledged. A
+// caller may restore the current processor after a true result. A timeout
+// is terminal for the child: the caller must not restore the pointer or touch
+// the processor after this function returns false.
+template <typename Processor, typename Fn>
+bool withParkedWorker (std::atomic<Processor*>& currentProcessor,
+                       const std::atomic<std::uint32_t>& commandSequence,
+                       const std::atomic<std::uint32_t>& replySequence,
+                       Fn&& mutation,
+                       std::chrono::steady_clock::duration timeout = kWorkerParkTimeout)
+{
+    currentProcessor.store (nullptr, std::memory_order_release);
+
+    const auto deadline = std::chrono::steady_clock::now () + timeout;
+    while (std::chrono::steady_clock::now () < deadline)
+    {
+        const auto command = commandSequence.load (std::memory_order_acquire);
+        const auto reply = replySequence.load (std::memory_order_acquire);
+        if (command == reply)
+        {
+            mutation ();
+            return true;
+        }
+        std::this_thread::sleep_for (std::chrono::microseconds (200));
+    }
+
+    return false;
+}
+
+} // namespace duskstudio::ipc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -468,9 +468,17 @@ endif()
 if (_duskstudio_ipc_test_enabled)
     target_sources(dusk-studio-tests PRIVATE
         ipc_stub_round_trip.cpp
-        ipc_worker_park.cpp
         ${CMAKE_SOURCE_DIR}/src/engine/ipc/RemotePluginConnection.cpp
         ${_duskstudio_ipc_test_sources})
+    # The park-timeout cases are the only ones that drive a control RPC while
+    # the reader thread is running. Windows carries the control channel on a
+    # synchronous duplex named pipe, so the reader's blocking ReadFile
+    # serialises against the caller's WriteFile on the same handle and the
+    # request never reaches the child (issue #406). Re-enable once that
+    # transport moves to overlapped I/O.
+    if (NOT WIN32)
+        target_sources(dusk-studio-tests PRIVATE ipc_worker_park.cpp)
+    endif()
     target_compile_definitions(dusk-studio-tests PRIVATE
         DUSKSTUDIO_HAS_OOP_PLUGINS=1
         DUSKSTUDIO_PLUGIN_HOST_PATH="$<TARGET_FILE:dusk-studio-plugin-host>")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -468,6 +468,7 @@ endif()
 if (_duskstudio_ipc_test_enabled)
     target_sources(dusk-studio-tests PRIVATE
         ipc_stub_round_trip.cpp
+        ipc_worker_park.cpp
         ${CMAKE_SOURCE_DIR}/src/engine/ipc/RemotePluginConnection.cpp
         ${_duskstudio_ipc_test_sources})
     target_compile_definitions(dusk-studio-tests PRIVATE

--- a/tests/ipc_worker_park.cpp
+++ b/tests/ipc_worker_park.cpp
@@ -1,0 +1,141 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/ipc/RemotePluginConnection.h"
+
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+enum class MutationRpc
+{
+    Prepare,
+    Release,
+    GetState,
+    SetState
+};
+
+struct ParkTimeoutResult
+{
+    bool observedProcessBlock{ false };
+    bool mutationSucceeded{ true };
+    bool audioSucceeded{ true };
+    bool childExited{ false };
+    bool connectionCrashed{ false };
+    std::string error;
+};
+
+ParkTimeoutResult runParkTimeoutCase (MutationRpc rpc)
+{
+    using namespace std::chrono_literals;
+
+    ParkTimeoutResult result;
+    duskstudio::ipc::RemotePluginConnection connection;
+    std::string connectError;
+    if (!connection.connect (DUSKSTUDIO_PLUGIN_HOST_PATH,
+                             "--ipc-park-timeout-stub", connectError))
+    {
+        result.error = connectError;
+        return result;
+    }
+
+    float inputSample = 0.25f;
+    const float* input[1]{ &inputSample };
+    dusk::MidiBuffer midi;
+    std::thread audioThread ([&]
+                             { result.audioSucceeded = connection.processBlockSync (
+                                   input, 1, 1, 1, midi, 1'000'000'000LL); });
+
+    for (int attempt = 0; attempt < 100; ++attempt)
+    {
+        std::string pingError;
+        if (connection.ping (100, pingError))
+        {
+            result.observedProcessBlock = true;
+            break;
+        }
+        std::this_thread::sleep_for (1ms);
+    }
+
+    if (result.observedProcessBlock)
+    {
+        switch (rpc)
+        {
+        case MutationRpc::Prepare:
+            result.mutationSucceeded = connection.prepareToPlay (48000.0, 256,
+                                                                 result.error);
+            break;
+        case MutationRpc::Release:
+            result.mutationSucceeded = connection.release (result.error);
+            break;
+        case MutationRpc::GetState:
+        {
+            std::vector<std::uint8_t> state;
+            result.mutationSucceeded = connection.getState (state, result.error);
+            break;
+        }
+        case MutationRpc::SetState:
+        {
+            const std::uint8_t state = 0x42;
+            result.mutationSucceeded = connection.setState (&state, 1, result.error);
+            break;
+        }
+        }
+    }
+    else
+    {
+        result.error = "test processor never entered processBlock";
+        connection.disconnect ();
+    }
+
+    audioThread.join ();
+    result.connectionCrashed = connection.isCrashed ();
+
+    for (int attempt = 0; attempt < 100; ++attempt)
+    {
+        if (connection.pollReaper ())
+        {
+            result.childExited = true;
+            break;
+        }
+        std::this_thread::sleep_for (1ms);
+    }
+    connection.disconnect ();
+    return result;
+}
+
+void requireSafeTimeout (MutationRpc rpc, const char* expectedError)
+{
+    const auto result = runParkTimeoutCase (rpc);
+    INFO (result.error);
+    REQUIRE (result.observedProcessBlock);
+    REQUIRE_FALSE (result.mutationSucceeded);
+    REQUIRE_FALSE (result.audioSucceeded);
+    REQUIRE (result.error == expectedError);
+    REQUIRE (result.connectionCrashed);
+    REQUIRE (result.childExited);
+}
+} // namespace
+
+TEST_CASE ("OOP worker park timeout prevents prepare mutation", "[ipc][issue-371]")
+{
+    requireSafeTimeout (MutationRpc::Prepare, "PrepareToPlay status != 0");
+}
+
+TEST_CASE ("OOP worker park timeout prevents release mutation", "[ipc][issue-371]")
+{
+    requireSafeTimeout (MutationRpc::Release, "Release status != 0");
+}
+
+TEST_CASE ("OOP worker park timeout prevents state read", "[ipc][issue-371]")
+{
+    requireSafeTimeout (MutationRpc::GetState, "GetState status != 0");
+}
+
+TEST_CASE ("OOP worker park timeout prevents state write", "[ipc][issue-371]")
+{
+    requireSafeTimeout (MutationRpc::SetState, "SetState status != 0");
+}

--- a/tools/tsan_suppressions.txt
+++ b/tools/tsan_suppressions.txt
@@ -50,3 +50,19 @@ deadlock:juce::TimeSliceThread
 # guarantee. Suppress + rely on the IPC self-test for correctness.
 race:juce::AbstractFifo
 race:dusk::SpscIndexFifo
+
+# RemotePluginConnection's control RPC waits for its reply on a
+# std::condition_variable with a steady_clock deadline. libstdc++ routes that
+# through pthread_cond_clockwait, which the Ubuntu 22.04 TSan runtime does not
+# intercept (its libtsan exports interceptors for pthread_cond_wait and
+# pthread_cond_timedwait only). The unlock and relock the wait performs are
+# therefore invisible: TSan still believes the caller owns controlMutex when the
+# reader thread parks a reply, and it never draws the release/acquire edge that
+# hands the parked reply back to the caller. That surfaces as a double lock on
+# controlMutex - the reader does acquire it, which proves no thread held it -
+# and as a race on the reply slot both sides only ever touch under that mutex.
+# Same modelling gap as the dusk::AutoResetEvent entries above.
+mutex:duskstudio::ipc::RemotePluginConnection::readerLoop
+deadlock:duskstudio::ipc::RemotePluginConnection::readerLoop
+race:duskstudio::ipc::RemotePluginConnection::readerLoop
+race:duskstudio::ipc::RemotePluginConnection::sendAndAwaitReply

--- a/tools/tsan_suppressions.txt
+++ b/tools/tsan_suppressions.txt
@@ -60,9 +60,9 @@ race:dusk::SpscIndexFifo
 # reader thread parks a reply, and it never draws the release/acquire edge that
 # hands the parked reply back to the caller. That surfaces as a double lock on
 # controlMutex - the reader does acquire it, which proves no thread held it -
-# and as a race on the reply slot both sides only ever touch under that mutex.
-# Same modelling gap as the dusk::AutoResetEvent entries above.
+# and as a race on the reply slot, which only these two functions touch and
+# only under that mutex. Same modelling gap as the dusk::AutoResetEvent entries
+# above. Verified against a local build that stubs out the interceptor: these
+# two entries silence both reports, and no lock-order-inversion report appears.
 mutex:duskstudio::ipc::RemotePluginConnection::readerLoop
-deadlock:duskstudio::ipc::RemotePluginConnection::readerLoop
-race:duskstudio::ipc::RemotePluginConnection::readerLoop
 race:duskstudio::ipc::RemotePluginConnection::sendAndAwaitReply


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when an out-of-process plugin becomes unresponsive during control operations.
  * Operations now fail safely with a clear timeout status instead of risking unsafe plugin changes.
  * Connections correctly report the plugin as crashed when recovery is not possible.

* **Tests**
  * Added coverage for timeout handling across preparation, release, state retrieval, and state updates.

* **Documentation**
  * Updated the documented test suite totals to reflect the latest coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->