### PR TITLE
Hide a foreign editor whose reparent fails

### DIFF
--- a/src/ui/PlatformWindowing_Windows.cpp
+++ b/src/ui/PlatformWindowing_Windows.cpp
@@ -78,8 +78,18 @@ public:
         ::SetWindowLongPtr (child, GWL_STYLE, style);
         if (! setWindowParent (child, nextParent))
         {
+            // The host shows its editor window before handing over the handle,
+            // so declining to host it has to put it away too. Otherwise the
+            // reparent failure leaves a titlebarred plugin window loose on the
+            // desktop that nothing positions and the user can still drive.
             if (::IsWindow (child))
+            {
                 ::SetWindowLongPtr (child, GWL_STYLE, originalStyle);
+                ::SetWindowPos (child, nullptr, 0, 0, 0, 0,
+                                  SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER
+                                    | SWP_NOACTIVATE | SWP_FRAMECHANGED
+                                    | SWP_HIDEWINDOW);
+            }
             return;
         }
         attachedParent = nextParent;

--- a/tests/platform_window_activation.cpp
+++ b/tests/platform_window_activation.cpp
@@ -153,6 +153,15 @@ TEST_CASE ("native window operations preserve activation and embedded editor geo
     REQUIRE (parentChanged.find ("setWindowParent") != std::string::npos);
     REQUIRE (parentChanged.find ("WS_VISIBLE") == std::string::npos);
 
+    // The host shows its editor window before handing the handle over, so a
+    // reparent that fails has to restore the original style AND hide the
+    // window; leaving it mapped strands a titlebarred plugin window on the
+    // desktop. The hide belongs to the failure branch, ahead of the success
+    // path's attachedParent publish.
+    requireInOrder (parentChanged, "! setWindowParent", "originalStyle");
+    requireInOrder (parentChanged, "originalStyle", "SWP_HIDEWINDOW");
+    requireInOrder (parentChanged, "SWP_HIDEWINDOW", "attachedParent = nextParent");
+
     const auto detachChild = definitionBody (windowsSource, "detachChild");
     REQUIRE (detachChild.find ("IsWindow") != std::string::npos);
     REQUIRE (detachChild.find ("setWindowParent") != std::string::npos);
@@ -164,6 +173,10 @@ TEST_CASE ("native window operations preserve activation and embedded editor geo
     REQUIRE (visibility.find ("ShowWindow") != std::string::npos);
     REQUIRE (visibility.find ("SW_HIDE") != std::string::npos);
     REQUIRE (visibility.find ("SW_SHOWNA") != std::string::npos);
+    // Visibility only follows a child this component actually holds: an
+    // unattached window is top-level and owned by the plugin host, and showing
+    // it from here floats it loose over the desktop.
+    requireInOrder (visibility, "attachedParent", "ShowWindow");
 
     const auto moved = definitionBody (windowsSource, "moved");
     REQUIRE (moved.find ("layoutChild") != std::string::npos);


### PR DESCRIPTION
Missed the #486 merge window, so it lands on its own.

The plugin host shows its editor window before it hands the window handle to the parent, and on Windows that window has a native titlebar. `ForeignHwndEmbed::parentHierarchyChanged` restored the original style and returned when `SetParent` failed, which left that window mapped on the desktop. Nothing positioned it after that and the user could still click around in it.

The failure branch now restores the style and hides the window, the same teardown `detachChild` already does.

There is no runtime harness for the Windows embed path. `ForeignHwndEmbed` sits in an anonymous namespace in a Windows-only translation unit, no `src/ui` windowing source is compiled into the test binary, and making `SetParent` fail on demand needs a cross-desktop HWND. The source-level checks in `tests/platform_window_activation.cpp` cover it instead, which is what that file already does for `setWindowParent`, `detachChild` and `layoutChild`. The new checks pin the hide to the failure branch and also cover the `visibilityChanged` attachment gate that went in with #486 without any coverage. Both fail if their fix is reverted, checked one at a time.

Validation on top of the merged main:

- `cmake --build build -j6` clean, no new warnings
- `ctest` 906/906
- `tools/juce-gate.sh` passes, 164 files, 8247 uses
- `scripts/run-selftest-xvfb.sh` 22 pass, 0 fail
- `coderabbit review --agent --uncommitted` 0 findings

The Windows source change itself still needs the Windows CI leg. No manual change, the fix restores intended behaviour rather than changing any documented one.