### PR TITLE
fix(scan): honor LV2 and AU cancellation

### DIFF
--- a/src/engine/PluginManager.cpp
+++ b/src/engine/PluginManager.cpp
@@ -680,9 +680,9 @@ int PluginManager::scanInstalledPlugins (
     const auto cancelled = [abort] { return abort != nullptr && abort->load (std::memory_order_relaxed); };
 
     if (! aborting && ! cancelled()) scanClapPlugins (abort);        // CLAP isn't a juce format - scan it alongside the JUCE pass
-    if (! aborting && ! cancelled()) scanLv2Plugins();               // native-LV2 rows are separate from JUCE's LV2 format
+    if (! aborting && ! cancelled()) scanLv2Plugins (abort);         // native-LV2 rows are separate from JUCE's LV2 format
     if (! aborting && ! cancelled()) scanVst3NativePlugins (abort);  // native-VST3 rows are separate from JUCE's VST3 format
-    if (! aborting && ! cancelled()) scanAuPlugins();                // native-AU rows come from the macOS component registry
+    if (! aborting && ! cancelled()) scanAuPlugins (abort);          // native-AU rows come from the macOS component registry
     return added;
 }
 
@@ -884,32 +884,41 @@ std::vector<PluginDescriptor> PluginManager::getClapInstrumentDescriptions() con
     return filterByInstrumentFlag (clapDescriptions, true);
 }
 
-void PluginManager::scanLv2Plugins()
+void PluginManager::scanLv2Plugins (const std::atomic<bool>* abort)
 {
 #if DUSKSTUDIO_HAS_NATIVE_LV2
-    const auto scanned = lv2::Lv2Scanner::scan();   // manifest parse outside the lock
+    const auto scanned = lv2::Lv2Scanner::scan (abort);   // manifest parse outside the lock
+    if (abort != nullptr && abort->load (std::memory_order_relaxed)) return;
+
+    std::vector<PluginDescriptor> fresh;
+    fresh.reserve (scanned.size());
+    for (const auto& s : scanned)
+    {
+        if (abort != nullptr && abort->load (std::memory_order_relaxed)) return;
+
+        // Audio effects (audio in + out) and instruments (atom/MIDI in,
+        // audio out, no audio in - classified by Lv2Bundle::describePlugin).
+        // MIDI-only utilities stay with the JUCE LV2 format.
+        const bool effect = s.desc.audioInputs > 0 && s.desc.audioOutputs > 0;
+        if (! effect && ! s.desc.isInstrument)
+            continue;
+        PluginDescriptor descriptor;
+        descriptor.name = s.desc.name;
+        descriptor.formatName = "LV2";
+        descriptor.backend = PluginBackend::Native;
+        descriptor.location = s.bundlePath;
+        descriptor.pluginId = s.desc.uri;
+        descriptor.isInstrument = s.desc.isInstrument;
+        fresh.push_back (std::move (descriptor));
+    }
+
     {
         const juce::ScopedLock sl (nativeDescriptionsLock);
-        lv2Descriptions.clear();
-        for (const auto& s : scanned)
-        {
-            // Audio effects (audio in + out) and instruments (atom/MIDI in,
-            // audio out, no audio in - classified by Lv2Bundle::describePlugin).
-            // MIDI-only utilities stay with the JUCE LV2 format.
-            const bool effect = s.desc.audioInputs > 0 && s.desc.audioOutputs > 0;
-            if (! effect && ! s.desc.isInstrument)
-                continue;
-            PluginDescriptor descriptor;
-            descriptor.name = s.desc.name;
-            descriptor.formatName = "LV2";
-            descriptor.backend = PluginBackend::Native;
-            descriptor.location = s.bundlePath;
-            descriptor.pluginId = s.desc.uri;
-            descriptor.isInstrument = s.desc.isInstrument;
-            lv2Descriptions.push_back (std::move (descriptor));
-        }
+        lv2Descriptions.swap (fresh);
     }
     saveNativeCache (lv2Descriptions, "lv2-native-cache.json");
+#else
+    (void) abort;
 #endif
 }
 
@@ -962,15 +971,18 @@ std::vector<PluginDescriptor> PluginManager::getVst3NativeInstrumentDescriptions
     return filterByInstrumentFlag (vst3NativeDescriptions, true);
 }
 
