### PR TITLE
Fix native window activation on macOS and Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -861,10 +861,7 @@ endif()
 
 # Cross-platform window-management primitives. One implementation per
 # platform; callsites #include only PlatformWindowing.h and stay
-# platform-agnostic. Mac and Windows impls are stubs today (see
-# PlatformWindowing.h for the eventual per-platform mechanisms) but
-# the files exist so the fix slot is obvious when the equivalent bugs
-# surface there.
+# platform-agnostic.
 if(APPLE)
     target_sources(DuskStudio PRIVATE src/ui/PlatformWindowing_Mac.mm)
 elseif(WIN32)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 896 Catch2 test cases across 176 test source files. Linux
+The C++ suite declares 898 Catch2 test cases across 177 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 896 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 898 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/docs/MAINTAINER-GUIDE.md
+++ b/docs/MAINTAINER-GUIDE.md
@@ -622,8 +622,8 @@ manual checks that the script cannot cover:
   that file alongside its license text.
 
 The release is accepted only when the asset/body check, checksum verification,
-PDF inspection, private-Xvfb smoke tests, payload inspection, and license checks
-all pass.
+PDF inspection, private-Xvfb smoke tests, payload inspection, macOS and Windows
+window-activation smoke tests, and license checks all pass.
 
 ---
 

--- a/docs/MAINTAINER-GUIDE.md
+++ b/docs/MAINTAINER-GUIDE.md
@@ -613,6 +613,9 @@ manual checks that the script cannot cover:
 - Inspect the tarball, DMG, and MSI payloads. Each must be Dusk-only, with no
   `JUCE-*` paths, and each must contain the complete
   [LICENSES.txt](../LICENSES.txt), not merely a file by that name.
+- On macOS and Windows, run the
+  [window-activation smoke test](../tests/window_activation_smoke_test.md) for
+  initial launch, session open, minimized restore, and second-process handoff.
 - In every bundled `LICENSES.txt`, confirm the full-text section is present and
   the JUCE-bundled entries cover HarfBuzz, SheenBidi, libjpeg, libpng, zlib,
   FLAC, and Ogg/Vorbis. If a future SheenBidi source adds a NOTICE file, ship

--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -168,8 +168,7 @@ public:
 
         // Combined async tick: setVisible(true) creates the peer at the
         // already-finalised bounds, then bringWindowToFront promotes
