### PR TITLE
Keep parented CLAP editors after false show

### DIFF
--- a/src/engine/clap/ClapEditor_Mac.mm
+++ b/src/engine/clap/ClapEditor_Mac.mm
@@ -3,6 +3,7 @@
 #import <AppKit/AppKit.h>
 
 #include <algorithm>
+#include <cstdio>
 
 namespace duskstudio::clap
 {
@@ -72,10 +73,15 @@ bool ClapEditor::embed (void* parentHandle, int x, int y, int w, int h,
     if (gui->set_parent == nullptr || ! gui->set_parent (plugin, &win))
     { errorOut = "gui set_parent() failed"; close(); return false; }
 
-    if (gui->show != nullptr && ! gui->show (plugin))
-    { errorOut = "gui show() failed"; close(); return false; }
+    // Match the other platform hosts: a false return is diagnostic only. Some
+    // plugins still draw after reporting failure, so tearing down a successfully
+    // parented GUI here would leave the editor view blank.
+    const bool shown = gui->show != nullptr && gui->show (plugin);
 
     embedded = true;
+    std::fputs (shown ? "[clap editor] embed: Cocoa show=1\n"
+                      : "[clap editor] embed: Cocoa show=0\n",
+                stderr);
     return true;
 }
 

--- a/src/engine/clap/ClapEditor_Win.cpp
+++ b/src/engine/clap/ClapEditor_Win.cpp
@@ -7,6 +7,7 @@
 #include "ClapEditor.h"
 
 #include <algorithm>
+#include <cstdio>
 
 namespace duskstudio::clap
 {
@@ -97,10 +98,15 @@ bool ClapEditor::embed (void* parentHandle, int x, int y, int w, int h,
     if (gui->set_parent == nullptr || ! gui->set_parent (plugin, &win))
     { errorOut = "gui set_parent() failed"; close(); return false; }
 
-    if (gui->show != nullptr && ! gui->show (plugin))
-    { errorOut = "gui show() failed"; close(); return false; }
+    // Match the other platform hosts: a false return is diagnostic only. Some
+    // plugins still draw after reporting failure, so tearing down a successfully
+    // parented GUI here would leave the editor view blank.
+    const bool shown = gui->show != nullptr && gui->show (plugin);
 
     embedded = true;
+    std::fputs (shown ? "[clap editor] embed: Win32 show=1\n"
+                      : "[clap editor] embed: Win32 show=0\n",
+                stderr);
     return true;
 }
 

--- a/tests/clap_editor_lifecycle.cpp
+++ b/tests/clap_editor_lifecycle.cpp
@@ -143,18 +143,33 @@ TEST_CASE ("the X11 empty-container check ignores pixels outside the visual dept
 }
 
 TEST_CASE ("a CLAP gui show() that reports failure keeps the editor",
-           "[clap][editor][regression][issue-361]")
+           "[clap][editor][regression][issue-361][issue-391]")
 {
-    const auto source = readSource ("src/engine/clap/ClapEditor.cpp");
-    const auto embed = source.find ("bool ClapEditor::embed");
-    const auto show = source.find ("gui->show", embed);
-    REQUIRE (show != std::string::npos);
+    for (const char* path : { "src/engine/clap/ClapEditor.cpp",
+                              "src/engine/clap/ClapEditor_Win.cpp",
+                              "src/engine/clap/ClapEditor_Mac.mm" })
+    {
+        const auto source = readSource (path);
+        const auto embed = source.find ("bool ClapEditor::embed");
+        const auto body = source.find ('{', embed);
+        const auto nextMethod = source.find ("ClapEditor::", body + 1);
+        const auto show = source.find ("gui->show", body);
+        const auto result = source.find ("const bool shown", body);
+        const auto castDiagnostic = source.find ("(int) shown", show);
+        const auto branchDiagnostic = source.find ("shown ?", show);
 
-    // Everything from the show call to the end of embed(): a close() there would
-    // destroy a GUI that may well be about to draw, leaving a blank editor.
-    const auto embedEnd = source.find ("\n}", show);
-    REQUIRE (embedEnd != std::string::npos);
-    REQUIRE (source.find ("close()", show) > embedEnd);
+        INFO (path);
+        REQUIRE (embed != std::string::npos);
+        REQUIRE (body != std::string::npos);
+        REQUIRE (nextMethod != std::string::npos);
+        REQUIRE (show < nextMethod);
+        REQUIRE (result < show);
+        REQUIRE ((castDiagnostic < nextMethod || branchDiagnostic < nextMethod));
+
+        // Tearing down after show() would destroy a GUI that may still draw.
+        REQUIRE (source.substr (show, nextMethod - show).find ("close()")
+                 == std::string::npos);
+    }
 }
 
 TEST_CASE ("a failed CLAP embed repaints its error",


### PR DESCRIPTION
Closes #391.

## Summary
- make Cocoa and Win32 follow the Linux post-parent `gui->show()` policy
- keep a successfully parented GUI alive when `show()` reports false while logging the exact result
- extend the bounded CLAP lifecycle regression across Linux, Win32, and Cocoa sources

## Validation
- `[issue-391]`: 24 assertions / 1 case on Linux, macOS, and Windows
- Linux full CTest: 876/876
- macOS full CTest: 844/844
- Windows full CTest: 838/838 with ASIO enabled
- DuskStudio application target built on all three platforms
- De-JUCE ratchet: 164 source files / 8256 uses
- local smoke review linter clean; model review unavailable, so not counted as a complete review

The local macOS validation cache has native LV2 disabled; Windows does not provide native LV2 hosting. Those skipped formats are unrelated to this native CLAP editor change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved plugin editor embedding on macOS and Windows when the GUI cannot be shown.
  - Embedding now continues instead of closing immediately or reporting a fatal failure.
  - The issue is recorded as a diagnostic message for troubleshooting.

- **Tests**
  - Expanded regression coverage across supported platform implementations.
  - Added checks to ensure failed GUI display attempts do not trigger premature editor closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->