### PR TITLE
Fix Windows plugin-host launch from Unicode paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 882 Catch2 test cases across 174 test source files. Linux
+The C++ suite declares 884 Catch2 test cases across 174 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 882 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 884 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/ipc/PluginHostMain.cpp
+++ b/src/engine/ipc/PluginHostMain.cpp
@@ -5,6 +5,8 @@
 //   --ipc-stub  : echo input -> output, no JUCE plugin. Exists so the
 //                 IPC self-test can validate shm + sync + spawn plumbing
 //                 without a plugin in the loop.
+//   --ipc-argv-stub: return the UTF-8 argv vector over the inherited channel.
+//                 Used to validate Windows UTF-16 launch and quoting.
 //   --ipc-control-reply-stub: deterministic request-correlation and reply-
 //                 validation regression child.
 //   --ipc-host  : full Phase-2 host. Loads a juce::AudioPluginInstance
@@ -138,6 +140,23 @@ bool sendControlReply (ipcp::NativeHandle& ch, const ControlMsgHeader& request,
     if (! ipcp::writeExact (ch, &hdr, sizeof (hdr))) return false;
     if (! ipcp::writeExact (ch, &p, sizeof (p)))    return false;
     return true;
+}
+
+int runIpcArgvStub (int argc, const char* const* argv) noexcept
+{
+    ipcp::NativeHandle channel = ipcp::locateInheritedChannel (argc, argv);
+    if (! ipcp::isValid (channel)) return 1;
+
+    const auto count = (std::uint32_t) argc;
+    if (! ipcp::writeExact (channel, &count, sizeof (count))) return 1;
+    for (int i = 0; i < argc; ++i)
+    {
+        const auto length = (std::uint32_t) std::strlen (argv[i]);
+        if (! ipcp::writeExact (channel, &length, sizeof (length))
+            || (length > 0 && ! ipcp::writeExact (channel, argv[i], length)))
+            return 1;
+    }
+    return 0;
 }
 
 // --- Phase 1 echo mode (kept for the IPC self-test) ----------------------
@@ -1284,6 +1303,7 @@ int main (int argc, char** argv)
 
     bool ipcStub = false;
     bool ipcStubTimeout = false;
+    bool ipcArgvStub = false;
     bool ipcControlReplyStub = false;
     bool ipcParkTimeoutStub = false;
     bool ipcHost = false;
@@ -1292,6 +1312,7 @@ int main (int argc, char** argv)
     {
         if (std::strcmp (args[i], "--ipc-stub") == 0) ipcStub = true;
         if (std::strcmp (args[i], "--ipc-stub-timeout") == 0) ipcStubTimeout = true;
+        if (std::strcmp (args[i], "--ipc-argv-stub") == 0) ipcArgvStub = true;
         if (std::strcmp (args[i], "--ipc-control-reply-stub") == 0) ipcControlReplyStub = true;
         if (std::strcmp (args[i], "--ipc-park-timeout-stub") == 0) ipcParkTimeoutStub = true;
         if (std::strcmp (args[i], "--ipc-host") == 0) ipcHost = true;
@@ -1302,6 +1323,7 @@ int main (int argc, char** argv)
     }
 
     if (scan)    return runScan (argc, args);
+    if (ipcArgvStub) return runIpcArgvStub (argc, args);
     if (ipcStub || ipcStubTimeout) return runIpcStub (argc, args, ipcStubTimeout);
     if (ipcControlReplyStub) return runIpcControlReplyStub (argc, args);
     if (ipcParkTimeoutStub) return runIpcParkTimeoutStub (argc, args);

--- a/src/engine/ipc/platform/IpcProcess.h
+++ b/src/engine/ipc/platform/IpcProcess.h
@@ -14,7 +14,7 @@
 // macOS  : posix_spawn() with file actions to remap the channel endpoint
 //          to kChildInheritFd. Parent-death tracking via kqueue NOTE_EXIT
 //          on the child PID; termination via SIGTERM + waitpid.
