### PR TITLE
fix: preserve Windows special-folder Unicode paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1537,6 +1537,11 @@ target_link_libraries(DuskStudio PRIVATE
     juce::juce_recommended_config_flags
     juce::juce_recommended_warning_flags)
 
+if(WIN32)
+    # Wide special-folder resolution in foundation/Fs.h.
+    target_link_libraries(DuskStudio PRIVATE shell32 ole32)
+endif()
+
 # LTO is on by default for release builds (5-10% smaller binary, slight perf
 # win) but it serializes the GCC link stage — lto-wrapper runs LTRANS jobs
 # one at a time, idling 127 of your 128 cores for 2-4 minutes per build.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 892 Catch2 test cases across 176 test source files. Linux
+The C++ suite declares 893 Catch2 test cases across 176 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 892 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 893 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/foundation/Fs.h
+++ b/src/foundation/Fs.h
@@ -3,8 +3,10 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -15,6 +17,7 @@
   #define NOMINMAX
  #endif
  #include <windows.h>
+ #include <shlobj.h>
 #else
  #include <pwd.h>
  #include <unistd.h>
@@ -176,14 +179,70 @@ inline std::string replaceAll (std::string s, const std::string& from, const std
         s.replace (pos, from.size(), to);
     return s;
 }
+
+#if defined(_WIN32)
+struct CoTaskMemDeleter
+{
+    void operator() (wchar_t* value) const noexcept { ::CoTaskMemFree (value); }
+};
+
+inline std::filesystem::path knownFolderPath (REFKNOWNFOLDERID folderId)
+{
+    wchar_t* value = nullptr;
+    if (FAILED (::SHGetKnownFolderPath (folderId, KF_FLAG_DEFAULT, nullptr, &value)))
+        return {};
+
+    const std::unique_ptr<wchar_t, CoTaskMemDeleter> owned (value);
+    return std::filesystem::path (owned.get());
+}
+#endif
+
+inline std::filesystem::path testSpecialLocation (const char* child)
+{
+ #if defined(DUSKSTUDIO_TESTS)
+   #if defined(_WIN32)
+    // Test-only UTF-16 override: Windows never consults the narrow CRT
+    // environment for paths. Shipping builds compile this branch out.
+    if (const wchar_t* root = ::_wgetenv (L"DUSKSTUDIO_TEST_SPECIAL_LOCATIONS_ROOT"))
+        if (*root != L'\0')
+            return std::filesystem::path (root) / std::filesystem::u8path (child);
+   #else
+    // The Dusk-named test flag has an explicit UTF-8 contract on POSIX.
+    if (const char* root = std::getenv ("DUSKSTUDIO_TEST_SPECIAL_LOCATIONS_ROOT"))
+        if (*root != '\0')
+            return std::filesystem::u8path (root) / child;
+   #endif
+ #else
+    (void) child;
+ #endif
+    return {};
+}
+
+#if defined(_WIN32)
+inline std::filesystem::path windowsTempPath()
+{
+    std::vector<wchar_t> buffer (MAX_PATH + 1);
+    for (;;)
+    {
+        const DWORD length = ::GetTempPathW ((DWORD) buffer.size(), buffer.data());
+        if (length == 0) return {};
+        if ((std::size_t) length < buffer.size())
+        {
+            const std::filesystem::path result (std::wstring (buffer.data(), length));
+            return result.has_filename() ? result : result.parent_path();
+        }
+        buffer.resize ((std::size_t) length + 1);
+    }
+}
+#endif
 } // namespace detail
 
 inline std::filesystem::path userHomeDir()
 {
+    if (const auto testPath = detail::testSpecialLocation ("Home"); ! testPath.empty())
+        return testPath;
 #if defined(_WIN32)
-    if (const char* profile = std::getenv ("USERPROFILE"))
-        return std::filesystem::path (profile);
-    return {};
+    return detail::knownFolderPath (FOLDERID_Profile);
 #else
     if (const char* home = std::getenv ("HOME"))
         return std::filesystem::path (home);
@@ -227,10 +286,10 @@ inline std::filesystem::path resolveXdgFolder (const std::string& key,
 // JUCE File::userApplicationDataDirectory.
 inline std::filesystem::path userConfigDir()
 {
+    if (const auto testPath = detail::testSpecialLocation ("Config"); ! testPath.empty())
+        return testPath;
 #if defined(_WIN32)
-    if (const char* appdata = std::getenv ("APPDATA"))
-        return std::filesystem::path (appdata);   // %APPDATA%, matches CSIDL_APPDATA
-    return {};
+    return detail::knownFolderPath (FOLDERID_RoamingAppData);
 #else
     const auto home = userHomeDir();
     if (home.empty()) return {};   // never build a CWD-relative config path
@@ -245,10 +304,10 @@ inline std::filesystem::path userConfigDir()
 // JUCE File::userMusicDirectory.
 inline std::filesystem::path userMusicDir()
 {
+    if (const auto testPath = detail::testSpecialLocation ("Music"); ! testPath.empty())
+        return testPath;
 #if defined(_WIN32)
-    if (const char* profile = std::getenv ("USERPROFILE"))
-        return std::filesystem::path (profile) / "Music";
-    return {};
+    return detail::knownFolderPath (FOLDERID_Music);
 #else
     const auto home = userHomeDir();
     if (home.empty()) return {};   // never build a CWD-relative music path
@@ -263,10 +322,10 @@ inline std::filesystem::path userMusicDir()
 // JUCE File::tempDirectory.
 inline std::filesystem::path tempDir()
 {
+    if (const auto testPath = detail::testSpecialLocation ("Temp"); ! testPath.empty())
+        return testPath;
 #if defined(_WIN32)
-    if (const char* t = std::getenv ("TEMP")) return std::filesystem::path (t);
-    if (const char* t = std::getenv ("TMP"))  return std::filesystem::path (t);
-    return std::filesystem::path ("C:\\Windows\\Temp");
+    return detail::windowsTempPath();
 #else
     if (const char* t = std::getenv ("TMPDIR")) return std::filesystem::path (t);
     return std::filesystem::path ("/tmp");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -179,9 +179,9 @@ target_include_directories(dusk-studio-tests PRIVATE
 target_include_directories(dusk-studio-tests SYSTEM PRIVATE ${CMAKE_SOURCE_DIR}/external/json)
 
 if(WIN32)
-    # shell32: CommandLineToArgvW, exercised by plugin_host_command_line.cpp
-    # against the same header the plugin host uses.
-    target_link_libraries(dusk-studio-tests PRIVATE shell32)
+    # shell32: CommandLineToArgvW plus SHGetKnownFolderPath; ole32:
+    # CoTaskMemFree for the returned known-folder path.
+    target_link_libraries(dusk-studio-tests PRIVATE shell32 ole32)
 endif()
 
 # pffft backend for dusk::audio::Fft, plus its A/B parity suite. The pffft
@@ -199,6 +199,7 @@ target_sources(dusk-studio-tests PRIVATE
     foundation_vector_ops.cpp
     foundation_fs.cpp
     foundation_special_locations.cpp
+    ${CMAKE_SOURCE_DIR}/src/session/RecentSessions.cpp
     foundation_json.cpp
     foundation_audio_math.cpp
     foundation_int_delay_line.cpp

--- a/tests/appconfig_store.cpp
+++ b/tests/appconfig_store.cpp
@@ -12,26 +12,13 @@ namespace
 {
 namespace stdfs = std::filesystem;
 
-// The store is located from the environment, so a test can point it at a
-// scratch directory instead of the developer's real configuration.
-const char* storeEnvVar()
-{
-   #if defined(_WIN32)
-    return "APPDATA";
-   #else
-    return "HOME";
-   #endif
-}
-
+#if ! defined(_WIN32)
 void setEnv (const char* name, const char* value)
 {
-   #if defined(_WIN32)
-    _putenv_s (name, value != nullptr ? value : "");
-   #else
     if (value != nullptr) ::setenv (name, value, 1);
     else                  ::unsetenv (name);
-   #endif
 }
+#endif
 
 // Redirects the store into a scratch directory and puts the environment back
 // afterwards. XDG_CONFIG_HOME is redirected too: left alone it outranks HOME on
@@ -41,23 +28,36 @@ class ScopedStore
 public:
     explicit ScopedStore (const char* name)
     {
-        if (const char* existing = std::getenv (storeEnvVar()))
+       #if defined(_WIN32)
+        if (const wchar_t* existing = ::_wgetenv (kStoreEnvVar))
+            previousStore = existing;
+       #else
+        if (const char* existing = std::getenv ("HOME"))
             previousStore = existing;
         if (const char* existing = std::getenv ("XDG_CONFIG_HOME"))
             previousXdg = existing;
+       #endif
 
         root = stdfs::temp_directory_path() / "dusk-appconfig" / name;
         std::error_code ec;
         stdfs::remove_all (root, ec);
         stdfs::create_directories (root, ec);
-        setEnv (storeEnvVar(), root.string().c_str());
+       #if defined(_WIN32)
+        ::_wputenv_s (kStoreEnvVar, root.c_str());
+       #else
+        setEnv ("HOME", root.string().c_str());
         setEnv ("XDG_CONFIG_HOME", (root / ".config").string().c_str());
+       #endif
     }
 
     ~ScopedStore()
     {
-        setEnv (storeEnvVar(), previousStore.empty() ? nullptr : previousStore.c_str());
+       #if defined(_WIN32)
+        ::_wputenv_s (kStoreEnvVar, previousStore.c_str());
+       #else
+        setEnv ("HOME", previousStore.empty() ? nullptr : previousStore.c_str());
         setEnv ("XDG_CONFIG_HOME", previousXdg.empty() ? nullptr : previousXdg.c_str());
+       #endif
     }
 
     // Located rather than constructed: the directory layout under the
@@ -89,8 +89,13 @@ public:
 
 private:
     stdfs::path root;
+   #if defined(_WIN32)
+    static constexpr const wchar_t* kStoreEnvVar = L"DUSKSTUDIO_TEST_SPECIAL_LOCATIONS_ROOT";
+    std::wstring previousStore;
+   #else
     std::string previousStore;
     std::string previousXdg;
+   #endif
 };
 } // namespace
 

--- a/tests/foundation_special_locations.cpp
+++ b/tests/foundation_special_locations.cpp
@@ -1,10 +1,16 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "foundation/Fs.h"
+#include "session/RecentSessions.h"
 
 #include <juce_core/juce_core.h>
 
+#include <chrono>
+#include <cstdlib>
 #include <filesystem>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 using namespace dusk;
 namespace stdfs = std::filesystem;
@@ -17,6 +23,90 @@ stdfs::path jucePath (juce::File::SpecialLocationType type)
     // would use the active code page on Windows).
     return stdfs::u8path (juce::File::getSpecialLocation (type).getFullPathName().toStdString());
 }
+
+class ScopedTestSpecialLocations
+{
+public:
+    explicit ScopedTestSpecialLocations (const stdfs::path& value)
+    {
+       #if defined(_WIN32)
+        if (const wchar_t* existing = ::_wgetenv (kWideName))
+        {
+            hadPrevious = true;
+            previous = existing;
+        }
+        if (::_wputenv_s (kWideName, value.c_str()) != 0)
+            throw std::runtime_error ("could not set the special-location test override");
+       #else
+        if (const char* existing = std::getenv (kName))
+        {
+            hadPrevious = true;
+            previous = existing;
+        }
+        const auto encoded = value.u8string();
+        if (::setenv (kName, encoded.c_str(), 1) != 0)
+            throw std::runtime_error ("could not set the special-location test override");
+       #endif
+    }
+
+    ~ScopedTestSpecialLocations()
+    {
+       #if defined(_WIN32)
+        ::_wputenv_s (kWideName, hadPrevious ? previous.c_str() : L"");
+       #else
+        if (hadPrevious) ::setenv (kName, previous.c_str(), 1);
+        else             ::unsetenv (kName);
+       #endif
+    }
+
+    ScopedTestSpecialLocations (const ScopedTestSpecialLocations&) = delete;
+    ScopedTestSpecialLocations& operator= (const ScopedTestSpecialLocations&) = delete;
+    ScopedTestSpecialLocations (ScopedTestSpecialLocations&&) = delete;
+    ScopedTestSpecialLocations& operator= (ScopedTestSpecialLocations&&) = delete;
+
+private:
+    static constexpr const char* kName = "DUSKSTUDIO_TEST_SPECIAL_LOCATIONS_ROOT";
+   #if defined(_WIN32)
+    static constexpr const wchar_t* kWideName = L"DUSKSTUDIO_TEST_SPECIAL_LOCATIONS_ROOT";
+    std::wstring previous {};
+   #else
+    std::string previous {};
+   #endif
+    bool hadPrevious = false;
+};
+
+#if defined(_WIN32)
+class ScopedWideEnvironment
+{
+public:
+    ScopedWideEnvironment (const wchar_t* nameIn, const stdfs::path& value)
+        : name (nameIn)
+    {
+        if (const wchar_t* existing = ::_wgetenv (name.c_str()))
+        {
+            hadPrevious = true;
+            previous = existing;
+        }
+        if (::_wputenv_s (name.c_str(), value.c_str()) != 0)
+            throw std::runtime_error ("could not set a wide environment override");
+    }
+
+    ~ScopedWideEnvironment()
+    {
+        ::_wputenv_s (name.c_str(), hadPrevious ? previous.c_str() : L"");
+    }
+
+    ScopedWideEnvironment (const ScopedWideEnvironment&) = delete;
+    ScopedWideEnvironment& operator= (const ScopedWideEnvironment&) = delete;
+    ScopedWideEnvironment (ScopedWideEnvironment&&) = delete;
+    ScopedWideEnvironment& operator= (ScopedWideEnvironment&&) = delete;
+
+private:
+    std::wstring name;
+    std::wstring previous {};
+    bool hadPrevious = false;
+};
+#endif
 } // namespace
 
 TEST_CASE ("dusk::fs special locations match juce::File", "[foundation][fs]")
@@ -38,13 +128,11 @@ TEST_CASE ("dusk::fs special locations match juce::File", "[foundation][fs]")
 
     SECTION ("tempDir")
     {
-#if defined(__linux__)
+#if defined(__linux__) || defined(_WIN32)
         REQUIRE (fs::tempDir() == jucePath (juce::File::tempDirectory));
 #else
-        // JUCE's macOS/Windows tempDirectory has bespoke semantics
-        // (~/Library/Caches/<exe>, GetTempPath); dusk::fs::tempDir deliberately
-        // follows the POSIX $TMPDIR/TMP convention. Temp files are ephemeral, so
-        // this divergence is intentional — assert only that it is usable.
+        // JUCE's macOS tempDirectory has bespoke ~/Library/Caches/<exe>
+        // semantics; dusk::fs deliberately follows $TMPDIR there.
         REQUIRE (std::filesystem::is_directory (fs::tempDir()));
 #endif
     }
@@ -77,4 +165,60 @@ TEST_CASE ("dusk::fs special locations match juce::File", "[foundation][fs]")
         REQUIRE_FALSE (ec2);
         REQUIRE (dusk == juce);
     }
+}
+
+
+TEST_CASE ("Special locations preserve Unicode paths end to end",
+           "[foundation][fs][windows][issue-379]")
+{
+    const auto root = stdfs::temp_directory_path()
+                    / stdfs::u8path (u8"dusk-locations-\u97f3\u58f0")
+                    / std::to_string ((long long) std::chrono::steady_clock::now()
+                                           .time_since_epoch().count());
+    std::error_code ec;
+    stdfs::remove_all (root, ec);
+    ec.clear();
+    for (const auto* child : { "Home", "Config", "Music", "Temp" })
+    {
+        REQUIRE (stdfs::create_directories (root / child, ec));
+        REQUIRE_FALSE (ec);
+    }
+
+   #if defined(_WIN32)
+    REQUIRE (stdfs::create_directories (root / L"ApiTemp", ec));
+    REQUIRE_FALSE (ec);
+    {
+        const ScopedWideEnvironment temp (L"TEMP", root / L"ApiTemp");
+        const ScopedWideEnvironment tmp (L"TMP", root / L"ApiTemp");
+        REQUIRE (fs::tempDir() == root / L"ApiTemp");
+    }
+   #endif
+
+    {
+        const ScopedTestSpecialLocations locations (root);
+        REQUIRE (fs::userHomeDir() == root / "Home");
+        REQUIRE (fs::userConfigDir() == root / "Config");
+        REQUIRE (fs::userMusicDir() == root / "Music");
+        REQUIRE (fs::tempDir() == root / "Temp");
+
+        const auto session = root / "Home" / stdfs::u8path (u8"session-\u66f8\u304d\u51fa\u3057");
+        REQUIRE (stdfs::create_directories (session, ec));
+        REQUIRE_FALSE (ec);
+        duskstudio::RecentSessions::add (session);
+        REQUIRE (duskstudio::RecentSessions::load() == std::vector<stdfs::path> { session });
+        REQUIRE (stdfs::is_regular_file (root / "Config" / "Dusk Studio" / "recent.txt"));
+
+        const auto work = fs::createUniqueTempDirectory ("dusk-unicode-");
+        REQUIRE_FALSE (work.empty());
+        REQUIRE (work.parent_path() == root / "Temp");
+        REQUIRE (fs::writeStringToFile (work / stdfs::u8path (u8"state-\u72b6\u614b.bin"), "state"));
+        REQUIRE (fs::writeStringToFile (work / stdfs::u8path (u8"import-\u97f3\u58f0.wav"), "audio"));
+        REQUIRE (fs::loadFileAsString (work / stdfs::u8path (u8"state-\u72b6\u614b.bin")) == "state");
+        REQUIRE (fs::loadFileAsString (work / stdfs::u8path (u8"import-\u97f3\u58f0.wav")) == "audio");
+
+        duskstudio::RecentSessions::clear();
+    }
+
+    stdfs::remove_all (root, ec);
+    REQUIRE_FALSE (ec);
 }


### PR DESCRIPTION
## Summary

- resolve Windows profile, roaming app data, and Music paths through wide known-folder APIs
- resolve temporary storage with GetTempPathW while keeping path overrides explicitly test-only
- cover Unicode recent-session, temporary state, and imported-audio paths end to end

Closes #379

## Validation

- Linux: focused issue regression (23 assertions) and full CTest 880/880
- macOS: focused issue regression (23 assertions) and full CTest 847/847
- Windows: focused issue regression (26 assertions) and full CTest 841/841; ASIO enabled and verified
- git diff --check
- review-local linters: clean; model review unavailable, so the local review was incomplete

macOS native LV2 coverage is unavailable in the current validation build. No frontier review was run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows handling for home, configuration, music, and temporary directories.
  - Added support for Unicode paths across file operations and recent-session persistence.
  - Fixed temporary-directory resolution and Windows special-folder compatibility.

- **Tests**
  - Expanded coverage for Windows and Unicode path scenarios.
  - Updated the documented test count to 893 cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->