### PR TITLE
fix: bound Windows plugin-host handshake reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 893 Catch2 test cases across 176 test source files. Linux
+The C++ suite declares 894 Catch2 test cases across 176 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 893 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 894 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/ipc/PluginHostMain.cpp
+++ b/src/engine/ipc/PluginHostMain.cpp
@@ -7,6 +7,8 @@
 //                 without a plugin in the loop.
 //   --ipc-argv-stub: return the UTF-8 argv vector over the inherited channel.
 //                 Used to validate Windows UTF-16 launch and quoting.
+//   --ipc-silent-handshake-stub: keep the inherited channel open without
+//                 acknowledging readiness, for the bounded-read regression.
 //   --ipc-control-reply-stub: deterministic request-correlation and reply-
 //                 validation regression child.
 //   --ipc-host  : full Phase-2 host. Loads a juce::AudioPluginInstance
@@ -156,6 +158,19 @@ int runIpcArgvStub (int argc, const char* const* argv) noexcept
             || (length > 0 && ! ipcp::writeExact (channel, argv[i], length)))
             return 1;
     }
+    return 0;
+}
+
+int runIpcSilentHandshakeStub (int argc, const char* const* argv) noexcept
+{
+    ipcp::NativeHandle channel = ipcp::locateInheritedChannel (argc, argv);
+    if (! ipcp::isValid (channel)) return 1;
+
+    // Stay alive and keep the channel open without writing the ready byte.
+    // Closing the parent end after its deadline releases this read so the
+    // child can tear down normally rather than needing a forced kill.
+    char ignored = 0;
+    (void) ipcp::readExact (channel, &ignored, sizeof (ignored));
     return 0;
 }
 
@@ -1304,6 +1319,7 @@ int main (int argc, char** argv)
     bool ipcStub = false;
     bool ipcStubTimeout = false;
     bool ipcArgvStub = false;
+    bool ipcSilentHandshakeStub = false;
     bool ipcControlReplyStub = false;
     bool ipcParkTimeoutStub = false;
     bool ipcHost = false;
@@ -1313,6 +1329,8 @@ int main (int argc, char** argv)
         if (std::strcmp (args[i], "--ipc-stub") == 0) ipcStub = true;
         if (std::strcmp (args[i], "--ipc-stub-timeout") == 0) ipcStubTimeout = true;
         if (std::strcmp (args[i], "--ipc-argv-stub") == 0) ipcArgvStub = true;
+        if (std::strcmp (args[i], "--ipc-silent-handshake-stub") == 0)
+            ipcSilentHandshakeStub = true;
         if (std::strcmp (args[i], "--ipc-control-reply-stub") == 0) ipcControlReplyStub = true;
         if (std::strcmp (args[i], "--ipc-park-timeout-stub") == 0) ipcParkTimeoutStub = true;
         if (std::strcmp (args[i], "--ipc-host") == 0) ipcHost = true;
@@ -1324,6 +1342,7 @@ int main (int argc, char** argv)
 
     if (scan)    return runScan (argc, args);
     if (ipcArgvStub) return runIpcArgvStub (argc, args);
+    if (ipcSilentHandshakeStub) return runIpcSilentHandshakeStub (argc, args);
     if (ipcStub || ipcStubTimeout) return runIpcStub (argc, args, ipcStubTimeout);
     if (ipcControlReplyStub) return runIpcControlReplyStub (argc, args);
     if (ipcParkTimeoutStub) return runIpcParkTimeoutStub (argc, args);

--- a/src/engine/ipc/RemotePluginConnection.cpp
+++ b/src/engine/ipc/RemotePluginConnection.cpp
@@ -138,7 +138,12 @@ bool RemotePluginConnection::connect (const std::string& hostExecutablePath,
         return false;
     }
 
