### PR TITLE
Fix VST3 host context ownership leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 886 Catch2 test cases across 174 test source files. Linux
+The C++ suite declares 887 Catch2 test cases across 175 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 886 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 887 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/vst3/Vst3HostContext.cpp
+++ b/src/engine/vst3/Vst3HostContext.cpp
@@ -18,8 +18,8 @@ namespace
 using namespace Steinberg;
 
 // One COM object exposing every host facet. Lifetime is the owning
-// Vst3HostContext (plugins addRef/release freely against the SDK's FUnknown
-// refcount from HostApplication, which never reaches zero while we hold ours).
+// Vst3HostContext. The SDK HostApplication's addRef/release are non-owning
+// no-ops, so the context must destroy this object explicitly.
 // Steinberg::Linux::IRunLoop is a Linux-only facet of the VST3 API: off Linux the
 // host object exposes only the portable host-application / component-handler /
 // plug-frame facets and keeps no fd or timer registry.
@@ -232,17 +232,18 @@ private:
 struct Vst3HostContext::Impl
 {
     Callbacks* callbacks = nullptr;
-    Steinberg::IPtr<HostObject> host;
+    std::unique_ptr<HostObject> host;
 };
 
 Vst3HostContext::Vst3HostContext() : impl (std::make_unique<Impl>())
 {
-    impl->host = Steinberg::owned (new HostObject (impl->callbacks));
+    impl->host = std::make_unique<HostObject> (impl->callbacks);
 }
 
 Vst3HostContext::~Vst3HostContext()
 {
     impl->host->teardown();
+    impl->host.reset();
 }
 
 void Vst3HostContext::setCallbacks (Callbacks* cb) noexcept { impl->callbacks = cb; }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -378,6 +378,7 @@ endif()
 if(DUSKSTUDIO_NATIVE_VST3)
     target_sources(dusk-studio-tests PRIVATE
         vst3_bundle_load.cpp
+        vst3_hostcontext_lifetime.cpp
         vst3_instance_process.cpp
         vst3_native_slot.cpp
         vst3_scanner.cpp

--- a/tests/vst3_hostcontext_lifetime.cpp
+++ b/tests/vst3_hostcontext_lifetime.cpp
@@ -1,0 +1,16 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/vst3/Vst3HostContext.h"
+
+TEST_CASE ("Vst3HostContext repeatedly releases its owned host object",
+           "[vst3][hostcontext][regression][issue-382]")
+{
+    for (int iteration = 0; iteration < 64; ++iteration)
+    {
+        CAPTURE (iteration);
+        duskstudio::vst3::Vst3HostContext context;
+        REQUIRE (context.hostApplication() != nullptr);
+        REQUIRE (context.componentHandler() != nullptr);
+        REQUIRE (context.plugFrame() != nullptr);
+    }
+}

--- a/tests/vst3_hostcontext_runloop.cpp
+++ b/tests/vst3_hostcontext_runloop.cpp
@@ -144,6 +144,29 @@ TEST_CASE ("Vst3HostContext run loop dispatches fds and timers", "[vst3][hostcon
         FdHandler handler;
         REQUIRE (runLoop->unregisterEventHandler (&handler) == kResultFalse);
     }
+
+    SECTION ("context destruction releases registered handlers")
+    {
+        int fds[2] {};
+        REQUIRE (::pipe (fds) == 0);
+
+        FdHandler fdHandler;
+        TimerHandler timerHandler;
+        {
+            duskstudio::vst3::Vst3HostContext scopedContext;
+            auto* scopedRunLoop = static_cast<Linux::IRunLoop*> (scopedContext.runLoop());
+            REQUIRE (scopedRunLoop != nullptr);
+            REQUIRE (scopedRunLoop->registerEventHandler (&fdHandler, fds[0]) == kResultOk);
+            REQUIRE (scopedRunLoop->registerTimer (&timerHandler, 50) == kResultOk);
+            REQUIRE (fdHandler.refs == 2);
+            REQUIRE (timerHandler.refs == 2);
+        }
+
+        REQUIRE (fdHandler.refs == 1);
+        REQUIRE (timerHandler.refs == 1);
+        ::close (fds[0]);
+        ::close (fds[1]);
+    }
 }
 
 #endif


### PR DESCRIPTION
## Summary

- replace the non-owning VST3 SDK smart pointer with explicit `Vst3HostContext` ownership
- release Linux run-loop fd and timer handlers before destroying the host object
- add a 64-cycle cross-platform lifetime regression and handler-release coverage

## Validation

- `ASAN_OPTIONS=detect_leaks=1` with ASan/UBSan: `[issue-382]` and `[vst3][hostcontext]` pass with no leaks
- Linux: focused regression passes; 874/874 full CTest
- macOS: focused regression passes; 843/843 full CTest (native LV2 unavailable in validation cache)
- Windows: focused regression passes; 837/837 full CTest; ASIO enabled (MP3 export unavailable in validation cache)
- no-new-JUCE ratchet: 164 files / 8,256 uses

Closes #382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VST3 host-context cleanup and ownership handling.
  * Ensured registered file-descriptor and timer handlers are released when the host context is destroyed.
  * Improved reliability when repeatedly creating and destroying VST3 host contexts.

* **Tests**
  * Added regression coverage for host-context lifetime and handler cleanup.

* **Documentation**
  * Updated the documented test inventory to reflect the latest test count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->