### PR TITLE
refactor: capture native host diagnostics before crashes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -710,6 +710,7 @@ target_sources(DuskStudio PRIVATE
     src/session/SessionSerializer.cpp
     src/session/SessionTemplates.cpp
     src/util/CrashHandler.cpp
+    src/util/HostInfo.cpp
     src/util/LogFile.cpp
     src/util/SingleInstance.cpp
     src/ui/AnalogVuMeter.cpp

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 970 Catch2 test cases across 184 test source files. Linux
+The C++ suite declares 973 Catch2 test cases across 185 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # Native log storage + CrashHandler signal reports
-tests/         # 970 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 973 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/util/CrashHandler.cpp
+++ b/src/util/CrashHandler.cpp
@@ -1,4 +1,5 @@
 #include "CrashHandler.h"
+#include "HostInfo.h"
 #include "LogFile.h"
 
 #include <juce_core/juce_core.h>
@@ -37,11 +38,13 @@ private:
     diagnostics::LogFile storage;
 };
 
-std::atomic<bool>             installed { false };
-std::string                   cachedAppVersion;
-juce::File                    cachedCrashDir;
-juce::File                    cachedLogFile;
-std::unique_ptr<LogAdapter>    ownedLogger;
+std::atomic<bool> installed { false };
+// Every object read by the retained callback must survive static teardown.
+auto& cachedAppVersion = *new std::string;
+auto& cachedCrashDir = *new juce::File;
+auto& cachedLogFile = *new juce::File;
+const std::string* cachedHostInfo = nullptr;
+std::unique_ptr<LogAdapter> ownedLogger;
 
 juce::File baseDir()
 {
@@ -77,10 +80,7 @@ void crashCallback (void* /*platformSpecific*/)
            << "Time:         " << juce::Time::getCurrentTime().toString (true, true) << "\n"
            << "App version:  " << cachedAppVersion.c_str() << "\n"
            << "JUCE version: " << juce::SystemStats::getJUCEVersion() << "\n"
-           << "OS:           " << juce::SystemStats::getOperatingSystemName() << "\n"
-           << "CPU:          " << juce::SystemStats::getCpuModel()
-           << " (" << juce::SystemStats::getNumCpus() << " cores)\n"
-           << "RAM:          " << juce::SystemStats::getMemorySizeInMegabytes() << " MB\n\n"
+           << cachedHostInfo->c_str()
            << "Backtrace\n"
            << "---------\n"
            << juce::SystemStats::getStackBacktrace() << "\n\n";
@@ -147,6 +147,11 @@ void install (const std::string& appVersion)
 
     cachedCrashDir = baseDir().getChildFile ("crashes");
     cachedCrashDir.createDirectory();
+
+    // The callback remains installed after detach and through static teardown.
+    // Keep its immutable startup snapshot alive for the rest of the process.
+    if (cachedHostInfo == nullptr)
+        cachedHostInfo = new const std::string (diagnostics::formatHostInfo (diagnostics::collectHostInfo()));
 
     juce::SystemStats::setApplicationCrashHandler (&crashCallback);
 }

--- a/src/util/HostInfo.cpp
+++ b/src/util/HostInfo.cpp
@@ -56,7 +56,9 @@ HostInfo collectHostInfo()
     }
     SYSTEM_INFO system {};
     GetNativeSystemInfo (&system);
-    info.logicalCpus = system.dwNumberOfProcessors;
+    info.logicalCpus = GetActiveProcessorCount (ALL_PROCESSOR_GROUPS);
+    if (info.logicalCpus == 0)
+        info.logicalCpus = system.dwNumberOfProcessors;
     MEMORYSTATUSEX memory {};
     memory.dwLength = sizeof (memory);
     if (GlobalMemoryStatusEx (&memory))

