### PR TITLE
Replace mastering thumbnail with Dusk waveform peaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -782,6 +782,7 @@ endif()
 target_sources(DuskStudio PRIVATE
     src/engine/audiofile/BufferedFileReader.cpp
     src/engine/audiofile/FileReader.cpp
+    src/engine/audiofile/WaveformPeaks.cpp
     src/engine/audiofile/FileWriter.cpp
     src/engine/audiofile/ThreadedFileWriter.cpp
     src/engine/audiofile/WriterDrainPool.cpp)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 955 Catch2 test cases across 182 test source files. Linux
+The C++ suite declares 966 Catch2 test cases across 183 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 955 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 966 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/audiofile/WaveformPeaks.cpp
+++ b/src/engine/audiofile/WaveformPeaks.cpp
@@ -1,0 +1,194 @@
+#include "WaveformPeaks.h"
+#include "../../foundation/PlanarBuffer.h"
+
+#include <algorithm>
+#include <cmath>
+#include <new>
+#include <stdexcept>
+
+namespace dusk::audio
+{
+namespace
+{
+WaveformPeaks::Peak merge (WaveformPeaks::Peak a, WaveformPeaks::Peak b) noexcept
+{
+    return { std::min (a.minimum, b.minimum), std::max (a.maximum, b.maximum) };
+}
+
+float finiteSample (float value) noexcept { return std::isfinite (value) ? value : 0.0f; }
+}
+
+std::shared_ptr<const WaveformPeaks> WaveformPeaks::generate (
+    const std::filesystem::path& path, const CancelCheck& cancelled)
+{
+    const auto shouldCancel = [&] { return cancelled && cancelled(); };
+    if (shouldCancel()) return {};
+
+    auto reader = FileReader::open (path);
+    if (reader == nullptr) return {};
+    const auto info = reader->info();
+    if (! std::isfinite (info.sampleRate) || info.sampleRate <= 0.0
+        || info.numChannels <= 0 || info.numChannels > 256 || info.numFrames < 0)
+        return {};
+
+    int framesPerBin = 1;
+    constexpr int64_t kDetailedPeakCount = 65536;
+    while (framesPerBin < kMaxFramesPerPeak && info.numFrames > kDetailedPeakCount * framesPerBin)
+        framesPerBin *= 2;
+    const auto bins = info.numFrames / framesPerBin + (info.numFrames % framesPerBin != 0);
+    const auto channels = (std::size_t) info.numChannels;
+    // Account for every level, including the extra parent of odd-sized levels.
+    std::size_t entries = 0;
+    for (auto n = bins; n > 0; n = n == 1 ? 0 : n / 2 + n % 2)
+    {
+        const auto remaining = kMaxPeakBytes / sizeof (Peak) - entries;
+        if ((uint64_t) n > remaining / channels) return {};
+        entries += (std::size_t) n * channels;
+    }
+    if (shouldCancel()) return {};
+
+    try
+    {
+        auto result = std::shared_ptr<WaveformPeaks> (new WaveformPeaks);
+        result->fileInfo = info;
+        result->resolution = framesPerBin;
+        if (bins == 0) return result;
+        result->levels.emplace_back ((std::size_t) bins * channels);
+
+        constexpr int kReadFrames = 8192;
+        PlanarBuffer scratch;
+        if (! scratch.setSize (info.numChannels, kReadFrames)) return {};
+        for (int64_t first = 0; first < info.numFrames;)
+        {
+            if (shouldCancel()) return {};
+            const auto count = std::min<int64_t> (kReadFrames, info.numFrames - first);
+            if (reader->read (scratch.data(), info.numChannels, first, count) != count)
+                return {};
+            for (int offset = 0; offset < count; offset += framesPerBin)
+            {
+                const auto index = (std::size_t) ((first + offset) / framesPerBin) * channels;
+                const auto end = std::min<int64_t> (count, offset + framesPerBin);
+                for (int channel = 0; channel < info.numChannels; ++channel)
+                {
+                    const auto* samples = scratch.channel (channel);
+                    const float initial = finiteSample (samples[offset]);
+                    Peak peak { initial, initial };
+                    for (auto frame = offset + 1; frame < end; ++frame)
+                    {
+                        const float value = finiteSample (samples[frame]);
+                        peak = merge (peak, { value, value });
+                    }
+                    result->levels[0][index + (std::size_t) channel] = peak;
+                }
+            }
+            first += count;
+        }
+
+        for (auto n = (std::size_t) bins; n > 1; n = n / 2 + n % 2)
+        {
+            if (shouldCancel()) return {};
+            const auto parentBins = n / 2 + n % 2;
+            std::vector<Peak> parent (parentBins * channels);
+            const auto& child = result->levels.back();
+            for (std::size_t bin = 0; bin < parentBins; ++bin)
+            {
+                if (bin % 4096 == 0 && shouldCancel()) return {};
+                for (std::size_t ch = 0; ch < channels; ++ch)
+                {
+                    const auto a = child[bin * 2 * channels + ch];
+                    parent[bin * channels + ch] = bin * 2 + 1 < n
+                        ? merge (a, child[(bin * 2 + 1) * channels + ch]) : a;
+                }
+            }
+            result->levels.push_back (std::move (parent));
+        }
+        if (shouldCancel()) return {};
+        return result;
+    }
+    catch (const std::bad_alloc&) { return {}; }
+    catch (const std::length_error&) { return {}; }
+}
+
+std::optional<WaveformPeaks::Peak> WaveformPeaks::query (
+    int channel, int64_t firstFrame, int64_t endFrame) const noexcept
+{
+    firstFrame = std::max<int64_t> (0, firstFrame);
+    endFrame = std::min (fileInfo.numFrames, endFrame);
+    if (channel < 0 || channel >= fileInfo.numChannels || firstFrame >= endFrame)
+        return {};
+
+    auto first = (std::size_t) (firstFrame / resolution);
+    auto end = (std::size_t) ((endFrame - 1) / resolution + 1);
+    std::optional<Peak> peak;
+    std::size_t level = 0;
+    const auto add = [&] (std::size_t bin)
+    {
+        const auto value = levels[level][bin * (std::size_t) fileInfo.numChannels + (std::size_t) channel];
+        peak = peak ? merge (*peak, value) : value;
+    };
+    while (first < end)
+    {
+        if (first % 2 != 0) add (first++);
+        if (end % 2 != 0) add (--end);
+        first /= 2;
+        end /= 2;
+        ++level;
+    }
+    return peak;
+}
+
+WaveformSource::WaveformSource() : worker ([this] { run(); }) {}
+
+WaveformSource::~WaveformSource()
+{
+    {
+        std::lock_guard<std::mutex> lock (mutex);
+        stopping = true;
+        generation.fetch_add (1, std::memory_order_release);
+        wake.notify_one();
+    }
+    worker.join();
+}
+
+void WaveformSource::setFile (const std::filesystem::path& file)
+{
+    std::lock_guard<std::mutex> lock (mutex);
+    pendingFile = file;
+    generation.fetch_add (1, std::memory_order_release);
+    pending = ! file.empty();
+    current = { pending ? State::Loading : State::Empty, {} };
+    wake.notify_one();
+}
+
+WaveformSource::Snapshot WaveformSource::snapshot() const
+{
+    std::lock_guard<std::mutex> lock (mutex);
+    return current;
+}
+
+void WaveformSource::run()
+{
+    std::unique_lock<std::mutex> lock (mutex);
+    while (true)
+    {
+        wake.wait (lock, [this] { return stopping || pending; });
+        if (stopping) return;
+        const auto file = std::move (pendingFile);
+        const auto request = generation.load (std::memory_order_acquire);
+        pending = false;
+        lock.unlock();
+        std::shared_ptr<const WaveformPeaks> peaks;
+        try
+        {
+            peaks = WaveformPeaks::generate (file, [this, request]
+            {
+                return generation.load (std::memory_order_acquire) != request;
+            });
+        }
+        catch (const std::exception&) {}
+        lock.lock();
+        if (generation.load (std::memory_order_acquire) == request)
+            current = { peaks ? State::Ready : State::Failed, std::move (peaks) };
+    }
+}
+} // namespace dusk::audio