-    platform::setReadTimeout (controlChannel, 5000);
+    if (! platform::setReadTimeout (controlChannel, 5000))
+    {
+        errorOut = "failed to configure child handshake timeout";
+        disconnect();
+        return false;
+    }
     char ack = 0;
     if (! platform::readExact (controlChannel, &ack, 1) || ack != 'k')
     {
@@ -149,7 +154,12 @@ bool RemotePluginConnection::connect (const std::string& hostExecutablePath,
     // Disable the kernel-level timeout now that the handshake is past.
     // Sync RPCs use replyCv.wait_until for per-call timeouts; reader
     // thread must be able to block indefinitely on an idle socket.
-    platform::setReadTimeout (controlChannel, 0);
+    if (! platform::setReadTimeout (controlChannel, 0))
+    {
+        errorOut = "failed to clear child handshake timeout";
+        disconnect();
+        return false;
+    }
 
     // --- Reply-producing modes: start the demultiplexing reader thread ---
     // The --ipc-stub child never writes a control frame after 'k', so

--- a/src/engine/ipc/platform/IpcChannel.h
+++ b/src/engine/ipc/platform/IpcChannel.h
@@ -31,6 +31,11 @@ struct NativeHandle
 {
    #if defined(_WIN32)
     void* h { nullptr };
+    // The parent pipe endpoint is opened for overlapped I/O so a pending read
+    // never serialises control writes on the same duplex handle. Child and
+    // non-channel handles remain synchronous.
+    bool overlapped { false };
+    int readTimeoutMs { 0 };
    #else
     int fd { -1 };
    #endif
@@ -86,7 +91,8 @@ bool readExact  (NativeHandle& h, void* buf, std::size_t n) noexcept;
 bool writeExact (NativeHandle& h, const void* buf, std::size_t n) noexcept;
 
 // Set the receive timeout on a channel endpoint. ms = 0 disables.
-// Linux: SO_RCVTIMEO. Used by control-plane RPCs that need a deadline.
+// Linux/macOS: SO_RCVTIMEO. Windows: an absolute deadline applied by the
+// overlapped read path. Used by control-plane RPCs that need a deadline.
 bool setReadTimeout (NativeHandle& h, int ms) noexcept;
 
 // Send a single NativeHandle to the peer over a connected channel.

--- a/src/engine/ipc/platform/IpcChannel_Windows.cpp
+++ b/src/engine/ipc/platform/IpcChannel_Windows.cpp
@@ -5,9 +5,11 @@
 #include <windows.h>
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <limits>
 
 // Windows uses a duplex named pipe instead of a Unix-domain socketpair.
 // The pipe name is unique per pair (process id + atomic counter) so
@@ -41,6 +43,71 @@ inline bool handleIsValid (HANDLE h) noexcept
 {
     return h != nullptr && h != INVALID_HANDLE_VALUE;
 }
+
+DWORD timeoutUntil (std::chrono::steady_clock::time_point deadline) noexcept
+{
+    using namespace std::chrono;
+    const auto now = steady_clock::now();
+    if (deadline <= now) return 0;
+    const auto remaining = deadline - now;
+    const auto ms = duration_cast<milliseconds> (remaining + nanoseconds (999999)).count();
+    return ms > (long long) std::numeric_limits<DWORD>::max()
+             ? std::numeric_limits<DWORD>::max()
+             : (DWORD) ms;
+}
+
+bool finishOverlapped (HANDLE handle, OVERLAPPED& operation,
+                       DWORD timeoutMs, DWORD& transferred) noexcept
+{
+    const DWORD waitResult = ::WaitForSingleObject (operation.hEvent, timeoutMs);
+    if (waitResult == WAIT_OBJECT_0)
+        return ::GetOverlappedResult (handle, &operation, &transferred, FALSE) != FALSE;
+
+    // OVERLAPPED and its event must stay alive until cancellation has
+    // completed, including the race where the operation finishes just before
+    // CancelIoEx observes it. Apply the same cleanup to WAIT_FAILED.
+    (void) ::CancelIoEx (handle, &operation);
+    (void) ::WaitForSingleObject (operation.hEvent, INFINITE);
+    DWORD ignored = 0;
+    (void) ::GetOverlappedResult (handle, &operation, &ignored, FALSE);
+    return false;
+}
+
+bool readOverlapped (HANDLE handle, void* buffer, DWORD size,
+                     DWORD timeoutMs, DWORD& transferred) noexcept
+{
+    OVERLAPPED operation {};
+    operation.hEvent = ::CreateEventW (nullptr, TRUE, FALSE, nullptr);
+    if (operation.hEvent == nullptr) return false;
+
+    const BOOL started = ::ReadFile (handle, buffer, size, nullptr, &operation);
+    bool ok = false;
+    if (started != FALSE)
+        ok = ::GetOverlappedResult (handle, &operation, &transferred, FALSE) != FALSE;
+    else if (::GetLastError() == ERROR_IO_PENDING)
+        ok = finishOverlapped (handle, operation, timeoutMs, transferred);
+
+    ::CloseHandle (operation.hEvent);
+    return ok;
+}
+
+bool writeOverlapped (HANDLE handle, const void* buffer, DWORD size,
+                      DWORD& transferred) noexcept
+{
+    OVERLAPPED operation {};
+    operation.hEvent = ::CreateEventW (nullptr, TRUE, FALSE, nullptr);
+    if (operation.hEvent == nullptr) return false;
+
+    const BOOL started = ::WriteFile (handle, buffer, size, nullptr, &operation);
+    bool ok = false;
+    if (started != FALSE)
+        ok = ::GetOverlappedResult (handle, &operation, &transferred, FALSE) != FALSE;
+    else if (::GetLastError() == ERROR_IO_PENDING)
+        ok = finishOverlapped (handle, operation, INFINITE, transferred);
+
+    ::CloseHandle (operation.hEvent);
+    return ok;
+}
 } // namespace
 
 void closeHandle (NativeHandle& h) noexcept
@@ -49,6 +116,8 @@ void closeHandle (NativeHandle& h) noexcept
     if (handleIsValid (w))
         ::CloseHandle (w);
     h.h = nullptr;
+    h.overlapped = false;
+    h.readTimeoutMs = 0;
 }
 
 bool createChannelPair (ChannelPair& out, std::string& errorOut) noexcept
@@ -64,7 +133,7 @@ bool createChannelPair (ChannelPair& out, std::string& errorOut) noexcept
 
     HANDLE server = ::CreateNamedPipeA (
         pipeName,
-        PIPE_ACCESS_DUPLEX,
+        PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
         PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
         1,                  // max instances
         64 * 1024,          // out buffer
@@ -104,6 +173,7 @@ bool createChannelPair (ChannelPair& out, std::string& errorOut) noexcept
     }
 
     storeWinHandle (out.parentEnd, server);
+    out.parentEnd.overlapped = true;
     storeWinHandle (out.childEnd,  client);
     return true;
 }
