### PR TITLE
fix: correlate OOP control replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 881 Catch2 test cases across 173 test source files. Linux
+The C++ suite declares 882 Catch2 test cases across 174 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 881 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 882 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/ipc/PluginHostMain.cpp
+++ b/src/engine/ipc/PluginHostMain.cpp
@@ -1,9 +1,12 @@
 // dusk-studio-plugin-host - the child binary that owns one out-of-process VST3
-// (or LV2) instance on behalf of Dusk Studio's main process. Three modes:
+// (or LV2) instance on behalf of Dusk Studio's main process. Supported modes
+// include:
 //
 //   --ipc-stub  : echo input -> output, no JUCE plugin. Exists so the
 //                 IPC self-test can validate shm + sync + spawn plumbing
 //                 without a plugin in the loop.
+//   --ipc-control-reply-stub: deterministic request-correlation and reply-
+//                 validation regression child.
 //   --ipc-host  : full Phase-2 host. Loads a juce::AudioPluginInstance
 //                 via the format manager, runs processBlock on a worker
 //                 thread, services control RPCs on a separate socket-
@@ -91,13 +94,14 @@ std::mutex& channelWriteMutex()
     return m;
 }
 
-bool sendControlReply (ipcp::NativeHandle& ch, std::uint32_t op,
-                          std::uint32_t status, const void* payload,
-                          std::uint32_t payloadLen) noexcept
+bool sendControlReply (ipcp::NativeHandle& ch, const ControlMsgHeader& request,
+                       std::uint32_t status, const void* payload,
+                       std::uint32_t payloadLen) noexcept
 {
     ControlMsgHeader hdr {};
     hdr.totalLen   = (std::uint32_t) sizeof (hdr) + payloadLen;
-    hdr.op         = op;
+    hdr.op         = request.op;
+    hdr.requestId  = request.requestId;
     hdr.status     = status;
     hdr.payloadLen = payloadLen;
     std::lock_guard<std::mutex> lk (channelWriteMutex());
@@ -126,6 +130,7 @@ bool sendControlReply (ipcp::NativeHandle& ch, std::uint32_t op,
     ControlMsgHeader hdr {};
     hdr.totalLen   = (std::uint32_t) sizeof (hdr) + (std::uint32_t) sizeof (p);
     hdr.op         = (std::uint32_t) OpCode::ParamChangedFromChild;
+    hdr.requestId  = 0;
     hdr.status     = 0;
     hdr.payloadLen = (std::uint32_t) sizeof (p);
 
@@ -224,6 +229,87 @@ int runIpcStub (int argc, const char* const* argv, bool suppressReplies) noexcep
     }
 
     return 0;
+}
+
+// Test-only child for control-reply correlation and validation. It withholds
+// reply A until request B arrives, then writes A before B. This guarantees the
+// late-reply ordering without scheduler sleeps: B cannot be sent until A has
+// timed out in the parent, and A cannot be released until B is on the wire.
+int runIpcControlReplyStub (int argc, const char* const* argv) noexcept
+{
+    ipcp::NativeHandle channel = ipcp::locateInheritedChannel (argc, argv);
+    if (! ipcp::isValid (channel)) return 1;
+
+    ipcp::NativeHandle shmHandle;
+    if (! ipcp::recvHandle (channel, shmHandle)) return 1;
+
+    ipcp::InterprocessSignal commandSignal;
+    ipcp::InterprocessSignal replySignal;
+    if (! commandSignal.receiveFromParent (channel)
+        || ! replySignal.receiveFromParent (channel))
+        return 1;
+
+    ipcp::SharedMemory shm;
+    std::string error;
+    if (! shm.mapInheritedHandle (shmHandle, kTotalSize, error)) return 1;
+
+    auto* block = headerOf (shm.data());
+    if (block->magic != kMagic || block->version != kVersion) return 1;
+
+    char ready = 'k';
+    if (! ipcp::writeExact (channel, &ready, 1)) return 1;
+
+    auto readRequest = [&channel] (ControlMsgHeader& request,
+                                    std::vector<std::uint8_t>& payload)
+    {
+        if (! ipcp::readExact (channel, &request, sizeof (request))) return false;
+        if (request.requestId == 0
+            || request.payloadLen > kMaxControlPayload
+            || request.totalLen != (std::uint32_t) sizeof (request) + request.payloadLen)
+            return false;
+        payload.resize (request.payloadLen);
+        return request.payloadLen == 0
+            || ipcp::readExact (channel, payload.data(), request.payloadLen);
+    };
+
+    ControlMsgHeader first {};
+    ControlMsgHeader second {};
+    std::vector<std::uint8_t> payload;
+    if (! readRequest (first, payload) || first.op != (std::uint32_t) OpCode::Ping)
+        return 1;
+    if (! readRequest (second, payload) || second.op != (std::uint32_t) OpCode::Ping)
+        return 1;
+
+    if (! sendControlReply (channel, first, 17, nullptr, 0)
+        || ! sendControlReply (channel, second, 0, nullptr, 0))
+        return 1;
+
+    ControlMsgHeader oversized {};
+    if (! readRequest (oversized, payload)
+        || oversized.op != (std::uint32_t) OpCode::LoadPlugin)
+        return 1;
+    std::vector<std::uint8_t> oversizedReply (sizeof (LoadPluginReply) + 1);
+    if (! sendControlReply (channel, oversized, 0,
+                            oversizedReply.data(),
+                            (std::uint32_t) oversizedReply.size()))
+        return 1;
+
+    ControlMsgHeader wrongOpcode {};
+    if (! readRequest (wrongOpcode, payload)
+        || wrongOpcode.op != (std::uint32_t) OpCode::Ping)
+        return 1;
+    auto wrongOpcodeReply = wrongOpcode;
+    wrongOpcodeReply.op = (std::uint32_t) OpCode::Release;
+    if (! sendControlReply (channel, wrongOpcodeReply, 0, nullptr, 0))
+        return 1;
+
+    ControlMsgHeader wrongPayload {};
+    if (! readRequest (wrongPayload, payload)
+        || wrongPayload.op != (std::uint32_t) OpCode::Ping)
+        return 1;
+    const std::uint8_t unexpectedPayload = 0;
+    return sendControlReply (channel, wrongPayload, 0,
+                             &unexpectedPayload, sizeof (unexpectedPayload)) ? 0 : 1;
 }
 
 // Test-only child shape used by the cross-platform regression suite. It runs