--- a/src/engine/audiofile/WaveformPeaks.h
+++ b/src/engine/audiofile/WaveformPeaks.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include "FileReader.h"
+
+#include <atomic>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <optional>
+#include <thread>
+
+namespace dusk::audio
+{
+// Immutable overview data. Generation does disk I/O; queries only read memory.
+class WaveformPeaks final
+{
+public:
+    struct Peak { float minimum = 0.0f, maximum = 0.0f; };
+    static constexpr int kMaxFramesPerPeak = 512;
+    static constexpr std::size_t kMaxPeakBytes = 128u * 1024u * 1024u;
+    using CancelCheck = std::function<bool()>;
+
+    // Returns null on cancellation, unreadable/truncated input or memory refusal
+    // (including the kMaxPeakBytes ceiling for the complete pyramid).
+    // Cancellation is checked between bounded reads and pyramid reductions.
+    static std::shared_ptr<const WaveformPeaks> generate (
+        const std::filesystem::path&, const CancelCheck& cancelled = {});
+
+    const FileInfo& info() const noexcept { return fileInfo; }
+    double durationSeconds() const noexcept { return (double) fileInfo.numFrames / fileInfo.sampleRate; }
+    int framesPerPeak() const noexcept { return resolution; }
+
+    // Half-open file-frame range, clipped to the file. Boundary bins are included
+    // whole, extending either edge by at most framesPerPeak()-1 frames. Short
+    // files use finer power-of-two bins, down to individual samples.
+    // Invalid channels and empty ranges return no peak. No allocation or I/O.
+    std::optional<Peak> query (int channel, int64_t firstFrame, int64_t endFrame) const noexcept;
+
+private:
+    WaveformPeaks() = default;
+    FileInfo fileInfo;
+    int resolution = 1;
+    std::vector<std::vector<Peak>> levels;
+};
+
+// One replaceable source for a view. Calls and destruction are non-RT. The worker
+// never invokes UI callbacks; a view polls snapshot() using its existing timer.
+class WaveformSource final
+{
+public:
+    enum class State { Empty, Loading, Ready, Failed };
+    struct Snapshot
+    {
+        State state = State::Empty;
+        std::shared_ptr<const WaveformPeaks> peaks;
+    };
+
+    WaveformSource();
+    ~WaveformSource();
+    WaveformSource (const WaveformSource&) = delete;
+    WaveformSource& operator= (const WaveformSource&) = delete;
+
+    // Each call invalidates even the same path, so callers request only on load
+    // or explicit reload, not on every repaint/refresh. Empty clears it.
+    void setFile (const std::filesystem::path&);
+    Snapshot snapshot() const;
+
+private:
+    void run();
+
+    mutable std::mutex mutex;
+    std::condition_variable wake;
+    std::atomic<uint64_t> generation { 0 };
+    std::filesystem::path pendingFile;
+    Snapshot current;
+    bool pending = false;
+    bool stopping = false;
+    std::thread worker;
+};
+} // namespace dusk::audio

