### PR TITLE
ci: run ASan and UBSan in CI

### DIFF
--- a/.github/workflows/linux-sanitizer.yml
+++ b/.github/workflows/linux-sanitizer.yml
@@ -1,10 +1,10 @@
-name: Linux sanitizer (TSan)
+name: Linux sanitizers
 
-# Validates the lock-free atomic / SPSC FIFO / message-thread-only
-# discipline in the engine (CLAUDE.md "Audio thread rules") by running
-# the Catch2 test binary under ThreadSanitizer. Runs on every PR + push
-# to main so a regression in the engine's RT-safety contract trips CI
-# rather than landing silently.
+# Runs the Catch2 inventory under complementary sanitizer runtimes:
+# ThreadSanitizer covers the engine's lock-free and message-thread rules,
+# while AddressSanitizer + UndefinedBehaviorSanitizer cover lifetime, bounds,
+# and invalid-value defects. They use separate jobs because their shadow-memory
+# runtimes cannot coexist in one process.
 
 on:
   push:
@@ -20,6 +20,10 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  # Both sanitizer jobs must compile the same donor snapshot.
+  DONOR_REV: 0a1b17f8e9dbecd26bf78dd45704c6c149e4b2ea
 
 jobs:
   tsan-tests:
@@ -116,7 +120,6 @@ jobs:
         # clone breaks configure. Bump every workflow's DONOR_REV together.
         env:
           DONOR_REPO: https://github.com/dusk-audio/dusk-audio-plugins.git
-          DONOR_REV: 0a1b17f8e9dbecd26bf78dd45704c6c149e4b2ea
         run: |
           set -euo pipefail
           git init -q "${RUNNER_TEMP}/plugins-main"
@@ -163,6 +166,125 @@ jobs:
         run: |
           ctest --test-dir build-tsan --output-on-failure \
                 -E "VCA detector mode toggle is a no-op|FET has no GR-driven sub-bass HPF"