@@ -331,7 +417,7 @@ int runIpcParkTimeoutStub (int argc, const char* const* argv) noexcept
         if (status == kControlStatusWorkerParkTimeout)
             block->state.store (kStateCrashed, std::memory_order_release);
 
-        const bool replySent = sendControlReply (channel, request.op, status, nullptr, 0);
+        const bool replySent = sendControlReply (channel, request, status, nullptr, 0);
 
         if (status == kControlStatusWorkerParkTimeout)
         {
@@ -1016,7 +1102,7 @@ int runIpcHost (int argc, const char* const* argv) noexcept
             }
 
             const bool replySent = sendControlReply (
-                host.channel, hdr.op, status,
+                host.channel, hdr, status,
                 reply.empty() ? nullptr : reply.data(),
                 (std::uint32_t) reply.size());
 
@@ -1198,6 +1284,7 @@ int main (int argc, char** argv)
 
     bool ipcStub = false;
     bool ipcStubTimeout = false;
+    bool ipcControlReplyStub = false;
     bool ipcParkTimeoutStub = false;
     bool ipcHost = false;
     bool scan    = false;
@@ -1205,6 +1292,7 @@ int main (int argc, char** argv)
     {
         if (std::strcmp (args[i], "--ipc-stub") == 0) ipcStub = true;
         if (std::strcmp (args[i], "--ipc-stub-timeout") == 0) ipcStubTimeout = true;
+        if (std::strcmp (args[i], "--ipc-control-reply-stub") == 0) ipcControlReplyStub = true;
         if (std::strcmp (args[i], "--ipc-park-timeout-stub") == 0) ipcParkTimeoutStub = true;
         if (std::strcmp (args[i], "--ipc-host") == 0) ipcHost = true;
         if (std::strcmp (args[i], "--scan")     == 0) scan    = true;
@@ -1215,6 +1303,7 @@ int main (int argc, char** argv)
 
     if (scan)    return runScan (argc, args);
     if (ipcStub || ipcStubTimeout) return runIpcStub (argc, args, ipcStubTimeout);
+    if (ipcControlReplyStub) return runIpcControlReplyStub (argc, args);
     if (ipcParkTimeoutStub) return runIpcParkTimeoutStub (argc, args);
     if (ipcHost) return runIpcHost (argc, args);
 

--- a/src/engine/ipc/PluginIpc.h
+++ b/src/engine/ipc/PluginIpc.h
@@ -23,7 +23,7 @@ namespace duskstudio::ipc
 {
 
 constexpr std::uint32_t kMagic     = 0x46434C30;  // 'FCL0'
-constexpr std::uint32_t kVersion   = 2;
+constexpr std::uint32_t kVersion   = 3;
 constexpr int           kMaxBlock  = 1024;        // upper bound on numSamples per block
 constexpr int           kMaxChans  = 2;           // stereo plenty for this host
 constexpr std::size_t   kMidiBytes = 16 * 1024;   // serialised MIDI-block byte cap
@@ -51,11 +51,12 @@ constexpr std::uint32_t kStateTeardown = 2;
 //
 //     [uint32 totalLen]   little-endian, includes the rest of the record
 //     [uint32 op]         OpCode value
+//     [uint32 requestId]  non-zero for request/reply RPCs; zero for pushes
 //     [uint32 status]     reply only - 0 = ok, non-zero = error code
 //     [uint32 payloadLen] length of the variable-size payload that follows
 //     [bytes  payload]    op-specific
 //
-// totalLen = 12 + payloadLen. Both sides drain one record at a time;
+// totalLen = 20 + payloadLen. Both sides drain one record at a time;
 // nothing is interleaved with the audio hot path (which lives entirely
 // in the SHM region). Anything > a few KB (state blobs) goes through the
 // SHM staging area at kStateOffset to avoid pressure on the socket
@@ -110,11 +111,15 @@ struct ParamChangedPayload
 // Wire-record header. Followed on the wire by `payloadLen` bytes.
 struct ControlMsgHeader
 {
-    std::uint32_t totalLen;     // 12 + payloadLen
+    std::uint32_t totalLen;     // sizeof (ControlMsgHeader) + payloadLen
     std::uint32_t op;           // cast from OpCode
+    std::uint32_t requestId;    // echoed by replies; zero for one-shot/push frames
     std::uint32_t status;       // 0 = ok on replies; ignored on requests
     std::uint32_t payloadLen;
 };
+
+static_assert (sizeof (ControlMsgHeader) == 20,
+               "ControlMsgHeader wire layout changed without a protocol update");
 
 // Fixed-size payloads for the simple ops. Variable ones (LoadPlugin XML)
 // are packed by hand at the call site - no need for a struct.

--- a/src/engine/ipc/RemotePluginConnection.cpp
+++ b/src/engine/ipc/RemotePluginConnection.cpp
@@ -298,7 +298,7 @@ bool RemotePluginConnection::sendAndAwaitReply (OpCode op,
                                                   std::string& errorOut,
                                                   int timeoutMs)
 {
-    std::lock_guard<std::mutex> rpcLifetimeLock (syncRpcMutex);
+    auto rpcLifetime = syncRpcGate.acquire();
 
     if (! platform::isValid (controlChannel)) { errorOut = "not connected"; return false; }
 

--- a/src/engine/ipc/RemotePluginConnection.cpp
+++ b/src/engine/ipc/RemotePluginConnection.cpp
@@ -313,7 +313,7 @@ bool RemotePluginConnection::sendAndAwaitReply (OpCode op,
     // Clear the consumed/empty slot and publish the correlation ID before
     // writing. The reader drops any reply whose ID does not match this one,
     // including a late frame from a request that already timed out.
-    replyReady   = false;
+    replyReady.store (false, std::memory_order_relaxed);
     replyHeader  = {};
     replyPayload.clear();
 
@@ -331,11 +331,12 @@ bool RemotePluginConnection::sendAndAwaitReply (OpCode op,
 
     const auto deadline = std::chrono::steady_clock::now()
                             + std::chrono::milliseconds (timeoutMs);
-    while (! replyReady && ! readerExited.load (std::memory_order_acquire))
+    while (! replyReady.load (std::memory_order_acquire)
+           && ! readerExited.load (std::memory_order_acquire))
     {
         if (replyCv.wait_until (lk, deadline) == std::cv_status::timeout)
         {
-            if (! replyReady)
+            if (! replyReady.load (std::memory_order_acquire))
             {
                 pendingControlRequestId = 0;
                 errorOut = "reply timeout";
@@ -344,7 +345,7 @@ bool RemotePluginConnection::sendAndAwaitReply (OpCode op,
         }
     }
 
-    if (! replyReady)
+    if (! replyReady.load (std::memory_order_acquire))
     {
         pendingControlRequestId = 0;
         errorOut = "reader thread exited before reply arrived";
@@ -353,7 +354,7 @@ bool RemotePluginConnection::sendAndAwaitReply (OpCode op,
 
     hdrOut   = replyHeader;
     replyOut = std::move (replyPayload);
-    replyReady = false;
+    replyReady.store (false, std::memory_order_relaxed);
     pendingControlRequestId = 0;
     if (hdrOut.requestId != requestId)
     {
@@ -669,7 +670,7 @@ void RemotePluginConnection::readerLoop()
         if (pendingControlRequestId == 0
             || hdr.requestId != pendingControlRequestId)
             continue;
-        if (replyReady)
+        if (replyReady.load (std::memory_order_relaxed))
             std::fprintf (stderr,
                           "[Dusk Studio/RemotePluginConnection] reader: "
                           "dropping unread reply slot (op=%u) - caller "
@@ -677,7 +678,7 @@ void RemotePluginConnection::readerLoop()
                           (unsigned) replyHeader.op);
         replyHeader = hdr;
         replyPayload = std::move (payload);
-        replyReady = true;
+        replyReady.store (true, std::memory_order_release);
         replyCv.notify_all();
     }
 

--- a/src/engine/ipc/RemotePluginConnection.cpp
+++ b/src/engine/ipc/RemotePluginConnection.cpp
@@ -61,12 +61,13 @@ void wakeReaderForShutdown (platform::NativeHandle& ch) noexcept
 // Send a control request: [header][payload]. Returns true on success.
 // Caller (sendAndAwaitReply / setRemoteParam) holds controlMutex so
 // concurrent senders can't interleave bytes on the socket.
-bool sendControl (platform::NativeHandle& ch, OpCode op,
+bool sendControl (platform::NativeHandle& ch, OpCode op, std::uint32_t requestId,
                     const void* payload, std::uint32_t payloadLen) noexcept
 {
     ControlMsgHeader hdr {};
     hdr.totalLen   = (std::uint32_t) sizeof (hdr) + payloadLen;
     hdr.op         = (std::uint32_t) op;
+    hdr.requestId  = requestId;
     hdr.status     = 0;
     hdr.payloadLen = payloadLen;
     if (! platform::writeExact (ch, &hdr, sizeof (hdr))) return false;
@@ -150,12 +151,14 @@ bool RemotePluginConnection::connect (const std::string& hostExecutablePath,
     // thread must be able to block indefinitely on an idle socket.
     platform::setReadTimeout (controlChannel, 0);
 
-    // --- ipc-host only: start the demultiplexing reader thread -------
+    // --- Reply-producing modes: start the demultiplexing reader thread ---
     // The --ipc-stub child never writes a control frame after 'k', so
     // a reader thread there would block forever on readExact. The
     // self-test connects with extraArg=="--ipc-stub" and would
     // otherwise leak a permanently-blocked thread per connection.
-    if (extraArg == "--ipc-host" || extraArg == "--ipc-park-timeout-stub")
+    if (extraArg == "--ipc-host"
+        || extraArg == "--ipc-control-reply-stub"
+        || extraArg == "--ipc-park-timeout-stub")
         startReaderThread();
 
     return true;
@@ -295,6 +298,8 @@ bool RemotePluginConnection::sendAndAwaitReply (OpCode op,
                                                   std::string& errorOut,
                                                   int timeoutMs)
 {
+    std::lock_guard<std::mutex> rpcLifetimeLock (syncRpcMutex);
+
     if (! platform::isValid (controlChannel)) { errorOut = "not connected"; return false; }
 
     std::unique_lock<std::mutex> lk (controlMutex);
@@ -305,17 +310,21 @@ bool RemotePluginConnection::sendAndAwaitReply (OpCode op,
         return false;
     }
 
-    // Clear stale slot in case a prior call timed out without consuming
-    // its reply. If a late reply for that previous call lands AFTER we
-    // send, we'd misattribute - but: the message thread is single, so
-    // a timeout means the caller already returned and no other call
-    // can be in flight. Discarding the prior slot is correct.
+    // Clear the consumed/empty slot and publish the correlation ID before
+    // writing. The reader drops any reply whose ID does not match this one,
+    // including a late frame from a request that already timed out.
     replyReady   = false;
     replyHeader  = {};
     replyPayload.clear();
 
-    if (! sendControl (controlChannel, op, payload, payloadLen))
+    std::uint32_t requestId = nextControlRequestId++;
+    if (requestId == 0)
+        requestId = nextControlRequestId++;
+    pendingControlRequestId = requestId;
+
+    if (! sendControl (controlChannel, op, requestId, payload, payloadLen))
     {
+        pendingControlRequestId = 0;
         errorOut = std::string ("control send failed: ") + std::strerror (errno);
         return false;
     }
@@ -326,13 +335,18 @@ bool RemotePluginConnection::sendAndAwaitReply (OpCode op,
     {
         if (replyCv.wait_until (lk, deadline) == std::cv_status::timeout)
         {
-            errorOut = "reply timeout";
-            return false;
+            if (! replyReady)
+            {
+                pendingControlRequestId = 0;
+                errorOut = "reply timeout";
+                return false;
+            }
         }
     }
 
     if (! replyReady)
     {
+        pendingControlRequestId = 0;
         errorOut = "reader thread exited before reply arrived";
         return false;
     }
@@ -340,6 +354,17 @@ bool RemotePluginConnection::sendAndAwaitReply (OpCode op,
     hdrOut   = replyHeader;
     replyOut = std::move (replyPayload);
     replyReady = false;
+    pendingControlRequestId = 0;
+    if (hdrOut.requestId != requestId)
+    {
+        errorOut = "reply request ID mismatch";
+        return false;
+    }
+    if (hdrOut.op != (std::uint32_t) op)
+    {
+        errorOut = "reply opcode mismatch";
+        return false;
+    }
     if (hdrOut.status == kControlStatusWorkerParkTimeout)
         crashed.store (true, std::memory_order_release);
     return true;
@@ -352,6 +377,7 @@ bool RemotePluginConnection::ping (int timeoutMs, std::string& errorOut)
     if (! sendAndAwaitReply (OpCode::Ping, nullptr, 0, hdr, reply, errorOut, timeoutMs))
         return false;
     if (hdr.status != 0) { errorOut = "Ping reply status != 0"; return false; }
+    if (! reply.empty()) { errorOut = "Ping reply payload size mismatch"; return false; }
     return true;
 }
 
@@ -387,9 +413,9 @@ bool RemotePluginConnection::loadPlugin (const std::string& pluginDescriptionXml
                                       reply.size());
         return false;
     }
-    if (reply.size() < sizeof (LoadPluginReply))
+    if (reply.size() != sizeof (LoadPluginReply))
     {
-        errorOut = "LoadPlugin reply too small";
+        errorOut = "LoadPlugin reply size mismatch";
         return false;
     }
     LoadPluginReply r {};
@@ -413,6 +439,7 @@ bool RemotePluginConnection::prepareToPlay (double sampleRate, int blockSize,
                                hdr, reply, errorOut, 10000))
         return false;
     if (hdr.status != 0) { errorOut = "PrepareToPlay status != 0"; return false; }
+    if (! reply.empty()) { errorOut = "PrepareToPlay reply payload size mismatch"; return false; }
     return true;
 }
 
@@ -424,6 +451,7 @@ bool RemotePluginConnection::release (std::string& errorOut)
                                hdr, reply, errorOut, 5000))
         return false;
     if (hdr.status != 0) { errorOut = "Release status != 0"; return false; }
+    if (! reply.empty()) { errorOut = "Release reply payload size mismatch"; return false; }
     return true;
 }
 
@@ -466,6 +494,7 @@ bool RemotePluginConnection::setState (const std::uint8_t* data, std::size_t siz
                                hdr, reply, errorOut, 30000))
         return false;
     if (hdr.status != 0) { errorOut = "SetState status != 0"; return false; }
+    if (! reply.empty()) { errorOut = "SetState reply payload size mismatch"; return false; }
     return true;
 }
 
@@ -501,6 +530,7 @@ bool RemotePluginConnection::hideEditor (std::string& errorOut)
                                hdr, reply, errorOut, 5000))
         return false;
     if (hdr.status != 0) { errorOut = "HideEditor status != 0"; return false; }
+    if (! reply.empty()) { errorOut = "HideEditor reply payload size mismatch"; return false; }
     return true;
 }
 
@@ -515,6 +545,7 @@ bool RemotePluginConnection::resizeEditor (int width, int height, std::string& e
                                hdr, reply, errorOut, 5000))
         return false;
     if (hdr.status != 0) { errorOut = "ResizeEditor status != 0"; return false; }
+    if (! reply.empty()) { errorOut = "ResizeEditor reply payload size mismatch"; return false; }
     return true;
 }
 
@@ -533,7 +564,7 @@ bool RemotePluginConnection::setRemoteParam (int paramIndex, float value01) noex
     if (readerExited.load (std::memory_order_acquire)) return false;
     // Fire-and-forget: child suppresses the reply for SetParam (per
     // PluginIpc.h opcode contract), so we do not wait on replyCv.
-    return sendControl (controlChannel, OpCode::SetParam, &p, sizeof (p));
+    return sendControl (controlChannel, OpCode::SetParam, 0, &p, sizeof (p));
 }
 
 void RemotePluginConnection::setParamChangedSink (ParamChangedSink sink)