@@ -149,11 +219,27 @@ bool readExact (NativeHandle& h, void* buf, std::size_t n) noexcept
 {
     auto* p = static_cast<char*> (buf);
     HANDLE w = asWinHandle (h);
+    const auto deadline = h.readTimeoutMs > 0
+                            ? std::chrono::steady_clock::now()
+                                + std::chrono::milliseconds (h.readTimeoutMs)
+                            : std::chrono::steady_clock::time_point::max();
     while (n > 0)
     {
         DWORD got = 0;
-        const BOOL ok = ::ReadFile (w, p, (DWORD) n, &got, nullptr);
-        if (! ok || got == 0) return false;
+        const DWORD chunk = n > (std::size_t) std::numeric_limits<DWORD>::max()
+                              ? std::numeric_limits<DWORD>::max()
+                              : (DWORD) n;
+        if (h.overlapped)
+        {
+            const DWORD timeout = h.readTimeoutMs > 0 ? timeoutUntil (deadline) : INFINITE;
+            if (! readOverlapped (w, p, chunk, timeout, got) || got == 0)
+                return false;
+        }
+        else
+        {
+            const BOOL ok = ::ReadFile (w, p, chunk, &got, nullptr);
+            if (! ok || got == 0) return false;
+        }
         p += got;
         n -= (std::size_t) got;
     }
@@ -167,21 +253,32 @@ bool writeExact (NativeHandle& h, const void* buf, std::size_t n) noexcept
     while (n > 0)
     {
         DWORD wrote = 0;
-        const BOOL ok = ::WriteFile (w, p, (DWORD) n, &wrote, nullptr);
-        if (! ok || wrote == 0) return false;
+        const DWORD chunk = n > (std::size_t) std::numeric_limits<DWORD>::max()
+                              ? std::numeric_limits<DWORD>::max()
+                              : (DWORD) n;
+        if (h.overlapped)
+        {
+            if (! writeOverlapped (w, p, chunk, wrote) || wrote == 0)
+                return false;
+        }
+        else
+        {
+            const BOOL ok = ::WriteFile (w, p, chunk, &wrote, nullptr);
+            if (! ok || wrote == 0) return false;
+        }
         p += wrote;
         n -= (std::size_t) wrote;
     }
     return true;
 }
 
