### PR TITLE
Fix duplicate macOS OOP editor windows

### DIFF
--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -2703,15 +2703,16 @@ void ChannelStripComponent::openPluginEditor()
    #if DUSKSTUDIO_HAS_OOP_PLUGINS
     if (pluginSlot.isRemote())
     {
-        // OOP path: ask the child to show the editor + report its
-        // native window handle. The child owns the editor's lifecycle;
-        // we either embed the handle (Linux XEmbed) or let it float
-        // as its own top-level window (Mac - cross-process NSView
-        // embedding is a polish item, not a 1.0 blocker).
+        // Linux and Windows ask the child to show its editor and then
+        // embed the reported native handle. macOS first tries the
+        // parent-process shell editor below; only its fallback presents
+        // the child's floating window.
         std::uint64_t windowId = 0;
         int w = 0, h = 0;
+       #if ! JUCE_MAC
         if (! pluginSlot.showRemoteEditor (windowId, w, h)) return;
         if (windowId == 0) return;
+       #endif
 
        #if JUCE_LINUX
         if (remoteEditorEmbed == nullptr)
@@ -2736,12 +2737,19 @@ void ChannelStripComponent::openPluginEditor()
        #elif JUCE_MAC
         // Mac OOP: dual-load shell pattern (3c-2). DSP stays in the
         // child; the editor lives in this process via PluginSlot's
-        // shell instance. windowId from showRemoteEditor is unused on
-        // Mac because the child's native window is NOT what we embed;
-        // the parent's shell-instance editor is. The IPC ShowEditor
-        // call still ran above for symmetry + so future param-mirror
-        // (3c-3) state-sync IPC can piggyback on it.
-        juce::ignoreUnused (windowId);
+        // shell instance. Do not send ShowEditor before trying the shell:
+        // that RPC presents the child-process window, while state sync uses
+        // its own GetState RPC and does not require a visible child editor.
+        if (remoteForeignEmbed != nullptr)
+        {
+            // The shell wrapper is cached when its modal closes. Reuse it
+            // instead of asking createShellEditor() for a second owner. Hide
+            // any child fallback that may still be visible before reopening.
+            if (! pluginSlot.hideRemoteEditor()) return;
+            pluginEditorModal.showBorrowed (*parent, *remoteForeignEmbed, onClose);
+            return;
+        }
+
         std::unique_ptr<juce::Component> embed;
         juce::String shellErr;
         if (pluginSlot.ensureShellInstanceForEditor (shellErr))
@@ -2797,20 +2805,31 @@ void ChannelStripComponent::openPluginEditor()
                           "load failed: %s - falling back to floating child window.\n",
                           shellErr.toRawUTF8());
         }