+
+      - name: ccache stats
+        if: always()
+        run: ccache -s
+
+  asan-ubsan-tests:
+    name: Catch2 tests (ASan + UBSan, Ubuntu 22.04)
+    runs-on: ubuntu-22.04
+
+    env:
+      # LeakSanitizer stays enabled for the general suite. The five tests that
+      # deliberately park live allocations for shutdown safety are rerun in a
+      # separate step with leak detection disabled only for those processes.
+      ASAN_OPTIONS: "halt_on_error=1:abort_on_error=1:detect_leaks=1:symbolize=1"
+      UBSAN_OPTIONS: "halt_on_error=1:abort_on_error=1:print_stacktrace=1"
+      ASAN_SYMBOLIZER_PATH: /usr/bin/llvm-symbolizer
+
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_MAXSIZE: 500M
+
+    steps:
+      - name: Checkout Dusk Studio
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Install Linux build deps
+        uses: ./.github/actions/apt-deps
+        with:
+          packages: >-
+            build-essential cmake ninja-build pkg-config ccache
+            llvm
+            libasound2-dev libjack-jackd2-dev libmp3lame-dev libsndfile1-dev libsodium-dev
+            libpipewire-0.3-dev
+            liblilv-dev libsuil-dev lv2-dev
+            ladspa-sdk
+            libcurl4-openssl-dev libfreetype-dev libfontconfig1-dev
+            libx11-dev libxcomposite-dev libxcursor-dev libxext-dev
+            libxinerama-dev libxrandr-dev libxrender-dev libxss-dev
+            libwebkit2gtk-4.0-dev libgl1-mesa-dev libglu1-mesa-dev xvfb
+            libwayland-dev libxkbcommon-dev libdecor-0-dev
+
+      - name: Cache ccache objects
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-linux-asan-ubsan-${{ github.sha }}
+          restore-keys: |
+            ccache-linux-asan-ubsan-
+
+      - name: Clone JUCE (Dusk-owned Wayland mirror, pinned)
+        env:
+          JUCE_MIRROR: https://github.com/dusk-audio/JUCE-wayland.git
+          JUCE_TAG: dusk-wayland-v2
+          JUCE_REV: 4d85afa175a45e0b5da11f9211de3ba88705588e
+        run: |
+          set -euo pipefail
+          git init -q "${RUNNER_TEMP}/JUCE-wayland"
+          cd "${RUNNER_TEMP}/JUCE-wayland"
+          git remote add origin "${JUCE_MIRROR}"
+          git fetch --depth 1 origin "refs/tags/${JUCE_TAG}"
+          git checkout -q FETCH_HEAD
+          [[ "$(git rev-parse HEAD)" == "${JUCE_REV}" ]] || {
+            echo "ERROR: JUCE checkout $(git rev-parse HEAD) != pinned ${JUCE_REV}" >&2; exit 1; }
+          grep -q "SIMDNativeOps<long long>" \
+            modules/juce_dsp/native/juce_SIMDNativeOps_sse.h || {
+            echo "ERROR: pinned JUCE missing the SIMDNativeOps<long long> alias." >&2; exit 1; }
+
+      - name: Clone Dusk plugins (donor DSP, pinned)
+        env:
+          DONOR_REPO: https://github.com/dusk-audio/dusk-audio-plugins.git
+        run: |
+          set -euo pipefail
+          git init -q "${RUNNER_TEMP}/plugins-main"
+          cd "${RUNNER_TEMP}/plugins-main"
+          git remote add origin "${DONOR_REPO}"
+          git fetch --depth 1 origin "${DONOR_REV}"
+          git checkout -q "${DONOR_REV}"
+          [[ "$(git rev-parse HEAD)" == "${DONOR_REV}" ]] || {
+            echo "ERROR: donor checkout $(git rev-parse HEAD) != pinned ${DONOR_REV}" >&2; exit 1; }
+
+      - name: Clone DAF stack (dusk-audio forks, pinned)
+        uses: ./.github/actions/clone-daf-stack
+
+      - name: Configure tests (ASan + UBSan, RelWithDebInfo)
+        run: |
+          cmake -S . -B build-asan -G Ninja \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DDUSKSTUDIO_BUILD_TESTS=ON \
+            -DDUSKSTUDIO_ENABLE_ASAN=ON \
+            -DDUSKSTUDIO_SKIP_FORK_CHECK=ON \
+            -DDUSKSTUDIO_REQUIRE_NATIVE_LV2=ON \
+            -DDUSKSTUDIO_REQUIRE_PIPEWIRE=ON \
+            -DJUCE_PATH="${RUNNER_TEMP}/JUCE-wayland" \
+            -DDUSK_PLUGINS_PATH="${RUNNER_TEMP}/plugins-main" \
+            -DDAF_PATH="${RUNNER_TEMP}/DAF" \
+            -DDAF_WIDGETS_PATH="${RUNNER_TEMP}/DAF-Widgets"
+
+      - name: Build tests (ASan + UBSan)
+        run: cmake --build build-asan --target dusk-studio-tests -j6
+
+      - name: Run suite with LeakSanitizer enabled
+        # These are the only tests whose contract intentionally retains a live
+        # allocation after exit: NativeInsertSlot parks an instance whose
+        # shutdown cannot be trusted, ALSA parks a device still referenced by a
+        # detached formerly wedged I/O thread, and the three TapeMachine donor
+        # parity cases keep JUCE's message-loop initialiser alive so its timer
+        # cannot race teardown. Every other test runs with leak detection on.
+        run: |
+          ctest --test-dir build-asan --output-on-failure \
+            -E '^(NativeInsertSlot bumps its generation on every identity change|AlsaAudioIODevice: wedged I/O thread leaks the device, never frees it|TapeMachineDSP nulls against the JUCE donor at 1x|TapeMachineDSP tracks the JUCE donor within tolerance at 2x and 4x|TapeMachineDSP latency is stable per oversampling factor)$'
+
+      - name: Run leak-for-safety tests under ASan + UBSan
+        env:
+          ASAN_OPTIONS: "halt_on_error=1:abort_on_error=1:detect_leaks=0:symbolize=1"
+        run: |
+          ctest --test-dir build-asan --output-on-failure \
+            -R '^(NativeInsertSlot bumps its generation on every identity change|AlsaAudioIODevice: wedged I/O thread leaks the device, never frees it|TapeMachineDSP nulls against the JUCE donor at 1x|TapeMachineDSP tracks the JUCE donor within tolerance at 2x and 4x|TapeMachineDSP latency is stable per oversampling factor)$'
 
       - name: ccache stats
         if: always()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1567,10 +1567,8 @@ endif()
 # AddressSanitizer + UBSan. Off by default; opt-in via
 # -DDUSKSTUDIO_ENABLE_ASAN=ON. Applied build-wide (directory-level options)
 # because sanitizer-instrumented code can't link against
-# non-instrumented code without symbol-resolution drama. Local-only: the
-# sanitizer workflow in CI runs TSan, so an ASAN pass over the test binary
-# (heap corruption / use-after-free / undefined behaviour) is something you
-# run by hand before a release.
+# non-instrumented code without symbol-resolution drama. CI runs this in a
+# separate job from TSan over the Catch2 inventory.
 # Not for production builds — overhead is ~2× CPU and ~3× memory.
 option(DUSKSTUDIO_ENABLE_ASAN "Enable AddressSanitizer + UBSan" OFF)
 

