### PR TITLE
refactor(ui): remove obsolete aux editor toggle

### DIFF
--- a/docs/dejuce-gui-plan.md
+++ b/docs/dejuce-gui-plan.md
@@ -666,16 +666,22 @@ application reads its own steady frame back as a PPM and
 **Preparation in progress; native console not started.** PRs #511–#513 removed
 unused master/bus metering, channel drawing helpers and obsolete console layout
 branches. The channel fader's conflicting range override was also removed in
-#513 so it uses the parameter domain of -100 to +12 dB, as documented. Together
+PR `#513` so it uses the parameter domain of -100 to +12 dB, as documented. Together
 these changes took the gate from 164 files / 8,241 uses to 164 / 8,149.
 
-The current cleanup removes the channel strip's unused GR/threshold labels and
-the GR polling/smoothing that fed them, and consolidates the input readout's
+PR #514 removed the channel strip's unused GR/threshold labels and
+the GR polling/smoothing that fed them, and consolidated the input readout's
 duplicate font setup. The labels never had drawable bounds;
 the visible GR meter owns its state and polling in `CompMeterStrip` and is
-unchanged. The gate falls to 164 / 8,097, with no allowlist departures or module
-unlinks. Remaining preparation includes the aux lane's no-op editor helper;
-the fader's screen-reader mute-label mismatch is a separate behavior fix.
+unchanged. The gate fell to 164 / 8,097, with no allowlist departures or module
+unlinks.
+
+The current cleanup removes the aux lane's empty editor-toggle helper and its
+unused PluginSlot forward declaration, plus obsolete bus-layout prose. The
+native-slot tooltip now describes removal instead of promising an editor toggle.
+Loaded slots still keep the picker closed; empty slots still open it. The gate
+stays at 164 / 8,097. The fader's screen-reader mute-label mismatch remains a
+separate behavior fix.
 
 G0, G1 and both G2 passes are already on main (G2 remainder: PR #356).
 The accessibility decision in §3 and G2's outstanding desktop sign-offs remain

--- a/src/ui/AuxLaneComponent.cpp
+++ b/src/ui/AuxLaneComponent.cpp
@@ -363,14 +363,10 @@ AuxLaneComponent::AuxLaneComponent (AuxLane& l, AuxLaneStrip& s, int idx,
             if (slotRef.isLoaded() || strip.isNativeClapLoaded (i) || strip.isNativeLv2Loaded (i)
                 || strip.isNativeVst3Loaded (i) || strip.isNativeAuLoaded (i))
             {
-                // Native CLAP fills the inline editor area when loaded (same as a JUCE
-                // plugin); clicking the name must not re-open the picker over it.
-                toggleEditorForSlot (i);
+                // Keep the picker closed for loaded slots; their editors are inline.
+                return;
             }
-            else
-            {
-                openPickerForSlot (i);
-            }
+            openPickerForSlot (i);
         };
         addAndMakeVisible (s.openOrAddButton);
 
@@ -689,7 +685,7 @@ void AuxLaneComponent::refreshSlotControls (int i)
             ? "This plug-in is offline after a restore or reactivation failure. "
               "Its saved reference and state will be preserved; replace or remove "
               "it to recover this slot."
-            : "Click to toggle the plug-in editor.");
+            : "Use X to remove this plug-in.");
     };
 
     const int mode = strip.insertMode[(size_t) i].load (std::memory_order_relaxed);
@@ -1127,13 +1123,6 @@ void AuxLaneComponent::unloadSlot (int slotIdx)
         self->refreshSlotControls (slotIdx);
         self->rebuildSlots();
     });
-}
-
-void AuxLaneComponent::toggleEditorForSlot (int /*slotIdx*/)
-{
-    // Editor embeds inline whenever the slot is loaded - nothing to
-    // toggle. Clicks on the slot's name button when loaded fall through
-    // to a no-op; users use the X button to unload the slot.
 }
 
 void AuxLaneComponent::attachEditorForSlot (int slotIdx)

--- a/src/ui/AuxLaneComponent.h
+++ b/src/ui/AuxLaneComponent.h
@@ -12,7 +12,6 @@
 
 namespace duskstudio
 {
-class PluginSlot;
 class AuxLaneStrip;
 class AudioEngine;
 class HardwareInsertEditor;
@@ -65,7 +64,6 @@ private:
     void openPickerForSlot (int slotIdx);
     void openHardwareInsertEditor (int slotIdx);
     void unloadSlot (int slotIdx);
-    void toggleEditorForSlot (int slotIdx);
     void refreshSlotControls (int slotIdx);
     void attachEditorForSlot (int slotIdx);
     void detachEditorForSlot (int slotIdx);

--- a/src/ui/BusComponent.cpp
+++ b/src/ui/BusComponent.cpp
@@ -574,11 +574,6 @@ BusComponent::BusComponent (Bus& b, Session& s, AudioEngine& e, int idx)
 
     // Comp section. The split header mirrors the channel-strip COMP and the
     // processor remains a fixed SSL-style glue topology.
-    //   - CompMeterStrip on the LEFT (handle + IN bar + dB scale + GR
-    //     bar). Threshold drag writes bus.strip.compThreshDb (-60..0).
-    //   - Knob grid on the RIGHT: RAT / ATK + REL / MAK across two rows.
-    //     The standalone THR knob is gone - threshold is set via the
-    //     triangle handle on the meter.
     compHeaderBtn = std::make_unique<SplitModuleButton> ("COMP");
     compHeaderBtn->setAccentColour (compGold);
     compHeaderBtn->setCallbacks (

--- a/src/ui/BusComponent.h
+++ b/src/ui/BusComponent.h
@@ -63,10 +63,6 @@ private:
     juce::Slider     eqHfGain  { juce::Slider::RotaryHorizontalVerticalDrag, juce::Slider::TextBoxBelow };
     juce::Label      eqLfLbl, eqMidLbl, eqHfLbl;
 
-    // Bus compressor controls. Shell mirrors the channel-strip COMP
-    // section visually: a split module button on top, a CompMeterStrip
-    // on the left, and the parameter knob grid on the right. The DSP
-    // underneath is still a fixed SSL-style glue topology - no mode picker.
     std::unique_ptr<SplitModuleButton> compHeaderBtn;
     std::unique_ptr<CompMeterStrip>   compMeter;
     juce::Slider     compRatio   { juce::Slider::RotaryHorizontalVerticalDrag, juce::Slider::TextBoxBelow };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated AUX plugin-slot behavior so loaded slots keep the picker closed, while empty slots open it directly.
  * Revised offline/native slot guidance to indicate how to remove the plugin.

* **Documentation**
  * Updated console preparation notes with the channel fader range and clarified current slot-picker behavior.
  * Removed outdated compressor layout and threshold-drag descriptions.
  * Documented remaining fader accessibility limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->