### PR TITLE
Fix Windows OOP editor coordinates

### DIFF
--- a/src/ui/EmbeddedModal.h
+++ b/src/ui/EmbeddedModal.h
@@ -730,23 +730,26 @@ private:
     }
 
     // Borrowed plugin-editor bodies resize themselves when the native
-    // window embeds or the plugin rescales its UI; the host resizes when
-    // the user resizes the main window with the editor open. Re-centre
-    // and re-fit the backdrop either way; moves are ignored (recenterBody
-    // itself moves the body, so reacting to them would recurse).
-    void componentMovedOrResized (juce::Component& c, bool, bool wasResized) override
+    // window embeds or the plugin rescales its UI; the host moves or resizes
+    // when its containing window changes. Re-centre and re-fit the backdrop
+    // either way. Direct body moves are handled by the body itself; after an
+    // ancestor-only move, resized() refreshes any embedded native child.
+    void componentMovedOrResized (juce::Component& c, bool wasMoved, bool wasResized) override
     {
-        if (! wasResized || borrowedBody_ == nullptr) return;
-        if (&c == borrowedBody_ || &c == host.getComponent())
-        {
-            recenterBody();
-            if (dim_ != nullptr && host != nullptr)
-                dim_->setBounds (host->getLocalBounds());
-            if (&c == host.getComponent())
-                if (auto callback = borrowedHostResized)
-                    callback (showGeneration_, ! activeModalStack().empty()
-                                                   && activeModalStack().back() == this);
-        }
+        if (borrowedBody_ == nullptr) return;
+        const bool bodyResized = &c == borrowedBody_ && wasResized;
+        const bool hostChanged = &c == host.getComponent() && (wasMoved || wasResized);
+        if (! bodyResized && ! hostChanged) return;
+
+        recenterBody();
+        if (hostChanged && wasMoved)
+            borrowedBody_->resized();
+        if (dim_ != nullptr && host != nullptr)
+            dim_->setBounds (host->getLocalBounds());
+        if (hostChanged && wasResized)
+            if (auto callback = borrowedHostResized)
+                callback (showGeneration_, ! activeModalStack().empty()
+                                               && activeModalStack().back() == this);
     }
 
     class Backdrop final : public juce::Component

--- a/src/ui/PlatformWindowing_Windows.cpp
+++ b/src/ui/PlatformWindowing_Windows.cpp
@@ -1,4 +1,5 @@
 #include "PlatformWindowing.h"
+#include "NativeEditorEmbedScale.h"
 
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
@@ -17,7 +18,7 @@ namespace
 // Component that adopts a foreign HWND (cross-process, owned by the
 // dusk-studio-plugin-host child) and reparents it into this JUCE
 // component's peer when first added to the hierarchy. Tracks size /
-// position via SetWindowPos on resized().
+// position via SetWindowPos on moves and resizes.
 class ForeignHwndEmbed final : public juce::Component
 {
 public:
@@ -78,11 +79,19 @@ public:
         layoutChild();
     }
 
