### PR TITLE
Surface native editor attach failures

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -238,9 +238,9 @@ jobs:
           archive="${RUNNER_TEMP}/libsodium-${SODIUM_VERSION}.tar.gz"
           source_dir="${RUNNER_TEMP}/libsodium-source"
           prefix="${RUNNER_TEMP}/libsodium"
-          curl --fail --location --retry 3 \
+          curl --fail --location --retry 3 --retry-all-errors \
             --output "${archive}" \
-            "https://download.libsodium.org/libsodium/releases/libsodium-${SODIUM_VERSION}.tar.gz"
+            "https://github.com/jedisct1/libsodium/releases/download/${SODIUM_VERSION}-RELEASE/libsodium-${SODIUM_VERSION}.tar.gz"
           echo "${SODIUM_SHA256}  ${archive}" | sha256sum --check
           mkdir -p "${source_dir}"
           tar -xzf "${archive}" -C "${source_dir}" --strip-components=1

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -60,9 +60,9 @@ jobs:
           archive="${RUNNER_TEMP}/libsodium-${SODIUM_VERSION}.tar.gz"
           source_dir="${RUNNER_TEMP}/libsodium-source"
           prefix="${RUNNER_TEMP}/libsodium"
-          curl --fail --location --retry 3 \
+          curl --fail --location --retry 3 --retry-all-errors \
             --output "${archive}" \
-            "https://download.libsodium.org/libsodium/releases/libsodium-${SODIUM_VERSION}.tar.gz"
+            "https://github.com/jedisct1/libsodium/releases/download/${SODIUM_VERSION}-RELEASE/libsodium-${SODIUM_VERSION}.tar.gz"
           echo "${SODIUM_SHA256}  ${archive}" | shasum -a 256 --check
           mkdir -p "${source_dir}"
           tar -xzf "${archive}" -C "${source_dir}" --strip-components=1

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -93,9 +93,9 @@ jobs:
           archive="${RUNNER_TEMP}/libsodium-${SODIUM_VERSION}.tar.gz"
           source_dir="${RUNNER_TEMP}/libsodium-source"
           prefix="${RUNNER_TEMP}/libsodium"
-          curl --fail --location --retry 3 \
+          curl --fail --location --retry 3 --retry-all-errors \
             --output "${archive}" \
-            "https://download.libsodium.org/libsodium/releases/libsodium-${SODIUM_VERSION}.tar.gz"
+            "https://github.com/jedisct1/libsodium/releases/download/${SODIUM_VERSION}-RELEASE/libsodium-${SODIUM_VERSION}.tar.gz"
           echo "${SODIUM_SHA256}  ${archive}" | shasum -a 256 --check
           mkdir -p "${source_dir}"
           tar -xzf "${archive}" -C "${source_dir}" --strip-components=1

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 887 Catch2 test cases across 175 test source files. Linux
+The C++ suite declares 888 Catch2 test cases across 175 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 887 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 888 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/hosting/NativeRestorePolicy.h
+++ b/src/engine/hosting/NativeRestorePolicy.h
@@ -16,6 +16,71 @@ struct NativeRestoreFailure
     int slotIndex = -1;
 };
 