-void PluginManager::scanAuPlugins()
+void PluginManager::scanAuPlugins (const std::atomic<bool>* abort)
 {
 #if DUSKSTUDIO_HAS_NATIVE_AU
-    auto fresh = au::AuScanner::scan();
+    auto fresh = au::AuScanner::scan (abort);
+    if (abort != nullptr && abort->load (std::memory_order_relaxed)) return;
     {
         const juce::ScopedLock sl (nativeDescriptionsLock);
         auDescriptions.swap (fresh);
     }
     saveNativeCache (auDescriptions, "au-native-cache.json");
+#else
+    (void) abort;
 #endif
 }
 

--- a/src/engine/PluginManager.h
+++ b/src/engine/PluginManager.h
@@ -45,7 +45,7 @@ public:
 
     std::vector<PluginDescriptor> getLv2EffectDescriptions() const;
     std::vector<PluginDescriptor> getLv2InstrumentDescriptions() const;
-    void scanLv2Plugins();
+    void scanLv2Plugins (const std::atomic<bool>* abort = nullptr);
 
     std::vector<PluginDescriptor> getVst3NativeEffectDescriptions() const;
     std::vector<PluginDescriptor> getVst3NativeInstrumentDescriptions() const;
@@ -53,7 +53,7 @@ public:
 
     std::vector<PluginDescriptor> getAuEffectDescriptions() const;
     std::vector<PluginDescriptor> getAuInstrumentDescriptions() const;
-    void scanAuPlugins();
+    void scanAuPlugins (const std::atomic<bool>* abort = nullptr);
 
     std::unique_ptr<juce::AudioPluginInstance>
     createPluginInstance (const juce::File& pluginFile,

--- a/src/engine/au/AuBundle.cpp
+++ b/src/engine/au/AuBundle.cpp
@@ -209,7 +209,7 @@ bool AuBundle::exists (const std::string& identifier) noexcept
     return AudioComponentFindNext (nullptr, &query) != nullptr;
 }
 
