### PR TITLE
Implement single-instance handoff on macOS and Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1535,8 +1535,9 @@ target_link_libraries(DuskStudio PRIVATE
     juce::juce_recommended_warning_flags)
 
 if(WIN32)
-    # Wide special-folder resolution in foundation/Fs.h.
-    target_link_libraries(DuskStudio PRIVATE shell32 ole32)
+    # Wide special-folder resolution in foundation/Fs.h plus the per-user ACL
+    # and token checks used by the single-instance named pipe.
+    target_link_libraries(DuskStudio PRIVATE shell32 ole32 advapi32)
 endif()
 
 # LTO is on by default for release builds (5-10% smaller binary, slight perf

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 898 Catch2 test cases across 177 test source files. Linux
+The C++ suite declares 903 Catch2 test cases across 177 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 898 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 903 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -2524,8 +2524,9 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
         return;
     }
 
-    // One instance per user + display. The .desktop entry and the session
-    // MIME handler both pass %f, so opening a session from a file manager
+    // One instance per Linux user + display, or per macOS/Windows user. The
+    // desktop entry and session MIME handler both pass a path, so opening a
+    // session from a file manager
     // launches the binary again; without this it would be a second engine
     // contending for the device and a second autosave loop writing the same
     // session directory. A launch that finds an instance already running

--- a/src/DuskStudioApp.h
+++ b/src/DuskStudioApp.h
@@ -15,11 +15,11 @@ public:
     // Stays open on every platform. The framework's own gate runs before
     // initialise(), so it would swallow the headless env-gated runs
     // (DUSKSTUDIO_RUN_SELFTEST, BOUNCE_TEST, the editor tests) whenever a GUI
-    // instance happens to be open - and on Linux it could not deliver the
-    // handoff anyway, its cross-process broadcast having no implementation
-    // there. Single-instance behaviour is Linux's own handshake in
-    // initialise() (single_instance::acquire), which sits after those env
-    // gates and dispatches into anotherInstanceStarted.
+    // instance happens to be open - and its platform broadcast is not the
+    // authenticated, bounded handoff Dusk needs. Cross-platform single-
+    // instance behaviour is handled by single_instance::acquire in
+    // initialise(), after those env gates, and dispatches into
+    // anotherInstanceStarted.
     bool moreThanOneInstanceAllowed() override             { return true; }
 
     void initialise (const juce::String& commandLine) override;

--- a/src/util/SingleInstance.cpp
+++ b/src/util/SingleInstance.cpp
@@ -39,7 +39,7 @@ namespace
 #if defined (DUSKSTUDIO_SINGLE_INSTANCE_TESTING)
 testing::Dispatcher testDispatcher;
 #if defined (_WIN32)
-std::atomic<bool> dropNextAcknowledgement { false };
+std::atomic<bool> dropNextAcknowledgementForTest { false };
 #endif
 #endif
 
@@ -791,7 +791,7 @@ void serveConnection (Listener& l)
     auto fn = l.onCommandLine;
     unsigned char accepted = dispatch ([fn, payload] { fn (payload); }) ? 1u : 0u;
 #if defined (DUSKSTUDIO_SINGLE_INSTANCE_TESTING)
-    if (accepted != 0 && dropNextAcknowledgement.exchange (false)) return;
+    if (accepted != 0 && dropNextAcknowledgementForTest.exchange (false)) return;
 #endif
     transferExact (l.pipe, &accepted, sizeof accepted, true,
                    l.stopEvent, deadline);
@@ -959,7 +959,7 @@ void testing::setDispatcher (Dispatcher dispatcher)
 #if defined (_WIN32)
 void testing::dropNextAcknowledgement()
 {
-    dropNextAcknowledgement.store (true);
+    dropNextAcknowledgementForTest.store (true);
 }
 #endif
 #endif

--- a/src/util/SingleInstance.cpp
+++ b/src/util/SingleInstance.cpp
@@ -58,6 +58,7 @@ namespace
 constexpr std::size_t kMaxPayloadBytes = 64 * 1024;
 constexpr int kReadBudgetMs = 2000;
 constexpr int kDeliveryBudgetMs = 2000;
+constexpr int kRefusalRetryMs = 250;
 using Deadline = std::chrono::steady_clock::time_point;
 
 struct Listener
@@ -138,6 +139,7 @@ void makeAddress (const std::string& path, sockaddr_un& addr, socklen_t& len)
     len = (socklen_t) (offsetof (sockaddr_un, sun_path) + path.size() + 1);
 }
 
+#if defined (__APPLE__)
 bool configureFd (int fd, bool nonBlocking)
 {
     const int descriptorFlags = ::fcntl (fd, F_GETFD);
@@ -152,9 +154,15 @@ bool configureFd (int fd, bool nonBlocking)
     }
     return true;
 }
+#endif
 
 int openSocket (bool nonBlocking)
 {
+#if defined (__linux__)
+    int type = SOCK_STREAM | SOCK_CLOEXEC;
+    if (nonBlocking) type |= SOCK_NONBLOCK;
+    return ::socket (AF_UNIX, type, 0);
+#else
     const int fd = ::socket (AF_UNIX, SOCK_STREAM, 0);
     if (fd < 0) return -1;
     if (! configureFd (fd, nonBlocking))
@@ -162,34 +170,41 @@ int openSocket (bool nonBlocking)
         ::close (fd);
         return -1;
     }
-#if defined (__APPLE__)
     const int noSigPipe = 1;
     if (::setsockopt (fd, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, sizeof noSigPipe) != 0)
     {
         ::close (fd);
         return -1;
     }
-#endif
     return fd;
+#endif
 }
 
 bool makeWakePipe (int (&fds)[2])
 {
+#if defined (__linux__)
+    return ::pipe2 (fds, O_CLOEXEC) == 0;
+#else
     if (::pipe (fds) != 0) return false;
     if (configureFd (fds[0], false) && configureFd (fds[1], false)) return true;
     ::close (fds[0]);
     ::close (fds[1]);
     fds[0] = fds[1] = -1;
     return false;
+#endif
 }
 
 int acceptPeer (int fd)
 {
+#if defined (__linux__)
+    return ::accept4 (fd, nullptr, nullptr, SOCK_CLOEXEC | SOCK_NONBLOCK);
+#else
     const int peer = ::accept (fd, nullptr, nullptr);
     if (peer < 0) return -1;
     if (configureFd (peer, true)) return peer;
     ::close (peer);
     return -1;
+#endif
 }
 
 // Closing the listening fd is what makes a later launch fall back to acting as
