### PR TITLE
Load sandboxed plugins off the message thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,12 @@ closes release-metadata gaps found during the pre-tag audit.
 - **Sandboxed plugin windows stay responsive on Windows and macOS.** Window
   creation, visibility changes, resizing, and teardown now run on the child
   process's pumping message thread instead of its blocking control thread.
+- **Loading a sandboxed plugin no longer freezes the window.** Starting the
+  plugin host and asking it to load waits up to five and thirty seconds
+  respectively, and both waits used to happen on the thread that draws the
+  application, so a plugin that stalled on startup in its own process could
+  lock the interface for over half a minute. Both now happen away from it, and
+  a load that fails still falls back to loading the plugin in-process.
 - **A sandboxed plugin whose process is killed drops out for a few buffers, not
   a tenth of a second.** No operating system wait the audio thread uses carries
   news of the child's death, so a killed plugin host used to hold the audio

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 922 Catch2 test cases across 178 test source files. Linux
+The C++ suite declares 923 Catch2 test cases across 178 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 922 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 923 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/PluginSlot.cpp
+++ b/src/engine/PluginSlot.cpp
@@ -2,6 +2,7 @@
 #include "AtomicPark.h"
 #include "PluginManager.h"
 #include <algorithm>
+#include <cmath>
 #include <cstdio>
 #include <cstring>
 
@@ -177,6 +178,12 @@ PluginSlot::~PluginSlot()
     }
    #endif
 
+   #if DUSKSTUDIO_HAS_OOP_PLUGINS
+    // An in-flight off-thread load still posts its completion; joining before
+    // the members below go away keeps those workers from outliving the slot.
+    joinRemoteLoads();
+   #endif
+
     // Audio thread should already be detached by the time this runs (the
     // owning ChannelStrip destructs after its AudioEngine has released the
     // device callback). Belt-and-suspenders: clear the atomic first so
@@ -248,6 +255,159 @@ void PluginSlot::pollRemoteReaper()
         // Stop polling - child has been reaped, nothing more to watch.
         reaperTimer.stopTimer();
     }
