### PR TITLE
ci: restore FileImporter coverage on Windows

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -275,11 +275,9 @@ jobs:
           }
 
       - name: Build + run tests (release gate)
-        # No MSI ships unless the suite passes on MSVC. FileImporter cases are
-        # excluded here only: they're filesystem-timing-flaky on the GitHub
-        # runner (Defender + CI disk lock the just-written temp WAV); a release
-        # gate must be deterministic. They still gate on Linux/macOS, and
-        # importAudio retries both file opens to harden real imports.
+        # No MSI ships unless the full suite passes on MSVC. Keep an explicit
+        # FileImporter inventory so conversion and bounded-lock coverage cannot
+        # silently disappear from the release gate.
         shell: bash
         run: |
           # Forward slashes for DAF's cmake - see windows-tests.yml.
@@ -301,7 +299,23 @@ jobs:
               echo "::error::${option} was not enabled in the test configure" >&2; exit 1; }
           done
           cmake --build build-tests --config Release --target dusk-studio-tests -j4
-          ctest --test-dir build-tests --output-on-failure -C Release -E "FileImporter"
+          inventory="$(ctest --test-dir build-tests -N -C Release)"
+          printf '%s\n' "$inventory"
+          for required in \
+            "FileImporter: transient file locks retry but remain bounded" \
+            "FileImporter: 44.1k mono -> 48k session preserves length" \
+            "FileImporter: 44.1k -> 48k upsample fills the tail with audio, not a held sample" \
+            "FileImporter: 96k mono -> 48k session preserves length" \
+            "FileImporter: stereo -> mono sums L+R at 0.5 each" \
+            "FileImporter: mono -> stereo duplicates to L and R" \
+            "FileImporter: matching rate and channels copies the source verbatim" \
+            "FileImporter: a matching 32-bit source is not truncated to 24-bit"; do
+            grep -Fq "$required" <<< "$inventory" || {
+              echo "::error::required release FileImporter regression missing from CTest: $required" >&2
+              exit 1
+            }
+          done
+          ctest --test-dir build-tests --output-on-failure -C Release
 
       - name: Set up WiX Toolset v3 (CPack -G WIX needs candle/light)
         # GitHub's windows runner image migration (windows-latest ->

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -159,15 +159,9 @@ jobs:
         run: cmake --build build-tests --config Release --target dusk_native_ui -j4
 
       - name: Run tests
-        # Full Catch2 suite on MSVC, minus the FileImporter cases. Those write
-        # a temp WAV and immediately re-open it; on the GitHub windows-latest
-        # runner the Defender real-time scan + slow CI disk intermittently lock
-        # the just-written file, so the open races and the import reports
-        # failure (the timing differs run-to-run, so it's non-deterministic).
-        # importAudio retries both opens to harden real imports, but a release
-        # gate must be deterministic, so these filesystem-timing tests don't
-        # gate Windows here; they still gate on Linux/macOS where they're
-        # stable. Drop the -E to run them locally.
+        # Full Catch2 suite on MSVC. FileImporter fixtures close their writers
+        # before import/readback, while a deterministic unit covers the bounded
+        # retry used for transient Defender/indexer locks.
         #
         # Loopback / firewall: the Windows IPC layer uses named pipes
         # (\\.\pipe\dusk-studio-ipc-*) + CreateFileMapping + kernel events.
@@ -189,4 +183,18 @@ jobs:
               exit 1
             }
           done
