### PR TITLE
Scope X11 editor teardown error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 885 Catch2 test cases across 174 test source files. Linux
+The C++ suite declares 886 Catch2 test cases across 174 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 885 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 886 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -147,10 +147,6 @@ public:
         addToDesktop (getDesktopWindowStyleFlags());
        #if defined(__linux__)
         duskstudio::platform::clearPreferX11ForNativeWindow();
-        // The peer now exists (JUCE's X display is up), so a non-fatal X error
-        // handler installed here captures JUCE's handler as its chain target.
-        // Stops a dying OOP plugin editor window from core-dumping the host.
-        duskstudio::platform::installNonFatalXErrorHandler();
        #endif
         refreshResizeLimits();
 
@@ -2184,10 +2180,8 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
         clapEditorTestWindow->centreWithSize (w, h);
         clapEditorTestWindow->setVisible (true);   // creates the peer -> consumes the X11 latch
         // Match MainWindow's native-window setup: release the X11 latch now the peer
-        // exists, and install the non-fatal X error handler so a dying CLAP editor
-        // window can't core-dump this harness.
+        // exists.
         duskstudio::platform::clearPreferX11ForNativeWindow();
-        duskstudio::platform::installNonFatalXErrorHandler();
         return;   // standalone - skip the normal engine + main-window startup
     }
 #endif // DUSKSTUDIO_HAS_NATIVE_CLAP
@@ -2233,7 +2227,6 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
         lv2EditorTest->window->centreWithSize (w, h);
         lv2EditorTest->window->setVisible (true);   // creates the peer -> consumes the X11 latch
         duskstudio::platform::clearPreferX11ForNativeWindow();
-        duskstudio::platform::installNonFatalXErrorHandler();
         return;
     }
 #endif // DUSKSTUDIO_HAS_NATIVE_LV2
@@ -2291,7 +2284,6 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
         vst3EditorTest->window->centreWithSize (w, h);
         vst3EditorTest->window->setVisible (true);   // creates the peer -> consumes the X11 latch
         duskstudio::platform::clearPreferX11ForNativeWindow();
-        duskstudio::platform::installNonFatalXErrorHandler();
         return;
     }
 #endif // DUSKSTUDIO_HAS_NATIVE_VST3

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -2937,7 +2937,8 @@ void ChannelStripComponent::closePluginEditor()
 #if JUCE_LINUX && DUSKSTUDIO_HAS_OOP_PLUGINS
 void ChannelStripComponent::resetRemoteEditorEmbed()
 {
-    duskstudio::platform::destroyX11EditorEmbed (remoteEditorEmbed, remoteEditorWindowId);
+    duskstudio::platform::runX11EditorTeardown (
+        remoteEditorWindowId, [this] { remoteEditorEmbed.reset(); });
     remoteEditorWindowId = 0;
 }
 #endif

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -2694,6 +2694,7 @@ void ChannelStripComponent::openPluginEditor()
                 (unsigned long) windowId,
                 /*wantsKeyboardFocus*/ true,
                 /*allowForeignWidgetToResizeComponent*/ false);
+            remoteEditorWindowId = windowId;
             remoteEditorEmbed->setSize (std::max (200, w),
                                           std::max (200, h));
             // Tag so EmbeddedModal hides this XEmbed window for the
@@ -2933,6 +2934,14 @@ void ChannelStripComponent::closePluginEditor()
    #endif
 }
 
