### PR TITLE
Keep VST3 audio bus activation consistent

### DIFF
--- a/src/engine/vst3/Vst3BusPlan.h
+++ b/src/engine/vst3/Vst3BusPlan.h
@@ -2,22 +2,104 @@
 
 #include <algorithm>
 #include <cstddef>
-#include <utility>
+#include <vector>
 
 namespace duskstudio::vst3::detail
 {
 enum class AudioBusDirection { Input, Output };
 
-// Keep the "activate every advertised bus" policy testable without loading a
-// third-party module. Modular plugins may access auxiliary buses even when the
-// mixer only exposes their selected main bus.
-template <typename Activate>
-void activateAllAudioBuses (int numInputs, int numOutputs, Activate&& activate)
+class AudioBusPlan
 {
+public:
+    AudioBusPlan() = default;
+    AudioBusPlan (int numInputs, int numOutputs)
+        : inputs ((std::size_t) std::max (0, numInputs)),
+          outputs ((std::size_t) std::max (0, numOutputs))
+    {
+    }
+
+    void setBus (AudioBusDirection direction, int bus, int channels, bool active)
+    {
+        auto& buses = direction == AudioBusDirection::Input ? inputs : outputs;
+        if (bus >= 0 && bus < (int) buses.size())
+        {
+            auto& entry = buses[(std::size_t) bus];
+            entry.channels = std::max (0, channels);
+            entry.active = active && entry.channels > 0;
+        }
+    }
+
+    int busCount (AudioBusDirection direction) const noexcept
+    {
+        return (int) (direction == AudioBusDirection::Input ? inputs : outputs).size();
+    }
+
+    int channelCount (AudioBusDirection direction, int bus) const noexcept
+    {
+        const auto& buses = direction == AudioBusDirection::Input ? inputs : outputs;
+        return bus >= 0 && bus < (int) buses.size()
+                 ? buses[(std::size_t) bus].channels : 0;
+    }
+
+    bool isActive (AudioBusDirection direction, int bus) const noexcept
+    {
+        const auto& buses = direction == AudioBusDirection::Input ? inputs : outputs;
+        return bus >= 0 && bus < (int) buses.size()
+                 ? buses[(std::size_t) bus].active : false;
+    }
+
+    int processChannelCount (AudioBusDirection direction, int bus) const noexcept
+    {
+        return isActive (direction, bus) ? channelCount (direction, bus) : 0;
+    }
+
+private:
+    struct Entry
+    {
+        int channels = 0;
+        bool active = false;
+    };
+
+    std::vector<Entry> inputs;
+    std::vector<Entry> outputs;
+};
+
+// Apply both activation and deactivation from the same shape used for layout
+// metadata and process buffers. Selected and default-active buses with channels
+// receive scratch; optional and zero-channel buses remain inactive.
+template <typename Activate>
+void applyAudioBusPlan (const AudioBusPlan& plan, Activate&& activate)
+{
+    for (const auto direction : { AudioBusDirection::Input, AudioBusDirection::Output })
+        for (int bus = 0; bus < plan.busCount (direction); ++bus)
+            activate (direction, bus, plan.isActive (direction, bus));
+}
+
+template <typename InputChannels, typename OutputChannels>
+bool matchesAudioBusShape (const AudioBusPlan& plan,
+                           int numInputs, int numOutputs,
+                           InputChannels&& inputChannels,
+                           OutputChannels&& outputChannels)
+{
+    if (numInputs != plan.busCount (AudioBusDirection::Input)
+        || numOutputs != plan.busCount (AudioBusDirection::Output))
+        return false;
+
     for (int bus = 0; bus < numInputs; ++bus)
-        activate (AudioBusDirection::Input, bus);
+        if (inputChannels (bus) != plan.channelCount (AudioBusDirection::Input, bus))
+            return false;
     for (int bus = 0; bus < numOutputs; ++bus)
-        activate (AudioBusDirection::Output, bus);
+        if (outputChannels (bus) != plan.channelCount (AudioBusDirection::Output, bus))
+            return false;
+    return true;
+}
+
+template <typename SetChannels>
+void applyAudioBufferPlan (const AudioBusPlan& plan, SetChannels&& setChannels)
+{
+    for (const auto direction : { AudioBusDirection::Input, AudioBusDirection::Output })
+        for (int bus = 0; bus < plan.busCount (direction); ++bus)
+            setChannels (direction, bus, plan.processChannelCount (direction, bus));
 }
 
 struct ScratchShape
@@ -27,23 +109,19 @@ struct ScratchShape
     int widestBus = 2;
 };
 