+    void moved() override
+    {
+        layoutChild();
+    }
+
 private:
     void layoutChild()
     {
         if (! attached || child == nullptr) return;
-        auto bounds = getBoundsInParent();   // peer-relative
+        auto* const topLevel = getTopLevelComponent();
+        if (topLevel == nullptr) return;
+        const auto logical = topLevel->getLocalArea (this, getLocalBounds());
+        const auto bounds = embedscale::toPhysical (*this, logical);
         ::SetWindowPos (child, nullptr,
                           bounds.getX(), bounds.getY(),
                           bounds.getWidth(), bounds.getHeight(),

--- a/tests/notepad_graphics_compatibility.cpp
+++ b/tests/notepad_graphics_compatibility.cpp
@@ -21,12 +21,23 @@ TEST_CASE ("Notepad Cocoa embedding uses the display backing scale",
 }
 
 TEST_CASE ("Native embeds retain the peer platform scale outside Cocoa",
-           "[notepad][scale]")
+           "[notepad][scale][windows][issue-367]")
 {
     CHECK_THAT (duskstudio::embedscale::factorFromSources (1.0, 1.5, 2.0, false),
                 WithinRel (1.5, 1e-12));
     CHECK_THAT (duskstudio::embedscale::factorFromSources (1.25, 1.5, 2.0, false),
                 WithinRel (1.875, 1e-12));
+
+    constexpr int hostX = 91;
+    constexpr int hostY = 47;
+    constexpr int modalX = 22;
+    constexpr int modalY = 18;
+    const auto nested = duskstudio::embedscale::toPhysicalBounds (
+        hostX + modalX, hostY + modalY, 641, 359, 1.5);
+    CHECK (nested.x == 170);
+    CHECK (nested.y == 98);
+    CHECK (nested.width == 961);
+    CHECK (nested.height == 538);
 }
 using duskstudio::notepad::assessGraphicsCompatibility;
 

--- a/tests/platform_window_activation.cpp
+++ b/tests/platform_window_activation.cpp
@@ -43,14 +43,11 @@ std::string definitionBody (const std::string& source, const std::string& method
         }
         REQUIRE (closeParen < source.size());
 
-        auto afterParameters = source.find_first_not_of (" \t\r\n", closeParen + 1);
-        std::size_t openBrace = std::string::npos;
-        if (afterParameters != std::string::npos && source[afterParameters] == '{')
-            openBrace = afterParameters;
-        else if (afterParameters != std::string::npos && source[afterParameters] == ':')
-            openBrace = source.find ('{', afterParameters + 1); // constructor initializer list
+        const auto openBrace = source.find ('{', closeParen + 1);
+        const auto declarationEnd = source.find (';', closeParen + 1);
 
-        if (openBrace == std::string::npos)
+        if (openBrace == std::string::npos
+            || (declarationEnd != std::string::npos && declarationEnd < openBrace))
         {
             searchFrom = afterName;
             continue;
@@ -82,8 +79,8 @@ void requireInOrder (const std::string& source,
 }
 }
 
-TEST_CASE ("native window activation restores and raises the platform peer",
-           "[windowing][macos][windows][regression][issue-369]")
+TEST_CASE ("native window operations preserve activation and embedded editor geometry",
+           "[windowing][macos][windows][regression][issue-367][issue-369]")
 {
     const auto mac = definitionBody (
         readSource ("src/ui/PlatformWindowing_Mac.mm"), "bringWindowToFront");
@@ -103,6 +100,27 @@ TEST_CASE ("native window activation restores and raises the platform peer",
     REQUIRE (windows.find ("SW_RESTORE") != std::string::npos);
     REQUIRE (windows.find ("AllowSetForegroundWindow") != std::string::npos);
     requireInOrder (windows, "SetForegroundWindow", "FlashWindowEx");
+
+    const auto windowsSource = readSource ("src/ui/PlatformWindowing_Windows.cpp");
+    const auto layout = definitionBody (windowsSource, "layoutChild");
+    REQUIRE (layout.find ("getTopLevelComponent") != std::string::npos);
+    REQUIRE (layout.find ("getLocalArea") != std::string::npos);
+    REQUIRE (layout.find ("getLocalBounds") != std::string::npos);
+    REQUIRE (layout.find ("embedscale::toPhysical") != std::string::npos);
+    REQUIRE (layout.find ("getBoundsInParent") == std::string::npos);
+    requireInOrder (layout, "getLocalArea", "embedscale::toPhysical");
+    requireInOrder (layout, "embedscale::toPhysical", "SetWindowPos");
+
+    const auto moved = definitionBody (windowsSource, "moved");
+    REQUIRE (moved.find ("layoutChild") != std::string::npos);
+    const auto resized = definitionBody (windowsSource, "resized");
+    REQUIRE (resized.find ("layoutChild") != std::string::npos);
+
+    const auto modal = definitionBody (
+        readSource ("src/ui/EmbeddedModal.h"), "componentMovedOrResized");
+    REQUIRE (modal.find ("wasMoved") != std::string::npos);
+    REQUIRE (modal.find ("hostChanged && wasMoved") != std::string::npos);
+    REQUIRE (modal.find ("borrowedBody_->resized") != std::string::npos);
 }
 
 TEST_CASE ("launch session load and instance handoff retain native activation",


### PR DESCRIPTION
## Summary

- translate the embedded child bounds into top-level peer coordinates before converting to physical pixels
- refresh the child HWND after direct or ancestor movement while preserving the existing host-resize callback behavior
- cover nested non-zero offsets, fractional DPI rounding, and the Windows layout contract

## Validation

- Linux: build, `[issue-367]` (48 assertions), 887/887 CTest
- macOS: build, `[issue-367]` (48 assertions), 856/856 CTest
- Windows: ASIO-enabled build, `[issue-367]` (48 assertions), 855/855 CTest
- JUCE gate: 164 source files / 8,253 uses (unchanged)

Closes #367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved embedded editor positioning when host windows or modal components move or resize.
  - Corrected nested modal bounds on displays using non-default scaling, including Windows.
  - Ensured borrowed plugin editors refresh and remain correctly centered after host movement.

- **Tests**
  - Added coverage for movement, resizing, native window activation, and scaled embedded-editor geometry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->