### PR TITLE
Fix Linux shutdown peer backend detection

### DIFF
--- a/src/ui/LinuxPeerTeardown.h
+++ b/src/ui/LinuxPeerTeardown.h
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace duskstudio::platform
+{
+enum class LinuxPeerTeardown
+{
+    x11,
+    wayland
+};
+
+[[nodiscard]] constexpr LinuxPeerTeardown linuxPeerTeardownForMapping (
+    bool peerHasWaylandMapping) noexcept
+{
+    return peerHasWaylandMapping ? LinuxPeerTeardown::wayland
+                                 : LinuxPeerTeardown::x11;
+}
+} // namespace duskstudio::platform

--- a/src/ui/PlatformWindowing_Linux.cpp
+++ b/src/ui/PlatformWindowing_Linux.cpp
@@ -15,6 +15,11 @@
 
 namespace duskstudio::platform
 {
+#if DUSKSTUDIO_JUCE_HAS_WAYLAND
+using juce::WaylandSymbols;
+using juce::WaylandWindowSystem;
+#endif
+
 namespace
 {
 // JUCE owns a single ::Display* connection to the X server which we
@@ -29,24 +34,6 @@ namespace
 {
     auto* sys = juce::XWindowSystem::getInstanceWithoutCreating();
     return sys != nullptr ? sys->getDisplay() : nullptr;
-}
-
-// True when the process is attached to a Wayland session. The plugin
-// editor toplevels are still X11 (via XWayland) but the main window is
-// a wl_surface, which is what makes the X-side focus dance no-op.
-//
-// Cached on first call: $WAYLAND_DISPLAY is fixed for the lifetime of
-// the session-manager-spawned process, and re-reading per call let the
-// focus logic toggle if the env var were ever cleared mid-flight (which
-// some shells do for child processes).
-bool isWaylandSession()
-{
-    static const bool cached = []
-    {
-        const char* wd = std::getenv ("WAYLAND_DISPLAY");
-        return wd != nullptr && *wd != '\0';
-    }();
-    return cached;
 }
 
 static_assert (BadWindow == x11::kBadWindow);
@@ -272,39 +259,30 @@ void prepareForTopLevelDestruction (juce::Component& topLevel)
     juce::Component::unfocusAllComponents();
     topLevel.giveAwayKeyboardFocus();
 
-    auto* d = juceDisplay();
+    bool topLevelUsesWayland = false;
+   #if DUSKSTUDIO_JUCE_HAS_WAYLAND
+    if (auto* sys = WaylandWindowSystem::getInstanceWithoutCreating())
+        topLevelUsesWayland = sys->getWaylandWindowForPeer (topLevel.getPeer()) != nullptr;
+   #endif
 
-    if (isWaylandSession())
+    if (topLevelUsesWayland)
     {
-        // Wayland-session path: the doomed plugin editor is an X11
-        // toplevel (via XWayland), the main Dusk Studio window is a
-        // wl_surface. Mutter does NOT honour X11 _NET_ACTIVE_WINDOW /
-        // XSetInputFocus / XIconify for focus_window updates on a
-        // Wayland session - the EWMH dance below is therefore a
-        // no-op. What we CAN do is unmap the doomed window cleanly
-        // and then yield to the compositor so it dispatches the
-        // resulting events on its main loop - which retargets
-        // focus_window off the unmapped X11 window.
-        if (d != nullptr)
-        {
-            if (auto* peer = topLevel.getPeer())
-            {
-                const auto win = (::Window) (uintptr_t) peer->getNativeHandle();
-                ::XWithdrawWindow (d, win, DefaultScreen (d));
-            }
-            ::XSync (d, False);
-            std::fprintf (stderr, "[Dusk Studio/Wayland] X11 unmap + roundtrip\n");
-        }
+        // A real Wayland peer has a wl_surface native handle, not an X11
+        // Window ID. Yield to the compositor without passing that handle to
+        // Xlib. The peer query above deliberately ignores WAYLAND_DISPLAY:
+        // forced-XWayland peers on a Wayland desktop must use the X11 path.
         requestFocusOnMainWaylandSurface();
+        std::fputs ("[Dusk Studio/Wayland] focus roundtrip\n", stderr);
         std::fflush (stderr);
         return;
     }
 
-    // Xorg session: the doomed window AND any sibling are both real
-    // X11 toplevels. EWMH _NET_ACTIVE_WINDOW on a sibling is the only
-    // path mutter actually honours for X11 focus_window retargeting;
-    // when no sibling exists, fall back to XIconify which routes
-    // through mutter's WM_CHANGE_STATE handler.
+    auto* d = juceDisplay();
+
+    // X11-peer path, both on Xorg and when forced through XWayland. EWMH
+    // _NET_ACTIVE_WINDOW on a sibling is the only path mutter actually
+    // honours for X11 focus_window retargeting; when no sibling exists,
+    // fall back to XIconify which routes through the WM_CHANGE_STATE handler.
     if (auto* sibling = pickSiblingFocusTargetPeer (topLevel))
     {
         bringWindowToFront (*sibling);
@@ -353,7 +331,7 @@ void clearXInputFocus()
 void preferX11ForNextNativeWindow()
 {
    #if DUSKSTUDIO_JUCE_HAS_WAYLAND
-    juce::WaylandWindowSystem::setSkipForPeerCreation (true);
+    WaylandWindowSystem::setSkipForPeerCreation (true);
    #endif
 }
 
@@ -383,11 +361,11 @@ void requestFocusOnMainWaylandSurface()
     // subsequent X11 destroy lands an additional message-loop tick
     // later, providing extra slack for any compositor work that
     // didn't make it into the same dispatch round.
-    auto* sys = juce::WaylandWindowSystem::getInstanceWithoutCreating();
+    auto* sys = WaylandWindowSystem::getInstanceWithoutCreating();
     if (sys == nullptr) return;
     auto* display = sys->getDisplay();
     if (display == nullptr) return;
-    juce::WaylandSymbols::getInstance()->displayRoundtrip (display);
+    WaylandSymbols::getInstance()->displayRoundtrip (display);
    #endif
 }
 

--- a/src/ui/PlatformWindowing_Linux.cpp
+++ b/src/ui/PlatformWindowing_Linux.cpp
@@ -4,6 +4,7 @@
 // PlatformWindowing.h - so it sits at the very top of this file.
 #define JUCE_GUI_BASICS_INCLUDE_XHEADERS 1
 
+#include "LinuxPeerTeardown.h"
 #include "PlatformWindowing.h"
 #include "X11EditorTeardownError.h"
 
@@ -259,13 +260,14 @@ void prepareForTopLevelDestruction (juce::Component& topLevel)
     juce::Component::unfocusAllComponents();
     topLevel.giveAwayKeyboardFocus();
 
-    bool topLevelUsesWayland = false;
+    auto teardown = LinuxPeerTeardown::x11;
    #if DUSKSTUDIO_JUCE_HAS_WAYLAND
     if (auto* sys = WaylandWindowSystem::getInstanceWithoutCreating())
-        topLevelUsesWayland = sys->getWaylandWindowForPeer (topLevel.getPeer()) != nullptr;
+        teardown = linuxPeerTeardownForMapping (
+            sys->getWaylandWindowForPeer (topLevel.getPeer()) != nullptr);
    #endif
 
-    if (topLevelUsesWayland)
+    if (teardown == LinuxPeerTeardown::wayland)
     {
         // A real Wayland peer has a wl_surface native handle, not an X11
         // Window ID. Yield to the compositor without passing that handle to

--- a/tests/platform_window_activation.cpp
+++ b/tests/platform_window_activation.cpp
@@ -1,5 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 
+#include "ui/LinuxPeerTeardown.h"
+
 #include <fstream>
 #include <iterator>
 #include <string>
@@ -83,6 +85,9 @@ TEST_CASE ("native window operations preserve activation and embedded editor geo
            "[windowing][linux][macos][windows][wayland][regression]"
            "[issue-367][issue-369][issue-376]")
 {
+    using duskstudio::platform::LinuxPeerTeardown;
+    using duskstudio::platform::linuxPeerTeardownForMapping;
+
     const auto mac = definitionBody (
         readSource ("src/ui/PlatformWindowing_Mac.mm"), "bringWindowToFront");
     REQUIRE (mac.find ("getNativeHandle") != std::string::npos);
@@ -117,6 +122,27 @@ TEST_CASE ("native window operations preserve activation and embedded editor geo
     const auto resized = definitionBody (windowsSource, "resized");
     REQUIRE (resized.find ("layoutChild") != std::string::npos);
 
+    struct LinuxTeardownCase
+    {
+        const char* configuration;
+        bool peerHasWaylandMapping;
+        LinuxPeerTeardown expected;
+    };
+
+    const LinuxTeardownCase linuxCases[] {
+        { "Xorg", false, LinuxPeerTeardown::x11 },
+        { "Wayland desktop, default XWayland peer", false, LinuxPeerTeardown::x11 },
+        { "Wayland desktop, DUSKSTUDIO_NATIVE_WAYLAND=1 peer", true,
+          LinuxPeerTeardown::wayland },
+    };
+
+    for (const auto& linuxCase : linuxCases)
+    {
+        INFO ("Linux configuration: " << linuxCase.configuration);
+        CHECK (linuxPeerTeardownForMapping (linuxCase.peerHasWaylandMapping)
+               == linuxCase.expected);
+    }
+
     const auto linuxTeardown = definitionBody (
         readSource ("src/ui/PlatformWindowing_Linux.cpp"),
         "prepareForTopLevelDestruction");
@@ -126,7 +152,8 @@ TEST_CASE ("native window operations preserve activation and embedded editor geo
     // development mode) may select the wl_surface roundtrip.
     REQUIRE (linuxTeardown.find ("getenv") == std::string::npos);
     REQUIRE (linuxTeardown.find ("getWaylandWindowForPeer") != std::string::npos);
-    requireInOrder (linuxTeardown, "getWaylandWindowForPeer", "if (topLevelUsesWayland)");
+    requireInOrder (linuxTeardown, "getWaylandWindowForPeer",
+                    "if (teardown == LinuxPeerTeardown::wayland)");
 
     // A wl_surface pointer must never be submitted to Xlib as a Window ID.
     REQUIRE (linuxTeardown.find ("XWithdrawWindow") == std::string::npos);

--- a/tests/platform_window_activation.cpp
+++ b/tests/platform_window_activation.cpp
@@ -80,7 +80,8 @@ void requireInOrder (const std::string& source,
 }
 
 TEST_CASE ("native window operations preserve activation and embedded editor geometry",
-           "[windowing][macos][windows][regression][issue-367][issue-369]")
+           "[windowing][linux][macos][windows][wayland][regression]"
+           "[issue-367][issue-369][issue-376]")
 {
     const auto mac = definitionBody (
         readSource ("src/ui/PlatformWindowing_Mac.mm"), "bringWindowToFront");
@@ -115,6 +116,22 @@ TEST_CASE ("native window operations preserve activation and embedded editor geo
     REQUIRE (moved.find ("layoutChild") != std::string::npos);
     const auto resized = definitionBody (windowsSource, "resized");
     REQUIRE (resized.find ("layoutChild") != std::string::npos);
+
+    const auto linuxTeardown = definitionBody (
+        readSource ("src/ui/PlatformWindowing_Linux.cpp"),
+        "prepareForTopLevelDestruction");
+
+    // Xorg and default XWayland peers both take the X11 branch, regardless of
+    // WAYLAND_DISPLAY. Only an actual Wayland peer (available to the native
+    // development mode) may select the wl_surface roundtrip.
+    REQUIRE (linuxTeardown.find ("getenv") == std::string::npos);
+    REQUIRE (linuxTeardown.find ("getWaylandWindowForPeer") != std::string::npos);
+    requireInOrder (linuxTeardown, "getWaylandWindowForPeer", "if (topLevelUsesWayland)");
+
+    // A wl_surface pointer must never be submitted to Xlib as a Window ID.
+    REQUIRE (linuxTeardown.find ("XWithdrawWindow") == std::string::npos);
+    REQUIRE (linuxTeardown.find ("requestFocusOnMainWaylandSurface") != std::string::npos);
+    REQUIRE (linuxTeardown.find ("XIconifyWindow") != std::string::npos);
 
     const auto modal = definitionBody (
         readSource ("src/ui/EmbeddedModal.h"), "componentMovedOrResized");

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -129,7 +129,7 @@ src/ui/NativeEditorEmbedScale.h	14
 src/ui/PianoRollComponent.cpp	381
 src/ui/PianoRollComponent.h	61
 src/ui/PlatformWindowing.h	14
-src/ui/PlatformWindowing_Linux.cpp	16
+src/ui/PlatformWindowing_Linux.cpp	15
 src/ui/PlatformWindowing_Mac.mm	19
 src/ui/PlatformWindowing_Windows.cpp	7
 src/ui/PluginPickerHelpers.cpp	135


### PR DESCRIPTION
## Summary

- choose the Linux shutdown path from the actual native peer backend instead of `WAYLAND_DISPLAY`
- keep forced-XWayland peers on the X11 sibling/iconify path and never pass a real `wl_surface` to Xlib
- exercise the production teardown selector for Xorg, default XWayland, and `DUSKSTUDIO_NATIVE_WAYLAND=1`
- ratchet JUCE usage from 8,253 to 8,252

## Validation

- Linux: `[issue-376]` 54 assertions; CTest 887/887
- macOS: `[issue-376]` 54 assertions; CTest 856/856
- Windows: ASIO enabled; `[issue-376]` 54 assertions; CTest 855/855
- `tools/juce-gate.sh`: 164 files / 8,252 uses
- `review-local`: incomplete (local model endpoint unavailable); remaining linter note is Catch2 macro expansion

Closes #376