@@ -404,6 +419,8 @@ Handoff handOver (const sockaddr_un& addr, socklen_t len, const std::string& pay
     failureErrno = 0;
     const auto deadline = std::chrono::steady_clock::now()
                         + std::chrono::milliseconds (kDeliveryBudgetMs);
+    const auto refusalDeadline = std::chrono::steady_clock::now()
+                               + std::chrono::milliseconds (kRefusalRetryMs);
     for (;;)
     {
         const int fd = openSocket (true);
@@ -451,9 +468,9 @@ Handoff handOver (const sockaddr_un& addr, socklen_t len, const std::string& pay
         }
 
         // A simultaneous primary may have bound but not reached listen() yet.
-        // Retry refusals for the bounded delivery window before classifying
-        // the socket as one a dead process left behind.
-        if (std::chrono::steady_clock::now() >= deadline) break;
+        // Retry refusals only long enough to cover the bind-to-listen race.
+        // A dead primary should not add the full delivery timeout to startup.
+        if (std::chrono::steady_clock::now() >= refusalDeadline) break;
         std::this_thread::sleep_for (std::chrono::milliseconds (25));
     }
     return Handoff::Refused;
@@ -793,7 +810,15 @@ void serveConnection (Listener& l)
 #if defined (DUSKSTUDIO_SINGLE_INSTANCE_TESTING)
     if (accepted != 0 && dropNextAcknowledgementForTest.exchange (false)) return;
 #endif
-    transferExact (l.pipe, &accepted, sizeof accepted, true,
+    if (! transferExact (l.pipe, &accepted, sizeof accepted, true,
+                         l.stopEvent, deadline))
+        return;
+
+    // Wait for the client to consume the acknowledgement before disconnecting;
+    // DisconnectNamedPipe discards unread buffered data. This read shares the
+    // handoff deadline and is cancelled by release(), so it cannot block join.
+    unsigned char confirmed = 0;
+    transferExact (l.pipe, &confirmed, sizeof confirmed, false,
                    l.stopEvent, deadline);
 }
 
@@ -872,6 +897,12 @@ Handoff handOver (const std::wstring& pipeName, const std::string& payload,
     unsigned char accepted = 0;
     if (submitted)
         delivered = transferExact (pipe, &accepted, sizeof accepted, false, nullptr, deadline);
+
+    if (delivered)
+    {
+        unsigned char confirmed = 1;
+        transferExact (pipe, &confirmed, sizeof confirmed, true, nullptr, deadline);
+    }
 
     if (! delivered) failureError = ::GetLastError();
     ::CloseHandle (pipe);

--- a/src/util/SingleInstance.cpp
+++ b/src/util/SingleInstance.cpp
@@ -38,6 +38,9 @@ namespace
 {
 #if defined (DUSKSTUDIO_SINGLE_INSTANCE_TESTING)
 testing::Dispatcher testDispatcher;
+#if defined (_WIN32)
+std::atomic<bool> dropNextAcknowledgement { false };
+#endif
 #endif
 
 bool dispatch (std::function<void()> fn)
@@ -482,7 +485,12 @@ bool acquire (const std::string& payload, std::function<void (std::string)> onCo
         }
         const int bindErr = errno;
         ::close (fd);
-        if (bindErr != EADDRINUSE) return true;
+        if (bindErr != EADDRINUSE
+#if defined (__APPLE__)
+            && bindErr != EEXIST
+#endif
+            )
+            return true;
 
         int handoffErrno = 0;
         const Handoff outcome = handOver (addr, len, payload, handoffErrno);
@@ -782,6 +790,9 @@ void serveConnection (Listener& l)
 
     auto fn = l.onCommandLine;
     unsigned char accepted = dispatch ([fn, payload] { fn (payload); }) ? 1u : 0u;
+#if defined (DUSKSTUDIO_SINGLE_INSTANCE_TESTING)
+    if (accepted != 0 && dropNextAcknowledgement.exchange (false)) return;
+#endif
     transferExact (l.pipe, &accepted, sizeof accepted, true,
                    l.stopEvent, deadline);
 }
@@ -819,7 +830,7 @@ bool startListener (std::unique_ptr<Listener> candidate,
     return true;
 }
 
-enum class Handoff { Delivered, Failed };
+enum class Handoff { Delivered, Submitted, Failed };
 
 Handoff handOver (const std::wstring& pipeName, const std::string& payload,
                   DWORD& failureError)
@@ -857,30 +868,33 @@ Handoff handOver (const std::wstring& pipeName, const std::string& payload,
         delivered = transferExact (pipe, const_cast<char*> (payload.data()), payload.size(),
                                    true, nullptr, deadline);
 
+    const bool submitted = delivered;
     unsigned char accepted = 0;
-    if (delivered)
-        delivered = transferExact (pipe, &accepted, sizeof accepted, false, nullptr, deadline)
-                 && accepted == 1u;
+    if (submitted)
+        delivered = transferExact (pipe, &accepted, sizeof accepted, false, nullptr, deadline);
 
     if (! delivered) failureError = ::GetLastError();
     ::CloseHandle (pipe);
-    return delivered ? Handoff::Delivered : Handoff::Failed;
+    if (delivered) return accepted == 1u ? Handoff::Delivered : Handoff::Failed;
+    return submitted ? Handoff::Submitted : Handoff::Failed;
 }
 } // namespace
 
 bool acquire (const std::string& payload, std::function<void (std::string)> onCommandLine)
 {
+    bool submitted = false;
+    DWORD handoffError = ERROR_SUCCESS;
     for (int attempt = 0; attempt < 2; ++attempt)
     {
         auto candidate = std::make_unique<Listener>();
-        if (! candidate->security.initialise()) return true;
+        if (! candidate->security.initialise()) return submitted ? false : true;
 
         std::wstring mutexName;
         makeNames (candidate->security.userSid, mutexName, candidate->pipeName);
         ::SetLastError (ERROR_SUCCESS);
         candidate->slotMutex = ::CreateMutexW (
             &candidate->security.attributes, FALSE, mutexName.c_str());
-        if (candidate->slotMutex == nullptr) return true;
+        if (candidate->slotMutex == nullptr) return submitted ? false : true;
 
         if (::GetLastError() != ERROR_ALREADY_EXISTS)
         {
@@ -889,23 +903,30 @@ bool acquire (const std::string& payload, std::function<void (std::string)> onCo
             return true;
         }
 
-        DWORD handoffError = ERROR_SUCCESS;
+        if (attempt != 0)
+        {
+            ::CloseHandle (candidate->slotMutex);
+            candidate->slotMutex = nullptr;
+            if (submitted) return false;
+
+            std::fprintf (stderr,
+                          "[Dusk Studio/SingleInstance] could not reach the running instance "
+                          "(Windows error %lu) - starting without the single-instance slot; "
+                          "this window will not receive sessions opened from the desktop\n",
+                          (unsigned long) handoffError);
+            return true;
+        }
+
         const Handoff outcome = handOver (candidate->pipeName, payload, handoffError);
         ::CloseHandle (candidate->slotMutex);
         candidate->slotMutex = nullptr;
         if (outcome == Handoff::Delivered) return false;
+        submitted = outcome == Handoff::Submitted;
 
         // Closing our handle lets the kernel remove a slot whose primary died
         // during handoff. A second CreateMutex distinguishes that stale owner
-        // from a live but unreachable primary without stealing the live slot.
-        if (attempt == 0) continue;
-
-        std::fprintf (stderr,
-                      "[Dusk Studio/SingleInstance] could not reach the running instance "
-                      "(Windows error %lu) - starting without the single-instance slot; "
-                      "this window will not receive sessions opened from the desktop\n",
-                      (unsigned long) handoffError);
-        return true;
+        // from a live but unreachable primary without replaying a request
+        // whose acknowledgement may have been lost after dispatch.
     }
     return true;
 }
@@ -934,5 +955,12 @@ void testing::setDispatcher (Dispatcher dispatcher)
 {
     testDispatcher = std::move (dispatcher);
 }
+
+#if defined (_WIN32)
+void testing::dropNextAcknowledgement()
+{
+    dropNextAcknowledgement.store (true);
+}
+#endif
 #endif
 } // namespace duskstudio::single_instance

--- a/src/util/SingleInstance.cpp
+++ b/src/util/SingleInstance.cpp
@@ -10,11 +10,13 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <memory>
 #include <string>
 #include <thread>
 #include <utility>
+#include <vector>
 
-#if defined (__linux__)
+#if defined (__linux__) || defined (__APPLE__)
  #include <cerrno>
  #include <fcntl.h>
  #include <poll.h>
@@ -22,11 +24,32 @@
  #include <sys/stat.h>
  #include <sys/un.h>
  #include <unistd.h>
+#elif defined (_WIN32)
+ #ifndef NOMINMAX
+  #define NOMINMAX
+ #endif
+ #include <windows.h>
+ #include <aclapi.h>
 #endif
 
 namespace duskstudio::single_instance
 {
-#if defined (__linux__)
+namespace
+{
+#if defined (DUSKSTUDIO_SINGLE_INSTANCE_TESTING)
+testing::Dispatcher testDispatcher;
+#endif
+
+bool dispatch (std::function<void()> fn)
+{
+#if defined (DUSKSTUDIO_SINGLE_INSTANCE_TESTING)
+    if (testDispatcher) return testDispatcher (std::move (fn));
+#endif
+    return dusk::callAsync (std::move (fn));
+}
+} // namespace
+
+#if defined (__linux__) || defined (__APPLE__)
 namespace
 {
 constexpr std::size_t kMaxPayloadBytes = 64 * 1024;
@@ -53,6 +76,7 @@ struct Listener
 // an abnormal exit leaks it, which the process exit cleans up anyway.
 Listener* listener = nullptr;
 
+#if defined (__linux__)
 std::uint64_t hashOf (const char* s) noexcept
 {
     std::uint64_t h = 1469598103934665603ull;
@@ -63,18 +87,20 @@ std::uint64_t hashOf (const char* s) noexcept
     }
     return h;
 }
+#endif
 
-// $XDG_RUNTIME_DIR/dusk-studio/instance-<display hash>.sock. The runtime dir is
-// per-user and 0700, which is the permission bit an abstract-namespace socket
-// does not have: without it any local process of any uid could bind the name
-// first (every real launch then hands off to nobody and quits) or connect and
-// feed the running instance a session of its choosing, whose plugin references
-// get loaded. The display is hashed rather than embedded because it can be an
-// absolute path, and a name long enough to truncate would collapse two
-// displays onto one slot.
+// Linux uses one slot per display under XDG_RUNTIME_DIR. macOS uses one slot
+// per login user under its private TMPDIR. In both cases the containing 0700
+// directory is the permission boundary an abstract socket would lack: without
+// it another uid could bind the name first or feed the running instance a
+// session of its choosing, whose plugin references would then be loaded.
 bool makeSocketPath (std::string& out)
 {
+#if defined (__linux__)
     const char* runtimeDir = std::getenv ("XDG_RUNTIME_DIR");
+#else
+    const char* runtimeDir = std::getenv ("TMPDIR");
+#endif
     if (runtimeDir == nullptr || *runtimeDir != '/') return false;
 
     const std::string dir = std::string (runtimeDir) + "/dusk-studio";
@@ -87,13 +113,16 @@ bool makeSocketPath (std::string& out)
         || (st.st_mode & (S_IRWXG | S_IRWXO)) != 0)
         return false;
 
+    char name[40] = {};
+#if defined (__linux__)
     const char* display = std::getenv ("WAYLAND_DISPLAY");
     if (display == nullptr || *display == '\0') display = std::getenv ("DISPLAY");
     if (display == nullptr) display = "";
-
-    char name[40] = {};
     std::snprintf (name, sizeof name, "/instance-%016llx.sock",
                    (unsigned long long) hashOf (display));
+#else
+    std::snprintf (name, sizeof name, "/instance.sock");
+#endif
     out = dir + name;
     return out.size() < sizeof (sockaddr_un::sun_path);
 }
@@ -104,6 +133,60 @@ void makeAddress (const std::string& path, sockaddr_un& addr, socklen_t& len)
     addr.sun_family = AF_UNIX;
     std::memcpy (addr.sun_path, path.c_str(), path.size());
     len = (socklen_t) (offsetof (sockaddr_un, sun_path) + path.size() + 1);
+}
+
+bool configureFd (int fd, bool nonBlocking)
+{
+    const int descriptorFlags = ::fcntl (fd, F_GETFD);
+    if (descriptorFlags < 0 || ::fcntl (fd, F_SETFD, descriptorFlags | FD_CLOEXEC) != 0)
+        return false;
+
+    if (nonBlocking)
+    {
+        const int statusFlags = ::fcntl (fd, F_GETFL);
+        if (statusFlags < 0 || ::fcntl (fd, F_SETFL, statusFlags | O_NONBLOCK) != 0)
+            return false;
+    }
+    return true;
+}
+
+int openSocket (bool nonBlocking)
+{
+    const int fd = ::socket (AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) return -1;
+    if (! configureFd (fd, nonBlocking))
+    {
+        ::close (fd);
+        return -1;
+    }
+#if defined (__APPLE__)
+    const int noSigPipe = 1;
+    if (::setsockopt (fd, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, sizeof noSigPipe) != 0)
+    {
+        ::close (fd);
+        return -1;
+    }
+#endif
+    return fd;
+}
+
+bool makeWakePipe (int (&fds)[2])
+{
+    if (::pipe (fds) != 0) return false;
+    if (configureFd (fds[0], false) && configureFd (fds[1], false)) return true;
+    ::close (fds[0]);
+    ::close (fds[1]);
+    fds[0] = fds[1] = -1;
+    return false;
+}
+
+int acceptPeer (int fd)
+{
+    const int peer = ::accept (fd, nullptr, nullptr);
+    if (peer < 0) return -1;
+    if (configureFd (peer, true)) return peer;
+    ::close (peer);
+    return -1;
 }
 
 // Closing the listening fd is what makes a later launch fall back to acting as