+}
+
+void PluginSlot::publishRemoteConnection (
+    std::unique_ptr<duskstudio::ipc::RemotePluginConnection> connection,
+    PluginDescriptor descriptor,
+    int numIn, int numOut, int latency, bool isInstrument)
+{
+    ownedRemote = std::move (connection);
+    {
+        // Same drain-then-reset-and-publish as loadFromFile.
+        const juce::SpinLock::ScopedLockType processGuard (processLock);
+        remoteNumIn .store (numIn,  std::memory_order_relaxed);
+        remoteNumOut.store (numOut, std::memory_order_relaxed);
+        remoteIsInstrument.store (isInstrument, std::memory_order_relaxed);
+        cachedLatencySamples.store (latency, std::memory_order_relaxed);
+        blocksSinceLoad     = 0;
+        consecutiveOverruns = 0;
+        autoBypassed .store (false, std::memory_order_relaxed);
+        remoteCrashed.store (false, std::memory_order_relaxed);
+        currentRemote.store (ownedRemote.get(), std::memory_order_release);
+    }
+    reaperTimer.startTimer (kReaperPeriodMs);
+    descriptor.isInstrument = isInstrument;
+    descriptor.numInputChannels = numIn;
+    descriptor.numOutputChannels = numOut;
+    loadedDescriptor = std::move (descriptor);
+    offlineDescriptor.reset();
+    offlineLegacyDescriptionXml.clear();
+    offlineStateBase64.clear();
+    offlineCapturePlaceholder = false;
+    lastKnownStateBase64.clear();
+}
+
+void PluginSlot::reapFinishedRemoteLoads() noexcept
+{
+    for (auto entry = remoteLoads.begin(); entry != remoteLoads.end();)
+    {
+        if (entry->finished->load (std::memory_order_acquire))
+        {
+            if (entry->worker.joinable()) entry->worker.join();
+            entry = remoteLoads.erase (entry);
+        }
+        else
+        {
+            ++entry;
+        }
+    }
+}
+
+void PluginSlot::joinRemoteLoads() noexcept
+{
+    for (auto& entry : remoteLoads)
+        if (entry.worker.joinable()) entry.worker.join();
+    remoteLoads.clear();
+}
+
+void PluginSlot::beginRemoteLoad (PluginDescriptor descriptor,
+                                  std::uint32_t epoch,
+                                  std::string hostPath,
+                                  LoadCompletion onDone)
+{
+    reapFinishedRemoteLoads();
+
+    struct Outcome
+    {
+        std::unique_ptr<duskstudio::ipc::RemotePluginConnection> connection;
+        int  numIn { 0 };
+        int  numOut { 0 };
+        int  latency { 0 };
+        bool isInstrument { false };
+        std::string error;
+    };
+
+    // Everything the worker touches is copied across: it must not read the slot,
+    // whose completion is the only part that runs back on the message thread.
+    const auto descriptionXml = manager->descriptorToLegacyXml (descriptor).toStdString();
+    const auto sampleRate = preparedSampleRate;
+    const auto blockSize  = preparedBlockSize;
+    std::weak_ptr<char> life = lifeToken;
+    auto finished = std::make_shared<std::atomic<bool>> (false);
+
+    std::thread worker (
+        [this, life, epoch, onDone, descriptor, hostPath, descriptionXml,
+         sampleRate, blockSize, finished]
+    {
+        auto outcome = std::make_shared<Outcome>();
+        auto remote = std::make_unique<duskstudio::ipc::RemotePluginConnection>();
+
+        if (! remote->connect (hostPath, "--ipc-host", outcome->error))
+            remote.reset();
+        else if (! remote->loadPlugin (descriptionXml, sampleRate, blockSize,
+                                        outcome->numIn, outcome->numOut,
+                                        outcome->latency, outcome->isInstrument,
+                                        outcome->error))
+            remote.reset();
+        else
+            outcome->connection = std::move (remote);
+
+        // A queue that has gone away (shutdown) drops the lambda, and the
+        // connection dies with it - killing the child, which is what we want.
+        (void) dusk::callAsync ([this, life, epoch, onDone, descriptor, outcome,
+                                 sampleRate, blockSize]
+        {
+            if (! life.lock()) return;
+            if (currentLoadEpoch.load (std::memory_order_relaxed) != epoch)
+            {
+                if (onDone) onDone (false, "load superseded");
+                return;
+            }
+            if (outcome->connection == nullptr)
+            {
+                std::fprintf (stderr,
+                              "[Dusk Studio/PluginSlot] OOP load failed (%s); "
+                              "falling back to in-process.\n",
+                              outcome->error.c_str());
+                beginInProcessLoad (descriptor, epoch, onDone);
+                return;
+            }
+            // A device change while the load was in flight leaves the child on
+            // the configuration the load captured. prepareToPlay only reaches a
+            // published connection, and this one is not published yet, so the
+            // re-prepare has to happen here or the child would process its first
+            // block at the wrong rate and block size.
+            const bool configurationMoved =
+                preparedBlockSize != blockSize
+                || std::abs (preparedSampleRate - sampleRate) > 0.0;
+            if (configurationMoved)
+            {
+                std::string prepareError;
+                if (preparedBlockSize > duskstudio::ipc::kMaxBlock
+                    || ! outcome->connection->prepareToPlay (preparedSampleRate,
+                                                              preparedBlockSize,
+                                                              prepareError))
+                {
+                    std::fprintf (stderr,
+                                  "[Dusk Studio/PluginSlot] OOP re-prepare after a device "
+                                  "change failed (%s); falling back to in-process.\n",
+                                  prepareError.c_str());
+                    beginInProcessLoad (descriptor, epoch, onDone);
+                    return;
+                }
+            }
+
+            publishRemoteConnection (std::move (outcome->connection), descriptor,
+                                      outcome->numIn, outcome->numOut,
+                                      outcome->latency, outcome->isInstrument);
+            if (onDone) onDone (true, {});
+        });
+
+        finished->store (true, std::memory_order_release);
+    });
+
+    remoteLoads.push_back ({ std::move (worker), std::move (finished) });
 }
 
 void PluginSlot::retireRemoteConnection()
