### PR TITLE
Use native storage for application startup logs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -710,6 +710,7 @@ target_sources(DuskStudio PRIVATE
     src/session/SessionSerializer.cpp
     src/session/SessionTemplates.cpp
     src/util/CrashHandler.cpp
+    src/util/LogFile.cpp
     src/util/SingleInstance.cpp
     src/ui/AnalogVuMeter.cpp
     src/ui/AppConfig.cpp

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ src/
       platform/# Linux / macOS / Windows IPC backends (shm + sync + process)
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
-  util/        # CrashHandler (FileLogger + signal-handler reports)
+  util/        # Native log storage + CrashHandler signal reports
 tests/         # 959 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 955 Catch2 test cases across 182 test source files. Linux
+The C++ suite declares 959 Catch2 test cases across 183 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 955 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 959 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -2585,7 +2585,7 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
         return;
     }
 
-    // Install crash handler + FileLogger AFTER every selftest env-gate
+    // Install crash handler + application log AFTER every selftest env-gate
     // above has had its chance to quit. Self-test paths don't want
     // stray daily log files littering the user's data dir (or CI
     // runner $HOME). Normal-user launches fall through to here, so the

--- a/src/util/CrashHandler.cpp
+++ b/src/util/CrashHandler.cpp
@@ -1,27 +1,50 @@
 #include "CrashHandler.h"
+#include "LogFile.h"
 
 #include <juce_core/juce_core.h>
 
 #include <algorithm>
 #include <atomic>
 #include <csignal>
