### PR TITLE
Issue 454 unreadable state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ canonical source.
 
 ### Fixed
 
+- **Unreadable plugin settings are preserved.** A damaged native plugin state
+  blob now leaves the slot offline and remains unchanged in the session instead
+  of loading the plugin at its defaults and overwriting the only saved copy.
 - **The macOS release now includes the plugin sandbox.** The disk image kept
   its macOS 11 deployment target, but the sandbox's shared-address wake API
   required macOS 14.4, so CMake omitted the plugin-host helper and scans ran

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1609,6 +1609,7 @@ When you load a session:
 
 - If the plugin is found on the system, it is loaded and the saved state is applied.
 - If the plugin is missing or moved, the slot shows "(plugin name) — offline". The saved description and state are preserved; the next session save round-trips them unmodified, so you do not lose the data by opening a session on a machine without that plugin installed. Reinstall the plugin and reload to restore.
+- If the saved state is unreadable or the plugin rejects it, the slot stays offline. The original plugin reference and state text remain in the session and survive later saves instead of being replaced by the plugin's defaults.
 
 ## Multi-sample instruments
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 904 Catch2 test cases across 177 test source files. Linux
+The C++ suite declares 905 Catch2 test cases across 177 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 904 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 905 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -1408,6 +1408,39 @@ static bool runHeadlessSelfTest()
                            .nativeClapStateBase64[(size_t) auxSlotIndex] == corruptBase64,
                 "prepared aux rejection discarded the saved state");
 
