### PR TITLE
Make LV2 test fixtures multi-config safe

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -161,8 +161,8 @@ jobs:
 
       - name: Configure tests
         run: |
-          cmake -S . -B build-tests -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release \
+          cmake -S . -B build-tests -G "Ninja Multi-Config" \
+            -DCMAKE_CONFIGURATION_TYPES=Release \
             -DDUSKSTUDIO_BUILD_TESTS=ON \
             -DDUSKSTUDIO_SKIP_FORK_CHECK=ON \
             -DDUSKSTUDIO_REQUIRE_NATIVE_LV2=ON \
@@ -173,17 +173,17 @@ jobs:
             -DDAF_WIDGETS_PATH="${RUNNER_TEMP}/DAF-Widgets"
 
       - name: Build tests
-        run: cmake --build build-tests --target dusk-studio-tests -j6
+        run: cmake --build build-tests --config Release --target dusk-studio-tests -j6
 
       - name: Run tests
-        run: ctest --test-dir build-tests --output-on-failure
+        run: ctest --test-dir build-tests --output-on-failure -C Release
 
       - name: Engine CLAP state round-trip (xvfb)
         run: |
           timeout 60 xvfb-run --auto-servernum \
             env DUSKSTUDIO_RUN_SELFTEST=1 \
                 DUSKSTUDIO_CLAP_STATE_TEST_ONLY=1 \
-                DUSKSTUDIO_CLAP_STATE_FIXTURE="$PWD/build-tests/dusk-studio-multi-bus-clap-fixture.clap" \
+                DUSKSTUDIO_CLAP_STATE_FIXTURE="$PWD/build-tests/Release/dusk-studio-multi-bus-clap-fixture.clap" \
             build-linux/DuskStudio_artefacts/Release/DuskStudio
 
       - name: ccache stats

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -353,7 +353,9 @@ if(DUSKSTUDIO_NATIVE_LV2)
     set_target_properties(dusk-studio-file-state-lv2-fixture PROPERTIES
         PREFIX ""
         OUTPUT_NAME "file_state_fixture"
-        LIBRARY_OUTPUT_DIRECTORY "${DUSKSTUDIO_FILE_STATE_LV2_BUNDLE}")
+        # A generator expression prevents multi-config generators from appending
+        # /<Config>, which would put the module somewhere manifest.ttl cannot find.
+        LIBRARY_OUTPUT_DIRECTORY "$<1:${DUSKSTUDIO_FILE_STATE_LV2_BUNDLE}>")
     target_compile_features(dusk-studio-file-state-lv2-fixture PRIVATE cxx_std_17)
     target_link_libraries(dusk-studio-file-state-lv2-fixture PRIVATE PkgConfig::LV2)
 
@@ -380,7 +382,7 @@ if(DUSKSTUDIO_NATIVE_LV2)
     set_target_properties(dusk-studio-many-patch-lv2-fixture PROPERTIES
         PREFIX ""
         OUTPUT_NAME "many_patch_fixture"
-        LIBRARY_OUTPUT_DIRECTORY "${DUSKSTUDIO_MANY_PATCH_LV2_BUNDLE}")
+        LIBRARY_OUTPUT_DIRECTORY "$<1:${DUSKSTUDIO_MANY_PATCH_LV2_BUNDLE}>")
     target_compile_features(dusk-studio-many-patch-lv2-fixture PRIVATE cxx_std_17)
     target_link_libraries(dusk-studio-many-patch-lv2-fixture PRIVATE PkgConfig::LV2)
 

--- a/tests/fixtures/file_state_lv2.cpp
+++ b/tests/fixtures/file_state_lv2.cpp
@@ -34,6 +34,10 @@ struct Instance
     float* inR = nullptr;
     float* outL = nullptr;
     float* outR = nullptr;
+    float* gain = nullptr;
+    const LV2_Atom_Sequence* controlIn = nullptr;
+    LV2_Atom_Sequence* controlOut = nullptr;
+    LV2_URID atomSequence = 0;
     std::string restoredPath;
     bool restoredReadable = false;
 };
@@ -45,6 +49,7 @@ LV2_Handle instantiate (const LV2_Descriptor*, double, const char*,
     if (map == nullptr) return nullptr;
     auto* self = new Instance;
     self->map = map;
+    self->atomSequence = map->map (map->handle, LV2_ATOM__Sequence);
     return self;
 }
 
@@ -57,19 +62,32 @@ void connectPort (LV2_Handle instance, uint32_t port, void* data)
         case 1: self.inR = static_cast<float*> (data); break;
         case 2: self.outL = static_cast<float*> (data); break;
         case 3: self.outR = static_cast<float*> (data); break;
+        case 4: self.gain = static_cast<float*> (data); break;
+        case 5: self.controlIn = static_cast<const LV2_Atom_Sequence*> (data); break;
+        case 6: self.controlOut = static_cast<LV2_Atom_Sequence*> (data); break;
         default: break;
     }
 }
 
 void run (LV2_Handle instance, uint32_t frames)
 {
-    const auto& self = *static_cast<Instance*> (instance);
+    auto& self = *static_cast<Instance*> (instance);
     for (uint32_t i = 0; i < frames; ++i)
     {
         if (self.outL != nullptr)
             self.outL[i] = self.restoredReadable && self.inL != nullptr ? self.inL[i] : 0.0f;
         if (self.outR != nullptr)
             self.outR[i] = self.restoredReadable && self.inR != nullptr ? self.inR[i] : 0.0f;
+    }
+
+    // Output Atom ports arrive as capacity-bearing chunks. Each run must turn
+    // that buffer into a valid sequence even when the fixture has no events.
+    if (self.controlOut != nullptr)
+    {
+        self.controlOut->atom.type = self.atomSequence;
+        self.controlOut->atom.size = sizeof (LV2_Atom_Sequence_Body);
+        self.controlOut->body.unit = 0;
+        self.controlOut->body.pad = 0;
     }
 }
 

--- a/tests/lv2_file_state.cpp
+++ b/tests/lv2_file_state.cpp
@@ -47,7 +47,7 @@ void requireRestoredAudio (duskstudio::lv2::Lv2Instance& instance)
 }
 
 TEST_CASE ("LV2 file-backed state survives consecutive save and restore generations",
-           "[lv2][state][integration][regression][issue-357]")
+           "[lv2][state][integration][regression][issue-357][issue-388]")
 {
     TempDirectory temp ("dusk-lv2-file-state-integration-");
     const auto stateDir = temp.path() / "state";


### PR DESCRIPTION
## Summary

- keep both LV2 fixture modules beside their manifests under multi-config generators
- connect all declared file-state fixture ports and emit a valid empty Atom output sequence
- run the Linux LV2 test build with Ninja Multi-Config and retain the CLAP self-test path

## Validation

Exact commit: `b1eec635433ce2ca511e31e2119ea2928bebc60a`

- Linux Ninja Multi-Config `[issue-388]`: 32 assertions, 1 case
- Linux full CTest: 876/876
- macOS full CTest: 844/844
- Windows full CTest: 838/838; ASIO enabled and verified
- `actionlint .github/workflows/linux-build.yml`
- `tools/juce-gate.sh`: 164 files, 8256 uses
- `git diff --check`

Native LV2 is enabled in the Linux validation build. The current macOS validation cache has native LV2 disabled, and Windows has no native LV2 implementation, so those platforms validate the exact commit build and their enabled full suites but not the LV2 fixture itself.

`review-local` lint/model review was incomplete because its local model endpoint was unavailable; the sole clang-tidy result was a false positive treating Catch2 `TEST_CASE` as a mutable global.

Closes #388