+#if JUCE_LINUX && DUSKSTUDIO_HAS_OOP_PLUGINS
+void ChannelStripComponent::resetRemoteEditorEmbed()
+{
+    duskstudio::platform::destroyX11EditorEmbed (remoteEditorEmbed, remoteEditorWindowId);
+    remoteEditorWindowId = 0;
+}
+#endif
+
 void ChannelStripComponent::dropPluginEditor (NativeEditorTeardown teardown)
 {
     closePluginEditor();
@@ -2999,7 +3008,7 @@ void ChannelStripComponent::dropPluginEditor (NativeEditorTeardown teardown)
     // been told to hide the editor by closePluginEditor above (or by
     // unloadPluginSlot which calls dropPluginEditor before
     // pluginSlot.unload). Either way the X client is safe to release.
-    remoteEditorEmbed.reset();
+    resetRemoteEditorEmbed();
    #endif
    #if DUSKSTUDIO_HAS_OOP_PLUGINS && ! JUCE_LINUX
     // Windows: ~ForeignHwndEmbed (in PlatformWindowing_Windows.cpp)
@@ -3057,7 +3066,7 @@ void ChannelStripComponent::loadNativeClapForChannel (const juce::File& clapFile
     // CLAP would otherwise leave the foreign X11 / HWND wrapper behind (mirrors
     // dropPluginEditor's teardown).
    #if JUCE_LINUX && DUSKSTUDIO_HAS_OOP_PLUGINS
-    remoteEditorEmbed.reset();
+    resetRemoteEditorEmbed();
    #endif
    #if DUSKSTUDIO_HAS_OOP_PLUGINS && ! JUCE_LINUX
     remoteForeignEmbed.reset();
@@ -3139,7 +3148,7 @@ void ChannelStripComponent::loadNativeLv2ForChannel (const juce::File& bundleDir
     pluginEditor.reset();
     pluginEditorOwner = nullptr;
    #if JUCE_LINUX && DUSKSTUDIO_HAS_OOP_PLUGINS
-    remoteEditorEmbed.reset();
+    resetRemoteEditorEmbed();
    #endif
    #if DUSKSTUDIO_HAS_OOP_PLUGINS && ! JUCE_LINUX
     remoteForeignEmbed.reset();
@@ -3215,7 +3224,7 @@ void ChannelStripComponent::loadNativeVst3ForChannel (const juce::File& vst3File
     pluginEditor.reset();
     pluginEditorOwner = nullptr;
    #if JUCE_LINUX && DUSKSTUDIO_HAS_OOP_PLUGINS
-    remoteEditorEmbed.reset();
+    resetRemoteEditorEmbed();
    #endif
    #if DUSKSTUDIO_HAS_OOP_PLUGINS && ! JUCE_LINUX
     remoteForeignEmbed.reset();
@@ -3288,7 +3297,7 @@ void ChannelStripComponent::loadNativeAuForChannel (const juce::String& componen
     pluginEditor.reset();
     pluginEditorOwner = nullptr;
    #if JUCE_LINUX && DUSKSTUDIO_HAS_OOP_PLUGINS
-    remoteEditorEmbed.reset();
+    resetRemoteEditorEmbed();
    #endif
    #if DUSKSTUDIO_HAS_OOP_PLUGINS && ! JUCE_LINUX
     remoteForeignEmbed.reset();
@@ -3421,7 +3430,7 @@ void ChannelStripComponent::loadNativeMultisampleForChannel (const juce::File& s
     pluginEditor.reset();
     pluginEditorOwner = nullptr;
    #if JUCE_LINUX && DUSKSTUDIO_HAS_OOP_PLUGINS
-    remoteEditorEmbed.reset();
+    resetRemoteEditorEmbed();
    #endif
    #if DUSKSTUDIO_HAS_OOP_PLUGINS && ! JUCE_LINUX
     remoteForeignEmbed.reset();

--- a/src/ui/ChannelStripComponent.h
+++ b/src/ui/ChannelStripComponent.h
@@ -411,6 +411,8 @@ private:
     // OOP: child plugin's X11 Window wrapped in XEmbedComponent fed
     // to PluginEditorWindow as the body. Lifetime matches pluginEditor.
     std::unique_ptr<juce::XEmbedComponent> remoteEditorEmbed;
+    std::uint64_t remoteEditorWindowId = 0;
+    void resetRemoteEditorEmbed();
    #endif
    #if DUSKSTUDIO_HAS_OOP_PLUGINS && ! JUCE_LINUX
     // Windows OOP via SetParent. macOS keeps null and falls through to

--- a/src/ui/PlatformWindowing.h
+++ b/src/ui/PlatformWindowing.h
@@ -9,7 +9,13 @@
 // and chokes on the bare juce::AudioProcessorEditor reference. Forward-
 // decl is cheaper than the full include AND keeps this header's
 // dependency surface narrow.
-namespace juce { class AudioProcessorEditor; }
+namespace juce
+{
+class AudioProcessorEditor;
+#if JUCE_LINUX
+class XEmbedComponent;
+#endif
+}
 
 namespace duskstudio::platform
 {
@@ -167,15 +173,15 @@ void requestFocusOnMainWaylandSurface();
 void preferX11ForNextNativeWindow();
 void clearPreferX11ForNativeWindow();
 
-// Install a process-wide X error handler that turns the benign
-// window-lifecycle races inherent to embedding an OUT-OF-PROCESS plugin
-// editor (the child's X11 toplevel can be freed by the server before the
-// parent's pending reparent / query-tree requests reach it) into a logged,
-// swallowed no-op instead of an Xlib-default abort() that core-dumps the host.
-// Non-benign errors chain to whatever handler was installed before (JUCE's, or
-// Xlib's default) so genuine bugs stay loud. Call ONCE, after the main window
-// peer exists (so JUCE's display is up). Linux-only; no-op on Mac/Windows.
-void installNonFatalXErrorHandler();
+#if JUCE_LINUX
+// Destroy an OOP editor's XEmbed wrapper under a local X error trap. The child
+// may already have freed editorWindowId, so the exact BadWindow responses made
+// by XEmbedComponent's detach sequence are swallowed. Pending errors are drained
+// before the trap, teardown is drained while it is active, and every unrelated
+// error chains to the previously installed handler.
+void destroyX11EditorEmbed (std::unique_ptr<juce::XEmbedComponent>& embed,
+                            std::uint64_t editorWindowId);
+#endif
 
 // Factory for a Component that adopts a foreign native window handle
 // (HWND on Windows, NSView on macOS, X11 Window on Linux) and embeds

--- a/src/ui/PlatformWindowing.h
+++ b/src/ui/PlatformWindowing.h
@@ -2,6 +2,8 @@
 
 #include <juce_gui_basics/juce_gui_basics.h>
 
+#include <functional>
+
 // Forward-decl in the juce namespace so createInProcessEditorHost's
 // AudioProcessorEditor* parameter (Mac-only) doesn't force every
 // includer to pull juce_audio_processors. Linux + Windows transitively
@@ -12,9 +14,6 @@
 namespace juce
 {
 class AudioProcessorEditor;
-#if JUCE_LINUX
-class XEmbedComponent;
-#endif
 }
 
 namespace duskstudio::platform
@@ -174,13 +173,13 @@ void preferX11ForNextNativeWindow();
 void clearPreferX11ForNativeWindow();
 
 #if JUCE_LINUX
-// Destroy an OOP editor's XEmbed wrapper under a local X error trap. The child
-// may already have freed editorWindowId, so the exact BadWindow responses made
-// by XEmbedComponent's detach sequence are swallowed. Pending errors are drained
-// before the trap, teardown is drained while it is active, and every unrelated
-// error chains to the previously installed handler.
-void destroyX11EditorEmbed (std::unique_ptr<juce::XEmbedComponent>& embed,
-                            std::uint64_t editorWindowId);
+// Run an OOP editor's XEmbed teardown under a local X error trap. The child may
+// already have freed editorWindowId, so the exact BadWindow responses made by
+// the detach sequence are swallowed. Pending errors are drained before the
+// trap, teardown is drained while it is active, and every unrelated error
+// chains to the previously installed handler.
+void runX11EditorTeardown (std::uint64_t editorWindowId,
+                           const std::function<void()>& teardown);
 #endif
 
 // Factory for a Component that adopts a foreign native window handle

--- a/src/ui/PlatformWindowing_Linux.cpp
+++ b/src/ui/PlatformWindowing_Linux.cpp
@@ -7,7 +7,6 @@
 #include "PlatformWindowing.h"
 #include "X11EditorTeardownError.h"
 
-#include <juce_gui_extra/juce_gui_extra.h>
 #include <X11/Xproto.h>
 
 #include <cstdio>
@@ -132,16 +131,16 @@ bool hasUsableDisplay()
 
 double nativeViewBackingScale (void*) { return 1.0; }
 
-void destroyX11EditorEmbed (std::unique_ptr<juce::XEmbedComponent>& embed,
-                            std::uint64_t editorWindowId)
+void runX11EditorTeardown (std::uint64_t editorWindowId,
+                           const std::function<void()>& teardown)
 {
-    if (embed == nullptr)
+    if (! teardown)
         return;
 
     auto* display = juceDisplay();
     if (display == nullptr || editorWindowId == 0)
     {
-        embed.reset();
+        teardown();
         return;
     }
 
@@ -155,7 +154,7 @@ void destroyX11EditorEmbed (std::unique_ptr<juce::XEmbedComponent>& embed,
     activeEditorTeardownTrap = &trap;
     trap.previous = ::XSetErrorHandler (&editorTeardownXErrorHandler);
 
-    embed.reset();
+    teardown();
     ::XSync (display, False);
 
     ::XSetErrorHandler (trap.previous);

--- a/src/ui/PlatformWindowing_Linux.cpp
+++ b/src/ui/PlatformWindowing_Linux.cpp
@@ -5,9 +5,14 @@
 #define JUCE_GUI_BASICS_INCLUDE_XHEADERS 1
 
 #include "PlatformWindowing.h"
+#include "X11EditorTeardownError.h"
+
+#include <juce_gui_extra/juce_gui_extra.h>
+#include <X11/Xproto.h>
 
 #include <cstdio>
 #include <cstdlib>
+#include <mutex>
 
 namespace duskstudio::platform
 {
@@ -45,45 +50,51 @@ bool isWaylandSession()
     return cached;
 }
 
-::XErrorHandler previousXErrorHandler = nullptr;
-bool xErrorHandlerInstalled = false;
+static_assert (BadWindow == x11::kBadWindow);
+static_assert (X_ChangeWindowAttributes == x11::kChangeWindowAttributes);
+static_assert (X_ReparentWindow == x11::kReparentWindow);
+static_assert (X_UnmapWindow == x11::kUnmapWindow);
 
-int nonFatalXErrorHandler (::Display* d, ::XErrorEvent* e)
+struct EditorTeardownErrorTrap
 {
-    // OOP plugin editors are X11 toplevels owned by a SEPARATE process. When
-    // one dies (crash / timeout-kill) the parent's already-queued reparent /
-    // query-tree / configure requests reference a window the server has freed.
-    // Xlib's default handler abort()s on the resulting BadWindow etc. - turning
-    // a plugin's death into a host core-dump. Swallow those benign races and
-    // log them; defer anything else to the prior handler so real bugs stay loud.
-    if (e != nullptr)
+    ::Display* display = nullptr;
+    std::uint64_t editorWindowId = 0;
+    ::XErrorHandler previous = nullptr;
+};
+
+EditorTeardownErrorTrap* activeEditorTeardownTrap = nullptr;
+std::mutex editorTeardownTrapMutex;
+
+int editorTeardownXErrorHandler (::Display* display, ::XErrorEvent* error)
+{
+    auto* trap = activeEditorTeardownTrap;
+    if (trap != nullptr && error != nullptr && display == trap->display
+        && x11::shouldSuppressEditorTeardownError (
+            error->error_code, error->request_code,
+            static_cast<std::uint64_t> (error->resourceid), trap->editorWindowId))
     {
-        switch (e->error_code)
-        {
-            case BadWindow:
-            case BadDrawable:
-            case BadMatch:
-            case BadValue:
-            {
-                char buf[128] = {};
-                if (d != nullptr)
-                    ::XGetErrorText (d, e->error_code, buf, (int) sizeof (buf) - 1);
-                std::fprintf (stderr,
-                              "[Dusk Studio/X] swallowed non-fatal X error: %s "
-                              "(request %u, resource 0x%lx) - likely a plugin "
-                              "editor window race\n",
-                              buf, (unsigned) e->request_code,
-                              (unsigned long) e->resourceid);
-                std::fflush (stderr);
-                return 0;
-            }
-            default:
-                break;
-        }
+        std::fprintf (stderr,
+                      "[Dusk Studio/X] ignored stale editor window 0x%lx "
+                      "during teardown request %u\n",
+                      static_cast<unsigned long> (error->resourceid),
+                      static_cast<unsigned int> (error->request_code));
+        std::fflush (stderr);
+        return 0;
     }
-    if (previousXErrorHandler != nullptr)
-        return previousXErrorHandler (d, e);
-    return 0;
+
+    if (trap != nullptr && trap->previous != nullptr)
+        return trap->previous (display, error);
+
+    // A null previous handler means Xlib's fatal default was active. Preserve
+    // that contract rather than silently accepting an unrelated protocol bug.
+    std::fprintf (stderr,
+                  "[Dusk Studio/X] unexpected X error during editor teardown "
+                  "(error %u, request %u, resource 0x%lx)\n",
+                  error != nullptr ? static_cast<unsigned int> (error->error_code) : 0u,
+                  error != nullptr ? static_cast<unsigned int> (error->request_code) : 0u,
+                  error != nullptr ? static_cast<unsigned long> (error->resourceid) : 0ul);
+    std::fflush (stderr);
+    std::abort();
 }
 
 juce::ComponentPeer* pickSiblingFocusTargetPeer (juce::Component& departing)
@@ -121,15 +132,34 @@ bool hasUsableDisplay()
 
 double nativeViewBackingScale (void*) { return 1.0; }
 
-void installNonFatalXErrorHandler()
+void destroyX11EditorEmbed (std::unique_ptr<juce::XEmbedComponent>& embed,
+                            std::uint64_t editorWindowId)
 {
-    // Install once. XSetErrorHandler returns the previously-installed handler
-    // (JUCE's, if it set one during peer creation - call this AFTER the main
-    // window exists - otherwise Xlib's default), which we chain to for any
-    // error we don't recognise as a benign plugin-window race.
-    if (xErrorHandlerInstalled) return;
-    xErrorHandlerInstalled = true;
-    previousXErrorHandler = ::XSetErrorHandler (&nonFatalXErrorHandler);
+    if (embed == nullptr)
+        return;
+
+    auto* display = juceDisplay();
+    if (display == nullptr || editorWindowId == 0)
+    {
+        embed.reset();
+        return;
+    }
+
+    const std::lock_guard<std::mutex> lock (editorTeardownTrapMutex);
+
+    // Deliver every older error to the normal handler before narrowing the
+    // policy. XEmbedComponent's destructor also syncs; the final sync covers
+    // any request it queues after its internal round-trip.
+    ::XSync (display, False);
+    EditorTeardownErrorTrap trap { display, editorWindowId, nullptr };
+    activeEditorTeardownTrap = &trap;
+    trap.previous = ::XSetErrorHandler (&editorTeardownXErrorHandler);
+
+    embed.reset();
+    ::XSync (display, False);
+
+    ::XSetErrorHandler (trap.previous);
+    activeEditorTeardownTrap = nullptr;
 }
 
 void setNativeCursorVisibleOnPeer (juce::ComponentPeer& peer, bool visible)

--- a/src/ui/PlatformWindowing_Mac.mm
+++ b/src/ui/PlatformWindowing_Mac.mm
@@ -137,8 +137,6 @@ void clearXInputFocus() {}                 // X-only; no-op on macOS
 void requestFocusOnMainWaylandSurface() {} // Wayland-only; no-op on macOS
 void preferX11ForNextNativeWindow() {}     // Wayland-only; no-op on macOS
 void clearPreferX11ForNativeWindow() {}    // Wayland-only; no-op on macOS
-void installNonFatalXErrorHandler() {}     // X-only; no-op on macOS
-
 std::unique_ptr<juce::Component> createForeignNativeWindowEmbed (std::uint64_t)
 {
     // Cross-process NSView reparenting is its own research project and

--- a/src/ui/PlatformWindowing_Windows.cpp
+++ b/src/ui/PlatformWindowing_Windows.cpp
@@ -121,8 +121,6 @@ void clearXInputFocus() {}                 // X-only; no-op on Windows
 void requestFocusOnMainWaylandSurface() {} // Wayland-only; no-op on Windows
 void preferX11ForNextNativeWindow() {}     // Linux-only; no-op on Windows
 void clearPreferX11ForNativeWindow() {}    // Linux-only; no-op on Windows
-void installNonFatalXErrorHandler() {}     // X-only; no-op on Windows
-
 std::unique_ptr<juce::Component> createForeignNativeWindowEmbed (std::uint64_t nativeHandle)
 {
     auto* hwnd = (HWND) (uintptr_t) nativeHandle;

--- a/src/ui/X11EditorTeardownError.h
+++ b/src/ui/X11EditorTeardownError.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstdint>
+
+namespace duskstudio::platform::x11
+{
+// Stable X11 protocol values, kept independent of Xlib so the routing policy is
+// testable on every platform.
+constexpr std::uint8_t kBadWindow = 3;
+constexpr std::uint8_t kChangeWindowAttributes = 2;
+constexpr std::uint8_t kReparentWindow = 7;
+constexpr std::uint8_t kUnmapWindow = 10;
+
+inline bool shouldSuppressEditorTeardownError (std::uint8_t errorCode,
+                                                std::uint8_t requestCode,
+                                                std::uint64_t resourceId,
+                                                std::uint64_t editorWindowId) noexcept
+{
+    if (editorWindowId == 0 || resourceId != editorWindowId || errorCode != kBadWindow)
+        return false;
+
+    return requestCode == kChangeWindowAttributes
+        || requestCode == kReparentWindow
+        || requestCode == kUnmapWindow;
+}
+} // namespace duskstudio::platform::x11

--- a/tests/x11_anti_pattern_guard.cpp
+++ b/tests/x11_anti_pattern_guard.cpp
@@ -1,5 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 
+#include "ui/X11EditorTeardownError.h"
+
 #include <fstream>
 #include <optional>
 #include <string>
@@ -88,4 +90,27 @@ TEST_CASE ("XOpenDisplay(nullptr) is confined to PlatformWindowing impls",
         REQUIRE_FALSE (contents->empty());
         REQUIRE_FALSE (containsXOpenDisplayNull (*contents));
     }
+}
+
+TEST_CASE ("X11 editor teardown suppression is request and resource scoped",
+           "[x11][issue-375]")
+{
+    using namespace duskstudio::platform::x11;
+    constexpr std::uint64_t editorWindow = 0x1234;
+
+    REQUIRE (shouldSuppressEditorTeardownError (
+        kBadWindow, kChangeWindowAttributes, editorWindow, editorWindow));
+    REQUIRE (shouldSuppressEditorTeardownError (
+        kBadWindow, kReparentWindow, editorWindow, editorWindow));
+    REQUIRE (shouldSuppressEditorTeardownError (
+        kBadWindow, kUnmapWindow, editorWindow, editorWindow));
+
+    REQUIRE_FALSE (shouldSuppressEditorTeardownError (
+        kBadWindow, kUnmapWindow, 0x5678, editorWindow));
+    REQUIRE_FALSE (shouldSuppressEditorTeardownError (
+        kBadWindow, 42, editorWindow, editorWindow));
+    REQUIRE_FALSE (shouldSuppressEditorTeardownError (
+        2, kUnmapWindow, editorWindow, editorWindow)); // BadValue
+    REQUIRE_FALSE (shouldSuppressEditorTeardownError (
+        8, kUnmapWindow, editorWindow, editorWindow)); // BadMatch
 }


### PR DESCRIPTION
Closes #375

## Summary
- replace the permanent process-wide X error suppressor with a trap scoped to XEmbed teardown
- suppress only BadWindow responses for the exact stale editor window and the three detach request types
- restore and chain the prior handler for every unrelated X protocol error
- add cross-platform policy coverage and update the documented test count

## Validation
- Linux: issue-375, 7 assertions; CTest 873/873
- macOS: issue-375, 7 assertions; CTest 842/842
- Windows with ASIO: issue-375, 7 assertions; CTest 836/836
- git diff --check
- review-local: incomplete because the local model endpoint was unavailable; linter output contained only generic Xlib-state and C-varargs warnings

No frontier review was run.