### PR TITLE
Preserve large LV2 patch synchronizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 888 Catch2 test cases across 175 test source files. Linux
+The C++ suite declares 889 Catch2 test cases across 176 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 888 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 889 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/lv2/Lv2Instance.cpp
+++ b/src/engine/lv2/Lv2Instance.cpp
@@ -21,6 +21,7 @@
 #include <array>
 #include <atomic>
 #include <cmath>
+#include <cstdio>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -28,6 +29,7 @@
 #include <iterator>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace duskstudio::lv2
@@ -256,9 +258,72 @@ struct Lv2Instance::Impl
     int controlAtomOutPos = -1;
 
     // Plugin -> host property feedback (audio-thread parse of the control atom
-    // output, drained into patchShadow on the message thread).
+    // output, drained into patchShadow on the message thread). Size this once
+    // from the declared float patch surface: one generic patch:Get may return
+    // every property in a single patch:Put, so a fixed queue silently truncates
+    // otherwise-valid large plug-ins.
     struct PatchFeedback { LV2_URID prop; float value; };
-    hosting::SpscRing<PatchFeedback, 128> patchOutRing;
+    class PatchFeedbackRing
+    {
+    public:
+        void configure (size_t itemCapacity)
+        {
+            slots.assign (std::max<size_t> (2, itemCapacity + 1), {});
+            writeIdx.store (0, std::memory_order_relaxed);
+            readIdx.store (0, std::memory_order_relaxed);
+        }
+
+        bool push (const PatchFeedback& value) noexcept
+        {
+            const size_t capacity = slots.size();
+            if (capacity < 2) return false;
+            const size_t write = writeIdx.load (std::memory_order_relaxed);
+            const size_t next = (write + 1) % capacity;
+            if (next == readIdx.load (std::memory_order_acquire)) return false;
+            slots[write] = value;
+            writeIdx.store (next, std::memory_order_release);
+            return true;
+        }
+
+        template <typename Fn>
+        void drain (Fn&& fn) noexcept
+        {
+            const size_t capacity = slots.size();
+            if (capacity < 2) return;
+            size_t read = readIdx.load (std::memory_order_relaxed);
+            const size_t write = writeIdx.load (std::memory_order_acquire);
+            while (read != write)
+            {
+                fn (slots[read]);
+                read = (read + 1) % capacity;
+            }
+            readIdx.store (read, std::memory_order_release);
+        }
+
+    private:
+        std::vector<PatchFeedback> slots;
+        std::atomic<size_t> writeIdx { 0 };
+        std::atomic<size_t> readIdx { 0 };
+    };
+
+    PatchFeedbackRing patchOutRing;
+    std::unordered_set<LV2_URID> patchPropertyUrids;
+    std::atomic<uint32_t> patchFeedbackOverflows { 0 };
+    std::atomic<uint32_t> patchGetQueueFailures { 0 };
+    std::atomic<bool> patchRefreshPending { false };
+
+    void queuePatchFeedback (LV2_URID property, float value) noexcept
+    {
+        // A generic patch:Get may include readable or internal properties that
+        // are not part of the host's declared parameter surface. They cannot
+        // update a parameter and must not consume capacity reserved for one.
+        if (patchPropertyUrids.find (property) == patchPropertyUrids.end()) return;
+        if (! patchOutRing.push ({ property, value }))
+        {
+            patchFeedbackOverflows.fetch_add (1, std::memory_order_relaxed);
+            patchRefreshPending.store (true, std::memory_order_release);
+        }
+    }
 
     // Audio thread. Queue one patch:Set / patch:Put object's float properties.
     void queuePatchObject (const LV2_Atom_Object* obj) noexcept
@@ -271,8 +336,9 @@ struct Lv2Instance::Impl
                                       uridPatchValue,    &valAtom, 0);
             if (propAtom != nullptr && propAtom->type == uridUridType
                 && valAtom != nullptr && valAtom->type == uridFloatType)
