### PR TITLE
Pin quiet OpenGL 3 refusal

### DIFF
--- a/.github/actions/clone-daf-stack/action.yml
+++ b/.github/actions/clone-daf-stack/action.yml
@@ -13,7 +13,7 @@ runs:
       shell: bash
       env:
         DAF_REPO: https://github.com/dusk-audio/DAF.git
-        DAF_REV: 66aa1e0365beef70ee097dcacfda4cfc5a25bcee
+        DAF_REV: 50ad8c22a2f05b85be4b40e473d830d2dc91c2c2
         PUGL_REV: 43d8e349c7ca7c4d76778a8c48b73226105bed14
         DAF_WIDGETS_REPO: https://github.com/dusk-audio/DAF-Widgets.git
         DAF_WIDGETS_REV: 798154e874eaaa024371f6076249398b51498142

--- a/BUILDING-LINUX.md
+++ b/BUILDING-LINUX.md
@@ -110,7 +110,7 @@ The session notepad is Dusk Studio's first native UI window: DAF/DGL for the Ope
 ```bash
 cd ~/projects
 git clone https://github.com/dusk-audio/DAF.git
-git -C DAF checkout 66aa1e0365beef70ee097dcacfda4cfc5a25bcee
+git -C DAF checkout 50ad8c22a2f05b85be4b40e473d830d2dc91c2c2
 git -C DAF submodule update --init
 git clone https://github.com/dusk-audio/DAF-Widgets.git
 git -C DAF-Widgets checkout 798154e874eaaa024371f6076249398b51498142

--- a/BUILDING-WINDOWS.md
+++ b/BUILDING-WINDOWS.md
@@ -66,7 +66,7 @@ The session notepad is a native window built on DAF/DGL plus the Dear ImGui laye
 ```cmd
 cd C:\dev
 git clone https://github.com/dusk-audio/DAF.git
-git -C DAF checkout 66aa1e0365beef70ee097dcacfda4cfc5a25bcee
+git -C DAF checkout 50ad8c22a2f05b85be4b40e473d830d2dc91c2c2
 git -C DAF submodule update --init
 git clone https://github.com/dusk-audio/DAF-Widgets.git
 git -C DAF-Widgets checkout 798154e874eaaa024371f6076249398b51498142

--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -273,7 +273,7 @@ pffft (FFT backend behind dusk::audio::Fft — spectrum analyser, DP alignment)
              top of external/pffft/pffft.h.
 
 DAF / DGL (Dusk Audio Framework graphics layer — backs the native notepad UI)
-  Version  : dusk-audio/DAF rev 66aa1e0365beef70ee097dcacfda4cfc5a25bcee
+  Version  : dusk-audio/DAF rev 50ad8c22a2f05b85be4b40e473d830d2dc91c2c2
              (CI pin DAF_REV in .github/actions/clone-daf-stack/action.yml)
   License  : ISC — Copyright (C) 2012-2025 Filipe Coelho <falktx@falktx.com>
              (DAF/LICENSE)
@@ -3797,7 +3797,7 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 DAF / DGL — ISC
-LICENSE at dusk-audio/DAF rev 66aa1e0365beef70ee097dcacfda4cfc5a25bcee
+LICENSE at dusk-audio/DAF rev 50ad8c22a2f05b85be4b40e473d830d2dc91c2c2
 --------------------------------------------------------------------------------
 
 Copyright (C) 2012-2025 Filipe Coelho <falktx@falktx.com>
@@ -3817,7 +3817,7 @@ PERFORMANCE OF THIS SOFTWARE.
 --------------------------------------------------------------------------------
 pugl — ISC
 dgl/src/pugl-upstream/COPYING at dusk-audio/DAF rev
-66aa1e0365beef70ee097dcacfda4cfc5a25bcee, pugl submodule rev
+50ad8c22a2f05b85be4b40e473d830d2dc91c2c2, pugl submodule rev
 43d8e349c7ca7c4d76778a8c48b73226105bed14
 --------------------------------------------------------------------------------
 
@@ -3882,7 +3882,7 @@ Copyright 2012-2023 David Robillard <d@drobilla.net>
 --------------------------------------------------------------------------------
 DAF no-X11 Wayland OpenGL3 backend — ISC and MIT notices
 dgl/src/pugl.cpp HAVE_WAYLAND branch at dusk-audio/DAF rev
-66aa1e0365beef70ee097dcacfda4cfc5a25bcee
+50ad8c22a2f05b85be4b40e473d830d2dc91c2c2
 --------------------------------------------------------------------------------
 
 daf__add_dgl_opengl3 defines DGL_OPENGL, so a supported Linux build without
@@ -4044,7 +4044,7 @@ DEALINGS IN THE SOFTWARE.
 --------------------------------------------------------------------------------
 NanoVG — zlib license
 dgl/src/nanovg/LICENSE.txt at dusk-audio/DAF rev
-66aa1e0365beef70ee097dcacfda4cfc5a25bcee
+50ad8c22a2f05b85be4b40e473d830d2dc91c2c2
 --------------------------------------------------------------------------------
 
 Copyright (c) 2013 Mikko Mononen memon@inside.org
@@ -4068,7 +4068,7 @@ misrepresented as being the original software.
 --------------------------------------------------------------------------------
 fontstash — zlib license
 Notice at the head of dgl/src/nanovg/fontstash.h at dusk-audio/DAF rev
