### PR TITLE
refactor(ui): remove obsolete bus meter and channel helpers

### DIFF
--- a/docs/dejuce-gui-plan.md
+++ b/docs/dejuce-gui-plan.md
@@ -663,12 +663,15 @@ application reads its own steady frame back as a PPM and
 
 ### G3 — The console
 
-**Preparation in progress; native console not started.** The first cleanup
-removes unused styling, layout and formatter helpers from
-`MasterStripComponent.cpp`, ahead of its structural rewrite. Live controls,
-formatting, layout and polling are unchanged. From the post-G2 base `de3a88e`,
-the gate moves from 164 files / 8,241 uses to 164 / 8,214; no file leaves the
-allowlist and no module unlinks.
+**Preparation in progress; native console not started.** The master-strip
+cleanup landed in PR #511, taking the gate from 164 files / 8,241 uses to
+164 / 8,214. The next cleanup removes the bus strip's permanently empty legacy
+GR meter, its unused polling and layout state, and the channel strip's unused
+drawing helper and redundant unused-value calls. The visible bus GR meter has
+its own polling and smoothing in `CompMeterStrip`; that path and the compressor
+editor's separate meter are unchanged. Live controls, formatting and layout
+are preserved. This pass takes the gate from 164 / 8,214 to 164 / 8,186;
+no file leaves the allowlist and no module unlinks.
 G0, G1 and both G2 passes are already on main (G2 remainder: PR #356).
 The accessibility decision in §3 and G2's outstanding desktop sign-offs remain
 prerequisites for the console port.

--- a/src/ui/BusComponent.cpp
+++ b/src/ui/BusComponent.cpp
@@ -3,7 +3,6 @@
 #include "DuskContextMenu.h"
 #include "DuskLabelEditor.h"
 #include "SteppedKnob.h"
-#include "CompBypassLed.h"
 #include "DuskStudioLookAndFeel.h"  // fourKColors palette
 #include "../session/MidiBindings.h"
 #include "../session/ParamEditAction.h"
@@ -1041,13 +1040,7 @@ void BusComponent::timerCallback()
         maxHold >= -12.0f ? juce::Colour (0xffe0c050) :
                              juce::Colour (0xffd0d0d0));
 
-    // GR is shown by the graphical GR meter; displayedGrDb still feeds it.
-    const float gr = bus.strip.meterGrDb.load (std::memory_order_relaxed);
-    if (gr < displayedGrDb) displayedGrDb = gr;
-    else                    displayedGrDb += (gr - displayedGrDb) * 0.5f;  // ~48 ms recovery (was ~167 ms)
-
     if (! meterArea.isEmpty())   repaint (meterArea);
-    if (! grMeterArea.isEmpty()) repaint (grMeterArea.expanded (2, 10));  // include "GR" caption
 
     // Motor-fader / motor-pan animation + Write/Touch capture - same grammar
     // as ChannelStripComponent. We poll the live* atoms (the engine writes
@@ -1328,48 +1321,10 @@ void BusComponent::paint (juce::Graphics& g)
                      displayedOutputRDb);
     }
 