+        const char* const unreadableStateText = "*** not base64 ***";
+        session->track (trackIndex).nativeClapStateBase64 = unreadableStateText;
+        session->auxLane (auxLaneIndex)
+               .nativeClapStateBase64[(size_t) auxSlotIndex] = unreadableStateText;
+
+        engine->consumePluginStateAfterLoad();
+        expect (! trackStrip.isNativeClapLoaded(),
+                "track with unreadable state came online at defaults");
+        expect (! auxStrip.isNativeClapLoaded (auxSlotIndex),
+                "aux with unreadable state came online at defaults");
+        expect (trackStrip.nativeClapReloadFailed(),
+                "track with unreadable state lost its failed-restore reference");
+        expect (auxStrip.nativeClapReloadFailed (auxSlotIndex),
+                "aux with unreadable state lost its failed-restore reference");
+        const auto& unreadableFailures = engine->getLastPluginLoadFailures();
+        expect (unreadableFailures.size() == 2,
+                "unreadable state did not report both track and aux failures");
+        if (unreadableFailures.size() == 2)
+        {
+            expect (unreadableFailures[0].reason.find ("18 bytes") != std::string::npos
+                        && unreadableFailures[0].reason.find ("unreadable") != std::string::npos,
+                    "unreadable track state omitted its encoded size or reason");
+            expect (unreadableFailures[1].reason.find ("18 bytes") != std::string::npos
+                        && unreadableFailures[1].reason.find ("unreadable") != std::string::npos,
+                    "unreadable aux state omitted its encoded size or reason");
+        }
+        engine->publishPluginStateForSave (true);
+        expect (session->track (trackIndex).nativeClapStateBase64 == unreadableStateText,
+                "unreadable track state did not survive publish");
+        expect (session->auxLane (auxLaneIndex)
+                           .nativeClapStateBase64[(size_t) auxSlotIndex] == unreadableStateText,
+                "unreadable aux state did not survive publish");
+
         const juce::File fixtureFile (fixturePath);
         ChannelStrip deferredTrack;
         deferredTrack.setPendingNativeClap (

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -16,6 +16,7 @@
 #include "LegacyStateBase64.h"
 #include "../foundation/Base64.h"
 #include "../foundation/MessageThread.h"
+#include "../foundation/Text.h"
 #if DUSKSTUDIO_HAS_NATIVE_AU
  #include "au/AuBundle.h"
 #endif
@@ -256,30 +257,18 @@ static std::filesystem::path lv2StateDirFor (Session& session, const juce::Strin
 
 #if DUSKSTUDIO_HAS_NATIVE_CLAP || DUSKSTUDIO_HAS_NATIVE_LV2 || DUSKSTUDIO_HAS_NATIVE_VST3 \
     || DUSKSTUDIO_HAS_NATIVE_AU || DUSKSTUDIO_HAS_MULTISAMPLE
-// Session-carried native plugin state blob (base64) -> bytes. Empty on any
-// decode failure - callers treat "no state" and "bad state" the same, so an
-// unreadable blob is otherwise indistinguishable from a plugin that saved
-// nothing. Say so once, or a corrupted session restores defaults with no trace.
-static std::vector<uint8_t> decodeBase64Blob (const juce::String& s, const char* slotKind)
+static DecodedStateBlob decodeBase64Blob (const juce::String& s, const char* slotKind)
 {
-    if (s.isEmpty()) return {};
-
-    auto blob = dusk::base64::decode (s.toRawUTF8(), s.getNumBytesAsUTF8());
-
-    // 0.13.1 migrated Audio Unit and soundfont slots onto their native keys
-    // without transcoding, so a session it converted holds the JUCE form here.
-    if (blob.empty())
-        blob = decodeLegacyStateBase64 (s.toStdString());
-
-    if (blob.empty())
+    auto decoded = decodeStoredStateBase64 (s.toStdString());
+    if (decoded.unreadable)
     {
         std::fprintf (stderr,
                       "[Dusk Studio/session] %s state is unreadable (%d chars); "
-                      "restoring the slot at its defaults\n",
+                      "leaving the slot offline to preserve it\n",
                       slotKind, s.length());
         std::fflush (stderr);
     }
-    return blob;
+    return decoded;
 }
 
 // Snapshot a loaded native slot's state into its session string. A plugin that
@@ -2187,6 +2176,76 @@ void AudioEngine::consumePluginStateAfterLoad()
     };
 #endif
 
+#if DUSKSTUDIO_HAS_NATIVE_CLAP || DUSKSTUDIO_HAS_NATIVE_LV2 || DUSKSTUDIO_HAS_NATIVE_VST3 \
+    || DUSKSTUDIO_HAS_NATIVE_AU || DUSKSTUDIO_HAS_MULTISAMPLE
+    auto rejectUnreadableTrackState = [&] (
+        const DecodedStateBlob& state, ChannelStrip& strip,
+        auto&& markRestoreFailed, const std::string& location,
+        const auto& name, const char* format)
+    {
+        if (! state.unreadable)
+            return false;
+
+#if DUSKSTUDIO_HAS_MULTISAMPLE
+        strip.getNativeMultisampleSlot().drainPendingLoads();
+#endif
+        const bool prepared = strip.isPrepared();
+        if (prepared) suspendProcessing();
+        const auto reason = hosting::enforceRestorePolicy (
+            true, state.supplied, false, "encoded state is unreadable",
+            state.encodedBytes, [&]
+            {
+                strip.unloadNativeClap();
+                strip.unloadNativeLv2();
+                strip.unloadNativeVst3();
+                strip.unloadNativeAu();
+                strip.unloadNativeMultisample();
+            });
+        if (prepared) resumeProcessing();
+        markRestoreFailed();
+        PluginLoadFailure failure;
+        failure.location = location.c_str();
+        failure.pluginName = name;
+        failure.format = format;
+        failure.reason = reason;
+        lastPluginLoadFailures.push_back (std::move (failure));
+        return true;
+    };
+
+#if DUSKSTUDIO_HAS_NATIVE_CLAP || DUSKSTUDIO_HAS_NATIVE_LV2 \
+    || DUSKSTUDIO_HAS_NATIVE_VST3 || DUSKSTUDIO_HAS_NATIVE_AU
+    auto rejectUnreadableAuxState = [&] (
+        const DecodedStateBlob& state, AuxLaneStrip& strip, int slotIndex,
+        auto&& markRestoreFailed, const std::string& location,
+        const auto& name, const char* format)
+    {
+        if (! state.unreadable)
+            return false;
+
+        const bool prepared = strip.isPrepared();
+        if (prepared) suspendProcessing();
+        const auto reason = hosting::enforceRestorePolicy (
+            true, state.supplied, false, "encoded state is unreadable",
+            state.encodedBytes, [&]
+            {
+                strip.unloadNativeClap (slotIndex);
+                strip.unloadNativeLv2 (slotIndex);
+                strip.unloadNativeVst3 (slotIndex);
+                strip.unloadNativeAu (slotIndex);
+            });
+        if (prepared) resumeProcessing();
+        markRestoreFailed();
+        PluginLoadFailure failure;
+        failure.location = location.c_str();
+        failure.pluginName = name;
+        failure.format = format;
+        failure.reason = reason;
+        lastPluginLoadFailures.push_back (std::move (failure));
+        return true;
+    };
+#endif
+#endif
+
     for (int t = 0; t < Session::kNumTracks; ++t)
     {
         auto& track = session.track (t);
@@ -2213,9 +2272,14 @@ void AudioEngine::consumePluginStateAfterLoad()
             slot.unload();
             strip.insertMode.store (ChannelStrip::kInsertPlugin, std::memory_order_release);
 
-            auto blob = decodeBase64Blob (track.nativeClapStateBase64, "track CLAP");
-
+            auto decoded = decodeBase64Blob (track.nativeClapStateBase64, "track CLAP");
             const juce::File clapFile (track.nativeClapPath);
+            if (rejectUnreadableTrackState (
+                    decoded, strip, [&] { strip.markNativeClapRestoreFailed(); },
+                    dusk::text::format ("Track %d", t + 1),
+                    clapFile.getFileNameWithoutExtension(), "CLAP"))
+                continue;
+            auto& blob = decoded.bytes;
             if (strip.isPrepared())
             {
                 suspendProcessing();
@@ -2262,9 +2326,14 @@ void AudioEngine::consumePluginStateAfterLoad()
             slot.unload();
             strip.insertMode.store (ChannelStrip::kInsertPlugin, std::memory_order_release);
 
-            auto blob = decodeBase64Blob (track.nativeLv2StateBase64, "track LV2");
-
+            auto decoded = decodeBase64Blob (track.nativeLv2StateBase64, "track LV2");
             const juce::File lv2File (track.nativeLv2Path);
+            if (rejectUnreadableTrackState (
+                    decoded, strip, [&] { strip.markNativeLv2RestoreFailed(); },
+                    dusk::text::format ("Track %d", t + 1),
+                    lv2File.getFileNameWithoutExtension(), "LV2"))
+                continue;
+            auto& blob = decoded.bytes;
             if (strip.isPrepared())
             {
                 suspendProcessing();
@@ -2311,9 +2380,14 @@ void AudioEngine::consumePluginStateAfterLoad()
             slot.unload();
             strip.insertMode.store (ChannelStrip::kInsertPlugin, std::memory_order_release);
 
-            auto blob = decodeBase64Blob (track.nativeVst3StateBase64, "track VST3");
-
+            auto decoded = decodeBase64Blob (track.nativeVst3StateBase64, "track VST3");
             const juce::File vst3File (track.nativeVst3Path);
+            if (rejectUnreadableTrackState (
+                    decoded, strip, [&] { strip.markNativeVst3RestoreFailed(); },
+                    dusk::text::format ("Track %d", t + 1),
+                    vst3File.getFileNameWithoutExtension(), "VST3"))
+                continue;
+            auto& blob = decoded.bytes;
             if (strip.isPrepared())
             {
                 suspendProcessing();
@@ -2355,7 +2429,13 @@ void AudioEngine::consumePluginStateAfterLoad()
         {
             slot.unload();
             strip.insertMode.store (ChannelStrip::kInsertPlugin, std::memory_order_release);
-            auto blob = decodeBase64Blob (track.nativeAuStateBase64, "track Audio Unit");
+            auto decoded = decodeBase64Blob (track.nativeAuStateBase64, "track Audio Unit");
+            if (rejectUnreadableTrackState (
+                    decoded, strip, [&] { strip.markNativeAuRestoreFailed(); },
+                    dusk::text::format ("Track %d", t + 1),
+                    auName (track.nativeAuIdentifier), "AU"))
+                continue;
+            auto& blob = decoded.bytes;
             if (strip.isPrepared())
             {
                 suspendProcessing();
@@ -2398,9 +2478,16 @@ void AudioEngine::consumePluginStateAfterLoad()
             slot.unload();
             strip.insertMode.store (ChannelStrip::kInsertPlugin, std::memory_order_release);
 
-            auto blob = decodeBase64Blob (track.nativeMultisampleStateBase64, "track multisample");
-
+            auto decoded = decodeBase64Blob (
+                track.nativeMultisampleStateBase64, "track multisample");
             const juce::File soundfont (track.nativeMultisamplePath);
+            if (rejectUnreadableTrackState (
+                    decoded, strip,
+                    [&] { strip.markNativeMultisampleRestoreFailed(); },
+                    dusk::text::format ("Track %d", t + 1),
+                    soundfont.getFileNameWithoutExtension(), "multisample"))
+                continue;
+            auto& blob = decoded.bytes;
             if (strip.isPrepared())
             {
                 // Two-phase: the soundfont parse + state restore run with the
@@ -2541,9 +2628,16 @@ void AudioEngine::consumePluginStateAfterLoad()
                 slot.unload();   // ensure no JUCE plugin lingers in this slot
                 strip.insertMode[(size_t) s].store (AuxLaneStrip::kInsertPlugin, std::memory_order_release);
 
-                auto blob = decodeBase64Blob (lane.nativeClapStateBase64[(size_t) s], "aux CLAP");
-
+                auto decoded = decodeBase64Blob (
+                    lane.nativeClapStateBase64[(size_t) s], "aux CLAP");
                 const juce::File clapFile (lane.nativeClapPath[(size_t) s]);
+                if (rejectUnreadableAuxState (
+                        decoded, strip, s,
+                        [&] { strip.markNativeClapRestoreFailed (s); },
+                        dusk::text::format ("Aux %d slot %d", a + 1, s + 1),
+                        clapFile.getFileNameWithoutExtension(), "CLAP"))
+                    continue;
+                auto& blob = decoded.bytes;
                 if (strip.isPrepared())
                 {
                     suspendProcessing();   // load is not RT-safe; fence the audio thread
@@ -2588,9 +2682,16 @@ void AudioEngine::consumePluginStateAfterLoad()
                 slot.unload();
                 strip.insertMode[(size_t) s].store (AuxLaneStrip::kInsertPlugin, std::memory_order_release);
 
-                auto blob = decodeBase64Blob (lane.nativeLv2StateBase64[(size_t) s], "aux LV2");
-
+                auto decoded = decodeBase64Blob (
+                    lane.nativeLv2StateBase64[(size_t) s], "aux LV2");
                 const juce::File lv2File (lane.nativeLv2Path[(size_t) s]);
+                if (rejectUnreadableAuxState (
+                        decoded, strip, s,
+                        [&] { strip.markNativeLv2RestoreFailed (s); },
+                        dusk::text::format ("Aux %d slot %d", a + 1, s + 1),
+                        lv2File.getFileNameWithoutExtension(), "LV2"))
+                    continue;
+                auto& blob = decoded.bytes;
                 if (strip.isPrepared())
                 {
                     suspendProcessing();   // load is not RT-safe; fence the audio thread
@@ -2640,9 +2741,16 @@ void AudioEngine::consumePluginStateAfterLoad()
                 slot.unload();
                 strip.insertMode[(size_t) s].store (AuxLaneStrip::kInsertPlugin, std::memory_order_release);
 
-                auto blob = decodeBase64Blob (lane.nativeVst3StateBase64[(size_t) s], "aux VST3");
-
+                auto decoded = decodeBase64Blob (
+                    lane.nativeVst3StateBase64[(size_t) s], "aux VST3");
                 const juce::File vst3File (lane.nativeVst3Path[(size_t) s]);
+                if (rejectUnreadableAuxState (
+                        decoded, strip, s,
+                        [&] { strip.markNativeVst3RestoreFailed (s); },
+                        dusk::text::format ("Aux %d slot %d", a + 1, s + 1),
+                        vst3File.getFileNameWithoutExtension(), "VST3"))
+                    continue;
+                auto& blob = decoded.bytes;
                 if (strip.isPrepared())
                 {
                     suspendProcessing();   // load is not RT-safe; fence the audio thread
@@ -2686,8 +2794,16 @@ void AudioEngine::consumePluginStateAfterLoad()
                 slot.unload();
                 strip.insertMode[(size_t) s].store (
                     AuxLaneStrip::kInsertPlugin, std::memory_order_release);
-                auto blob = decodeBase64Blob (lane.nativeAuStateBase64[(size_t) s], "aux Audio Unit");
+                auto decoded = decodeBase64Blob (
+                    lane.nativeAuStateBase64[(size_t) s], "aux Audio Unit");
                 const auto identifier = lane.nativeAuIdentifier[(size_t) s];
+                if (rejectUnreadableAuxState (
+                        decoded, strip, s,
+                        [&] { strip.markNativeAuRestoreFailed (s); },
+                        dusk::text::format ("Aux %d slot %d", a + 1, s + 1),
+                        auName (identifier), "AU"))
+                    continue;
+                auto& blob = decoded.bytes;
                 if (strip.isPrepared())
                 {
                     suspendProcessing();

--- a/src/engine/LegacyStateBase64.h
+++ b/src/engine/LegacyStateBase64.h
@@ -30,46 +30,56 @@ inline int legacySextet (char c) noexcept
     return reverse[(unsigned char) c];
 }
 
-// Decode of the MemoryBlock form, mirroring JUCE's MemoryBlock fromBase64Encoding
-// bit for bit: a decimal byte count, a '.', then 6-bit groups laid down LSB-first
-// into a zero-filled buffer of exactly that count. Characters outside the
-// alphabet are skipped without advancing the bit cursor, bits past the declared
-// size are dropped, and a shorter-than-declared payload leaves the tail zeroed,
-// all exactly as the JUCE reader behaved. False only when there is no '.' at
-// all (not this encoding), or when the declared count is beyond what the
-// payload could ever have carried, which the real encoder cannot produce.
+// Decode of the MemoryBlock form, mirroring JUCE's MemoryBlock encoder bit for
+// bit: a decimal byte count, a '.', then 6-bit groups laid down LSB-first into a
+// zero-filled buffer of exactly that count. The encoder always writes a decimal
+// count and exactly ceil(count * 8 / 6) payload characters drawn from the
+// alphabet above, so anything else - a non-decimal count, a short or over-long
+// payload, an off-alphabet character, a set padding bit - is a corrupt string.
+// False for all of them: the caller must see corruption as unreadable rather
+// than restore a slot from a partly zeroed buffer and save that back over the
+// last good copy.
 inline bool decodeLegacyBlob (const std::string& s, std::vector<std::uint8_t>& out)
 {
     out.clear();
 
     const std::size_t dot = s.find ('.');
-    if (dot == std::string::npos) return false;
+    if (dot == std::string::npos || dot == 0) return false;
 
     std::size_t numBytes = 0;
     for (std::size_t i = 0; i < dot; ++i)
     {
         const char c = s[i];
-        if (c < '0' || c > '9') break;          // getIntValue semantics: digits, then stop
-        numBytes = numBytes * 10 + (std::size_t) (c - '0');
-        if (numBytes > (std::size_t) 1 << 30) return false;
+        if (c < '0' || c > '9') return false;
+        const auto digit = (std::size_t) (c - '0');
+        constexpr std::size_t kMaxDecodedBytes = (std::size_t) 1 << 30;
+        if (numBytes > (kMaxDecodedBytes - digit) / 10) return false;
+        numBytes = numBytes * 10 + digit;
     }
 
-    // The encoder writes ceil(bytes * 8 / 6) payload characters, so a count the
-    // payload cannot fill is corruption, not a state to allocate.
-    const std::size_t dataChars = s.size() - dot - 1;
-    if (numBytes > (dataChars * 6) / 8 + 8) return false;
+    if (s.size() - dot - 1 != (numBytes * 8 + 5) / 6) return false;
 
     out.assign (numBytes, 0);
     std::size_t pos = 0;
     for (std::size_t i = dot + 1; i < s.size(); ++i)
     {
         const int v = legacySextet (s[i]);
-        if (v < 0) continue;
+        if (v < 0) { out.clear(); return false; }
         for (int k = 0; k < 6; ++k)
         {
             const std::size_t bit = pos + (std::size_t) k;
-            if ((bit >> 3) >= out.size()) break;
-            out[bit >> 3] = (std::uint8_t) (out[bit >> 3] | (((v >> k) & 1) << (bit & 7)));
+            const int b = (v >> k) & 1;
+
+            // The final sextet carries up to five bits past the declared count.
+            // The encoder reads those from beyond its buffer, where it sees
+            // zeros, so a set one marks a string it could not have written.
+            if ((bit >> 3) >= out.size())
+            {
+                if (b) { out.clear(); return false; }
+                continue;
+            }
+
+            out[bit >> 3] = (std::uint8_t) (out[bit >> 3] | (b << (bit & 7)));
         }
         pos += 6;
     }

--- a/src/engine/LegacyStateBase64.h
+++ b/src/engine/LegacyStateBase64.h
@@ -77,6 +77,33 @@ inline bool decodeLegacyBlob (const std::string& s, std::vector<std::uint8_t>& o
 }
 } // namespace detail
 
+struct DecodedStateBlob
+{
+    std::vector<std::uint8_t> bytes;
+    std::size_t encodedBytes = 0;
+    bool supplied = false;
+    bool unreadable = false;
+};
+
+inline DecodedStateBlob decodeStoredStateBase64 (const std::string& encoded)
+{
+    DecodedStateBlob result;
+    result.encodedBytes = encoded.size();
+    result.supplied = ! encoded.empty();
+    if (! result.supplied)
+        return result;
+
+    result.bytes = dusk::base64::decode (encoded.data(), encoded.size());
+    if (! result.bytes.empty())
+        return result;
+
+    if (detail::decodeLegacyBlob (encoded, result.bytes))
+        return result;
+
+    result.unreadable = true;
+    return result;
+}
+
 // Slots that used to be hosted through the JUCE plugin path stored their state
 // in JUCE's MemoryBlock encoding; the native keys those slots migrate onto are
 // RFC 4648. The two decoders reject each other's output outright, so the string

--- a/tests/legacy_state_base64.cpp
+++ b/tests/legacy_state_base64.cpp
@@ -1,7 +1,10 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "engine/LegacyStateBase64.h"
+#include "engine/hosting/NativeRestorePolicy.h"
 #include "foundation/Base64.h"
+#include "session/Session.h"
+#include "session/SessionSerializer.h"
 
 #include <juce_core/juce_core.h>
 
@@ -10,6 +13,7 @@
 #include <vector>
 
 using duskstudio::decodeLegacyStateBase64;
+using duskstudio::decodeStoredStateBase64;
 using duskstudio::transcodeLegacyStateBase64;
 
 namespace
@@ -41,19 +45,63 @@ TEST_CASE ("legacy state transcodes onto the native keys", "[session][migration]
              == juce::Base64::toBase64 (original.data(), original.size()).toStdString());
 }
 
-TEST_CASE ("legacy state transcode reports unreadable input", "[session][migration]")
+TEST_CASE ("unreadable stored state is rejected without data loss",
+           "[session][migration][native][regression][issue-454]")
 {
-    std::string migrated { "untouched" };
+    SECTION ("legacy migration leaves the source untouched")
+    {
+        std::string migrated { "untouched" };
 
-    // No '.' byte-count prefix: not the legacy encoding at all. Migrating on a
-    // false return would strand the only copy of the user's settings.
-    REQUIRE_FALSE (transcodeLegacyStateBase64 ("Zm9vYmFy", migrated));
-    REQUIRE_FALSE (transcodeLegacyStateBase64 ("not a blob", migrated));
-    REQUIRE (migrated == "untouched");
+        // No '.' byte-count prefix: not the legacy encoding at all. Migrating on a
+        // false return would strand the only copy of the user's settings.
+        REQUIRE_FALSE (transcodeLegacyStateBase64 ("Zm9vYmFy", migrated));
+        REQUIRE_FALSE (transcodeLegacyStateBase64 ("not a blob", migrated));
+        REQUIRE (migrated == "untouched");
 
-    // An empty legacy slot has nothing to lose and migrates cleanly.
-    REQUIRE (transcodeLegacyStateBase64 ({}, migrated));
-    REQUIRE (migrated.empty());
+        // An empty legacy slot has nothing to lose and migrates cleanly.
+        REQUIRE (transcodeLegacyStateBase64 ({}, migrated));
+        REQUIRE (migrated.empty());
+    }
+
+    SECTION ("native state remains saveable after rejection")
+    {
+        const std::string corruptState = "*** not base64 ***";
+        const auto decoded = decodeStoredStateBase64 (corruptState);
+        REQUIRE (decoded.supplied);
+        REQUIRE (decoded.unreadable);
+        REQUIRE (decoded.bytes.empty());
+        REQUIRE (decoded.encodedBytes == corruptState.size());
+
+        bool unloaded = false;
+        const auto reason = duskstudio::hosting::enforceRestorePolicy (
+            true, decoded.supplied, ! decoded.unreadable, "encoded state is unreadable",
+            decoded.encodedBytes, [&] { unloaded = true; });
+        REQUIRE (unloaded);
+        REQUIRE (reason == "saved state was rejected (18 bytes): encoded state is unreadable; "
+                           "slot left offline to preserve the saved state");
+
+        const auto target = juce::File::getSpecialLocation (juce::File::tempDirectory)
+                                .getNonexistentChildFile (
+                                    "dusk-unreadable-native-state", ".json", false);
+        const struct ScopedFile
+        {
+            juce::File file;
+            ~ScopedFile() { file.deleteFile(); }
+        } scopedFile { target };
+
+        duskstudio::Session session;
+        auto& track = session.track (0);
+        track.nativeClapPath = "/plugins/Synth.clap";
+        track.nativeClapPluginId = "studio.dusk.synth";
+        track.nativeClapStateBase64 = corruptState;
+        REQUIRE (duskstudio::SessionSerializer::save (session, target));
+
+        duskstudio::Session restored;
+        REQUIRE (duskstudio::SessionSerializer::load (restored, target));
+        REQUIRE (restored.track (0).nativeClapPath == track.nativeClapPath);
+        REQUIRE (restored.track (0).nativeClapPluginId == track.nativeClapPluginId);
+        REQUIRE (restored.track (0).nativeClapStateBase64.toStdString() == corruptState);
+    }
 }
 
 // A plugin that saved no state at all encodes as "0.". Reading that as a failure
@@ -67,6 +115,11 @@ TEST_CASE ("legacy state transcode accepts an empty saved state", "[session][mig
     std::string migrated { "untouched" };
     REQUIRE (transcodeLegacyStateBase64 (legacy, migrated));
     REQUIRE (migrated.empty());
+
+    const auto decoded = decodeStoredStateBase64 (legacy);
+    REQUIRE (decoded.supplied);
+    REQUIRE_FALSE (decoded.unreadable);
+    REQUIRE (decoded.bytes.empty());
 }
 
 // 0.13.1 copied the legacy string onto the native key instead of transcoding it,
@@ -81,6 +134,10 @@ TEST_CASE ("0.13.1-migrated state still decodes",
 
     REQUIRE (decode (carried).empty());                    // not RFC 4648
     REQUIRE (decodeLegacyStateBase64 (carried) == original);
+    const auto decoded = decodeStoredStateBase64 (carried);
+    REQUIRE (decoded.supplied);
+    REQUIRE_FALSE (decoded.unreadable);
+    REQUIRE (decoded.bytes == original);
 
     // The fallback must not claim RFC 4648 strings: it needs the '.' byte-count
     // prefix, which base64 output never contains.

--- a/tests/legacy_state_base64.cpp
+++ b/tests/legacy_state_base64.cpp
@@ -167,3 +167,52 @@ TEST_CASE ("legacy decode matches juce::MemoryBlock across lengths", "[session][
         REQUIRE (decodeLegacyStateBase64 (legacy) == original);
     }
 }
+
+// A count that is not decimal, a payload that stops short of the declared byte
+// count, a character outside the alphabet, or a final sextet whose bits past the
+// declared count are set all mean the string is corrupt.
+// Decoding them anyway hands the slot a partly zeroed state that the next save
+// writes back over the last good copy, so each must read as unreadable.
+TEST_CASE ("malformed legacy state reads as unreadable",
+           "[session][migration][regression][issue-454]")
+{
+    const std::vector<std::uint8_t> original { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66 };
+    const auto legacy = juce::MemoryBlock (original.data(), original.size())
+                            .toBase64Encoding().toStdString();
+    REQUIRE (decodeLegacyStateBase64 (legacy) == original);
+
+    const std::string malformed[] {
+        "x.",                                        // count is not a number
+        ".ABCDEFGH",                                 // no count at all
+        "9999999999999999999999999999999999999999.", // count overflows size_t
+        "6.",                                        // count with no payload
+        legacy.substr (0, legacy.size() - 1),        // payload one character short
+        legacy + "A",                                // payload one character long
+        legacy.substr (0, legacy.size() - 1) + "*",  // character outside the alphabet
+    };
+
+    for (const auto& s : malformed)
+    {
+        CAPTURE (s);
+        REQUIRE (decodeLegacyStateBase64 (s).empty());
+
+        const auto decoded = decodeStoredStateBase64 (s);
+        REQUIRE (decoded.supplied);
+        REQUIRE (decoded.unreadable);
+        REQUIRE (decoded.bytes.empty());
+
+        std::string migrated { "untouched" };
+        REQUIRE_FALSE (transcodeLegacyStateBase64 (s, migrated));
+        REQUIRE (migrated == "untouched");
+    }
+
+    // The last character of a one-byte blob carries two data bits and four that
+    // the encoder always writes as zero, because it reads them from past the end
+    // of its own buffer. Setting one produces a string the encoder could not
+    // have written, so it must be rejected rather than silently decoded.
+    const std::vector<std::uint8_t> oneByte { 0xff };
+    REQUIRE (juce::MemoryBlock (oneByte.data(), 1).toBase64Encoding().toStdString() == "1.+C");
+    REQUIRE (decodeLegacyStateBase64 ("1.+C") == oneByte);
+    REQUIRE (decodeLegacyStateBase64 ("1.+G").empty());
+    REQUIRE (decodeStoredStateBase64 ("1.+G").unreadable);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Unreadable saved plugin state now keeps the affected slot offline instead of loading default settings.
  - Original plugin references and state data are preserved during subsequent session saves.
  - Plugin-load failures now provide clearer status information, including unreadable-state details.

- **Documentation**
  - Added guidance for handling unreadable or rejected plugin state.
  - Updated the documented test-suite count.

- **Tests**
  - Expanded coverage for malformed state data, legacy formats, and session preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->