-66aa1e0365beef70ee097dcacfda4cfc5a25bcee
+50ad8c22a2f05b85be4b40e473d830d2dc91c2c2
 --------------------------------------------------------------------------------
 
 Copyright (c) 2009-2013 Mikko Mononen memon@inside.org
@@ -4090,7 +4090,7 @@ freely, subject to the following restrictions:
 --------------------------------------------------------------------------------
 fontstash embedded UTF-8 decoder — MIT
 Notice at dgl/src/nanovg/fontstash.h:509-510 at dusk-audio/DAF rev
-66aa1e0365beef70ee097dcacfda4cfc5a25bcee. NanoVG.cpp compiles nanovg.c,
+50ad8c22a2f05b85be4b40e473d830d2dc91c2c2. NanoVG.cpp compiles nanovg.c,
 which includes fontstash.h. The compiled 2010 decoder variation carries these
 exact source lines:
 
@@ -4124,7 +4124,7 @@ SOFTWARE.
 --------------------------------------------------------------------------------
 stb_truetype — MIT / public domain dual license
 Notice at the foot of dgl/src/nanovg/stb_truetype.h at dusk-audio/DAF rev
-66aa1e0365beef70ee097dcacfda4cfc5a25bcee
+50ad8c22a2f05b85be4b40e473d830d2dc91c2c2
 --------------------------------------------------------------------------------
 
 ------------------------------------------------------------------------------
@@ -4170,7 +4170,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 --------------------------------------------------------------------------------
 stb_image — public-domain dedication and fallback permission
 License notice in dgl/src/nanovg/stb_image.h at dusk-audio/DAF rev
-66aa1e0365beef70ee097dcacfda4cfc5a25bcee
+50ad8c22a2f05b85be4b40e473d830d2dc91c2c2
 --------------------------------------------------------------------------------
 
 This software is in the public domain. Where that dedication is not
@@ -4180,7 +4180,7 @@ distribute, and modify this file as you see fit.
 --------------------------------------------------------------------------------
 DejaVu Sans — Bitstream Vera Fonts License and Arev Fonts License
 dgl/src/resources/LICENSE-DejaVuSans.ttf.txt at dusk-audio/DAF rev
-66aa1e0365beef70ee097dcacfda4cfc5a25bcee
+50ad8c22a2f05b85be4b40e473d830d2dc91c2c2
 --------------------------------------------------------------------------------
 
 Fonts are (c) Bitstream (see below). DejaVu changes are in public domain.
@@ -4284,7 +4284,7 @@ from Tavmjong Bah. For further information, contact: tavmjong @ free
 --------------------------------------------------------------------------------
 Khronos GL headers — MIT notices
 dgl/src/khronos/GL/glext.h and dgl/src/khronos/KHR/khrplatform.h at
-dusk-audio/DAF rev 66aa1e0365beef70ee097dcacfda4cfc5a25bcee
+dusk-audio/DAF rev 50ad8c22a2f05b85be4b40e473d830d2dc91c2c2
 --------------------------------------------------------------------------------
 
 glext.h carries this exact notice:

--- a/docs/MAINTAINER-GUIDE.md
+++ b/docs/MAINTAINER-GUIDE.md
@@ -306,7 +306,7 @@ CMake auto-detects four external repos at configure time, on top of three git su
 cd /path/to/dusk-studio
 
 git clone https://github.com/dusk-audio/DAF.git ../DAF
-git -C ../DAF checkout 66aa1e0365beef70ee097dcacfda4cfc5a25bcee
+git -C ../DAF checkout 50ad8c22a2f05b85be4b40e473d830d2dc91c2c2
 git -C ../DAF submodule update --init     # dgl/src/pugl-upstream
 
 git clone https://github.com/dusk-audio/DAF-Widgets.git ../DAF-Widgets

--- a/tests/notepad_graphics_compatibility.cpp
+++ b/tests/notepad_graphics_compatibility.cpp
@@ -58,7 +58,7 @@ TEST_CASE ("Open notepad geometry responds to display scale changes",
 using duskstudio::notepad::assessGraphicsCompatibility;
 
 TEST_CASE ("Notepad rejects graphics stacks known to end the host process",
-           "[notepad][windows]")
+           "[notepad][windows][issue-336]")
 {
     CHECK (assessGraphicsCompatibility ("1.1.0", "GDI Generic")
            == GraphicsCompatibility::noOpenGL3);


### PR DESCRIPTION
## Summary

- pin DAF to `50ad8c22a2f05b85be4b40e473d830d2dc91c2c2`, which quietly refuses unavailable OpenGL 3 entry points
- tag the existing pre-OpenGL-3 notepad refusal regression with `[issue-336]`
- update active build documentation and license provenance to the merged DAF revision

Closes #336

## Validation

- Linux: focused `[issue-336]` passed; 888/888 CTest tests passed
- macOS: focused `[issue-336]` passed; 867/867 CTest tests passed
- Windows (ASIO-enabled): focused `[issue-336]` passed; 856/856 CTest tests passed
- JUCE ratchet: unchanged at 164 coupled files / 8251 uses
- `git diff --check`: clean

The macOS validation cache has native LV2 disabled, matching the existing validation environment.

No frontier-model review was run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated DAF revision references in build instructions, maintainer guidance, and license records.

* **Chores**
  * Updated the automated DAF checkout to a newer pinned revision.

* **Tests**
  * Added an issue reference to the existing Windows graphics compatibility test metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->