### PR TITLE
Fix live notepad display scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 903 Catch2 test cases across 177 test source files. Linux
+The C++ suite declares 904 Catch2 test cases across 177 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 903 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 904 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/ui/imgui/DuskImGuiHost.cpp
+++ b/src/ui/imgui/DuskImGuiHost.cpp
@@ -1,5 +1,6 @@
 #include "DuskImGuiHost.h"
 #include "FirstFrameProbe.h"
+#include "DuskImGuiScale.h"
 #include "../../foundation/MessageThread.h"
 
 #if defined (_WIN32)
@@ -158,6 +159,8 @@ struct DuskImGuiHost::Impl final : private dusk::Timer
             }
 
             window->focus();
+            appliedScaleFactor = window->getScaleFactor();
+            embeddedParent = nativeParent;
             probe.arm (renderer);
             armedMarker = true;
         }
@@ -192,8 +195,23 @@ struct DuskImGuiHost::Impl final : private dusk::Timer
 
     void setGeometry (Geometry geometry)
     {
-        if (window == nullptr || geometry.width < 2 || geometry.height < 2)
+        if (window == nullptr || closeRequested
+            || geometry.width < 2 || geometry.height < 2)
             return;
+
+        if (requiresScaleRecreation (appliedScaleFactor, geometry.scaleFactor))
+        {
+            // DGL fixes an embedded window's draw scale at construction. Rebuild
+            // only that graphics shell so the caller's document, undo history and
+            // in-progress editor state survive the display-scale change.
+            const auto parent = embeddedParent;
+            probe.disarm();
+            armedMarker = false;
+            if (! open (parent, geometry) && callbacks.closed)
+                callbacks.closed();
+            return;
+        }
+
         window->setSize (geometry.width, geometry.height);
         window->setEmbeddedOffset (geometry.x, geometry.y);
     }
@@ -311,6 +329,8 @@ struct DuskImGuiHost::Impl final : private dusk::Timer
     std::string lastFailure;
     std::unique_ptr<DGL::Window> window;
     std::unique_ptr<DGL::TopLevelWidget> widget;
+    std::uintptr_t embeddedParent = 0;
+    double appliedScaleFactor = 1.0;
     bool firstFrameConfirmed = false;
     bool graphicsFailed = false;
     bool armedMarker = false;

--- a/src/ui/imgui/DuskImGuiScale.h
+++ b/src/ui/imgui/DuskImGuiScale.h
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace duskstudio::imgui
+{
+constexpr bool requiresScaleRecreation (double applied, double requested) noexcept
+{
+    return applied < requested || requested < applied;
+}
+} // namespace duskstudio::imgui

--- a/tests/notepad_graphics_compatibility.cpp
+++ b/tests/notepad_graphics_compatibility.cpp
@@ -3,6 +3,7 @@
 
 #include "ui/NotepadGraphicsCompatibility.h"
 #include "ui/NativeEditorEmbedScale.h"
+#include "ui/imgui/DuskImGuiScale.h"
 
 #include <fstream>
 #include <iterator>
@@ -38,6 +39,21 @@ TEST_CASE ("Native embeds retain the peer platform scale outside Cocoa",
     CHECK (nested.y == 98);
     CHECK (nested.width == 961);
     CHECK (nested.height == 538);
+}
+
+TEST_CASE ("Open notepad geometry responds to display scale changes",
+           "[notepad][scale][issue-338]")
+{
+    const auto standard = duskstudio::embedscale::toPhysicalBounds (20, 15, 940, 700, 1.0);
+    const auto retina = duskstudio::embedscale::toPhysicalBounds (20, 15, 940, 700, 2.0);
+
+    CHECK (standard.width == 940);
+    CHECK (standard.height == 700);
+    CHECK (retina.width == 1880);
+    CHECK (retina.height == 1400);
+    CHECK_FALSE (duskstudio::imgui::requiresScaleRecreation (2.0, 2.0));
+    CHECK (duskstudio::imgui::requiresScaleRecreation (1.0, 2.0));
+    CHECK (duskstudio::imgui::requiresScaleRecreation (2.0, 1.0));
 }
 using duskstudio::notepad::assessGraphicsCompatibility;
 


### PR DESCRIPTION
Closes #338

## Summary
- recreate the embedded DGL/ImGui graphics shell when the requested display scale changes
- preserve the notepad document, undo history, selection, scroll, and chord-entry state owned outside the graphics widget
- add an issue-tagged regression test for scale transitions and keep README test counts synchronized

## Validation
- Linux: focused `[issue-338]` test + 888/888 full CTest
- macOS: focused `[issue-338]` test + 867/867 full CTest
- Windows: ASIO-enabled build, focused `[issue-338]` test + 856/856 full CTest
- `tools/juce-gate.sh`: 164 coupled files / 8,251 uses

No frontier-model review was run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Embedded ImGui windows now adapt when the display scale changes, rebuilding with the correct geometry and scale.

- **Bug Fixes**
  - Improved handling of pending closes and undersized window geometry to prevent invalid updates.

- **Tests**
  - Added coverage for display-scale changes and correctly scaled notepad window geometry.

- **Documentation**
  - Updated the documented C++ test count from 903 to 904.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->