-template <typename InputChannels, typename OutputChannels>
-ScratchShape planScratch (int numInputs, int numOutputs,
-                          InputChannels&& inputChannels,
-                          OutputChannels&& outputChannels)
+inline ScratchShape planScratch (const AudioBusPlan& plan)
 {
     ScratchShape result;
-    for (int bus = 0; bus < numInputs; ++bus)
+    for (const auto direction : { AudioBusDirection::Input, AudioBusDirection::Output })
     {
-        const int channels = std::max (0, inputChannels (bus));
-        result.inputChannels += (std::size_t) channels;
-        result.widestBus = std::max (result.widestBus, channels);
-    }
-    for (int bus = 0; bus < numOutputs; ++bus)
-    {
-        const int channels = std::max (0, outputChannels (bus));
-        result.outputChannels += (std::size_t) channels;
-        result.widestBus = std::max (result.widestBus, channels);
+        for (int bus = 0; bus < plan.busCount (direction); ++bus)
+        {
+            const int channels = plan.processChannelCount (direction, bus);
+            auto& total = direction == AudioBusDirection::Input
+                            ? result.inputChannels : result.outputChannels;
+            total += (std::size_t) channels;
+            result.widestBus = std::max (result.widestBus, channels);
+        }
     }
     return result;
 }

--- a/src/engine/vst3/Vst3Instance.cpp
+++ b/src/engine/vst3/Vst3Instance.cpp
@@ -42,6 +42,7 @@ struct Vst3Instance::Impl : public Vst3HostContext::Callbacks
     IPtr<Vst::ConnectionProxy> componentCP, controllerCP;
 
     hosting::PortLayout layout;
+    detail::AudioBusPlan audioBuses;
     int  mainInBus = -1, mainOutBus = -1, sidechainBus = -1;
     bool hasEventIn = false;
 
@@ -177,6 +178,7 @@ struct Vst3Instance::Impl : public Vst3HostContext::Callbacks
 
         host.setCallbacks (nullptr);
         params.clear();
+        audioBuses = {};
         resizeViewFn = nullptr;
         if (controller && ! controllerIsComponent)
             controller->terminate();