-// Windows: CreateProcess() with bInheritHandles=TRUE, the child handle
+// Windows: CreateProcessW() with bInheritHandles=TRUE, the child handle
 //          duplicated into the new process and recorded in
 //          STARTUPINFOEX::lpAttributeList. Job object configured with
 //          JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE so the child dies with us;

--- a/src/engine/ipc/platform/IpcProcess_Windows.cpp
+++ b/src/engine/ipc/platform/IpcProcess_Windows.cpp
@@ -6,10 +6,11 @@
 
 #include <cstdio>
 #include <cstring>
+#include <limits>
 #include <string>
 #include <vector>
 
-// CreateProcess with bInheritHandles = TRUE. Inheritable handles (the
+// CreateProcessW with bInheritHandles = TRUE. Inheritable handles (the
 // channel child end + the SHM mapping) flow into the child at the same
 // numeric HANDLE value. A Job object with
 // JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE wraps the child so it dies if the
@@ -34,6 +35,74 @@ struct WinProcessState
 WinProcessState* impl (std::intptr_t opaque) noexcept
 {
     return reinterpret_cast<WinProcessState*> (opaque);
+}
+
+bool widenUtf8 (const std::string& utf8, std::wstring& wide,
+                const char* description, std::string& errorOut)
+{
+    if (utf8.find ('\0') != std::string::npos
+        || utf8.size() > (std::size_t) std::numeric_limits<int>::max())
+    {
+        errorOut = std::string (description) + " is not a valid Windows argument";
+        return false;
+    }
+
+    if (utf8.empty())
+    {
+        wide.clear();
+        return true;
+    }
+
+    const int sourceLength = (int) utf8.size();
+    const int required = ::MultiByteToWideChar (
+        CP_UTF8, MB_ERR_INVALID_CHARS, utf8.data(), sourceLength, nullptr, 0);
+    if (required <= 0)
+    {
+        errorOut = std::string (description) + " is not valid UTF-8";
+        return false;
+    }
+
+    wide.resize ((std::size_t) required);
+    if (::MultiByteToWideChar (CP_UTF8, MB_ERR_INVALID_CHARS,
+                               utf8.data(), sourceLength,
+                               wide.data(), required) != required)
+    {
+        errorOut = std::string ("failed to convert ") + description + " to UTF-16";
+        return false;
+    }
+    return true;
+}
+
+// Quote one argv element using the escaping rules consumed by
+// CommandLineToArgvW and the Microsoft C runtime. Backslashes are doubled only
+// when they precede a quote or the closing quote; elsewhere they remain literal.
+void appendQuotedArgument (std::wstring& commandLine, const std::wstring& argument)
+{
+    commandLine.push_back (L'"');
+    std::size_t backslashes = 0;
+    for (const wchar_t ch : argument)
+    {
+        if (ch == L'\\')
+        {
+            ++backslashes;
+            continue;
+        }
+
+        if (ch == L'"')
+        {
+            commandLine.append (backslashes * 2 + 1, L'\\');
+            commandLine.push_back (L'"');
+        }
+        else
+        {
+            commandLine.append (backslashes, L'\\');
+            commandLine.push_back (ch);
+        }
+        backslashes = 0;
+    }
+
+    commandLine.append (backslashes * 2, L'\\');
+    commandLine.push_back (L'"');
 }
 } // namespace
 
@@ -81,33 +150,50 @@ bool ChildProcess::spawn (const std::string& executablePath,
         return false;
     }
 