+
+        // A prior shell attempt may have fallen back to the child window. Do
+        // not present the new shell unless that window is confirmed hidden.
+        if (embed != nullptr && ! pluginSlot.hideRemoteEditor())
+            embed.reset();
+
         if (embed != nullptr)
         {
-            embed->setSize (std::max (200, w), std::max (200, h));
+            embed->setSize (std::max (200, embed->getWidth()),
+                            std::max (200, embed->getHeight()));
             // Tag so a later settings / quit modal hides the shell-editor
             // wrapper too (same reason as the Linux XEmbed + in-process
-            // paths). Defensive today - createInProcessEditorHost is a Mac
-            // stub returning nullptr - but correct once the shell host lands.
+            // paths): its native peer can otherwise cover a JUCE modal.
             embed->getProperties().set (kPluginEditorTag, true);
             pluginEditorModal.showBorrowed (*parent, *embed, onClose);
             remoteForeignEmbed = std::move (embed);
         }
         else
         {
-            // Fallback: child opened its own native-titlebar top-level.
+            // Fallback: only now ask the child to create and present its
+            // native-titlebar top-level. A successful shell path never sends
+            // ShowEditor, so it cannot leave a second visible editor behind.
+            if (! pluginSlot.showRemoteEditor (windowId, w, h)) return;
+            if (windowId == 0) return;
+
             // Subsequent clicks re-fire ShowEditor and the child raises
             // the existing window. NOTE: this floating window lives in the
             // child process and is NOT a child of our parent, so EmbeddedModal

--- a/tests/platform_window_activation.cpp
+++ b/tests/platform_window_activation.cpp
@@ -83,7 +83,7 @@ void requireInOrder (const std::string& source,
 
 TEST_CASE ("native window operations preserve activation and embedded editor geometry",
            "[windowing][linux][macos][windows][wayland][regression]"
-           "[issue-367][issue-369][issue-376]")
+           "[issue-367][issue-369][issue-376][issue-380]")
 {
     using duskstudio::platform::LinuxPeerTeardown;
     using duskstudio::platform::linuxPeerTeardownForMapping;
@@ -159,6 +159,41 @@ TEST_CASE ("native window operations preserve activation and embedded editor geo
     REQUIRE (linuxTeardown.find ("XWithdrawWindow") == std::string::npos);
     REQUIRE (linuxTeardown.find ("requestFocusOnMainWaylandSurface") != std::string::npos);
     REQUIRE (linuxTeardown.find ("XIconifyWindow") != std::string::npos);
+
+    const auto remoteEditor = definitionBody (
+        readSource ("src/ui/ChannelStripComponent.cpp"),
+        "ChannelStripComponent::openPluginEditor");
+    const auto remoteBranch = remoteEditor.find ("if (pluginSlot.isRemote())");
+    const auto nonMacGuard = remoteEditor.find ("#if ! JUCE_MAC", remoteBranch);
+    const auto nonMacShow = remoteEditor.find ("showRemoteEditor", nonMacGuard);
+    const auto macBranch = remoteEditor.find ("#elif JUCE_MAC", nonMacShow);
+    const auto cachedShell = remoteEditor.find ("remoteForeignEmbed != nullptr", macBranch);
+    const auto cachedHide = remoteEditor.find ("hideRemoteEditor", cachedShell);
+    const auto cachedShow = remoteEditor.find ("pluginEditorModal.showBorrowed", cachedHide);
+    const auto shellLoad = remoteEditor.find ("ensureShellInstanceForEditor", macBranch);
+    const auto stateSync = remoteEditor.find ("syncShellStateFromChild", shellLoad);
+    const auto shellHost = remoteEditor.find ("createInProcessEditorHost", stateSync);
+    const auto shellHide = remoteEditor.find ("hideRemoteEditor", shellHost);
+    const auto shellShow = remoteEditor.find ("pluginEditorModal.showBorrowed", shellHide);
+    const auto fallbackShow = remoteEditor.find ("showRemoteEditor", shellShow);
+    const auto nextPlatformBranch = remoteEditor.find ("#else", fallbackShow);
+
+    // On macOS the child window is a fallback, not a prerequisite for the
+    // parent-side shell editor. State arrives through GetState before the shell
+    // is hosted; ShowEditor occurs only after shell hosting has failed.
+    REQUIRE (remoteBranch != std::string::npos);
+    REQUIRE (nonMacGuard < nonMacShow);
+    REQUIRE (nonMacShow < macBranch);
+    REQUIRE (macBranch < cachedShell);
+    REQUIRE (cachedShell < cachedHide);
+    REQUIRE (cachedHide < cachedShow);
+    REQUIRE (cachedShow < shellLoad);
+    REQUIRE (shellLoad < stateSync);
+    REQUIRE (stateSync < shellHost);
+    REQUIRE (shellHost < shellHide);
+    REQUIRE (shellHide < shellShow);
+    REQUIRE (shellShow < fallbackShow);
+    REQUIRE (fallbackShow < nextPlatformBranch);
 
     const auto modal = definitionBody (
         readSource ("src/ui/EmbeddedModal.h"), "componentMovedOrResized");

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -69,7 +69,7 @@ src/ui/BusComponent.cpp	309
 src/ui/BusComponent.h	47
 src/ui/ChannelEqEditor.cpp	93
 src/ui/ChannelEqEditor.h	13
-src/ui/ChannelStripComponent.cpp	771
+src/ui/ChannelStripComponent.cpp	770
 src/ui/ChannelStripComponent.h	111
 src/ui/ClapPluginEditorComponent.cpp	18
 src/ui/ClapPluginEditorComponent.h	8


### PR DESCRIPTION
## Summary

- try the parent-process macOS shell editor before presenting the child editor window
- reuse cached shell wrappers and hide any previous child fallback before showing the shell
- preserve floating child fallback when shell creation or hiding fails
- add an issue-tagged source contract regression and reduce the JUCE allowlist count

## Validation

- Linux: 887/887 CTest; [issue-380] 69 assertions
- macOS: 856/856 CTest; [issue-380] 69 assertions
- Windows (ASIO enabled): 855/855 CTest; [issue-380] 69 assertions
- release mechanics and JUCE gate

Closes #380

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS remote plug-in editor opening by prioritizing the embedded editor shell.
  - Prevented duplicate or unwanted floating editor windows from appearing during launch.
  - Preserved editor sizing using the embedded shell’s dimensions.
  - Added a fallback so the plug-in’s floating editor appears when embedded presentation is unavailable.

- **Tests**
  - Added regression coverage for editor presentation order, window activation, and embedded editor geometry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->