--- a/src/ui/MasteringView.cpp
+++ b/src/ui/MasteringView.cpp
@@ -13,6 +13,7 @@
  #include "imgui/MasteringLimiterView.h"
 #endif
 #include <algorithm>
+#include <cmath>
 #if DUSKSTUDIO_HAS_DUSK_DSP
   #include "ModernCompressorPanels.h"   // multi-comp - MultibandCompressorPanel
 #endif
@@ -41,10 +42,8 @@ imgui::DuskPanelWindow::Geometry nativePanelGeometry (const juce::Component& vie
 }
 
 WaveformDisplay::WaveformDisplay (MasteringPlayer& p)
-    : player (p),
-      thumbnail (512, formatManager, thumbnailCache)
+    : player (p)
 {
-    formatManager.registerBasicFormats();
     setOpaque (true);
     startTimerHz (20);
 }
@@ -53,15 +52,18 @@ WaveformDisplay::~WaveformDisplay() { stopTimer(); }
 
 void WaveformDisplay::setSource (const juce::File& file)
 {
-    if (file == juce::File()) { thumbnail.setSource (nullptr); repaint(); return; }
-    thumbnail.setSource (new juce::FileInputSource (file));
+    waveformSource.setFile (std::filesystem::u8path (file.getFullPathName().toStdString()));
+    waveformSnapshot = waveformSource.snapshot();
     repaint();
 }
 
 void WaveformDisplay::timerCallback()
 {
     const auto p = player.getPlayhead();
-    if (p == lastPlayhead) return;
+    auto next = waveformSource.snapshot();
+    if (p == lastPlayhead && next.state == waveformSnapshot.state
+        && next.peaks == waveformSnapshot.peaks) return;
+    waveformSnapshot = std::move (next);
     lastPlayhead = p;
     repaint();   // cheap - small region
 }
@@ -72,23 +74,26 @@ void WaveformDisplay::paint (juce::Graphics& g)
     g.setColour (juce::Colour (0xff2a2a32));
     g.drawRect (getLocalBounds(), 1);
 