--- a/src/util/HostInfo.cpp
+++ b/src/util/HostInfo.cpp
@@ -1,0 +1,131 @@
+#include "HostInfo.h"
+#include "../foundation/Text.h"
+
+#include <cstring>
+#include <fstream>
+
+#if defined(_WIN32)
+ #ifndef NOMINMAX
+  #define NOMINMAX
+ #endif
+ #include <windows.h>
+ #include <winternl.h>
+ #if defined(_M_IX86) || defined(_M_X64)
+  #include <intrin.h>
+ #endif
+#elif defined(__APPLE__)
+ #include <sys/sysctl.h>
+#elif defined(__linux__)
+ #include <sys/sysinfo.h>
+ #include <unistd.h>
+#endif
+
+namespace duskstudio::diagnostics
+{
+namespace
+{
+#if defined(__APPLE__)
+std::string sysctlString (const char* key)
+{
+    char buffer[256] {};
+    auto size = sizeof (buffer) - 1;
+    if (sysctlbyname (key, buffer, &size, nullptr, 0) != 0) return {};
+    return dusk::text::trim (buffer);
+}
+#endif
+}
+
+HostInfo collectHostInfo()
+{
+    HostInfo info;
+   #if defined(_WIN32)
+    info.operatingSystem = "Windows";
+    const auto module = GetModuleHandleW (L"ntdll.dll");
+    const auto address = module ? GetProcAddress (module, "RtlGetVersion") : nullptr;
+    using VersionQuery = LONG (WINAPI*) (PRTL_OSVERSIONINFOW);
+    VersionQuery query = nullptr;
+    static_assert (sizeof (query) == sizeof (address));
+    std::memcpy (&query, &address, sizeof (query));
+    RTL_OSVERSIONINFOW version {};
+    version.dwOSVersionInfoSize = sizeof (version);
+    if (query != nullptr && query (&version) == 0)
+    {
+        info.operatingSystem += " " + std::to_string (version.dwMajorVersion)
+            + "." + std::to_string (version.dwMinorVersion)
+            + " (build " + std::to_string (version.dwBuildNumber) + ")";
+    }
+    SYSTEM_INFO system {};
+    GetNativeSystemInfo (&system);
+    info.logicalCpus = system.dwNumberOfProcessors;
+    MEMORYSTATUSEX memory {};
+    memory.dwLength = sizeof (memory);
+    if (GlobalMemoryStatusEx (&memory))
+        info.memoryMiB = memory.ullTotalPhys / (1024 * 1024);
+    #if defined(_M_IX86) || defined(_M_X64)
+    int registers[4] {};
+    __cpuid (registers, (int) 0x80000000u);
+    if ((unsigned int) registers[0] >= 0x80000004u)
+    {
+        char model[49] {};
+        for (unsigned int leaf = 0; leaf < 3; ++leaf)
+        {
+            __cpuid (registers, (int) (0x80000002u + leaf));
+            std::memcpy (model + leaf * 16, registers, sizeof (registers));
+        }
+        info.cpuModel = dusk::text::trim (model);
+    }
+    #elif defined(_M_ARM) || defined(_M_ARM64)
+    wchar_t model[256] {};
+    DWORD modelBytes = sizeof (model);
+    info.cpuModel = "Unknown Model";
+    if (RegGetValueW (HKEY_LOCAL_MACHINE, L"HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0",
+                      L"ProcessorNameString", RRF_RT_REG_SZ, nullptr, model, &modelBytes) == ERROR_SUCCESS)
+    {
+        char utf8[768] {};
+        if (WideCharToMultiByte (CP_UTF8, 0, model, -1, utf8, sizeof (utf8), nullptr, nullptr) > 0)
+        {
+            const auto value = dusk::text::trim (utf8);
+            if (! value.empty()) info.cpuModel = value;
+        }
+    }
+    #endif
+   #elif defined(__APPLE__)
+    info.operatingSystem = "Mac OSX";
+    if (const auto version = sysctlString ("kern.osproductversion"); ! version.empty())
+        info.operatingSystem += " " + version;
+    info.cpuModel = sysctlString ("machdep.cpu.brand_string");
+    auto size = sizeof (info.logicalCpus);
+    if (sysctlbyname ("hw.activecpu", &info.logicalCpus, &size, nullptr, 0) != 0)
+        info.logicalCpus = 0;
+    std::uint64_t bytes = 0;
+    size = sizeof (bytes);
+    if (sysctlbyname ("hw.memsize", &bytes, &size, nullptr, 0) == 0)
+        info.memoryMiB = bytes / (1024 * 1024);
+   #elif defined(__linux__)
+    info.operatingSystem = "Linux";
+    const auto cpus = sysconf (_SC_NPROCESSORS_ONLN);
+    if (cpus > 0) info.logicalCpus = (unsigned int) cpus;
+    struct sysinfo memory {};
+    if (sysinfo (&memory) == 0)
+        info.memoryMiB = (std::uint64_t) memory.totalram * memory.mem_unit / (1024 * 1024);
+    std::ifstream cpuInfo ("/proc/cpuinfo");
+    std::string line;
+    while (std::getline (cpuInfo, line))
+    {
+        const auto colon = line.find (':');
+        if (colon != std::string::npos && dusk::text::trim (std::string_view (line).substr (0, colon)) == "model name")
+            info.cpuModel = dusk::text::trim (std::string_view (line).substr (colon + 1));
+    }
+   #endif
+    return info;
+}
+
+std::string formatHostInfo (const HostInfo& info)
+{
+    const auto known = [] (const std::string& value) { return value.empty() ? "unavailable" : value; };
+    const auto cpus = info.logicalCpus == 0 ? "unavailable" : std::to_string (info.logicalCpus);
+    const auto memory = info.memoryMiB == 0 ? "unavailable" : std::to_string (info.memoryMiB) + " MiB";
+    return "OS:           " + known (info.operatingSystem) + "\nCPU:          " + known (info.cpuModel)
+        + " (" + cpus + " logical cores)\nRAM:          " + memory + "\n\n";
+}
+} // namespace duskstudio::diagnostics