-std::vector<PluginDesc> AuBundle::enumerate()
+std::vector<PluginDesc> AuBundle::enumerate (const std::atomic<bool>* abort)
 {
     std::vector<PluginDesc> found;
     constexpr std::array<OSType, 3> types {
@@ -217,11 +217,13 @@ std::vector<PluginDesc> AuBundle::enumerate()
     };
     for (const auto type : types)
     {
+        if (abort != nullptr && abort->load (std::memory_order_relaxed)) break;
         AudioComponentDescription query {};
         query.componentType = type;
         AudioComponent component = nullptr;
         while ((component = AudioComponentFindNext (component, &query)) != nullptr)
         {
+            if (abort != nullptr && abort->load (std::memory_order_relaxed)) break;
             PluginDesc description;
             if (describe (component, description))
                 found.push_back (std::move (description));

--- a/src/engine/au/AuBundle.h
+++ b/src/engine/au/AuBundle.h
@@ -2,6 +2,7 @@
 
 #include <AudioToolbox/AudioToolbox.h>
 
+#include <atomic>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -54,7 +55,7 @@ public:
     static bool isInstrumentType (std::uint32_t type) noexcept;
     static std::string categoryForType (std::uint32_t type);
     static bool describe (AudioComponent component, PluginDesc& out) noexcept;
-    static std::vector<PluginDesc> enumerate();
+    static std::vector<PluginDesc> enumerate (const std::atomic<bool>* abort = nullptr);
 
 private:
     AudioComponent audioComponent = nullptr;

--- a/src/engine/au/AuScanner.cpp
+++ b/src/engine/au/AuScanner.cpp
@@ -4,11 +4,12 @@
 
 namespace duskstudio::au
 {
-std::vector<PluginDescriptor> AuScanner::scan()
+std::vector<PluginDescriptor> AuScanner::scan (const std::atomic<bool>* abort)
 {
     std::vector<PluginDescriptor> rows;
-    for (const auto& plugin : AuBundle::enumerate())
+    for (const auto& plugin : AuBundle::enumerate (abort))
     {
+        if (abort != nullptr && abort->load (std::memory_order_relaxed)) break;
         PluginDescriptor descriptor;
         descriptor.name = plugin.name;
         descriptor.descriptiveName = plugin.name;

--- a/src/engine/au/AuScanner.h
+++ b/src/engine/au/AuScanner.h
@@ -2,6 +2,7 @@
 
 #include "../PluginDescriptor.h"
 
+#include <atomic>
 #include <vector>
 
 namespace duskstudio::au
@@ -11,6 +12,6 @@ namespace duskstudio::au
 class AuScanner
 {
 public:
-    static std::vector<PluginDescriptor> scan();
+    static std::vector<PluginDescriptor> scan (const std::atomic<bool>* abort = nullptr);
 };
 } // namespace duskstudio::au

--- a/src/engine/lv2/Lv2Scanner.cpp
+++ b/src/engine/lv2/Lv2Scanner.cpp
@@ -4,9 +4,11 @@
 
 namespace duskstudio::lv2
 {
-std::vector<ScannedLv2> Lv2Scanner::scan()
+std::vector<ScannedLv2> Lv2Scanner::scan (const std::atomic<bool>* abort)
 {
     std::vector<ScannedLv2> found;
+    if (abort != nullptr && abort->load (std::memory_order_relaxed)) return found;
+
     LilvWorld* world = lilv_world_new();
     if (world == nullptr) return found;
     lilv_world_load_all (world);   // $LV2_PATH, else the spec default directories
@@ -14,6 +16,7 @@ std::vector<ScannedLv2> Lv2Scanner::scan()
     const LilvPlugins* all = lilv_world_get_all_plugins (world);
     LILV_FOREACH (plugins, it, all)
     {
+        if (abort != nullptr && abort->load (std::memory_order_relaxed)) break;
         const LilvPlugin* p = lilv_plugins_get (all, it);
 
         // The bundle directory is what NativeLv2Slot::load takes. A malformed

--- a/src/engine/lv2/Lv2Scanner.h
+++ b/src/engine/lv2/Lv2Scanner.h
@@ -2,6 +2,7 @@
 
 #include "Lv2Bundle.h"
 
+#include <atomic>
 #include <string>
 #include <vector>
 
@@ -24,6 +25,6 @@ struct ScannedLv2
 class Lv2Scanner
 {
 public:
-    static std::vector<ScannedLv2> scan();
+    static std::vector<ScannedLv2> scan (const std::atomic<bool>* abort = nullptr);
 };
 } // namespace duskstudio::lv2

--- a/tests/au_native.cpp
+++ b/tests/au_native.cpp
@@ -7,6 +7,7 @@
 #include "engine/au/NativeAuSlot.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <filesystem>
 #include <string>
@@ -58,12 +59,16 @@ TEST_CASE ("Audio Unit identifiers round-trip and classify", "[au][identifier]")
     CHECK_FALSE (AuBundle::isInstrumentType (fourcc ("aufx")));
 }
 
-TEST_CASE ("Audio Unit scanner emits stable native descriptor rows", "[au][scanner]")
+TEST_CASE ("Audio Unit scanner cancels and emits stable native descriptor rows",
+           "[au][scanner][regression][issue-466]")
 {
     using duskstudio::PluginBackend;
     using duskstudio::au::AuBundle;
     using duskstudio::au::AuScanner;
     using duskstudio::au::ComponentId;
+
+    std::atomic<bool> abort { true };
+    CHECK (AuScanner::scan (&abort).empty());
 
     const auto rows = AuScanner::scan();
     REQUIRE_FALSE (rows.empty());

--- a/tests/lv2_bundle_load.cpp
+++ b/tests/lv2_bundle_load.cpp
@@ -5,8 +5,10 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "engine/lv2/Lv2Bundle.h"
+#include "engine/lv2/Lv2Scanner.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cstdlib>
 #include <string>
 
@@ -21,8 +23,12 @@ TEST_CASE ("Lv2Bundle rejects a non-bundle path cleanly", "[lv2][bundle]")
     REQUIRE (bundle.world() == nullptr);
 }
 
-TEST_CASE ("Lv2Bundle loads + enumerates a real LV2 bundle", "[lv2][bundle]")
+TEST_CASE ("LV2 discovery cancels and loads a real bundle",
+           "[lv2][bundle][scanner][regression][issue-466]")
 {
+    std::atomic<bool> abort { true };
+    CHECK (duskstudio::lv2::Lv2Scanner::scan (&abort).empty());
+
     const char* path = std::getenv ("DUSKSTUDIO_TEST_LV2");
     if (path == nullptr || *path == '\0')
     {


### PR DESCRIPTION
Closes #466

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Plugin discovery scans can now be cancelled while in progress for LV2 and Audio Unit plugins.
  * Cancelling a scan returns promptly without producing partial results.
  * Plugin discovery results remain stable when scans complete normally.

* **Tests**
  * Added regression coverage for cancelling LV2 and Audio Unit scans before processing begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->