### PR TITLE
refactor(ui): remove unused channel meter labels

### DIFF
--- a/docs/dejuce-gui-plan.md
+++ b/docs/dejuce-gui-plan.md
@@ -663,15 +663,20 @@ application reads its own steady frame back as a PPM and
 
 ### G3 — The console
 
-**Preparation in progress; native console not started.** The master-strip
-cleanup landed in PR #511, taking the gate from 164 files / 8,241 uses to
-164 / 8,214. The next cleanup removes the bus strip's permanently empty legacy
-GR meter, its unused polling and layout state, and the channel strip's unused
-drawing helper and redundant unused-value calls. The visible bus GR meter has
-its own polling and smoothing in `CompMeterStrip`; that path and the compressor
-editor's separate meter are unchanged. Live controls, formatting and layout
-are preserved. This pass takes the gate from 164 / 8,214 to 164 / 8,186;
-no file leaves the allowlist and no module unlinks.
+**Preparation in progress; native console not started.** PRs #511–#513 removed
+unused master/bus metering, channel drawing helpers and obsolete console layout
+branches. The channel fader's conflicting range override was also removed in
+#513 so it uses the parameter domain of -100 to +12 dB, as documented. Together
+these changes took the gate from 164 files / 8,241 uses to 164 / 8,149.
+
+The current cleanup removes the channel strip's unused GR/threshold labels and
+the GR polling/smoothing that fed them, and consolidates the input readout's
+duplicate font setup. The labels never had drawable bounds;
+the visible GR meter owns its state and polling in `CompMeterStrip` and is
+unchanged. The gate falls to 164 / 8,097, with no allowlist departures or module
+unlinks. Remaining preparation includes the aux lane's no-op editor helper;
+the fader's screen-reader mute-label mismatch is a separate behavior fix.
+
 G0, G1 and both G2 passes are already on main (G2 remainder: PR #356).
 The accessibility decision in §3 and G2's outstanding desktop sign-offs remain
 prerequisites for the console port.

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -542,7 +542,7 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
     }
     addAndMakeVisible (compMeter.get());
 
-    startTimerHz (30);  // input + GR meter refresh on the main strip
+    startTimerHz (30);
 
     for (size_t i = 0; i < bandSpecs().size(); ++i)
     {
@@ -928,64 +928,10 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
     // 1 px border drew on top of the textbox edge, looking like overlap.
     inputPeakLabel.setColour (juce::Label::outlineColourId,    juce::Colours::transparentBlack);
     inputPeakLabel.setFont (juce::Font (juce::FontOptions (juce::Font::getDefaultMonospacedFontName(),
-                                                            10.0f, juce::Font::bold)));
-    inputPeakLabel.setMinimumHorizontalScale (1.0f);   // never truncate to "..."
+                                                            11.0f, juce::Font::bold)));
+    inputPeakLabel.setMinimumHorizontalScale (0.40f);
     inputPeakLabel.setText ("-inf", juce::dontSendNotification);
     addAndMakeVisible (inputPeakLabel);
-
-    // GR readout - sits to the right of the input peak. Negative dB when
-    // the comp is pulling the signal down. Uses gold-on-black to read as a
-    // comp-section indicator distinct from the input level.
-    grPeakLabel.setJustificationType (juce::Justification::centred);
-    grPeakLabel.setColour (juce::Label::textColourId,        juce::Colour (0xffe0c050));
-    grPeakLabel.setColour (juce::Label::backgroundColourId,  juce::Colours::transparentBlack);
-    grPeakLabel.setColour (juce::Label::outlineColourId,     juce::Colours::transparentBlack);
-    grPeakLabel.setFont (juce::Font (juce::FontOptions (juce::Font::getDefaultMonospacedFontName(),
-                                                          12.0f, juce::Font::bold)));
-    grPeakLabel.setText ("0.0", juce::dontSendNotification);
-    grPeakLabel.setTooltip ("Gain reduction in dB (negative = comp pulling down). "
-                             "Goes inert when the comp is bypassed.");
-    addAndMakeVisible (grPeakLabel);
-
-    // Fader-side GR numeric readout - mirrors grPeakLabel's
-    // styling so it reads as the same UI element, just attached to the
-    // fader-side slim LED instead of the COMP section. Hidden by default;
-    // resized() flips it on when the layout is active.
-    grReadoutLabel.setJustificationType (juce::Justification::centred);
-    grReadoutLabel.setColour (juce::Label::textColourId,        juce::Colour (0xffe0c050));
-    grReadoutLabel.setColour (juce::Label::backgroundColourId,  juce::Colours::transparentBlack);
-    grReadoutLabel.setColour (juce::Label::outlineColourId,     juce::Colours::transparentBlack);
-    grReadoutLabel.setFont (juce::Font (juce::FontOptions (juce::Font::getDefaultMonospacedFontName(),
-                                                              12.0f, juce::Font::bold)));
-    grReadoutLabel.setMinimumHorizontalScale (1.0f);
-    grReadoutLabel.setText ("0.0", juce::dontSendNotification);
-    grReadoutLabel.setTooltip ("Gain reduction in dB. Inert while the comp is bypassed.");
-    grReadoutLabel.setVisible (false);
-    addAndMakeVisible (grReadoutLabel);
-
-    // The bottom-row readouts live in a far
-    // narrower column than the default kPeakColumnW slot, so the 12-pt
-    // monospaced font (chosen for the wider default layout) truncates
-    // "-13.5"/"-inf" with an ellipsis. Override AFTER the default setup
-    // so these stick; small font + permissive horizontal scale so JUCE
-    // squishes to fit instead of clipping.
-    {
-        const juce::Font readoutFont (juce::FontOptions (
-            juce::Font::getDefaultMonospacedFontName(), 11.0f, juce::Font::bold));
-        inputPeakLabel.setFont (readoutFont);
-        inputPeakLabel.setMinimumHorizontalScale (0.40f);
-        grReadoutLabel.setFont (readoutFont);
-        grReadoutLabel.setMinimumHorizontalScale (0.40f);
-    }
-
-    // "THR" label sits above CompMeterStrip's drag handle so the engineer
-    // sees what the triangle pointer controls. Same gold tone as the COMP
-    // section labels so it reads as part of the comp UI.
-    threshMeterLabel.setText ("THR", juce::dontSendNotification);
-    threshMeterLabel.setJustificationType (juce::Justification::centred);
-    threshMeterLabel.setColour (juce::Label::textColourId, juce::Colour (0xffb07050));
-    threshMeterLabel.setFont (juce::Font (juce::FontOptions (8.5f, juce::Font::bold)));
-    addAndMakeVisible (threshMeterLabel);
 
     // Input monitor toggle (IN)
     monitorButton.setClickingTogglesState (true);
