### PR TITLE
Clamp restored LV2 control state

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 889 Catch2 test cases across 176 test source files. Linux
+The C++ suite declares 890 Catch2 test cases across 176 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 889 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 890 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/lv2/Lv2Instance.cpp
+++ b/src/engine/lv2/Lv2Instance.cpp
@@ -411,13 +411,13 @@ struct Lv2Instance::Impl
         return it != portIndexBySymbol.end() ? (int) it->second : -1;
     }
 
-    bool normalizeRestoredControlValue (size_t index, float& value) const noexcept
+    bool normalizeRestoredControlValue (size_t index, double& value) const noexcept
     {
         if (index >= controlRestoreInfo.size() || ! std::isfinite (value)) return false;
         const auto& info = controlRestoreInfo[index];
         if (! info.hasUsableRange) return false;
 
-        value = std::clamp (value, info.minValue, info.maxValue);
+        value = std::clamp (value, (double) info.minValue, (double) info.maxValue);
         if (info.toggled)
         {
             if (info.minValue > 0.0f || info.maxValue < 1.0f) return false;
@@ -433,8 +433,8 @@ struct Lv2Instance::Impl
         }
         else if (info.integer)
         {
-            const float integerMin = std::ceil (info.minValue);
-            const float integerMax = std::floor (info.maxValue);
+            const double integerMin = std::ceil ((double) info.minValue);
+            const double integerMax = std::floor ((double) info.maxValue);
             if (integerMin > integerMax) return false;
             value = std::clamp (std::round (value), integerMin, integerMax);
         }
@@ -468,18 +468,19 @@ struct Lv2Instance::Impl
             return;
 
         // States written by other hosts may carry any numeric atom type.
-        float v = 0.0f;
-        if      (type == self->uridFloat  && size >= sizeof (float))   v = *static_cast<const float*> (value);
-        else if (type == self->uridDouble && size >= sizeof (double))  v = (float) *static_cast<const double*> (value);
-        else if (type == self->uridInt    && size >= sizeof (int32_t)) v = (float) *static_cast<const int32_t*> (value);
-        else if (type == self->uridLong   && size >= sizeof (int64_t)) v = (float) *static_cast<const int64_t*> (value);
+        double v = 0.0;
+        if      (type == self->uridFloat  && size >= sizeof (float))   v = (double) *static_cast<const float*> (value);
+        else if (type == self->uridDouble && size >= sizeof (double))  v = *static_cast<const double*> (value);
+        else if (type == self->uridInt    && size >= sizeof (int32_t)) v = (double) *static_cast<const int32_t*> (value);
+        else if (type == self->uridLong   && size >= sizeof (int64_t)) v = (double) *static_cast<const int64_t*> (value);
         else return;
         if (! self->normalizeRestoredControlValue ((size_t) idx, v)) return;
-        self->portValues[(size_t) idx] = v;
+        const auto restoredValue = (float) v;
+        self->portValues[(size_t) idx] = restoredValue;
         // A restore supersedes any staged UI value for this port.
         if ((size_t) idx < self->uiDirty.size())
         {
-            self->uiShadow[(size_t) idx] = v;
+            self->uiShadow[(size_t) idx] = restoredValue;
             self->uiDirty [(size_t) idx] = 0;
         }
     }

--- a/src/engine/lv2/Lv2Instance.cpp
+++ b/src/engine/lv2/Lv2Instance.cpp
@@ -183,6 +183,17 @@ struct Lv2Instance::Impl
     std::vector<uint32_t> otherPorts;   // CV / unclassified - LV2 requires every port connected
     int latencyPortIndex = -1;
 