-    if (thumbnail.getNumChannels() == 0
-        || thumbnail.getTotalLength() <= 0.0)
+    const auto& peaks = waveformSnapshot.peaks;
+    if (! peaks || peaks->info().numFrames == 0)
     {
         g.setColour (juce::Colour (0xff707074));
         g.setFont (juce::Font (juce::FontOptions (13.0f)));
-        g.drawText (juce::CharPointer_UTF8 ("No mix loaded - pick one with Load mix..."),
+        const auto message = waveformSnapshot.state == dusk::audio::WaveformSource::State::Loading
+            ? "Loading waveform..."
+            : waveformSnapshot.state == dusk::audio::WaveformSource::State::Failed
+                ? "Waveform unavailable" : "No mix loaded - pick one with Load mix...";
+        g.drawText (message,
                      getLocalBounds(), juce::Justification::centred, false);
         return;
     }
 
     auto bounds = getLocalBounds().reduced (4);
+    if (bounds.isEmpty()) return;
 
     const double sr      = player.getSourceSampleRate();
-    const double total   = thumbnail.getTotalLength();
+    const double total   = peaks->durationSeconds();
     const double playSecRaw = (sr > 0.0) ? (double) player.getPlayhead() / sr : 0.0;
-    // Clamp to [0, total]: if the playhead runs past EOF, an unclamped playSec
-    // makes the unplayed drawChannels() call's startTime exceed its endTime.
     const double playSec = jlimit (0.0, total, playSecRaw);
     const float  frac    = (total > 0.0) ? (float) (playSec / total) : 0.0f;
     const int    splitX  = bounds.getX() + (int) (frac * bounds.getWidth());
@@ -97,24 +102,28 @@ void WaveformDisplay::paint (juce::Graphics& g)
     g.setColour (juce::Colour (0xff202028));
     g.drawHorizontalLine (bounds.getCentreY(), (float) bounds.getX(), (float) bounds.getRight());
 
-    // Played portion bright, unplayed dim - position reads at a glance.
-    // Both passes draw the FULL time range into the FULL rect and let a clip
-    // region do the split: drawChannels re-derives its time-to-pixel mapping
-    // from the rect it's given, so drawing the two halves into two rects that
-    // resize every frame makes the rendered wave shimmer during playback.
-    if (splitX > bounds.getX())
+    // Keep the time-to-pixel mapping fixed as the played colour boundary moves.
+    const auto frames = peaks->info().numFrames;
+    const int channels = peaks->info().numChannels;
+    for (int channel = 0; channel < channels; ++channel)
     {
-        juce::Graphics::ScopedSaveState ss (g);
-        g.reduceClipRegion (bounds.withRight (splitX));
-        g.setColour (juce::Colour (0xff7ab0ee));
-        thumbnail.drawChannels (g, bounds, 0.0, total, 1.0f);
-    }
-    if (splitX < bounds.getRight())
-    {
-        juce::Graphics::ScopedSaveState ss (g);
-        g.reduceClipRegion (bounds.withLeft (splitX));
-        g.setColour (juce::Colour (0xff3c5c84));
-        thumbnail.drawChannels (g, bounds, 0.0, total, 1.0f);
+        const float top = (float) (bounds.getY() + channel * bounds.getHeight() / channels);
+        const float bottom = (float) (bounds.getY() + (channel + 1) * bounds.getHeight() / channels);
+        const float centre = (top + bottom) * 0.5f;
+        const float scale = (bottom - top) * 0.5f;
+        for (int pixel = 0; pixel < bounds.getWidth(); ++pixel)
+        {
+            const auto firstFrame = (std::int64_t) ((double) pixel * (double) frames / bounds.getWidth());
+            const auto endFrame = std::max (firstFrame + 1,
+                (std::int64_t) std::ceil ((double) (pixel + 1) * (double) frames / bounds.getWidth()));
+            const auto peak = peaks->query (channel, firstFrame, endFrame);
+            if (! peak || (peak->minimum >= 0.0f && peak->maximum <= 0.0f)) continue;
+            const int x = bounds.getX() + pixel;
+            g.setColour (x < splitX ? juce::Colour (0xff7ab0ee) : juce::Colour (0xff3c5c84));
+            const float y1 = std::clamp (centre - std::clamp (peak->maximum, -1.0f, 1.0f) * scale - 0.3f, top, bottom);
+            const float y2 = std::clamp (centre - std::clamp (peak->minimum, -1.0f, 1.0f) * scale + 0.3f, top, bottom);
+            g.drawVerticalLine (x, y1, y2);
+        }
     }
 
     // Time ruler along the bottom - a handful of mm:ss ticks.
@@ -152,14 +161,14 @@ void WaveformDisplay::paint (juce::Graphics& g)
 
 void WaveformDisplay::mouseDown (const juce::MouseEvent& e)
 {
-    const double sr = player.getSourceSampleRate();
-    const double total = thumbnail.getTotalLength();
-    if (sr <= 0.0 || total <= 0.0) return;
+    const auto frames = player.getLengthSamples();
+    if (! player.isLoaded() || frames <= 0
+        || waveformSnapshot.state == dusk::audio::WaveformSource::State::Empty) return;
     auto bounds = getLocalBounds().reduced (4);
     if (bounds.getWidth() <= 0) return;
     const float frac = jlimit (0.0f, 1.0f,
                                        (float) (e.x - bounds.getX()) / (float) bounds.getWidth());
-    const auto target = (std::int64_t) (frac * total * sr);
+    const auto target = (std::int64_t) ((double) frac * (double) frames);
     player.setPlayhead (target);
     repaint();
 }

--- a/src/ui/MasteringView.cpp
+++ b/src/ui/MasteringView.cpp
@@ -49,7 +49,7 @@ WaveformDisplay::WaveformDisplay (MasteringPlayer& p)
     startTimerHz (20);
 }
 
-WaveformDisplay::~WaveformDisplay() { stopTimer(); thumbnail.setSource (nullptr); }
+WaveformDisplay::~WaveformDisplay() { stopTimer(); }
 
 void WaveformDisplay::setSource (const juce::File& file)
 {

--- a/src/ui/MasteringView.h
+++ b/src/ui/MasteringView.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <juce_audio_utils/juce_audio_utils.h>
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <memory>
 #include <vector>
 #include "EmbeddedModal.h"
 #include "DuskComboBox.h"
 #include "../engine/AudioEngine.h"
+#include "../engine/audiofile/WaveformPeaks.h"
 #include "../session/Session.h"
 #include "../foundation/MessageThread.h"
 
@@ -42,7 +42,7 @@ private:
 };
 #endif
 
-// Inline AudioThumbnail above the mastering controls + playhead line
+// Inline waveform above the mastering controls + playhead line
 // that follows MasteringPlayer. Click anywhere to seek.
 class WaveformDisplay final : public juce::Component, private dusk::Timer
 {
@@ -58,9 +58,8 @@ private:
     void timerCallback() override;
 
     MasteringPlayer&            player;
-    juce::AudioFormatManager    formatManager;
-    juce::AudioThumbnailCache   thumbnailCache { 4 };
-    juce::AudioThumbnail        thumbnail;
+    dusk::audio::WaveformSource waveformSource;
+    dusk::audio::WaveformSource::Snapshot waveformSnapshot;
     std::int64_t                 lastPlayhead = -1;
 };
 

