### PR TITLE
fix: stop CLAP-only voices with transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 895 Catch2 test cases across 176 test source files. Linux
+The C++ suite declares 896 Catch2 test cases across 176 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 895 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 896 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -4672,7 +4672,7 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
     });
 
     // Hanging-note protection. Detect two events that warrant a per-MIDI-
-    // track "All Notes Off" flush this block:
+    // track hanging-note panic this block:
     //   - Transport rolling -> stopped (held notes won't get their Note
     //     Off from the region or input stream).
     //   - Playhead discontinuity while still rolling (loop wrap, scrub).
@@ -4963,7 +4963,8 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
         // MIDI input filter - pull events from the track's selected input
         // Hanging-note flush. Emitted FIRST (sample 0) so the synth
         // releases any held voices before we add this block's new events
-        // on top. CC 64 = sustain pedal off, CC 123 = all notes off.
+        // on top. CC 64 = sustain pedal off, CC 123 = all notes off,
+        // CC 120 = all sound off (the hard-stop fallback).
         // We hit all 16 channels because we don't track which channels
         // had active notes - cheap brute-force is fine, the synth ignores
         // the redundant channels in the same processBlock pass.
@@ -4987,7 +4988,7 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
         constexpr int kGeneratedEventBytes = 6 + 3;
         constexpr int kGeneratedMidiBudget = 2 * (int) dusk::kMidiBlockBytes;
         constexpr int kMidiScheduleScanBudget = 32768;
-        constexpr int kHangingResetMessageCount = 16 * 2;
+        constexpr int kHangingResetMessageCount = 16 * 3;
         constexpr int kHangingResetBytes = kHangingResetMessageCount
                                          * kGeneratedEventBytes;
         static_assert (kGeneratedMidiBudget
@@ -5030,7 +5031,7 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
         };
         auto emitHangingMidiReset = [&] (int sampleOffset) noexcept
         {
-            // A reset is structural: either all 32 three-byte messages fit or
+            // A reset is structural: either all 48 three-byte messages fit or
             // none are emitted. Discretionary scheduling reserves this exact
             // capacity before it can consume the shared generated-event budget.
             if (! generatedMidiBudget.consumeStructural (kHangingResetBytes))
@@ -5041,10 +5042,14 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
                     (std::uint8_t) (0xB0 | (ch - 1)), 64, 0 };
                 const std::array<std::uint8_t, 3> allNotesOff {
                     (std::uint8_t) (0xB0 | (ch - 1)), 123, 0 };
+                const std::array<std::uint8_t, 3> allSoundOff {
+                    (std::uint8_t) (0xB0 | (ch - 1)), 120, 0 };
                 if (! perTrackMidi[(size_t) t].addEvent (
                         sustainOff.data(), (int) sustainOff.size(), sampleOffset)
                     || ! perTrackMidi[(size_t) t].addEvent (
-                        allNotesOff.data(), (int) allNotesOff.size(), sampleOffset))
+                        allNotesOff.data(), (int) allNotesOff.size(), sampleOffset)
+                    || ! perTrackMidi[(size_t) t].addEvent (
+                        allSoundOff.data(), (int) allSoundOff.size(), sampleOffset))
                     return false;
             }
             return true;