+    struct ControlRestoreInfo
+    {
+        float minValue = 0.0f, maxValue = 0.0f;
+        bool hasUsableRange = false;
+        bool toggled = false, integer = false, enumeration = false;
+        std::vector<float> scalePoints;
+    };
+    // Snapshotted for every input control port, including designated/hidden
+    // ports that are deliberately absent from the user parameter surface.
+    std::vector<ControlRestoreInfo> controlRestoreInfo;
+
     // Per-port scratch backing otherPorts: maxFrames floats each, so an audio-rate
     // CV port can safely read silence or sink its output.
     std::vector<std::vector<float>> otherScratch;
@@ -400,6 +411,36 @@ struct Lv2Instance::Impl
         return it != portIndexBySymbol.end() ? (int) it->second : -1;
     }
 
+    bool normalizeRestoredControlValue (size_t index, float& value) const noexcept
+    {
+        if (index >= controlRestoreInfo.size() || ! std::isfinite (value)) return false;
+        const auto& info = controlRestoreInfo[index];
+        if (! info.hasUsableRange) return false;
+
+        value = std::clamp (value, info.minValue, info.maxValue);
+        if (info.toggled)
+        {
+            if (info.minValue > 0.0f || info.maxValue < 1.0f) return false;
+            value = value > 0.0f ? 1.0f : 0.0f;
+        }
+        else if (info.enumeration)
+        {
+            if (info.scalePoints.empty()) return false;
+            value = *std::min_element (
+                info.scalePoints.begin(), info.scalePoints.end(),
+                [value] (float a, float b)
+                { return std::abs (a - value) < std::abs (b - value); });
+        }
+        else if (info.integer)
+        {
+            const float integerMin = std::ceil (info.minValue);
+            const float integerMax = std::floor (info.maxValue);
+            if (integerMin > integerMax) return false;
+            value = std::clamp (std::round (value), integerMin, integerMax);
+        }
+        return true;
+    }
+
     // lilv state callbacks (message thread; save/restore are fenced by the caller
     // when the instance is live, same contract as activate/deactivate).
     static const void* getPortValue (const char* symbol, void* userData,
@@ -433,7 +474,7 @@ struct Lv2Instance::Impl
         else if (type == self->uridInt    && size >= sizeof (int32_t)) v = (float) *static_cast<const int32_t*> (value);
         else if (type == self->uridLong   && size >= sizeof (int64_t)) v = (float) *static_cast<const int64_t*> (value);
         else return;
-        if (! std::isfinite (v)) return;
+        if (! self->normalizeRestoredControlValue ((size_t) idx, v)) return;
         self->portValues[(size_t) idx] = v;
         // A restore supersedes any staged UI value for this port.
         if ((size_t) idx < self->uiDirty.size())
@@ -465,16 +506,17 @@ bool Lv2Instance::create (const Lv2Bundle& bundle, const std::string& uri, std::
     LilvNode* inputClass   = lilv_new_uri (world, LV2_CORE__InputPort);
     LilvNode* atomClass    = lilv_new_uri (world, LV2_ATOM__AtomPort);
     LilvNode* latencyDesig = lilv_new_uri (world, LV2_CORE__latency);
+    const uint32_t numPorts = lilv_plugin_get_num_ports (impl->plugin);
 
     impl->audioInPorts.clear();  impl->audioOutPorts.clear();
     impl->controlPorts.clear();  impl->atomInPorts.clear(); impl->atomOutPorts.clear();
     impl->otherPorts.clear();
     impl->portIndexBySymbol.clear();
+    impl->controlRestoreInfo.assign ((size_t) numPorts, {});
     impl->uiShadow.clear();
     impl->uiDirty.clear();
     impl->latencyPortIndex = -1;
 
-    const uint32_t numPorts = lilv_plugin_get_num_ports (impl->plugin);
     for (uint32_t i = 0; i < numPorts; ++i)
     {
         const LilvPort* port = lilv_plugin_get_port_by_index (impl->plugin, i);
@@ -509,6 +551,41 @@ bool Lv2Instance::create (const Lv2Bundle& bundle, const std::string& uri, std::
             const LilvPort* port = lilv_plugin_get_port_by_index (impl->plugin, i);
             if (! lilv_port_is_a (impl->plugin, port, inputClass))
                 continue;   // output control ports (meters, lv2:latency) aren't parameters
+
+            auto& restore = impl->controlRestoreInfo[(size_t) i];
+            float defaultValue = 0.0f;
+            LilvNode* def = nullptr; LilvNode* mn = nullptr; LilvNode* mx = nullptr;
+            lilv_port_get_range (impl->plugin, port, &def, &mn, &mx);
+            if (mn  != nullptr) { restore.minValue = lilv_node_as_float (mn); lilv_node_free (mn); }
+            if (mx  != nullptr) { restore.maxValue = lilv_node_as_float (mx); lilv_node_free (mx); }
+            if (def != nullptr) { defaultValue = lilv_node_as_float (def);    lilv_node_free (def); }
+            restore.hasUsableRange = std::isfinite (restore.minValue)
+                                  && std::isfinite (restore.maxValue)
+                                  && restore.minValue < restore.maxValue;
+            restore.toggled = lilv_port_has_property (impl->plugin, port, toggledProp);
+            restore.integer = lilv_port_has_property (impl->plugin, port, integerProp);
+            restore.enumeration = lilv_port_has_property (impl->plugin, port, enumProp);
+            if (restore.enumeration)
+            {
+                if (LilvScalePoints* points = lilv_port_get_scale_points (impl->plugin, port))
+                {
+                    LILV_FOREACH (scale_points, point, points)
+                    {
+                        const auto* scalePoint = lilv_scale_points_get (points, point);
+                        const float v = lilv_node_as_float (
+                            lilv_scale_point_get_value (scalePoint));
+                        if (std::isfinite (v) && restore.hasUsableRange
+                            && v >= restore.minValue && v <= restore.maxValue)
+                            restore.scalePoints.push_back (v);
+                    }
+                    lilv_scale_points_free (points);
+                    std::sort (restore.scalePoints.begin(), restore.scalePoints.end());
+                    restore.scalePoints.erase (
+                        std::unique (restore.scalePoints.begin(), restore.scalePoints.end()),
+                        restore.scalePoints.end());
+                }
+            }
+
             // Designated ports (lv2:enabled, lv2:freeWheeling, time/transport
             // feeds) are host-managed, not user parameters; notOnGUI ports are
             // hidden by the plugin's own request. JUCE-wrapped LV2s expose ONLY
@@ -529,15 +606,11 @@ bool Lv2Instance::create (const Lv2Bundle& bundle, const std::string& uri, std::
                 p.name = lilv_node_as_string (nm);
                 lilv_node_free (nm);
             }
-            LilvNode* def = nullptr; LilvNode* mn = nullptr; LilvNode* mx = nullptr;
-            lilv_port_get_range (impl->plugin, port, &def, &mn, &mx);
-            if (mn  != nullptr) { p.minValue     = lilv_node_as_float (mn);  lilv_node_free (mn); }
-            if (mx  != nullptr) { p.maxValue     = lilv_node_as_float (mx);  lilv_node_free (mx); }
-            if (def != nullptr) { p.defaultValue = lilv_node_as_float (def); lilv_node_free (def); }
+            p.minValue = restore.minValue;
+            p.maxValue = restore.maxValue;
+            p.defaultValue = defaultValue;
             if (! (p.minValue < p.maxValue)) { p.minValue = 0.0f; p.maxValue = 1.0f; }
-            p.stepped = lilv_port_has_property (impl->plugin, port, toggledProp)
-                     || lilv_port_has_property (impl->plugin, port, integerProp)
-                     || lilv_port_has_property (impl->plugin, port, enumProp);
+            p.stepped = restore.toggled || restore.integer || restore.enumeration;
             impl->params.push_back (std::move (p));
         }
         lilv_node_free (notOnGuiProp);

--- a/src/engine/lv2/Lv2Instance.cpp
+++ b/src/engine/lv2/Lv2Instance.cpp
@@ -415,7 +415,8 @@ struct Lv2Instance::Impl
     {
         if (index >= controlRestoreInfo.size() || ! std::isfinite (value)) return false;
         const auto& info = controlRestoreInfo[index];
-        if (! info.hasUsableRange) return false;
+        if (! info.hasUsableRange)
+            return ! info.toggled && ! info.integer && ! info.enumeration;
 
         value = std::clamp (value, (double) info.minValue, (double) info.maxValue);
         if (info.toggled)
@@ -476,6 +477,7 @@ struct Lv2Instance::Impl
         else return;
         if (! self->normalizeRestoredControlValue ((size_t) idx, v)) return;
         const auto restoredValue = (float) v;
+        if (! std::isfinite (restoredValue)) return;
         self->portValues[(size_t) idx] = restoredValue;
         // A restore supersedes any staged UI value for this port.
         if ((size_t) idx < self->uiDirty.size())

--- a/tests/fixtures/file_state_lv2.cpp
+++ b/tests/fixtures/file_state_lv2.cpp
@@ -13,6 +13,7 @@
 namespace
 {
 constexpr const char* kPluginUri = "urn:duskstudio:test:file-state";
+constexpr const char* kControlPluginUri = "urn:duskstudio:test:control-state";
 constexpr const char* kPathKey = "urn:duskstudio:test:file-state#path";
 constexpr const char* kPayload = "dusk-lv2-file-state-v1";
 constexpr const char* kRestorePayload = "dusk-lv2-restore-make-path-v1";
@@ -182,14 +183,21 @@ const void* extensionData (const char* uri)
     return std::strcmp (uri, LV2_STATE__interface) == 0 ? &stateInterface : nullptr;
 }
 
-const LV2_Descriptor descriptor {
+const LV2_Descriptor fileStateDescriptor {
     kPluginUri, &instantiate, &connectPort, nullptr, &run, nullptr, &cleanup,
     &extensionData
+};
+
+const LV2_Descriptor controlStateDescriptor {
+    kControlPluginUri, &instantiate, &connectPort, nullptr, &run, nullptr, &cleanup,
+    nullptr
 };
 }
 
 extern "C" LV2_SYMBOL_EXPORT
 const LV2_Descriptor* lv2_descriptor (uint32_t index)
 {
-    return index == 0 ? &descriptor : nullptr;
+    if (index == 0) return &fileStateDescriptor;
+    if (index == 1) return &controlStateDescriptor;
+    return nullptr;
 }

--- a/tests/fixtures/file_state_lv2.cpp
+++ b/tests/fixtures/file_state_lv2.cpp
@@ -70,6 +70,13 @@ void connectPort (LV2_Handle instance, uint32_t port, void* data)
     }
 }
 
+void connectControlPort (LV2_Handle instance, uint32_t port, void* data)
+{
+    // The control-state descriptor shares the audio and gain ports only. Its
+    // ports 5-8 are controls, not the Atom ports used by the file-state plugin.
+    if (port <= 4) connectPort (instance, port, data);
+}
+
 void run (LV2_Handle instance, uint32_t frames)
 {
     auto& self = *static_cast<Instance*> (instance);
@@ -189,7 +196,7 @@ const LV2_Descriptor fileStateDescriptor {
 };
 
 const LV2_Descriptor controlStateDescriptor {
-    kControlPluginUri, &instantiate, &connectPort, nullptr, &run, nullptr, &cleanup,
+    kControlPluginUri, &instantiate, &connectControlPort, nullptr, &run, nullptr, &cleanup,
     nullptr
 };
 }

--- a/tests/fixtures/file_state_manifest.ttl
+++ b/tests/fixtures/file_state_manifest.ttl
@@ -5,3 +5,8 @@
     a lv2:Plugin ;
     lv2:binary <file_state_fixture.so> ;
     rdfs:seeAlso <file_state_plugin.ttl> .
+
+<urn:duskstudio:test:control-state>
+    a lv2:Plugin ;
+    lv2:binary <file_state_fixture.so> ;
+    rdfs:seeAlso <file_state_plugin.ttl> .

--- a/tests/fixtures/file_state_plugin.ttl
+++ b/tests/fixtures/file_state_plugin.ttl
@@ -1,5 +1,6 @@
 @prefix atom:  <http://lv2plug.in/ns/ext/atom#> .
 @prefix patch: <http://lv2plug.in/ns/ext/patch#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix doap:  <http://usefulinc.com/ns/doap#> .
 @prefix lv2:   <http://lv2plug.in/ns/lv2core#> .
@@ -118,3 +119,40 @@
           lv2:index 6 ; lv2:symbol "control_out" ; lv2:name "Control Out" ;
           lv2:designation lv2:control ;
           atom:bufferType atom:Sequence ; atom:supports patch:Message ] .
+
+# No state:interface: Lilv serializes these control values solely through the
+# host callbacks, making this a small fixture for malformed preset values.
+<urn:duskstudio:test:control-state>
+    a lv2:Plugin ;
+    doap:name "Dusk control-state fixture" ;
+    lv2:requiredFeature urid:map ;
+    lv2:port
+        [ a lv2:InputPort, lv2:AudioPort ;
+          lv2:index 0 ; lv2:symbol "in_l" ; lv2:name "Input L" ],
+        [ a lv2:InputPort, lv2:AudioPort ;
+          lv2:index 1 ; lv2:symbol "in_r" ; lv2:name "Input R" ],
+        [ a lv2:OutputPort, lv2:AudioPort ;
+          lv2:index 2 ; lv2:symbol "out_l" ; lv2:name "Output L" ],
+        [ a lv2:OutputPort, lv2:AudioPort ;
+          lv2:index 3 ; lv2:symbol "out_r" ; lv2:name "Output R" ],
+        [ a lv2:InputPort, lv2:ControlPort ;
+          lv2:index 4 ; lv2:symbol "gain" ; lv2:name "Gain" ;
+          lv2:minimum 0.0 ; lv2:maximum 1.0 ; lv2:default 0.25 ],
+        [ a lv2:InputPort, lv2:ControlPort ;
+          lv2:index 5 ; lv2:symbol "toggle" ; lv2:name "Toggle" ;
+          lv2:minimum 0.0 ; lv2:maximum 1.0 ; lv2:default 0.0 ;
+          lv2:portProperty lv2:toggled ],
+        [ a lv2:InputPort, lv2:ControlPort ;
+          lv2:index 6 ; lv2:symbol "integer" ; lv2:name "Integer" ;
+          lv2:minimum -5.0 ; lv2:maximum 5.0 ; lv2:default 0.0 ;
+          lv2:portProperty lv2:integer ],
+        [ a lv2:InputPort, lv2:ControlPort ;
+          lv2:index 7 ; lv2:symbol "enumeration" ; lv2:name "Enumeration" ;
+          lv2:minimum 0.0 ; lv2:maximum 4.0 ; lv2:default 2.0 ;
+          lv2:portProperty lv2:enumeration ;
+          lv2:scalePoint [ rdfs:label "Low" ; rdf:value 0.0 ] ,
+                         [ rdfs:label "Middle" ; rdf:value 2.0 ] ,
+                         [ rdfs:label "High" ; rdf:value 4.0 ] ],
+        [ a lv2:InputPort, lv2:ControlPort ;
+          lv2:index 8 ; lv2:symbol "unbounded" ; lv2:name "Unbounded" ;
+          lv2:default 0.25 ] .

--- a/tests/lv2_file_state.cpp
+++ b/tests/lv2_file_state.cpp
@@ -299,7 +299,7 @@ TEST_CASE ("LV2 control-state restore rejects or normalizes corrupt values",
     SECTION ("finite values clamp and discrete ports normalize")
     {
         auto corruptState = cleanState;
-        REQUIRE (replacePortValue (corruptState, { "gain", "\"1e38\"^^xsd:double" }));
+        REQUIRE (replacePortValue (corruptState, { "gain", "\"1e100\"^^xsd:double" }));
         REQUIRE (replacePortValue (corruptState, { "toggle", "\"0.25\"^^xsd:float" }));
         REQUIRE (replacePortValue (corruptState, { "integer", "\"3.6\"^^xsd:float" }));
         REQUIRE (replacePortValue (corruptState, { "enumeration", "\"3.6\"^^xsd:float" }));

--- a/tests/lv2_file_state.cpp
+++ b/tests/lv2_file_state.cpp
@@ -10,6 +10,7 @@
 
 #include <filesystem>
 #include <algorithm>
+#include <cmath>
 #include <cstring>
 #include <fstream>
 #include <iterator>
@@ -21,6 +22,7 @@ namespace
 {
 namespace fs = std::filesystem;
 constexpr const char* kPluginUri = "urn:duskstudio:test:file-state";
+constexpr const char* kControlPluginUri = "urn:duskstudio:test:control-state";
 constexpr const char* kPayload = "dusk-lv2-file-state-v1";
 constexpr const char* kRestorePayload = "dusk-lv2-restore-make-path-v1";
 
@@ -31,6 +33,58 @@ std::string readFile (const fs::path& path)
     std::ifstream input (path, std::ios::binary);
     return { std::istreambuf_iterator<char> (input),
              std::istreambuf_iterator<char>() };
+}
+
+struct PortValueMutation
+{
+    std::string symbol;
+    std::string replacement;
+};
+
+bool replacePortValue (std::vector<uint8_t>& blob, const PortValueMutation& mutation)
+{
+    std::string state (blob.begin(), blob.end());
+    std::string symbolMarker = "lv2:symbol \"";
+    symbolMarker.append (mutation.symbol).append ("\"");
+    const auto symbolPos = state.find (symbolMarker);
+    if (symbolPos == std::string::npos) return false;
+    const std::string valueMarker = "pset:value ";
+    const auto markerPos = state.find (valueMarker, symbolPos);
+    if (markerPos == std::string::npos) return false;
+    const auto valueBegin = markerPos + valueMarker.size();
+    const auto valueEnd = state.find_first_of (" \t\r\n;]", valueBegin);
+    if (valueEnd == std::string::npos) return false;
+    state.replace (valueBegin, valueEnd - valueBegin, mutation.replacement);
+    blob.assign (state.begin(), state.end());
+    return true;
+}
+
+const duskstudio::lv2::Lv2Instance::ParamInfo* findParam (
+    const duskstudio::lv2::Lv2Instance& instance, const std::string& name)
+{
+    for (int i = 0; i < instance.paramCount(); ++i)
+        if (const auto* param = instance.paramInfo (i);
+            param != nullptr && param->name == name)
+            return param;
+    return nullptr;
+}
+
+double paramValue (const duskstudio::lv2::Lv2Instance& instance,
+                   const std::string& name)
+{
+    const auto* param = findParam (instance, name);
+    if (param == nullptr)
+    {
+        std::string message = "missing LV2 parameter: ";
+        throw std::runtime_error (message.append (name));
+    }
+    double value = 0.0;
+    if (! instance.getParamValue (param->id, value))
+    {
+        std::string message = "unreadable LV2 parameter: ";
+        throw std::runtime_error (message.append (name));
+    }
+    return value;
 }
 
 void requireRestoredAudio (duskstudio::lv2::Lv2Instance& instance)
@@ -227,6 +281,73 @@ TEST_CASE ("LV2 patch parameters are exposed in a stable order",
     std::sort (sorted.begin(), sorted.end());
     REQUIRE (names.size() == 12);
     REQUIRE (names == sorted);
+}
+
+TEST_CASE ("LV2 control-state restore rejects or normalizes corrupt values",
+           "[lv2][state][regression][issue-387]")
+{
+    duskstudio::lv2::Lv2Bundle bundle;
+    std::string error;
+    REQUIRE (bundle.load (DUSKSTUDIO_FILE_STATE_LV2_FIXTURE_PATH, error));
+
+    duskstudio::lv2::Lv2Instance source;
+    REQUIRE (source.create (bundle, kControlPluginUri, error));
+    REQUIRE (source.activate (48000.0, 32, error));
+    std::vector<uint8_t> cleanState;
+    REQUIRE (source.saveState (cleanState));
+
+    SECTION ("finite values clamp and discrete ports normalize")
+    {
+        auto corruptState = cleanState;
+        REQUIRE (replacePortValue (corruptState, { "gain", "\"1e38\"^^xsd:double" }));
+        REQUIRE (replacePortValue (corruptState, { "toggle", "\"0.25\"^^xsd:float" }));
+        REQUIRE (replacePortValue (corruptState, { "integer", "\"3.6\"^^xsd:float" }));
+        REQUIRE (replacePortValue (corruptState, { "enumeration", "\"3.6\"^^xsd:float" }));
+        REQUIRE (replacePortValue (corruptState, { "unbounded", "\"1e38\"^^xsd:double" }));
+
+        duskstudio::lv2::Lv2Instance restored;
+        REQUIRE (restored.create (bundle, kControlPluginUri, error));
+        REQUIRE (restored.activate (48000.0, 32, error));
+        REQUIRE (restored.loadState (corruptState));
+        CHECK_THAT (paramValue (restored, "Gain"),
+                    Catch::Matchers::WithinAbs (1.0, 1.0e-7));
+        CHECK_THAT (paramValue (restored, "Toggle"),
+                    Catch::Matchers::WithinAbs (1.0, 1.0e-7));
+        CHECK_THAT (paramValue (restored, "Integer"),
+                    Catch::Matchers::WithinAbs (4.0, 1.0e-7));
+        CHECK_THAT (paramValue (restored, "Enumeration"),
+                    Catch::Matchers::WithinAbs (4.0, 1.0e-7));
+        // With no advertised min/max there is no safe basis for clamping, so
+        // the callback rejects the state value and preserves the port default.
+        CHECK_THAT (paramValue (restored, "Unbounded"),
+                    Catch::Matchers::WithinAbs (0.25, 1.0e-7));
+    }
+
+    SECTION ("NaN and infinity cannot publish a non-finite or out-of-range value")
+    {
+        duskstudio::lv2::Lv2Instance restored;
+        REQUIRE (restored.create (bundle, kControlPluginUri, error));
+        REQUIRE (restored.activate (48000.0, 32, error));
+        const auto* gain = findParam (restored, "Gain");
+        REQUIRE (gain != nullptr);
+        restored.setParamValue (gain->id, 0.75);
+
+        auto nanState = cleanState;
+        REQUIRE (replacePortValue (nanState, { "gain", "\"NaN\"^^xsd:float" }));
+        REQUIRE (restored.loadState (nanState));
+        const double afterNan = paramValue (restored, "Gain");
+        CHECK (std::isfinite (afterNan));
+        CHECK (afterNan >= 0.0);
+        CHECK (afterNan <= 1.0);
+
+        auto infinityState = cleanState;
+        REQUIRE (replacePortValue (infinityState, { "gain", "\"INF\"^^xsd:float" }));
+        REQUIRE (restored.loadState (infinityState));
+        const double afterInfinity = paramValue (restored, "Gain");
+        CHECK (std::isfinite (afterInfinity));
+        CHECK (afterInfinity >= 0.0);
+        CHECK (afterInfinity <= 1.0);
+    }
 }
 
 TEST_CASE ("LV2 editor events carry current control and patch values",

--- a/tests/lv2_file_state.cpp
+++ b/tests/lv2_file_state.cpp
@@ -296,14 +296,13 @@ TEST_CASE ("LV2 control-state restore rejects or normalizes corrupt values",
     std::vector<uint8_t> cleanState;
     REQUIRE (source.saveState (cleanState));
 
-    SECTION ("finite values clamp and discrete ports normalize")
+    SECTION ("finite bounded values clamp and discrete ports normalize")
     {
         auto corruptState = cleanState;
         REQUIRE (replacePortValue (corruptState, { "gain", "\"1e100\"^^xsd:double" }));
         REQUIRE (replacePortValue (corruptState, { "toggle", "\"0.25\"^^xsd:float" }));
         REQUIRE (replacePortValue (corruptState, { "integer", "\"3.6\"^^xsd:float" }));
         REQUIRE (replacePortValue (corruptState, { "enumeration", "\"3.6\"^^xsd:float" }));
-        REQUIRE (replacePortValue (corruptState, { "unbounded", "\"1e38\"^^xsd:double" }));
 
         duskstudio::lv2::Lv2Instance restored;
         REQUIRE (restored.create (bundle, kControlPluginUri, error));
@@ -317,10 +316,22 @@ TEST_CASE ("LV2 control-state restore rejects or normalizes corrupt values",
                     Catch::Matchers::WithinAbs (4.0, 1.0e-7));
         CHECK_THAT (paramValue (restored, "Enumeration"),
                     Catch::Matchers::WithinAbs (4.0, 1.0e-7));
-        // With no advertised min/max there is no safe basis for clamping, so
-        // the callback rejects the state value and preserves the port default.
+    }
+
+    SECTION ("finite unbounded values survive save and restore")
+    {
+        const auto* unbounded = findParam (source, "Unbounded");
+        REQUIRE (unbounded != nullptr);
+        source.setParamValue (unbounded->id, 0.75);
+        std::vector<uint8_t> unboundedState;
+        REQUIRE (source.saveState (unboundedState));
+
+        duskstudio::lv2::Lv2Instance restored;
+        REQUIRE (restored.create (bundle, kControlPluginUri, error));
+        REQUIRE (restored.activate (48000.0, 32, error));
+        REQUIRE (restored.loadState (unboundedState));
         CHECK_THAT (paramValue (restored, "Unbounded"),
-                    Catch::Matchers::WithinAbs (0.25, 1.0e-7));
+                    Catch::Matchers::WithinAbs (0.75, 1.0e-7));
     }
 
     SECTION ("NaN and infinity cannot publish a non-finite or out-of-range value")


### PR DESCRIPTION
Closes #387

## Summary
- snapshot every input control port's advertised restore metadata, including hidden/designated ports
- clamp bounded finite values in double precision and normalize toggled, integer, and enumerated ports
- restore finite, float-representable unbounded continuous controls while rejecting non-finite or invalid values
- isolate the control-state fixture's port wiring so control ports cannot be treated as Atom buffers
- add malformed-state and unbounded save/restore regression coverage
- update the README Catch2 count required by the release contract

## Validation
- exact commit: `9c349152486ec11f3b205f9c9448a8e1db35d253`
- Linux `[issue-387]`: 42 assertions in 1 case
- Linux `[lv2]`: 1,238 assertions in 36 cases
- Linux full CTest: 877/877; native CLAP state harness passed
- macOS full CTest: 844/844; stock AU 492 assertions in 5 cases; native CLAP state harness passed
- Windows full CTest: 838/838; ASIO verified; live VST3 state (269 + 5 assertions) and native CLAP state harnesses passed
- macOS and Windows do not build native LV2 in the current validation caches, so `[issue-387]` is Linux-only
- `review-local --base origin/main`: incomplete (exit 2) because the local model endpoint was unavailable; not treated as a pass

No frontier review was run.
