### PR TITLE
fix: isolate Windows plugin child handles

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 894 Catch2 test cases across 176 test source files. Linux
+The C++ suite declares 895 Catch2 test cases across 176 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 894 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 895 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/ipc/PluginHostMain.cpp
+++ b/src/engine/ipc/PluginHostMain.cpp
@@ -9,6 +9,8 @@
 //                 Used to validate Windows UTF-16 launch and quoting.
 //   --ipc-silent-handshake-stub: keep the inherited channel open without
 //                 acknowledging readiness, for the bounded-read regression.
+//   --ipc-handle-probe-stub: report which Windows mapping handles reached the
+//                 child, for the explicit inheritance-allowlist regression.
 //   --ipc-control-reply-stub: deterministic request-correlation and reply-
 //                 validation regression child.
 //   --ipc-host  : full Phase-2 host. Loads a juce::AudioPluginInstance
@@ -61,11 +63,22 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
+
+#if defined (_WIN32)
+ #ifndef WIN32_LEAN_AND_MEAN
+  #define WIN32_LEAN_AND_MEAN
+ #endif
+ #ifndef NOMINMAX
+  #define NOMINMAX
+ #endif
+ #include <windows.h>
+#endif
 
 #if defined (DUSKSTUDIO_USE_WINDOWS_SOFTWARE_OPENGL)
 namespace
@@ -173,6 +186,62 @@ int runIpcSilentHandshakeStub (int argc, const char* const* argv) noexcept
     (void) ipcp::readExact (channel, &ignored, sizeof (ignored));
     return 0;
 }
+
+#if defined (_WIN32)
+bool findHandleArgument (int argc, const char* const* argv,
+                         const char* prefix, HANDLE& handleOut) noexcept
+{
+    const auto prefixLength = std::strlen (prefix);
+    for (int i = 1; i < argc; ++i)
+    {
+        if (argv[i] == nullptr || std::strncmp (argv[i], prefix, prefixLength) != 0)
+            continue;
+
+        const char* const valueText = argv[i] + prefixLength;
+        char* end = nullptr;
+        errno = 0;
+        const auto value = std::strtoull (valueText, &end, 0);
+        if (errno != 0 || end == valueText || *end != '\0'
+            || value == 0
+            || value > (unsigned long long) std::numeric_limits<std::uintptr_t>::max())
+            return false;
+        handleOut = reinterpret_cast<HANDLE> ((std::uintptr_t) value);
+        return true;
+    }
+    return false;
+}
+
+std::uint8_t readMappingMarker (HANDLE handle) noexcept
+{
+    const void* const view = ::MapViewOfFile (handle, FILE_MAP_READ, 0, 0, 1);
+    if (view == nullptr) return 0;
+    const auto marker = *static_cast<const std::uint8_t*> (view);
+    (void) ::UnmapViewOfFile (view);
+    return marker;
+}
+
+int runIpcHandleProbeStub (int argc, const char* const* argv) noexcept
+{
+    ipcp::NativeHandle channel = ipcp::locateInheritedChannel (argc, argv);
+    if (! ipcp::isValid (channel)) return 1;
+
+    HANDLE mappingA = nullptr;
+    HANDLE mappingB = nullptr;
+    if (! findHandleArgument (argc, argv, "--ipc-probe-a=", mappingA)
+        || ! findHandleArgument (argc, argv, "--ipc-probe-b=", mappingB))
+        return 1;
+
+    const std::uint8_t markers[2] {
+        readMappingMarker (mappingA), readMappingMarker (mappingB)
+    };
+    if (! ipcp::writeExact (channel, markers, sizeof (markers))) return 1;
+
+    // Keep the inherited mapping alive until the owning connection closes.
+    char ignored = 0;
+    (void) ipcp::readExact (channel, &ignored, sizeof (ignored));
+    return 0;
+}
+#endif
 
 // --- Phase 1 echo mode (kept for the IPC self-test) ----------------------
 int runIpcStub (int argc, const char* const* argv, bool suppressReplies) noexcept
@@ -1320,6 +1389,9 @@ int main (int argc, char** argv)
     bool ipcStubTimeout = false;
     bool ipcArgvStub = false;
     bool ipcSilentHandshakeStub = false;