-                patchOutRing.push ({ reinterpret_cast<const LV2_Atom_URID*> (propAtom)->body,
-                                     reinterpret_cast<const LV2_Atom_Float*> (valAtom)->body });
+                queuePatchFeedback (
+                    reinterpret_cast<const LV2_Atom_URID*> (propAtom)->body,
+                    reinterpret_cast<const LV2_Atom_Float*> (valAtom)->body);
         }
         else if (obj->body.otype == uridPatchPut)
         {
@@ -282,8 +348,9 @@ struct Lv2Instance::Impl
             const auto* body = reinterpret_cast<const LV2_Atom_Object*> (bodyAtom);
             LV2_ATOM_OBJECT_FOREACH (body, p)
                 if (p->value.type == uridFloatType)
-                    patchOutRing.push ({ p->key,
-                        reinterpret_cast<const LV2_Atom_Float*> (&p->value)->body });
+                    queuePatchFeedback (
+                        p->key,
+                        reinterpret_cast<const LV2_Atom_Float*> (&p->value)->body);
         }
     }
 
@@ -429,6 +496,7 @@ bool Lv2Instance::create (const Lv2Bundle& bundle, const std::string& uri, std::
     // MIDI Learn). Snapshot name + range + steppedness now so later reads
     // never touch lilv.
     impl->params.clear();
+    impl->patchPropertyUrids.clear();
     impl->lastTouchedParam.store (-1, std::memory_order_relaxed);
     {
         LilvNode* toggledProp  = lilv_new_uri (world, LV2_CORE__toggled);
@@ -554,6 +622,18 @@ bool Lv2Instance::create (const Lv2Bundle& bundle, const std::string& uri, std::
         lilv_node_free (enumProp);
         lilv_node_free (designation);
     }
+
+    size_t patchPropertyCount = 0;
+    for (const auto& param : impl->params)
+    {
+        if (! param.isPatchProperty) continue;
+        impl->patchPropertyUrids.insert (param.id & ~Impl::kPatchIdFlag);
+        ++patchPropertyCount;
+    }
+    impl->patchOutRing.configure (patchPropertyCount);
+    impl->patchFeedbackOverflows.store (0, std::memory_order_relaxed);
+    impl->patchGetQueueFailures.store (0, std::memory_order_relaxed);
+    impl->patchRefreshPending.store (false, std::memory_order_relaxed);
 
     // Which atom input takes injected patch events: the lv2:control-designated
     // one, else the first.
@@ -1154,6 +1234,22 @@ void Lv2Instance::drainPatchFeedback()
     {
         impl->patchShadow[f.prop] = f.value;
     });
+
+    const auto overflows = impl->patchFeedbackOverflows.exchange (
+        0, std::memory_order_acq_rel);
+    const auto requestFailures = impl->patchGetQueueFailures.exchange (
+        0, std::memory_order_acq_rel);
+    if (overflows != 0)
+        std::fprintf (stderr,
+                      "[lv2] patch feedback overflow dropped %u value(s); requesting a full refresh\n",
+                      overflows);
+    if (requestFailures != 0)
+        std::fprintf (stderr,
+                      "[lv2] patch feedback refresh queue was full %u time(s); retrying\n",
+                      requestFailures);
+
+    if (impl->patchRefreshPending.exchange (false, std::memory_order_acq_rel))
+        requestPatchParameterValuesForUi();
 }
 
 int Lv2Instance::lastTouchedParamIndex() const noexcept
@@ -1207,8 +1303,11 @@ void Lv2Instance::requestPatchParameterValuesForUi() noexcept
 
     Impl::AtomBlob blob;
     blob.size = impl->forgePatchGet (blob.data, sizeof (blob.data));
-    if (blob.size != 0)
-        impl->atomRing.push (blob);
+    if (blob.size != 0 && ! impl->atomRing.push (blob))
+    {
+        impl->patchGetQueueFailures.fetch_add (1, std::memory_order_relaxed);
+        impl->patchRefreshPending.store (true, std::memory_order_release);
+    }
 }
 
 void Lv2Instance::forwardUiAtomEvent (const void* atomData, uint32_t sizeBytes) noexcept

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -340,7 +340,10 @@ endif()
 if(DUSKSTUDIO_NATIVE_LV2)
     set(DUSKSTUDIO_FILE_STATE_LV2_BUNDLE
         "${CMAKE_CURRENT_BINARY_DIR}/file-state-fixture.lv2")