@@ -747,32 +907,9 @@ bool PluginSlot::loadFromDescriptor (const PluginDescriptor& descriptor,
                 }
                 else
                 {
-                    ownedRemote = std::move (remote);
-                    {
-                        // Same drain-then-reset-and-publish as loadFromFile above.
-                        const juce::SpinLock::ScopedLockType processGuard (processLock);
-                        remoteNumIn .store (numIn,  std::memory_order_relaxed);
-                        remoteNumOut.store (numOut, std::memory_order_relaxed);
-                        remoteIsInstrument.store (isInstrument,
-                                                    std::memory_order_relaxed);
-                        cachedLatencySamples.store (latency, std::memory_order_relaxed);
-                        blocksSinceLoad     = 0;
-                        consecutiveOverruns = 0;
-                        autoBypassed .store (false, std::memory_order_relaxed);
-                        remoteCrashed.store (false, std::memory_order_relaxed);
-                        currentRemote.store (ownedRemote.get(),
-                                                std::memory_order_release);
-                    }
-                    reaperTimer.startTimer (kReaperPeriodMs);
-                    fixedDescriptor.isInstrument = isInstrument;
-                    fixedDescriptor.numInputChannels = numIn;
-                    fixedDescriptor.numOutputChannels = numOut;
-                    loadedDescriptor = fixedDescriptor;
-                    offlineDescriptor.reset();
-                    offlineLegacyDescriptionXml.clear();
-                    offlineStateBase64.clear();
-                    offlineCapturePlaceholder = false;
-                    lastKnownStateBase64.clear();
+                    publishRemoteConnection (std::move (remote),
+                                              std::move (fixedDescriptor),
+                                              numIn, numOut, latency, isInstrument);
                     return true;
                 }
             }