+   #if defined (_WIN32)
+    bool ipcHandleProbeStub = false;
+   #endif
     bool ipcControlReplyStub = false;
     bool ipcParkTimeoutStub = false;
     bool ipcHost = false;
@@ -1331,6 +1403,10 @@ int main (int argc, char** argv)
         if (std::strcmp (args[i], "--ipc-argv-stub") == 0) ipcArgvStub = true;
         if (std::strcmp (args[i], "--ipc-silent-handshake-stub") == 0)
             ipcSilentHandshakeStub = true;
+       #if defined (_WIN32)
+        if (std::strcmp (args[i], "--ipc-handle-probe-stub") == 0)
+            ipcHandleProbeStub = true;
+       #endif
         if (std::strcmp (args[i], "--ipc-control-reply-stub") == 0) ipcControlReplyStub = true;
         if (std::strcmp (args[i], "--ipc-park-timeout-stub") == 0) ipcParkTimeoutStub = true;
         if (std::strcmp (args[i], "--ipc-host") == 0) ipcHost = true;
@@ -1343,6 +1419,9 @@ int main (int argc, char** argv)
     if (scan)    return runScan (argc, args);
     if (ipcArgvStub) return runIpcArgvStub (argc, args);
     if (ipcSilentHandshakeStub) return runIpcSilentHandshakeStub (argc, args);
+   #if defined (_WIN32)
+    if (ipcHandleProbeStub) return runIpcHandleProbeStub (argc, args);
+   #endif
     if (ipcStub || ipcStubTimeout) return runIpcStub (argc, args, ipcStubTimeout);
     if (ipcControlReplyStub) return runIpcControlReplyStub (argc, args);
     if (ipcParkTimeoutStub) return runIpcParkTimeoutStub (argc, args);

--- a/src/engine/ipc/RemotePluginConnection.cpp
+++ b/src/engine/ipc/RemotePluginConnection.cpp
@@ -114,7 +114,9 @@ bool RemotePluginConnection::connect (const std::string& hostExecutablePath,
     }
 
     std::vector<std::string> args { extraArg };