@@ -1606,13 +1552,7 @@ void ChannelStripComponent::setCompSectionVisible (bool visible)
     vcaAttackKnob   .setVisible (visible);  vcaAttackLabel  .setVisible (visible);
     vcaReleaseKnob  .setVisible (visible);  vcaReleaseLabel .setVisible (visible);
     vcaOutputKnob   .setVisible (visible);  vcaOutputLabel  .setVisible (visible);
-    // compMeter now lives INSIDE the COMP section (next to the per-mode
-    // knobs) so it follows section visibility. In compact mode the popup
-    // owns its own threshold drag so we don't lose access.
     if (compMeter != nullptr) compMeter->setVisible (visible);
-    threshMeterLabel.setVisible (false);   // "THR" header unused; drag lives in the COMP meter strip
-    grPeakLabel    .setVisible (false);    // numeric GR readout retired - the
-                                            // meter bar already shows GR clearly
 
     // Re-apply the per-mode filter so only the active mode's knobs are
     // shown. Without this, flipping out of TIMELINE (or any path that
@@ -4440,14 +4380,6 @@ void ChannelStripComponent::timerCallback()
         }
     }
 
-    const float gr = track.meterGrDb.load (std::memory_order_relaxed);
-    if (gr < displayedGrDb)
-        displayedGrDb = gr;                              // instant attack
-    else
-        // ~48 ms recovery (was 0.18 = ~167 ms, which masked comp release times
-        // faster than the meter's own ballistic). Truer GR readout.
-        displayedGrDb += (gr - displayedGrDb) * 0.5f;
-
     // Input level meter - fast attack on rise, slow decay; with a peak-hold
     // marker that lingers for ~600 ms before falling. Stereo mode also
     // smooths the R channel so the second LED bar can be drawn alongside.
@@ -4520,39 +4452,6 @@ void ChannelStripComponent::timerCallback()
         inputPeakHoldDb >= -3.0f  ? juce::Colour (0xffff5050) :
         inputPeakHoldDb >= -12.0f ? juce::Colour (0xffe0c050) :
                                      juce::Colour (0xffd0d0d0));
-
-    // GR readout: show "-X.X" when the comp is reducing, dim "0.0" otherwise.
-    // displayedGrDb is already smoothed above (asymmetric: fast attack on
-    // rise, slow release on fall), matching the visual GR meter.
-    if (displayedGrDb <= -0.05f)
-    {
-        grPeakLabel.setText (juce::String (displayedGrDb, 1), juce::dontSendNotification);
-        grPeakLabel.setColour (juce::Label::textColourId, juce::Colour (0xffe0c050));
-    }
-    else
-    {
-        grPeakLabel.setText ("0.0", juce::dontSendNotification);
-        grPeakLabel.setColour (juce::Label::textColourId, juce::Colour (0xff606064));
-    }
-
-    // Fader-side GR readout: numeric value sitting below the slim
-    // GR LED. Inert grey when bypassed or no compression; gold when active.
-    {
-        const bool engaged = track.strip.compEnabled.load (std::memory_order_relaxed);
-        if (engaged && displayedGrDb <= -0.05f)
-        {
-            grReadoutLabel.setText (juce::String (displayedGrDb, 1),
-                                      juce::dontSendNotification);
-            grReadoutLabel.setColour (juce::Label::textColourId,
-                                        juce::Colour (0xffe0c050));
-        }
-        else
-        {
-            grReadoutLabel.setText ("0.0", juce::dontSendNotification);
-            grReadoutLabel.setColour (juce::Label::textColourId,
-                                        juce::Colour (0xff606064));
-        }
-    }
 
     // Motor-fader / motor-pan animation: when the audio engine is feeding
     // a live atom from the lane (Read, or Touch when not grabbed), mirror