@@ -848,26 +985,13 @@ bool PluginSlot::installInProcessInstance (std::unique_ptr<juce::AudioPluginInst
 }
 
 void PluginSlot::loadFromDescriptorAsync (const PluginDescriptor& descriptor,
-                                          std::function<void (bool, juce::String)> onDone)
+                                          LoadCompletion onDone)
 {
     if (manager == nullptr)
     {
         if (onDone) onDone (false, "PluginSlot has no PluginManager bound");
         return;
     }
-
-   #if DUSKSTUDIO_HAS_OOP_PLUGINS
-    // OOP load is already bounded by the IPC connect/load timeouts, so keep it
-    // synchronous; the off-thread path is the in-process win (slow sample
-    // decode). When OOP is enabled, fall back to the proven sync load.
-    if (manager->isOopEnabled())
-    {
-        juce::String err;
-        const bool ok = loadFromDescriptor (descriptor, err);
-        if (onDone) onDone (ok, err);
-        return;
-    }
-   #endif
 
     // Bump the load epoch first: a stale async completion compares epochs and
     // bails if a newer load / unload superseded it.
@@ -909,14 +1033,38 @@ void PluginSlot::loadFromDescriptorAsync (const PluginDescriptor& descriptor,
     // keeps playing the OOP plugin after currentInstance is nulled.
     retireRemoteConnection();
     remoteCrashed.store (false, std::memory_order_relaxed);
+
+    if (manager->isOopEnabled()
+        && preparedBlockSize > 0
+        && preparedBlockSize <= duskstudio::ipc::kMaxBlock)
+    {
+        const auto hostPath = manager->getHostExecutablePath();
+        if (hostPath.isNotEmpty() && juce::File (hostPath).existsAsFile())
+        {
+            beginRemoteLoad (std::move (fixedDescriptor), epoch,
+                              hostPath.toStdString(), std::move (onDone));
+            return;
+        }
+        std::fprintf (stderr,
+                      "[Dusk Studio/PluginSlot] OOP requested but host binary not found "
+                      "at \"%s\"; falling back to in-process.\n",
+                      hostPath.toRawUTF8());
+    }
    #endif
 
+    beginInProcessLoad (std::move (fixedDescriptor), epoch, std::move (onDone));
+}
+
+void PluginSlot::beginInProcessLoad (PluginDescriptor descriptor,
+                                     std::uint32_t epoch,
+                                     LoadCompletion onDone)
+{
     // Off-thread create; the completion fires on the MESSAGE thread. weak_ptr
     // to lifeToken guards against the slot being destroyed mid-load (token dies
     // with the slot -> weak_ptr expires -> bail before touching `this`).
     std::weak_ptr<char> life = lifeToken;
-    manager->createPluginInstanceAsync (fixedDescriptor, preparedSampleRate, preparedBlockSize,
-        [this, life, epoch, onDone, fixedDescriptor]
+    manager->createPluginInstanceAsync (descriptor, preparedSampleRate, preparedBlockSize,
+        [this, life, epoch, onDone, descriptor]
         (std::unique_ptr<juce::AudioPluginInstance> inst, juce::String err)
     {
         if (! life.lock()) return;                      // slot destroyed mid-load
@@ -931,7 +1079,7 @@ void PluginSlot::loadFromDescriptorAsync (const PluginDescriptor& descriptor,
                                                         : juce::String ("plugin creation failed"));
             return;
         }
-        const bool ok = installInProcessInstance (std::move (inst), fixedDescriptor);
+        const bool ok = installInProcessInstance (std::move (inst), descriptor);
         if (onDone) onDone (ok, ok ? juce::String() : juce::String ("install failed"));
     });
 }

--- a/src/engine/PluginSlot.h
+++ b/src/engine/PluginSlot.h
@@ -16,6 +16,9 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <string>
+#include <thread>
+#include <vector>
 
 namespace duskstudio
 {
@@ -35,6 +38,8 @@ class PluginManager;
 class PluginSlot : private dusk::Timer
 {
     using PluginInstancePtr = std::unique_ptr<juce::AudioPluginInstance>;
+    // Delivered on the message thread when an off-thread load settles.
+    using LoadCompletion = std::function<void (bool success, juce::String error)>;
 
 public:
     PluginSlot();
@@ -73,14 +78,15 @@ public:
     bool loadFromDescriptor (const PluginDescriptor& descriptor,
                              juce::String& errorMessage);
 
-    // Off-thread load (in-process only - OOP falls back to the sync path).
-    // Creates the instance on a background thread so a slow sample decode never
-    // freezes the UI, then swaps it in + fires onDone(success, error) ON THE
-    // MESSAGE THREAD. Safe against the slot being destroyed or a newer
-    // load/unload arriving mid-load (weak-token + load-epoch guards).
-    void loadFromDescriptorAsync (
-        const PluginDescriptor& descriptor,
-        std::function<void (bool success, juce::String error)> onDone);
+    // Off-thread load. Builds the instance away from the message thread - a
+    // background thread for the in-process create, the plugin host's own
+    // process for an out-of-process one - so neither a slow sample decode nor
+    // a child that stalls its handshake freezes the UI. Swaps the result in and
+    // fires onDone(success, error) ON THE MESSAGE THREAD. Safe against the slot
+    // being destroyed or a newer load/unload arriving mid-load (weak-token +
+    // load-epoch guards).
+    void loadFromDescriptorAsync (const PluginDescriptor& descriptor,
+                                  LoadCompletion onDone);
 
     void unload();
 
@@ -258,6 +264,14 @@ public:
    #endif
 
 private:
+    // Message-thread tail of an off-thread load: hands the descriptor to the
+    // plugin-instance builder and installs the result. Split out so the
+    // out-of-process path can fall back to it after a failed connect or
+    // LoadPlugin without re-rotating the keep-alive rings.
+    void beginInProcessLoad (PluginDescriptor descriptor,
+                             std::uint32_t epoch,
+                             LoadCompletion onDone);
+
     // Message-thread install tail shared by descriptor-based sync and async
     // loads. Primes + atomically swaps in the
     // already-built instance; caller has already rotated the keep-alive ring.
@@ -362,6 +376,37 @@ private:
     };
     ReaperTimer reaperTimer { *this };
     void pollRemoteReaper();
+
+    // Connect + LoadPlugin run here rather than on the message thread: the
+    // handshake alone waits 5 s and the RPC 30 s, so a plugin that stalls in
+    // the child would otherwise freeze the editor for the sum of the two.
+    //
+    // Workers are kept rather than joined at the next load: a second load
+    // arriving while the first child is still stalled must not inherit that
+    // wait, which is the freeze this whole path exists to avoid. Each worker
+    // raises its own flag on the way out and only flagged ones are joined,
+    // so the message thread never blocks on a live one. The slot's destructor
+    // joins whatever is left, bounded by the RPC timeouts and concurrent
+    // across workers.
+    struct RemoteLoad
+    {
+        std::thread worker;
+        std::shared_ptr<std::atomic<bool>> finished;
+    };
+    std::vector<RemoteLoad> remoteLoads;
+    void reapFinishedRemoteLoads() noexcept;
+    void joinRemoteLoads() noexcept;
+    void beginRemoteLoad (PluginDescriptor descriptor,
+                          std::uint32_t epoch,
+                          std::string hostPath,
+                          LoadCompletion onDone);
+
+    // Hand a connected child to the audio path. Shared by the synchronous and
+    // off-thread descriptor loads so the publish ordering lives in one place.
+    void publishRemoteConnection (
+        std::unique_ptr<duskstudio::ipc::RemotePluginConnection> connection,
+        PluginDescriptor descriptor,
+        int numIn, int numOut, int latency, bool isInstrument);
 
     // Stop the reaper, unpublish the live connection and shift it into the
     // deferred-destruction ring. Nulling currentRemote is not enough on its

--- a/tests/plugin_slot_lifecycle.cpp
+++ b/tests/plugin_slot_lifecycle.cpp
@@ -87,6 +87,33 @@ TEST_CASE ("PluginSlot republishes an in-process instance after release and prep
 }
 
 #if DUSKSTUDIO_HAS_OOP_PLUGINS
+// Connecting to the plugin host waits up to 5 s for the handshake and its
+// LoadPlugin RPC up to 30 s, so running either on the message thread hands a
+// plugin that stalls in the child the power to freeze the editor for over half
+// a minute - the failure the sandbox exists to contain. The load has to be
+// handed off, which shows up here as the completion never arriving inside the
+// call.
+TEST_CASE ("PluginSlot does not complete an out-of-process load inline")
+{
+    PluginManager manager;
+    manager.setOopEnabled (true);
+
+    PluginSlot slot;
+    slot.setManager (manager);
+    slot.prepareToPlay (48000.0, 64);
+
+    PluginDescriptor descriptor;
+    descriptor.name = "missing";
+    descriptor.formatName = "VST3";
+    descriptor.location = "/nonexistent/missing.vst3";
+
+    bool completed = false;
+    slot.loadFromDescriptorAsync (descriptor,
+                                  [&] (bool, juce::String) { completed = true; });
+
+    CHECK_FALSE (completed);
+}
+
 // The audio thread try-locks processLock and then stays inside
 // RemotePluginConnection::processBlockSync for up to the OOP block timeout,
 // reading the child's shared memory the whole time. Every message-thread path

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -24,7 +24,7 @@ src/engine/PlaybackEngine.cpp	3
 src/engine/PlaybackEngine.h	2
 src/engine/PluginManager.cpp	106
 src/engine/PluginManager.h	29
-src/engine/PluginSlot.cpp	71
+src/engine/PluginSlot.cpp	70
 src/engine/PluginSlot.h	40
 src/engine/RecordManager.cpp	3
 src/engine/RecordManager.h	2


### PR DESCRIPTION
Second half of #471. The first half (bounding the audio thread's wait on a dead child) went in with #486.

`loadFromDescriptorAsync` handed the work straight to the synchronous load whenever the sandbox was on. Connecting waits up to 5 seconds for the child's handshake and LoadPlugin up to 30, so a plugin that stalled on startup inside its own process froze the interface for over half a minute. That is the failure the sandbox is supposed to contain.

Connect and LoadPlugin now run on a worker and the result is published back on the message thread under the epoch and weak-token guards that were already there. A failed connect or load still falls back to loading the plugin in-process.

Two things that came out of review while writing it:

Workers are kept rather than joined when the next load starts. Joining there would have handed a second load whatever was left of the stalled child's timeout, which is the same freeze one step along. Each worker raises a flag on its way out and only flagged ones get joined, so the message thread never waits on a live one. The destructor joins what is left, bounded by the RPC timeouts and concurrent across workers.

A device change during a load is applied to the child before it is published. `prepareToPlay` only reaches a published connection and this one is not published yet, so without it the child would process its first block at the rate and block size the load captured. That window does not exist on the synchronous path; making the load async created it.

The publish sequence moved into `publishRemoteConnection`, shared with the synchronous path so the ordering lives in one place, and the completion type has a name now instead of being spelled out at all three load entry points.

The test asserts the completion never arrives inside the call, which is deterministic: with the sandbox off the existing async path already defers, with it on the old code completed inline. It does not exercise the worker itself. The test binary has no plugin host next to it, so `getHostExecutablePath` misses and the load takes the in-process fallback. Covering the real connect and publish path needs the host binary copied next to the test binary plus a stub that stalls, which I would rather do on its own.

Validation:

- `cmake --build build -j6` clean, no new warnings
- `ctest` 907/907
- `tools/juce-gate.sh` passes, 164 files, 8246 uses, down from 8247
- `scripts/run-selftest-xvfb.sh` 22 pass, 0 fail
- `coderabbit review --agent --uncommitted` 0 findings

No manual change. Nothing documented changes behaviour, the load just stops blocking the window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sandboxed plugin loading freezing the application window.
  * Plugin startup and loading now run in the background, keeping the interface responsive.
  * Failed sandboxed loads continue to fall back to in-process loading.

* **Tests**
  * Added coverage verifying out-of-process plugin loads complete asynchronously.

* **Documentation**
  * Updated the reported test-suite count in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->