### PR TITLE
refactor(util): remove unused crash handler accessors

### DIFF
--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -2691,10 +2691,8 @@ void DuskStudioApp::shutdown()
 #endif
     bounceTest.reset();             // headless bounce harness: worker joined, then engine/session
 
-    // Tear down the FileLogger installed by crash_handler::install so
-    // JUCE's leak detector doesn't complain at exit. The crash callback
-    // installed via setApplicationCrashHandler is harmless if it stays
-    // registered - process is exiting either way.
+    // Detach the logger after UI and engine teardown. Its storage is retained
+    // for any logging calls still in progress.
     duskstudio::crash_handler::uninstall();
 }
 

--- a/src/util/CrashHandler.cpp
+++ b/src/util/CrashHandler.cpp
@@ -1,5 +1,7 @@
 #include "CrashHandler.h"
 
+#include <juce_core/juce_core.h>
+
 #include <algorithm>
 #include <atomic>
 #include <csignal>
@@ -134,15 +136,12 @@ void uninstall()
     bool expected = true;
     if (! installed.compare_exchange_strong (expected, false)) return;
     juce::Logger::setCurrentLogger (nullptr);
-    // Intentionally leak the FileLogger. juce::Logger::setCurrentLogger
-    // is not thread-safe - a background thread that loaded the old
+    // Intentionally leak the FileLogger. JUCE's logger replacement is
+    // not thread-safe - a background thread that loaded the old
     // pointer just before the null-store could still be inside
     // writeToLog and would dereference a destroyed object after .reset().
     // Process is exiting; the OS reclaims the memory either way.
     (void) ownedLogger.release();
 }
 
-juce::File getLogDir()     { return baseDir().getChildFile ("log"); }
-juce::File getCrashDir()   { return baseDir().getChildFile ("crashes"); }
-juce::File getCurrentLogFile() { return cachedLogFile; }
 } // namespace duskstudio::crash_handler

--- a/src/util/CrashHandler.h
+++ b/src/util/CrashHandler.h
@@ -1,14 +1,12 @@
 #pragma once
 
-#include <juce_core/juce_core.h>
 #include <string>
 
 namespace duskstudio::crash_handler
 {
 // Install the global JUCE FileLogger + JUCE crash callback. Idempotent.
 // Call once from DuskStudioApp::initialise BEFORE any audio init so the
-// first thing a crashing build does is leave a paste-able report at
-// getCrashDir().
+// first thing a crashing build does is leave a report in the crashes directory.
 //
 // Layout under ${userApplicationData}/Dusk Studio/:
 //   log/dusk-studio-YYYYMMDD.log   - rotating daily, FileLogger
@@ -19,12 +17,7 @@ namespace duskstudio::crash_handler
 // that's enough to triage 90% of reports without back-and-forth.
 void install (const std::string& appVersion);
 
-// Detach + delete the FileLogger so JUCE's leak detector stays quiet at
-// shutdown. The crash callback registered via SystemStats stays put
-// (process is exiting). Idempotent.
+// Detach the logger at shutdown, retaining its storage for in-flight logging.
+// The crash callback stays registered. Idempotent.
 void uninstall();
-
-juce::File getLogDir();
-juce::File getCrashDir();
-juce::File getCurrentLogFile();
 } // namespace duskstudio::crash_handler

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -160,5 +160,4 @@ src/ui/multisample/AriaGuiComponent.cpp	90
 src/ui/multisample/AriaGuiComponent.h	17
 src/ui/multisample/DuskMultisampleEditor.cpp	68
 src/ui/multisample/DuskMultisampleEditor.h	21
-src/util/CrashHandler.cpp	32
-src/util/CrashHandler.h	4
+src/util/CrashHandler.cpp	29


### PR DESCRIPTION
Remove the three unused crash-handler path accessors and move the framework include into the implementation. `CrashHandler.h` is now framework-free. Correct teardown comments to describe the existing retained logger storage; runtime logging and crash behavior are unchanged.

Partial preparation for #313. Native logging, crash reporting and the remaining application utilities are still pending.

Validation:
- Release application and test builds with `-j4`; zero new warning texts against the baseline.
- CTest: 939/939 passed.
- JUCE gate: 164 files / 8,097 uses → 163 files / 8,090 uses. `src/util/CrashHandler.h` leaves the allowlist.
- Standalone header compile, repository-wide accessor/caller search, source review against the repository checklist, and `git diff --check` passed. The source review's two stale-comment findings were verified and corrected.

No audio-path code changed; no runtime audio selftest was needed. No release files changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crash-reporting shutdown behavior by preserving in-flight log data while the application closes.
  * Crash callbacks remain available during shutdown to help capture unexpected failures.

* **Documentation**
  * Clarified crash logging and shutdown behavior in the relevant documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->