### PR TITLE
fix: preserve Unicode MP3 output paths on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 891 Catch2 test cases across 176 test source files. Linux
+The C++ suite declares 892 Catch2 test cases across 176 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 891 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 892 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/BounceEngine.cpp
+++ b/src/engine/BounceEngine.cpp
@@ -136,7 +136,11 @@ std::unique_ptr<dusk::audio::IFileWriteSink>
 BounceEngine::makeWriter (const juce::File& outFile, std::string& errOut) const
 {
     constexpr int kNumChannels = 2;   // bounce is always stereo
-    const auto path = outFile.getFullPathName().toStdString();
+#if defined (_WIN32)
+    const auto path = std::filesystem::path (outFile.getFullPathName().toWideCharPointer());
+#else
+    const auto path = std::filesystem::u8path (outFile.getFullPathName().toStdString());
+#endif
 
     if (renderFormat == Format::Mp3)
     {

--- a/src/engine/LameMp3Writer.cpp
+++ b/src/engine/LameMp3Writer.cpp
@@ -19,6 +19,16 @@ int mp3BufferCapacity (int numFrames) noexcept
 // Deinterleave + encode this many frames per LAME call, so writeInterleaved
 // stays allocation-free for any ring-chunk size the drain hands it.
 constexpr int kEncodeChunkFrames = 1 << 14;
+
+std::FILE* openOutputFile (const std::filesystem::path& path) noexcept
+{
+#if defined (_WIN32)
+    std::FILE* output = nullptr;
+    return ::_wfopen_s (&output, path.c_str(), L"wb") == 0 ? output : nullptr;
+#else
+    return std::fopen (path.c_str(), "wb");
+#endif
+}
 } // namespace
 
 LameMp3Writer::LameMp3Writer (const std::filesystem::path& path, double sampleRate,
@@ -26,7 +36,7 @@ LameMp3Writer::LameMp3Writer (const std::filesystem::path& path, double sampleRa
     : channels (std::clamp (numChannels, 1, 2)),
       bitrate (bitrateKbps)
 {
-    file = std::fopen (path.string().c_str(), "wb");
+    file = openOutputFile (path);
     if (file == nullptr)
         return;
 #if DUSKSTUDIO_HAS_LAME

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -629,13 +629,14 @@ if(DUSK_PLUGINS_PATH)
         JucePlugin_ProducesMidiOutput=0)
 endif()
 
-# MP3 bounce writer — only when libmp3lame is available (mirrors the app build).
+# The native path-opening regression runs even without LAME; encoding coverage
+# is enabled when libmp3lame is available (mirrors the app build).
+target_sources(dusk-studio-tests PRIVATE
+    lame_mp3_writer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/engine/LameMp3Writer.cpp)
 find_path(LAME_INCLUDE_DIR NAMES lame/lame.h)
 find_library(LAME_LIBRARY NAMES mp3lame lame)
 if(LAME_INCLUDE_DIR AND LAME_LIBRARY)
-    target_sources(dusk-studio-tests PRIVATE
-        lame_mp3_writer.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/../src/engine/LameMp3Writer.cpp)
     target_include_directories(dusk-studio-tests PRIVATE "${LAME_INCLUDE_DIR}")
     target_link_libraries(dusk-studio-tests PRIVATE "${LAME_LIBRARY}")
     target_compile_definitions(dusk-studio-tests PRIVATE DUSKSTUDIO_HAS_LAME=1)

--- a/tests/lame_mp3_writer.cpp
+++ b/tests/lame_mp3_writer.cpp
@@ -1,15 +1,20 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "../src/engine/LameMp3Writer.h"
+#include "TestTempDirectory.h"
 
 #include <juce_audio_formats/juce_audio_formats.h>
+#include <array>
 #include <cmath>
+#include <fstream>
+#include <system_error>
 #include <vector>
 
 using namespace duskstudio;
 
 namespace
 {
+#if DUSKSTUDIO_HAS_LAME
 // Encode `src` to a fresh temp .mp3 via LameMp3Writer and return the file.
 juce::File encodeToMp3 (const juce::AudioBuffer<float>& src, double sr, int bitrate)
 {
@@ -26,8 +31,10 @@ juce::File encodeToMp3 (const juce::AudioBuffer<float>& src, double sr, int bitr
     REQUIRE (writer.writeInterleaved (interleaved.data(), n));
     return mp3;   // writer destructor (end of scope) flushes + closes
 }
+#endif
 }
 
+#if DUSKSTUDIO_HAS_LAME
 // JUCE bundles no MP3 *decoder* by default, so verify the bytes structurally:
 // a valid MPEG-1 Layer III frame header at the chosen rate/bitrate, a file size
 // consistent with CBR, and — the part that proves the audio actually reached the
@@ -99,4 +106,38 @@ TEST_CASE ("LameMp3Writer emits a valid 48k/320k MP3 carrying the signal", "[mp3
 
     sineMp3.deleteFile();
     silenceMp3.deleteFile();
+}
+#endif
+
+TEST_CASE ("LameMp3Writer writes and reopens a Unicode path", "[mp3][issue-381]")
+{
+    duskstudio::test::TempDirectory temp ("dusk-mp3-unicode");
+    const auto unicodeDir = temp.path() / std::filesystem::u8path (u8"audio-\u97f3\u58f0");
+    const auto mp3 = unicodeDir / std::filesystem::u8path (u8"bounce-\u66f8\u304d\u51fa\u3057.mp3");
+
+    std::error_code ec;
+    REQUIRE (std::filesystem::create_directory (unicodeDir, ec));
+    REQUIRE_FALSE (ec);
+
+    {
+        LameMp3Writer writer (mp3, 48000.0, 2, 320);
+        REQUIRE (writer.fileOpened());
+
+#if DUSKSTUDIO_HAS_LAME
+        REQUIRE (writer.isOk());
+        std::array<float, 2304> silence {};
+        REQUIRE (writer.writeInterleaved (silence.data(), (std::int64_t) silence.size() / 2));
+        REQUIRE (writer.flush());
+#endif
+    }
+
+    std::ifstream input (mp3, std::ios::binary);
+    REQUIRE (input.is_open());
+#if DUSKSTUDIO_HAS_LAME
+    CHECK (input.peek() != std::ifstream::traits_type::eof());
+#endif
+
+    const auto missingParent = unicodeDir / "missing" / std::filesystem::u8path (u8"bounce-\u97f3\u58f0.mp3");
+    LameMp3Writer missingWriter (missingParent, 48000.0, 2, 320);
+    CHECK_FALSE (missingWriter.fileOpened());
 }


### PR DESCRIPTION
Closes #381

## Summary
- preserve the native wide path from the JUCE bounce destination into `std::filesystem::path` on Windows
- open LAME output with the wide-character CRT API and keep failure non-throwing
- add Unicode directory/file creation, encode, reopen, and missing-parent regression coverage
- keep native path coverage active in builds without LAME while retaining full encoding checks when LAME is available

## Validation
- Linux: app + tests built; 879/879 CTest; `[issue-381]` 9 assertions
- macOS: app + tests built; 846/846 CTest; `[issue-381]` 9 assertions (native LV2 unavailable)
- Windows VM: app + tests built with ASIO; 840/840 CTest; `[issue-381]` native Unicode create/reopen/failure coverage (LAME unavailable in VM)
- release-mechanics contract
- `git diff --check`

Hosted Windows installs libmp3lame and will exercise the full encode/non-empty-file branch of the regression. The free local model review was attempted but incomplete because its endpoint was unreachable. No frontier review was run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio export reliability for file paths containing Unicode characters, including on Windows.
  * Export attempts to unavailable directories now fail cleanly.

* **Tests**
  * Added coverage for Unicode output paths and invalid destination directories.
  * Updated the documented Catch2 test count to 892.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->