-          ctest --test-dir build-tests --output-on-failure -C Release -E "FileImporter"
+          for required in \
+            "FileImporter: transient file locks retry but remain bounded" \
+            "FileImporter: 44.1k mono -> 48k session preserves length" \
+            "FileImporter: 44.1k -> 48k upsample fills the tail with audio, not a held sample" \
+            "FileImporter: 96k mono -> 48k session preserves length" \
+            "FileImporter: stereo -> mono sums L+R at 0.5 each" \
+            "FileImporter: mono -> stereo duplicates to L and R" \
+            "FileImporter: matching rate and channels copies the source verbatim" \
+            "FileImporter: a matching 32-bit source is not truncated to 24-bit"; do
+            grep -Fq "$required" <<< "$inventory" || {
+              echo "::error::required Windows FileImporter regression missing from CTest: $required" >&2
+              exit 1
+            }
+          done
+          ctest --test-dir build-tests --output-on-failure -C Release

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 890 Catch2 test cases across 176 test source files. Linux
+The C++ suite declares 891 Catch2 test cases across 176 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 890 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 891 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/FileImporter.cpp
+++ b/src/engine/FileImporter.cpp
@@ -8,9 +8,11 @@
 #include "../foundation/WindowedSincInterpolator.h"
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cmath>
 #include <cstring>
 #include <map>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -18,6 +20,13 @@ namespace duskstudio::fileimport
 {
 namespace
 {
+using namespace std::chrono_literals;
+
+void waitForTransientFileLock()
+{
+    std::this_thread::sleep_for (20ms);
+}
+
 template <typename FileType>
 std::filesystem::path toStdPath (const FileType& file)
 {
@@ -109,13 +118,9 @@ AudioImportResult importAudio (const AudioImportRequest& req)
     // transiently locked by the indexer or AV real-time scan, so the first open
     // returns null even though the file is valid. Retry briefly before treating
     // it as unreadable; genuine unsupported files just exhaust the attempts.
-    std::unique_ptr<dusk::audio::FileReader> reader;
-    for (int attempt = 0; attempt < 5 && reader == nullptr; ++attempt)
-    {
-        reader = dusk::audio::FileReader::open (toStdPath (req.source));
-        if (reader == nullptr && attempt < 4)
-            juce::Thread::sleep (20);
-    }
+    auto reader = detail::retryTransientFileOperation (
+        [&] { return dusk::audio::FileReader::open (toStdPath (req.source)); },
+        waitForTransientFileLock);
     if (reader == nullptr)
     {
         result.errorMessage = ("Unsupported or unreadable audio file: "
@@ -161,13 +166,9 @@ AudioImportResult importAudio (const AudioImportRequest& req)
             outFile = req.audioDir.getNonexistentChildFile (
                 outFile.getFileNameWithoutExtension(), ext);
 
-        bool copied = false;
-        for (int attempt = 0; attempt < 5 && ! copied; ++attempt)
-        {
-            copied = req.source.copyFileTo (outFile);
-            if (! copied && attempt < 4)
-                juce::Thread::sleep (20);
-        }
+        const bool copied = detail::retryTransientFileOperation (
+            [&] { return req.source.copyFileTo (outFile); },
+            waitForTransientFileLock);
         if (! copied)
         {
             outFile.deleteFile();   // drop any partial copy (matches the slow path)
@@ -216,15 +217,9 @@ AudioImportResult importAudio (const AudioImportRequest& req)
     writeSpec.numChannels   = req.targetChannels;
     writeSpec.bitsPerSample = 24;
     writeSpec.format        = dusk::audio::WriteSpec::Format::Wav;
-    std::unique_ptr<dusk::audio::FileWriter> writer;
-    for (int attempt = 0; attempt < 5; ++attempt)
-    {
-        writer = dusk::audio::FileWriter::create (toStdPath (outFile), writeSpec);
-        if (writer != nullptr)
-            break;
-        if (attempt < 4)
-            juce::Thread::sleep (20);
-    }
+    auto writer = detail::retryTransientFileOperation (
+        [&] { return dusk::audio::FileWriter::create (toStdPath (outFile), writeSpec); },
+        waitForTransientFileLock);
     if (writer == nullptr)
     {
         result.errorMessage = ("Could not open output file for writing: "

--- a/src/engine/FileImporter.h
+++ b/src/engine/FileImporter.h
@@ -6,6 +6,26 @@
 
 namespace duskstudio::fileimport
 {
+namespace detail
+{
+// Windows indexers and antivirus scanners can briefly deny access to a newly
+// created file. Keep the retry policy in one testable place so every importer
+// file operation remains bounded and waits only between failed attempts.
+inline constexpr int kTransientFileAttempts = 5;
+
+template <typename Operation, typename Wait>
+auto retryTransientFileOperation (Operation&& operation, Wait&& wait)
+{
+    auto result = operation();
+    for (int attempt = 1; ! result && attempt < kTransientFileAttempts; ++attempt)
+    {
+        wait();
+        result = operation();
+    }
+    return result;
+}
+} // namespace detail
+
 // Message-thread orchestrator for bringing user-supplied audio / MIDI
 // files into a Dusk Studio session, always copying into the session's
 // audio directory so the session stays self-contained.

--- a/tests/file_importer_audio.cpp
+++ b/tests/file_importer_audio.cpp
@@ -101,7 +101,46 @@ struct TempScope
 };
 }
 
-TEST_CASE ("FileImporter: 44.1k mono -> 48k session preserves length", "[FileImporter]")
+TEST_CASE ("FileImporter: transient file locks retry but remain bounded",
+           "[FileImporter][issue-377]")
+{
+    SECTION ("a later attempt succeeds")
+    {
+        int attempts = 0;
+        int waits = 0;
+        const bool opened = duskstudio::fileimport::detail::retryTransientFileOperation (
+            [&]
+            {
+                ++attempts;
+                return attempts == 3;
+            },
+            [&] { ++waits; });
+
+        REQUIRE (opened);
+        REQUIRE (attempts == 3);
+        REQUIRE (waits == 2);
+    }
+
+    SECTION ("a persistent lock exhausts the fixed attempt budget")
+    {
+        int attempts = 0;
+        int waits = 0;
+        const bool opened = duskstudio::fileimport::detail::retryTransientFileOperation (
+            [&]
+            {
+                ++attempts;
+                return false;
+            },
+            [&] { ++waits; });
+
+        REQUIRE_FALSE (opened);
+        REQUIRE (attempts == duskstudio::fileimport::detail::kTransientFileAttempts);
+        REQUIRE (waits == attempts - 1);
+    }
+}
+
+TEST_CASE ("FileImporter: 44.1k mono -> 48k session preserves length",
+           "[FileImporter][issue-377]")
 {
     TempScope tmp;
     const auto src = tmp.dir.getChildFile ("source.wav");
@@ -134,7 +173,8 @@ TEST_CASE ("FileImporter: 44.1k mono -> 48k session preserves length", "[FileImp
     REQUIRE (res.region.numChannels == 1);
 }
 
-TEST_CASE ("FileImporter: 44.1k -> 48k upsample fills the tail with audio, not a held sample", "[FileImporter]")
+TEST_CASE ("FileImporter: 44.1k -> 48k upsample fills the tail with audio, not a held sample",
+           "[FileImporter][issue-377]")
 {
     // Regression: importAudio mistook CatmullRomInterpolator::process()'s return
     // (number of INPUT samples consumed, ~= srcLength) for the produced-output
@@ -180,7 +220,8 @@ TEST_CASE ("FileImporter: 44.1k -> 48k upsample fills the tail with audio, not a
     REQUIRE ((hi - lo) > 0.5f);
 }
 
-TEST_CASE ("FileImporter: 96k mono -> 48k session preserves length", "[FileImporter]")
+TEST_CASE ("FileImporter: 96k mono -> 48k session preserves length",
+           "[FileImporter][issue-377]")
 {
     TempScope tmp;
     const auto src = tmp.dir.getChildFile ("source.wav");
@@ -206,7 +247,8 @@ TEST_CASE ("FileImporter: 96k mono -> 48k session preserves length", "[FileImpor
     REQUIRE (std::abs (rb.lengthInSamples - 48000) <= 64);
 }
 
-TEST_CASE ("FileImporter: stereo -> mono sums L+R at 0.5 each", "[FileImporter]")
+TEST_CASE ("FileImporter: stereo -> mono sums L+R at 0.5 each",
+           "[FileImporter][issue-377]")
 {
     TempScope tmp;
     const auto src = tmp.dir.getChildFile ("source.wav");
@@ -233,7 +275,8 @@ TEST_CASE ("FileImporter: stereo -> mono sums L+R at 0.5 each", "[FileImporter]"
     REQUIRE_THAT (bufferPeak (rb.buffer, 0), WithinAbs (0.0f, 1.0e-3f));
 }
 
-TEST_CASE ("FileImporter: mono -> stereo duplicates to L and R", "[FileImporter]")
+TEST_CASE ("FileImporter: mono -> stereo duplicates to L and R",
+           "[FileImporter][issue-377]")
 {
     TempScope tmp;
     const auto src = tmp.dir.getChildFile ("source.wav");
@@ -258,7 +301,8 @@ TEST_CASE ("FileImporter: mono -> stereo duplicates to L and R", "[FileImporter]
     REQUIRE_THAT (bufferPeak (rb.buffer, 1), WithinAbs (kAmp, 1.0e-4f));
 }
 
-TEST_CASE ("FileImporter: matching rate and channels copies the source verbatim", "[FileImporter]")
+TEST_CASE ("FileImporter: matching rate and channels copies the source verbatim",
+           "[FileImporter][issue-377]")
 {
     // When the source already matches the session rate AND the requested
     // channel layout, the importer must copy it byte-for-byte — no decode,
@@ -301,7 +345,8 @@ TEST_CASE ("FileImporter: matching rate and channels copies the source verbatim"
     REQUIRE (res.region.timelineStart   == 7);
 }
 
-TEST_CASE ("FileImporter: a matching 32-bit source is not truncated to 24-bit", "[FileImporter]")
+TEST_CASE ("FileImporter: a matching 32-bit source is not truncated to 24-bit",
+           "[FileImporter][issue-377]")
 {
     // The old path decoded to float and always re-wrote 24-bit, silently
     // truncating a >24-bit source. The verbatim copy preserves the original

--- a/tests/release_mechanics.sh
+++ b/tests/release_mechanics.sh
@@ -768,6 +768,29 @@ assert all(pins == [pinned_donor.group(1)] for pins in donor_pins.values()), (
     f"DONOR_REV drift across workflows: {donor_pins}"
 )
 
+file_importer_tests = (
+    "FileImporter: transient file locks retry but remain bounded",
+    "FileImporter: 44.1k mono -> 48k session preserves length",
+    "FileImporter: 44.1k -> 48k upsample fills the tail with audio, not a held sample",
+    "FileImporter: 96k mono -> 48k session preserves length",
+    "FileImporter: stereo -> mono sums L+R at 0.5 each",
+    "FileImporter: mono -> stereo duplicates to L and R",
+    "FileImporter: matching rate and channels copies the source verbatim",
+    "FileImporter: a matching 32-bit source is not truncated to 24-bit",
+)
+for workflow_name in ("windows-tests.yml", "windows-build.yml"):
+    workflow_text = (
+        source_root / ".github" / "workflows" / workflow_name
+    ).read_text(encoding="utf-8")
+    folded_workflow = re.sub(r"\\\n\s*", " ", workflow_text)
+    assert not re.search(r"ctest[^\n]*-E[^\n]*FileImporter", folded_workflow), (
+        f"{workflow_name} must not exclude the FileImporter suite"
+    )
+    for test_name in file_importer_tests:
+        assert test_name in workflow_text, (
+            f"{workflow_name} lost required FileImporter inventory: {test_name}"
+        )
+
 sanitizer_workflow = (
     source_root / ".github" / "workflows" / "linux-sanitizer.yml"
 ).read_text(encoding="utf-8")

--- a/tests/release_mechanics.sh
+++ b/tests/release_mechanics.sh
@@ -783,7 +783,10 @@ for workflow_name in ("windows-tests.yml", "windows-build.yml"):
         source_root / ".github" / "workflows" / workflow_name
     ).read_text(encoding="utf-8")
     folded_workflow = re.sub(r"\\\n\s*", " ", workflow_text)
-    assert not re.search(r"ctest[^\n]*-E[^\n]*FileImporter", folded_workflow), (
+    assert not re.search(
+        r"ctest[^\n]*(?:-E|--exclude-regex)[^\n]*FileImporter",
+        folded_workflow,
+    ), (
         f"{workflow_name} must not exclude the FileImporter suite"
     )
     for test_name in file_importer_tests:


### PR DESCRIPTION
Closes #377.

Summary:
- run every FileImporter conversion test in Windows PR and release workflows
- centralize the bounded transient-file retry and cover success and exhaustion deterministically
- assert the complete Windows FileImporter inventory and prevent broad exclusions from returning
- replace the importer JUCE sleeps with std::this_thread

Validation:
- Linux: 878/878 CTest tests passed
- macOS: 845/845 CTest tests passed
- Windows: 839/839 CTest tests passed with ASIO enabled
- Windows focused: 79 assertions in 8 issue-377 test cases passed
- release mechanics and actionlint passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio file importing reliability when files are temporarily locked.
  * Preserved audio tails during sample-rate conversion.
  * Preserved matching 32-bit source files without truncation.

* **Tests**
  * Expanded regression coverage for file-lock retries and audio conversion.
  * Windows validation now runs and verifies the complete FileImporter test suite.

* **Documentation**
  * Updated the documented test count from 890 to 891.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->