--- a/src/ui/ScreenshotCapture.cpp
+++ b/src/ui/ScreenshotCapture.cpp
@@ -492,10 +492,12 @@ void MainComponent::captureNativePanels (std::string outDir)
 
     // The mastering stage's EQ and limiter are framework children inside a JUCE view, so
     // its figure is the JUCE snapshot with each child's own frame pasted back in.
-    steps->push_back ({ 0, [] (MainComponent& self)
+    steps->push_back ({ 0, [dir] (MainComponent& self)
     {
         self.switchToStage (AudioEngine::Stage::Mastering);
         self.resized();
+        if (self.masteringView != nullptr)
+            self.masteringView->loadFile (dir.getChildFile ("_demo").getChildFile ("demo-take.wav"));
     } });
     steps->push_back ({ 900, [masteringCaptures, dir] (MainComponent& self)
     {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -249,11 +249,13 @@ endif()
 # CMakeLists (config package where available, plain library search otherwise).
 target_sources(dusk-studio-tests PRIVATE
     audiofile_roundtrip.cpp
+    waveform_peaks.cpp
     audiofile_ab_null.cpp
     audiofile_buffered_reader.cpp
     audiofile_drain_pool.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/audiofile/BufferedFileReader.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/audiofile/FileReader.cpp
+    ${CMAKE_SOURCE_DIR}/src/engine/audiofile/WaveformPeaks.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/audiofile/FileWriter.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/audiofile/ThreadedFileWriter.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/audiofile/WriterDrainPool.cpp)

--- a/tests/waveform_peaks.cpp
+++ b/tests/waveform_peaks.cpp
@@ -1,0 +1,320 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "engine/audiofile/WaveformPeaks.h"
+#include "engine/audiofile/FileWriter.h"
+#include "TestTempDirectory.h"
+
+#include <sndfile.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <fstream>
+#include <limits>
+#include <thread>
+#include <type_traits>
+
+using namespace dusk::audio;
+using Catch::Matchers::WithinAbs;
+
+namespace
+{
+void writeWave (const std::filesystem::path& path, const std::vector<std::vector<float>>& samples)
+{
+    WriteSpec spec;
+    spec.numChannels = (int) samples.size();
+    spec.sampleRate = 44100.0;
+    spec.bitsPerSample = 32;
+    auto writer = FileWriter::create (path, spec);
+    REQUIRE (writer != nullptr);
+    std::vector<const float*> channels;
+    for (const auto& channel : samples) channels.push_back (channel.data());
+    REQUIRE (writer->write (channels.data(), spec.numChannels, (int64_t) samples.front().size()));
+}
+
+void checkPeak (const std::optional<WaveformPeaks::Peak>& peak, float minimum, float maximum)
+{
+    REQUIRE (peak.has_value());
+    REQUIRE_THAT (peak->minimum, WithinAbs (minimum, 1.0e-6));
+    REQUIRE_THAT (peak->maximum, WithinAbs (maximum, 1.0e-6));
+}
+
+WaveformSource::Snapshot awaitSnapshot (const WaveformSource& source)
+{
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds (5);
+    auto snapshot = source.snapshot();
+    while (snapshot.state == WaveformSource::State::Loading
+           && std::chrono::steady_clock::now() < deadline)
+    {
+        std::this_thread::yield();
+        snapshot = source.snapshot();
+    }
+    REQUIRE (snapshot.state != WaveformSource::State::Loading);
+    return snapshot;
+}
+}
+
+TEST_CASE ("Waveform peaks preserve channels, polarity, gain and the final partial bin", "[waveform]")
+{
+    duskstudio::test::TempDirectory dir ("dusk-waveform");
+    const auto file = dir.path() / "stereo.wav";
+    constexpr int frames = 65537;
+    std::vector<std::vector<float>> samples (2, std::vector<float> (frames, 0.25f));
+    std::fill (samples[1].begin(), samples[1].end(), -0.5f);
+    samples[0][511] = 1.5f;
+    samples[0][512] = -0.75f;
+    samples[1][1030] = -1.25f;
+    samples[1][frames - 1] = -0.875f;
+    writeWave (file, samples);
+    const auto peaks = WaveformPeaks::generate (file);
+    STATIC_REQUIRE (std::is_const_v<std::remove_reference_t<decltype (*peaks)>>);
+    REQUIRE (peaks != nullptr);
+    REQUIRE (peaks->info().numChannels == 2);
+    REQUIRE (peaks->info().numFrames == frames);
+    REQUIRE (peaks->framesPerPeak() == 2);
+    REQUIRE_THAT (peaks->info().sampleRate, WithinAbs (44100.0, 1.0e-9));
+    REQUIRE_THAT (peaks->durationSeconds(), WithinAbs ((double) frames / 44100.0, 1.0e-12));
+    checkPeak (peaks->query (0, 0, 512), 0.25f, 1.5f);
+    checkPeak (peaks->query (0, 512, 1024), -0.75f, 0.25f);
+    checkPeak (peaks->query (0, 1024, 1031), 0.25f, 0.25f);
+    checkPeak (peaks->query (1, 0, 1024), -0.5f, -0.5f);
+    checkPeak (peaks->query (1, 1024, 1031), -1.25f, -0.5f);
+    checkPeak (peaks->query (1, frames - 1, frames), -0.875f, -0.875f);
+    std::filesystem::remove (file);
+    checkPeak (peaks->query (1, 0, 1031), -1.25f, -0.5f);
+}
+
+TEST_CASE ("Waveform range queries match conservative sample extrema at every pyramid level", "[waveform]")
+{
+    duskstudio::test::TempDirectory dir ("dusk-waveform-ranges");
+    const auto file = dir.path() / "ranges.wav";
+    constexpr int frames = 512 * 35 + 17;
+    std::vector<std::vector<float>> samples (3, std::vector<float> (frames));
+    for (int channel = 0; channel < 3; ++channel)
+        for (int frame = 0; frame < frames; ++frame)
+            samples[(size_t) channel][(size_t) frame] = std::sin ((float) (frame * (channel + 1)) * 0.0031f);
+    writeWave (file, samples);
+    const auto peaks = WaveformPeaks::generate (file);
+    REQUIRE (peaks != nullptr);
+    for (int channel = 0; channel < 3; ++channel)
+        for (int first = 0; first < frames; first += 509)
+            for (int end = first + 1; end <= frames; end += 997)
+            {
+                const int resolution = peaks->framesPerPeak();
+                const int expandedFirst = first / resolution * resolution;
+                const int expandedEnd = std::min (frames, ((end - 1) / resolution + 1) * resolution);
+                const auto& data = samples[(size_t) channel];
+                const auto range = std::minmax_element (data.begin() + expandedFirst, data.begin() + expandedEnd);
+                checkPeak (peaks->query (channel, first, end), *range.first, *range.second);
+            }
+    const auto firstBin = std::minmax_element (samples[0].begin(), samples[0].begin() + peaks->framesPerPeak());
+    checkPeak (peaks->query (0, -100, 1), *firstBin.first, *firstBin.second);
+    REQUIRE_FALSE (peaks->query (-1, 0, 1));
+    REQUIRE_FALSE (peaks->query (3, 0, 1));
+    REQUIRE_FALSE (peaks->query (0, 1, 1));
+    REQUIRE_FALSE (peaks->query (0, 100, 99));
+    REQUIRE_FALSE (peaks->query (0, -100, -1));
+    REQUIRE_FALSE (peaks->query (0, frames, std::numeric_limits<int64_t>::max()));
+    const auto whole = peaks->query (0, std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::max());
+    const auto expected = std::minmax_element (samples[0].begin(), samples[0].end());
+    checkPeak (whole, *expected.first, *expected.second);
+}
+
+TEST_CASE ("Short waveform overviews retain transients without coarse-bin smearing", "[waveform]")
+{
+    duskstudio::test::TempDirectory dir ("dusk-waveform-detail");
+    const auto file = dir.path() / "detail.wav";
+    constexpr int frames = 44100 * 18 / 10;
+    constexpr int transient = 30001;
+    std::vector<float> samples (frames, 0.0f);
+    samples[transient] = 1.0f;
+    writeWave (file, { samples });
+    const auto peaks = WaveformPeaks::generate (file);
+    REQUIRE (peaks != nullptr);
+    REQUIRE (peaks->framesPerPeak() == 2);
+    checkPeak (peaks->query (0, transient, transient + 1), 0.0f, 1.0f);
+    checkPeak (peaks->query (0, transient - 3, transient - 1), 0.0f, 0.0f);
+    checkPeak (peaks->query (0, transient + 1, transient + 3), 0.0f, 0.0f);
+    constexpr int width = 1200;
+    int occupiedPixels = 0;
+    for (int pixel = 0; pixel < width; ++pixel)
+    {
+        const int first = pixel * frames / width;
+        const int end = ((pixel + 1) * frames + width - 1) / width;
+        const auto peak = peaks->query (0, first, end);
+        REQUIRE (peak.has_value());
+        if (peak->maximum > 0.0f) ++occupiedPixels;
+        if (first <= transient && end > transient)
+            REQUIRE_THAT (peak->maximum, WithinAbs (1.0f, 1.0e-6));
+    }
+    REQUIRE (occupiedPixels == 1);
+}
+
+TEST_CASE ("Normal-duration waveform pixels conservatively cover source extrema", "[waveform]")
+{
+    duskstudio::test::TempDirectory dir ("dusk-waveform-overview");
+    const auto file = dir.path() / "overview.wav";
+    constexpr int frames = 44100 * 60;
+    std::vector<float> samples (frames, 0.0f);
+    for (int frame = 121; frame < frames; frame += 10007)
+        samples[(size_t) frame] = (frame % 2 == 0) ? 0.75f : -0.5f;
+    writeWave (file, { samples });
+    const auto peaks = WaveformPeaks::generate (file);
+    REQUIRE (peaks != nullptr);
+    REQUIRE (peaks->framesPerPeak() > 1);
+    REQUIRE (peaks->framesPerPeak() <= WaveformPeaks::kMaxFramesPerPeak);
+    constexpr int width = 1200;
+    for (int pixel = 0; pixel < width; ++pixel)
+    {
+        const auto first = (int64_t) pixel * frames / width;
+        const auto end = ((int64_t) (pixel + 1) * frames + width - 1) / width;
+        const auto expected = std::minmax_element (samples.begin() + first, samples.begin() + end);
+        const auto peak = peaks->query (0, first, end);
+        REQUIRE (peak.has_value());
+        REQUIRE (peak->minimum <= *expected.first);
+        REQUIRE (peak->maximum >= *expected.second);
+    }
+}
+
+TEST_CASE ("Waveform generation treats non-finite samples as silence", "[waveform]")
+{
+    duskstudio::test::TempDirectory dir ("dusk-waveform-nonfinite");
+    const auto file = dir.path() / "nonfinite.wav";
+    writeWave (file, { { std::numeric_limits<float>::quiet_NaN(),
+                        std::numeric_limits<float>::infinity(),
+                        -std::numeric_limits<float>::infinity(), 0.5f } });
+    const auto peaks = WaveformPeaks::generate (file);
+    REQUIRE (peaks != nullptr);
+    checkPeak (peaks->query (0, 0, 4), 0.0f, 0.5f);
+}
+
+TEST_CASE ("Waveform generation handles missing, corrupt and empty sources", "[waveform]")
+{
+    duskstudio::test::TempDirectory dir ("dusk-waveform-invalid");
+    const auto file = dir.path() / "source.wav";
+    REQUIRE_FALSE (WaveformPeaks::generate (file));
+    { std::ofstream output (file); output << "not an audio file"; }
+    REQUIRE_FALSE (WaveformPeaks::generate (file));
+    WriteSpec spec;
+    { auto writer = FileWriter::create (file, spec); REQUIRE (writer != nullptr); }
+    const auto empty = WaveformPeaks::generate (file);
+    REQUIRE (empty != nullptr);
+    REQUIRE (empty->info().numFrames == 0);
+    REQUIRE_THAT (empty->durationSeconds(), WithinAbs (0.0, 1.0e-12));
+    REQUIRE_FALSE (empty->query (0, 0, 1));
+}
+
+TEST_CASE ("Waveform cancellation never publishes partial peaks and permits a fresh build", "[waveform]")
+{
+    duskstudio::test::TempDirectory dir ("dusk-waveform-cancel");
+    const auto file = dir.path() / "cancel.wav";
+    writeWave (file, { std::vector<float> (40000, 0.625f) });
+    int checks = 0;
+    const auto complete = WaveformPeaks::generate (file, [&] { ++checks; return false; });
+    REQUIRE (complete != nullptr);
+    REQUIRE (checks > 8);
+    for (int cancelAt = 1; cancelAt <= checks; ++cancelAt)
+    {
+        int current = 0;
+        REQUIRE_FALSE (WaveformPeaks::generate (file, [&] { return ++current == cancelAt; }));
+        REQUIRE (current == cancelAt);
+    }
+    checkPeak (complete->query (0, 0, 40000), 0.625f, 0.625f);
+    const auto fresh = WaveformPeaks::generate (file);
+    REQUIRE (fresh != nullptr);
+    checkPeak (fresh->query (0, 0, 40000), 0.625f, 0.625f);
+}
+
+// NTFS needs explicit sparse-file setup; seeking alone can allocate gigabytes.
+#ifndef _WIN32
+TEST_CASE ("Waveform long-file cancellation uses bounded reads and 64-bit frame counts", "[waveform]")
+{
+    duskstudio::test::TempDirectory dir ("dusk-waveform-long");
+    const auto file = dir.path() / "sparse.wav";
+    SF_INFO info {};
+    info.channels = 1;
+    info.samplerate = 48000;
+    info.format = SF_FORMAT_RF64 | SF_FORMAT_PCM_16;
+    auto* writer = sf_open (file.c_str(), SFM_WRITE, &info);
+    REQUIRE (writer != nullptr);
+    constexpr int64_t lastFrame = (int64_t) std::numeric_limits<int32_t>::max() + 1024;
+    const auto position = sf_seek (writer, lastFrame, SEEK_SET);
+    const float tail = 0.5f;
+    const auto written = sf_writef_float (writer, &tail, 1);
+    const auto closed = sf_close (writer);
+    REQUIRE (position == lastFrame);
+    REQUIRE (written == 1);
+    REQUIRE (closed == 0);
+    const auto reader = FileReader::open (file);
+    REQUIRE (reader != nullptr);
+    REQUIRE (reader->info().numFrames == lastFrame + 1);
+    int checks = 0;
+    REQUIRE_FALSE (WaveformPeaks::generate (file, [&] { return ++checks == 4; }));
+    REQUIRE (checks == 4);
+}
+#endif
+
+TEST_CASE ("Waveform source clear invalidates queued and active work", "[waveform]")
+{
+    duskstudio::test::TempDirectory dir ("dusk-waveform-clear");
+    const auto file = dir.path() / "clear.wav";
+    writeWave (file, { std::vector<float> (40000, 0.25f) });
+    WaveformSource source;
+    REQUIRE (source.snapshot().state == WaveformSource::State::Empty);
+    for (int attempt = 0; attempt < 20; ++attempt)
+    {
+        source.setFile (file);
+        source.setFile ({});
+        const auto snapshot = source.snapshot();
+        REQUIRE (snapshot.state == WaveformSource::State::Empty);
+        REQUIRE_FALSE (snapshot.peaks);
+    }
+}
+
+TEST_CASE ("Waveform source publishes only the latest file and reloads changed contents", "[waveform]")
+{
+    duskstudio::test::TempDirectory dir ("dusk-waveform-publish");
+    const auto firstFile = dir.path() / "first.wav";
+    const auto secondFile = dir.path() / "second.wav";
+    writeWave (firstFile, { std::vector<float> (40000, 0.25f) });
+    writeWave (secondFile, { std::vector<float> (1000, -0.5f) });
+    WaveformSource source;
+    source.setFile (firstFile);
+    const auto original = awaitSnapshot (source);
+    REQUIRE (original.state == WaveformSource::State::Ready);
+    REQUIRE (original.peaks != nullptr);
+    checkPeak (original.peaks->query (0, 0, 40000), 0.25f, 0.25f);
+
+    source.setFile (firstFile);
+    source.setFile ({});
+    source.setFile (secondFile);
+    const auto replacement = awaitSnapshot (source);
+    REQUIRE (replacement.state == WaveformSource::State::Ready);
+    REQUIRE (replacement.peaks != nullptr);
+    REQUIRE (replacement.peaks->info().numFrames == 1000);
+    checkPeak (replacement.peaks->query (0, 0, 1000), -0.5f, -0.5f);
+    checkPeak (original.peaks->query (0, 0, 40000), 0.25f, 0.25f);
+
+    writeWave (secondFile, { std::vector<float> (1000, 0.75f) });
+    source.setFile (secondFile);
+    const auto reloaded = awaitSnapshot (source);
+    REQUIRE (reloaded.state == WaveformSource::State::Ready);
+    REQUIRE (reloaded.peaks != nullptr);
+    checkPeak (reloaded.peaks->query (0, 0, 1000), 0.75f, 0.75f);
+    checkPeak (replacement.peaks->query (0, 0, 1000), -0.5f, -0.5f);
+}
+
+TEST_CASE ("Waveform source publishes failure for unreadable input and then clears", "[waveform]")
+{
+    duskstudio::test::TempDirectory dir ("dusk-waveform-failed");
+    WaveformSource source;
+    source.setFile (dir.path() / "missing.wav");
+    const auto failed = awaitSnapshot (source);
+    REQUIRE (failed.state == WaveformSource::State::Failed);
+    REQUIRE_FALSE (failed.peaks);
+    source.setFile ({});
+    const auto empty = source.snapshot();
+    REQUIRE (empty.state == WaveformSource::State::Empty);
+    REQUIRE_FALSE (empty.peaks);
+}

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -113,8 +113,8 @@ src/ui/MainComponent.cpp	459
 src/ui/MainComponent.h	57
 src/ui/MasterStripComponent.cpp	330
 src/ui/MasterStripComponent.h	57
-src/ui/MasteringView.cpp	154
-src/ui/MasteringView.h	32
+src/ui/MasteringView.cpp	149
+src/ui/MasteringView.h	28
 src/ui/MidiBindingsPanel.cpp	49
 src/ui/MidiBindingsPanel.h	15
 src/ui/MiniTimelineStrip.cpp	19


### PR DESCRIPTION
The mastering overview now renders from Dusk-owned waveform peaks instead of AudioThumbnail. Loading a mix generates immutable peak data in the background, and the existing timer repaints when a snapshot arrives even while playback is stopped. Clicking the waveform still seeks while generation is loading. The existing Component, controls and accessibility surface remain intact.

The source uses bounded 8192-frame reads, a 128 MiB peak-pyramid ceiling, adaptive 1–512-frame bins and cancellation that rejects superseded loads. Range queries read memory only and conservatively include partial boundary bins. Short files retain fine waveform detail; rendering keeps a fixed frame-to-pixel mapping as playback moves.

Validation:
- Linux app and test builds passed with four workers and no new warnings; 950/950 CTest entries passed, including 11 waveform cases and the release contract.
- Tests cover signed extrema, channels, short-file detail, normal-duration envelopes, cancellation, Ready/Failed delivery, replacement and same-path reload. An additional worker probe passed 100 clear/replacement cycles.
- Isolated before/after captures at 1.8 seconds and 60 seconds show loaded waveforms and zero changed pixels outside the waveform band. The 60-second source was checked by duration, ruler and matching file hashes.
- Isolated self-test exited successfully with no test failures. Physical audio devices were unavailable in isolation; the optional native CLAP fixture was not supplied.
- Source review against the repository checklist found no actionable defects. The JUCE ratchet drops from 8097 to 8088 uses across 164 files.

Partial progress toward #306. AudioRegionEditor detail windows, persistent caching and final module unlinking remain for later phases. The sparse RF64 test is POSIX-only to avoid dense multi-gigabyte allocation on NTFS. Physical screen-reader and audio-device sign-off are not claimed.