@@ -348,15 +350,9 @@ bool Vst3Instance::create (const Vst3Bundle& bundle, const std::string& classId,
     impl->layout = {};
     impl->mainInBus = impl->mainOutBus = impl->sidechainBus = -1;
 
-    const auto busChannels = [this] (Vst::BusDirection dir, int32 index) -> int
-    {
-        Vst::SpeakerArrangement arr = 0;
-        if (impl->processor->getBusArrangement (dir, index, arr) == kResultOk)
-            return (int) Vst::SpeakerArr::getChannelCount (arr);
-        return 0;
-    };
-
     const int32 numIn = impl->component->getBusCount (Vst::kAudio, Vst::kInput);
+    const int32 numOut = impl->component->getBusCount (Vst::kAudio, Vst::kOutput);
+    impl->audioBuses = detail::AudioBusPlan ((int) numIn, (int) numOut);
     for (int32 i = 0; i < numIn; ++i)
     {
         Vst::BusInfo info {};
@@ -365,24 +361,31 @@ bool Vst3Instance::create (const Vst3Bundle& bundle, const std::string& classId,
         hosting::BusInfo b;
         b.kind = hosting::BusInfo::Kind::Audio;
         b.dir  = hosting::BusInfo::Direction::Input;
-        b.channelCount = busChannels (Vst::kInput, i);
-        b.active = b.channelCount > 0;
+        bool hostConnected = false;
         if (info.busType == Vst::kMain && impl->mainInBus < 0)
         {
             b.role = hosting::BusInfo::Role::Main;
+            hostConnected = true;
             impl->mainInBus = (int) i;
             impl->layout.mainInIndex = (int) impl->layout.inputs.size();
         }
         else if (info.busType == Vst::kAux && impl->sidechainBus < 0)
         {
             b.role = hosting::BusInfo::Role::Sidechain;
+            hostConnected = true;
             impl->sidechainBus = (int) i;
             impl->layout.sidechainInIndex = (int) impl->layout.inputs.size();
         }
+        impl->audioBuses.setBus (
+            detail::AudioBusDirection::Input, (int) i, (int) info.channelCount,
+            hostConnected || (info.flags & Vst::BusInfo::kDefaultActive) != 0);
+        b.channelCount = impl->audioBuses.channelCount (
+            detail::AudioBusDirection::Input, (int) i);
+        b.active = impl->audioBuses.isActive (
+            detail::AudioBusDirection::Input, (int) i);
         impl->layout.inputs.push_back (b);
     }
 
-    const int32 numOut = impl->component->getBusCount (Vst::kAudio, Vst::kOutput);
     for (int32 i = 0; i < numOut; ++i)
     {
         Vst::BusInfo info {};
@@ -391,14 +394,21 @@ bool Vst3Instance::create (const Vst3Bundle& bundle, const std::string& classId,
         hosting::BusInfo b;
         b.kind = hosting::BusInfo::Kind::Audio;
         b.dir  = hosting::BusInfo::Direction::Output;
-        b.channelCount = busChannels (Vst::kOutput, i);
-        b.active = b.channelCount > 0;
+        bool hostConnected = false;
         if (info.busType == Vst::kMain && impl->mainOutBus < 0)
         {
             b.role = hosting::BusInfo::Role::Main;
+            hostConnected = true;
             impl->mainOutBus = (int) i;
             impl->layout.mainOutIndex = (int) impl->layout.outputs.size();
         }
+        impl->audioBuses.setBus (
+            detail::AudioBusDirection::Output, (int) i, (int) info.channelCount,
+            hostConnected || (info.flags & Vst::BusInfo::kDefaultActive) != 0);
+        b.channelCount = impl->audioBuses.channelCount (
+            detail::AudioBusDirection::Output, (int) i);
+        b.active = impl->audioBuses.isActive (
+            detail::AudioBusDirection::Output, (int) i);
         impl->layout.outputs.push_back (b);
     }
 
@@ -419,18 +429,18 @@ bool Vst3Instance::create (const Vst3Bundle& bundle, const std::string& classId,
     if (impl->mainOutBus < 0)
     { errorOut = "plugin has no main audio output bus"; impl->destroy(); return false; }
 
-    // Activate every advertised audio bus. Modular plugins such as VCV Rack
-    // expose many main/aux buses and may still touch their complete bus array
-    // while monitored. processBlock supplies silence/sinks for buses the mixer
-    // does not expose, so no active bus is ever handed null channel pointers.
-    detail::activateAllAudioBuses (
-        numIn, numOut, [this] (detail::AudioBusDirection direction, int bus)
+    // Modular plugins may touch every non-empty bus while monitored, so keep
+    // those active and supply independent silence/sinks below. A zero-channel
+    // bus stays inactive and is represented as such everywhere.
+    detail::applyAudioBusPlan (
+        impl->audioBuses,
+        [this] (detail::AudioBusDirection direction, int bus, bool active)
         {
             impl->component->activateBus (
                 Vst::kAudio,
                 direction == detail::AudioBusDirection::Input
                     ? Vst::kInput : Vst::kOutput,
-                bus, true);
+                bus, active);
         });
     if (impl->hasEventIn)
         impl->component->activateBus (Vst::kEvent, Vst::kInput, 0, true);
@@ -460,6 +470,24 @@ bool Vst3Instance::activate (double sampleRate, int maxBlockFrames, std::string&
     // at ours - the plugin would process the SDK's private (silent) scratch.
     if (! impl->processData.prepare (*impl->component, 0, Vst::kSample32))
     { errorOut = "process-data prepare failed"; return false; }
+    if (! detail::matchesAudioBusShape (
+            impl->audioBuses,
+            (int) impl->processData.numInputs, (int) impl->processData.numOutputs,
+            [this] (int bus) { return (int) impl->processData.inputs[bus].numChannels; },
+            [this] (int bus) { return (int) impl->processData.outputs[bus].numChannels; }))
+    {
+        impl->processData.unprepare();
+        errorOut = "process-data bus shape changed after discovery";
+        return false;
+    }
+    detail::applyAudioBufferPlan (
+        impl->audioBuses,
+        [this] (detail::AudioBusDirection direction, int bus, int channels)
+        {
+            auto* buffers = direction == detail::AudioBusDirection::Input
+                              ? impl->processData.inputs : impl->processData.outputs;
+            buffers[bus].numChannels = channels;
+        });
     impl->processData.inputParameterChanges  = &impl->inParams;
     impl->processData.outputParameterChanges = &impl->outParams;
     // Pre-warm the queue pool; per-queue point storage keeps its capacity across
@@ -474,10 +502,7 @@ bool Vst3Instance::activate (double sampleRate, int maxBlockFrames, std::string&
     // Give every channel independent scratch. VST3 buffers are writable and
     // may be processed in place, so aliasing unused buses lets one bus corrupt
     // another. Pointer scratch is sized to the widest bus.
-    const auto scratch = detail::planScratch (
-        impl->processData.numInputs, impl->processData.numOutputs,
-        [this] (int bus) { return (int) impl->processData.inputs[bus].numChannels; },
-        [this] (int bus) { return (int) impl->processData.outputs[bus].numChannels; });
+    const auto scratch = detail::planScratch (impl->audioBuses);
     impl->silence.assign (scratch.inputChannels * (size_t) impl->maxFrames, 0.0f);
     impl->sink.assign (scratch.outputChannels * (size_t) impl->maxFrames, 0.0f);
     impl->scratchPtrs.assign ((size_t) scratch.widestBus, nullptr);
@@ -528,12 +553,14 @@ void Vst3Instance::processBlock (const hosting::PortBuffers& io) noexcept
         return;
     }
 
-    // Connect every advertised input bus. The mixer-facing main and sidechain
-    // buses receive caller data; all other buses receive valid silence.
+    // Connect every planned input bus. The mixer-facing main and sidechain buses
+    // receive caller data; all other active buses receive valid silence.
     size_t inputScratchChannel = 0;
-    for (int32 bus = 0; bus < impl->processData.numInputs; ++bus)
+    for (int bus = 0;
+         bus < impl->audioBuses.busCount (detail::AudioBusDirection::Input); ++bus)
     {
-        const int busCh = impl->processData.inputs[bus].numChannels;
+        const int busCh = impl->audioBuses.processChannelCount (
+            detail::AudioBusDirection::Input, bus);
         for (int c = 0; c < busCh; ++c)
         {
             float* channel = impl->silence.data()
@@ -558,9 +585,11 @@ void Vst3Instance::processBlock (const hosting::PortBuffers& io) noexcept
     // Likewise, connect every output. Only the selected main bus reaches the
     // mixer; auxiliary outputs are safely discarded into independent sinks.
     size_t outputScratchChannel = 0;
-    for (int32 bus = 0; bus < impl->processData.numOutputs; ++bus)
+    for (int bus = 0;
+         bus < impl->audioBuses.busCount (detail::AudioBusDirection::Output); ++bus)
     {
-        const int busCh = impl->processData.outputs[bus].numChannels;
+        const int busCh = impl->audioBuses.processChannelCount (
+            detail::AudioBusDirection::Output, bus);
         for (int c = 0; c < busCh; ++c)
         {
             impl->scratchPtrs[(size_t) c] =

--- a/tests/vst3_instance_process.cpp
+++ b/tests/vst3_instance_process.cpp
@@ -18,34 +18,68 @@
 #include <cmath>
 #include <cstdlib>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
-TEST_CASE ("VST3 modular bus plan activates every bus with independent scratch",
-           "[vst3][bus][regression][issue-361]")
+TEST_CASE ("VST3 audio bus plan keeps activation and scratch shape consistent",
+           "[vst3][bus][regression][issue-361][issue-390]")
 {
     using namespace duskstudio::vst3::detail;
 
-    std::vector<std::pair<AudioBusDirection, int>> activated;
-    activateAllAudioBuses (3, 4, [&] (AudioBusDirection direction, int bus)
+    AudioBusPlan plan (3, 4);
+    plan.setBus (AudioBusDirection::Input, 0, 2, true);    // main
+    plan.setBus (AudioBusDirection::Input, 1, 2, false);   // inactive optional
+    plan.setBus (AudioBusDirection::Input, 2, 1, true);    // sidechain
+    plan.setBus (AudioBusDirection::Output, 0, 2, true);   // main
+    plan.setBus (AudioBusDirection::Output, 1, 0, true);   // zero-channel optional
+    plan.setBus (AudioBusDirection::Output, 2, 8, true);   // modular aux
+    plan.setBus (AudioBusDirection::Output, 3, 4, false);  // inactive optional
+
+    std::vector<std::tuple<AudioBusDirection, int, bool>> activation;
+    applyAudioBusPlan (plan, [&] (AudioBusDirection direction, int bus, bool active)
     {
-        activated.emplace_back (direction, bus);
+        activation.emplace_back (direction, bus, active);
     });
-    REQUIRE (activated == std::vector<std::pair<AudioBusDirection, int>> {
-        { AudioBusDirection::Input, 0 }, { AudioBusDirection::Input, 1 },
-        { AudioBusDirection::Input, 2 }, { AudioBusDirection::Output, 0 },
-        { AudioBusDirection::Output, 1 }, { AudioBusDirection::Output, 2 },
-        { AudioBusDirection::Output, 3 }
+    REQUIRE (activation == std::vector<std::tuple<AudioBusDirection, int, bool>> {
+        { AudioBusDirection::Input, 0, true },
+        { AudioBusDirection::Input, 1, false },
+        { AudioBusDirection::Input, 2, true },
+        { AudioBusDirection::Output, 0, true },
+        { AudioBusDirection::Output, 1, false },
+        { AudioBusDirection::Output, 2, true },
+        { AudioBusDirection::Output, 3, false }
     });
 
-    const int inputChannels[] = { 2, 1, 8 };
-    const int outputChannels[] = { 2, 8, 1, 4 };
-    const auto shape = planScratch (
-        3, 4,
+    const int inputChannels[] = { 2, 2, 1 };
+    const int outputChannels[] = { 2, 0, 8, 4 };
+    REQUIRE (matchesAudioBusShape (
+        plan, 3, 4,
         [&] (int bus) { return inputChannels[bus]; },
-        [&] (int bus) { return outputChannels[bus]; });
-    REQUIRE (shape.inputChannels == 11);
-    REQUIRE (shape.outputChannels == 15);
+        [&] (int bus) { return outputChannels[bus]; }));
+    REQUIRE_FALSE (matchesAudioBusShape (
+        plan, 3, 4,
+        [] (int bus) { return bus == 1 ? 0 : (bus == 2 ? 1 : 2); },
+        [&] (int bus) { return outputChannels[bus]; }));
+
+    std::vector<std::tuple<AudioBusDirection, int, int>> processChannels;
+    applyAudioBufferPlan (plan, [&] (AudioBusDirection direction, int bus, int channels)
+    {
+        processChannels.emplace_back (direction, bus, channels);
+    });
+    REQUIRE (processChannels == std::vector<std::tuple<AudioBusDirection, int, int>> {
+        { AudioBusDirection::Input, 0, 2 },
+        { AudioBusDirection::Input, 1, 0 },
+        { AudioBusDirection::Input, 2, 1 },
+        { AudioBusDirection::Output, 0, 2 },
+        { AudioBusDirection::Output, 1, 0 },
+        { AudioBusDirection::Output, 2, 8 },
+        { AudioBusDirection::Output, 3, 0 }
+    });
+
+    const auto shape = planScratch (plan);
+    REQUIRE (shape.inputChannels == 3);
+    REQUIRE (shape.outputChannels == 10);
     REQUIRE (shape.widestBus == 8);
 
     constexpr int frames = 64;


### PR DESCRIPTION
Closes #390

## Summary
- derive metadata, component activation, process-buffer channels, and scratch sizing from one VST3 audio bus plan
- keep zero-channel and default-inactive optional buses inactive while preserving selected main/sidechain and default-active modular buses
- retain the advertised SDK bus shape and reject unexpected shape changes before processing

## Validation
- `ctest --test-dir build-tests -j3 --output-on-failure` (Linux: 874/874)
- `[issue-390]` (26 assertions on Linux, macOS, and Windows)
- cross-platform full suites: Linux 874/874, macOS 843/843, Windows 837/837
- Windows ASIO configuration verified
- `tools/juce-gate.sh` (164 files / 8,256 uses)