### PR TITLE
Prevent recent-session scan exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 884 Catch2 test cases across 174 test source files. Linux
+The C++ suite declares 885 Catch2 test cases across 174 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 884 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 885 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/foundation/Fs.h
+++ b/src/foundation/Fs.h
@@ -69,6 +69,22 @@ inline bool matchesWildcard (std::string_view name, std::string_view pattern)
     return pi == p.size();
 }
 
+// Walk a filesystem iterator without invoking its throwing operator++. Returning
+// false from the visitor stops normally; a false result means construction or
+// increment reported an error through ec.
+template <typename Iterator, typename Visitor>
+inline bool walkDirectoryEntries (Iterator iterator, std::error_code& ec, Visitor&& visitor)
+{
+    const Iterator end;
+    while (! ec && iterator != end)
+    {
+        if (! visitor (*iterator))
+            return true;
+        iterator.increment (ec);
+    }
+    return ! ec;
+}
+
 inline std::vector<std::filesystem::path> findChildFiles (const std::filesystem::path& dir,
                                                           std::string_view wildcard,
                                                           bool recursive)

--- a/src/ui/imgui/StartupView.cpp
+++ b/src/ui/imgui/StartupView.cpp
@@ -1,6 +1,7 @@
 #include "StartupView.h"
 #include "DuskTheme.h"
 #include "../../engine/audiofile/FileReader.h"
+#include "../../foundation/Fs.h"
 
 #include <algorithm>
 #include <cmath>
@@ -117,25 +118,27 @@ void inferAudioFormat (const std::filesystem::path& sessionDir, std::string& sam
         return;
 
     std::filesystem::path candidate;
-    for (const auto& entry : std::filesystem::directory_iterator (audioDir, error))
+    auto iterator = std::filesystem::directory_iterator (audioDir, error);
+    const auto scanSucceeded = dusk::fs::walkDirectoryEntries (
+        std::move (iterator), error, [&] (const std::filesystem::directory_entry& entry)
     {
-        if (error)
-            return;
-        if (! entry.is_regular_file (error))
-            continue;
+        std::error_code inspectionError;
+        if (! entry.is_regular_file (inspectionError) || inspectionError)
+            return true;
         auto extension = entry.path().extension().string();
         std::transform (extension.begin(), extension.end(), extension.begin(),
                         [] (unsigned char c) { return static_cast<char> (std::tolower (c)); });
         if (extension == ".wav")
         {
             candidate = entry.path();
-            break;
+            return false;
         }
         if (candidate.empty()
             && (extension == ".flac" || extension == ".aiff" || extension == ".aif"))
             candidate = entry.path();
-    }
-    if (candidate.empty())
+        return true;
+    });
+    if (! scanSucceeded || candidate.empty())
         return;
 
     const auto reader = dusk::audio::FileReader::open (candidate);

--- a/tests/foundation_fs.cpp
+++ b/tests/foundation_fs.cpp
@@ -8,6 +8,7 @@
 #include <filesystem>
 #include <random>
 #include <set>
+#include <stdexcept>
 #include <string>
 
 using namespace dusk;
@@ -31,6 +32,36 @@ std::set<std::string> duskNames (const stdfs::path& dir, const std::string& wild
         out.insert (p.filename().string());
     return out;
 }
+
+class FailingDirectoryIterator
+{
+public:
+    FailingDirectoryIterator() = default;
+    explicit FailingDirectoryIterator (int* incrementsIn) : increments (incrementsIn), atEnd (false) {}
+
+    int operator*() const noexcept { return 42; }
+
+    FailingDirectoryIterator& operator++()
+    {
+        throw std::runtime_error ("throwing increment must not be used");
+    }
+
+    void increment (std::error_code& error)
+    {
+        ++*increments;
+        error = std::make_error_code (std::errc::io_error);
+    }
+
+    friend bool operator!= (const FailingDirectoryIterator& lhs,
+                            const FailingDirectoryIterator& rhs) noexcept
+    {
+        return lhs.atEnd != rhs.atEnd;
+    }
+
+private:
+    int* increments = nullptr;
+    bool atEnd = true;
+};
 } // namespace
 
 TEST_CASE ("dusk::fs matches juce::File", "[foundation][fs]")
@@ -82,4 +113,28 @@ TEST_CASE ("dusk::fs::matchesWildcard", "[foundation][fs]")
     REQUIRE_FALSE (fs::matchesWildcard ("xx.txt", "?.txt"));
     REQUIRE (fs::matchesWildcard ("anything", "*"));
     REQUIRE_FALSE (fs::matchesWildcard ("a.wav", "*.flac"));
+}
+
+TEST_CASE ("directory walks report increment errors without throwing", "[foundation][fs][issue-374]")
+{
+    std::error_code error;
+    int increments = 0;
+    int visits = 0;
+    int visitedValue = 0;
+    bool completed = true;
+
+    REQUIRE_NOTHROW (completed = fs::walkDirectoryEntries (
+                         FailingDirectoryIterator (&increments), error,
+                         [&] (int value)
+                         {
+                             ++visits;
+                             visitedValue = value;
+                             return true;
+                         }));
+
+    REQUIRE_FALSE (completed);
+    REQUIRE (error == std::errc::io_error);
+    REQUIRE (visits == 1);
+    REQUIRE (visitedValue == 42);
+    REQUIRE (increments == 1);
 }


### PR DESCRIPTION
Closes #374

## Summary
- walk recent-session audio directories with error-code-based iterator increments
- skip entries whose file-type inspection fails and omit format metadata after a walk error
- add a deterministic iterator-failure regression that proves throwing increment is never used

## Validation
- Linux: [issue-374] 6 assertions; 872/872 CTest
- macOS: [issue-374] 6 assertions; 841/841 CTest
- Windows (ASIO): [issue-374] 6 assertions; 835/835 CTest
- review-local incomplete because its local model was unavailable; non-model checks found no issues and the diff was manually inspected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved audio file detection during startup, allowing directory access errors to be handled safely without unexpected crashes.
  - Audio scanning now stops promptly once a supported WAV file is found.

- **Documentation**
  - Updated the documented Catch2 test count from 884 to 885.

- **Tests**
  - Added coverage for directory scanning failures and safe error propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->