-bool setReadTimeout (NativeHandle& h, int /*ms*/) noexcept
+bool setReadTimeout (NativeHandle& h, int ms) noexcept
 {
-    // Win32 named pipes don't have an SO_RCVTIMEO equivalent for
-    // synchronous I/O. Phase 2 leaves this as a no-op; the parent
-    // relies on the child terminating to unblock a hung read. Future
-    // work: switch to overlapped I/O + WaitForSingleObject(timeout).
-    (void) h;
+    if (! isValid (h) || ms < 0) return false;
+    // A positive timeout can only be honoured on a handle opened with
+    // FILE_FLAG_OVERLAPPED. Refuse false confidence on synchronous handles.
+    if (ms > 0 && ! h.overlapped) return false;
+    h.readTimeoutMs = ms;
     return true;
 }
 
@@ -194,6 +291,8 @@ bool sendHandle (NativeHandle& channel, const NativeHandle& payload) noexcept
 bool recvHandle (NativeHandle& channel, NativeHandle& payloadOut) noexcept
 {
     payloadOut.h = nullptr;
+    payloadOut.overlapped = false;
+    payloadOut.readTimeoutMs = 0;
     std::uint64_t value = 0;
     if (! readExact (channel, &value, sizeof (value))) return false;
     storeWinHandle (payloadOut, (HANDLE) (std::uintptr_t) value);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -508,17 +508,11 @@ if (_duskstudio_ipc_test_enabled)
         ipc_stub_round_trip.cpp
         ${CMAKE_SOURCE_DIR}/src/engine/ipc/RemotePluginConnection.cpp
         ${_duskstudio_ipc_test_sources})
-    # The park-timeout cases are the only ones that drive a control RPC while
-    # the reader thread is running. Windows carries the control channel on a
-    # synchronous duplex named pipe, so the reader's blocking ReadFile
-    # serialises against the caller's WriteFile on the same handle and the
-    # request never reaches the child (issue #406). Re-enable once that
-    # transport moves to overlapped I/O.
-    if (NOT WIN32)
-        target_sources(dusk-studio-tests PRIVATE
-            ipc_control_reply.cpp
-            ipc_worker_park.cpp)
-    endif()
+    # The parent pipe endpoint uses overlapped I/O on Windows, so the reader's
+    # pending read and the caller's control write can progress concurrently.
+    target_sources(dusk-studio-tests PRIVATE
+        ipc_control_reply.cpp
+        ipc_worker_park.cpp)
     target_compile_definitions(dusk-studio-tests PRIVATE
         DUSKSTUDIO_HAS_OOP_PLUGINS=1
         DUSKSTUDIO_PLUGIN_HOST_PATH="$<TARGET_FILE:dusk-studio-plugin-host>")

--- a/tests/ipc_stub_round_trip.cpp
+++ b/tests/ipc_stub_round_trip.cpp
@@ -35,7 +35,6 @@ constexpr int  kNumChans   = 2;
 constexpr int  kIterations = 32;
 constexpr long long kTimeoutNs = 100'000'000LL;  // 100 ms
 
