### PR TITLE
Preserve accessible fader mute values and scope the native bridge

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2226,18 +2226,20 @@ Either way, free the device in the other app (or run `pactl suspend-sink <sink-n
 
 Dusk Studio targets functional accessibility for screen reader users. The 24-channel strip is dense; the goal is for a screen reader to identify each control's role and read its current value without the user having to guess.
 
-## What works today
+## Current support
 
-- Every channel-strip rotary (HPF, LPF, EQ band gain / freq / Q, compressor knobs, pan, fader, aux sends) has an accessibility title and reports its formatted value: `-4.2 dB`, `L42`, `OFF`, `4:1`, etc. VoiceOver on macOS and Orca on Linux speak both the role and the value on focus.
-- Bus strips, aux returns, and the master strip follow the same convention.
-- Help text (the long-form description for each control) is wired from the existing tooltip strings, so the screen reader's verbose-mode readout matches what a sighted user sees on hover.
-- Every text-input dialog (region rename, marker rename, MIDI region label) renders inside the main window via the EmbeddedModal framework — no native popups that escape the screen reader's focus tree.
+- Channel faders, pan, HPF/LPF, mute, solo, record arm, input monitor, insert slots and aux sends have track-specific accessible names. Several continuous controls report formatted values such as `-4.2 dB`, `L42`, `OFF` and `4:1`. Channel faders report `-INF dB` throughout the hard-mute range, at or below −90 dB. A screen reader's text-value action can send `-INF` or `-INF dB` to set the fader to its muted minimum; the fader has no editable text box.
+- Aux return faders, aux mute buttons and aux plugin slots have lane-specific names. Transport buttons are named Play, Stop, Record, Rewind and Fast forward. Standard sliders and buttons expose their tooltip text as accessible help.
+- The popup menu exposes its active option and an activation action. Keyboard navigation updates the active-option announcement; this is not a separately navigable accessible item for every painted row.
+- macOS and Windows have platform accessibility support for the existing component controls. Coverage and focus behavior still need hands-on screen-reader verification. Native panels need the accessibility bridge that is currently being developed.
+- Linux screen-reader support through AT-SPI, including Orca, is not yet implemented. The existing control names and values do not by themselves make the Linux application accessible.
 
 ## What's still rough
 
+- Naming and formatted-value coverage is incomplete, particularly in the EQ editors, bus and master strips. Modal keyboard focus handling does not guarantee that a screen reader is confined to the active dialog or returns to the expected control after dismissal.
 - In the **Recording** and **Mixing** stages, **Left / Right arrows** move a gold focus ring across the 24 channel strips, automatically flipping the visible page as you cross a boundary. The focused strip is the target for the **A / S / X** (arm / solo / mute) shortcuts, so you can walk the mixer and toggle states without the mouse. (Clicking a strip moves the ring too.)
 - Region drag-and-drop on the timeline relies on mouse gestures. Region edit actions (split, trim, fade, gain) are all available via the keyboard reference; the drag-to-move case is the gap.
-- Plugin editors are out of Dusk Studio's accessibility control surface. JUCE forwards screen-reader requests to each plugin; vendor accessibility varies.
+- Plugin editors provide their own accessibility support; coverage varies by vendor and plugin format.
 
 ## Filing issues
 

--- a/docs/dejuce-accessibility-plan.md
+++ b/docs/dejuce-accessibility-plan.md
@@ -1,0 +1,167 @@
+# GUI accessibility bridge — issue #305
+
+**Decision, 2026-09-08:** preserve screen-reader support with a platform
+accessibility bridge. G3 must preserve the existing semantic controls and pass
+desktop accessibility checks before the JUCE console is replaced. This decision
+does not waive the G2 desktop checks in [the GUI plan](dejuce-gui-plan.md).
+
+**First phase:** inventory the current support floor and correct the channel
+fader's accessible mute value and infinity-text parsing. No native bridge is implemented by this phase;
+#305 remains open. The next implementation must connect real native controls
+to a platform adapter and test their actions, not stop at a detached tree model.
+
+## What exists today
+
+This is a source audit of main `64efac2` and its fader correction, not a report
+from a running screen reader. Explicit accessibility annotations occur in six
+UI files: MainComponent, ChannelStripComponent, AuxLaneComponent, TransportBar,
+DuskComboBox and SplitModuleButton. Other JUCE widgets still inherit default
+handlers, so absence of explicit annotations is not absence of semantics.
+
+The Linux JUCE-wayland input supplies the shared handlers but no Linux native
+accessibility implementation. Its `modules/juce_gui_basics/juce_gui_basics.cpp`
+includes native accessibility implementations for macOS, Windows, iOS and
+Android; `native/accessibility/juce_Accessibility.cpp` supplies an empty native
+implementation otherwise. Therefore the labels below are existing application
+semantics to preserve, not evidence of working Linux AT-SPI or Orca support.
+Linux exposure is added capability; macOS and Windows require preservation of
+their existing native accessibility paths. Neither platform is signed off by
+this source audit.
+
+| Surface and source | Existing names, roles, values and actions | Limits to carry into the bridge work |
+|---|---|---|
+| [MainComponent](../src/ui/MainComponent.cpp), constructor | Title `Dusk Studio mixer`; description `16-channel portastudio-style mixer`; default component role is unspecified. The root requests keyboard focus. | The description is stale: the session has 24 tracks. The comment promising per-strip focus setup is not supported by a `setWantsKeyboardFocus` call in ChannelStripComponent or ConsoleView. Do not claim a verified strip traversal order. |
+| [ChannelStripComponent](../src/ui/ChannelStripComponent.cpp), constructor | Container title `Track N`, description `Channel strip for track N`. Track-qualified titles identify fader, pan, mute, solo, record arm, input monitor, print effects, HPF/LPF, EQ, insert slot and aux sends. | Compressor helper titles use their control label; the constructor's claim that every control is named is broader than the track-qualified title list. Preserve default button text and tooltip help too. |
+| Channel fader | Slider role, range −100 to +12 dB, step 0.1, reset to 0 dB on double-click. Value text is `-INF dB` at or below `ChannelStripParams::kFaderInfThreshDb` (−90), otherwise one decimal plus ` dB`. Case-insensitive `-INF` / `-INF dB` input selects the muted minimum. | Before this phase the formatter used −99.95, misreporting 100 valid hard-muted slider values. DSP uses ≤ −90; the standalone visible label uses ≤ −89.95, equivalent for the 0.1 dB slider grid. The default text parser interpreted the infinity label as zero; this phase keeps an accessible string round-trip muted and retains the default finite-number parsing. |
+| Channel pan and filter knobs | Slider roles. Pan speaks `C`, `L<pct>` or `R<pct>`. HPF/LPF speak `OFF` at their bypass ends, otherwise formatted frequency. Compressor helpers supply titles, suffixes and formatted values, including FET ratio. | Preserve units and bypass words. Pan and FET ratio still lack matching text parsers: `L50`/`R50` parse to centre, and `4:1`/`8:1`/`12:1`/`20:1` parse or clamp to index 4 (`All`). Their editable readouts and accessible string setters need separate corrections before native parity; this phase changes only the fader. |
+| Channel mute/solo/arm/monitor and [TransportBar](../src/ui/TransportBar.cpp) | JUCE button handler supplies press, checkable/checked state and `On`/`Off` for toggleable buttons. Transport has `Transport bar` plus `Play`, `Stop`, `Record`, `Rewind`, `Fast forward` titles. | Actions must use the existing callback path. A transport press invokes engine behavior; mute callbacks also handle automation. Writing only a boolean would omit these effects. |
+| Channel print/freeze control | `refreshPrintButtonForMode()` updates title and help between `Print effects on record`, `Freeze track` and `Unfreeze track`. | The dynamic title loses the constructor's track prefix. Preserve the mode-dependent meaning; track disambiguation is a follow-up, not established parity. |
+| [AuxLaneComponent](../src/ui/AuxLaneComponent.cpp), constructor | `Aux N`, description `Aux send/return lane N`; `Aux N return fader`, `Aux N mute`, `Aux N plugin slot M`. JUCE slider/button defaults supply value and actions. | Bus and master controls also inherit JUCE defaults; this audit found no matching explicit title pass there. They need a per-control inventory before their port. |
+| [SplitModuleButton](../src/ui/SplitModuleButton.h) | Explicit group role; two real child buttons named `<label> enabled` and `Open <label> editor`. The indicator is toggleable, and `refresh()` synchronizes external model state before repaint. | Keep both children actionable. A single painted region with one press loses the bypass/editor distinction. Child titles do not inherit a custom track-qualified group title. |
+| [DuskComboBox](../src/ui/DuskComboBox.cpp), MenuPanel | Explicit popup-menu role with press action. Painted rows are represented by the panel's active-row title; navigation emits `titleChanged`. Empty grid search announces no matching presets. | This is active-row announcement, not a tree of selectable row children. Disabled entries and headings cannot be activated. A richer row tree would improve this floor, not describe existing behavior. |
+| [EmbeddedModal](../src/ui/EmbeddedModal.h) | Opening requests body keyboard focus. A modal stack restores focus to the newest remaining body, or the registered shell target. Deferred restoration is invalidated when a newer modal opens. | There is no explicit accessible dialog/modal role or accessibility-tree exclusion in this seam. Visual dimming and keyboard handling do not establish screen-reader modality. |
+
+The JUCE behavior above is grounded in `juce_Slider.cpp`,
+`detail/juce_ButtonAccessibilityHandler.h`, `juce_Button.cpp` and
+`juce_Component.cpp` under `modules/juce_gui_basics` in the selected JUCE input.
+Slider accessible set-value uses `ScopedDragNotification`, synchronous value
+notification and the same min/max/interval as the widget. Its string setter uses
+the widget parser. Slider help comes from its tooltip, even when the app also
+sets help text. Buttons similarly use tooltip help; their press action triggers
+the button callback, and their toggle action updates the toggle state with
+notification.
+
+## Keyboard and focus contract
+
+These are source-supported handlers, not proof that every control is reachable
+from Tab in the shipped layout:
+
+- With shell keyboard focus in Recording/Mixing, unmodified Left/Right calls
+  `ConsoleView::moveFocus`, moving the painted strip ring and the A/S/X shortcut
+  target. This is separate from native accessibility focus and Tab traversal.
+- A focused JUCE slider accepts unmodified Up/Right to increment one accessible
+  interval and Down/Left to decrement it, with synchronous notification.
+  Accessible set-value additionally brackets the change with drag start/end;
+  those hooks matter for fader Touch automation and grouping.
+- A focused JUCE button accepts Return to trigger its click. Do not promise
+  Space for every button: Space is also a shell transport shortcut.
+- The flat combo menu uses Up/Down, Page Up/Down and Home/End to move among
+  selectable rows; Return or accessible press activates the active row. Escape
+  dismisses. The grid has its own navigation; Escape first clears an active
+  filter and only then closes. Every active-row change must remain announceable.
+- EmbeddedModal handles Escape unless dismissal is disabled. Its shortcut
+  forwarding admits selected transport/navigation keys, excludes edit and
+  destructive keys, and respects a body's claimed keys. Text entry and nested
+  popups must retain their keys. Focus restoration must not jump past a still
+  open modal or steal focus after another modal opens.
+
+## Native seams and the first bridge slice
+
+[DuskPanelView and DuskPanelWindow](../src/ui/imgui/DuskPanelWindow.h) already
+separate view drawing from window lifecycle, modal dismissal and shortcut
+ownership. [DuskImGuiHost](../src/ui/imgui/DuskImGuiHost.h) owns the native window,
+geometry and deferred teardown. Neither exposes an accessibility tree.
+[PanelControls](../src/ui/imgui/PanelControls.cpp) owns form combos, buttons,
+checkboxes and sliders, but its `##` IDs, separate painted labels, tooltips and
+ImGui focus do not currently publish platform semantics. DAF/DAF-Widgets remain
+shared read-only inputs during this application phase.
+
+The first implementation candidate is the **General section of the existing
+[AudioSettingsView](../src/ui/imgui/AudioSettingsView.cpp)**: `Expand tape strip
+by default` (checkbox), `Autosave every` (combo with five named choices), and
+`UI scale` (0.50–2.00 slider with `%.2fx` value). These exercise state, selection,
+numeric value, clipping, help and modal focus using real controls. UI scale is
+particularly useful proof: it previews while changing and persists on release.
+The accessible action must take the same apply/release route. Tests must inject
+settings effects rather than touch the user's settings or audio devices.
+
+Proposed ownership, subject to the next phase's reviewed implementation scope:
+
+1. App-owned semantic submission beside these control calls supplies explicit
+   name, role, stable identity, bounds, enabled state, current value and actions.
+   A panel instance owns identities; reopening must invalidate old actions.
+   An ImGui label hash alone must not identify a control across native windows.
+2. The panel window publishes a completed snapshot after layout. Focus and
+   selected value changes must be observable without a pointer event. Controls
+   outside a clipped scroll view must not claim visible bounds; focus actions
+   must scroll a target into view before reporting it focused.
+3. A platform adapter consumes that snapshot. AT-SPI actions arriving off the UI
+   thread queue commands for the UI owner; they do not dereference a view or
+   mutate settings directly. The current panel generation, visibility, enabled
+   state and modal ownership are rechecked when executing each action.
+4. The same command path handles pointer, keyboard and accessibility activation.
+   Closing first invalidates the action target, then destroys the view/adapter
+   in the native host's deferred lifecycle. Late queries use owned snapshots,
+   never pointers into frame-local strings or ImGui draw data.
+
+Evaluate **AccessKit's C API** before writing three platform adapters. Its
+documented adapters target Linux AT-SPI, macOS NSAccessibility and Windows UI
+Automation. The C bindings provide CMake integration and require Rust when built
+from source. This is a candidate dependency, not an adopted or pinned one.
+([Adapter overview](https://accesskit.dev/how-it-works/),
+[C integration and build requirements](https://github.com/AccessKit/accesskit-c/blob/main/README.md))
+The dependency decision must resolve embedded-child ownership alongside the
+JUCE shell, native handles and focus events, callback threading, clean builds
+on all three platforms and licensing notices. Do not substitute synthetic
+click coordinates for semantic actions.
+
+The next phase must be split into reviewed batches of at most five files;
+structural changes to the large host/view files require their own cleanup
+commit first. It should produce a working, limited native slice and deterministic
+tests together. Completing those three controls alone does not make the whole
+settings panel accessible or unblock the console port.
+
+## Support floor and proof required before replacement
+
+| Platform | Required bridge outcome | Proof still owed |
+|---|---|---|
+| Linux, native Wayland and supported X11 path | AT-SPI exposes named controls, roles, values, actions, focus and modal ownership. | Query the live tree and invoke actions on a private accessibility bus; then verify actual Orca reading and keyboard use on Marc's desktop. This is new Linux platform exposure. |
+| macOS | NSAccessibility retains the current app semantics and connects native child panels to the host window. | Build and inspect the tree, invoke value/press actions, and test VoiceOver across child open/close and focus restoration. |
+| Windows | UI Automation retains the current app semantics and connects native child panels to the host window. | Build and inspect control patterns, invoke actions, and test Narrator or NVDA across child open/close and focus restoration. |
+
+Deterministic semantic/action tests must cover the actual first-slice producer:
+
+- Stable IDs across redraw/scale; correct parentage, names, roles, help, ranges,
+  selected labels and checked states; missing controls removed on the next
+  snapshot; no duplicate or dangling children after reopen.
+- Checkbox press, combo selection and numeric set-value take the same model
+  path as direct interaction. Numeric input rejects non-finite values, respects
+  the real range/step, and preserves begin/change/end semantics and release-only
+  persistence. Disabled controls and stale IDs cannot mutate the model.
+- Focus follows keyboard/accessibility changes, reveals clipped controls and
+  moves into a modal; nested popup dismissal restores the panel before the shell.
+  Late actions after close and actions behind the active modal are rejected.
+- No unchanged snapshot or meter polling produces repeated announcements. No
+  accessibility callback or tree work runs on the audio thread.
+
+Source-bound fader boundary checks, unit tests, a headless semantic tree and
+successful builds prove different layers. None establishes physical screen-reader
+usability. Preserve the JUCE console until its full control inventory, native
+parity, platform integration and outstanding desktop checks have passed.
+
+## Resume
+
+Issue #305 first phase is the fader correction and this inventory. Next: review
+the adapter/embedded-host dependency decision, then implement the three real
+Audio Settings controls with semantic/action tests and isolated platform proof.
+The GUI tower's G3 replacement remains gated.

--- a/docs/dejuce-gui-plan.md
+++ b/docs/dejuce-gui-plan.md
@@ -322,7 +322,7 @@ desktop application.
 | 6 | Keyboard focus | Fixed on `dusk/302-app-contract`, lands with the G0 repin | `wayland.c:1555`, `Widget::onFocusChanged` |
 | 7 | Clipboard | Partial (text only, no primary) | `wayland.c:4093`, `:4109` |
 | 8 | Cursors | Hide fixed on `dusk/302-app-contract`, lands with the G0 repin; still no custom image | `wayland.c:2519`, `kMouseCursorNone` |
-| 9 | Accessibility | Absent (nothing in the tree) | — |
+| 9 | Accessibility | Bridge chosen; implementation and parity outstanding | [Accessibility plan](dejuce-accessibility-plan.md) |
 | 10 | Headless automation | Absent in the backend | `wayland.c:2911` |
 | 11 | HiDPI / fractional scaling | Present | `wayland.c:312`, `:355` |
 | 12 | Timers and event loop | Present, real blocking wait with timeout | `wayland.c:3454`, `:3612` |
@@ -366,11 +366,12 @@ Detail on the ones that change the plan:
   application the string the portal wants through
   `Window::getPortalParentHandle()`: `x11:` and a window id, or `wayland:` and
   an xdg-foreign handle, empty where there is none. Verified on both backends.
-- **Accessibility (9).** Nothing exists, in either the framework or ImGui, and
-  `src/ui/` already carries JUCE accessibility labelling that would regress
-  silently. This needs a deliberate decision from Marc before G3, not after:
-  either an AT-SPI bridge fed from the ImGui widget kit, or a written,
-  documented decision to drop screen-reader support in the native UI.
+- **Accessibility (9).** Marc chose a platform accessibility bridge on
+  2026-09-08. Preserve existing JUCE semantics and provide native platform
+  exposure; G3 waits for implementation, parity and desktop checks. The
+  [accessibility plan](dejuce-accessibility-plan.md) records the source inventory,
+  the distinction between current semantics and new Linux AT-SPI support, and
+  the first native control slice. The framework/ImGui bridge is still unbuilt.
 - **Headless automation (10).** The backend hard-fails without a compositor and
   has no screenshot hook. This is workable and already solved twice over: run
   under a private headless `mutter` as this gate did, and let the application
@@ -676,16 +677,19 @@ the visible GR meter owns its state and polling in `CompMeterStrip` and is
 unchanged. The gate fell to 164 / 8,097, with no allowlist departures or module
 unlinks.
 
-The current cleanup removes the aux lane's empty editor-toggle helper and its
+PR #515 removed the aux lane's empty editor-toggle helper and its
 unused PluginSlot forward declaration, plus obsolete bus-layout prose. The
 native-slot tooltip now describes removal instead of promising an editor toggle.
 Loaded slots still keep the picker closed; empty slots still open it. The gate
-stays at 164 / 8,097. The fader's screen-reader mute-label mismatch remains a
-separate behavior fix.
+stays at 164 / 8,097. Issue #305's first phase corrects the fader's accessible
+mute label to use the DSP's existing -90 dB threshold, keeps infinity-text input
+muted, and records the
+[accessibility support floor and bridge plan](dejuce-accessibility-plan.md).
+It does not implement the native bridge or complete #305.
 
 G0, G1 and both G2 passes are already on main (G2 remainder: PR #356).
-The accessibility decision in §3 and G2's outstanding desktop sign-offs remain
-prerequisites for the console port.
+The accessibility bridge's parity and desktop checks in §3 and G2's outstanding
+desktop sign-offs remain prerequisites for the console port.
 
 The largest and riskiest phase, and the one the spike measured.
 `ChannelStripComponent` (6,340 lines), `MasterStripComponent`, `BusComponent`,
@@ -771,7 +775,8 @@ Owed to Marc's bench, and not inferable from this gate:
   elsewhere, and its CMake carries the same MSVC GL 3.x loader the notepad
   needs, but neither has been built. If the shell's portability is in question
   before G5, build `dusk-gui-spike` on both.
-- **The accessibility decision** (§3, row 9), which is Marc's call and gates G3.
+- **Accessibility bridge parity and desktop checks** (§3, row 9). The bridge
+  decision is made; implementation and screen-reader verification still gate G3.
 
 ## 7. Naming
 

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -720,8 +720,19 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
     // value matches what's drawn ("-4.2 dB" rather than raw "-4.2").
     faderSlider.textFromValueFunction = [] (double v) -> juce::String
     {
-        if (v <= ChannelStripParams::kFaderMinDb + 0.05) return "-INF dB";
+        if (v <= ChannelStripParams::kFaderInfThreshDb) return "-INF dB";
         return juce::String (v, 1) + " dB";
+    };
+    faderSlider.valueFromTextFunction = [] (const auto& text) -> double
+    {
+        const auto trimmed = text.trim();
+        if (trimmed.equalsIgnoreCase ("-INF") || trimmed.equalsIgnoreCase ("-INF dB"))
+            return ChannelStripParams::kFaderMinDb;
+
+        auto numericText = text.trimStart();
+        while (numericText.startsWithChar ('+'))
+            numericText = numericText.substring (1).trimStart();
+        return numericText.initialSectionContainingOnly ("0123456789.,-").getDoubleValue();
     };
     // No "dB" suffix - strip is narrow enough that "0.0 dB" truncates.
     // The dB scale column to the right of the meter makes the unit obvious.


### PR DESCRIPTION
Channel faders could report finite gain while the DSP was already hard-muted, and their accessible text setter parsed `-INF dB` as 0 dB. Align the spoken mute boundary with the existing −90 dB DSP constant and preserve mute when an accessibility client sends infinity text, while retaining the existing finite-number parsing behavior.

Record the current names, roles, values, actions, focus and modal semantics, Marc’s platform-bridge decision, and a concrete next native-panel slice. Correct the manual’s unsupported Linux/Orca and full-control-coverage claims. This is the first phase of #305; it does not implement the bridge, complete screen-reader parity, or permit G3 console replacement.

Validation: Release app build passed with zero new warnings; test build and all 939 tests passed. A source-bound probe checked every 0.1 dB fader position, and an executable linked to the actual JUCE core passed 101 muted and 1,020 finite formatter/parser round-trips, five infinity spellings, and 15 comparisons with the upstream finite parser. JUCE gate is unchanged at 164 files / 8,097 uses. Complete diff received source review against the repository checklist. No physical screen-reader or macOS/Windows accessibility sign-off is claimed.