-        // focus once the peer exists. bringWindowToFront is a no-op on
-        // non-Linux builds.
+        // focus once the peer exists.
         juce::Component::SafePointer<MainWindow> safeThis (this);
         dusk::callAsync ([safeThis]
         {

--- a/src/ui/PlatformWindowing.h
+++ b/src/ui/PlatformWindowing.h
@@ -25,8 +25,8 @@ namespace duskstudio::platform
 // Why a dedicated module rather than scattered #if guards: every
 // "Linux fix" we've needed (focus-stealing-prevention defeat, X server
 // flush before window destruction) has a Mac and Windows analogue
-// (NSApp activate, AllowSetForegroundWindow / SetForegroundWindow on
-// Win, RunLoop drain on Mac). Keeping the contract uniform makes the
+// (NSApp activation, foreground activation / taskbar notice on Win,
+// RunLoop drain on Mac). Keeping the contract uniform makes the
 // fix slot obvious when the equivalent bug surfaces on the other
 // platforms - and the user develops on macOS but only smoke-tests on
 // Linux, so the platform asymmetry of past bug reports does NOT mean
@@ -60,8 +60,9 @@ double nativeViewBackingScale (void* nativeViewHandle);
 // Linux: _NET_WM_USER_TIME = max-int + WM_CHANGE_STATE NormalState +
 //        _NET_ACTIVE_WINDOW (source = pager) - the ICCCM/EWMH dance
 //        that defeats Mutter's focus-stealing-prevention policy.
-// macOS: [NSApp activateIgnoringOtherApps:YES] then makeKeyAndOrderFront.
-// Win:   AllowSetForegroundWindow + SetForegroundWindow.
+// macOS: activate NSApp, restore if minimized, then makeKeyAndOrderFront.
+// Win:   restore if minimized, request foreground focus, and flash the
+//        taskbar if Windows' focus policy denies activation.
 //
 // Must be called on the message thread, AFTER the peer exists (i.e.
 // after addToDesktop / setVisible(true)). No-op if peer is null.

--- a/src/ui/PlatformWindowing_Mac.mm
+++ b/src/ui/PlatformWindowing_Mac.mm
@@ -2,16 +2,9 @@
 #include <juce_audio_processors/juce_audio_processors.h>
 #import <AppKit/AppKit.h>   // NSCursor (hide/unhide) - not pulled in transitively
 
-// Stubs for now. The Mac/Win equivalents of the Linux fixes haven't
-// surfaced yet because the user smoke-tests on Linux only - but the
-// fix slots need to exist so when (not if) the bugs appear, the
-// scope of the change is one platform-impl file rather than a
-// cross-cutting refactor. See PlatformWindowing.h for the eventual
-// per-platform implementations:
-//   bringWindowToFront     -> [NSApp activateIgnoringOtherApps:YES]
-//                              + makeKeyAndOrderFront on the peer's
-//                              NSWindow (peer.getNativeHandle() returns
-//                              the NSView; .window pulls the window).
+// Native counterparts to the Linux windowing operations. A peer's native
+// handle is its NSView; the containing NSWindow owns activation and ordering.
+// The remaining operations are intentionally small platform hooks:
 //   flushWindowOperations  -> drain a single NSRunLoop iteration with
 //                              dateLimit = +1 ms.
 //   prepareNativePeer...   -> no-op (NSView reparenting is
@@ -113,7 +106,24 @@ double nativeViewBackingScale (void* nativeViewHandle)
                                        : [[NSScreen mainScreen] backingScaleFactor];
     return scale > 0.0 ? scale : 1.0;
 }
-void bringWindowToFront (juce::ComponentPeer&)             {}
+void bringWindowToFront (juce::ComponentPeer& peer)
+{
+    auto* const view = static_cast<NSView*> (peer.getNativeHandle());
+    auto* const window = view != nil ? [view window] : nil;
+    if (window == nil) return;
+
+    // NSApplication::activate is the supported API on macOS 14+, while the
+    // deployment target remains macOS 11. Keep the older API only as the
+    // availability fallback for systems where activate does not exist.
+    if (@available(macOS 14.0, *))
+        [NSApp activate];
+    else
+        [NSApp activateIgnoringOtherApps:YES];
+
+    if ([window isMiniaturized])
+        [window deminiaturize:nil];
+    [window makeKeyAndOrderFront:nil];
+}
 void flushWindowOperations()                                {}
 void prepareNativePeerForChildAttach (juce::ComponentPeer&) {}
 

--- a/src/ui/PlatformWindowing_Windows.cpp
+++ b/src/ui/PlatformWindowing_Windows.cpp
@@ -4,10 +4,9 @@
 #define NOMINMAX
 #include <windows.h>
 
-// Stubs for now. Win32 equivalents (eventual implementations):
-//   bringWindowToFront     -> AllowSetForegroundWindow(GetCurrentProcessId())
-//                              + SetForegroundWindow(hwnd) on the
-//                              peer's HWND (peer.getNativeHandle()).
+// Native counterparts to the Linux windowing operations. A peer's native
+// handle is its HWND; Win32 owns restoration, activation and taskbar notice.
+// The remaining operations are intentionally small platform hooks:
 //   flushWindowOperations  -> while (PeekMessage(&msg, ...)) DispatchMessage.
 //   prepareNativePeer...   -> no-op (Win32 SetParent is synchronous).
 
@@ -95,7 +94,33 @@ private:
 };
 } // namespace
 
