### PR TITLE
fix(hosting): deliver transport panic reliably

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ canonical source.
 
 ### Fixed
 
+- **Stop now silences every hosted instrument reliably.** Transport panic events
+  still reach MIDI tracks while they are muted or excluded by solo, VST3 synths
+  that do not map the standard panic controllers receive note-offs for their
+  sounding notes, and CLAP instruments receive a choke on every note-input port.
 - **The macOS release now includes the plugin sandbox.** The disk image kept
   its macOS 11 deployment target, but the sandbox's shared-address wake API
   required macOS 14.4, so CMake omitted the plugin-host helper and scans ran

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -532,7 +532,9 @@ Switching into or out of MASTERING force-stops the transport. The mix engine and
 
 From left to right:
 
-- **Stop** (■). Halts playback or recording, returns the playhead to bar 1.
+- **Stop** (■). Halts playback or recording, returns the playhead to bar 1, and
+  silences held notes in hosted instruments even when their tracks are muted or
+  excluded by solo.
 - **Rewind** (◀◀). Brief press jumps to the previous marker; if there is no previous marker, jumps to bar 1. Hold for more than 180 milliseconds to scrub backwards at 10× speed.
 - **Play** (▶). Toggles play. If loop is enabled and the playhead is outside the loop region, the playhead snaps to the loop start before playback begins.
 - **Forward** (▶▶). Brief press jumps to the next marker (no overshoot past the last one). Hold to scrub forward at 10× speed.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 904 Catch2 test cases across 177 test source files. Linux