-    if (! child.spawn (hostExecutablePath, args, pair.childEnd, errorOut))
+    if (! child.spawn (hostExecutablePath, args, pair.childEnd,
+                       { shm.handle(), commandSignal.handle(), replySignal.handle() },
+                       errorOut))
     {
         platform::closeHandle (pair.parentEnd);
         platform::closeHandle (pair.childEnd);

--- a/src/engine/ipc/platform/IpcProcess.h
+++ b/src/engine/ipc/platform/IpcProcess.h
@@ -14,9 +14,9 @@
 // macOS  : posix_spawn() with file actions to remap the channel endpoint
 //          to kChildInheritFd. Parent-death tracking via kqueue NOTE_EXIT
 //          on the child PID; termination via SIGTERM + waitpid.
-// Windows: CreateProcessW() with bInheritHandles=TRUE, the child handle
-//          duplicated into the new process and recorded in
-//          STARTUPINFOEX::lpAttributeList. Job object configured with
+// Windows: CreateProcessW() with bInheritHandles=TRUE and an explicit
+//          PROC_THREAD_ATTRIBUTE_HANDLE_LIST containing only the channel and
+//          caller-approved IPC handles. Job object configured with
 //          JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE so the child dies with us;
 //          termination via TerminateProcess() + WaitForSingleObject.
 
@@ -34,8 +34,9 @@ public:
 
     // Spawn `executablePath` with `args` (the executable path itself is
     // argv[0]; pass only the trailing flags in `args`). The child end
-    // of `channelToInherit` is duped to kChildInheritFd in the child
-    // process; the parent end stays with the caller.
+    // of `childChannelEnd` is duped to kChildInheritFd in a POSIX child;
+    // Windows inherits it plus `additionalInheritedHandles` through an
+    // explicit handle allowlist. The parent end stays with the caller.
     //
     // On success the child's end of the channel is closed in the parent
     // (the child sees the dup'd copy at kChildInheritFd) and the
@@ -43,6 +44,7 @@ public:
     bool spawn (const std::string& executablePath,
                   const std::vector<std::string>& args,
                   NativeHandle& childChannelEnd,
+                  const std::vector<NativeHandle>& additionalInheritedHandles,
                   std::string& errorOut) noexcept;
 
     // Non-blocking check. Returns true if the child has exited.

--- a/src/engine/ipc/platform/IpcProcess_Linux.cpp
+++ b/src/engine/ipc/platform/IpcProcess_Linux.cpp
@@ -19,6 +19,7 @@ ChildProcess::~ChildProcess()
 bool ChildProcess::spawn (const std::string& executablePath,
                               const std::vector<std::string>& args,
                               NativeHandle& childChannelEnd,
+                              const std::vector<NativeHandle>&,
                               std::string& errorOut) noexcept
 {
     const pid_t forked = ::fork();

--- a/src/engine/ipc/platform/IpcProcess_Mac.cpp
+++ b/src/engine/ipc/platform/IpcProcess_Mac.cpp
@@ -27,6 +27,7 @@ ChildProcess::~ChildProcess()
 bool ChildProcess::spawn (const std::string& executablePath,
                               const std::vector<std::string>& args,
                               NativeHandle& childChannelEnd,
+                              const std::vector<NativeHandle>&,
                               std::string& errorOut) noexcept
 {
     const pid_t forked = ::fork();

--- a/src/engine/ipc/platform/IpcProcess_Windows.cpp
+++ b/src/engine/ipc/platform/IpcProcess_Windows.cpp
@@ -4,15 +4,17 @@
 #define NOMINMAX
 #include <windows.h>
 
+#include <algorithm>
 #include <cstdio>
 #include <cstring>
 #include <limits>
 #include <string>
 #include <vector>
 
-// CreateProcessW with bInheritHandles = TRUE. Inheritable handles (the
-// channel child end + the SHM mapping) flow into the child at the same
-// numeric HANDLE value. A Job object with
+// CreateProcessW with bInheritHandles = TRUE and an explicit
+// PROC_THREAD_ATTRIBUTE_HANDLE_LIST. Only the channel child end and the
+// caller-approved IPC handles flow into the child, at the same numeric HANDLE
+// values. A Job object with
 // JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE wraps the child so it dies if the
 // parent crashes or exits, mirroring Linux's prctl(PR_SET_PDEATHSIG).
 //
@@ -123,8 +125,47 @@ ChildProcess::~ChildProcess()
 bool ChildProcess::spawn (const std::string& executablePath,
                               const std::vector<std::string>& args,
                               NativeHandle& childChannelEnd,
+                              const std::vector<NativeHandle>& additionalInheritedHandles,
                               std::string& errorOut) noexcept
 {
+    std::vector<HANDLE> inheritedHandles;
+    inheritedHandles.reserve (additionalInheritedHandles.size() + 1);
+    const auto addInheritedHandle = [&] (const NativeHandle& native)
+    {
+        const auto handle = reinterpret_cast<HANDLE> (native.h);
+        if (handle == nullptr || handle == INVALID_HANDLE_VALUE)
+            return false;
+        if (std::find (inheritedHandles.begin(), inheritedHandles.end(), handle)
+            == inheritedHandles.end())
+            inheritedHandles.push_back (handle);
+        return true;
+    };
+
+    if (! addInheritedHandle (childChannelEnd))
+    {
+        errorOut = "child channel handle is invalid";
+        return false;
+    }
+    for (const auto& handle : additionalInheritedHandles)
+    {
+        if (! addInheritedHandle (handle))
+        {
+            errorOut = "additional child handle is invalid";
+            return false;
+        }
+    }
+
+    for (const auto handle : inheritedHandles)
+    {
+        DWORD flags = 0;
+        if (! ::GetHandleInformation (handle, &flags)
+            || (flags & HANDLE_FLAG_INHERIT) == 0)
+        {
+            errorOut = "child handle is not inheritable";
+            return false;
+        }
+    }
+
     auto* state = new WinProcessState;
 
     state->job = ::CreateJobObjectA (nullptr, nullptr);
@@ -152,9 +193,8 @@ bool ChildProcess::spawn (const std::string& executablePath,
 
     std::vector<std::string> childArgs = args;
     {
-        // Pass the inherited channel HANDLE value on the command line
-        // so the child can locate it after CreateProcess(bInheritHandles
-        // = TRUE) reproduces the same numeric value in its handle table.
+        // Pass the allowlisted channel HANDLE value on the command line so the
+        // child can locate it at the numeric value preserved by inheritance.
         char buf[64];
         std::snprintf (buf, sizeof (buf), "--ipc-channel=0x%llx",
                         (unsigned long long) (std::uintptr_t)
@@ -187,8 +227,50 @@ bool ChildProcess::spawn (const std::string& executablePath,
     std::vector<wchar_t> commandBuffer (commandLine.begin(), commandLine.end());
     commandBuffer.push_back (L'\0');
 
-    STARTUPINFOW si {};
-    si.cb = sizeof (si);
+    SIZE_T attributeBytes = 0;
+    (void) ::InitializeProcThreadAttributeList (nullptr, 1, 0, &attributeBytes);
+    if (attributeBytes == 0)
+    {
+        char buf[128]; std::snprintf (buf, sizeof (buf),
+            "InitializeProcThreadAttributeList sizing failed: %lu",
+            (unsigned long) ::GetLastError());
+        errorOut = buf;
+        ::CloseHandle (state->job);
+        delete state;
+        return false;
+    }
+
+    std::vector<unsigned char> attributeStorage (attributeBytes);
+    auto* attributeList = reinterpret_cast<LPPROC_THREAD_ATTRIBUTE_LIST> (
+        attributeStorage.data());
+    if (! ::InitializeProcThreadAttributeList (attributeList, 1, 0, &attributeBytes))
+    {
+        char buf[128]; std::snprintf (buf, sizeof (buf),
+            "InitializeProcThreadAttributeList failed: %lu",
+            (unsigned long) ::GetLastError());
+        errorOut = buf;
+        ::CloseHandle (state->job);
+        delete state;
+        return false;
+    }
+
+    if (! ::UpdateProcThreadAttribute (
+            attributeList, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+            inheritedHandles.data(), inheritedHandles.size() * sizeof (HANDLE),
+            nullptr, nullptr))
+    {
+        char buf[128]; std::snprintf (buf, sizeof (buf),
+            "UpdateProcThreadAttribute failed: %lu", (unsigned long) ::GetLastError());
+        errorOut = buf;
+        ::DeleteProcThreadAttributeList (attributeList);
+        ::CloseHandle (state->job);
+        delete state;
+        return false;
+    }
+
+    STARTUPINFOEXW si {};
+    si.StartupInfo.cb = sizeof (si);
+    si.lpAttributeList = attributeList;
     PROCESS_INFORMATION pi {};
 
     const BOOL ok = ::CreateProcessW (
@@ -196,15 +278,39 @@ bool ChildProcess::spawn (const std::string& executablePath,
         commandBuffer.data(),
         nullptr, nullptr,
         TRUE,                       // bInheritHandles
-        CREATE_SUSPENDED | CREATE_NO_WINDOW,
+        CREATE_SUSPENDED | CREATE_NO_WINDOW | EXTENDED_STARTUPINFO_PRESENT,
         nullptr, nullptr,
-        &si, &pi);
+        &si.StartupInfo, &pi);
+    const DWORD createError = ok ? ERROR_SUCCESS : ::GetLastError();
+    ::DeleteProcThreadAttributeList (attributeList);
+
+    DWORD clearInheritError = ERROR_SUCCESS;
+    for (const auto handle : inheritedHandles)
+    {
+        if (! ::SetHandleInformation (handle, HANDLE_FLAG_INHERIT, 0)
+            && clearInheritError == ERROR_SUCCESS)
+            clearInheritError = ::GetLastError();
+    }
 
     if (! ok)
     {
         char buf[128]; std::snprintf (buf, sizeof (buf),
-            "CreateProcess failed: %lu", (unsigned long) ::GetLastError());
+            "CreateProcess failed: %lu", (unsigned long) createError);
         errorOut = buf;
+        ::CloseHandle (state->job);
+        delete state;
+        return false;
+    }
+
+    if (clearInheritError != ERROR_SUCCESS)
+    {
+        char buf[128]; std::snprintf (buf, sizeof (buf),
+            "failed to clear child handle inheritance: %lu",
+            (unsigned long) clearInheritError);
+        errorOut = buf;
+        ::TerminateProcess (pi.hProcess, 1);
+        ::CloseHandle (pi.hProcess);
+        ::CloseHandle (pi.hThread);
         ::CloseHandle (state->job);
         delete state;
         return false;

--- a/src/engine/ipc/platform/IpcSync.h
+++ b/src/engine/ipc/platform/IpcSync.h
@@ -69,6 +69,10 @@ public:
     bool receiveFromParent (NativeHandle& channel) noexcept;
     void close() noexcept;
 
+    // Parent-side kernel object passed through ChildProcess's Windows handle
+    // allowlist. Invalid/no-op on platforms whose signal lives in shared memory.
+    const NativeHandle& handle() const noexcept { return nativeHandle; }
+
     // Block while `addr` still equals `expected`, up to `deadline`. The
     // sequence atom makes missed/coalesced event wakes harmless: every caller
     // re-checks it after this returns.

--- a/tests/ipc_stub_round_trip.cpp
+++ b/tests/ipc_stub_round_trip.cpp
@@ -21,12 +21,24 @@
 #include <juce_audio_basics/juce_audio_basics.h>
 
 #include <cmath>
+#include <atomic>
 #include <chrono>
+#include <cstdio>
 #include <cstdint>
 #include <filesystem>
 #include <string>
 #include <utility>
 #include <vector>
+
+#if defined (_WIN32)
+ #ifndef WIN32_LEAN_AND_MEAN
+  #define WIN32_LEAN_AND_MEAN
+ #endif
+ #ifndef NOMINMAX
+  #define NOMINMAX
+ #endif
+ #include <windows.h>
+#endif
 
 namespace
 {
@@ -48,6 +60,117 @@ struct ScopedChannelPair
 } // namespace
 
 #if defined (_WIN32)
+TEST_CASE ("Windows IPC children inherit only their own shared-memory handles",
+           "[ipc][windows][issue-365]")
+{
+    namespace ipcp = duskstudio::ipc::platform;
+
+    static std::atomic<std::uint64_t> mappingSequence { 0 };
+    const auto makeMappingName = [&]
+    {
+        return std::string ("Local\\dusk-studio-ipc-inherit-test-")
+            + std::to_string ((unsigned long) ::GetCurrentProcessId()) + "-"
+            + std::to_string (mappingSequence.fetch_add (1, std::memory_order_relaxed));
+    };
+    const auto mappingAName = makeMappingName();
+    const auto mappingBName = makeMappingName();
+
+    SECURITY_ATTRIBUTES attributes {};
+    attributes.nLength = sizeof (attributes);
+    attributes.bInheritHandle = TRUE;
+
+    ipcp::NativeHandle mappingA;
+    ipcp::NativeHandle mappingB;
+    mappingA.h = ::CreateFileMappingA (INVALID_HANDLE_VALUE, &attributes,
+                                       PAGE_READWRITE, 0, 4096, mappingAName.c_str());
+    mappingB.h = ::CreateFileMappingA (INVALID_HANDLE_VALUE, &attributes,
+                                       PAGE_READWRITE, 0, 4096, mappingBName.c_str());
+    REQUIRE (ipcp::isValid (mappingA));
+    REQUIRE (ipcp::isValid (mappingB));
+
+    const auto writeMarker = [] (const ipcp::NativeHandle& mapping,
+                                 std::uint8_t marker)
+    {
+        void* const view = ::MapViewOfFile (reinterpret_cast<HANDLE> (mapping.h),
+                                            FILE_MAP_WRITE, 0, 0, 1);
+        REQUIRE (view != nullptr);
+        *static_cast<std::uint8_t*> (view) = marker;
+        REQUIRE (::UnmapViewOfFile (view));
+    };
+    constexpr std::uint8_t markerA = 0xa5;
+    constexpr std::uint8_t markerB = 0x5a;
+    writeMarker (mappingA, markerA);
+    writeMarker (mappingB, markerB);
+
+    const auto handleArgument = [] (const char* prefix,
+                                    const ipcp::NativeHandle& mapping)
+    {
+        char buffer[96];
+        std::snprintf (buffer, sizeof (buffer), "%s0x%llx", prefix,
+                       (unsigned long long) (std::uintptr_t) mapping.h);
+        return std::string (buffer);
+    };
+    const std::vector<std::string> probeArguments {
+        "--ipc-handle-probe-stub",
+        handleArgument ("--ipc-probe-a=", mappingA),
+        handleArgument ("--ipc-probe-b=", mappingB)
+    };
+
+    ScopedChannelPair channelsA;
+    ScopedChannelPair channelsB;
+    std::string error;
+    REQUIRE (ipcp::createChannelPair (channelsA.value, error));
+    REQUIRE (ipcp::createChannelPair (channelsB.value, error));
+
+    ipcp::ChildProcess childA;
+    ipcp::ChildProcess childB;
+    REQUIRE (childA.spawn (DUSKSTUDIO_PLUGIN_HOST_PATH, probeArguments,
+                           channelsA.value.childEnd, { mappingA }, error));
+    REQUIRE (childB.spawn (DUSKSTUDIO_PLUGIN_HOST_PATH, probeArguments,
+                           channelsB.value.childEnd, { mappingB }, error));
+
+    std::uint8_t childAMarkers[2] {};
+    std::uint8_t childBMarkers[2] {};
+    REQUIRE (ipcp::readExact (channelsA.value.parentEnd,
+                              childAMarkers, sizeof (childAMarkers)));
+    REQUIRE (ipcp::readExact (channelsB.value.parentEnd,
+                              childBMarkers, sizeof (childBMarkers)));
+    REQUIRE (childAMarkers[0] == markerA);
+    REQUIRE (childAMarkers[1] == 0);
+    REQUIRE (childBMarkers[0] == 0);
+    REQUIRE (childBMarkers[1] == markerB);
+
+    DWORD mappingAFlags = 0;
+    DWORD mappingBFlags = 0;
+    REQUIRE (::GetHandleInformation (reinterpret_cast<HANDLE> (mappingA.h),
+                                     &mappingAFlags));
+    REQUIRE (::GetHandleInformation (reinterpret_cast<HANDLE> (mappingB.h),
+                                     &mappingBFlags));
+    REQUIRE ((mappingAFlags & HANDLE_FLAG_INHERIT) == 0);
+    REQUIRE ((mappingBFlags & HANDLE_FLAG_INHERIT) == 0);
+
+    ipcp::closeHandle (mappingA);
+    ipcp::closeHandle (mappingB);
+    const auto mappingExists = [] (const std::string& name)
+    {
+        HANDLE mapping = ::OpenFileMappingA (FILE_MAP_READ, FALSE, name.c_str());
+        if (mapping == nullptr) return false;
+        ::CloseHandle (mapping);
+        return true;
+    };
+    REQUIRE (mappingExists (mappingAName));
+    REQUIRE (mappingExists (mappingBName));
+
+    ipcp::closeHandle (channelsA.value.parentEnd);
+    childA.terminate (1000);
+    REQUIRE_FALSE (mappingExists (mappingAName));
+    REQUIRE (mappingExists (mappingBName));
+
+    ipcp::closeHandle (channelsB.value.parentEnd);
+    childB.terminate (1000);
+    REQUIRE_FALSE (mappingExists (mappingBName));
+}
+
 TEST_CASE ("Windows IPC launcher preserves Unicode paths and arguments",
            "[ipc][windows][issue-373]")
 {
@@ -80,7 +203,7 @@ TEST_CASE ("Windows IPC launcher preserves Unicode paths and arguments",
 
     ipcp::ChildProcess child;
     const bool spawned = child.spawn (copiedHost.u8string(), suppliedArguments,
-                                      channels.value.childEnd, error);
+                                      channels.value.childEnd, {}, error);
     INFO ("spawn error: " << error);
     REQUIRE (spawned);
 
@@ -125,7 +248,7 @@ TEST_CASE ("Plugin-host handshake read timeout bounds a silent live child",
     ipcp::ChildProcess child;
     REQUIRE (child.spawn (DUSKSTUDIO_PLUGIN_HOST_PATH,
                           { "--ipc-silent-handshake-stub" },
-                          channels.value.childEnd, error));
+                          channels.value.childEnd, {}, error));
     REQUIRE (child.isAlive());
     REQUIRE (ipcp::setReadTimeout (channels.value.parentEnd, 75));
 


### PR DESCRIPTION
Closes #365

## Summary
- launch Windows plugin children with an explicit `PROC_THREAD_ATTRIBUTE_HANDLE_LIST`
- allow only each child channel, shared-memory mapping, and synchronization events to cross the process boundary
- clear inheritance from the parent-owned handles after spawning
- add a two-child Windows regression covering mapping isolation and teardown lifetime

## Validation
- Linux: app build + 881/881 tests
- macOS: app build + 847/847 tests
- Windows: app build with ASIO + 848/848 tests

Validated exact commit: `55748ff2c2ffc2ab62e50a24c661db52146f290c`