-void bringWindowToFront (juce::ComponentPeer&)             {}
+void bringWindowToFront (juce::ComponentPeer& peer)
+{
+    auto* const hwnd = static_cast<HWND> (peer.getNativeHandle());
+    if (hwnd == nullptr || ! ::IsWindow (hwnd)) return;
+
+    if (::IsIconic (hwnd))
+        ::ShowWindow (hwnd, SW_RESTORE);
+    else if (! ::IsWindowVisible (hwnd))
+        ::ShowWindow (hwnd, SW_SHOW);
+
+    // Windows may refuse foreground activation when this process did not
+    // receive the user's most recent input. Ask through the documented path,
+    // then respect that policy and flash the taskbar instead of attaching
+    // input queues or otherwise forcing focus.
+    ::AllowSetForegroundWindow (::GetCurrentProcessId());
+    if (::SetForegroundWindow (hwnd) == FALSE)
+    {
+        auto info = FLASHWINFO {
+            sizeof (FLASHWINFO),
+            hwnd,
+            FLASHW_TRAY | FLASHW_TIMERNOFG,
+            3,
+            0
+        };
+        ::FlashWindowEx (&info);
+    }
+}
 void flushWindowOperations()                                {}
 void prepareNativePeerForChildAttach (juce::ComponentPeer&) {}
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(dusk-studio-tests
     embedded_modal_close_safety.cpp
     native_editor_owner.cpp
     x11_anti_pattern_guard.cpp
+    platform_window_activation.cpp
     clap_editor_lifecycle.cpp
     plugin_state_diagnostics.cpp
     channel_strip_context_rename.cpp

--- a/tests/platform_window_activation.cpp
+++ b/tests/platform_window_activation.cpp
@@ -1,0 +1,122 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <fstream>
+#include <iterator>
+#include <string>
+
+#ifndef DUSKSTUDIO_SOURCE_DIR
+#define DUSKSTUDIO_SOURCE_DIR "."
+#endif
+
+namespace
+{
+std::string readSource (const char* relativePath)
+{
+    std::ifstream input (std::string (DUSKSTUDIO_SOURCE_DIR) + "/" + relativePath);
+    REQUIRE (input.good());
+    return { std::istreambuf_iterator<char> (input),
+             std::istreambuf_iterator<char>() };
+}
+
+std::string definitionBody (const std::string& source, const std::string& methodName)
+{
+    std::size_t searchFrom = 0;
+    for (;;)
+    {
+        const auto method = source.find (methodName, searchFrom);
+        if (method == std::string::npos) break;
+
+        const auto afterName = method + methodName.size();
+        const auto openParen = source.find_first_not_of (" \t\r\n", afterName);
+        if (openParen == std::string::npos || source[openParen] != '(')
+        {
+            searchFrom = afterName;
+            continue;
+        }
+
+        std::size_t closeParen = openParen;
+        int parenDepth = 0;
+        for (; closeParen < source.size(); ++closeParen)
+        {
+            if (source[closeParen] == '(') ++parenDepth;
+            if (source[closeParen] == ')' && --parenDepth == 0) break;
+        }
+        REQUIRE (closeParen < source.size());
+
+        auto afterParameters = source.find_first_not_of (" \t\r\n", closeParen + 1);
+        std::size_t openBrace = std::string::npos;
+        if (afterParameters != std::string::npos && source[afterParameters] == '{')
+            openBrace = afterParameters;
+        else if (afterParameters != std::string::npos && source[afterParameters] == ':')
+            openBrace = source.find ('{', afterParameters + 1); // constructor initializer list
+
+        if (openBrace == std::string::npos)
+        {
+            searchFrom = afterName;
+            continue;
+        }
+
+        int braceDepth = 1;
+        for (auto cursor = openBrace + 1; cursor < source.size(); ++cursor)
+        {
+            if (source[cursor] == '{') ++braceDepth;
+            if (source[cursor] == '}' && --braceDepth == 0)
+                return source.substr (openBrace + 1, cursor - openBrace - 1);
+        }
+        FAIL ("unterminated method body for " << methodName);
+        return {};
+    }
+
+    FAIL ("method definition not found: " << methodName);
+    return {};
+}
+
+void requireInOrder (const std::string& source,
+                     const std::string& first,
+                     const std::string& second)
+{
+    const auto firstAt = source.find (first);
+    REQUIRE (firstAt != std::string::npos);
+    const auto secondAt = source.find (second, firstAt + first.size());
+    REQUIRE (secondAt != std::string::npos);
+}
+}
+
+TEST_CASE ("native window activation restores and raises the platform peer",
+           "[windowing][macos][windows][regression][issue-369]")
+{
+    const auto mac = definitionBody (
+        readSource ("src/ui/PlatformWindowing_Mac.mm"), "bringWindowToFront");
+    REQUIRE (mac.find ("getNativeHandle") != std::string::npos);
+    REQUIRE (mac.find ("@available(macOS 14.0") != std::string::npos);
+    REQUIRE (mac.find ("[NSApp activate]") != std::string::npos);
+    REQUIRE (mac.find ("activateIgnoringOtherApps") != std::string::npos);
+    REQUIRE (mac.find ("isMiniaturized") != std::string::npos);
+    REQUIRE (mac.find ("deminiaturize") != std::string::npos);
+    requireInOrder (mac, "[NSApp activate]", "makeKeyAndOrderFront");
+
+    const auto windows = definitionBody (
+        readSource ("src/ui/PlatformWindowing_Windows.cpp"), "bringWindowToFront");
+    REQUIRE (windows.find ("getNativeHandle") != std::string::npos);
+    REQUIRE (windows.find ("IsWindow") != std::string::npos);
+    REQUIRE (windows.find ("IsIconic") != std::string::npos);
+    REQUIRE (windows.find ("SW_RESTORE") != std::string::npos);
+    REQUIRE (windows.find ("AllowSetForegroundWindow") != std::string::npos);
+    requireInOrder (windows, "SetForegroundWindow", "FlashWindowEx");
+}
+
+TEST_CASE ("launch session load and instance handoff retain native activation",
+           "[windowing][regression][issue-369]")
+{
+    const auto app = readSource ("src/DuskStudioApp.cpp");
+    const auto initialLaunch = definitionBody (app, "MainWindow");
+    requireInOrder (initialLaunch, "self->setVisible (true)", "bringWindowToFront");
+
+    const auto handoff = definitionBody (app, "anotherInstanceStarted");
+    requireInOrder (handoff, "mainWindow->toFront (true)", "bringWindowToFront");
+    requireInOrder (handoff, "bringWindowToFront", "openSessionPath");
+
+    const auto sessionLoad = definitionBody (
+        readSource ("src/ui/MainComponent.cpp"), "finishLoadingSessionFrom");
+    REQUIRE (sessionLoad.find ("bringWindowToFront") != std::string::npos);
+}

--- a/tests/window_activation_smoke_test.md
+++ b/tests/window_activation_smoke_test.md
@@ -1,0 +1,22 @@
+# macOS and Windows window-activation smoke test (manual)
+
+Run this checklist against the packaged application on both macOS and Windows
+before a release. It covers behavior that CI can compile and source-check but
+cannot reliably assert without controlling the foreground desktop session.
+
+Use two disposable sessions, with a harmless unsaved edit in the first one for
+the handoff case. On Windows, foreground activation is deliberately subject to
+the operating system's focus policy: when Windows denies focus, a restored
+window plus a flashing taskbar button is the expected result. The implementation
+must not force focus by joining another process's input queue.
+
+| Case | Action | macOS result | Windows result |
+|---|---|---|---|
+| Initial launch | Put another app in front, then launch Dusk Studio from Finder / Explorer. | Dusk Studio becomes active and its main window is key and frontmost. | The main window is visible and foreground when policy permits; otherwise its taskbar button flashes. |
+| Session open | Open the second session from Dusk Studio while another window partly occludes the main window. | The rebuilt main window is key and frontmost; any load alert stays above it. | The rebuilt main window is foreground when permitted; any load alert remains visible. |
+| Minimized | Minimize Dusk Studio, then open a session through the OS file association. | The existing window leaves the Dock and comes to the front. | The existing window is restored; it receives focus or its taskbar button flashes. |
+| Second-process handoff | With an unsaved edit open, double-click the second session so the running instance receives the request. | The existing window and save prompt come to the front; no second main window remains. | The existing window is restored and the save prompt is visible; focus is granted or the taskbar flashes, and no second main window remains. |
+
+Second-process enforcement on macOS and Windows is implemented separately by
+issue #368. Run the handoff rows after that milestone item has landed; keep this
+checklist as the release regression check for both changes.


### PR DESCRIPTION
## Summary

- activate the application and restore/key/order the peer window on macOS, using the supported macOS 14 API with a deployment-target fallback
- restore minimized Windows peers, request foreground activation through Win32, and flash the taskbar when Windows focus policy denies the request
- add source-contract regression coverage and a macOS/Windows release smoke checklist for launch, session load, minimized restore, and second-process handoff
- add no JUCE usage; the ratchet remains at 164 coupled files and drops to 8,253 uses

## Validation

Exact commit: `022ceaf4e63f126b505dbcdb6d9109cbe955554b`

- Linux: app + tests build; `[issue-369]` 36 assertions; CTest 884/884
- macOS: app + tests build; `[issue-369]` 36 assertions; CTest 850/850
- Windows: app + tests build; ASIO confirmed enabled; `[issue-369]` 36 assertions; CTest 851/851
- release-mechanics contract and JUCE ratchet pass

Coverage notes: the existing macOS validation cache has native LV2 disabled; the Windows cache has MP3 export disabled. Neither feature is touched by this change.

Closes #369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved window activation on macOS and Windows, including restoring minimized windows and handling OS focus restrictions.
  * Added taskbar notification behavior when Windows prevents foreground activation.

* **Bug Fixes**
  * Window activation now works during launch, session opening, minimized restores, and second-process handoffs.

* **Documentation**
  * Added cross-platform window-activation smoke-test guidance.
  * Updated documented test-suite totals.

* **Tests**
  * Added regression coverage for platform-specific activation behavior and activation call sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->