+The C++ suite declares 906 Catch2 test cases across 178 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 904 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 906 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/dsp/ChannelStrip.cpp
+++ b/src/dsp/ChannelStrip.cpp
@@ -962,7 +962,7 @@ void ChannelStrip::processAndAccumulate (const float* inL,
     const bool pingRequested = (req == kInsertHardware
                                 || activeInsertMode == kInsertHardware)
                             && hardwareSlot.isPingRequested();
-    if (! passByGate && ! needsProcessedMono && ! pingRequested)
+    if (! passByGate && ! isMidi && ! needsProcessedMono && ! pingRequested)
     {
         faderGain.setTargetValue (0.0f);
         for (auto& s : busGain)     s.setTargetValue (0.0f);

--- a/src/engine/clap/ClapInstance.cpp
+++ b/src/engine/clap/ClapInstance.cpp
@@ -157,17 +157,27 @@ bool ClapInstance::create (const ClapBundle& bundle, const std::string& pluginId
     noteInPort      = false;
     noteDialectClap = false;
     noteDialectMidi = false;
+    primaryNoteInputPort = 0;
+    clapNoteInputPorts.clear();
     if (const auto* np = static_cast<const clap_plugin_note_ports_t*> (
             plugin->get_extension (plugin, CLAP_EXT_NOTE_PORTS));
         np != nullptr && np->count != nullptr && np->get != nullptr
         && np->count (plugin, true) > 0)
     {
-        clap_note_port_info_t info {};
-        if (np->get (plugin, 0, true, &info))
+        const uint32_t count = std::min<uint32_t> (np->count (plugin, true), 32768u);
+        for (uint32_t index = 0; index < count; ++index)
         {
-            noteInPort      = true;
-            noteDialectClap = (info.supported_dialects & CLAP_NOTE_DIALECT_CLAP) != 0;
-            noteDialectMidi = (info.supported_dialects & CLAP_NOTE_DIALECT_MIDI) != 0;
+            clap_note_port_info_t info {};
+            if (! np->get (plugin, index, true, &info)) continue;
+            if (! noteInPort)
+            {
+                noteInPort = true;
+                primaryNoteInputPort = (int16_t) index;
+                noteDialectClap = (info.supported_dialects & CLAP_NOTE_DIALECT_CLAP) != 0;
+                noteDialectMidi = (info.supported_dialects & CLAP_NOTE_DIALECT_MIDI) != 0;
+            }
+            if ((info.supported_dialects & CLAP_NOTE_DIALECT_CLAP) != 0)
+                clapNoteInputPorts.push_back ((int16_t) index);
         }
     }
 
@@ -265,8 +275,13 @@ bool ClapInstance::activate (double sampleRate, int maxBlock, std::string& error
     inScratchR .assign ((size_t) maxFrames, 0.0f);
     outScratchL.assign ((size_t) maxFrames, 0.0f);
     outScratchR.assign ((size_t) maxFrames, 0.0f);
-    // Params (ring capacity) + a block's worth of notes/MIDI.
-    eventScratch.assign ((size_t) kParamRingCap + 512, AnyEvent {});
+    // Params, a block's ordinary MIDI, and the extra fan-out required when the
+    // transport's 16-channel panic becomes one NOTE_CHOKE per CLAP note port.
+    constexpr size_t kMidiEventCapacity = 512;
+    constexpr size_t kMidiChannelCount = 16;
+    const size_t panicFanOut = kMidiChannelCount * clapNoteInputPorts.size();
+    eventScratch.assign ((size_t) kParamRingCap + kMidiEventCapacity + panicFanOut,
+                         AnyEvent {});
 
     if (plugin->activate == nullptr
         || ! plugin->activate (plugin, sampleRate, 1, (uint32_t) maxFrames))
@@ -472,31 +487,35 @@ void ClapInstance::appendMidiEvents (const dusk::MidiBuffer& midi) noexcept
                              && (status == 0x80 || (status == 0x90 && d[2] == 0));
         const bool allSoundOff = status == 0xB0 && meta.numBytes >= 3 && d[1] == 120;
 
-        auto& slot = eventScratch[(size_t) eventCount];
-        if (noteDialectClap && ! noteDialectMidi && allSoundOff)
+        if (! clapNoteInputPorts.empty() && allSoundOff)
         {
-            // CLAP-only note ports cannot receive the raw MIDI panic emitted
-            // when transport stops. NOTE_CHOKE is CLAP's hard-stop event; the
-            // wildcard key targets every voice on this MIDI channel.
-            auto& ev = slot.note;
-            ev.header = { (uint32_t) sizeof (clap_event_note_t),
-                          (uint32_t) meta.samplePosition, CLAP_CORE_EVENT_SPACE_ID,
-                          CLAP_EVENT_NOTE_CHOKE, 0 };
-            ev.note_id    = -1;
-            ev.port_index = 0;
-            ev.channel    = channel;
-            ev.key        = -1;
-            ev.velocity   = 0.0;
-            ++eventCount;
+            for (const int16_t port : clapNoteInputPorts)
+            {
+                if (eventCount >= cap) break;
+                auto& ev = eventScratch[(size_t) eventCount].note;
+                ev.header = { (uint32_t) sizeof (clap_event_note_t),
+                              (uint32_t) meta.samplePosition, CLAP_CORE_EVENT_SPACE_ID,
+                              CLAP_EVENT_NOTE_CHOKE, 0 };
+                ev.note_id    = -1;
+                ev.port_index = port;
+                ev.channel    = channel;
+                ev.key        = -1;
+                ev.velocity   = 0.0;
+                ++eventCount;
+            }
+            if (! noteDialectMidi) continue;
+            if (eventCount >= cap) break;
         }
-        else if (noteDialectClap && (noteOn || noteOff))
+
+        if (noteDialectClap && (noteOn || noteOff))
         {
+            auto& slot = eventScratch[(size_t) eventCount];
             auto& ev = slot.note;
             ev.header = { (uint32_t) sizeof (clap_event_note_t),
                           (uint32_t) meta.samplePosition, CLAP_CORE_EVENT_SPACE_ID,
                           (uint16_t) (noteOn ? CLAP_EVENT_NOTE_ON : CLAP_EVENT_NOTE_OFF), 0 };
             ev.note_id    = -1;
-            ev.port_index = 0;
+            ev.port_index = primaryNoteInputPort;
             ev.channel    = channel;
             ev.key        = (int16_t) d[1];
             ev.velocity   = (double) d[2] / 127.0;
@@ -504,13 +523,14 @@ void ClapInstance::appendMidiEvents (const dusk::MidiBuffer& midi) noexcept
         }
         else if (noteDialectMidi && meta.numBytes <= 3 && status >= 0x80 && status <= 0xE0)
         {
+            auto& slot = eventScratch[(size_t) eventCount];
             // Everything else (CC, pitch bend, aftertouch - and the notes
             // themselves when the plugin only takes raw MIDI).
             auto& ev = slot.midi;
             ev.header = { (uint32_t) sizeof (clap_event_midi_t),
                           (uint32_t) meta.samplePosition, CLAP_CORE_EVENT_SPACE_ID,
                           CLAP_EVENT_MIDI, 0 };
-            ev.port_index = 0;
+            ev.port_index = (uint16_t) primaryNoteInputPort;
             ev.data[0] = d[0];
             ev.data[1] = (uint8_t) (meta.numBytes > 1 ? d[1] : 0);
             ev.data[2] = (uint8_t) (meta.numBytes > 2 ? d[2] : 0);

--- a/src/engine/clap/ClapInstance.h
+++ b/src/engine/clap/ClapInstance.h
@@ -185,6 +185,8 @@ private:
 
     // Note-input negotiation (CLAP_EXT_NOTE_PORTS), recorded at create().
     bool noteInPort = false, noteDialectClap = false, noteDialectMidi = false;
+    int16_t primaryNoteInputPort = 0;
+    std::vector<int16_t> clapNoteInputPorts;
 
     // Audio thread. Convert the block's MidiBuffer into note / raw-MIDI events
     // appended after the drained param changes.

--- a/src/engine/vst3/Vst3Instance.cpp
+++ b/src/engine/vst3/Vst3Instance.cpp
@@ -2,6 +2,7 @@
 #include "Vst3Bundle.h"
 #include "Vst3BusPlan.h"
 #include "Vst3HostContext.h"
+#include "Vst3MidiNoteTracker.h"
 
 #include <public.sdk/source/vst/hosting/connectionproxy.h>
 #include <public.sdk/source/vst/hosting/eventlist.h>
@@ -65,6 +66,7 @@ struct Vst3Instance::Impl : public Vst3HostContext::Callbacks
     std::vector<float>       silence;                 // per-channel silent input scratch
     std::vector<float>       sink;                    // per-channel output sink scratch
     std::vector<float*>      scratchPtrs;             // per-channel pointer scratch
+    detail::MidiNoteTracker  midiNotes;
 
     // Parameters: snapshot at create(); UI->RT ring drained into inParams each block.
     std::vector<ParamInfo> params;
@@ -511,6 +513,7 @@ bool Vst3Instance::activate (double sampleRate, int maxBlockFrames, std::string&
     { errorOut = "setActive(true) failed"; return false; }
 
     impl->latencySamples = (int) impl->processor->getLatencySamples();
+    impl->midiNotes.reset();
 
     impl->processor->setProcessing (true);
     impl->processing = true;
@@ -632,13 +635,14 @@ void Vst3Instance::processBlock (const hosting::PortBuffers& io) noexcept
             const uint32_t id = impl->ccParamId[(size_t) (channel * Vst::kCountCtrlNumber
                                                           + ctrl)]
                                     .load (std::memory_order_relaxed);
-            if (id == Impl::kNoCcParam) return;
+            if (id == Impl::kNoCcParam) return false;
             int32 queueIndex = 0;
             if (auto* queue = impl->inParams.addParameterData ((Vst::ParamID) id, queueIndex))
             {
                 int32 pointIndex = 0;
                 queue->addPoint (offset, normalized, pointIndex);
             }
+            return true;
         };
 
         for (const auto meta : *io.midiIn)
@@ -667,12 +671,35 @@ void Vst3Instance::processBlock (const hosting::PortBuffers& io) noexcept
                     ev.noteOff = { channel, (int16_t) d[1],
                                    (float) d[2] / 127.0f, -1, 0.0f };
                 }
-                impl->inEvents.addEvent (ev);
+                if (impl->inEvents.addEvent (ev) == kResultTrue)
+                {
+                    if (ev.type == Vst::Event::kNoteOnEvent)
+                        impl->midiNotes.noteOn (channel, (int) d[1]);
+                    else
+                        impl->midiNotes.noteOff (channel, (int) d[1]);
+                }
             }
             else if (status == 0xB0 && meta.numBytes >= 3 && d[1] < 128)
             {
-                queueCcParam (channel, (int16_t) d[1],
-                              (double) d[2] / 127.0, meta.samplePosition);
+                const auto controller = (int16_t) d[1];
+                const bool mapped = queueCcParam (channel, controller,
+                                                  (double) d[2] / 127.0,
+                                                  meta.samplePosition);
+                if (! mapped && impl->hasEventIn
+                    && (controller == Vst::kCtrlAllSoundsOff
+                        || controller == Vst::kCtrlAllNotesOff))
+                {
+                    impl->midiNotes.releaseChannel (channel, [&] (int key)
+                    {
+                        Vst::Event ev {};
+                        ev.busIndex     = 0;
+                        ev.sampleOffset = meta.samplePosition;
+                        ev.flags        = Vst::Event::kIsLive;
+                        ev.type         = Vst::Event::kNoteOffEvent;
+                        ev.noteOff      = { channel, (int16_t) key, 0.0f, -1, 0.0f };
+                        return impl->inEvents.addEvent (ev) == kResultTrue;
+                    });
+                }
             }
             else if (status == 0xE0 && meta.numBytes >= 3)
             {

--- a/src/engine/vst3/Vst3MidiNoteTracker.h
+++ b/src/engine/vst3/Vst3MidiNoteTracker.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+namespace duskstudio::vst3::detail
+{
+class MidiNoteTracker
+{
+public:
+    void reset() noexcept { sounding.fill (false); }
+
+    void noteOn (int channel, int key) noexcept
+    {
+        if (valid (channel, key)) sounding[index (channel, key)] = true;
+    }
+
+    void noteOff (int channel, int key) noexcept
+    {
+        if (valid (channel, key)) sounding[index (channel, key)] = false;
+    }
+
+    bool isSounding (int channel, int key) const noexcept
+    {
+        return valid (channel, key) && sounding[index (channel, key)];
+    }
+
+    template <typename Emit>
+    void releaseChannel (int channel, Emit&& emit) noexcept
+    {
+        if (channel < 0 || channel >= kChannels) return;
+        for (int key = 0; key < kKeys; ++key)
+        {
+            auto& active = sounding[index (channel, key)];
+            if (active && emit (key)) active = false;
+        }
+    }
+
+private:
+    static constexpr int kChannels = 16;
+    static constexpr int kKeys = 128;
+
+    static bool valid (int channel, int key) noexcept
+    {
+        return channel >= 0 && channel < kChannels && key >= 0 && key < kKeys;
+    }
+
+    static std::size_t index (int channel, int key) noexcept
+    {
+        return (std::size_t) (channel * kKeys + key);
+    }
+
+    std::array<bool, (std::size_t) kChannels * kKeys> sounding {};
+};
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,6 +52,8 @@ add_executable(dusk-studio-tests
     platform_window_activation.cpp
     clap_editor_lifecycle.cpp
     plugin_state_diagnostics.cpp
+    channel_strip_midi_gate.cpp
+    ${CMAKE_SOURCE_DIR}/src/dsp/ChannelStrip.cpp
     channel_strip_context_rename.cpp
     snap_helpers.cpp
     fade_shapes.cpp

--- a/tests/channel_strip_midi_gate.cpp
+++ b/tests/channel_strip_midi_gate.cpp
@@ -1,0 +1,41 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "dsp/ChannelStrip.h"
+
+#include <array>
+#include <cstdint>
+
+TEST_CASE ("muted MIDI strips still process transport panic events",
+           "[channel-strip][midi][regression][issue-460]")
+{
+    constexpr int kBlock = 64;
+    duskstudio::ChannelStripParams params;
+    duskstudio::ChannelStrip strip;
+    strip.bind (params);
+    strip.prepare (48000.0, kBlock);
+
+    std::array<float, kBlock> masterL {}, masterR {};
+    std::array<std::array<float, kBlock>, duskstudio::ChannelStrip::kNumBuses> busL {}, busR {};
+    std::array<std::array<float, kBlock>, duskstudio::ChannelStrip::kNumAuxSends> auxL {}, auxR {};
+    std::array<float*, duskstudio::ChannelStrip::kNumBuses> busLPtrs {}, busRPtrs {};
+    std::array<float*, duskstudio::ChannelStrip::kNumAuxSends> auxLPtrs {}, auxRPtrs {};
+    for (std::size_t i = 0; i < busLPtrs.size(); ++i)
+    {
+        busLPtrs[i] = busL[i].data();
+        busRPtrs[i] = busR[i].data();
+    }
+    for (std::size_t i = 0; i < auxLPtrs.size(); ++i)
+    {
+        auxLPtrs[i] = auxL[i].data();
+        auxRPtrs[i] = auxR[i].data();
+    }
+
+    juce::MidiBuffer panic;
+    panic.addEvent (juce::MidiMessage::controllerEvent (1, 123, 0), 0);
+    strip.processAndAccumulate (nullptr, nullptr, panic, true,
+                                masterL.data(), masterR.data(),
+                                busLPtrs, busRPtrs, auxLPtrs, auxRPtrs,
+                                kBlock, false);
+
+    REQUIRE (strip.getLastProcessedSamples() == kBlock);
+}

--- a/tests/clap_instance_process.cpp
+++ b/tests/clap_instance_process.cpp
@@ -55,8 +55,8 @@ TEST_CASE ("ClapInstance connects every advertised bus and tolerates duplicate m
     }
 }
 
-TEST_CASE ("ClapInstance chokes CLAP-only voices on the transport panic",
-           "[clap][instance][midi][regression][issue-402]")
+TEST_CASE ("ClapInstance chokes every CLAP note-input port on the transport panic",
+           "[clap][instance][midi][regression][issue-402][issue-460]")
 {
     duskstudio::clap::ClapBundle bundle;
     std::string err;
@@ -86,7 +86,9 @@ TEST_CASE ("ClapInstance chokes CLAP-only voices on the transport panic",
 
     // This is the engine's transport-stop sequence. The fixture advertises
     // only CLAP note events, so raw CCs cannot reach it; CC 120 must become a
-    // wildcard CLAP NOTE_CHOKE and silence the latched voice.
+    // wildcard CLAP NOTE_CHOKE on every declared note-input port and channel.
+    // The fixture exposes 80 ports so the full reset exceeds the old fixed
+    // 1,024-event scratch capacity.
     dusk::MidiBuffer panic;
     for (int channel = 0; channel < 16; ++channel)
     {

--- a/tests/fixtures/multi_bus_clap.cpp
+++ b/tests/fixtures/multi_bus_clap.cpp
@@ -14,11 +14,12 @@ constexpr std::array<std::uint8_t, 8> kStateHeader {
 };
 constexpr const char* kFeatures[] = { CLAP_PLUGIN_FEATURE_AUDIO_EFFECT,
                                       CLAP_PLUGIN_FEATURE_STEREO, nullptr };
+constexpr std::size_t kNotePortCount = 80;
 
 struct PluginData
 {
     std::uint32_t processCount = 0;
-    bool voiceActive = false;
+    std::array<std::array<bool, 16>, kNotePortCount> voiceActive {};
 };
 
 const clap_plugin_descriptor_t kDescriptor {
@@ -58,16 +59,16 @@ const clap_plugin_audio_ports_t kAudioPorts { audioPortCount, audioPortGet };
 
 uint32_t CLAP_ABI notePortCount (const clap_plugin_t*, bool isInput)
 {
-    return isInput ? 1u : 0u;
+    return isInput ? (uint32_t) kNotePortCount : 0u;
 }
 
 bool CLAP_ABI notePortGet (const clap_plugin_t*, uint32_t index, bool isInput,
                            clap_note_port_info_t* info)
 {
-    if (! isInput || index != 0 || info == nullptr) return false;
+    if (! isInput || index >= kNotePortCount || info == nullptr) return false;
     *info = {};
-    info->id = 0;
-    std::snprintf (info->name, sizeof (info->name), "Note input");
+    info->id = index;
+    std::snprintf (info->name, sizeof (info->name), "Note input %u", index + 1);
     // Deliberately CLAP-only: raw MIDI controllers are unavailable, so the
     // host must translate its transport panic into a CLAP note event.
     info->supported_dialects = CLAP_NOTE_DIALECT_CLAP;
@@ -149,7 +150,8 @@ bool CLAP_ABI pluginStart (const clap_plugin_t*) { return true; }
 void CLAP_ABI pluginStop (const clap_plugin_t*) {}
 void CLAP_ABI pluginReset (const clap_plugin_t* plugin)
 {
-    static_cast<PluginData*> (plugin->plugin_data)->voiceActive = false;
+    for (auto& port : static_cast<PluginData*> (plugin->plugin_data)->voiceActive)
+        port.fill (false);
 }
 
 clap_process_status CLAP_ABI pluginProcess (const clap_plugin_t* plugin,
@@ -168,11 +170,26 @@ clap_process_status CLAP_ABI pluginProcess (const clap_plugin_t* plugin,
             const auto* event = process->in_events->get (process->in_events, i);
             if (event == nullptr || event->space_id != CLAP_CORE_EVENT_SPACE_ID)
                 continue;
-            if (event->type == CLAP_EVENT_NOTE_ON)
-                data->voiceActive = true;
-            else if (event->type == CLAP_EVENT_NOTE_OFF
-                     || event->type == CLAP_EVENT_NOTE_CHOKE)
-                data->voiceActive = false;
+            if ((event->type == CLAP_EVENT_NOTE_ON
+                 || event->type == CLAP_EVENT_NOTE_OFF
+                 || event->type == CLAP_EVENT_NOTE_CHOKE)
+                && event->size >= sizeof (clap_event_note_t))
+            {
+                const auto* note = reinterpret_cast<const clap_event_note_t*> (event);
+                if (event->type == CLAP_EVENT_NOTE_ON)
+                {
+                    // Model independently latched voices on every channel of every
+                    // port so a truncated transport panic remains observable.
+                    for (auto& port : data->voiceActive) port.fill (true);
+                }
+                else if (note->port_index >= 0
+                         && note->port_index < (int16_t) kNotePortCount
+                         && note->channel >= 0 && note->channel < 16)
+                {
+                    data->voiceActive[(std::size_t) note->port_index]
+                                     [(std::size_t) note->channel] = false;
+                }
+            }
         }
     }
 
@@ -193,9 +210,13 @@ clap_process_status CLAP_ABI pluginProcess (const clap_plugin_t* plugin,
         // channels too: a host that omits those buffers fails deterministically.
         for (uint32_t channel = 0; channel < 2; ++channel)
         {
+            bool anyVoiceActive = false;
+            for (const auto& port : data->voiceActive)
+                for (const bool active : port)
+                    anyVoiceActive = anyVoiceActive || active;
             process->audio_outputs[0].data32[channel][frame]
                 = process->audio_inputs[0].data32[channel][frame]
-                    + (data->voiceActive ? 0.25f : 0.0f);
+                    + (anyVoiceActive ? 0.25f : 0.0f);
             process->audio_outputs[1].data32[channel][frame]
                 = process->audio_inputs[1].data32[channel][frame];
         }

--- a/tests/vst3_instance_process.cpp
+++ b/tests/vst3_instance_process.cpp
@@ -11,6 +11,7 @@
 #include "engine/vst3/Vst3BusPlan.h"
 #include "engine/vst3/Vst3HostContext.h"
 #include "engine/vst3/Vst3Instance.h"
+#include "engine/vst3/Vst3MidiNoteTracker.h"
 
 #include <pluginterfaces/vst/ivsteditcontroller.h>
 
@@ -21,6 +22,27 @@
 #include <tuple>
 #include <utility>
 #include <vector>
+
+TEST_CASE ("VST3 panic releases every sounding note when its CC is unmapped",
+           "[vst3][midi][regression][issue-460]")
+{
+    duskstudio::vst3::detail::MidiNoteTracker tracker;
+    tracker.noteOn (2, 48);
+    tracker.noteOn (2, 72);
+    tracker.noteOn (3, 60);
+    tracker.noteOff (2, 48);
+
+    std::vector<int> released;
+    tracker.releaseChannel (2, [&] (int key)
+    {
+        released.push_back (key);
+        return true;
+    });
+
+    REQUIRE (released == std::vector<int> { 72 });
+    REQUIRE_FALSE (tracker.isSounding (2, 72));
+    REQUIRE (tracker.isSounding (3, 60));
+}
 
 TEST_CASE ("VST3 audio bus plan keeps activation and scratch shape consistent",
            "[vst3][bus][regression][issue-361][issue-390]")


### PR DESCRIPTION
Keep MIDI instruments processing behind mute and solo gates, synthesize VST3 note-offs when panic controllers are unmapped, and fan CLAP chokes out across every declared note port.

Closes #460