### PR TITLE
Restore CLAP regression coverage

### DIFF
--- a/tests/clap_editor_lifecycle.cpp
+++ b/tests/clap_editor_lifecycle.cpp
@@ -57,10 +57,12 @@ TEST_CASE ("the X11 CLAP editor maps whatever window the plugin parents into it"
     // A plugin that builds its window off the message thread parents it after
     // embed() returns, so pump() itself must retry rather than merely leaving a
     // second occurrence such as the method definition elsewhere in the file.
-    const auto pump = source.find ("void ClapEditor::pump");
+    const auto pump = source.find ("ClapEditor::pump");
     REQUIRE (pump != std::string::npos);
-    const auto nextMethod = source.find ("\nvoid ClapEditor::", pump + 1);
-    const auto retryMap = source.find ("mapPluginChildren()", pump);
+    const auto pumpBody = source.find ('{', pump);
+    REQUIRE (pumpBody != std::string::npos);
+    const auto nextMethod = source.find ("ClapEditor::", pumpBody + 1);
+    const auto retryMap = source.find ("mapPluginChildren()", pumpBody);
     REQUIRE (nextMethod != std::string::npos);
     REQUIRE (retryMap < nextMethod);
     REQUIRE (source.find ("XMapWindow (dpy, children[i])") != std::string::npos);

--- a/tests/clap_editor_lifecycle.cpp
+++ b/tests/clap_editor_lifecycle.cpp
@@ -43,7 +43,7 @@ TEST_CASE ("CLAP editors size the GUI before parenting it",
 }
 
 TEST_CASE ("the X11 CLAP editor maps whatever window the plugin parents into it",
-           "[clap][editor][regression][issue-361]")
+           "[clap][editor][regression][issue-361][issue-397]")
 {
     const auto source = readSource ("src/engine/clap/ClapEditor.cpp");
 
@@ -55,8 +55,14 @@ TEST_CASE ("the X11 CLAP editor maps whatever window the plugin parents into it"
     REQUIRE (mapChildren != std::string::npos);
 
     // A plugin that builds its window off the message thread parents it after
-    // embed() returns, so the one map at embed time is not enough.
-    REQUIRE (source.find ("mapPluginChildren", mapChildren + 1) != std::string::npos);
+    // embed() returns, so pump() itself must retry rather than merely leaving a
+    // second occurrence such as the method definition elsewhere in the file.
+    const auto pump = source.find ("void ClapEditor::pump");
+    REQUIRE (pump != std::string::npos);
+    const auto nextMethod = source.find ("\nvoid ClapEditor::", pump + 1);
+    const auto retryMap = source.find ("mapPluginChildren()", pump);
+    REQUIRE (nextMethod != std::string::npos);
+    REQUIRE (retryMap < nextMethod);
     REQUIRE (source.find ("XMapWindow (dpy, children[i])") != std::string::npos);
 }
 

--- a/tests/clap_native_slot.cpp
+++ b/tests/clap_native_slot.cpp
@@ -114,23 +114,18 @@ TEST_CASE ("NativeClapSlot loads, processes, and unloads cleanly", "[clap][slot]
     }
 }
 
-TEST_CASE ("NativeClapSlot reactivate keeps the same instance (no destroy)", "[clap][slot][reactivate]")
+TEST_CASE ("NativeClapSlot reactivate keeps the same instance and signal path",
+           "[clap][slot][reactivate][regression][issue-397]")
 {
     // Regression: changing the global oversampling factor (or device rate) re-prepares
     // the strip. The old code did a full reload, destroying the instance the editor's
     // GUI was attached to — plugin->destroy with a live GUI aborts u-he plugins
     // ("host forgot to destroy the gui" → terminate). reactivate must re-activate the
     // SAME instance so the GUI and parameter state survive.
-    const char* path = std::getenv ("DUSKSTUDIO_TEST_CLAP");
-    if (path == nullptr || *path == '\0')
-    {
-        SUCCEED ("DUSKSTUDIO_TEST_CLAP not set — skipping live CLAP-reactivate test");
-        return;
-    }
-
     duskstudio::clap::NativeClapSlot slot;
     std::string err;
-    REQUIRE (slot.load (std::filesystem::u8path (path), 48000.0, 512, err));
+    REQUIRE (slot.load (std::filesystem::u8path (DUSKSTUDIO_MULTI_BUS_CLAP_FIXTURE_PATH),
+                        48000.0, 512, err));
     auto* before = slot.getInstance();
     REQUIRE (before != nullptr);
 
@@ -146,6 +141,8 @@ TEST_CASE ("NativeClapSlot reactivate keeps the same instance (no destroy)", "[c
     double phase = 0.0;
     constexpr double kPi = 3.14159265358979323846;
     const double dw = 2.0 * kPi * 1000.0 / 96000.0;
+    float peakOut = 0.0f;
+    float maxError = 0.0f;
     for (int b = 0; b < 40; ++b)
     {
         for (int i = 0; i < kBlock; ++i) { const float s = 0.25f * (float) std::sin (phase); phase += dw; inL[(size_t) i] = inR[(size_t) i] = s; }
@@ -154,8 +151,15 @@ TEST_CASE ("NativeClapSlot reactivate keeps the same instance (no destroy)", "[c
         {
             REQUIRE (std::isfinite (outL[(size_t) i]));
             REQUIRE (std::isfinite (outR[(size_t) i]));
+            peakOut = std::max ({ peakOut, std::abs (outL[(size_t) i]),
+                                  std::abs (outR[(size_t) i]) });
+            maxError = std::max ({ maxError,
+                                   std::abs (outL[(size_t) i] - inL[(size_t) i]),
+                                   std::abs (outR[(size_t) i] - inR[(size_t) i]) });
         }
     }
+    REQUIRE (peakOut > 0.2f);
+    REQUIRE (maxError < 1.0e-7f);
 }
 
 TEST_CASE ("NativeClapSlot state round-trips into a fresh slot",


### PR DESCRIPTION
Closes #397

## Summary
- run the CLAP reactivation regression against the bundled multi-bus effect instead of skipping without an external plug-in
- verify reactivation preserves both the instance and the expected non-silent pass-through signal
- scope the late-child remap assertion to `ClapEditor::pump()` so a method definition cannot satisfy it

## Validation
- `[issue-397]`: 20,495 assertions on Linux, macOS, and Windows
- cross-platform full suites: Linux 874/874, macOS 843/843, Windows 837/837
- Windows ASIO configuration verified
- `tools/juce-gate.sh` (164 files / 8,256 uses)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened regression coverage for X11 editor recovery and retry behavior.
  * Improved validation of native audio slot reactivation to confirm active audio processing and accurate output.
  * Standardized affected tests around dedicated multi-bus test fixtures for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->