-    std::string cmdline = "\"" + executablePath + "\"";
-    for (const auto& a : args)
-    {
-        cmdline += " \"";
-        cmdline += a;
-        cmdline += "\"";
-    }
+    std::vector<std::string> childArgs = args;
     {
         // Pass the inherited channel HANDLE value on the command line
         // so the child can locate it after CreateProcess(bInheritHandles
         // = TRUE) reproduces the same numeric value in its handle table.
         char buf[64];
-        std::snprintf (buf, sizeof (buf), " --ipc-channel=0x%llx",
+        std::snprintf (buf, sizeof (buf), "--ipc-channel=0x%llx",
                         (unsigned long long) (std::uintptr_t)
                             reinterpret_cast<HANDLE> (childChannelEnd.h));
-        cmdline += buf;
+        childArgs.emplace_back (buf);
     }
-    std::vector<char> cmdBuf (cmdline.begin(), cmdline.end());
-    cmdBuf.push_back (0);
 
-    STARTUPINFOA si {};
+    std::wstring wideExecutable;
+    if (! widenUtf8 (executablePath, wideExecutable, "executable path", errorOut))
+    {
+        ::CloseHandle (state->job);
+        delete state;
+        return false;
+    }
+
+    std::wstring commandLine;
+    appendQuotedArgument (commandLine, wideExecutable);
+    for (const auto& argument : childArgs)
+    {
+        std::wstring wideArgument;
+        if (! widenUtf8 (argument, wideArgument, "process argument", errorOut))
+        {
+            ::CloseHandle (state->job);
+            delete state;
+            return false;
+        }
+        commandLine.push_back (L' ');
+        appendQuotedArgument (commandLine, wideArgument);
+    }
+    std::vector<wchar_t> commandBuffer (commandLine.begin(), commandLine.end());
+    commandBuffer.push_back (L'\0');
+
+    STARTUPINFOW si {};
     si.cb = sizeof (si);
     PROCESS_INFORMATION pi {};
 
-    const BOOL ok = ::CreateProcessA (
-        executablePath.c_str(),
-        cmdBuf.data(),
+    const BOOL ok = ::CreateProcessW (
+        wideExecutable.c_str(),
+        commandBuffer.data(),
         nullptr, nullptr,
         TRUE,                       // bInheritHandles
         CREATE_SUSPENDED | CREATE_NO_WINDOW,

--- a/tests/ipc_stub_round_trip.cpp
+++ b/tests/ipc_stub_round_trip.cpp
@@ -49,12 +49,10 @@ struct ScopedChannelPair
 #endif
 } // namespace
 
+#if defined (_WIN32)
 TEST_CASE ("Windows IPC launcher preserves Unicode paths and arguments",
            "[ipc][windows][issue-373]")
 {
-#if ! defined (_WIN32)
-    SUCCEED ("Windows-only process launch regression");
-#else
     namespace ipcp = duskstudio::ipc::platform;
 
     duskstudio::test::TempDirectory temp ("dusk-ipc-unicode-launch-");
@@ -110,8 +108,8 @@ TEST_CASE ("Windows IPC launcher preserves Unicode paths and arguments",
     for (std::size_t i = 0; i < suppliedArguments.size(); ++i)
         REQUIRE (receivedArguments[i + 1] == suppliedArguments[i]);
     REQUIRE (receivedArguments.back().rfind ("--ipc-channel=0x", 0) == 0);
-#endif
 }
+#endif
 
 TEST_CASE ("ipc-stub: connect, round-trip 32 blocks, byte-exact echo",
             "[ipc]")

--- a/tests/ipc_stub_round_trip.cpp
+++ b/tests/ipc_stub_round_trip.cpp
@@ -15,12 +15,17 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include "engine/ipc/RemotePluginConnection.h"
+#include "engine/ipc/platform/IpcProcess.h"
+#include "TestTempDirectory.h"
 
 #include <juce_audio_basics/juce_audio_basics.h>
 
 #include <cmath>
 #include <chrono>
+#include <cstdint>
+#include <filesystem>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace
@@ -29,7 +34,84 @@ constexpr int  kBlockSize  = 256;
 constexpr int  kNumChans   = 2;
 constexpr int  kIterations = 32;
 constexpr long long kTimeoutNs = 100'000'000LL;  // 100 ms
+
+#if defined (_WIN32)
+struct ScopedChannelPair
+{
+    ~ScopedChannelPair()
+    {
+        duskstudio::ipc::platform::closeHandle (value.parentEnd);
+        duskstudio::ipc::platform::closeHandle (value.childEnd);
+    }
+
+    duskstudio::ipc::platform::ChannelPair value;
+};
+#endif
 } // namespace
+
+TEST_CASE ("Windows IPC launcher preserves Unicode paths and arguments",
+           "[ipc][windows][issue-373]")
+{
+#if ! defined (_WIN32)
+    SUCCEED ("Windows-only process launch regression");
+#else
+    namespace ipcp = duskstudio::ipc::platform;
+
+    duskstudio::test::TempDirectory temp ("dusk-ipc-unicode-launch-");
+    const auto unicodeDirectory = temp.path()
+        / std::filesystem::u8path (u8"\u5B89\u88C5 \u8DEF\u5F84");
+    std::error_code filesystemError;
+    REQUIRE (std::filesystem::create_directory (unicodeDirectory, filesystemError));
+    REQUIRE_FALSE (filesystemError);
+
+    const auto sourceHost = std::filesystem::u8path (DUSKSTUDIO_PLUGIN_HOST_PATH);
+    const auto copiedHost = unicodeDirectory / sourceHost.filename();
+    REQUIRE (std::filesystem::copy_file (
+        sourceHost, copiedHost, std::filesystem::copy_options::overwrite_existing,
+        filesystemError));
+    REQUIRE_FALSE (filesystemError);
+
+    const std::vector<std::string> suppliedArguments {
+        "--ipc-argv-stub",
+        u8"\u63D2\u4EF6 \u0430\u0440\u0433\u0443\u043C\u0435\u043D\u0442",
+        R"(C:\folder with spaces\)",
+        R"(say \\"hello" and C:\tail\\)"
+    };
+
+    ScopedChannelPair channels;
+    std::string error;
+    REQUIRE (ipcp::createChannelPair (channels.value, error));
+
+    ipcp::ChildProcess child;
+    const bool spawned = child.spawn (copiedHost.u8string(), suppliedArguments,
+                                      channels.value.childEnd, error);
+    INFO ("spawn error: " << error);
+    REQUIRE (spawned);
+
+    std::uint32_t argumentCount = 0;
+    REQUIRE (ipcp::readExact (channels.value.parentEnd,
+                              &argumentCount, sizeof (argumentCount)));
+    REQUIRE (argumentCount == suppliedArguments.size() + 2);
+
+    std::vector<std::string> receivedArguments;
+    receivedArguments.reserve (argumentCount);
+    for (std::uint32_t i = 0; i < argumentCount; ++i)
+    {
+        std::uint32_t length = 0;
+        REQUIRE (ipcp::readExact (channels.value.parentEnd, &length, sizeof (length)));
+        REQUIRE (length < 4096);
+        std::string argument (length, '\0');
+        if (length > 0)
+            REQUIRE (ipcp::readExact (channels.value.parentEnd, argument.data(), length));
+        receivedArguments.push_back (std::move (argument));
+    }
+
+    REQUIRE (receivedArguments.front() == copiedHost.u8string());
+    for (std::size_t i = 0; i < suppliedArguments.size(); ++i)
+        REQUIRE (receivedArguments[i + 1] == suppliedArguments[i]);
+    REQUIRE (receivedArguments.back().rfind ("--ipc-channel=0x", 0) == 0);
+#endif
+}
 
 TEST_CASE ("ipc-stub: connect, round-trip 32 blocks, byte-exact echo",
             "[ipc]")

--- a/tests/plugin_host_command_line.cpp
+++ b/tests/plugin_host_command_line.cpp
@@ -32,4 +32,12 @@ TEST_CASE ("Utf8CommandLine reports nothing for an empty command line", "[ipc][w
     REQUIRE (cmd.argc() == 0);
 }
 
+#else
+
+TEST_CASE ("Windows IPC launcher regression is registered on every platform",
+           "[ipc][windows][issue-373]")
+{
+    SUCCEED ("Windows-only process launch regression");
+}
+
 #endif


### PR DESCRIPTION
Closes #373

## Summary
- launch the OOP plugin host with UTF-16 paths and arguments via CreateProcessW
- apply Windows-compatible quoting for embedded quotes and trailing backslashes
- exercise the production launcher from a Unicode path with Unicode and escaped arguments

## Validation
- Linux: [issue-373] 1 assertion; 871/871 CTest
- macOS: [issue-373] 1 assertion; 840/840 CTest
- Windows (ASIO): [issue-373] 32 assertions; 834/834 CTest
- review-local was incomplete because its local model was unavailable; reported linter hints were manually checked