@@ -129,10 +212,17 @@ void teardown (Listener& l)
 
 bool peerIsThisUser (int fd)
 {
+#if defined (__linux__)
     ucred cred {};
     socklen_t len = sizeof cred;
     if (::getsockopt (fd, SOL_SOCKET, SO_PEERCRED, &cred, &len) != 0) return false;
     return len == sizeof cred && cred.uid == ::getuid();
+#else
+    uid_t effectiveUid = 0;
+    gid_t effectiveGid = 0;
+    return ::getpeereid (fd, &effectiveUid, &effectiveGid) == 0
+        && effectiveUid == ::geteuid();
+#endif
 }
 
 int pollUntil (int fd, short events, const Deadline deadline)
@@ -156,11 +246,16 @@ int pollUntil (int fd, short events, const Deadline deadline)
 
 bool writeAll (int fd, const std::string& payload, const Deadline deadline)
 {
+#if defined (__linux__)
+    constexpr int sendFlags = MSG_NOSIGNAL;
+#else
+    constexpr int sendFlags = 0; // SO_NOSIGPIPE is installed by openSocket().
+#endif
     std::size_t sent = 0;
     while (sent < payload.size())
     {
         if (std::chrono::steady_clock::now() >= deadline) return false;
-        const ssize_t n = ::send (fd, payload.data() + sent, payload.size() - sent, MSG_NOSIGNAL);
+        const ssize_t n = ::send (fd, payload.data() + sent, payload.size() - sent, sendFlags);
         if (n > 0) { sent += (std::size_t) n; continue; }
         if (n < 0 && errno == EINTR) continue;
         if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
@@ -238,7 +333,7 @@ void listenLoop (Listener* l)
         }
         if ((fds[0].revents & POLLIN) == 0) continue;
 
-        const int peer = ::accept4 (fd, nullptr, nullptr, SOCK_CLOEXEC | SOCK_NONBLOCK);
+        const int peer = acceptPeer (fd);
         if (peer < 0)
         {
             if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK || errno == ECONNABORTED)
@@ -256,7 +351,7 @@ void listenLoop (Listener* l)
             ::close (peer);
             if (! completed) return;
             auto fn = l->onCommandLine;
-            dusk::callAsync ([fn, payload] { fn (payload); });
+            dispatch ([fn, payload] { fn (payload); });
         }
         else
         {
@@ -271,7 +366,7 @@ bool startListener (int fd, const std::string& path,
     if (::listen (fd, 8) != 0) return false;
 
     auto* l = new Listener();
-    if (::pipe2 (l->wakeFds, O_CLOEXEC) != 0)
+    if (! makeWakePipe (l->wakeFds))
     {
         delete l;
         return false;
@@ -304,13 +399,13 @@ Handoff handOver (const sockaddr_un& addr, socklen_t len, const std::string& pay
                   int& failureErrno)
 {
     failureErrno = 0;
-    for (int attempt = 0; attempt < 2; ++attempt)
+    const auto deadline = std::chrono::steady_clock::now()
+                        + std::chrono::milliseconds (kDeliveryBudgetMs);
+    for (;;)
     {
-        const int fd = ::socket (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0);
+        const int fd = openSocket (true);
         if (fd < 0) { failureErrno = errno; return Handoff::Failed; }
 
-        const auto deadline = std::chrono::steady_clock::now()
-                                + std::chrono::milliseconds (kDeliveryBudgetMs);
         bool connected = false;
         int connectErr = 0;
         if (::connect (fd, (const sockaddr*) &addr, len) == 0)
@@ -352,11 +447,11 @@ Handoff handOver (const sockaddr_un& addr, socklen_t len, const std::string& pay
             return Handoff::Failed;
         }
 
-        // A primary that has bound but not yet called listen() refuses
-        // connections for a moment. Retry once before reading the refusal as
-        // "the file outlived the process that made it".
-        if (attempt == 0)
-            std::this_thread::sleep_for (std::chrono::milliseconds (50));
+        // A simultaneous primary may have bound but not reached listen() yet.
+        // Retry refusals for the bounded delivery window before classifying
+        // the socket as one a dead process left behind.
+        if (std::chrono::steady_clock::now() >= deadline) break;
+        std::this_thread::sleep_for (std::chrono::milliseconds (25));
     }
     return Handoff::Refused;
 }
@@ -373,7 +468,7 @@ bool acquire (const std::string& payload, std::function<void (std::string)> onCo
 
     for (int attempt = 0; attempt < 2; ++attempt)
     {
-        const int fd = ::socket (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+        const int fd = openSocket (false);
         if (fd < 0) return true;
 
         if (::bind (fd, (const sockaddr*) &addr, len) == 0)
@@ -433,10 +528,411 @@ void release()
     delete l;
 }
 
+#elif defined (_WIN32)
+
+namespace
+{
+constexpr std::size_t kMaxPayloadBytes = 64 * 1024;
+constexpr DWORD kDeliveryBudgetMs = 2000;
+using Deadline = std::chrono::steady_clock::time_point;
+
+struct Security
+{
+    std::vector<unsigned char> tokenUser;
+    PSID userSid = nullptr;
+    PACL acl = nullptr;
+    SECURITY_DESCRIPTOR descriptor {};
+    SECURITY_ATTRIBUTES attributes {};
+
+    ~Security()
+    {
+        if (acl != nullptr) ::LocalFree (acl);
+    }
+
+    bool initialise()
+    {
+        HANDLE token = nullptr;
+        if (! ::OpenProcessToken (::GetCurrentProcess(), TOKEN_QUERY, &token)) return false;
+
+        DWORD bytes = 0;
+        ::GetTokenInformation (token, TokenUser, nullptr, 0, &bytes);
+        if (bytes == 0)
+        {
+            ::CloseHandle (token);
+            return false;
+        }
+
+        tokenUser.resize (bytes);
+        const bool gotUser = ::GetTokenInformation (
+            token, TokenUser, tokenUser.data(), bytes, &bytes) != FALSE;
+        ::CloseHandle (token);
+        if (! gotUser) return false;
+
+        userSid = reinterpret_cast<TOKEN_USER*> (tokenUser.data())->User.Sid;
+        if (! ::IsValidSid (userSid)) return false;
+
+        EXPLICIT_ACCESSW access {};
+        access.grfAccessPermissions = GENERIC_ALL;
+        access.grfAccessMode = SET_ACCESS;
+        access.grfInheritance = NO_INHERITANCE;
+        ::BuildTrusteeWithSidW (&access.Trustee, userSid);
+        if (::SetEntriesInAclW (1, &access, nullptr, &acl) != ERROR_SUCCESS) return false;
+
+        if (! ::InitializeSecurityDescriptor (&descriptor, SECURITY_DESCRIPTOR_REVISION)
+            || ! ::SetSecurityDescriptorDacl (&descriptor, TRUE, acl, FALSE))
+            return false;
+
+        attributes.nLength = sizeof attributes;
+        attributes.lpSecurityDescriptor = &descriptor;
+        attributes.bInheritHandle = FALSE;
+        return true;
+    }
+};
+
+std::uint64_t hashBytes (const void* bytes, std::size_t size,
+                         std::uint64_t h = 1469598103934665603ull) noexcept
+{
+    const auto* p = static_cast<const unsigned char*> (bytes);
+    for (std::size_t i = 0; i < size; ++i)
+    {
+        h ^= p[i];
+        h *= 1099511628211ull;
+    }
+    return h;
+}
+
+void makeNames (PSID sid, std::wstring& mutexName, std::wstring& pipeName)
+{
+    std::uint64_t hash = hashBytes (sid, ::GetLengthSid (sid));
+#if defined (DUSKSTUDIO_SINGLE_INSTANCE_TESTING)
+    if (const char* suffix = std::getenv ("DUSKSTUDIO_TEST_SINGLE_INSTANCE_SLOT"))
+        hash = hashBytes (suffix, std::strlen (suffix), hash);
+#endif
+    const std::wstring key = std::to_wstring ((unsigned long long) hash);
+    mutexName = L"Local\\DuskStudio.SingleInstance." + key;
+    pipeName = L"\\\\.\\pipe\\DuskStudio.SingleInstance." + key;
+}
+
+struct Listener
+{
+    Security security;
+    std::thread thread;
+    HANDLE slotMutex = nullptr;
+    HANDLE stopEvent = nullptr;
+    HANDLE pipe = INVALID_HANDLE_VALUE;
+    std::wstring pipeName;
+    std::function<void (std::string)> onCommandLine;
+
+    ~Listener()
+    {
+        if (pipe != INVALID_HANDLE_VALUE) ::CloseHandle (pipe);
+        if (stopEvent != nullptr) ::CloseHandle (stopEvent);
+        if (slotMutex != nullptr) ::CloseHandle (slotMutex);
+    }
+};
+
+Listener* listener = nullptr;
+
+DWORD remainingMillis (Deadline deadline)
+{
+    const auto now = std::chrono::steady_clock::now();
+    if (now >= deadline) return 0;
+    const auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds> (
+        deadline - now).count();
+    return (DWORD) std::max<std::int64_t> (1, milliseconds);
+}
+
+void cancelAndDrain (HANDLE handle, OVERLAPPED& operation)
+{
+    ::CancelIoEx (handle, &operation);
+    DWORD ignored = 0;
+    ::GetOverlappedResult (handle, &operation, &ignored, TRUE);
+}
+
+bool transferExact (HANDLE pipe, void* bytes, std::size_t size, bool writing,
+                    HANDLE stopEvent, Deadline deadline)
+{
+    auto* cursor = static_cast<unsigned char*> (bytes);
+    std::size_t transferred = 0;
+    while (transferred < size)
+    {
+        const DWORD remaining = remainingMillis (deadline);
+        if (remaining == 0) return false;
+
+        HANDLE event = ::CreateEventW (nullptr, TRUE, FALSE, nullptr);
+        if (event == nullptr) return false;
+        OVERLAPPED operation {};
+        operation.hEvent = event;
+
+        DWORD completed = 0;
+        const DWORD chunk = (DWORD) std::min<std::size_t> (size - transferred, MAXDWORD);
+        const BOOL started = writing
+            ? ::WriteFile (pipe, cursor + transferred, chunk, &completed, &operation)
+            : ::ReadFile (pipe, cursor + transferred, chunk, &completed, &operation);
+
+        bool ok = started != FALSE;
+        if (! ok && ::GetLastError() == ERROR_IO_PENDING)
+        {
+            HANDLE events[2] = { event, stopEvent };
+            const DWORD count = stopEvent != nullptr ? 2u : 1u;
+            const DWORD wait = ::WaitForMultipleObjects (count, events, FALSE, remaining);
+            if (wait == WAIT_OBJECT_0)
+                ok = ::GetOverlappedResult (pipe, &operation, &completed, FALSE) != FALSE;
+            else
+                cancelAndDrain (pipe, operation);
+        }
+
+        ::CloseHandle (event);
+        if (! ok || completed == 0) return false;
+        transferred += completed;
+    }
+    return true;
+}
+
+bool clientIsThisUser (HANDLE pipe, PSID expectedSid)
+{
+    ULONG processId = 0;
+    if (! ::GetNamedPipeClientProcessId (pipe, &processId)) return false;
+
+    HANDLE process = ::OpenProcess (PROCESS_QUERY_LIMITED_INFORMATION, FALSE, processId);
+    if (process == nullptr) return false;
+    HANDLE token = nullptr;
+    const bool openedToken = ::OpenProcessToken (process, TOKEN_QUERY, &token) != FALSE;
+    ::CloseHandle (process);
+    if (! openedToken) return false;
+
+    DWORD bytes = 0;
+    ::GetTokenInformation (token, TokenUser, nullptr, 0, &bytes);
+    std::vector<unsigned char> tokenUser (bytes);
+    const bool gotUser = bytes != 0
+        && ::GetTokenInformation (token, TokenUser, tokenUser.data(), bytes, &bytes) != FALSE;
+    ::CloseHandle (token);
+    if (! gotUser) return false;
+
+    const auto sid = reinterpret_cast<TOKEN_USER*> (tokenUser.data())->User.Sid;
+    return ::IsValidSid (sid) && ::EqualSid (expectedSid, sid) != FALSE;
+}
+
+HANDLE createPipe (Listener& l)
+{
+    return ::CreateNamedPipeW (
+        l.pipeName.c_str(),
+        PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
+        PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
+        1,
+        (DWORD) kMaxPayloadBytes + sizeof (std::uint32_t),
+        (DWORD) kMaxPayloadBytes + sizeof (std::uint32_t),
+        0,
+        &l.security.attributes);
+}
+
+bool awaitConnection (Listener& l)
+{
+    HANDLE event = ::CreateEventW (nullptr, TRUE, FALSE, nullptr);
+    if (event == nullptr) return false;
+    OVERLAPPED operation {};
+    operation.hEvent = event;
+
+    bool connected = ::ConnectNamedPipe (l.pipe, &operation) != FALSE;
+    if (! connected)
+    {
+        const DWORD error = ::GetLastError();
+        if (error == ERROR_PIPE_CONNECTED)
+        {
+            connected = true;
+        }
+        else if (error == ERROR_IO_PENDING)
+        {
+            HANDLE events[2] = { event, l.stopEvent };
+            const DWORD wait = ::WaitForMultipleObjects (2, events, FALSE, INFINITE);
+            if (wait == WAIT_OBJECT_0)
+            {
+                DWORD ignored = 0;
+                connected = ::GetOverlappedResult (
+                    l.pipe, &operation, &ignored, FALSE) != FALSE;
+            }
+            else
+            {
+                cancelAndDrain (l.pipe, operation);
+            }
+        }
+    }
+
+    ::CloseHandle (event);
+    return connected;
+}
+
+void serveConnection (Listener& l)
+{
+    if (! clientIsThisUser (l.pipe, l.security.userSid)) return;
+
+    const auto deadline = std::chrono::steady_clock::now()
+                        + std::chrono::milliseconds (kDeliveryBudgetMs);
+    std::uint32_t payloadSize = 0;
+    if (! transferExact (l.pipe, &payloadSize, sizeof payloadSize, false,
+                         l.stopEvent, deadline)
+        || payloadSize > kMaxPayloadBytes)
+        return;
+
+    std::string payload (payloadSize, '\0');
+    if (payloadSize != 0
+        && ! transferExact (l.pipe, &payload[0], payload.size(), false,
+                            l.stopEvent, deadline))
+        return;
+
+    auto fn = l.onCommandLine;
+    unsigned char accepted = dispatch ([fn, payload] { fn (payload); }) ? 1u : 0u;
+    transferExact (l.pipe, &accepted, sizeof accepted, true,
+                   l.stopEvent, deadline);
+}
+
+void listenLoop (Listener* l)
+{
+    while (::WaitForSingleObject (l->stopEvent, 0) != WAIT_OBJECT_0)
+    {
+        if (l->pipe == INVALID_HANDLE_VALUE) l->pipe = createPipe (*l);
+        if (l->pipe == INVALID_HANDLE_VALUE) return;
+
+        if (awaitConnection (*l)) serveConnection (*l);
+        ::DisconnectNamedPipe (l->pipe);
+        ::CloseHandle (l->pipe);
+        l->pipe = INVALID_HANDLE_VALUE;
+    }
+}
+
+bool startListener (std::unique_ptr<Listener> candidate,
+                    std::function<void (std::string)> onCommandLine)
+{
+    candidate->stopEvent = ::CreateEventW (nullptr, TRUE, FALSE, nullptr);
+    if (candidate->stopEvent == nullptr) return false;
+    candidate->pipe = createPipe (*candidate);
+    if (candidate->pipe == INVALID_HANDLE_VALUE)
+    {
+        ::CloseHandle (candidate->stopEvent);
+        candidate->stopEvent = nullptr;
+        return false;
+    }
+
+    candidate->onCommandLine = std::move (onCommandLine);
+    listener = candidate.release();
+    listener->thread = std::thread (listenLoop, listener);
+    return true;
+}
+
+enum class Handoff { Delivered, Failed };
+
+Handoff handOver (const std::wstring& pipeName, const std::string& payload,
+                  DWORD& failureError)
+{
+    failureError = ERROR_SUCCESS;
+    if (payload.size() > kMaxPayloadBytes)
+    {
+        failureError = ERROR_BUFFER_OVERFLOW;
+        return Handoff::Failed;
+    }
+
+    const auto deadline = std::chrono::steady_clock::now()
+                        + std::chrono::milliseconds (kDeliveryBudgetMs);
+    HANDLE pipe = INVALID_HANDLE_VALUE;
+    while (remainingMillis (deadline) != 0)
+    {
+        pipe = ::CreateFileW (
+            pipeName.c_str(), GENERIC_READ | GENERIC_WRITE, 0, nullptr,
+            OPEN_EXISTING,
+            FILE_FLAG_OVERLAPPED | SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION,
+            nullptr);
+        if (pipe != INVALID_HANDLE_VALUE) break;
+
+        failureError = ::GetLastError();
+        if (failureError != ERROR_FILE_NOT_FOUND && failureError != ERROR_PIPE_BUSY)
+            return Handoff::Failed;
+        ::WaitNamedPipeW (pipeName.c_str(), std::min<DWORD> (50, remainingMillis (deadline)));
+    }
+    if (pipe == INVALID_HANDLE_VALUE) return Handoff::Failed;
+
+    std::uint32_t payloadSize = (std::uint32_t) payload.size();
+    bool delivered = transferExact (pipe, &payloadSize,
+                                    sizeof payloadSize, true, nullptr, deadline);
+    if (delivered && payloadSize != 0)
+        delivered = transferExact (pipe, const_cast<char*> (payload.data()), payload.size(),
+                                   true, nullptr, deadline);
+
+    unsigned char accepted = 0;
+    if (delivered)
+        delivered = transferExact (pipe, &accepted, sizeof accepted, false, nullptr, deadline)
+                 && accepted == 1u;
+
+    if (! delivered) failureError = ::GetLastError();
+    ::CloseHandle (pipe);
+    return delivered ? Handoff::Delivered : Handoff::Failed;
+}
+} // namespace
+
+bool acquire (const std::string& payload, std::function<void (std::string)> onCommandLine)
+{
+    for (int attempt = 0; attempt < 2; ++attempt)
+    {
+        auto candidate = std::make_unique<Listener>();
+        if (! candidate->security.initialise()) return true;
+
+        std::wstring mutexName;
+        makeNames (candidate->security.userSid, mutexName, candidate->pipeName);
+        ::SetLastError (ERROR_SUCCESS);
+        candidate->slotMutex = ::CreateMutexW (
+            &candidate->security.attributes, FALSE, mutexName.c_str());
+        if (candidate->slotMutex == nullptr) return true;
+
+        if (::GetLastError() != ERROR_ALREADY_EXISTS)
+        {
+            if (! startListener (std::move (candidate), std::move (onCommandLine)))
+                return true;
+            return true;
+        }
+
+        DWORD handoffError = ERROR_SUCCESS;
+        const Handoff outcome = handOver (candidate->pipeName, payload, handoffError);
+        ::CloseHandle (candidate->slotMutex);
+        candidate->slotMutex = nullptr;
+        if (outcome == Handoff::Delivered) return false;
+
+        // Closing our handle lets the kernel remove a slot whose primary died
+        // during handoff. A second CreateMutex distinguishes that stale owner
+        // from a live but unreachable primary without stealing the live slot.
+        if (attempt == 0) continue;
+
+        std::fprintf (stderr,
+                      "[Dusk Studio/SingleInstance] could not reach the running instance "
+                      "(Windows error %lu) - starting without the single-instance slot; "
+                      "this window will not receive sessions opened from the desktop\n",
+                      (unsigned long) handoffError);
+        return true;
+    }
+    return true;
+}
+
+void release()
+{
+    Listener* l = listener;
+    if (l == nullptr) return;
+    listener = nullptr;
+
+    if (l->stopEvent != nullptr) ::SetEvent (l->stopEvent);
+    if (l->thread.joinable()) l->thread.join();
+
+    delete l;
+}
+
 #else
 
 bool acquire (const std::string&, std::function<void (std::string)>) { return true; }
 void release() {}
 
+#endif
+
+#if defined (DUSKSTUDIO_SINGLE_INSTANCE_TESTING)
+void testing::setDispatcher (Dispatcher dispatcher)
+{
+    testDispatcher = std::move (dispatcher);
+}
 #endif
 } // namespace duskstudio::single_instance

--- a/src/util/SingleInstance.h
+++ b/src/util/SingleInstance.h
@@ -18,17 +18,23 @@ namespace duskstudio::single_instance
 // A failed handshake reports "primary" rather than blocking the launch: a
 // broken socket must not stop the app from starting. Only a refused connection
 // is read as "the primary is gone" and clears the slot; every other handshake
-// failure leaves the existing socket untouched and this launch runs without
+// failure leaves the existing endpoint untouched and this launch runs without
 // owning the slot, because the process behind it may still be alive and two
-// primaries would contend for one audio device. Linux only - the slot
-// lives under XDG_RUNTIME_DIR, whose per-user ownership is half of what keeps
-// a hostile local process out of the handoff, and the .desktop %f double
-// launch it guards against is a Linux problem. Elsewhere this is a no-op that
-// always returns true.
+// primaries would contend for one audio device. Linux and macOS use a private
+// per-user Unix socket and verify the peer uid. Windows uses a local named
+// mutex and an ACL-restricted named pipe keyed by the current user's SID.
 bool acquire (const std::string& payload,
               std::function<void (std::string)> onCommandLine);
 
 // Drop the slot and join the listener. Idempotent; safe if acquire() was
 // never called or returned false.
 void release();
+
+#if defined (DUSKSTUDIO_SINGLE_INSTANCE_TESTING)
+namespace testing
+{
+using Dispatcher = std::function<bool (std::function<void()>)>;
+void setDispatcher (Dispatcher dispatcher);
+}
+#endif
 } // namespace duskstudio::single_instance

--- a/src/util/SingleInstance.h
+++ b/src/util/SingleInstance.h
@@ -35,6 +35,9 @@ namespace testing
 {
 using Dispatcher = std::function<bool (std::function<void()>)>;
 void setDispatcher (Dispatcher dispatcher);
+#if defined (_WIN32)
+void dropNextAcknowledgement();
+#endif
 }
 #endif
 } // namespace duskstudio::single_instance

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -181,8 +181,9 @@ target_include_directories(dusk-studio-tests SYSTEM PRIVATE ${CMAKE_SOURCE_DIR}/
 
 if(WIN32)
     # shell32: CommandLineToArgvW plus SHGetKnownFolderPath; ole32:
-    # CoTaskMemFree for the returned known-folder path.
-    target_link_libraries(dusk-studio-tests PRIVATE shell32 ole32)
+    # CoTaskMemFree for the returned known-folder path; advapi32: per-user
+    # security descriptors and token checks for the single-instance pipe.
+    target_link_libraries(dusk-studio-tests PRIVATE shell32 ole32 advapi32)
 endif()
 
 # pffft backend for dusk::audio::Fft, plus its A/B parity suite. The pffft
@@ -468,12 +469,15 @@ if(TARGET sfizz_static)
     target_compile_definitions(dusk-studio-tests PRIVATE DUSKSTUDIO_HAS_MULTISAMPLE=1)
 endif()
 
-# Single-instance socket lifecycle. Linux only: everywhere else acquire() is
-# the no-op that always reports primary, so there is no socket to test.
-if (UNIX AND NOT APPLE)
+# Cross-platform single-instance ownership and handoff. The test-only
+# dispatcher exercises transport delivery without depending on a GUI event
+# loop on the headless macOS runner.
+if (UNIX OR WIN32)
     target_sources(dusk-studio-tests PRIVATE
         single_instance_socket_lifecycle.cpp
         ${CMAKE_SOURCE_DIR}/src/util/SingleInstance.cpp)
+    target_compile_definitions(dusk-studio-tests PRIVATE
+        DUSKSTUDIO_SINGLE_INSTANCE_TESTING=1)
 endif()
 
 # IPC round-trip regression — Linux + Windows + macOS 14.4+. The test

--- a/tests/single_instance_socket_lifecycle.cpp
+++ b/tests/single_instance_socket_lifecycle.cpp
@@ -276,7 +276,9 @@ TEST_CASE ("a refused handoff reclaims a dead primary socket",
     const auto staleInode = inodeOf (sock);
     REQUIRE (staleInode != 0);
 
+    const auto reclaimStarted = std::chrono::steady_clock::now();
     REQUIRE (duskstudio::single_instance::acquire ("", noPayload));
+    REQUIRE (std::chrono::steady_clock::now() - reclaimStarted < std::chrono::seconds (1));
     const auto reclaimedInode = inodeOf (sock);
     ::close (staleFd);
     REQUIRE (reclaimedInode != 0);

--- a/tests/single_instance_socket_lifecycle.cpp
+++ b/tests/single_instance_socket_lifecycle.cpp
@@ -2,66 +2,136 @@
 
 #include "util/SingleInstance.h"
 
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
+#include <functional>
+#include <mutex>
 #include <string>
 #include <system_error>
-#include <sys/socket.h>
-#include <sys/stat.h>
-#include <sys/un.h>
-#include <unistd.h>
+#include <thread>
+#include <vector>
+
+#if defined (_WIN32)
+ #ifndef NOMINMAX
+  #define NOMINMAX
+ #endif
+ #include <windows.h>
+#else
+ #include <sys/socket.h>
+ #include <sys/stat.h>
+ #include <sys/un.h>
+ #include <unistd.h>
+#endif
 
 namespace
 {
 namespace fs = std::filesystem;
 
-// A private XDG_RUNTIME_DIR per case: the slot lives under it, so a real Dusk
-// Studio on this desktop is neither seen nor disturbed. Restored on the way out
-// (and the listener released) so a thrown REQUIRE still leaves the process as
-// it found it.
-class ScopedRuntimeDir
+class ScopedSlot
 {
 public:
-    ScopedRuntimeDir()
+    ScopedSlot()
     {
-        if (const char* prev = std::getenv ("XDG_RUNTIME_DIR"))
+        duskstudio::single_instance::release();
+        duskstudio::single_instance::testing::setDispatcher (
+            [] (std::function<void()> fn)
+            {
+                fn();
+                return true;
+            });
+
+#if defined (_WIN32)
+        static std::atomic<unsigned long> counter { 0 };
+        slotName = std::to_string ((unsigned long) ::GetCurrentProcessId()) + "-"
+                 + std::to_string (counter.fetch_add (1));
+        _putenv_s ("DUSKSTUDIO_TEST_SINGLE_INSTANCE_SLOT", slotName.c_str());
+#else
+ #if defined (__APPLE__)
+        variable = "TMPDIR";
+ #else
+        variable = "XDG_RUNTIME_DIR";
+ #endif
+        if (const char* prev = std::getenv (variable.c_str()))
         {
             previous = prev;
             hadPrevious = true;
         }
 
-        // Terse name on purpose: the socket path built under here has to fit
-        // sockaddr_un::sun_path, and acquire() quietly gives up when it doesn't,
-        // which would surface as a socket-lifecycle failure rather than as a
-        // too-long TMPDIR. Check the headroom before anything exists to clean up.
+        // Terse name leaves sockaddr_un headroom even under a long system
+        // temporary root. The production path rejects rather than truncates.
         std::string tmpl = (fs::temp_directory_path() / "dusk-si-XXXXXX").string();
         REQUIRE (tmpl.size() + std::strlen ("/dusk-studio/instance-0123456789abcdef.sock")
                    < sizeof (sockaddr_un::sun_path));
         REQUIRE (::mkdtemp (&tmpl[0]) != nullptr);
         dir = tmpl;
-        ::setenv ("XDG_RUNTIME_DIR", dir.c_str(), 1);
+        REQUIRE (::setenv (variable.c_str(), dir.c_str(), 1) == 0);
+#endif
     }
 
-    ~ScopedRuntimeDir()
+    ~ScopedSlot()
     {
         duskstudio::single_instance::release();
-        if (hadPrevious) ::setenv ("XDG_RUNTIME_DIR", previous.c_str(), 1);
-        else             ::unsetenv ("XDG_RUNTIME_DIR");
+        duskstudio::single_instance::testing::setDispatcher ({});
+#if defined (_WIN32)
+        _putenv_s ("DUSKSTUDIO_TEST_SINGLE_INSTANCE_SLOT", "");
+#else
+        if (hadPrevious) ::setenv (variable.c_str(), previous.c_str(), 1);
+        else             ::unsetenv (variable.c_str());
         std::error_code ec;
         fs::remove_all (dir, ec);
+#endif
     }
 
+#if ! defined (_WIN32)
     const fs::path& path() const noexcept { return dir; }
+#endif
 
 private:
+#if defined (_WIN32)
+    std::string slotName;
+#else
     fs::path dir;
+    std::string variable;
     std::string previous;
     bool hadPrevious = false;
+#endif
 };
 
-// acquire() names the socket after a hash of the display, so the tests find the
-// file the primary made rather than recomputing that hash.
+struct Deliveries
+{
+    void accept (std::string payload)
+    {
+        std::lock_guard<std::mutex> lock (mutex);
+        payloads.push_back (std::move (payload));
+        changed.notify_all();
+    }
+
+    bool waitFor (std::size_t count)
+    {
+        std::unique_lock<std::mutex> lock (mutex);
+        return changed.wait_for (lock, std::chrono::seconds (5),
+                                 [&] { return payloads.size() >= count; });
+    }
+
+    std::vector<std::string> copy()
+    {
+        std::lock_guard<std::mutex> lock (mutex);
+        return payloads;
+    }
+
+    std::mutex mutex;
+    std::condition_variable changed;
+    std::vector<std::string> payloads;
+};
+
+void noPayload (std::string) {}
+
+#if ! defined (_WIN32)
 fs::path soleSocketIn (const fs::path& runtimeDir)
 {
     fs::path found;
@@ -75,7 +145,6 @@ fs::path soleSocketIn (const fs::path& runtimeDir)
     return found;
 }
 
-// 0 when nothing is there, which is what the "was it removed?" assertions want.
 ino_t inodeOf (const fs::path& p)
 {
     struct stat st {};
@@ -84,7 +153,7 @@ ino_t inodeOf (const fs::path& p)
 
 int bindSocketAt (const fs::path& p)
 {
-    const int fd = ::socket (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    const int fd = ::socket (AF_UNIX, SOCK_STREAM, 0);
     REQUIRE (fd >= 0);
 
     sockaddr_un addr {};
@@ -95,53 +164,104 @@ int bindSocketAt (const fs::path& p)
     REQUIRE (::bind (fd, (const sockaddr*) &addr, sizeof addr) == 0);
     return fd;
 }
-
-void noPayload (std::string) {}
+#endif
 } // namespace
 
-TEST_CASE ("a handoff that fails without a refusal leaves the primary's socket alone",
-           "[single-instance][socket]")
+TEST_CASE ("single-instance handoff preserves quoted Unicode and empty payloads",
+           "[single-instance][issue-368]")
 {
-    ScopedRuntimeDir runtime;
+    ScopedSlot slot;
+    Deliveries delivered;
+    const auto receive = [&] (std::string payload) { delivered.accept (std::move (payload)); };
 
+    REQUIRE (duskstudio::single_instance::acquire ("", receive));
+    const std::string session = "\"C:\\Sessions\\Björk – take 2\\mix.dusksession\"";
+    REQUIRE_FALSE (duskstudio::single_instance::acquire (session, noPayload));
+    REQUIRE_FALSE (duskstudio::single_instance::acquire ("", noPayload));
+    REQUIRE (delivered.waitFor (2));
+    REQUIRE (delivered.copy() == std::vector<std::string> { session, "" });
+}
+
+TEST_CASE ("simultaneous single-instance launches elect exactly one owner",
+           "[single-instance][issue-368]")
+{
+    ScopedSlot slot;
+    Deliveries delivered;
+    const auto receive = [&] (std::string payload) { delivered.accept (std::move (payload)); };
+    constexpr int launchCount = 8;
+    std::atomic<int> ready { 0 };
+    std::atomic<bool> go { false };
+    std::vector<int> primary (launchCount, 0);
+    std::vector<std::string> payloads;
+    std::vector<std::thread> launches;
+
+    for (std::size_t i = 0; i < (std::size_t) launchCount; ++i)
+        payloads.push_back ("launch-" + std::to_string (i));
+    for (std::size_t i = 0; i < (std::size_t) launchCount; ++i)
+        launches.emplace_back ([&, i]
+        {
+            ready.fetch_add (1);
+            while (! go.load()) std::this_thread::yield();
+            primary[i] = duskstudio::single_instance::acquire (payloads[i], receive) ? 1 : 0;
+        });
+
+    while (ready.load() != launchCount) std::this_thread::yield();
+    go.store (true);
+    for (auto& launch : launches) launch.join();
+
+    REQUIRE (std::count (primary.begin(), primary.end(), 1) == 1);
+    REQUIRE (delivered.waitFor (launchCount - 1));
+    auto received = delivered.copy();
+    REQUIRE (received.size() == launchCount - 1);
+
+    const auto owner = (std::size_t) std::distance (
+        primary.begin(), std::find (primary.begin(), primary.end(), 1));
+    payloads.erase (payloads.begin() + (std::ptrdiff_t) owner);
+    std::sort (payloads.begin(), payloads.end());
+    std::sort (received.begin(), received.end());
+    REQUIRE (received == payloads);
+}
+
+TEST_CASE ("single-instance release permits clean reacquisition",
+           "[single-instance][issue-368]")
+{
+    ScopedSlot slot;
     REQUIRE (duskstudio::single_instance::acquire ("", noPayload));
-    const auto sock = soleSocketIn (runtime.path());
+    duskstudio::single_instance::release();
+    REQUIRE (duskstudio::single_instance::acquire ("", noPayload));
+}
+
+#if ! defined (_WIN32)
+TEST_CASE ("a handoff failure leaves the live primary socket alone",
+           "[single-instance][socket][issue-368]")
+{
+    ScopedSlot slot;
+    REQUIRE (duskstudio::single_instance::acquire ("", noPayload));
+    const auto sock = soleSocketIn (slot.path());
     REQUIRE_FALSE (sock.empty());
     const auto primaryInode = inodeOf (sock);
     REQUIRE (primaryInode != 0);
 
-    // The primary is listening and healthy; this launch cannot reach it.
-    // Connecting to a mode-000 socket fails with EACCES, which says nothing
-    // about whether the process behind it is still alive.
     REQUIRE (::chmod (sock.c_str(), 0) == 0);
     const bool secondActsAsPrimary =
         duskstudio::single_instance::acquire ("/tmp/elsewhere/session.json", noPayload);
     REQUIRE (::chmod (sock.c_str(), 0755) == 0);
 
-    // A broken handshake must not block the launch...
     REQUIRE (secondActsAsPrimary);
-    // ...but the live primary keeps the slot: clearing it here would put a
-    // second engine on the same audio device.
     REQUIRE (inodeOf (sock) == primaryInode);
 }
 
-TEST_CASE ("a refused handoff still reclaims the socket a dead primary left behind",
-           "[single-instance][socket]")
+TEST_CASE ("a refused handoff reclaims a dead primary socket",
+           "[single-instance][socket][issue-368]")
 {
-    ScopedRuntimeDir runtime;
-
+    ScopedSlot slot;
     REQUIRE (duskstudio::single_instance::acquire ("", noPayload));
-    const auto sock = soleSocketIn (runtime.path());
+    const auto sock = soleSocketIn (slot.path());
     REQUIRE_FALSE (sock.empty());
 
     duskstudio::single_instance::release();
     REQUIRE (inodeOf (sock) == 0);
 
-    // What a primary killed with SIGKILL leaves at that path: a socket file
-    // with nothing accepting on it, so connecting to it is refused. The fd
-    // stays open across the acquire below - a bound socket that never listens
-    // still refuses, and holding it pins the inode so the filesystem cannot
-    // hand the same number back to the socket that replaces it.
     const int staleFd = bindSocketAt (sock);
     const auto staleInode = inodeOf (sock);
     REQUIRE (staleInode != 0);
@@ -153,26 +273,88 @@ TEST_CASE ("a refused handoff still reclaims the socket a dead primary left behi
     REQUIRE (reclaimedInode != staleInode);
 }
 
-TEST_CASE ("release leaves a socket a newer primary bound at the same path",
-           "[single-instance][socket]")
+TEST_CASE ("release leaves a newer primary socket at the same path",
+           "[single-instance][socket][issue-368]")
 {
-    ScopedRuntimeDir runtime;
-
+    ScopedSlot slot;
     REQUIRE (duskstudio::single_instance::acquire ("", noPayload));
-    const auto sock = soleSocketIn (runtime.path());
+    const auto sock = soleSocketIn (slot.path());
     REQUIRE_FALSE (sock.empty());
 
-    // Stand in for a successor that took the slot after this process lost it:
-    // same name, different file.
     ::unlink (sock.c_str());
     const int successorFd = bindSocketAt (sock);
     const auto successorInode = inodeOf (sock);
     REQUIRE (successorInode != 0);
 
     duskstudio::single_instance::release();
-
     REQUIRE (inodeOf (sock) == successorInode);
 
     ::close (successorFd);
     ::unlink (sock.c_str());
 }
+#endif
+
+#if defined (_WIN32)
+TEST_CASE ("single-instance crash owner helper", "[.single-instance-crash-helper]")
+{
+    const char* readyPath = std::getenv ("DUSKSTUDIO_SINGLE_INSTANCE_CRASH_READY");
+    REQUIRE (readyPath != nullptr);
+    duskstudio::single_instance::testing::setDispatcher (
+        [] (std::function<void()> fn) { fn(); return true; });
+    REQUIRE (duskstudio::single_instance::acquire ("", noPayload));
+
+    HANDLE ready = ::CreateFileA (readyPath, GENERIC_WRITE, 0, nullptr,
+                                  CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+    REQUIRE (ready != INVALID_HANDLE_VALUE);
+    ::CloseHandle (ready);
+    ::Sleep (INFINITE);
+}
+
+TEST_CASE ("Windows recovers ownership after the primary process crashes",
+           "[single-instance][issue-368]")
+{
+    ScopedSlot slot;
+    char tempPath[MAX_PATH] = {};
+    REQUIRE (::GetTempPathA (MAX_PATH, tempPath) != 0);
+    const std::string readyPath = std::string (tempPath) + "dusk-si-ready-"
+                                + std::to_string ((unsigned long) ::GetCurrentProcessId());
+    ::DeleteFileA (readyPath.c_str());
+    _putenv_s ("DUSKSTUDIO_SINGLE_INSTANCE_CRASH_READY", readyPath.c_str());
+
+    wchar_t executable[MAX_PATH] = {};
+    REQUIRE (::GetModuleFileNameW (nullptr, executable, MAX_PATH) != 0);
+    std::wstring command = L"\"" + std::wstring (executable)
+                         + L"\" \"single-instance crash owner helper\" --reporter compact";
+    std::vector<wchar_t> commandLine (command.begin(), command.end());
+    commandLine.push_back (L'\0');
+
+    STARTUPINFOW startup {};
+    startup.cb = sizeof startup;
+    PROCESS_INFORMATION child {};
+    REQUIRE (::CreateProcessW (nullptr, commandLine.data(), nullptr, nullptr, FALSE,
+                               CREATE_NO_WINDOW, nullptr, nullptr, &startup, &child));
+    ::CloseHandle (child.hThread);
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds (10);
+    while (::GetFileAttributesA (readyPath.c_str()) == INVALID_FILE_ATTRIBUTES
+           && std::chrono::steady_clock::now() < deadline)
+        std::this_thread::sleep_for (std::chrono::milliseconds (20));
+
+    const bool ready = ::GetFileAttributesA (readyPath.c_str()) != INVALID_FILE_ATTRIBUTES;
+    if (! ready)
+    {
+        ::TerminateProcess (child.hProcess, 1);
+        ::WaitForSingleObject (child.hProcess, 5000);
+        ::CloseHandle (child.hProcess);
+    }
+    REQUIRE (ready);
+
+    REQUIRE (::TerminateProcess (child.hProcess, 3));
+    REQUIRE (::WaitForSingleObject (child.hProcess, 5000) == WAIT_OBJECT_0);
+    ::CloseHandle (child.hProcess);
+    REQUIRE (duskstudio::single_instance::acquire ("", noPayload));
+
+    _putenv_s ("DUSKSTUDIO_SINGLE_INSTANCE_CRASH_READY", "");
+    ::DeleteFileA (readyPath.c_str());
+}
+#endif

--- a/tests/single_instance_socket_lifecycle.cpp
+++ b/tests/single_instance_socket_lifecycle.cpp
@@ -5,12 +5,10 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
-#include <condition_variable>
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <functional>
-#include <mutex>
 #include <string>
 #include <system_error>
 #include <thread>
@@ -111,27 +109,23 @@ struct Deliveries
 {
     void accept (std::string payload)
     {
-        std::lock_guard<std::mutex> lock (mutex);
         payloads.push_back (std::move (payload));
-        changed.notify_all();
+        published.store (payloads.size(), std::memory_order_release);
     }
 
     bool waitFor (std::size_t count)
     {
-        std::unique_lock<std::mutex> lock (mutex);
-        return changed.wait_for (lock, std::chrono::seconds (5),
-                                 [&] { return payloads.size() >= count; });
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds (5);
+        while (published.load (std::memory_order_acquire) < count
+               && std::chrono::steady_clock::now() < deadline)
+            std::this_thread::sleep_for (std::chrono::milliseconds (1));
+        return published.load (std::memory_order_acquire) >= count;
     }
 
-    std::vector<std::string> copy()
-    {
-        std::lock_guard<std::mutex> lock (mutex);
-        return payloads;
-    }
+    const std::vector<std::string>& copy() const noexcept { return payloads; }
 
-    std::mutex mutex;
-    std::condition_variable changed;
     std::vector<std::string> payloads;
+    std::atomic<std::size_t> published { 0 };
 };
 
 void noPayload (std::string) {}
@@ -184,12 +178,15 @@ TEST_CASE ("single-instance handoff preserves quoted Unicode and empty payloads"
     REQUIRE_FALSE (duskstudio::single_instance::acquire (session, noPayload));
     REQUIRE_FALSE (duskstudio::single_instance::acquire ("", noPayload));
     REQUIRE (delivered.waitFor (2));
+    duskstudio::single_instance::release();
     REQUIRE (delivered.copy() == std::vector<std::string> { session, "" });
 
 #if defined (_WIN32)
+    REQUIRE (duskstudio::single_instance::acquire ("", receive));
     duskstudio::single_instance::testing::dropNextAcknowledgement();
     REQUIRE_FALSE (duskstudio::single_instance::acquire ("lost-ack", noPayload));
     REQUIRE (delivered.waitFor (3));
+    duskstudio::single_instance::release();
     REQUIRE (delivered.copy() == std::vector<std::string> { session, "", "lost-ack" });
 #endif
 }
@@ -223,6 +220,7 @@ TEST_CASE ("simultaneous single-instance launches elect exactly one owner",
 
     REQUIRE (std::count (primary.begin(), primary.end(), 1) == 1);
     REQUIRE (delivered.waitFor (launchCount - 1));
+    duskstudio::single_instance::release();
     auto received = delivered.copy();
     REQUIRE (received.size() == launchCount - 1);
 

--- a/tests/single_instance_socket_lifecycle.cpp
+++ b/tests/single_instance_socket_lifecycle.cpp
@@ -65,7 +65,12 @@ public:
         // Terse name leaves sockaddr_un headroom even under a long system
         // temporary root. The production path rejects rather than truncates.
         std::string tmpl = (fs::temp_directory_path() / "dusk-si-XXXXXX").string();
-        REQUIRE (tmpl.size() + std::strlen ("/dusk-studio/instance-0123456789abcdef.sock")
+#if defined (__APPLE__)
+        constexpr auto socketSuffix = "/dusk-studio/instance.sock";
+#else
+        constexpr auto socketSuffix = "/dusk-studio/instance-0123456789abcdef.sock";
+#endif
+        REQUIRE (tmpl.size() + std::strlen (socketSuffix)
                    < sizeof (sockaddr_un::sun_path));
         REQUIRE (::mkdtemp (&tmpl[0]) != nullptr);
         dir = tmpl;

--- a/tests/single_instance_socket_lifecycle.cpp
+++ b/tests/single_instance_socket_lifecycle.cpp
@@ -185,6 +185,13 @@ TEST_CASE ("single-instance handoff preserves quoted Unicode and empty payloads"
     REQUIRE_FALSE (duskstudio::single_instance::acquire ("", noPayload));
     REQUIRE (delivered.waitFor (2));
     REQUIRE (delivered.copy() == std::vector<std::string> { session, "" });
+
+#if defined (_WIN32)
+    duskstudio::single_instance::testing::dropNextAcknowledgement();
+    REQUIRE_FALSE (duskstudio::single_instance::acquire ("lost-ack", noPayload));
+    REQUIRE (delivered.waitFor (3));
+    REQUIRE (delivered.copy() == std::vector<std::string> { session, "", "lost-ack" });
+#endif
 }
 
 TEST_CASE ("simultaneous single-instance launches elect exactly one owner",


### PR DESCRIPTION
Closes #368

## Summary

- extend the native single-instance gate to macOS with a private per-user Unix socket and peer-UID validation
- add a Windows per-user SID mutex plus ACL-restricted local named pipe with client-SID validation
- preserve exact UTF-8/empty launch payloads, recover stale owners, prevent replay after a lost Windows acknowledgement, and cleanly release listeners
- add cross-platform regression coverage for simultaneous launches, handoff payloads, stale/crashed owners, and shutdown/reacquisition

## Validation

Exact commit: `f9f238741ec484215849d005b61dcc633afa4af5`

- Linux: `[issue-368]` 57 assertions / 6 cases; CTest 887/887
- macOS: `[issue-368]` 57 assertions / 6 cases; CTest 856/856
- Windows: `[issue-368]` 22 assertions / 4 cases; CTest 855/855; ASIO enabled and verified
- JUCE ratchet: 164 coupled source files, 8,253 uses (no increase)
- release mechanics and `git diff --check`: pass

Coverage note: the macOS validation cache has native LV2 disabled. The private local model smoke review was incomplete because its model endpoint was unreachable; its linter pass reported only non-blocking style diagnostics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added single-instance support on Windows and macOS.
  - Improved per-user instance isolation and secure session handoff across supported platforms.
  - Added reliable recovery when an existing application instance closes unexpectedly.
  - Enhanced handling of Unicode and empty session handoff data.

- **Bug Fixes**
  - Improved retry behavior and connection reliability during session handoff.

- **Documentation**
  - Updated single-instance behavior documentation and corrected the documented test count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->