@@ -5063,7 +5068,7 @@ void AudioEngine::audioDeviceIOCallback (const float* const* inputChannelData,
         //     and apply the per-track channel filter.
         // The strip's instrument plugin then sees one unified buffer.
         // Note: scratch already cleared above by the flush block, plus any
-        // emitted All Notes Off events. Both source paths add to those.
+        // emitted panic events. Both source paths add to those.
         // Live-input MIDI pull. Shared by the stopped/record live-monitor
         // branch and the play-along overlay in the disk-playback branch:
         // applies the per-track channel filter, mirrors the dusk->juce raw-byte

--- a/src/engine/AudioEngine.h
+++ b/src/engine/AudioEngine.h
@@ -994,7 +994,7 @@ private:
     bool deviceFallbackHold_ = false;
 
     // Audio-thread-only. Together these let us detect two events that
-    // require a per-block "All Notes Off" flush:
+    // require a per-block hanging-note panic:
     //   - rolling -> stopped: held notes from playback or live input
     //     would otherwise sustain forever.
     //   - playhead discontinuity (loop wrap, scrub): notes whose Note

--- a/src/engine/clap/ClapInstance.cpp
+++ b/src/engine/clap/ClapInstance.cpp
@@ -470,9 +470,26 @@ void ClapInstance::appendMidiEvents (const dusk::MidiBuffer& midi) noexcept
         const bool noteOn  = status == 0x90 && meta.numBytes >= 3 && d[2] > 0;
         const bool noteOff = meta.numBytes >= 3
                              && (status == 0x80 || (status == 0x90 && d[2] == 0));
+        const bool allSoundOff = status == 0xB0 && meta.numBytes >= 3 && d[1] == 120;
 
         auto& slot = eventScratch[(size_t) eventCount];
-        if (noteDialectClap && (noteOn || noteOff))
+        if (noteDialectClap && allSoundOff)
+        {
+            // CLAP-only note ports cannot receive the raw MIDI panic emitted
+            // when transport stops. NOTE_CHOKE is CLAP's hard-stop event; the
+            // wildcard key targets every voice on this MIDI channel.
+            auto& ev = slot.note;
+            ev.header = { (uint32_t) sizeof (clap_event_note_t),
+                          (uint32_t) meta.samplePosition, CLAP_CORE_EVENT_SPACE_ID,
+                          CLAP_EVENT_NOTE_CHOKE, 0 };
+            ev.note_id    = -1;
+            ev.port_index = 0;
+            ev.channel    = channel;
+            ev.key        = -1;
+            ev.velocity   = 0.0;
+            ++eventCount;
+        }
+        else if (noteDialectClap && (noteOn || noteOff))
         {
             auto& ev = slot.note;
             ev.header = { (uint32_t) sizeof (clap_event_note_t),

--- a/src/engine/clap/ClapInstance.cpp
+++ b/src/engine/clap/ClapInstance.cpp
@@ -473,7 +473,7 @@ void ClapInstance::appendMidiEvents (const dusk::MidiBuffer& midi) noexcept
         const bool allSoundOff = status == 0xB0 && meta.numBytes >= 3 && d[1] == 120;
 
         auto& slot = eventScratch[(size_t) eventCount];
-        if (noteDialectClap && allSoundOff)
+        if (noteDialectClap && ! noteDialectMidi && allSoundOff)
         {
             // CLAP-only note ports cannot receive the raw MIDI panic emitted
             // when transport stops. NOTE_CHOKE is CLAP's hard-stop event; the

--- a/tests/clap_instance_process.cpp
+++ b/tests/clap_instance_process.cpp
@@ -11,7 +11,9 @@
 #include "engine/hosting/InsertAdapter.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
+#include <cstdint>
 #include <cstdlib>
 #include <string>
 #include <vector>
@@ -27,10 +29,11 @@ TEST_CASE ("ClapInstance connects every advertised bus and tolerates duplicate m
 
     duskstudio::clap::ClapInstance inst;
     REQUIRE (inst.create (bundle, bundle.plugins().front().id, err));
-    REQUIRE (inst.portLayout().inputs.size() == 2);
+    REQUIRE (inst.portLayout().inputs.size() == 3);
     REQUIRE (inst.portLayout().outputs.size() == 2);
     REQUIRE (inst.portLayout().mainInIndex == 0);
     REQUIRE (inst.portLayout().mainOutIndex == 0);
+    REQUIRE (inst.portLayout().eventInIndex == 2);
     REQUIRE (inst.activate (48000.0, 64, err));
 
     duskstudio::hosting::InsertAdapter adapter;
@@ -50,6 +53,56 @@ TEST_CASE ("ClapInstance connects every advertised bus and tolerates duplicate m
         REQUIRE_THAT (left[i], Catch::Matchers::WithinAbs (expectedLeft[i], 1.0e-7f));
         REQUIRE_THAT (right[i], Catch::Matchers::WithinAbs (expectedRight[i], 1.0e-7f));
     }
+}
+
+TEST_CASE ("ClapInstance chokes CLAP-only voices on the transport panic",
+           "[clap][instance][midi][regression][issue-402]")
+{
+    duskstudio::clap::ClapBundle bundle;
+    std::string err;
+    REQUIRE (bundle.load (DUSKSTUDIO_MULTI_BUS_CLAP_FIXTURE_PATH, err));
+    REQUIRE (bundle.plugins().size() == 1);
+
+    duskstudio::clap::ClapInstance inst;
+    REQUIRE (inst.create (bundle, bundle.plugins().front().id, err));
+    REQUIRE (inst.activate (48000.0, 64, err));
+
+    std::array<float, 64> inL {}, inR {}, outL {}, outR {};
+    float* inputs[] = { inL.data(), inR.data() };
+    float* outputs[] = { outL.data(), outR.data() };
+    duskstudio::hosting::PortBuffers io;
+    io.mainIn = inputs;
+    io.mainInChannels = 2;
+    io.mainOut = outputs;
+    io.mainOutChannels = 2;
+    io.numFrames = 64;
+
+    dusk::MidiBuffer noteOn;
+    const std::array<std::uint8_t, 3> note { 0x90, 60, 100 };
+    REQUIRE (noteOn.addEvent (note.data(), (int) note.size(), 0));
+    io.midiIn = &noteOn;
+    inst.processBlock (io);
+    REQUIRE_THAT (outL[0], Catch::Matchers::WithinAbs (0.25f, 1.0e-7f));
+
+    // This is the engine's transport-stop sequence. The fixture advertises
+    // only CLAP note events, so raw CCs cannot reach it; CC 120 must become a
+    // wildcard CLAP NOTE_CHOKE and silence the latched voice.
+    dusk::MidiBuffer panic;
+    for (int channel = 0; channel < 16; ++channel)
+    {
+        for (const std::uint8_t controller : { std::uint8_t { 64 },
+                                               std::uint8_t { 123 },
+                                               std::uint8_t { 120 } })
+        {
+            const std::array<std::uint8_t, 3> cc {
+                (std::uint8_t) (0xB0 | channel), controller, 0 };
+            REQUIRE (panic.addEvent (cc.data(), (int) cc.size(), 0));
+        }
+    }
+    io.midiIn = &panic;
+    inst.processBlock (io);
+    REQUIRE_THAT (outL[0], Catch::Matchers::WithinAbs (0.0f, 1.0e-7f));
+    REQUIRE_THAT (outR[0], Catch::Matchers::WithinAbs (0.0f, 1.0e-7f));
 }
 
 TEST_CASE ("ClapInstance loads + processes a real CLAP plugin", "[clap][instance]")

--- a/tests/fixtures/multi_bus_clap.cpp
+++ b/tests/fixtures/multi_bus_clap.cpp
@@ -18,6 +18,7 @@ constexpr const char* kFeatures[] = { CLAP_PLUGIN_FEATURE_AUDIO_EFFECT,
 struct PluginData
 {
     std::uint32_t processCount = 0;
+    bool voiceActive = false;
 };
 
 const clap_plugin_descriptor_t kDescriptor {
@@ -54,6 +55,27 @@ bool CLAP_ABI audioPortGet (const clap_plugin_t*, uint32_t index, bool isInput,
 }
 
 const clap_plugin_audio_ports_t kAudioPorts { audioPortCount, audioPortGet };
+
+uint32_t CLAP_ABI notePortCount (const clap_plugin_t*, bool isInput)
+{
+    return isInput ? 1u : 0u;
+}
+
+bool CLAP_ABI notePortGet (const clap_plugin_t*, uint32_t index, bool isInput,
+                           clap_note_port_info_t* info)
+{
+    if (! isInput || index != 0 || info == nullptr) return false;
+    *info = {};
+    info->id = 0;
+    std::snprintf (info->name, sizeof (info->name), "Note input");
+    // Deliberately CLAP-only: raw MIDI controllers are unavailable, so the
+    // host must translate its transport panic into a CLAP note event.
+    info->supported_dialects = CLAP_NOTE_DIALECT_CLAP;
+    info->preferred_dialect = CLAP_NOTE_DIALECT_CLAP;
+    return true;
+}
+
+const clap_plugin_note_ports_t kNotePorts { notePortCount, notePortGet };
 
 bool writeAll (const clap_ostream_t* stream, const void* data, std::uint64_t size)
 {
@@ -125,7 +147,10 @@ bool CLAP_ABI pluginActivate (const clap_plugin_t*, double, uint32_t, uint32_t) 
 void CLAP_ABI pluginDeactivate (const clap_plugin_t*) {}
 bool CLAP_ABI pluginStart (const clap_plugin_t*) { return true; }
 void CLAP_ABI pluginStop (const clap_plugin_t*) {}
-void CLAP_ABI pluginReset (const clap_plugin_t*) {}
+void CLAP_ABI pluginReset (const clap_plugin_t* plugin)
+{
+    static_cast<PluginData*> (plugin->plugin_data)->voiceActive = false;
+}
 
 clap_process_status CLAP_ABI pluginProcess (const clap_plugin_t* plugin,
                                             const clap_process_t* process)
@@ -133,6 +158,23 @@ clap_process_status CLAP_ABI pluginProcess (const clap_plugin_t* plugin,
     if (process == nullptr || process->audio_inputs_count != 2
         || process->audio_outputs_count != 2)
         return CLAP_PROCESS_ERROR;
+
+    auto* data = static_cast<PluginData*> (plugin->plugin_data);
+    if (process->in_events != nullptr)
+    {
+        const auto count = process->in_events->size (process->in_events);
+        for (uint32_t i = 0; i < count; ++i)
+        {
+            const auto* event = process->in_events->get (process->in_events, i);
+            if (event == nullptr || event->space_id != CLAP_CORE_EVENT_SPACE_ID)
+                continue;
+            if (event->type == CLAP_EVENT_NOTE_ON)
+                data->voiceActive = true;
+            else if (event->type == CLAP_EVENT_NOTE_OFF
+                     || event->type == CLAP_EVENT_NOTE_CHOKE)
+                data->voiceActive = false;
+        }
+    }
 
     for (uint32_t port = 0; port < 2; ++port)
     {
@@ -152,18 +194,20 @@ clap_process_status CLAP_ABI pluginProcess (const clap_plugin_t* plugin,
         for (uint32_t channel = 0; channel < 2; ++channel)
         {
             process->audio_outputs[0].data32[channel][frame]
-                = process->audio_inputs[0].data32[channel][frame];
+                = process->audio_inputs[0].data32[channel][frame]
+                    + (data->voiceActive ? 0.25f : 0.0f);
             process->audio_outputs[1].data32[channel][frame]
                 = process->audio_inputs[1].data32[channel][frame];
         }
     }
-    ++static_cast<PluginData*> (plugin->plugin_data)->processCount;
+    ++data->processCount;
     return CLAP_PROCESS_CONTINUE;
 }
 
 const void* CLAP_ABI pluginExtension (const clap_plugin_t*, const char* id)
 {
     if (std::strcmp (id, CLAP_EXT_AUDIO_PORTS) == 0) return &kAudioPorts;
+    if (std::strcmp (id, CLAP_EXT_NOTE_PORTS) == 0) return &kNotePorts;
     if (std::strcmp (id, CLAP_EXT_STATE) == 0) return &kState;
     return nullptr;
 }

--- a/tests/generated_midi_budget.cpp
+++ b/tests/generated_midi_budget.cpp
@@ -8,7 +8,7 @@ TEST_CASE ("Generated MIDI structural reset releases its reserved capacity",
            "[audio-engine][midi][budget]")
 {
     constexpr int eventBytes = 9;
-    constexpr int resetBytes = 32 * eventBytes;
+    constexpr int resetBytes = 48 * eventBytes;
     GeneratedMidiBudget budget (resetBytes + 2 * eventBytes);
 
     REQUIRE (budget.reserveStructural (resetBytes));
@@ -28,7 +28,7 @@ TEST_CASE ("Generated MIDI structural reset consumption is all or nothing",
            "[audio-engine][midi][budget]")
 {
     constexpr int eventBytes = 9;
-    constexpr int resetBytes = 32 * eventBytes;
+    constexpr int resetBytes = 48 * eventBytes;
     GeneratedMidiBudget budget (resetBytes - eventBytes);
 
     CHECK_FALSE (budget.reserveStructural (resetBytes));


### PR DESCRIPTION
## Summary

- add All Sound Off to the transport/discontinuity MIDI panic sequence
- translate CC120 to a wildcard CLAP note-choke event for CLAP-only note ports
- add a latched-voice CLAP regression covering the reported stop behavior

## Testing

- Linux app build and 882/882 CTest
- macOS app build and 848/848 CTest
- Windows ASIO app build and 849/849 CTest
- no-new-JUCE gate: 164 coupled files, 8253 uses (unchanged)

Closes #402

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MIDI panic handling to reliably silence hanging notes across all channels.
  * CLAP instruments now correctly respond to All Sound Off messages by choking active notes.
  * Preserved existing behavior for other MIDI messages and non-CLAP note inputs.

* **Tests**
  * Added coverage for multi-channel panic handling and note-choke behavior.

* **Documentation**
  * Updated the documented test-suite count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->