+    set(DUSKSTUDIO_MANY_PATCH_LV2_BUNDLE
+        "${CMAKE_CURRENT_BINARY_DIR}/many-patch-fixture.lv2")
     file(MAKE_DIRECTORY "${DUSKSTUDIO_FILE_STATE_LV2_BUNDLE}")
+    file(MAKE_DIRECTORY "${DUSKSTUDIO_MANY_PATCH_LV2_BUNDLE}")
     configure_file(fixtures/file_state_manifest.ttl
         "${DUSKSTUDIO_FILE_STATE_LV2_BUNDLE}/manifest.ttl" COPYONLY)
     configure_file(fixtures/file_state_plugin.ttl
@@ -354,9 +357,37 @@ if(DUSKSTUDIO_NATIVE_LV2)
     target_compile_features(dusk-studio-file-state-lv2-fixture PRIVATE cxx_std_17)
     target_link_libraries(dusk-studio-file-state-lv2-fixture PRIVATE PkgConfig::LV2)
 
+    set(DUSKSTUDIO_MANY_PATCH_PROPERTY_DEFINITIONS "")
+    set(DUSKSTUDIO_MANY_PATCH_WRITABLE_PROPERTIES "")
+    foreach(property_index RANGE 0 159)
+        string(APPEND DUSKSTUDIO_MANY_PATCH_PROPERTY_DEFINITIONS
+            "<urn:duskstudio:test:many-patches#p${property_index}>\n"
+            "    a lv2:Parameter ; rdfs:label \"p${property_index}\" ;\n"
+            "    rdfs:range atom:Float ; lv2:minimum 0.0 ;\n"
+            "    lv2:maximum 200.0 ; lv2:default 0.0 .\n\n")
+        if(property_index GREATER 0)
+            string(APPEND DUSKSTUDIO_MANY_PATCH_WRITABLE_PROPERTIES ",\n                   ")
+        endif()
+        string(APPEND DUSKSTUDIO_MANY_PATCH_WRITABLE_PROPERTIES
+            "<urn:duskstudio:test:many-patches#p${property_index}>")
+    endforeach()
+    configure_file(fixtures/many_patch_manifest.ttl
+        "${DUSKSTUDIO_MANY_PATCH_LV2_BUNDLE}/manifest.ttl" COPYONLY)
+    configure_file(fixtures/many_patch_plugin.ttl.in
+        "${DUSKSTUDIO_MANY_PATCH_LV2_BUNDLE}/many_patch_plugin.ttl" @ONLY)
+    add_library(dusk-studio-many-patch-lv2-fixture MODULE
+        fixtures/many_patch_lv2.cpp)
+    set_target_properties(dusk-studio-many-patch-lv2-fixture PROPERTIES
+        PREFIX ""
+        OUTPUT_NAME "many_patch_fixture"
+        LIBRARY_OUTPUT_DIRECTORY "${DUSKSTUDIO_MANY_PATCH_LV2_BUNDLE}")
+    target_compile_features(dusk-studio-many-patch-lv2-fixture PRIVATE cxx_std_17)
+    target_link_libraries(dusk-studio-many-patch-lv2-fixture PRIVATE PkgConfig::LV2)
+
     target_sources(dusk-studio-tests PRIVATE
         lv2_bundle_load.cpp
         lv2_file_state.cpp
+        lv2_patch_feedback.cpp
         lv2_instance_process.cpp
         lv2_native_slot.cpp
         ${CMAKE_SOURCE_DIR}/src/engine/lv2/Lv2Bundle.cpp
@@ -365,8 +396,11 @@ if(DUSKSTUDIO_NATIVE_LV2)
     target_link_libraries(dusk-studio-tests PRIVATE PkgConfig::LILV PkgConfig::SUIL PkgConfig::LV2)
     target_compile_definitions(dusk-studio-tests PRIVATE
         DUSKSTUDIO_HAS_NATIVE_LV2=1
-        DUSKSTUDIO_FILE_STATE_LV2_FIXTURE_PATH="${DUSKSTUDIO_FILE_STATE_LV2_BUNDLE}")
-    add_dependencies(dusk-studio-tests dusk-studio-file-state-lv2-fixture)
+        DUSKSTUDIO_FILE_STATE_LV2_FIXTURE_PATH="${DUSKSTUDIO_FILE_STATE_LV2_BUNDLE}"
+        DUSKSTUDIO_MANY_PATCH_LV2_FIXTURE_PATH="${DUSKSTUDIO_MANY_PATCH_LV2_BUNDLE}")
+    add_dependencies(dusk-studio-tests
+        dusk-studio-file-state-lv2-fixture
+        dusk-studio-many-patch-lv2-fixture)
 endif()
 
 if(DUSKSTUDIO_NATIVE_CLAP OR DUSKSTUDIO_NATIVE_LV2 OR DUSKSTUDIO_NATIVE_VST3)

--- a/tests/fixtures/many_patch_lv2.cpp
+++ b/tests/fixtures/many_patch_lv2.cpp
@@ -1,0 +1,144 @@
+#include <lv2/atom/atom.h>
+#include <lv2/atom/forge.h>
+#include <lv2/atom/util.h>
+#include <lv2/core/lv2.h>
+#include <lv2/patch/patch.h>
+#include <lv2/urid/urid.h>
+
+#include <array>
+#include <cstdio>
+#include <cstring>
+
+namespace
+{
+constexpr const char* kPluginUri = "urn:duskstudio:test:many-patches";
+constexpr size_t kPropertyCount = 160;
+
+template <typename T>
+const T* feature (const LV2_Feature* const* features, const char* uri)
+{
+    if (features == nullptr) return nullptr;
+    for (size_t i = 0; features[i] != nullptr; ++i)
+        if (std::strcmp (features[i]->URI, uri) == 0)
+            return static_cast<const T*> (features[i]->data);
+    return nullptr;
+}
+
+struct Instance
+{
+    LV2_URID_Map* map = nullptr;
+    float* inL = nullptr;
+    float* inR = nullptr;
+    float* outL = nullptr;
+    float* outR = nullptr;
+    const LV2_Atom_Sequence* controlIn = nullptr;
+    LV2_Atom_Sequence* controlOut = nullptr;
+    LV2_URID atomObject = 0;
+    LV2_URID patchGet = 0;
+    LV2_URID patchPut = 0;
+    LV2_URID patchBody = 0;
+    std::array<LV2_URID, kPropertyCount> properties {};
+};
+
+LV2_Handle instantiate (const LV2_Descriptor*, double, const char*,
+                        const LV2_Feature* const* features)
+{
+    auto* map = const_cast<LV2_URID_Map*> (
+        feature<LV2_URID_Map> (features, LV2_URID__map));
+    if (map == nullptr) return nullptr;
+
+    auto* self = new Instance;
+    self->map = map;
+    self->atomObject = map->map (map->handle, LV2_ATOM__Object);
+    self->patchGet = map->map (map->handle, LV2_PATCH__Get);
+    self->patchPut = map->map (map->handle, LV2_PATCH__Put);
+    self->patchBody = map->map (map->handle, LV2_PATCH__body);
+    for (size_t i = 0; i < kPropertyCount; ++i)
+    {
+        char uri[64] {};
+        std::snprintf (uri, sizeof (uri), "%s#p%zu", kPluginUri, i);
+        self->properties[i] = map->map (map->handle, uri);
+    }
+    return self;
+}
+
+void connectPort (LV2_Handle instance, uint32_t port, void* data)
+{
+    auto& self = *static_cast<Instance*> (instance);
+    switch (port)
+    {
+        case 0: self.inL = static_cast<float*> (data); break;
+        case 1: self.inR = static_cast<float*> (data); break;
+        case 2: self.outL = static_cast<float*> (data); break;
+        case 3: self.outR = static_cast<float*> (data); break;
+        case 4: self.controlIn = static_cast<const LV2_Atom_Sequence*> (data); break;
+        case 5: self.controlOut = static_cast<LV2_Atom_Sequence*> (data); break;
+        default: break;
+    }
+}
+
+bool patchGetRequested (const Instance& self)
+{
+    if (self.controlIn == nullptr) return false;
+    LV2_ATOM_SEQUENCE_FOREACH (self.controlIn, event)
+    {
+        if (event->body.type != self.atomObject) continue;
+        const auto* object = reinterpret_cast<const LV2_Atom_Object*> (&event->body);
+        if (object->body.otype == self.patchGet) return true;
+    }
+    return false;
+}
+
+void forgeResponse (Instance& self, bool includeProperties)
+{
+    if (self.controlOut == nullptr) return;
+    const size_t capacity = sizeof (LV2_Atom) + self.controlOut->atom.size;
+
+    LV2_Atom_Forge forge;
+    lv2_atom_forge_init (&forge, self.map);
+    lv2_atom_forge_set_buffer (
+        &forge, reinterpret_cast<uint8_t*> (self.controlOut), capacity);
+    LV2_Atom_Forge_Frame sequenceFrame;
+    lv2_atom_forge_sequence_head (&forge, &sequenceFrame, 0);
+    if (includeProperties)
+    {
+        lv2_atom_forge_frame_time (&forge, 0);
+        LV2_Atom_Forge_Frame putFrame;
+        lv2_atom_forge_object (&forge, &putFrame, 0, self.patchPut);
+        lv2_atom_forge_key (&forge, self.patchBody);
+        LV2_Atom_Forge_Frame bodyFrame;
+        lv2_atom_forge_object (&forge, &bodyFrame, 0, 0);
+        for (size_t i = 0; i < kPropertyCount; ++i)
+        {
+            lv2_atom_forge_key (&forge, self.properties[i]);
+            lv2_atom_forge_float (&forge, static_cast<float> (i));
+        }
+        lv2_atom_forge_pop (&forge, &bodyFrame);
+        lv2_atom_forge_pop (&forge, &putFrame);
+    }
+    lv2_atom_forge_pop (&forge, &sequenceFrame);
+}
+
+void run (LV2_Handle instance, uint32_t frames)
+{
+    auto& self = *static_cast<Instance*> (instance);
+    for (uint32_t i = 0; i < frames; ++i)
+    {
+        if (self.outL != nullptr) self.outL[i] = self.inL != nullptr ? self.inL[i] : 0.0f;
+        if (self.outR != nullptr) self.outR[i] = self.inR != nullptr ? self.inR[i] : 0.0f;
+    }
+    forgeResponse (self, patchGetRequested (self));
+}
+
+void cleanup (LV2_Handle instance) { delete static_cast<Instance*> (instance); }
+
+const LV2_Descriptor descriptor {
+    kPluginUri, &instantiate, &connectPort, nullptr, &run, nullptr, &cleanup, nullptr
+};
+}
+
+extern "C" LV2_SYMBOL_EXPORT
+const LV2_Descriptor* lv2_descriptor (uint32_t index)
+{
+    return index == 0 ? &descriptor : nullptr;
+}

--- a/tests/fixtures/many_patch_manifest.ttl
+++ b/tests/fixtures/many_patch_manifest.ttl
@@ -1,0 +1,7 @@
+@prefix lv2:  <http://lv2plug.in/ns/lv2core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<urn:duskstudio:test:many-patches>
+    a lv2:Plugin ;
+    lv2:binary <many_patch_fixture.so> ;
+    rdfs:seeAlso <many_patch_plugin.ttl> .

--- a/tests/fixtures/many_patch_plugin.ttl.in
+++ b/tests/fixtures/many_patch_plugin.ttl.in
@@ -1,0 +1,31 @@
+@prefix atom:  <http://lv2plug.in/ns/ext/atom#> .
+@prefix patch: <http://lv2plug.in/ns/ext/patch#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix doap:  <http://usefulinc.com/ns/doap#> .
+@prefix lv2:   <http://lv2plug.in/ns/lv2core#> .
+@prefix urid:  <http://lv2plug.in/ns/ext/urid#> .
+
+@DUSKSTUDIO_MANY_PATCH_PROPERTY_DEFINITIONS@
+
+<urn:duskstudio:test:many-patches>
+    a lv2:Plugin ;
+    doap:name "Dusk many-patch fixture" ;
+    lv2:requiredFeature urid:map ;
+    patch:writable @DUSKSTUDIO_MANY_PATCH_WRITABLE_PROPERTIES@ ;
+    lv2:port
+        [ a lv2:InputPort, lv2:AudioPort ;
+          lv2:index 0 ; lv2:symbol "in_l" ; lv2:name "Input L" ],
+        [ a lv2:InputPort, lv2:AudioPort ;
+          lv2:index 1 ; lv2:symbol "in_r" ; lv2:name "Input R" ],
+        [ a lv2:OutputPort, lv2:AudioPort ;
+          lv2:index 2 ; lv2:symbol "out_l" ; lv2:name "Output L" ],
+        [ a lv2:OutputPort, lv2:AudioPort ;
+          lv2:index 3 ; lv2:symbol "out_r" ; lv2:name "Output R" ],
+        [ a lv2:InputPort, atom:AtomPort ;
+          lv2:index 4 ; lv2:symbol "control_in" ; lv2:name "Control In" ;
+          lv2:designation lv2:control ;
+          atom:bufferType atom:Sequence ; atom:supports patch:Message ],
+        [ a lv2:OutputPort, atom:AtomPort ;
+          lv2:index 5 ; lv2:symbol "control_out" ; lv2:name "Control Out" ;
+          lv2:designation lv2:control ;
+          atom:bufferType atom:Sequence ; atom:supports patch:Message ] .

--- a/tests/lv2_patch_feedback.cpp
+++ b/tests/lv2_patch_feedback.cpp
@@ -1,0 +1,49 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "engine/hosting/InsertAdapter.h"
+#include "engine/lv2/Lv2Bundle.h"
+#include "engine/lv2/Lv2Instance.h"
+
+#include <array>
+#include <string>
+
+namespace
+{
+constexpr const char* kPluginUri = "urn:duskstudio:test:many-patches";
+constexpr int kPropertyCount = 160;
+}
+
+TEST_CASE ("LV2 initial patch synchronization retains more than 128 properties",
+           "[lv2][params][integration][regression][issue-394]")
+{
+    duskstudio::lv2::Lv2Bundle bundle;
+    std::string error;
+    REQUIRE (bundle.load (DUSKSTUDIO_MANY_PATCH_LV2_FIXTURE_PATH, error));
+
+    duskstudio::lv2::Lv2Instance instance;
+    REQUIRE (instance.create (bundle, kPluginUri, error));
+    REQUIRE (instance.activate (48000.0, 32, error));
+    REQUIRE (instance.paramCount() == kPropertyCount);
+
+    instance.requestPatchParameterValuesForUi();
+    duskstudio::hosting::InsertAdapter adapter;
+    adapter.prepare (instance.portLayout(), 32);
+    std::array<float, 32> left {};
+    std::array<float, 32> right {};
+    adapter.process (instance, left.data(), right.data(), 32);
+    instance.drainPatchFeedback();
+
+    for (int i = 0; i < kPropertyCount; ++i)
+    {
+        const auto* parameter = instance.paramInfo (i);
+        REQUIRE (parameter != nullptr);
+        REQUIRE (parameter->isPatchProperty);
+        REQUIRE (parameter->name.size() > 1);
+        REQUIRE (parameter->name.front() == 'p');
+        const auto expected = std::stod (parameter->name.substr (1));
+        double value = -1.0;
+        REQUIRE (instance.getParamValue (parameter->id, value));
+        CHECK_THAT (value, Catch::Matchers::WithinAbs (expected, 1.0e-7));
+    }
+}


### PR DESCRIPTION
Closes #394.

## Summary
- size the plugin-to-host patch feedback queue from the declared float patch-property surface
- ignore undeclared patch properties and diagnose/retry queue or request overflow instead of silently truncating initial synchronization
- add a real LV2 fixture with 160 patch properties and verify every value reaches the host

## Validation
- Linux: focused `[issue-394]` regression, 964 assertions; full CTest 876/876
- macOS: full CTest 844/844 (local native LV2 host disabled because lilv/suil/lv2 are unavailable)
- Windows: full CTest 838/838 with ASIO enabled (native LV2 hosting unsupported)
- TSan: `[issue-394]` and `[lv2]` passed
- DuskStudio application target and release mechanics passed
- JUCE ratchet unchanged at 164 coupled source files / 8256 uses

Hosted macOS CI is the authoritative native-LV2 macOS check for the new fixture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LV2 patch feedback handling for plugins with large numbers of properties.
  * Prevented lost updates when patch feedback exceeds the previous capacity.
  * Added automatic parameter refreshes and diagnostics when feedback overflows.

* **Tests**
  * Added coverage for synchronizing 160 LV2 patch properties.
  * Updated documented test counts to 889 test cases across 176 test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->