-    // Bus-comp GR meter - fills DOWN from top as compression bites. Same
-    // colour story as the channel strip's GR bar so the visual language is
-    // consistent across the mixer.
-    if (! grMeterArea.isEmpty())
-    {
-        const auto bar = grMeterArea.toFloat();
-        g.setColour (juce::Colour (0xff0c0c0e));
-        g.fillRoundedRectangle (bar, 1.5f);
-        g.setColour (juce::Colour (0xff2a2a2e));
-        g.drawRoundedRectangle (bar, 1.5f, 0.5f);
-
-        constexpr float kGrFloorDb = 20.0f;
-        const float grAbs = jlimit (0.0f, kGrFloorDb, std::abs (displayedGrDb));
-        if (grAbs > 0.05f)
-        {
-            const float frac = grAbs / kGrFloorDb;
-            const float fillH = (bar.getHeight() - 4.0f) * frac;
-            auto fillRect = juce::Rectangle<float> (bar.getX() + 1.5f,
-                                                      bar.getY() + 2.0f,
-                                                      bar.getWidth() - 3.0f, fillH);
-            juce::ColourGradient grad (juce::Colour (0xffe0c050).brighter (0.2f),
-                                         bar.getX(), bar.getY(),
-                                         juce::Colour (0xffe05050).brighter (0.1f),
-                                         bar.getX(), bar.getBottom(), false);
-            g.setGradientFill (grad);
-            g.fillRoundedRectangle (fillRect, 1.0f);
-        }
-
-        // Tiny "GR" caption above the bar so the user knows what it is.
-        g.setColour (juce::Colour (0xff909094));
-        g.setFont (juce::Font (juce::FontOptions (7.0f, juce::Font::bold)));
-        g.drawText ("GR",
-                     juce::Rectangle<float> (bar.getX() - 2.0f, bar.getY() - 9.0f,
-                                              bar.getWidth() + 4.0f, 8.0f),
-                     juce::Justification::centred, false);
-    }
-
     // Fader dB scale labels - drawn LEFT of the slider's track (track-3
     // grammar). Each label has a short tick line stub extending toward
     // the track; the label glyph sits a few px further left for breathing
-    // room. Skipped when the fader scale column was carved out (legacy
-    // layout fallback).
+    // room.
     {
         const auto& range = faderSlider.getNormalisableRange();
         const auto sliderB = faderSlider.getBounds().toFloat();
@@ -1544,17 +1499,9 @@ void BusComponent::resized()
     }
     area.removeFromTop (3);
 
-    // Comp section. Mirrors the channel strip:
-    //   Header  : CompHeaderButton (full width, 16 px)
-    //   Body    : CompMeterStrip on the LEFT (36 px), 2×2 knob grid on
-    //             the RIGHT (RAT / MAK on top, ATK / REL on bottom).
-    //             Threshold is set via the triangle handle on the meter
-    //             - no dedicated THR knob.
     {
         constexpr int kCompKnobLabelH = 10;
         constexpr int kCompKnobRowH   = kCompKnobLabelH + kKnobBlockH;
-        constexpr int kCompMeterW     = 36;
-        constexpr int kCompMeterGap   = 4;
 
         // Single-row COMP body (matches channel-strip track-3 grammar):
         // 4 knobs (RAT / ATK / REL / MAK) across one row - no 2×2 grid.
@@ -1568,10 +1515,6 @@ void BusComponent::resized()
         s.removeFromTop (2);
 
         auto body = s.removeFromTop (kCompBodyH);
-        // The comp GR indicator is the fader-side GR LED (placed beside the
-        // level meter further below), not inside the COMP section, so the
-        // 4-knob row uses the full body width.
-        juce::ignoreUnused (kCompMeterW, kCompMeterGap);
 
         auto layoutCell = [&] (juce::Rectangle<int> cell,
                                  juce::Slider& knob, juce::Label& label)
@@ -1667,13 +1610,6 @@ void BusComponent::resized()
     constexpr int kFaderColW = 50;
     if (area.getWidth() > kFaderColW)
         area = area.removeFromRight (kFaderColW);
-    // paint() positions the scale labels directly left of the fader track, so
-    // no column is carved out for them here.
-    faderScaleArea = juce::Rectangle<int>();
-    // grMeterArea was the old standalone GR bar; compMeter now owns the
-    // GR display (placed beside the level meter below). Empty rect tells
-    // paint() to skip drawing the legacy bar + caption.
-    grMeterArea = juce::Rectangle<int>();
 
     // Pan knob/label centred on the FADER column X.
     const int faderCentreX = area.getCentreX();

--- a/src/ui/BusComponent.h
+++ b/src/ui/BusComponent.h
@@ -108,11 +108,7 @@ private:
 
     // Stereo output meter (L | R) on the right side of the fader, matching
     // the master strip's layout. Smoothed and peak-hold values per channel.
-    // Plus a slim vertical GR bar (top-down fill, gold->red) so the user
-    // sees compressor activity at a glance, not just as a numeric readout.
     juce::Rectangle<int> meterArea;
-    juce::Rectangle<int> grMeterArea;
-    juce::Rectangle<int> faderScaleArea;
     // Painted background bands for the EQ + COMP sections - same framed
     // look as the channel strip's eqArea / compArea so all strip types
     // share one visual grammar.
@@ -138,7 +134,6 @@ private:
     juce::Label outputPeakLabel;
     float displayedOutputLDb = -100.0f;
     float displayedOutputRDb = -100.0f;
-    float displayedGrDb      = 0.0f;
     float outputPeakHoldLDb  = -100.0f;
     float outputPeakHoldRDb  = -100.0f;
     int   outputPeakHoldFramesL = 0;

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -2836,7 +2836,6 @@ void ChannelStripComponent::openPluginEditor()
             // cannot hide it under a settings/quit modal - that needs an
             // explicit IPC HideEditor/ShowEditor round-trip driven by modal
             // open/close, deferred to the tracked NSView-embed work.
-            juce::ignoreUnused (w, h);
         }
        #else
         // Windows: cross-process HWND reparenting via SetParent
