### PR TITLE
Ship the macOS plugin sandbox on Big Sur

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -135,6 +135,17 @@ jobs:
         # but keep the limit explicit so generator changes cannot unbound it.
         run: cmake --build build -j5
 
+      - name: Verify macOS 11 sandbox helper
+        run: |
+          set -euo pipefail
+          app="build/DuskStudio_artefacts/Release/DuskStudio.app/Contents/MacOS"
+          for binary in "$app/DuskStudio" "$app/dusk-studio-plugin-host"; do
+            [[ -x "$binary" ]] || {
+              echo "::error::missing executable: $binary" >&2; exit 1; }
+            otool -l "$binary" | grep -Eq 'minos +11\.0' || {
+              echo "::error::$binary does not target macOS 11.0" >&2; exit 1; }
+          done
+
       - name: Smoke launch (--version)
         run: build/DuskStudio_artefacts/Release/DuskStudio.app/Contents/MacOS/DuskStudio --version
 

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -142,7 +142,7 @@ jobs:
           for binary in "$app/DuskStudio" "$app/dusk-studio-plugin-host"; do
             [[ -x "$binary" ]] || {
               echo "::error::missing executable: $binary" >&2; exit 1; }
-            otool -l "$binary" | grep -Eq 'minos +11\.0' || {
+            otool -l "$binary" | grep -E 'minos +11\.0' >/dev/null || {
               echo "::error::$binary does not target macOS 11.0" >&2; exit 1; }
           done
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -802,7 +802,7 @@ jobs:
           for binary in "$app/DuskStudio" "$app/dusk-studio-plugin-host"; do
             [[ -x "$binary" ]] || {
               echo "::error::missing executable: $binary" >&2; exit 1; }
-            otool -l "$binary" | grep -Eq 'minos +11\.0' || {
+            otool -l "$binary" | grep -E 'minos +11\.0' >/dev/null || {
               echo "::error::$binary does not target macOS 11.0" >&2; exit 1; }
           done
 
@@ -877,7 +877,7 @@ jobs:
             echo "::error::packaged app has no plugin sandbox helper" >&2
             exit 1
           }
-          otool -l "$HELPER" | grep -Eq 'minos +11\.0' || {
+          otool -l "$HELPER" | grep -E 'minos +11\.0' >/dev/null || {
             echo "::error::packaged plugin sandbox does not target macOS 11.0" >&2
             exit 1
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -795,6 +795,17 @@ jobs:
         # but keep the limit explicit so generator changes cannot unbound it.
         run: cmake --build build -j5
 
+      - name: Verify macOS 11 sandbox helper
+        run: |
+          set -euo pipefail
+          app="build/DuskStudio_artefacts/Release/DuskStudio.app/Contents/MacOS"
+          for binary in "$app/DuskStudio" "$app/dusk-studio-plugin-host"; do
+            [[ -x "$binary" ]] || {
+              echo "::error::missing executable: $binary" >&2; exit 1; }
+            otool -l "$binary" | grep -Eq 'minos +11\.0' || {
+              echo "::error::$binary does not target macOS 11.0" >&2; exit 1; }
+          done
+
       - name: Build + run tests (release gate)
         # No DMG ships unless the full Catch2 suite passes.
         run: |
@@ -861,6 +872,15 @@ jobs:
               exit 1; }
           trap 'hdiutil detach "$MNT" >/dev/null 2>&1 || true' EXIT
           APP="$MNT/DuskStudio.app"
+          HELPER="$APP/Contents/MacOS/dusk-studio-plugin-host"
+          [[ -x "$HELPER" ]] || {
+            echo "::error::packaged app has no plugin sandbox helper" >&2
+            exit 1
+          }
+          otool -l "$HELPER" | grep -Eq 'minos +11\.0' || {
+            echo "::error::packaged plugin sandbox does not target macOS 11.0" >&2
+            exit 1
+          }
           codesign --verify --strict --deep --verbose=2 "$APP"
           if otool -L "$APP/Contents/MacOS/DuskStudio" \
               | tail -n +2 | awk '{print $1}' \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ canonical source.
 
 ### Fixed
 
+- **The macOS release now includes the plugin sandbox.** The disk image kept
+  its macOS 11 deployment target, but the sandbox's shared-address wake API
+  required macOS 14.4, so CMake omitted the plugin-host helper and scans ran
+  inside Dusk Studio. The macOS IPC backend now uses a deadline-aware pipe
+  signal available on Big Sur, and release verification refuses a disk image
+  without the helper.
 - **LV2 plugin windows open with the sound's current settings.** Opening or
   reopening an LV2 editor used to leave its controls at the plugin's factory
   defaults even though the restored audio engine was already using the saved

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1157,11 +1157,9 @@ endif()
 # Supported platforms:
 #   Linux   : memfd_create + futex + socketpair + SCM_RIGHTS
 #   Windows : CreateFileMapping + inheritable events + named pipe
-#   macOS   : shm_open + os_sync_wait_on_address + socketpair + SCM_RIGHTS
-#             (requires macOS 14.4 — os_sync_wait_on_address shared
-#             addresses were added in Sonoma 14.4; older systems fall
-#             back to the in-process path because DUSKSTUDIO_HAS_OOP_PLUGINS
-#             stays undefined.)
+#   macOS   : shm_open + non-blocking pipes + socketpair + SCM_RIGHTS
+#             (works at the release's macOS 11 deployment target; the pipes
+#             replace the shared-address API that is available only on 14.4.)
 # DUSKSTUDIO_HAS_OOP_PLUGINS gates every #if branch in PluginSlot that
 # routes through RemotePluginConnection.
 set(_duskstudio_oop_enabled FALSE)
@@ -1187,7 +1185,7 @@ elseif(WIN32)
         src/engine/ipc/platform/IpcChannel_Windows.cpp
         src/engine/ipc/platform/IpcShm_Windows.cpp
         src/engine/ipc/platform/IpcSync_Windows.cpp)
-elseif(APPLE AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_GREATER_EQUAL 14.4)
+elseif(APPLE)
     set(_duskstudio_oop_enabled TRUE)
     set(_duskstudio_ipc_platform_sources
         src/engine/ipc/platform/IpcChannel_Mac.cpp

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -320,7 +320,7 @@ Assign a strip to one of eight fader groups (right-click the strip → **Fader g
 ## System requirements
 
 - **Linux**: PipeWire (recommended) or ALSA. Dusk Studio talks to the PipeWire graph directly through its own backend, so the client shows up as "Dusk Studio" and reports its node latency to the graph; ALSA reaches the raw hardware for exclusive low-latency use. An X11 display is required: on a Wayland desktop this means XWayland (present and enabled by default on GNOME and KDE; compositors like sway, niri and labwc can run without it — enable it there, or Dusk Studio will refuse to start with a message pointing here).
-- **macOS**: 11 (Big Sur) or later, Apple Silicon. The out-of-process plugin sandbox needs a build whose deployment target is 14.4 (Sonoma) or later; the released DMG targets macOS 11, so it hosts and scans plugins in-process whatever version of macOS you run it on.
+- **macOS**: 11 (Big Sur) or later, Apple Silicon. The released DMG includes the out-of-process plugin sandbox while retaining this deployment target.
 - **Windows**: Windows 10 or later, ASIO driver recommended.
 - **The notepad** needs OpenGL 3. The Windows installer includes a CPU-based
   Mesa llvmpipe renderer and the packaged application selects it automatically,
@@ -1585,9 +1585,9 @@ OOP is supported on:
 
 - **Linux**: always.
 - **Windows**: always.
-- **macOS**: compiled in only when the build's deployment target is macOS 14.4 or later, which the released DMG is not; a source build configured with `-DCMAKE_OSX_DEPLOYMENT_TARGET=14.4` gets it. Where it is present, the plugin **editor** is hosted in-process via a shell instance and embeds as a centred modal like the other platforms — see *Opening the editor* above.
+- **macOS**: always. The plugin **editor** is hosted in-process via a shell instance and embeds as a centred modal like the other platforms — see *Opening the editor* above.
 
-Plugins run **in-process by default** — it gives the most responsive plugin editors and the lowest CPU cost. To run third-party binary plugins in the OOP sandbox instead, launch with `DUSKSTUDIO_USE_OOP_PLUGINS=1`; a plugin that crashes or hangs then takes down only the host child, not Dusk Studio. The switch reaches standard-host rows only. Native rows — **CLAP** and **VST3-Native** on every OS, **LV2-Native** on Linux and macOS, plus **AudioUnit** on macOS — always run in-process and ignore it, as *Native plugin hosting* above says. If the `dusk-studio-plugin-host` binary is missing the loader falls back to in-process automatically. Standard-host plugin **scanning** runs in the sandboxed child, so a plugin that crashes while being probed is blacklisted instead of crashing the app; native scanning follows the format-specific rules described under *Scanning*. A build without the sandbox compiled in, which includes the released macOS DMG, scans in-process, so a plugin that crashes or hangs while being probed there can take the app with it. (Dusk Studio's own bundled plugins always run in-process.)
+Plugins run **in-process by default** — it gives the most responsive plugin editors and the lowest CPU cost. To run third-party binary plugins in the OOP sandbox instead, launch with `DUSKSTUDIO_USE_OOP_PLUGINS=1`; a plugin that crashes or hangs then takes down only the host child, not Dusk Studio. The switch reaches standard-host rows only. Native rows — **CLAP** and **VST3-Native** on every OS, **LV2-Native** on Linux and macOS, plus **AudioUnit** on macOS — always run in-process and ignore it, as *Native plugin hosting* above says. If the `dusk-studio-plugin-host` binary is missing the loader falls back to in-process automatically. Standard-host plugin **scanning** runs in the sandboxed child, so a plugin that crashes while being probed is blacklisted instead of crashing the app; native scanning follows the format-specific rules described under *Scanning*. The released macOS DMG includes the child, so standard-host scanning is sandboxed there too. (Dusk Studio's own bundled plugins always run in-process.)
 
 When a plugin crashes in OOP mode:
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 
 ## Status
 
-**Beta.** Built to a production bar; released as Beta. See [CHANGELOG.md](CHANGELOG.md) for what shipped in each release and the [tags](https://github.com/dusk-audio/dusk-studio/tags) for the current version. Feature backlog effectively closed: every spec phase, Tascam DP-24SD parity, MTC + MIDI Clock sync, automatic cross-track plugin delay compensation, broad undo coverage (notes, automation, tempo, renames), portable session folders (relative audio paths, move/copy between machines), an optional out-of-process plugin sandbox with sandboxed plugin scanning (Linux and Windows; the macOS DMG targets macOS 11 and ships without it), a true-peak mastering limiter, a piecewise tempo map (changing tempo within a song), session open-with, an update notice on launch, and the rename to Dusk Studio have shipped. Plugins host in-process by default for the most responsive editors; `DUSKSTUDIO_USE_OOP_PLUGINS=1` opts into the crash-isolating sandbox. All three OSes ship unsigned binaries (Linux tarball + Windows MSI + macOS DMG) to the private releases repo on each tag. Remaining work toward the public 1.0 is release-engineering polish, low-spec/Raspberry-Pi performance, and deeper accessibility.
+**Beta.** Built to a production bar; released as Beta. See [CHANGELOG.md](CHANGELOG.md) for what shipped in each release and the [tags](https://github.com/dusk-audio/dusk-studio/tags) for the current version. Feature backlog effectively closed: every spec phase, Tascam DP-24SD parity, MTC + MIDI Clock sync, automatic cross-track plugin delay compensation, broad undo coverage (notes, automation, tempo, renames), portable session folders (relative audio paths, move/copy between machines), an optional out-of-process plugin sandbox with sandboxed plugin scanning on all three OSes, a true-peak mastering limiter, a piecewise tempo map (changing tempo within a song), session open-with, an update notice on launch, and the rename to Dusk Studio have shipped. Plugins host in-process by default for the most responsive editors; `DUSKSTUDIO_USE_OOP_PLUGINS=1` opts into the crash-isolating sandbox. All three OSes ship unsigned binaries (Linux tarball + Windows MSI + macOS DMG) to the private releases repo on each tag. Remaining work toward the public 1.0 is release-engineering polish, low-spec/Raspberry-Pi performance, and deeper accessibility.
 
 | Stage | Status |
 |---|---|
@@ -35,8 +35,8 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | Plugin hosting (per-channel CLAP / VST3 / LV2 / AU + per-aux return) | Working |
 | Native soundfonts (`.sfz` + `.sf2` via sfizz, no external synth) | Working |
 | Plugin offline-state preservation (missing plugin doesn't wipe save) | Working |
-| Out-of-process plugin sandbox — audio, opt-in (Linux + Windows; macOS needs a 14.4 deployment-target build, which the released DMG is not) | Working |
-| Out-of-process plugin sandbox — editor embed (Linux XEmbed, Windows SetParent, macOS in-process shell on a 14.4 build) | Working |
+| Out-of-process plugin sandbox — audio, opt-in (Linux + macOS + Windows) | Working |
+| Out-of-process plugin sandbox — editor embed (Linux XEmbed, Windows SetParent, macOS in-process shell) | Working |
 | Mastering view (waveform + 5-band EQ + multiband comp + brick-wall limiter + BS.1770) | Working |
 | Offline bounce / mixdown export (master) | Working |
 | Single-pass stem export (tracks + buses + aux returns) | Working |
@@ -98,7 +98,7 @@ Channels 1-24 ───────────────→ 4 Aux Buses ─�
 ```
 
 - **DSP** is extracted from the Dusk Audio plugin suite (4K EQ, Multi-Comp FET/Opto/VCA, Multi-Q, TapeMachine, shared AnalogEmulation) so the mixer and the standalone plugins share a single DSP source of truth.
-- **Plugin host**: CLAP + VST3 + LV2 + AU on every channel strip; aux returns host reverb / delay. In-process by default; the **opt-in** out-of-process sandbox (`DUSKSTUDIO_USE_OOP_PLUGINS=1`) runs each plugin in a child via a per-platform IPC backend (Linux `memfd_create` + `futex`, macOS `shm_open` + `os_sync_wait_on_address`, Windows `CreateFileMapping` + inheritable kernel events) so a crashing plugin can't take the host down. Standard-host plugin *scanning* runs in that child; native CLAP and VST3 bundle scanning uses a child too, on its own gate, and falls back in-process when no child binary is present; native LV2 and AU discovery never loads plugin code. The macOS sandbox needs `os_sync_wait_on_address`, so it compiles in only at deployment target 14.4 or later: the released DMG targets macOS 11 and ships no child binary, so it hosts and scans everything in-process.
+- **Plugin host**: CLAP + VST3 + LV2 + AU on every channel strip; aux returns host reverb / delay. In-process by default; the **opt-in** out-of-process sandbox (`DUSKSTUDIO_USE_OOP_PLUGINS=1`) runs each plugin in a child via a per-platform IPC backend (Linux `memfd_create` + `futex`, macOS `shm_open` + non-blocking pipes, Windows `CreateFileMapping` + inheritable kernel events) so a crashing plugin can't take the host down. Standard-host plugin *scanning* runs in that child; native CLAP and VST3 bundle scanning uses a child too, on its own gate, and falls back in-process when no child binary is present; native LV2 and AU discovery never loads plugin code. The released macOS DMG includes the sandbox helper while retaining its macOS 11 deployment target.
 - **Soundfonts**: `.sfz` and `.sf2` play through the built-in [dusk-fizz](https://github.com/dusk-audio/dusk-fizz) engine, our maintained hard fork of sfizz (SF2 → SFZ on load). No external synth required.
 
 ## Repository

--- a/docs/MAINTAINER-GUIDE.md
+++ b/docs/MAINTAINER-GUIDE.md
@@ -367,7 +367,7 @@ VST3/LV2/AU plugins run **in-process by default**. Out-of-process hosting (a sep
 
 ### How parent and child talk
 
-- **Audio hot path:** a shared-memory region (memfd on Linux, `shm_open` on macOS, `CreateFileMapping` on Windows) holds the audio buffers; the parent and child hand off via a cross-process futex / `WaitOnAddress` / `os_sync_wait_on_address` round-trip — no allocations, RT-safe. See [src/engine/ipc/platform/IpcShm*](../src/engine/ipc/platform/) and `IpcSync*`.
+- **Audio hot path:** a shared-memory region (memfd on Linux, `shm_open` on macOS, `CreateFileMapping` on Windows) holds the audio buffers; the parent and child hand off via a cross-process futex / non-blocking pipe / kernel-event round-trip — no allocations, RT-safe. See [src/engine/ipc/platform/IpcShm*](../src/engine/ipc/platform/) and `IpcSync*`.
 - **Control plane:** load/prepare/setState/release commands go over a socketpair (blocking is fine, it's the message thread). See `RemotePluginConnection` and `IpcChannel*`.
 - **Scanning:** the child runs `--scan <format> <file>`, prints the plugin description wrapped in sentinels (`==DUSK_SCAN_BEGIN==`…`==DUSK_SCAN_END==`), the parent parses it. A crash/timeout blacklists the file. See [src/engine/ipc/PluginScanProtocol.h](../src/engine/ipc/PluginScanProtocol.h) and `OutOfProcessPluginScanner` in [src/engine/PluginManager.cpp](../src/engine/PluginManager.cpp).
 

--- a/src/engine/ipc/platform/IpcSync.h
+++ b/src/engine/ipc/platform/IpcSync.h
@@ -15,9 +15,8 @@
 // Linux  : futex(SYS_futex, FUTEX_WAIT_BITSET / FUTEX_WAKE) - non-private
 //          so the address is hashed by physical page and works across
 //          two processes mmap'ing the same memfd.
-// macOS  : os_sync_wait_on_address_with_timeout / os_sync_wake_by_address
-//          (macOS 14.4+) - supports OS_SYNC_WAIT_ON_ADDRESS_SHARED for
-//          cross-process. Fallback: POSIX semaphores in shared memory.
+// macOS  : non-blocking pipe + poll. Both descriptors are transferred to
+//          the child over SCM_RIGHTS, so either process can wake its waiter.
 // Windows: an inheritable auto-reset event per signal direction. Win32's
 //          address-wait APIs are process-local even for shared mappings.
 //
@@ -38,7 +37,7 @@ enum class WaitResult
 
 // Absolute monotonic-clock deadline. Each platform converts to its own
 // timeout shape (Linux: struct timespec for FUTEX_WAIT_BITSET, Windows:
-// ms relative for WaitForSingleObject, macOS: ns relative for os_sync_*).
+// ms relative for WaitForSingleObject, macOS: ms relative for poll).
 struct Deadline
 {
     std::int64_t monotonicSec  { 0 };
@@ -60,17 +59,17 @@ public:
     InterprocessSignal (const InterprocessSignal&) = delete;
     InterprocessSignal& operator= (const InterprocessSignal&) = delete;
 
-    // Parent-side setup and control-channel handoff. Linux and macOS need no
-    // separate kernel object, so these are successful no-ops there. Windows
-    // creates an inheritable event before spawn and sends its inherited handle
-    // value to the child after the shared-memory handle.
+    // Parent-side setup and control-channel handoff. Linux needs no separate
+    // kernel object. macOS creates a non-blocking pipe and transfers both ends
+    // after spawn. Windows creates an inheritable event before spawn and sends
+    // its inherited handle value to the child after the shared-memory handle.
     bool create (std::string& errorOut) noexcept;
     bool sendToChild (NativeHandle& channel) const noexcept;
     bool receiveFromParent (NativeHandle& channel) noexcept;
     void close() noexcept;
 
     // Parent-side kernel object passed through ChildProcess's Windows handle
-    // allowlist. Invalid/no-op on platforms whose signal lives in shared memory.
+    // allowlist. Invalid on POSIX; macOS transfers its pipe after spawn.
     const NativeHandle& handle() const noexcept { return nativeHandle; }
 
     // Block while `addr` still equals `expected`, up to `deadline`. The
@@ -80,12 +79,17 @@ public:
                        std::uint32_t expected,
                        const Deadline* deadline) noexcept;
 
-    // Publish one non-blocking wake. `addr` identifies the futex/os_sync word
-    // on Linux/macOS; Windows uses this object's auto-reset event.
+    // Publish one non-blocking wake. Linux uses `addr` as the futex word;
+    // macOS uses this object's pipe and Windows its auto-reset event.
     void wake (std::atomic<std::uint32_t>* addr) noexcept;
 
 private:
     NativeHandle nativeHandle {};
+
+   #if defined(__APPLE__)
+    NativeHandle readHandle {};
+    NativeHandle writeHandle {};
+   #endif
 };
 
 // Polite spin pause for the bounded-spin loop in processBlockSync.

--- a/src/engine/ipc/platform/IpcSync_Mac.cpp
+++ b/src/engine/ipc/platform/IpcSync_Mac.cpp
@@ -1,21 +1,21 @@
 #include "IpcSync.h"
 
-#include <chrono>
+#include <cerrno>
 #include <cstdint>
+#include <cstring>
 #include <ctime>
-#include <errno.h>
-#include <os/os_sync_wait_on_address.h>
+#include <fcntl.h>
+#include <limits>
+#include <poll.h>
 #include <thread>
+#include <unistd.h>
 
-// macOS 14.4+ provides os_sync_wait_on_address - equivalent to
-// Linux's FUTEX_WAIT_BITSET, and supports cross-process wait/wake when
-// the address is in a shared mapping
-// via the OS_SYNC_WAIT_ON_ADDRESS_SHARED flag.
-//
-// Older macOS would need a fallback (named sem_open + sem_wait, or
-// the private __ulock_wait/__ulock_wake APIs); for now Dusk Studio's
-// OOP host requires macOS 14.4 and the in-process fallback handles
-// older systems via DUSKSTUDIO_HAS_OOP_PLUGINS being undefined.
+// macOS gained a public shared-address wait only in 14.4. Use a pipe instead
+// so the release can retain its macOS 11 deployment target. Both processes own
+// duplicates of both descriptors: wake() is a non-blocking write, and wait()
+// polls the read end up to the same monotonic deadline used by the other
+// platforms. The shared sequence word remains the predicate, so stale or
+// coalesced pipe bytes are harmless.
 
 namespace duskstudio::ipc::platform
 {
@@ -45,6 +45,28 @@ std::uint64_t remainingNs (const Deadline& d) noexcept
     if (total <= 0) return 0;
     return (std::uint64_t) total;
 }
+
+bool configurePipeDescriptor (int fd) noexcept
+{
+    const int descriptorFlags = ::fcntl (fd, F_GETFD);
+    if (descriptorFlags < 0
+        || ::fcntl (fd, F_SETFD, descriptorFlags | FD_CLOEXEC) < 0)
+        return false;
+
+    const int statusFlags = ::fcntl (fd, F_GETFL);
+    return statusFlags >= 0
+        && ::fcntl (fd, F_SETFL, statusFlags | O_NONBLOCK) == 0;
+}
+
+int deadlineToTimeoutMs (const Deadline& deadline) noexcept
+{
+    const std::uint64_t ns = remainingNs (deadline);
+    if (ns == 0) return 0;
+
+    const std::uint64_t ms = ns / 1000000ULL + (ns % 1000000ULL != 0 ? 1ULL : 0ULL);
+    const auto max = (std::uint64_t) std::numeric_limits<int>::max();
+    return (int) (ms < max ? ms : max);
+}
 } // namespace
 
 InterprocessSignal::~InterprocessSignal()
@@ -52,44 +74,109 @@ InterprocessSignal::~InterprocessSignal()
     close();
 }
 
-bool InterprocessSignal::create (std::string&) noexcept { return true; }
-bool InterprocessSignal::sendToChild (NativeHandle&) const noexcept { return true; }
-bool InterprocessSignal::receiveFromParent (NativeHandle&) noexcept { return true; }
-void InterprocessSignal::close() noexcept {}
+bool InterprocessSignal::create (std::string& errorOut) noexcept
+{
+    close();
+
+    int descriptors[2] { -1, -1 };
+    if (::pipe (descriptors) != 0)
+    {
+        errorOut = std::string ("pipe failed: ") + std::strerror (errno);
+        return false;
+    }
+
+    readHandle.fd  = descriptors[0];
+    writeHandle.fd = descriptors[1];
+    if (configurePipeDescriptor (readHandle.fd)
+        && configurePipeDescriptor (writeHandle.fd))
+        return true;
+
+    const int error = errno;
+    close();
+    errorOut = std::string ("pipe setup failed: ") + std::strerror (error);
+    return false;
+}
+
+bool InterprocessSignal::sendToChild (NativeHandle& channel) const noexcept
+{
+    return isValid (readHandle) && isValid (writeHandle)
+        && sendHandle (channel, readHandle)
+        && sendHandle (channel, writeHandle);
+}
+
+bool InterprocessSignal::receiveFromParent (NativeHandle& channel) noexcept
+{
+    close();
+    if (! recvHandle (channel, readHandle)
+        || ! recvHandle (channel, writeHandle)
+        || ! configurePipeDescriptor (readHandle.fd)
+        || ! configurePipeDescriptor (writeHandle.fd))
+    {
+        close();
+        return false;
+    }
+    return true;
+}
+
+void InterprocessSignal::close() noexcept
+{
+    closeHandle (readHandle);
+    closeHandle (writeHandle);
+}
 
 WaitResult InterprocessSignal::wait (std::atomic<std::uint32_t>* addr,
                                       std::uint32_t expected,
                                       const Deadline* deadline) noexcept
 {
-    constexpr os_sync_wait_on_address_flags_t flags = OS_SYNC_WAIT_ON_ADDRESS_SHARED;
+    if (! isValid (readHandle)) return WaitResult::Error;
+    if (addr->load (std::memory_order_acquire) != expected)
+        return WaitResult::ValueChanged;
 
-    int r;
-    if (deadline == nullptr)
+    struct pollfd descriptor { readHandle.fd, POLLIN, 0 };
+    const int timeoutMs = deadline != nullptr ? deadlineToTimeoutMs (*deadline) : -1;
+    const int result = ::poll (&descriptor, 1, timeoutMs);
+    if (result == 0) return WaitResult::Timeout;
+    if (result < 0)
     {
-        r = ::os_sync_wait_on_address (addr, (uint64_t) expected,
-                                          sizeof (expected), flags);
-    }
-    else
-    {
-        const std::uint64_t ns = remainingNs (*deadline);
-        r = ::os_sync_wait_on_address_with_timeout (
-                addr, (uint64_t) expected, sizeof (expected), flags,
-                OS_CLOCK_MACH_ABSOLUTE_TIME, ns);
+        return errno == EINTR ? WaitResult::Interrupted : WaitResult::Error;
     }
 
-    if (r >= 0) return WaitResult::Awoken;
-    switch (errno)
+    if ((descriptor.revents & POLLIN) != 0)
     {
-        case ETIMEDOUT: return WaitResult::Timeout;
-        case EINTR:     return WaitResult::Interrupted;
-        default:        return WaitResult::Error;
+        // Fast producer/consumer pairs often observe the sequence during the
+        // spin phase and never enter wait(), leaving old wake bytes queued.
+        // Drain them together so the first later wait cannot spend one syscall
+        // per completed audio block. A concurrent new wake either lands in
+        // this drain (the sequence re-check observes it) or remains readable.
+        std::uint8_t bytes[256];
+        for (;;)
+        {
+            const ssize_t count = ::read (readHandle.fd, bytes, sizeof (bytes));
+            if (count > 0) continue;
+            if (count < 0 && errno == EINTR) continue;
+            if (count < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+                return WaitResult::Awoken;
+            return WaitResult::Error;
+        }
     }
+
+    return WaitResult::Error;
 }
 
-void InterprocessSignal::wake (std::atomic<std::uint32_t>* addr) noexcept
+void InterprocessSignal::wake (std::atomic<std::uint32_t>*) noexcept
 {
-    (void) ::os_sync_wake_by_address_any (addr, sizeof (std::uint32_t),
-                                             OS_SYNC_WAKE_BY_ADDRESS_SHARED);
+    if (! isValid (writeHandle)) return;
+
+    const std::uint8_t byte = 1;
+    for (;;)
+    {
+        if (::write (writeHandle.fd, &byte, sizeof (byte)) == (ssize_t) sizeof (byte))
+            return;
+        if (errno == EINTR) continue;
+        // EAGAIN means at least one wake is already pending. The sequence word
+        // carries the actual state, so another byte is unnecessary.
+        return;
+    }
 }
 
 void cpuRelax() noexcept

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -480,7 +480,7 @@ if (UNIX OR WIN32)
         DUSKSTUDIO_SINGLE_INSTANCE_TESTING=1)
 endif()
 
-# IPC round-trip regression — Linux + Windows + macOS 14.4+. The test
+# IPC round-trip regression — Linux + Windows + macOS 11+. The test
 # spawns the dusk-studio-plugin-host child in --ipc-stub mode, so we
 # hard-depend on that target being built first. DUSKSTUDIO_PLUGIN_HOST_PATH
 # is resolved via a generator expression so it points to wherever CMake
@@ -500,7 +500,7 @@ elseif (WIN32)
         ${CMAKE_SOURCE_DIR}/src/engine/ipc/platform/IpcProcess_Windows.cpp
         ${CMAKE_SOURCE_DIR}/src/engine/ipc/platform/IpcShm_Windows.cpp
         ${CMAKE_SOURCE_DIR}/src/engine/ipc/platform/IpcSync_Windows.cpp)
-elseif (APPLE AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_GREATER_EQUAL 14.4)
+elseif (APPLE)
     set(_duskstudio_ipc_test_enabled TRUE)
     set(_duskstudio_ipc_test_sources
         ${CMAKE_SOURCE_DIR}/src/engine/ipc/platform/IpcChannel_Mac.cpp

--- a/tests/ipc_stub_round_trip.cpp
+++ b/tests/ipc_stub_round_trip.cpp
@@ -7,7 +7,7 @@
 //     SHM offset / channel-stride drift between parent and child.
 //
 // Platforms: Linux (memfd_create + futex), Windows (CreateFileMapping +
-// auto-reset events), macOS 14.4+ (shm_open + os_sync_wait_on_address). The
+// auto-reset events), macOS 11+ (shm_open + non-blocking pipes). The
 // transport differences are hidden behind RemotePluginConnection, so this
 // file uses only platform-agnostic APIs. tests/CMakeLists.txt gates the
 // translation unit on _duskstudio_ipc_test_enabled, which mirrors the
@@ -346,7 +346,7 @@ TEST_CASE ("Plugin-host handshake read timeout bounds a silent live child",
 }
 
 TEST_CASE ("ipc-stub: connect, round-trip 32 blocks, byte-exact echo",
-            "[ipc][issue-366]")
+            "[ipc][issue-325][issue-366]")
 {
 #if ! defined (_WIN32)
     namespace ipcp = duskstudio::ipc::platform;


### PR DESCRIPTION
Closes #325

## Summary

- replace the macOS 14.4-only shared-address wake API with non-blocking pipe signals transferred over the existing control channel
- enable the out-of-process plugin host and IPC regressions for every supported macOS deployment target
- fail macOS build/release jobs when the app or packaged DMG lacks a macOS 11-compatible sandbox helper
- update user and maintainer documentation for sandbox availability on macOS

## Validation

- Linux: `[issue-325]` passed (16,951 assertions); CTest 888/888 passed
- macOS: clean `CMAKE_OSX_DEPLOYMENT_TARGET=11.0` helper/test build passed; helper reports `minos 11.0`; `[issue-325]` passed (16,879 assertions)
- macOS cross-platform checkout: CTest 867/867 passed (native LV2 is disabled in this validation cache)
- Windows VM: ASIO enabled; `[issue-325]` passed (16,612 assertions); CTest 856/856 passed
- `tools/juce-gate.sh`: 164 files / 8,251 uses (unchanged)
- `actionlint` and `git diff --check` passed

`review-local` was incomplete because its local model was unavailable. Its Apple-member diagnostics came from parsing the macOS implementation in a Linux preprocessor context; the native macOS 11 build compiled that implementation successfully. No frontier review was run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * macOS releases now include the plugin sandbox helper in the packaged disk image.
  * Out-of-process plugin hosting works on macOS 11 and later, avoiding fallback to in-process hosting on older supported versions.
  * macOS IPC synchronization now supports the project’s macOS 11 deployment target.

* **Documentation**
  * Updated macOS system requirements and plugin sandboxing documentation to reflect support on macOS 11+.

* **Tests**
  * Added release checks to verify the sandbox helper is included and targets macOS 11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->