+enum class NativeEditorFormat
+{
+    Clap,
+    Lv2,
+    Vst3,
+    AudioUnit,
+};
+
+struct NativeEditorAttachFailure
+{
+    std::string logLine;
+    std::string title;
+    std::string message;
+};
+
+inline std::string_view nativeEditorFormatName (NativeEditorFormat format) noexcept
+{
+    switch (format)
+    {
+        case NativeEditorFormat::Clap:      return "CLAP";
+        case NativeEditorFormat::Lv2:       return "LV2";
+        case NativeEditorFormat::Vst3:      return "VST3";
+        case NativeEditorFormat::AudioUnit: return "Audio Unit";
+    }
+    return "native plug-in";
+}
+
+inline NativeEditorAttachFailure describeNativeEditorAttachFailure (
+    NativeEditorFormat format,
+    std::string_view pluginName,
+    std::string_view error)
+{
+    const std::string formatName (nativeEditorFormatName (format));
+    const std::string name = pluginName.empty() ? "Unknown plug-in"
+                                                 : std::string (pluginName);
+    const std::string reason = error.empty() ? "The plug-in did not report a reason."
+                                              : std::string (error);
+    return {
+        "[Dusk Studio/native editor] " + name + " [" + formatName + "]: " + reason,
+        "Couldn't open " + formatName + " editor",
+        name + " [" + formatName + "]:\n" + reason,
+    };
+}
+
+// One decision point for every native format: a failed attach is both logged
+// for diagnostics and surfaced to the user. Callers provide the presentation
+// callbacks so this policy remains JUCE-free and directly testable.
+template <typename LogFn, typename AlertFn>
+bool enforceNativeEditorAttachPolicy (bool attached,
+                                      NativeEditorFormat format,
+                                      std::string_view pluginName,
+                                      std::string_view error,
+                                      LogFn&& log,
+                                      AlertFn&& alert)
+{
+    if (attached)
+        return true;
+
+    const auto failure = describeNativeEditorAttachFailure (
+        format, pluginName, error);
+    std::forward<LogFn> (log) (failure.logLine);
+    std::forward<AlertFn> (alert) (failure.title, failure.message);
+    return false;
+}
+
 inline std::string nativePluginName (const std::string& path,
                                      const std::string& pluginId = {})
 {

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -35,6 +35,7 @@
 #include "../engine/AudioEngine.h"
 #include "../engine/PluginSlot.h"
 #include "../engine/PluginManager.h"
+#include "../engine/hosting/NativeRestorePolicy.h"
 #include "PlatformWindowing.h"
 #include "../session/ParamEditAction.h"
 #include "../session/RegionEditActions.h"
@@ -52,6 +53,30 @@ constexpr const char* kPeerBoundStandardVst3EditorTag =
 // clamp with jlimit's argument order (lo, hi, value).
 template <typename T>
 inline T jlimit (T lo, T hi, T value) noexcept { return std::clamp (value, lo, std::max (lo, hi)); }
+
+template <typename Editor, typename Instance>
+bool attachNativePluginEditor (Editor& editor,
+                               Instance& instance,
+                               juce::Component& alertParent,
+                               hosting::NativeEditorFormat format,
+                               const std::string& pluginName)
+{
+    juce::String error;
+    const bool attached = editor.attach (instance, error);
+    return hosting::enforceNativeEditorAttachPolicy (
+        attached, format, pluginName, std::string (error.toRawUTF8()),
+        [] (const std::string& line)
+        {
+            std::fputs (line.c_str(), stderr);
+            std::fputc ('\n', stderr);
+        },
+        [&alertParent] (const std::string& title, const std::string& message)
+        {
+            showDuskAlert (alertParent,
+                           juce::String::fromUTF8 (title.c_str()),
+                           juce::String::fromUTF8 (message.c_str()));
+        });
+}
 
 struct BandSpec
 {
@@ -2572,22 +2597,20 @@ void ChannelStripComponent::openPluginEditor()
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
     if (engine.getChannelStrip (trackIndex).isNativeClapLoaded())
     {
-        auto* inst = engine.getChannelStrip (trackIndex).getNativeClapSlot().getInstance();
+        auto& slot = engine.getChannelStrip (trackIndex).getNativeClapSlot();
+        auto* inst = slot.getInstance();
         if (inst == nullptr) return;
         if (clapEditor == nullptr)
         {
             clapEditor = std::make_unique<ClapPluginEditorComponent>();
-            juce::String err;
-            if (! clapEditor->attach (*inst, err))
+            if (! attachNativePluginEditor (
+                    *clapEditor, *inst, *this, hosting::NativeEditorFormat::Clap,
+                    hosting::nativePluginName (slot.getPath(), slot.getPluginId())))
             {
-                std::fprintf (stderr, "[chan clap] %s\n", err.toRawUTF8());
                 clapEditor.reset();
-                // Nothing gets shown on this path, so without this the click on the
-                // slot looks like it did nothing at all.
-                showDuskAlert (*this, "Couldn't open CLAP editor", err);
                 return;
             }
-            clapEditor->bindOwner (engine.getChannelStrip (trackIndex).getNativeClapSlot());
+            clapEditor->bindOwner (slot);
         }
         pluginEditorModal.showBorrowed (*parent, *clapEditor, onClose);
         return;
@@ -2596,19 +2619,20 @@ void ChannelStripComponent::openPluginEditor()
 #if DUSKSTUDIO_HAS_NATIVE_LV2
     if (engine.getChannelStrip (trackIndex).isNativeLv2Loaded())
     {
-        auto* inst = engine.getChannelStrip (trackIndex).getNativeLv2Slot().getInstance();
+        auto& slot = engine.getChannelStrip (trackIndex).getNativeLv2Slot();
+        auto* inst = slot.getInstance();
         if (inst == nullptr) return;
         if (lv2Editor == nullptr)
         {
             lv2Editor = std::make_unique<Lv2PluginEditorComponent>();
-            juce::String err;
-            if (! lv2Editor->attach (*inst, err))
+            if (! attachNativePluginEditor (
+                    *lv2Editor, *inst, *this, hosting::NativeEditorFormat::Lv2,
+                    hosting::nativePluginName (slot.getPath(), slot.getPluginId())))
             {
-                std::fprintf (stderr, "[chan lv2] %s\n", err.toRawUTF8());
                 lv2Editor.reset();
                 return;
             }
-            lv2Editor->bindOwner (engine.getChannelStrip (trackIndex).getNativeLv2Slot());
+            lv2Editor->bindOwner (slot);
         }
         pluginEditorModal.showBorrowed (*parent, *lv2Editor, onClose);
         return;
@@ -2617,19 +2641,20 @@ void ChannelStripComponent::openPluginEditor()
 #if DUSKSTUDIO_HAS_NATIVE_VST3
     if (engine.getChannelStrip (trackIndex).isNativeVst3Loaded())
     {
-        auto* inst = engine.getChannelStrip (trackIndex).getNativeVst3Slot().getInstance();
+        auto& slot = engine.getChannelStrip (trackIndex).getNativeVst3Slot();
+        auto* inst = slot.getInstance();
         if (inst == nullptr) return;
         if (vst3Editor == nullptr)
         {
             vst3Editor = std::make_unique<Vst3PluginEditorComponent>();
-            juce::String err;
-            if (! vst3Editor->attach (*inst, err))
+            if (! attachNativePluginEditor (
+                    *vst3Editor, *inst, *this, hosting::NativeEditorFormat::Vst3,
+                    hosting::nativePluginName (slot.getPath(), slot.getPluginId())))
             {
-                std::fprintf (stderr, "[chan vst3] %s\n", err.toRawUTF8());
                 vst3Editor.reset();
                 return;
             }
-            vst3Editor->bindOwner (engine.getChannelStrip (trackIndex).getNativeVst3Slot());
+            vst3Editor->bindOwner (slot);
         }
         pluginEditorModal.showBorrowed (*parent, *vst3Editor, onClose);
         return;
@@ -2638,19 +2663,23 @@ void ChannelStripComponent::openPluginEditor()
 #if DUSKSTUDIO_HAS_NATIVE_AU
     if (engine.getChannelStrip (trackIndex).isNativeAuLoaded())
     {
-        auto* inst = engine.getChannelStrip (trackIndex).getNativeAuSlot().getInstance();
+        auto& slot = engine.getChannelStrip (trackIndex).getNativeAuSlot();
+        auto* inst = slot.getInstance();
         if (inst == nullptr) return;
         if (auEditor == nullptr)
         {
             auEditor = std::make_unique<AuPluginEditorComponent>();
-            juce::String err;
-            if (! auEditor->attach (*inst, err))
+            auto pluginName = slot.displayName();
+            if (pluginName.empty())
+                pluginName = hosting::nativePluginName (slot.getPath(), slot.getPluginId());
+            if (! attachNativePluginEditor (
+                    *auEditor, *inst, *this, hosting::NativeEditorFormat::AudioUnit,
+                    pluginName))
             {
-                std::fprintf (stderr, "[chan au] %s\n", err.toRawUTF8());
                 auEditor.reset();
                 return;
             }
-            auEditor->bindOwner (engine.getChannelStrip (trackIndex).getNativeAuSlot());
+            auEditor->bindOwner (slot);
         }
         pluginEditorModal.showBorrowed (*parent, *auEditor, onClose);
         return;

--- a/tests/plugin_state_diagnostics.cpp
+++ b/tests/plugin_state_diagnostics.cpp
@@ -62,6 +62,45 @@ TEST_CASE ("native restore policy keeps healthy slots saveable and reports load 
              == "http://example.test/plugins/reverb");
 }
 
+TEST_CASE ("native editor attach failures always log and alert with format identity",
+           "[ui][native][regression][issue-396]")
+{
+    using Format = duskstudio::hosting::NativeEditorFormat;
+    for (const auto format : { Format::Clap, Format::Lv2, Format::Vst3,
+                               Format::AudioUnit })
+    {
+        const auto formatName = duskstudio::hosting::nativeEditorFormatName (format);
+        INFO (formatName);
+
+        std::string logged;
+        std::string alertTitle;
+        std::string alertMessage;
+        REQUIRE_FALSE (duskstudio::hosting::enforceNativeEditorAttachPolicy (
+            false, format, "Space Echo", "view attachment rejected",
+            [&] (const std::string& line) { logged = line; },
+            [&] (const std::string& title, const std::string& message)
+            {
+                alertTitle = title;
+                alertMessage = message;
+            }));
+
+        REQUIRE (logged.find (formatName) != std::string::npos);
+        REQUIRE (logged.find ("Space Echo") != std::string::npos);
+        REQUIRE (logged.find ("view attachment rejected") != std::string::npos);
+        REQUIRE (alertTitle.find (formatName) != std::string::npos);
+        REQUIRE (alertMessage.find (formatName) != std::string::npos);
+        REQUIRE (alertMessage.find ("Space Echo") != std::string::npos);
+        REQUIRE (alertMessage.find ("view attachment rejected") != std::string::npos);
+    }
+
+    int callbacks = 0;
+    REQUIRE (duskstudio::hosting::enforceNativeEditorAttachPolicy (
+        true, Format::Clap, "Space Echo", {},
+        [&] (const std::string&) { ++callbacks; },
+        [&] (const std::string&, const std::string&) { ++callbacks; }));
+    REQUIRE (callbacks == 0);
+}
+
 TEST_CASE ("native reactivation failure quarantines rather than unloads",
            "[session][native][regression][issue-386]")
 {

--- a/tests/release_mechanics.sh
+++ b/tests/release_mechanics.sh
@@ -767,6 +767,46 @@ assert set(donor_pins) == expected_donor_workflows, (
 assert all(pins == [pinned_donor.group(1)] for pins in donor_pins.values()), (
     f"DONOR_REV drift across workflows: {donor_pins}"
 )
+
+# Source-built libsodium must come from the release asset hosted alongside the
+# upstream repository. download.libsodium.org has repeatedly failed DNS lookup
+# on GitHub's macOS runners. Keep all static-build workflows on one audited
+# version/hash pair, and prevent the unreliable host from being reintroduced.
+sodium_pins = {}
+expected_sodium_workflows = {
+    "linux-release.yml",
+    "macos-build.yml",
+    "macos-release.yml",
+}
+github_sodium_asset = (
+    '"https://github.com/jedisct1/libsodium/releases/download/'
+    '${SODIUM_VERSION}-RELEASE/libsodium-${SODIUM_VERSION}.tar.gz"'
+)
+for workflow_path in (source_root / ".github" / "workflows").glob("*.yml"):
+    workflow_text = workflow_path.read_text(encoding="utf-8")
+    assert "download.libsodium.org" not in workflow_text, (
+        f"{workflow_path.name} must not depend on the unreliable libsodium host"
+    )
+    versions = re.findall(
+        r"^\s*SODIUM_VERSION:\s*([^\s#]+)$", workflow_text, re.MULTILINE
+    )
+    hashes = re.findall(
+        r"^\s*SODIUM_SHA256:\s*([0-9a-f]{64})$", workflow_text, re.MULTILINE
+    )
+    if versions or hashes:
+        assert len(versions) == 1 and len(hashes) == 1, (
+            f"{workflow_path.name} must carry exactly one libsodium version/hash pair"
+        )
+        assert github_sodium_asset in workflow_text, (
+            f"{workflow_path.name} must fetch the official GitHub release asset"
+        )
+        sodium_pins[workflow_path.name] = (versions[0], hashes[0])
+assert set(sodium_pins) == expected_sodium_workflows, (
+    f"unexpected source-built libsodium workflow set: {sodium_pins.keys()}"
+)
+assert len(set(sodium_pins.values())) == 1, (
+    f"libsodium version/hash drift across workflows: {sodium_pins}"
+)
 for guide_name in ("BUILDING-LINUX.md", "BUILDING-WINDOWS.md"):
     guide = (source_root / guide_name).read_text(encoding="utf-8")
     assert (


### PR DESCRIPTION
Closes #396

## Summary
- route CLAP, LV2, VST3, and Audio Unit channel-strip attach failures through one JUCE-free policy
- preserve diagnostic logging and show a Dusk alert containing the format, plug-in name, and failure reason
- cover the shared success and failure behavior for all four native formats
- fetch pinned static libsodium from its official GitHub release asset in macOS CI and both release workflows, with a contract test preventing host or pin drift

## Validation
- Linux: focused `[issue-396]` 34 assertions / 1 case; full CTest 875/875
- macOS: focused `[issue-396]` 34 assertions / 1 case; full CTest 844/844
- Windows: focused `[issue-396]` 34 assertions / 1 case; full CTest 838/838; ASIO configuration verified
- GitHub macOS runner: `Build static libsodium (pinned)` passed using the replacement asset
- replacement archive resolves on macOS and matches the existing pinned SHA-256
- release-mechanics contract and workflow structure validation
- `tools/juce-gate.sh` (164 coupled source files, 8256 uses)
- `git diff --check`
- `review-local --base origin/main` linters passed after replacing a varargs log call; model review unavailable (exit 2, incomplete)