### PR TITLE
Replace unsafe POSIX plugin-host fork

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1250,6 +1250,12 @@ if(_duskstudio_oop_enabled)
         # shell32: CommandLineToArgvW, which the child uses to read its own
         # arguments as UTF-16 instead of trusting the ANSI-converted argv.
         target_link_libraries(dusk-studio-plugin-host PRIVATE shell32)
+    elseif(APPLE)
+        find_library(DUSKSTUDIO_OOP_AUDIOUNIT_FRAMEWORK AudioUnit REQUIRED)
+        find_library(DUSKSTUDIO_OOP_COREAUDIOKIT_FRAMEWORK CoreAudioKit REQUIRED)
+        target_link_libraries(dusk-studio-plugin-host PRIVATE
+            ${DUSKSTUDIO_OOP_AUDIOUNIT_FRAMEWORK}
+            ${DUSKSTUDIO_OOP_COREAUDIOKIT_FRAMEWORK})
     endif()
     target_include_directories(dusk-studio-plugin-host PRIVATE src)
     target_include_directories(dusk-studio-plugin-host SYSTEM PRIVATE external/json)

--- a/src/engine/ipc/PluginHostMain.cpp
+++ b/src/engine/ipc/PluginHostMain.cpp
@@ -80,6 +80,11 @@
  #include <windows.h>
 #endif
 