--- a/src/util/HostInfo.cpp
+++ b/src/util/HostInfo.cpp
@@ -30,7 +30,7 @@ std::string sysctlString (const char* key)
     char buffer[256] {};
     auto size = sizeof (buffer) - 1;
     if (sysctlbyname (key, buffer, &size, nullptr, 0) != 0) return {};
-    return dusk::text::trim (buffer);
+    return buffer;
 }
 #endif
 }

--- a/src/util/HostInfo.h
+++ b/src/util/HostInfo.h
@@ -14,7 +14,8 @@ struct HostInfo
 };
 
 // Blocking, non-RT probes. Capture and format before installing a crash callback.
-// Empty strings and zero counts mean the platform query was unavailable.
+// Empty strings and zero counts indicate unavailable queries; Windows ARM
+// retains the existing "Unknown Model" fallback for the CPU name.
 HostInfo collectHostInfo();
 std::string formatHostInfo (const HostInfo&);
 } // namespace duskstudio::diagnostics

--- a/src/util/HostInfo.h
+++ b/src/util/HostInfo.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace duskstudio::diagnostics
+{
+struct HostInfo
+{
+    std::string operatingSystem;
+    std::string cpuModel;
+    unsigned int logicalCpus = 0;
+    std::uint64_t memoryMiB = 0;
+};
+
+// Blocking, non-RT probes. Capture and format before installing a crash callback.
+// Empty strings and zero counts mean the platform query was unavailable.
+HostInfo collectHostInfo();
+std::string formatHostInfo (const HostInfo&);
+} // namespace duskstudio::diagnostics

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -209,6 +209,8 @@ target_sources(dusk-studio-tests PRIVATE
     foundation_fs.cpp
     log_file.cpp
     ${CMAKE_SOURCE_DIR}/src/util/LogFile.cpp
+    host_info.cpp
+    ${CMAKE_SOURCE_DIR}/src/util/HostInfo.cpp
     foundation_special_locations.cpp
     ${CMAKE_SOURCE_DIR}/src/session/RecentSessions.cpp
     foundation_json.cpp

--- a/tests/host_info.cpp
+++ b/tests/host_info.cpp
@@ -3,6 +3,10 @@
 
 #include "util/HostInfo.h"
 
+#if defined(_WIN32)
+ #include <windows.h>
+#endif
+
 using namespace duskstudio::diagnostics;
 
 TEST_CASE ("Host diagnostics preserve supplied values and explicit units", "[issue-313][host-info]")
@@ -23,14 +27,21 @@ TEST_CASE ("Native host probes retain current platform diagnostic facts", "[issu
     INFO (formatHostInfo (info));
     REQUIRE_FALSE (info.operatingSystem.empty());
     REQUIRE (info.cpuModel == juce::SystemStats::getCpuModel().toStdString());
-    REQUIRE (info.logicalCpus == (unsigned int) juce::SystemStats::getNumCpus());
    #if defined(_WIN32)
+    unsigned int logicalCpus = 0;
+    const auto groups = GetActiveProcessorGroupCount();
+    for (WORD group = 0; group < groups; ++group)
+        logicalCpus += GetActiveProcessorCount (group);
+    if (logicalCpus == 0)
+        logicalCpus = (unsigned int) juce::SystemStats::getNumCpus();
+    REQUIRE (info.logicalCpus == logicalCpus);
     // The prior provider added one MiB unconditionally; report the actual floor.
     if (info.memoryMiB != 0)
         REQUIRE (info.memoryMiB + 1 == (std::uint64_t) juce::SystemStats::getMemorySizeInMegabytes());
     REQUIRE (info.operatingSystem.find ("Windows ") == 0);
     REQUIRE (info.operatingSystem.find (" (build ") != std::string::npos);
    #else
+    REQUIRE (info.logicalCpus == (unsigned int) juce::SystemStats::getNumCpus());
     REQUIRE (info.memoryMiB == (std::uint64_t) juce::SystemStats::getMemorySizeInMegabytes());
     REQUIRE (info.operatingSystem == juce::SystemStats::getOperatingSystemName().toStdString());
    #endif

--- a/tests/host_info.cpp
+++ b/tests/host_info.cpp
@@ -26,7 +26,8 @@ TEST_CASE ("Native host probes retain current platform diagnostic facts", "[issu
     REQUIRE (info.logicalCpus == (unsigned int) juce::SystemStats::getNumCpus());
    #if defined(_WIN32)
     // The prior provider added one MiB unconditionally; report the actual floor.
-    REQUIRE (info.memoryMiB + 1 == (std::uint64_t) juce::SystemStats::getMemorySizeInMegabytes());
+    if (info.memoryMiB != 0)
+        REQUIRE (info.memoryMiB + 1 == (std::uint64_t) juce::SystemStats::getMemorySizeInMegabytes());
     REQUIRE (info.operatingSystem.find ("Windows ") == 0);
     REQUIRE (info.operatingSystem.find (" (build ") != std::string::npos);
    #else

--- a/tests/host_info.cpp
+++ b/tests/host_info.cpp
@@ -1,0 +1,36 @@
+#include <catch2/catch_test_macros.hpp>
+#include <juce_core/juce_core.h>
+
+#include "util/HostInfo.h"
+
+using namespace duskstudio::diagnostics;
+
+TEST_CASE ("Host diagnostics preserve supplied values and explicit units", "[issue-313][host-info]")
+{
+    REQUIRE (formatHostInfo ({ "Test OS 1.2", "Test CPU", 24, 32768 })
+        == "OS:           Test OS 1.2\nCPU:          Test CPU (24 logical cores)\nRAM:          32768 MiB\n\n");
+}
+
+TEST_CASE ("Unavailable host probes stay identifiable in crash diagnostics", "[issue-313][host-info]")
+{
+    REQUIRE (formatHostInfo ({})
+        == "OS:           unavailable\nCPU:          unavailable (unavailable logical cores)\nRAM:          unavailable\n\n");
+}
+
+TEST_CASE ("Native host probes retain current platform diagnostic facts", "[issue-313][host-info]")
+{
+    const auto info = collectHostInfo();
+    INFO (formatHostInfo (info));
+    REQUIRE_FALSE (info.operatingSystem.empty());
+    REQUIRE (info.cpuModel == juce::SystemStats::getCpuModel().toStdString());
+    REQUIRE (info.logicalCpus == (unsigned int) juce::SystemStats::getNumCpus());
+   #if defined(_WIN32)
+    // The prior provider added one MiB unconditionally; report the actual floor.
+    REQUIRE (info.memoryMiB + 1 == (std::uint64_t) juce::SystemStats::getMemorySizeInMegabytes());
+    REQUIRE (info.operatingSystem.find ("Windows ") == 0);
+    REQUIRE (info.operatingSystem.find (" (build ") != std::string::npos);
+   #else
+    REQUIRE (info.memoryMiB == (std::uint64_t) juce::SystemStats::getMemorySizeInMegabytes());
+    REQUIRE (info.operatingSystem == juce::SystemStats::getOperatingSystemName().toStdString());
+   #endif
+}

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -160,4 +160,4 @@ src/ui/multisample/AriaGuiComponent.cpp	90
 src/ui/multisample/AriaGuiComponent.h	17
 src/ui/multisample/DuskMultisampleEditor.cpp	68
 src/ui/multisample/DuskMultisampleEditor.h	21
-src/util/CrashHandler.cpp	29
+src/util/CrashHandler.cpp	25


### PR DESCRIPTION
Captures native OS, CPU, logical-core and physical-memory information during startup, then reuses the immutable text in crash reports. The retained callback's version and path objects also survive static teardown. Windows reports the actual kernel version/build, physical MiB floor and active logical processors across all processor groups; Mac CPU-brand whitespace is preserved.

Part of #313, based on the merged logging work in #520. Targets main.

Validation:
- Current `682ff39` passed Linux app/test builds with `-j4`, zero warnings, and 957/957 CTests (30.13 s).
- Preceding `907b1a1` passed exact CI: Linux 957/957, macOS 949/949, Windows 916/916, plus arm64 and sanitizers. Subsequent changes guard the unavailable-memory test comparison and count Windows processors across all groups with the previous group-local value as a fallback. Current CI is pending.
- Three focused cases cover supplied formatting, unavailable values, and platform-provider comparisons.
- Isolated Linux fixtures verified complete crash reports and recent logs after logger detach and after static teardown. The report implementation is unchanged by the rebase and test guard.
- JUCE gate against current main: 163 files / 8,081 uses to 163 files / 8,077 uses. No additional files leave the allowlist.
- Source review and the repository checklist covered native API contracts, platform parity and retained callback state. The Windows test now sums individual processor groups rather than requiring equality with the former group-local count.

The existing crash hook, stream/backtrace calls and logger adapter remain for later phases. This change does not establish an async-signal-safe crash reporter.

Latest review findings: the memory guard was already present and is retained, along with the unavailable-value and CPU-model assertions. The Mac query is unchanged because Apple documents hw.activecpu and hw.logicalcpu as aliases. Local Windows validation could not start because the marked VM was unreachable (SSH: No route to host); the simulated multi-group/fallback probe also remains unrun.