@@ -631,12 +662,13 @@ void RemotePluginConnection::readerLoop()
             continue;
         }
 
-        // Anything else is a sync-RPC reply. Park it for the waiting
-        // sender. Single in-flight RPC is the invariant (message thread
-        // is JUCE-single-threaded), so overwriting an unconsumed reply
-        // would be a bug - we still publish to avoid deadlocking, and
-        // drop the prior unread slot on the floor with a stderr line.
+        // Anything else is a sync-RPC reply. A timed-out request can reply
+        // after its caller has started a newer RPC, so only publish a frame
+        // carrying the currently pending request ID.
         std::lock_guard<std::mutex> lk (controlMutex);
+        if (pendingControlRequestId == 0
+            || hdr.requestId != pendingControlRequestId)
+            continue;
         if (replyReady)
             std::fprintf (stderr,
                           "[Dusk Studio/RemotePluginConnection] reader: "

--- a/src/engine/ipc/RemotePluginConnection.h
+++ b/src/engine/ipc/RemotePluginConnection.h
@@ -228,23 +228,26 @@ private:
     //   - parks every other opcode in {replyHeader, replyPayload, reply
     //     Ready} as the next sync-RPC reply and signals replyCv.
     //
-    // Started ONLY in --ipc-host mode (extraArg). The --ipc-stub child
-    // never sends a frame after the 'k' handshake; spinning a reader on
-    // it would block forever and burn a thread per slot.
+    // Started for --ipc-host and the control-reply regression stubs. The
+    // audio-only --ipc-stub child never sends a frame after the 'k'
+    // handshake; spinning a reader on it would block forever and burn a
+    // thread per slot.
     std::thread             readerThread;
     bool                    readerStarted { false };
     std::atomic<bool>       readerExited  { false };
 
-    // controlMutex covers both the outbound write ordering AND the
-    // reply state. One mutex is enough because the message thread is
-    // the only caller of sync RPCs (JUCE single-threads it). The reader
-    // thread takes the mutex only briefly to publish a reply / exit
-    // flag, so the contention window is tiny.
+    // syncRpcMutex serialises synchronous callers for the full request
+    // lifetime. controlMutex covers outbound write ordering and the shared
+    // reply slot; replyCv releases it while waiting, so it cannot by itself
+    // prevent a second caller from replacing the pending request.
+    std::mutex                  syncRpcMutex;
     mutable std::mutex          controlMutex;
     std::condition_variable     replyCv;
     bool                        replyReady { false };
     ControlMsgHeader            replyHeader {};
     std::vector<std::uint8_t>   replyPayload;
+    std::uint32_t               nextControlRequestId { 1 };
+    std::uint32_t               pendingControlRequestId { 0 };
 
     // Sink state lives in a separately-allocated shared object so a
     // callAsync lambda queued by the reader thread can outlive the
@@ -272,10 +275,10 @@ private:
     void readerLoop();
 
     // Replaces the old "sendControl + recvControl" pair for every sync
-    // RPC. Holds controlMutex across the write + CV wait so a reply
-    // arriving while we're mid-write can't be lost. timeoutMs caps the
-    // wait; on expiry the function returns false with errorOut set
-    // (the connection is NOT marked crashed - caller decides).
+    // RPC. Holds syncRpcMutex through reply consumption or timeout and uses
+    // controlMutex with replyCv for the reader handoff. The monotonically
+    // increasing request ID keeps a late timed-out reply from completing
+    // the next waiter.
     bool sendAndAwaitReply (OpCode op,
                               const void* payload, std::uint32_t payloadLen,
                               ControlMsgHeader& hdrOut,

--- a/src/engine/ipc/RemotePluginConnection.h
+++ b/src/engine/ipc/RemotePluginConnection.h
@@ -236,11 +236,50 @@ private:
     bool                    readerStarted { false };
     std::atomic<bool>       readerExited  { false };
 
-    // syncRpcMutex serialises synchronous callers for the full request
-    // lifetime. controlMutex covers outbound write ordering and the shared
-    // reply slot; replyCv releases it while waiting, so it cannot by itself
-    // prevent a second caller from replacing the pending request.
-    std::mutex                  syncRpcMutex;
+    // Serialises synchronous callers without holding the gate's own mutex
+    // while a request owns controlMutex. Lease destruction clears the active
+    // slot after the later-declared control lock has been released, including
+    // on early returns and exceptions.
+    class SyncRpcGate
+    {
+    public:
+        class Lease
+        {
+        public:
+            explicit Lease (SyncRpcGate& ownerIn) noexcept : owner (ownerIn) {}
+            ~Lease() { owner.release(); }
+
+            Lease (const Lease&) = delete;
+            Lease& operator= (const Lease&) = delete;
+
+        private:
+            SyncRpcGate& owner;
+        };
+
+        [[nodiscard]] Lease acquire()
+        {
+            std::unique_lock<std::mutex> lk (mutex);
+            available.wait (lk, [this] { return ! active; });
+            active = true;
+            return Lease (*this);
+        }
+
+    private:
+        void release()
+        {
+            {
+                std::lock_guard<std::mutex> lk (mutex);
+                active = false;
+            }
+            available.notify_one();
+        }
+
+        std::mutex              mutex;
+        std::condition_variable available;
+        bool                    active { false };
+    };
+
+    SyncRpcGate                syncRpcGate;
     mutable std::mutex          controlMutex;
     std::condition_variable     replyCv;
     bool                        replyReady { false };
@@ -275,10 +314,10 @@ private:
     void readerLoop();
 
     // Replaces the old "sendControl + recvControl" pair for every sync
-    // RPC. Holds syncRpcMutex through reply consumption or timeout and uses
-    // controlMutex with replyCv for the reader handoff. The monotonically
-    // increasing request ID keeps a late timed-out reply from completing
-    // the next waiter.
+    // RPC. Holds a SyncRpcGate lease through reply consumption or timeout and
+    // uses controlMutex with replyCv for the reader handoff. The monotonically
+    // increasing request ID keeps a late timed-out reply from completing the
+    // next waiter.
     bool sendAndAwaitReply (OpCode op,
                               const void* payload, std::uint32_t payloadLen,
                               ControlMsgHeader& hdrOut,

--- a/src/engine/ipc/RemotePluginConnection.h
+++ b/src/engine/ipc/RemotePluginConnection.h
@@ -282,7 +282,9 @@ private:
     SyncRpcGate                syncRpcGate;
     mutable std::mutex          controlMutex;
     std::condition_variable     replyCv;
-    bool                        replyReady { false };
+    // The release/acquire handoff also makes the reply payload visible to
+    // older TSan runtimes that do not intercept pthread_cond_clockwait.
+    std::atomic<bool>           replyReady { false };
     ControlMsgHeader            replyHeader {};
     std::vector<std::uint8_t>   replyPayload;
     std::uint32_t               nextControlRequestId { 1 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -477,7 +477,9 @@ if (_duskstudio_ipc_test_enabled)
     # request never reaches the child (issue #406). Re-enable once that
     # transport moves to overlapped I/O.
     if (NOT WIN32)
-        target_sources(dusk-studio-tests PRIVATE ipc_worker_park.cpp)
+        target_sources(dusk-studio-tests PRIVATE
+            ipc_control_reply.cpp
+            ipc_worker_park.cpp)
     endif()
     target_compile_definitions(dusk-studio-tests PRIVATE
         DUSKSTUDIO_HAS_OOP_PLUGINS=1

--- a/tests/ipc_control_reply.cpp
+++ b/tests/ipc_control_reply.cpp
@@ -1,0 +1,42 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/ipc/RemotePluginConnection.h"
+
+#include <string>
+
+TEST_CASE ("OOP control replies correlate requests and validate their shape",
+           "[ipc][issue-370]")
+{
+    duskstudio::ipc::RemotePluginConnection connection;
+    std::string error;
+    REQUIRE (connection.connect (DUSKSTUDIO_PLUGIN_HOST_PATH,
+                                 "--ipc-control-reply-stub", error));
+
+    // The child holds A until it receives B, so this timeout establishes the
+    // ordering without sleeps or scheduler polling.
+    REQUIRE_FALSE (connection.ping (20, error));
+    REQUIRE (error == "reply timeout");
+
+    // The child now sends A's failing reply first, followed by B's success.
+    // B must ignore A by request ID and consume only its own frame.
+    error.clear();
+    REQUIRE (connection.ping (500, error));
+    REQUIRE (error.empty());
+
+    int numInputs = 0;
+    int numOutputs = 0;
+    int latency = 0;
+    bool isInstrument = false;
+    REQUIRE_FALSE (connection.loadPlugin ("", 48000.0, 256,
+                                          numInputs, numOutputs, latency,
+                                          isInstrument, error));
+    REQUIRE (error == "LoadPlugin reply size mismatch");
+
+    error.clear();
+    REQUIRE_FALSE (connection.ping (500, error));
+    REQUIRE (error == "reply opcode mismatch");
+
+    error.clear();
+    REQUIRE_FALSE (connection.ping (500, error));
+    REQUIRE (error == "Ping reply payload size mismatch");
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IPC reliability by matching replies to their requests and preventing delayed responses from affecting later operations.
  * Added validation for unexpected reply types, payloads, and malformed plugin-loading responses.
  * Improved handling of timed-out control requests and concurrent communication.

* **Tests**
  * Added coverage for out-of-order, mismatched, oversized, and malformed IPC replies.

* **Documentation**
  * Updated documented test totals and repository details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->