--- a/tests/plugin_state_diagnostics.cpp
+++ b/tests/plugin_state_diagnostics.cpp
@@ -157,7 +157,7 @@ TEST_CASE ("aux replacement fallback requires the exact native state owner",
 
     duskstudio::Session session;
     auto& lane = session.auxLane (1);
-    constexpr size_t slot = 2;
+    constexpr size_t slot = 0;
     lane.nativeVst3Path[slot] = "/plugins/Delay.vst3";
     lane.nativeVst3PluginId[slot] = "com.dusk.delay";
 

--- a/tests/release_mechanics.sh
+++ b/tests/release_mechanics.sh
@@ -771,17 +771,20 @@ assert all(pins == [pinned_donor.group(1)] for pins in donor_pins.values()), (
 sanitizer_workflow = (
     source_root / ".github" / "workflows" / "linux-sanitizer.yml"
 ).read_text(encoding="utf-8")
+intentional_leak_tests = (
+    "NativeInsertSlot bumps its generation on every identity change",
+    "AlsaAudioIODevice: wedged I/O thread leaks the device, never frees it",
+    "TapeMachineDSP nulls against the JUCE donor at 1x",
+    "TapeMachineDSP tracks the JUCE donor within tolerance at 2x and 4x",
+    "TapeMachineDSP latency is stable per oversampling factor",
+)
 for required in (
     "asan-ubsan-tests:",
     "DUSKSTUDIO_ENABLE_ASAN=ON",
     "ASAN_SYMBOLIZER_PATH: /usr/bin/llvm-symbolizer",
     "halt_on_error=1:abort_on_error=1:detect_leaks=1:symbolize=1",
     "halt_on_error=1:abort_on_error=1:print_stacktrace=1",
-    "NativeInsertSlot bumps its generation on every identity change",
-    "AlsaAudioIODevice: wedged I/O thread leaks the device, never frees it",
-    "TapeMachineDSP nulls against the JUCE donor at 1x",
-    "TapeMachineDSP tracks the JUCE donor within tolerance at 2x and 4x",
-    "TapeMachineDSP latency is stable per oversampling factor",
+    *intentional_leak_tests,
     "detect_leaks=0",
 ):
     assert required in sanitizer_workflow, (
@@ -789,6 +792,11 @@ for required in (
     )
 assert sanitizer_workflow.count("detect_leaks=0") == 1, (
     "LeakSanitizer may be disabled only for the dedicated leak-for-safety rerun"
+)
+intentional_leak_filter = f"'^({'|'.join(intentional_leak_tests)})$'"
+assert sanitizer_workflow.count(intentional_leak_filter) == 2, (
+    "LeakSanitizer's exclude and rerun filters must contain exactly the five "
+    "documented intentional-leak tests"
 )
 
 # Source-built libsodium must come from the release asset hosted alongside the

--- a/tests/release_mechanics.sh
+++ b/tests/release_mechanics.sh
@@ -771,6 +771,12 @@ assert all(pins == [pinned_donor.group(1)] for pins in donor_pins.values()), (
 sanitizer_workflow = (
     source_root / ".github" / "workflows" / "linux-sanitizer.yml"
 ).read_text(encoding="utf-8")
+asan_job_match = re.search(
+    r"(?ms)^  asan-ubsan-tests:\n(?P<body>.*?)(?=^  [a-z0-9-]+:\n|\Z)",
+    sanitizer_workflow,
+)
+assert asan_job_match, "linux-sanitizer.yml lost its asan-ubsan-tests job"
+asan_job = asan_job_match.group("body")
 intentional_leak_tests = (
     "NativeInsertSlot bumps its generation on every identity change",
     "AlsaAudioIODevice: wedged I/O thread leaks the device, never frees it",
@@ -779,24 +785,42 @@ intentional_leak_tests = (
     "TapeMachineDSP latency is stable per oversampling factor",
 )
 for required in (
-    "asan-ubsan-tests:",
     "DUSKSTUDIO_ENABLE_ASAN=ON",
     "ASAN_SYMBOLIZER_PATH: /usr/bin/llvm-symbolizer",
     "halt_on_error=1:abort_on_error=1:detect_leaks=1:symbolize=1",
     "halt_on_error=1:abort_on_error=1:print_stacktrace=1",
-    *intentional_leak_tests,
-    "detect_leaks=0",
 ):
-    assert required in sanitizer_workflow, (
-        f"linux-sanitizer.yml lost ASan/UBSan coverage: {required}"
+    assert required in asan_job, (
+        f"linux-sanitizer.yml ASan/UBSan job lost coverage: {required}"
     )
-assert sanitizer_workflow.count("detect_leaks=0") == 1, (
-    "LeakSanitizer may be disabled only for the dedicated leak-for-safety rerun"
-)
 intentional_leak_filter = f"'^({'|'.join(intentional_leak_tests)})$'"
-assert sanitizer_workflow.count(intentional_leak_filter) == 2, (
-    "LeakSanitizer's exclude and rerun filters must contain exactly the five "
-    "documented intentional-leak tests"
+
+def workflow_step(job, name):
+    match = re.search(
+        rf"(?ms)^      - name: {re.escape(name)}\n(?P<body>.*?)(?=^      - name: |\Z)",
+        job,
+    )
+    assert match, f"linux-sanitizer.yml lost step: {name}"
+    return match.group("body")
+
+leak_enabled_step = workflow_step(
+    asan_job, "Run suite with LeakSanitizer enabled"
+)
+assert f"-E {intentional_leak_filter}" in leak_enabled_step, (
+    "LeakSanitizer-enabled CTest must exclude exactly the five documented tests"
+)
+assert "detect_leaks=0" not in leak_enabled_step, (
+    "LeakSanitizer-enabled CTest must not disable leak detection"
+)
+
+intentional_leak_step = workflow_step(
+    asan_job, "Run leak-for-safety tests under ASan + UBSan"
+)
+assert "detect_leaks=0" in intentional_leak_step, (
+    "the intentional-leak rerun must disable LeakSanitizer"
+)
+assert f"-R {intentional_leak_filter}" in intentional_leak_step, (
+    "the leak-disabled CTest must rerun exactly the five documented tests"
 )
 
 # Source-built libsodium must come from the release asset hosted alongside the

--- a/tests/release_mechanics.sh
+++ b/tests/release_mechanics.sh
@@ -768,6 +768,29 @@ assert all(pins == [pinned_donor.group(1)] for pins in donor_pins.values()), (
     f"DONOR_REV drift across workflows: {donor_pins}"
 )
 
+sanitizer_workflow = (
+    source_root / ".github" / "workflows" / "linux-sanitizer.yml"
+).read_text(encoding="utf-8")
+for required in (
+    "asan-ubsan-tests:",
+    "DUSKSTUDIO_ENABLE_ASAN=ON",
+    "ASAN_SYMBOLIZER_PATH: /usr/bin/llvm-symbolizer",
+    "halt_on_error=1:abort_on_error=1:detect_leaks=1:symbolize=1",
+    "halt_on_error=1:abort_on_error=1:print_stacktrace=1",
+    "NativeInsertSlot bumps its generation on every identity change",
+    "AlsaAudioIODevice: wedged I/O thread leaks the device, never frees it",
+    "TapeMachineDSP nulls against the JUCE donor at 1x",
+    "TapeMachineDSP tracks the JUCE donor within tolerance at 2x and 4x",
+    "TapeMachineDSP latency is stable per oversampling factor",
+    "detect_leaks=0",
+):
+    assert required in sanitizer_workflow, (
+        f"linux-sanitizer.yml lost ASan/UBSan coverage: {required}"
+    )
+assert sanitizer_workflow.count("detect_leaks=0") == 1, (
+    "LeakSanitizer may be disabled only for the dedicated leak-for-safety rerun"
+)
+
 # Source-built libsodium must come from the release asset hosted alongside the
 # upstream repository. download.libsodium.org has repeatedly failed DNS lookup
 # on GitHub's macOS runners. Keep all static-build workflows on one audited


### PR DESCRIPTION
Closes #384

## Summary
- add a dedicated ASan + UBSan Catch2 job alongside TSan
- keep LeakSanitizer enabled for 872 tests and narrowly rerun five documented intentional-leak tests with leak detection disabled
- add a release-mechanics contract so sanitizer coverage and the narrow exception list cannot silently disappear

## Validation
- fresh RelWithDebInfo ASan+UBSan configure and build
- 872/872 tests passed with LeakSanitizer enabled
- 5/5 intentional-leak tests passed with ASan+UBSan enabled and only LeakSanitizer disabled
- release-mechanics contract
- actionlint
- git diff --check

The free local model review was attempted but incomplete because its endpoint was unreachable. No frontier review was run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded Linux continuous integration coverage with AddressSanitizer, UndefinedBehaviorSanitizer, and ThreadSanitizer checks.
  * Added leak-detection validation, including dedicated handling for tests with intentional live allocations.
  * Added safeguards to verify that sanitizer coverage and runtime settings remain enabled.

* **Documentation**
  * Updated build guidance to reflect the separate sanitizer checks performed in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->