+#if defined (__linux__)
+ #include <sys/prctl.h>
+ #include <unistd.h>
+#endif
+
 #if defined (DUSKSTUDIO_USE_WINDOWS_SOFTWARE_OPENGL)
 namespace
 {
@@ -99,6 +104,36 @@ namespace
 {
 using namespace duskstudio::ipc;
 namespace ipcp = duskstudio::ipc::platform;
+
+#if defined (__linux__)
+bool armParentDeathSignal (int argc, char* const* argv) noexcept
+{
+    constexpr char prefix[] = "--ipc-parent-pid=";
+    for (int i = 1; i < argc; ++i)
+    {
+        if (std::strncmp (argv[i], prefix, sizeof (prefix) - 1) != 0)
+            continue;
+
+        char* end = nullptr;
+        errno = 0;
+        const long long parsed = std::strtoll (argv[i] + sizeof (prefix) - 1,
+                                               &end, 10);
+        if (errno != 0 || end == nullptr || *end != '\0' || parsed <= 1
+            || parsed > (long long) std::numeric_limits<pid_t>::max())
+            return false;
+
+        const auto expectedParent = (pid_t) parsed;
+        if (::prctl (PR_SET_PDEATHSIG, SIGTERM) != 0)
+            return false;
+
+        // The parent can die between posix_spawn() and this prctl(). In that
+        // race the kernel cannot deliver the configured signal retroactively,
+        // so reject a helper that has already been reparented.
+        return ::getppid() == expectedParent;
+    }
+    return true;
+}
+#endif
 
 // Single mutex guards every outbound write on the control socket so the
 // sockThread's sync-RPC replies cannot interleave with the async push
@@ -1371,6 +1406,10 @@ int runScan (int argc, const char* const* argv) noexcept
 
 int main (int argc, char** argv)
 {
+   #if defined (__linux__)
+    if (! armParentDeathSignal (argc, argv)) return 70;
+   #endif
+
    #if ! defined (_WIN32)
     signal (SIGPIPE, SIG_IGN);
    #endif

--- a/src/engine/ipc/RemotePluginConnection.cpp
+++ b/src/engine/ipc/RemotePluginConnection.cpp
@@ -114,7 +114,7 @@ bool RemotePluginConnection::connect (const std::string& hostExecutablePath,
     }
 
     std::vector<std::string> args { extraArg };
-    if (! child.spawn (hostExecutablePath, args, pair.childEnd,
+    if (! child.spawn (hostExecutablePath, args, pair.childEnd, pair.parentEnd,
                        { shm.handle(), commandSignal.handle(), replySignal.handle() },
                        errorOut))
     {

--- a/src/engine/ipc/platform/IpcChannel.h
+++ b/src/engine/ipc/platform/IpcChannel.h
@@ -73,9 +73,9 @@ bool createChannelPair (ChannelPair& out, std::string& errorOut) noexcept;
 constexpr int kChildInheritFd = 3;
 
 // Move the given handle so its underlying fd is exactly `targetFd`.
-// Linux: dup2() + close-source. Used in the forked child between
-// fork() and execv() so the channel lands at kChildInheritFd. Windows:
-// no-op success (handle inheritance + CLI value used instead).
+// POSIX: dup2() + close-source. Windows: no-op success (handle inheritance
+// + CLI value used instead). Process launch uses posix_spawn file actions;
+// this remains the platform-level primitive for other handle-remap callers.
 bool moveHandleToFd (NativeHandle& h, int targetFd) noexcept;
 
 // Child-side: find the channel endpoint the parent's spawn handed us.

--- a/src/engine/ipc/platform/IpcProcess.h
+++ b/src/engine/ipc/platform/IpcProcess.h
@@ -8,12 +8,14 @@
 
 // Spawn + supervise the dusk-studio-plugin-host child binary.
 //
-// Linux  : fork() + dup2(channel, kChildInheritFd) + prctl(PR_SET_PDEATHSIG)
-//          + execv(). Reaping via waitpid(WNOHANG); termination via SIGTERM
-//          then SIGKILL.
+// Linux  : posix_spawn() with file actions to remap the channel endpoint.
+//          The exec'd helper arms prctl(PR_SET_PDEATHSIG) and verifies the
+//          expected parent PID before doing other work. Reaping via
+//          waitpid(WNOHANG); termination via SIGTERM then SIGKILL.
 // macOS  : posix_spawn() with file actions to remap the channel endpoint
-//          to kChildInheritFd. Parent-death tracking via kqueue NOTE_EXIT
-//          on the child PID; termination via SIGTERM + waitpid.
+//          to kChildInheritFd. Normal teardown is parent-supervised; a hard
+//          parent crash can leave an orphan because macOS has no PDEATHSIG.
+//          Termination uses SIGTERM + waitpid, then SIGKILL if needed.
 // Windows: CreateProcessW() with bInheritHandles=TRUE and an explicit
 //          PROC_THREAD_ATTRIBUTE_HANDLE_LIST containing only the channel and
 //          caller-approved IPC handles. Job object configured with
@@ -34,7 +36,7 @@ public:
 
     // Spawn `executablePath` with `args` (the executable path itself is
     // argv[0]; pass only the trailing flags in `args`). The child end
-    // of `childChannelEnd` is duped to kChildInheritFd in a POSIX child;
+    // of `childChannelEnd` is duped to kChildInheritFd by POSIX spawn actions;
     // Windows inherits it plus `additionalInheritedHandles` through an
     // explicit handle allowlist. The parent end stays with the caller.
     //

--- a/src/engine/ipc/platform/IpcProcess.h
+++ b/src/engine/ipc/platform/IpcProcess.h
@@ -36,7 +36,8 @@ public:
 
     // Spawn `executablePath` with `args` (the executable path itself is
     // argv[0]; pass only the trailing flags in `args`). The child end
-    // of `childChannelEnd` is duped to kChildInheritFd by POSIX spawn actions;
+    // of the channel is duped to kChildInheritFd by POSIX spawn actions;
+    // the parent end is explicitly closed in the spawned process.
     // Windows inherits it plus `additionalInheritedHandles` through an
     // explicit handle allowlist. The parent end stays with the caller.
     //
@@ -46,6 +47,7 @@ public:
     bool spawn (const std::string& executablePath,
                   const std::vector<std::string>& args,
                   NativeHandle& childChannelEnd,
+                  const NativeHandle& parentChannelEnd,
                   const std::vector<NativeHandle>& additionalInheritedHandles,
                   std::string& errorOut) noexcept;
 

--- a/src/engine/ipc/platform/IpcProcess_Linux.cpp
+++ b/src/engine/ipc/platform/IpcProcess_Linux.cpp
@@ -16,6 +16,7 @@ ChildProcess::~ChildProcess()
 bool ChildProcess::spawn (const std::string& executablePath,
                               const std::vector<std::string>& args,
                               NativeHandle& childChannelEnd,
+                              const NativeHandle& parentChannelEnd,
                               const std::vector<NativeHandle>&,
                               std::string& errorOut) noexcept
 {
@@ -24,6 +25,7 @@ bool ChildProcess::spawn (const std::string& executablePath,
 
     pid_t spawned = -1;
     if (! detail::posixSpawn (executablePath, childArgs, childChannelEnd,
+                              parentChannelEnd,
                               spawned, errorOut))
         return false;
 

--- a/src/engine/ipc/platform/IpcProcess_Linux.cpp
+++ b/src/engine/ipc/platform/IpcProcess_Linux.cpp
@@ -1,10 +1,7 @@
 #include "IpcProcess.h"
+#include "IpcProcess_Posix.h"
 
-#include <cerrno>
 #include <csignal>
-#include <cstdio>
-#include <cstring>
-#include <sys/prctl.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -22,35 +19,15 @@ bool ChildProcess::spawn (const std::string& executablePath,
                               const std::vector<NativeHandle>&,
                               std::string& errorOut) noexcept
 {
-    const pid_t forked = ::fork();
-    if (forked < 0)
-    {
-        errorOut = std::string ("fork failed: ") + std::strerror (errno);
+    auto childArgs = args;
+    childArgs.push_back ("--ipc-parent-pid=" + std::to_string ((long long) ::getpid()));
+
+    pid_t spawned = -1;
+    if (! detail::posixSpawn (executablePath, childArgs, childChannelEnd,
+                              spawned, errorOut))
         return false;
-    }
-    pid = (std::intptr_t) forked;
 
-    if (forked == 0)
-    {
-        if (! moveHandleToFd (childChannelEnd, kChildInheritFd))
-            ::_exit (127);
-
-        // Best-effort: kill the child if the parent dies. Cannot fail
-        // in a way the child can report; ignore the return value.
-        (void) ::prctl (PR_SET_PDEATHSIG, SIGTERM);
-
-        std::vector<const char*> argv;
-        argv.reserve (args.size() + 2);
-        argv.push_back (executablePath.c_str());
-        for (const auto& a : args) argv.push_back (a.c_str());
-        argv.push_back (nullptr);
-
-        ::execv (executablePath.c_str(), const_cast<char* const*> (argv.data()));
-        std::fprintf (stderr, "[dusk-studio-plugin-host] execv failed: %s\n",
-                       std::strerror (errno));
-        ::_exit (127);
-    }
-
+    pid = (std::intptr_t) spawned;
     closeHandle (childChannelEnd);
     alive = true;
     return true;

--- a/src/engine/ipc/platform/IpcProcess_Mac.cpp
+++ b/src/engine/ipc/platform/IpcProcess_Mac.cpp
@@ -1,10 +1,7 @@
 #include "IpcProcess.h"
+#include "IpcProcess_Posix.h"
 
-#include <cerrno>
 #include <csignal>
-#include <cstdio>
-#include <cstdint>
-#include <cstring>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -30,31 +27,12 @@ bool ChildProcess::spawn (const std::string& executablePath,
                               const std::vector<NativeHandle>&,
                               std::string& errorOut) noexcept
 {
-    const pid_t forked = ::fork();
-    if (forked < 0)
-    {
-        errorOut = std::string ("fork failed: ") + std::strerror (errno);
+    pid_t spawned = -1;
+    if (! detail::posixSpawn (executablePath, args, childChannelEnd,
+                              spawned, errorOut))
         return false;
-    }
-    pid = (std::intptr_t) forked;
 
-    if (forked == 0)
-    {
-        if (! moveHandleToFd (childChannelEnd, kChildInheritFd))
-            ::_exit (127);
-
-        std::vector<const char*> argv;
-        argv.reserve (args.size() + 2);
-        argv.push_back (executablePath.c_str());
-        for (const auto& a : args) argv.push_back (a.c_str());
-        argv.push_back (nullptr);
-
-        ::execv (executablePath.c_str(), const_cast<char* const*> (argv.data()));
-        std::fprintf (stderr, "[dusk-studio-plugin-host] execv failed: %s\n",
-                       std::strerror (errno));
-        ::_exit (127);
-    }
-
+    pid = (std::intptr_t) spawned;
     closeHandle (childChannelEnd);
     alive = true;
     return true;

--- a/src/engine/ipc/platform/IpcProcess_Mac.cpp
+++ b/src/engine/ipc/platform/IpcProcess_Mac.cpp
@@ -24,11 +24,13 @@ ChildProcess::~ChildProcess()
 bool ChildProcess::spawn (const std::string& executablePath,
                               const std::vector<std::string>& args,
                               NativeHandle& childChannelEnd,
+                              const NativeHandle& parentChannelEnd,
                               const std::vector<NativeHandle>&,
                               std::string& errorOut) noexcept
 {
     pid_t spawned = -1;
     if (! detail::posixSpawn (executablePath, args, childChannelEnd,
+                              parentChannelEnd,
                               spawned, errorOut))
         return false;
 

--- a/src/engine/ipc/platform/IpcProcess_Posix.h
+++ b/src/engine/ipc/platform/IpcProcess_Posix.h
@@ -15,12 +15,13 @@ namespace duskstudio::ipc::platform::detail
 inline bool posixSpawn (const std::string& executablePath,
                         const std::vector<std::string>& args,
                         const NativeHandle& childChannelEnd,
+                        const NativeHandle& parentChannelEnd,
                         pid_t& childPidOut,
                         std::string& errorOut) noexcept
 {
-    if (! isValid (childChannelEnd))
+    if (! isValid (childChannelEnd) || ! isValid (parentChannelEnd))
     {
-        errorOut = "posix_spawn received an invalid child channel";
+        errorOut = "posix_spawn received an invalid channel";
         return false;
     }
 
@@ -33,8 +34,10 @@ inline bool posixSpawn (const std::string& executablePath,
         return false;
     }
 
-    result = ::posix_spawn_file_actions_adddup2 (
-        &actions, childChannelEnd.fd, kChildInheritFd);
+    result = ::posix_spawn_file_actions_addclose (&actions, parentChannelEnd.fd);
+    if (result == 0)
+        result = ::posix_spawn_file_actions_adddup2 (
+            &actions, childChannelEnd.fd, kChildInheritFd);
     if (result == 0 && childChannelEnd.fd != kChildInheritFd)
         result = ::posix_spawn_file_actions_addclose (&actions, childChannelEnd.fd);
 

--- a/src/engine/ipc/platform/IpcProcess_Posix.h
+++ b/src/engine/ipc/platform/IpcProcess_Posix.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "IpcChannel.h"
+
+#include <cstring>
+#include <spawn.h>
+#include <string>
+#include <vector>
+
+extern "C" char** environ;
+
+namespace duskstudio::ipc::platform::detail
+{
+
+inline bool posixSpawn (const std::string& executablePath,
+                        const std::vector<std::string>& args,
+                        const NativeHandle& childChannelEnd,
+                        pid_t& childPidOut,
+                        std::string& errorOut) noexcept
+{
+    if (! isValid (childChannelEnd))
+    {
+        errorOut = "posix_spawn received an invalid child channel";
+        return false;
+    }
+
+    posix_spawn_file_actions_t actions;
+    int result = ::posix_spawn_file_actions_init (&actions);
+    if (result != 0)
+    {
+        errorOut = std::string ("posix_spawn file-actions init failed: ")
+            + std::strerror (result);
+        return false;
+    }
+
+    result = ::posix_spawn_file_actions_adddup2 (
+        &actions, childChannelEnd.fd, kChildInheritFd);
+    if (result == 0 && childChannelEnd.fd != kChildInheritFd)
+        result = ::posix_spawn_file_actions_addclose (&actions, childChannelEnd.fd);
+
+    if (result != 0)
+    {
+        ::posix_spawn_file_actions_destroy (&actions);
+        errorOut = std::string ("posix_spawn file action failed: ")
+            + std::strerror (result);
+        return false;
+    }
+
+    std::vector<char*> argv;
+    argv.reserve (args.size() + 2);
+    argv.push_back (const_cast<char*> (executablePath.c_str()));
+    for (const auto& arg : args)
+        argv.push_back (const_cast<char*> (arg.c_str()));
+    argv.push_back (nullptr);
+
+    result = ::posix_spawn (&childPidOut, executablePath.c_str(), &actions,
+                            nullptr, argv.data(), environ);
+    ::posix_spawn_file_actions_destroy (&actions);
+    if (result != 0)
+    {
+        errorOut = std::string ("posix_spawn failed: ") + std::strerror (result);
+        return false;
+    }
+    return true;
+}
+
+} // namespace duskstudio::ipc::platform::detail

--- a/src/engine/ipc/platform/IpcProcess_Windows.cpp
+++ b/src/engine/ipc/platform/IpcProcess_Windows.cpp
@@ -125,6 +125,7 @@ ChildProcess::~ChildProcess()
 bool ChildProcess::spawn (const std::string& executablePath,
                               const std::vector<std::string>& args,
                               NativeHandle& childChannelEnd,
+                              const NativeHandle&,
                               const std::vector<NativeHandle>& additionalInheritedHandles,
                               std::string& errorOut) noexcept
 {

--- a/tests/ipc_stub_round_trip.cpp
+++ b/tests/ipc_stub_round_trip.cpp
@@ -91,6 +91,7 @@ public:
                               (unsigned long long) current,
                               allocations[(std::size_t) (current % allocations.size())].size());
                 std::fflush (sink);
+                ready.store (true, std::memory_order_release);
             }
         });
     }
@@ -102,11 +103,21 @@ public:
         if (sink != nullptr) std::fclose (sink);
     }
 
-    bool isReady() const noexcept { return sink != nullptr && worker.joinable(); }
+    bool waitUntilReady() const noexcept
+    {
+        if (sink == nullptr || ! worker.joinable()) return false;
+        const auto deadline = std::chrono::steady_clock::now()
+            + std::chrono::seconds (2);
+        while (! ready.load (std::memory_order_acquire)
+               && std::chrono::steady_clock::now() < deadline)
+            std::this_thread::sleep_for (std::chrono::milliseconds (1));
+        return ready.load (std::memory_order_acquire);
+    }
 
 private:
     std::FILE* sink { nullptr };
     std::atomic<bool> stopping { false };
+    std::atomic<bool> ready { false };
     std::thread worker;
 };
 #endif
@@ -178,9 +189,11 @@ TEST_CASE ("Windows IPC children inherit only their own shared-memory handles",
     ipcp::ChildProcess childA;
     ipcp::ChildProcess childB;
     REQUIRE (childA.spawn (DUSKSTUDIO_PLUGIN_HOST_PATH, probeArguments,
-                           channelsA.value.childEnd, { mappingA }, error));
+                           channelsA.value.childEnd, channelsA.value.parentEnd,
+                           { mappingA }, error));
     REQUIRE (childB.spawn (DUSKSTUDIO_PLUGIN_HOST_PATH, probeArguments,
-                           channelsB.value.childEnd, { mappingB }, error));
+                           channelsB.value.childEnd, channelsB.value.parentEnd,
+                           { mappingB }, error));
 
     std::uint8_t childAMarkers[2] {};
     std::uint8_t childBMarkers[2] {};
@@ -256,7 +269,8 @@ TEST_CASE ("Windows IPC launcher preserves Unicode paths and arguments",
 
     ipcp::ChildProcess child;
     const bool spawned = child.spawn (copiedHost.u8string(), suppliedArguments,
-                                      channels.value.childEnd, {}, error);
+                                      channels.value.childEnd,
+                                      channels.value.parentEnd, {}, error);
     INFO ("spawn error: " << error);
     REQUIRE (spawned);
 
@@ -286,7 +300,7 @@ TEST_CASE ("Windows IPC launcher preserves Unicode paths and arguments",
 #endif
 
 TEST_CASE ("Plugin-host handshake read timeout bounds a silent live child",
-           "[ipc][issue-364]")
+           "[ipc][issue-364][issue-366]")
 {
     namespace ipcp = duskstudio::ipc::platform;
     using namespace std::chrono_literals;
@@ -301,7 +315,8 @@ TEST_CASE ("Plugin-host handshake read timeout bounds a silent live child",
     ipcp::ChildProcess child;
     REQUIRE (child.spawn (DUSKSTUDIO_PLUGIN_HOST_PATH,
                           { "--ipc-silent-handshake-stub" },
-                          channels.value.childEnd, {}, error));
+                          channels.value.childEnd, channels.value.parentEnd,
+                          {}, error));
     REQUIRE (child.isAlive());
     REQUIRE (ipcp::setReadTimeout (channels.value.parentEnd, 75));
 
@@ -316,11 +331,16 @@ TEST_CASE ("Plugin-host handshake read timeout bounds a silent live child",
     REQUIRE (readElapsed < 2s);
     REQUIRE (child.isAlive());
 
-    // Releasing the parent end wakes the silent child's blocking read. The
-    // normal process teardown then reaps it without leaving a wedged child.
+    // Releasing the parent end must wake the child's blocking read. If the
+    // spawned process retained that endpoint, it would never observe EOF.
     ipcp::closeHandle (channels.value.parentEnd);
     const auto teardownStarted = std::chrono::steady_clock::now();
-    child.terminate (1000);
+    while (child.isAlive()
+           && std::chrono::steady_clock::now() - teardownStarted < 2s)
+    {
+        (void) child.pollExit();
+        std::this_thread::sleep_for (1ms);
+    }
     REQUIRE_FALSE (child.isAlive());
     REQUIRE (std::chrono::steady_clock::now() - teardownStarted < 2s);
 }
@@ -335,7 +355,7 @@ TEST_CASE ("ipc-stub: connect, round-trip 32 blocks, byte-exact echo",
     REQUIRE (::pthread_atfork (countForkPrepare, nullptr, nullptr) == 0);
 
     AllocatorAndStdioChurn churn;
-    REQUIRE (churn.isReady());
+    REQUIRE (churn.waitUntilReady());
 
     for (int iteration = 0; iteration < 24; ++iteration)
     {
@@ -347,7 +367,8 @@ TEST_CASE ("ipc-stub: connect, round-trip 32 blocks, byte-exact echo",
         ipcp::ChildProcess child;
         REQUIRE (child.spawn (DUSKSTUDIO_PLUGIN_HOST_PATH,
                               { "--ipc-argv-stub" },
-                              channels.value.childEnd, {}, spawnError));
+                              channels.value.childEnd, channels.value.parentEnd,
+                              {}, spawnError));
 
         std::uint32_t argumentCount = 0;
         REQUIRE (ipcp::readExact (channels.value.parentEnd,

--- a/tests/ipc_stub_round_trip.cpp
+++ b/tests/ipc_stub_round_trip.cpp
@@ -27,6 +27,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -38,6 +39,8 @@
   #define NOMINMAX
  #endif
  #include <windows.h>
+#else
+ #include <pthread.h>
 #endif
 
 namespace
@@ -57,6 +60,56 @@ struct ScopedChannelPair
 
     duskstudio::ipc::platform::ChannelPair value;
 };
+
+#if ! defined (_WIN32)
+std::atomic<int> forkPrepareCalls { 0 };
+
+void countForkPrepare() noexcept
+{
+    forkPrepareCalls.fetch_add (1, std::memory_order_relaxed);
+}
+
+class AllocatorAndStdioChurn
+{
+public:
+    AllocatorAndStdioChurn()
+        : sink (std::fopen ("/dev/null", "w"))
+    {
+        if (sink == nullptr) return;
+        worker = std::thread ([this]
+        {
+            std::uint64_t sequence = 0;
+            while (! stopping.load (std::memory_order_relaxed))
+            {
+                std::vector<std::string> allocations;
+                allocations.reserve (64);
+                for (int i = 0; i < 64; ++i)
+                    allocations.emplace_back (1024, (char) ('a' + i % 26));
+
+                const auto current = sequence++;
+                std::fprintf (sink, "%llu %zu\n",
+                              (unsigned long long) current,
+                              allocations[(std::size_t) (current % allocations.size())].size());
+                std::fflush (sink);
+            }
+        });
+    }
+
+    ~AllocatorAndStdioChurn()
+    {
+        stopping.store (true, std::memory_order_relaxed);
+        if (worker.joinable()) worker.join();
+        if (sink != nullptr) std::fclose (sink);
+    }
+
+    bool isReady() const noexcept { return sink != nullptr && worker.joinable(); }
+
+private:
+    std::FILE* sink { nullptr };
+    std::atomic<bool> stopping { false };
+    std::thread worker;
+};
+#endif
 } // namespace
 
 #if defined (_WIN32)
@@ -273,8 +326,57 @@ TEST_CASE ("Plugin-host handshake read timeout bounds a silent live child",
 }
 
 TEST_CASE ("ipc-stub: connect, round-trip 32 blocks, byte-exact echo",
-            "[ipc]")
+            "[ipc][issue-366]")
 {
+#if ! defined (_WIN32)
+    namespace ipcp = duskstudio::ipc::platform;
+
+    const int forkCallsBefore = forkPrepareCalls.load (std::memory_order_relaxed);
+    REQUIRE (::pthread_atfork (countForkPrepare, nullptr, nullptr) == 0);
+
+    AllocatorAndStdioChurn churn;
+    REQUIRE (churn.isReady());
+
+    for (int iteration = 0; iteration < 24; ++iteration)
+    {
+        CAPTURE (iteration);
+        ScopedChannelPair channels;
+        std::string spawnError;
+        REQUIRE (ipcp::createChannelPair (channels.value, spawnError));
+
+        ipcp::ChildProcess child;
+        REQUIRE (child.spawn (DUSKSTUDIO_PLUGIN_HOST_PATH,
+                              { "--ipc-argv-stub" },
+                              channels.value.childEnd, {}, spawnError));
+
+        std::uint32_t argumentCount = 0;
+        REQUIRE (ipcp::readExact (channels.value.parentEnd,
+                                  &argumentCount, sizeof (argumentCount)));
+        bool sawArgvStub = false;
+        for (std::uint32_t i = 0; i < argumentCount; ++i)
+        {
+            std::uint32_t length = 0;
+            REQUIRE (ipcp::readExact (channels.value.parentEnd,
+                                      &length, sizeof (length)));
+            REQUIRE (length < 4096);
+            std::string argument (length, '\0');
+            if (length > 0)
+                REQUIRE (ipcp::readExact (channels.value.parentEnd,
+                                          argument.data(), length));
+            if (argument == "--ipc-argv-stub") sawArgvStub = true;
+        }
+        REQUIRE (sawArgvStub);
+        child.terminate (1000);
+        REQUIRE_FALSE (child.isAlive());
+    }
+
+    // pthread_atfork handlers run for a direct fork(), but POSIX does not
+    // invoke them for posix_spawn(). This makes the no-fork contract
+    // deterministic while the churn thread exercises allocator and stdio
+    // activity throughout every launch.
+    REQUIRE (forkPrepareCalls.load (std::memory_order_relaxed) == forkCallsBefore);
+#endif
+
     duskstudio::ipc::RemotePluginConnection conn;
 
     std::string err;


### PR DESCRIPTION
## Summary

- replace the Linux and macOS plugin-host `fork`/`exec` launch path with `posix_spawn` and parent-prepared file actions
- preserve Linux parent-death cleanup by passing and validating the expected parent PID before arming `PR_SET_PDEATHSIG` in the helper
- explicitly close the parent channel endpoint in the spawned process so child teardown observes EOF
- add multithreaded allocator/stdio churn and parent-end EOF regressions for the launcher
- link the Apple frameworks required by the macOS 14.4 out-of-process helper

## Validation

- Linux: `[issue-366]` 16,962 assertions / 2 cases; CTest 887/887
- macOS 14.4: `[issue-366]` 16,890 assertions / 2 cases; CTest 866/866 (native LV2 disabled)
- Windows: `[issue-366]` 16,623 assertions / 2 cases; CTest 855/855; ASIO enabled and verified
- `tests/release_mechanics.sh`
- JUCE ratchet unchanged: 164 coupled files, 8,251 uses

Closes #366