+#include <filesystem>
 #include <memory>
 
 namespace duskstudio::crash_handler
 {
 namespace
 {
+class LogAdapter final : public juce::Logger
+{
+public:
+    LogAdapter (const std::filesystem::path& file, const std::string& appVersion)
+        : storage (file)
+    {
+        (void) storage.prepare();
+        const auto timestamp = juce::Time::getCurrentTime().toString (true, true).toStdString();
+        logMessage ("\r\n**********************************************************\r\nDusk Studio "
+                    + appVersion + " - " + timestamp + "\r\nLog started: " + timestamp + "\r\n");
+    }
+
+    void logMessage (const juce::String& message) override
+    {
+       #if JUCE_DEBUG
+        juce::Logger::outputDebugString (message);
+       #endif
+        (void) storage.append (message.toRawUTF8());
+    }
+
+private:
+    diagnostics::LogFile storage;
+};
+
 std::atomic<bool>             installed { false };
 std::string                   cachedAppVersion;
 juce::File                    cachedCrashDir;
 juce::File                    cachedLogFile;
-std::unique_ptr<juce::FileLogger> ownedLogger;
+std::unique_ptr<LogAdapter>    ownedLogger;
 
 juce::File baseDir()
 {
-    // ~/.local/share/Dusk Studio on Linux, ~/Library/Application Support/Dusk Studio
-    // on macOS, %APPDATA%/Dusk Studio on Windows. Same root used by the
-    // Patreon support docs so users know where to look.
     return juce::File::getSpecialLocation (juce::File::userApplicationDataDirectory)
               .getChildFile ("Dusk Studio");
 }
@@ -105,7 +128,7 @@ void install (const std::string& appVersion)
 {
     // Always refresh version - a second install() call from a future
     // hot-reload / test harness updates the crash report header even
-    // though the FileLogger + signal handler stay registered as-is.
+    // though the logger + signal handler stay registered as-is.
     cachedAppVersion = appVersion;
 
     bool expected = false;
@@ -116,13 +139,10 @@ void install (const std::string& appVersion)
     cachedLogFile = makeLogFile();
     cachedLogFile.getParentDirectory().createDirectory();
 
-    // Replace any pre-existing logger (none in normal flow, but tests
-    // may have installed one). FileLogger appends; daily rotation comes
-    // from the date in the filename - next-day startup picks a new file.
-    ownedLogger = std::make_unique<juce::FileLogger> (
-        cachedLogFile,
-        "Dusk Studio " + juce::String (appVersion) + " - "
-            + juce::Time::getCurrentTime().toString (true, true));
+    // The dated path rotates on startup; the native sink preserves the
+    // existing startup trim and appends the new run's banner.
+    ownedLogger = std::make_unique<LogAdapter> (
+        std::filesystem::u8path (cachedLogFile.getFullPathName().toStdString()), appVersion);
     juce::Logger::setCurrentLogger (ownedLogger.get());
 
     cachedCrashDir = baseDir().getChildFile ("crashes");
@@ -136,7 +156,7 @@ void uninstall()
     bool expected = true;
     if (! installed.compare_exchange_strong (expected, false)) return;
     juce::Logger::setCurrentLogger (nullptr);
-    // Intentionally leak the FileLogger. JUCE's logger replacement is
+    // Intentionally leak the adapter and its sink. JUCE's logger replacement is
     // not thread-safe - a background thread that loaded the old
     // pointer just before the null-store could still be inside
     // writeToLog and would dereference a destroyed object after .reset().

--- a/src/util/CrashHandler.h
+++ b/src/util/CrashHandler.h
@@ -4,12 +4,12 @@
 
 namespace duskstudio::crash_handler
 {
-// Install the global JUCE FileLogger + JUCE crash callback. Idempotent.
+// Install the native log sink with a JUCE logger adapter and crash callback. Idempotent.
 // Call once from DuskStudioApp::initialise BEFORE any audio init so the
 // first thing a crashing build does is leave a report in the crashes directory.
 //
 // Layout under ${userApplicationData}/Dusk Studio/:
-//   log/dusk-studio-YYYYMMDD.log   - rotating daily, FileLogger
+//   log/dusk-studio-YYYYMMDD.log   - daily files, trimmed at startup
 //   crashes/crash-<iso>.txt  - one per terminate; backtrace + env summary
 //
 // Patreon support flow: ask user to attach the most recent file from

--- a/src/util/LogFile.cpp
+++ b/src/util/LogFile.cpp
@@ -56,8 +56,13 @@ bool LogFile::prepare()
     std::filesystem::create_directories (parent, error);
     if (error) return false;
 
-    const auto size = std::filesystem::file_size (path, error);
+    const auto fileStatus = std::filesystem::status (path, error);
     if (error) return error == std::errc::no_such_file_or_directory;
+    if (! std::filesystem::exists (fileStatus)) return true;
+    if (! std::filesystem::is_regular_file (fileStatus)) return false;
+
+    const auto size = std::filesystem::file_size (path, error);
+    if (error) return false;
     if (size <= kMaxInitialBytes) return true;
     if (size > static_cast<std::uintmax_t> (std::numeric_limits<std::streamoff>::max())) return false;
 

--- a/src/util/LogFile.cpp
+++ b/src/util/LogFile.cpp
@@ -1,0 +1,110 @@
+#include "LogFile.h"
+
+#include <atomic>
+#include <chrono>
+#include <fstream>
+#include <limits>
+#include <string>
+#include <thread>
+#include <utility>
+
+namespace duskstudio::diagnostics
+{
+namespace
+{
+class TrimDirectory
+{
+public:
+    explicit TrimDirectory (const std::filesystem::path& parent)
+    {
+        static std::atomic<unsigned long long> sequence { 0 };
+        const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
+        for (int attempt = 0; attempt < 128; ++attempt)
+        {
+            const auto candidate = parent / (".dusk-log-trim-" + std::to_string (tick) + "-"
+                                             + std::to_string (sequence.fetch_add (1, std::memory_order_relaxed)));
+            std::error_code error;
+            if (std::filesystem::create_directory (candidate, error))
+            {
+                path = candidate;
+                break;
+            }
+            if (error) break;
+        }
+    }
+
+    ~TrimDirectory()
+    {
+        if (path.empty()) return;
+        std::error_code error;
+        std::filesystem::remove (path / "log", error);
+        std::filesystem::remove (path, error);
+    }
+
+    std::filesystem::path path;
+};
+} // namespace
+
+LogFile::LogFile (std::filesystem::path file) : path (std::move (file)) {}
+
+bool LogFile::prepare()
+{
+    const std::lock_guard<std::mutex> lock (mutex);
+    if (path.empty() || path.filename().empty()) return false;
+    std::error_code error;
+    const auto parent = path.has_parent_path() ? path.parent_path() : std::filesystem::path (".");
+    std::filesystem::create_directories (parent, error);
+    if (error) return false;
+
+    const auto size = std::filesystem::file_size (path, error);
+    if (error) return error == std::errc::no_such_file_or_directory;
+    if (size <= kMaxInitialBytes) return true;
+    if (size > static_cast<std::uintmax_t> (std::numeric_limits<std::streamoff>::max())) return false;
+
+    std::string tail (kMaxInitialBytes, '\0');
+    {
+        std::ifstream input (path, std::ios::binary);
+        if (! input) return false;
+        input.seekg (static_cast<std::streamoff> (size - kMaxInitialBytes));
+        input.read (tail.data(), static_cast<std::streamsize> (tail.size()));
+        if (input.gcount() != static_cast<std::streamsize> (tail.size())) return false;
+    }
+    const auto boundary = tail.find_first_of ("\r\n");
+    // Keep an unbroken or binary fragment intact, matching existing startup
+    // trimming. A later append supplies a boundary for the next startup.
+    if (boundary == std::string::npos || tail.find ('\0') < boundary) return true;
+
+    const TrimDirectory temporary (parent);
+    if (temporary.path.empty()) return false;
+    const auto replacement = temporary.path / "log";
+    {
+        std::ofstream output (replacement, std::ios::binary | std::ios::trunc);
+        if (! output) return false;
+        output.write (tail.data() + boundary, static_cast<std::streamsize> (tail.size() - boundary));
+        output.close();
+        if (! output) return false;
+    }
+    // Match startup's existing retry window when another process briefly
+    // holds the destination open (notably Windows file scanners).
+    for (int attempt = 0; attempt < 5; ++attempt)
+    {
+        std::filesystem::rename (replacement, path, error);
+        if (! error) return true;
+        std::this_thread::sleep_for (std::chrono::milliseconds (100));
+    }
+    return false;
+}
+
+bool LogFile::append (std::string_view message)
+{
+    const std::lock_guard<std::mutex> lock (mutex);
+    if (path.empty() || message.size() > static_cast<std::size_t> (std::numeric_limits<std::streamsize>::max()))
+        return false;
+    std::ofstream output (path, std::ios::binary | std::ios::app);
+    if (! output) return false;
+    if (! message.empty()) output.write (message.data(), static_cast<std::streamsize> (message.size()));
+    output.write ("\r\n", 2);
+    output.close();
+    return static_cast<bool> (output);
+}
+} // namespace duskstudio::diagnostics

--- a/src/util/LogFile.h
+++ b/src/util/LogFile.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cstddef>
+#include <filesystem>
+#include <mutex>
+#include <string_view>
+
+namespace duskstudio::diagnostics
+{
+// Blocking, non-RT storage for the application log. The owner must outlive
+// all callers; prepare once before publishing it to logging threads.
+class LogFile
+{
+public:
+    explicit LogFile (std::filesystem::path file);
+
+    // Creates parents and trims an existing log at a line boundary. Failure
+    // leaves the original file intact; append can still be attempted.
+    bool prepare();
+    bool append (std::string_view message);
+
+    static constexpr std::size_t kMaxInitialBytes = 128 * 1024;
+
+private:
+    std::filesystem::path path;
+    std::mutex mutex;
+};
+} // namespace duskstudio::diagnostics

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -207,6 +207,8 @@ target_sources(dusk-studio-tests PRIVATE
     foundation_text_format.cpp
     foundation_vector_ops.cpp
     foundation_fs.cpp
+    log_file.cpp
+    ${CMAKE_SOURCE_DIR}/src/util/LogFile.cpp
     foundation_special_locations.cpp
     ${CMAKE_SOURCE_DIR}/src/session/RecentSessions.cpp
     foundation_json.cpp

--- a/tests/log_file.cpp
+++ b/tests/log_file.cpp
@@ -1,0 +1,103 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "TestTempDirectory.h"
+#include "foundation/Fs.h"
+#include "util/LogFile.h"
+
+#include <juce_core/juce_core.h>
+
+#include <filesystem>
+#include <string>
+
+namespace
+{
+juce::File asJuceFile (const std::filesystem::path& path)
+{
+    return juce::File (juce::String::fromUTF8 (path.u8string().c_str()));
+}
+} // namespace
+
+TEST_CASE ("application logs append UTF-8 to existing Unicode paths", "[diagnostics][issue-313]")
+{
+    duskstudio::test::TempDirectory directory { "dusk-log-test-" };
+    const auto path = directory.path() / std::filesystem::u8path (u8"Gr\u00fc\u00dfe-\u97f3\u58f0") / "daily.log";
+    duskstudio::diagnostics::LogFile log (path);
+    REQUIRE (log.prepare());
+    REQUIRE (log.append (u8"session: caf\u00e9 \U0001f3b9"));
+    REQUIRE (dusk::fs::loadFileAsString (path) == u8"session: caf\u00e9 \U0001f3b9\r\n");
+
+    duskstudio::diagnostics::LogFile reopened (path);
+    REQUIRE (reopened.prepare());
+    REQUIRE (reopened.append ("second startup\nmore detail"));
+    REQUIRE (reopened.append ({}));
+    REQUIRE (dusk::fs::loadFileAsString (path)
+             == u8"session: caf\u00e9 \U0001f3b9\r\nsecond startup\nmore detail\r\n\r\n");
+}
+
+TEST_CASE ("application log startup trimming matches the existing file logger", "[diagnostics][issue-313]")
+{
+    using duskstudio::diagnostics::LogFile;
+    duskstudio::test::TempDirectory directory { "dusk-log-test-" };
+    const auto path = directory.path() / "native.log";
+    const auto reference = directory.path() / "reference.log";
+    std::string original;
+
+    SECTION ("below the limit") { original = "existing\r\nrecords\r\n"; }
+    SECTION ("exactly at the limit") { original = std::string (LogFile::kMaxInitialBytes - 1, 'x') + '\n'; }
+    SECTION ("LF boundary") { original = std::string (LogFile::kMaxInitialBytes, 'x') + "\nrecent\n"; }
+    SECTION ("CRLF boundary") { original = std::string (LogFile::kMaxInitialBytes, 'x') + "\r\nrecent\r\n"; }
+    SECTION ("CR boundary") { original = std::string (LogFile::kMaxInitialBytes, 'x') + "\rrecent\r"; }
+    SECTION ("no complete line") { original = std::string (LogFile::kMaxInitialBytes + 10, 'x'); }
+    SECTION ("embedded zero before the boundary")
+    {
+        original = std::string (LogFile::kMaxInitialBytes, 'x') + std::string ("\0recent\n", 8);
+    }
+    REQUIRE (dusk::fs::writeStringToFile (path, original));
+    REQUIRE (dusk::fs::writeStringToFile (reference, original));
+    juce::FileLogger::trimFileSize (asJuceFile (reference), static_cast<juce::int64> (LogFile::kMaxInitialBytes));
+
+    LogFile log (path);
+    REQUIRE (log.prepare());
+    REQUIRE (dusk::fs::loadFileAsString (path) == dusk::fs::loadFileAsString (reference));
+    REQUIRE (log.append ("new startup"));
+    REQUIRE (dusk::fs::loadFileAsString (path) == dusk::fs::loadFileAsString (reference) + "new startup\r\n");
+    for (const auto& entry : std::filesystem::directory_iterator (directory.path()))
+        REQUIRE (entry.is_regular_file());
+}
+
+TEST_CASE ("application logs retain whole recent records during startup trimming", "[diagnostics][issue-313]")
+{
+    using duskstudio::diagnostics::LogFile;
+    duskstudio::test::TempDirectory directory { "dusk-log-test-" };
+    const auto path = directory.path() / "daily.log";
+    const std::string recent = "\nfirst recent record\nsecond recent record\n";
+    REQUIRE (dusk::fs::writeStringToFile (path, std::string (LogFile::kMaxInitialBytes * 2, 'x') + recent));
+    LogFile log (path);
+    REQUIRE (log.prepare());
+    REQUIRE (dusk::fs::loadFileAsString (path) == recent);
+    REQUIRE (std::filesystem::file_size (path) <= LogFile::kMaxInitialBytes);
+
+    REQUIRE (log.append (std::string (LogFile::kMaxInitialBytes, 'y')));
+    REQUIRE (std::filesystem::file_size (path) > LogFile::kMaxInitialBytes);
+}
+
+TEST_CASE ("application log failures preserve existing paths and report failure", "[diagnostics][issue-313]")
+{
+    using duskstudio::diagnostics::LogFile;
+    duskstudio::test::TempDirectory directory { "dusk-log-test-" };
+    const auto blocker = directory.path() / "file";
+    REQUIRE (dusk::fs::writeStringToFile (blocker, "keep this file"));
+    LogFile blocked (blocker / "nested.log");
+    REQUIRE_FALSE (blocked.prepare());
+    REQUIRE_FALSE (blocked.append ("unwritten"));
+    REQUIRE (dusk::fs::loadFileAsString (blocker) == "keep this file");
+
+    LogFile directoryTarget (directory.path());
+    REQUIRE_FALSE (directoryTarget.prepare());
+    REQUIRE_FALSE (directoryTarget.append ("unwritten"));
+    REQUIRE (std::filesystem::is_directory (directory.path()));
+
+    LogFile emptyPath (std::filesystem::path {});
+    REQUIRE_FALSE (emptyPath.prepare());
+    REQUIRE_FALSE (emptyPath.append ("unwritten"));
+}


### PR DESCRIPTION
Replaces the application log's storage with a native, non-RT file sink. Existing daily log paths, UTF-8 output, startup trimming and welcome banners are preserved. The current logger adapter retains its sink after shutdown detach so in-flight callers keep valid storage. Directory paths are explicitly rejected on every platform.

Depends on #517; this PR targets its cleanup branch. Part of #313.

Validation on `1fbfa17dfa74282bfb36b948e958a7b9a39513dd`:
- Linux app and test builds passed with `-j4`, no new warnings, and 943/943 CTests (31.46 s).
- macOS app and test builds passed, with 918/918 CTests (22.14 s). Warning identities all occur in the parent validation logs.
- Windows app and test builds passed with ASIO enabled, with 903/903 CTests (60.63 s).
- Both remote platforms passed all four focused storage tests (78 assertions): A/B startup-trim comparisons, Unicode paths, repeated startup, recent-record preservation and path failures.
- Two normal Linux application startups on private Xvfb displays, with isolated home/audio/devices, verified that the existing daily log gains a second startup banner.
- JUCE gate: 163 files / 8,090 uses before and after. No additional files leave the allowlist in this phase.
- Source review and the repository checklist cover file replacement, failure handling, and retained-resource lifetime.

The macOS environment has LV2 disabled; Windows lacks LAME and samplerate. These runs validate the compiled configurations, without claiming hardware or plugin runtime coverage. Build workflows do not run against this stacked base yet; the exact-commit results above are local and remote validation.

The crash callback and existing logger callers remain for later phases. This change does not claim native crash-handler completion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native application log storage with automatic directory creation and append support.
  * Log files are trimmed at startup while preserving complete recent log entries.
  * Crash reports now use the native application log storage.

* **Documentation**
  * Updated test counts and utility descriptions in the README.
  * Clarified application logging and startup log-trimming behavior.

* **Tests**
  * Added coverage for appending logs, trimming behavior, Unicode paths, and storage failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->