-#if defined (_WIN32)
 struct ScopedChannelPair
 {
     ~ScopedChannelPair()
@@ -46,7 +45,6 @@ struct ScopedChannelPair
 
     duskstudio::ipc::platform::ChannelPair value;
 };
-#endif
 } // namespace
 
 #if defined (_WIN32)
@@ -110,6 +108,46 @@ TEST_CASE ("Windows IPC launcher preserves Unicode paths and arguments",
     REQUIRE (receivedArguments.back().rfind ("--ipc-channel=0x", 0) == 0);
 }
 #endif
+
+TEST_CASE ("Plugin-host handshake read timeout bounds a silent live child",
+           "[ipc][issue-364]")
+{
+    namespace ipcp = duskstudio::ipc::platform;
+    using namespace std::chrono_literals;
+
+    ipcp::NativeHandle invalid;
+    REQUIRE_FALSE (ipcp::setReadTimeout (invalid, 75));
+
+    ScopedChannelPair channels;
+    std::string error;
+    REQUIRE (ipcp::createChannelPair (channels.value, error));
+
+    ipcp::ChildProcess child;
+    REQUIRE (child.spawn (DUSKSTUDIO_PLUGIN_HOST_PATH,
+                          { "--ipc-silent-handshake-stub" },
+                          channels.value.childEnd, error));
+    REQUIRE (child.isAlive());
+    REQUIRE (ipcp::setReadTimeout (channels.value.parentEnd, 75));
+
+    char ready = 0;
+    const auto readStarted = std::chrono::steady_clock::now();
+    REQUIRE_FALSE (ipcp::readExact (channels.value.parentEnd, &ready, sizeof (ready)));
+    const auto readElapsed = std::chrono::steady_clock::now() - readStarted;
+
+    // A premature EOF would make this test pass instantly, so require evidence
+    // that the live child held the pipe open until the configured deadline.
+    REQUIRE (readElapsed >= 25ms);
+    REQUIRE (readElapsed < 2s);
+    REQUIRE (child.isAlive());
+
+    // Releasing the parent end wakes the silent child's blocking read. The
+    // normal process teardown then reaps it without leaving a wedged child.
+    ipcp::closeHandle (channels.value.parentEnd);
+    const auto teardownStarted = std::chrono::steady_clock::now();
+    child.terminate (1000);
+    REQUIRE_FALSE (child.isAlive());
+    REQUIRE (std::chrono::steady_clock::now() - teardownStarted < 2s);
+}
 
 TEST_CASE ("ipc-stub: connect, round-trip 32 blocks, byte-exact echo",
             "[ipc]")


### PR DESCRIPTION
Closes #364

## Summary

- open the parent Windows named-pipe endpoint for overlapped I/O and enforce read deadlines with cancellation
- surface handshake timeout configuration failures instead of silently accepting a no-op
- add a live silent-child teardown regression and re-enable the Windows OOP control-reply tests
- update the documented Catch2 case count to 894

## Validation

Exact commit: `582efe5032ae91a5f71cbbe2d6927bc10c4076d7`

- Linux: 881/881 CTest; `[issue-364]` 11 assertions
- macOS: 847/847 CTest (native LV2 and OOP IPC tests are not enabled in this machine configuration)
- Windows: 847/847 CTest with ASIO; `[issue-364]` 11 assertions; all five re-enabled OOP control tests pass
- `git diff --check`
- `review-local --base origin/main` returned exit 2 because the local model was unreachable; its Linux-side clang-tidy output contained no valid finding after source verification

No new JUCE usage. No frontier review was run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin communication reliability on Windows by enabling asynchronous channel operations.
  * Added proper handling and reporting when communication timeouts cannot be configured.
  * Prevented stalled plugin handshakes from waiting indefinitely and ensured clean shutdown.

* **Tests**
  * Added coverage for handshake timeout behavior and cross-platform IPC communication.

* **Documentation**
  * Updated the documented test count from 893 to 894.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->