@@ -2853,12 +2852,6 @@ void ChannelStripComponent::openPluginEditor()
             embed->getProperties().set (kPluginEditorTag, true);
             pluginEditorModal.showBorrowed (*parent, *embed, onClose);
             remoteForeignEmbed = std::move (embed);
-        }
-        else
-        {
-            // Embed creation failed (HWND no longer valid, etc.) - let
-            // the child's floating window stand in.
-            juce::ignoreUnused (w, h);
         }
        #endif
         return;
@@ -5635,19 +5628,6 @@ void ChannelStripComponent::armCompOnUserEdit()
         track.strip.compEnabled.store (true, std::memory_order_relaxed);
         refreshCompModeButtonState();
     }
-}
-
-static void drawSectionPlaceholder (juce::Graphics& g, juce::Rectangle<int> r,
-                                    const juce::String& label, juce::Colour accent)
-{
-    if (r.isEmpty()) return;
-    g.setColour (juce::Colour (0xff222226));
-    g.fillRoundedRectangle (r.toFloat(), 3.0f);
-    g.setColour (accent.withAlpha (0.45f));
-    g.drawRoundedRectangle (r.toFloat().reduced (0.5f), 3.0f, 0.8f);
-    g.setColour (accent.withAlpha (0.85f));
-    g.setFont (juce::Font (juce::FontOptions (9.5f, juce::Font::bold)));
-    g.drawText (label, r.reduced (4, 2), juce::Justification::centredTop, false);
 }
 
 namespace

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -65,11 +65,11 @@ src/ui/AuxView.cpp	60
 src/ui/AuxView.h	5
 src/ui/BounceDialog.cpp	45
 src/ui/BounceDialog.h	12
-src/ui/BusComponent.cpp	309
-src/ui/BusComponent.h	47
+src/ui/BusComponent.cpp	294
+src/ui/BusComponent.h	45
 src/ui/ChannelEqEditor.cpp	93
 src/ui/ChannelEqEditor.h	13
-src/ui/ChannelStripComponent.cpp	770
+src/ui/ChannelStripComponent.cpp	759
 src/ui/ChannelStripComponent.h	111
 src/ui/ClapPluginEditorComponent.cpp	18
 src/ui/ClapPluginEditorComponent.h	8


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Interface**
  * Removed the redundant standalone gain-reduction meter from the bus strip.
  * Gain-reduction monitoring remains available through the fader-side meter, with its existing polling and smoothing unchanged.
  * The compressor editor’s separate meter is unaffected.

* **Documentation**
  * Updated the De-JUCE GUI cleanup plan to reflect completed and upcoming work.

* **Refactor**
  * Removed unused channel-strip drawing and layout code without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->