@@ -6342,9 +6241,6 @@ void ChannelStripComponent::resized()
         }
     }
 
-    grPeakLabel  .setVisible (false);
-    grReadoutLabel.setVisible (false);
-
     // Numeric output-peak readout centred under the meter + GR-LED cluster,
     // matching the bus / master strips (the LED itself is the level scale;
     // the number is the peak hold). The cluster spans the level meter through
@@ -6366,8 +6262,6 @@ void ChannelStripComponent::resized()
     const int bottomTrim = (int) duskstudio::kFaderTrackPad
                            + (compactMode ? kCompactFaderBottomTrim : 0);
     meterColumn = meterColumn.withTrimmedBottom (bottomTrim);
-
-    threshMeterLabel.setVisible (false);
 
     // Pan section pinned to the TOP of the fader column. Knob is centered on
     // the same fixed centreline as the slider thumb's track.

--- a/src/ui/ChannelStripComponent.h
+++ b/src/ui/ChannelStripComponent.h
@@ -94,7 +94,6 @@ private:
     class PluginSlot& pluginSlot;
     AudioEngine& engine;
     std::array<std::uint32_t, ChannelStripParams::kNumBuses> lastBusColours {};
-    float displayedGrDb = 0.0f;
     float displayedInputDb = -100.0f;
     float inputPeakHoldDb = -100.0f;
     int   inputPeakHoldFrames = 0;
@@ -203,12 +202,9 @@ private:
     bool lastGroupMaster = false;
     juce::Colour lastTrackColour;   // cached so the timer repaints on external colour change (undo)
     juce::Label inputPeakLabel;
-    juce::Label grPeakLabel;
-    juce::Label grReadoutLabel;
     // Slider runs NoTextBox so the cap at min value doesn't overlap
     // the textbox area.
     juce::Label faderValueLabel;
-    juce::Label threshMeterLabel;
     juce::TextButton muteButton    { "M" };
     juce::TextButton soloButton    { "S" };
     juce::TextButton phaseButton   { juce::CharPointer_UTF8 ("\xc3\x98") };  // Ø

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -69,8 +69,8 @@ src/ui/BusComponent.cpp	294
 src/ui/BusComponent.h	45
 src/ui/ChannelEqEditor.cpp	93
 src/ui/ChannelEqEditor.h	13
-src/ui/ChannelStripComponent.cpp	740
-src/ui/ChannelStripComponent.h	109
+src/ui/ChannelStripComponent.cpp	691
+src/ui/ChannelStripComponent.h	106
 src/ui/ClapPluginEditorComponent.cpp	18
 src/ui/ClapPluginEditorComponent.h	8
 src/ui/CompBypassLed.h	10


### PR DESCRIPTION
The channel strip constructed and updated three labels that never had drawable bounds. Remove those labels and their private GR polling/smoothing, and consolidate the input readout's duplicate font setup while preserving its effective appearance. The visible CompMeterStrip, input metering, layout and automation updates remain unchanged.

G3 preparation for #307 in the Complete JUCE removal campaign. Updates the GUI plan checkpoint; native console work remains gated on the accessibility decision in #305 and outstanding G2 desktop checks.

- JUCE gate: 164 files / 8,149 uses → 164 files / 8,097 uses. No allowlist departures, module unlinks or TSan changes.
- App and test builds passed with `-j4`, zero new warnings; ctest passed 939/939 in 31.87 seconds.
- All 38 before/after capture pairs were pixel-identical under isolated Xvfb; recording, mixing and compact channel layouts were visually reviewed.
- Reference, accessibility/focus, atomic-semantics and full-diff checks completed. No audio-path change; engine selftest was not rerun.

Four files changed. Release files, shared dependencies and scenario seams are untouched. Aux cleanup and the existing fader accessibility mute-label mismatch remain separate follow-ups.

Do not merge before v0.13.3 is tagged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Changes**
  - Removed gain-reduction and threshold readouts from channel strips.
  - Removed related gain-reduction smoothing and display updates.
  - Improved the input peak readout’s sizing and readability.
  - Simplified the channel strip’s lower-row display formatting.

- **Documentation**
  - Updated console preparation documentation to reflect the latest metering and layout cleanup progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->