### PR TITLE
Diag/518 windows hang

### DIFF
--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -157,30 +157,26 @@ jobs:
         # without elevation.
         shell: bash
         run: |
-          inventory="$(ctest --test-dir build-tests -N -C Release)"
-          printf '%s\n' "$inventory"
-          for required in \
-            "ipc-stub: connect, round-trip 32 blocks, byte-exact echo" \
-            "ipc-stub: rejects oversize block" \
-            "ipc-stub: timeout is bounded and marks the connection crashed" \
-            "ipc-stub: repeated connect, block, and teardown"; do
-            grep -Fq "$required" <<< "$inventory" || {
-              echo "::error::required Windows IPC regression missing from CTest: $required" >&2
-              exit 1
-            }
-          done
-          for required in \
-            "FileImporter: transient file locks retry but remain bounded" \
-            "FileImporter: 44.1k mono -> 48k session preserves length" \
-            "FileImporter: 44.1k -> 48k upsample fills the tail with audio, not a held sample" \
-            "FileImporter: 96k mono -> 48k session preserves length" \
-            "FileImporter: stereo -> mono sums L+R at 0.5 each" \
-            "FileImporter: mono -> stereo duplicates to L and R" \
-            "FileImporter: matching rate and channels copies the source verbatim" \
-            "FileImporter: a matching 32-bit source is not truncated to 24-bit"; do
-            grep -Fq "$required" <<< "$inventory" || {
-              echo "::error::required Windows FileImporter regression missing from CTest: $required" >&2
-              exit 1
-            }
-          done
-          ctest --test-dir build-tests --output-on-failure -C Release
+          set -uo pipefail
+          exe=$(find build-tests -name dusk-studio-tests.exe | head -1)
+          echo "exe=$exe"; ls -la "$exe"
+          CDB="/c/Program Files (x86)/Windows Kits/10/Debuggers/x64/cdb.exe"; ls -la "$CDB" || true
+          echo "== list-tests =="
+          timeout 60 "$exe" --list-tests --verbosity quiet | wc -l; echo "list rc=${PIPESTATUS[0]}"
+          echo "== direct test #1 =="
+          timeout 60 "$exe" "PortLayout describes a plain stereo insert effect"; echo "direct rc=$?"
+          echo "== direct coremidi test =="
+          timeout 60 "$exe" "CoreMIDI packets separate channel and system messages"; echo "coremidi rc=$?"
+          echo "== stack capture of a hanging invocation =="
+          "$exe" "PortLayout describes a plain stereo insert effect" > "$RUNNER_TEMP/t1.out" 2>&1 &
+          sleep 25
+          tasklist | grep -i dusk-studio-tests || echo "process already exited"
+          if [ -x "$CDB" ] && tasklist | grep -qi dusk-studio-tests.exe; then
+            "$CDB" -pn dusk-studio-tests.exe -c "~* kb; q" | tail -150
+          fi
+          tail -20 "$RUNNER_TEMP/t1.out" || true
+          taskkill //F //IM dusk-studio-tests.exe || true
+          echo "== ctest single test verbose =="
+          timeout 120 ctest --test-dir build-tests -C Release -R "PortLayout describes a plain" -V; echo "ctest1 rc=$?"
+          echo "== full ctest, 60s cap per test, stop on first failure =="
+          ctest --test-dir build-tests --output-on-failure -C Release --timeout 60 --stop-on-failure; echo "full rc=$?"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -946,8 +946,8 @@ if(UNIX AND NOT APPLE)
     target_compile_definitions(DuskStudio PRIVATE DUSKSTUDIO_HAS_ALSA=1)
 endif()
 
-# No native MIDI backend off Linux: the seam falls back to JUCE's MIDI device
-# API, confined to this one TU. This condition is the exact inverse of the
+# MIDI selection off Linux still uses JUCE's MIDI device API, confined to this
+# one TU. This condition is the exact inverse of the
 # __linux__ branch MidiDevices.cpp picks its backend with, so the backend it
 # asks for is always compiled in. (The ALSA block above uses the wider
 # UNIX-AND-NOT-APPLE, so a non-Linux Unix would build AlsaSeqMidi.cpp too - as
@@ -955,6 +955,16 @@ endif()
 # actually targeted.)
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_sources(DuskStudio PRIVATE src/engine/midi/JuceMidiBackend.cpp)
+endif()
+
+if(APPLE)
+    add_library(dusk-coremidi STATIC src/engine/midi/CoreMidiBackend.mm)
+    target_compile_features(dusk-coremidi PUBLIC cxx_std_17)
+    set_target_properties(dusk-coremidi PROPERTIES OBJCXX_STANDARD 17 OBJCXX_STANDARD_REQUIRED ON)
+    target_include_directories(dusk-coremidi PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/src")
+    target_compile_options(dusk-coremidi PRIVATE -Wall -Wextra -Wpedantic -fblocks)
+    target_link_libraries(dusk-coremidi PUBLIC "-framework CoreMIDI" "-framework CoreFoundation")
+    target_link_libraries(DuskStudio PRIVATE dusk-coremidi)
 endif()
 
 # Dusk Studio-owned native PipeWire backend - a dusk device::IODevice +

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -946,14 +946,14 @@ if(UNIX AND NOT APPLE)
     target_compile_definitions(DuskStudio PRIVATE DUSKSTUDIO_HAS_ALSA=1)
 endif()
 
-# MIDI selection off Linux still uses JUCE's MIDI device API, confined to this
-# one TU. This condition is the exact inverse of the
-# __linux__ branch MidiDevices.cpp picks its backend with, so the backend it
-# asks for is always compiled in. (The ALSA block above uses the wider
-# UNIX-AND-NOT-APPLE, so a non-Linux Unix would build AlsaSeqMidi.cpp too - as
-# its own non-Linux stub, unreferenced. Only Linux, macOS and Windows are
-# actually targeted.)
-if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+option(DUSKSTUDIO_NATIVE_COREMIDI "Use the native CoreMIDI device backend on macOS" OFF)
+if(DUSKSTUDIO_NATIVE_COREMIDI AND NOT APPLE)
+    message(FATAL_ERROR "DUSKSTUDIO_NATIVE_COREMIDI requires macOS")
+endif()
+
+if(DUSKSTUDIO_NATIVE_COREMIDI)
+    target_compile_definitions(DuskStudio PRIVATE DUSKSTUDIO_HAS_NATIVE_COREMIDI=1)
+elseif(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_sources(DuskStudio PRIVATE src/engine/midi/JuceMidiBackend.cpp)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 955 Catch2 test cases across 182 test source files. Linux
+The C++ suite declares 963 Catch2 test cases across 183 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # CrashHandler (FileLogger + signal-handler reports)
-tests/         # 955 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 963 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/docs/dejuce-coremidi-plan.md
+++ b/docs/dejuce-coremidi-plan.md
@@ -1,0 +1,37 @@
+# Native CoreMIDI — first macOS device phase
+
+Partial work for issue #298. CoreAudio, the JUCE audio-device module, Windows MIDI, and hardware sign-off remain separate work.
+
+## Boundaries
+
+The existing `IMidiInputBackend` / `IMidiOutputBackend` interfaces and `MidiInputClient` / `MidiOutputBank` own the application-facing routes. The new backend exposes factories behind those interfaces. Linux continues using ALSA-seq. `DUSKSTUDIO_NATIVE_COREMIDI=ON` selects CoreMIDI on macOS; it defaults to `OFF`. The JUCE fallback remains available when the option is off. Other platforms reject an explicit native CoreMIDI request.
+
+Input packets use a fresh correlation between `mach_absolute_time()` and `backendClockMs()` for every callback. A zero CoreMIDI timestamp means current callback time. Complete messages retain their first-byte time across packet boundaries. Each source owns a fixed parser buffer sized for the existing collector ring. Oversized SysEx is discarded whole; realtime messages still pass. EOX outside SysEx clears pending/running status and is not emitted alone. Undefined F4/F5 statuses retain the existing one-byte treatment.
+
+Input callback state is retained by CoreMIDI's block. An atomic admission gate permits one callback per source, rejects stopped or concurrent delivery, and fences admitted callbacks before port disposal. Restart creates fresh callback state. Disabling input ports preserves the current attachment and endpoint notifications; detaching fences both input delivery and notifications. The message thread owns configuration. A single process client survives backend creation/destruction because Apple warns against disposing and recreating the last client. Ports and endpoint subscriptions close normally; weak notification subscriptions cannot keep an input backend alive.
+
+Native IDs use `coremidi:<signed unique ID>`. Migration reconstructs existing JUCE identifiers from endpoint/device relationships and connected external IDs, including space-joined device/endpoint IDs and comma-joined connections. An alias matching more than one endpoint is refused. The forward lookup recognizes both verified single-entity external-device formats: device UID in JUCE 8.0.4 and endpoint UID in the newer fork. The reverse Apple-only lookup selects from the fallback's actual current enumeration, with the same ambiguity refusal, rather than guessing which format that framework version emits. The native canonical ID remains independent of names and enumeration order. Legacy name-prefix comparisons decode Unicode codepoints and use the current locale's single-character uppercase mapping, matching the fallback; they deliberately avoid broader Unicode folding or normalization.
+
+Output uses one bounded scheduling worker across all destinations. Each send dispatches already-due events before returning, preserving the intended direct panic/control ordering before route closure. Future events remain on the worker, which orders deadlines in the same clock domain and sends only due packets to CoreMIDI. Closing routes or destroying the backend discards its remaining pending records. It does not flush destination-wide output belonging to other clients. The byte-packet CoreMIDI API remains deliberate while the application content model carries MIDI 1 bytes; UMP/MIDI 2 is outside this phase.
+
+## Verification
+
+Portable Catch tests cover message framing, packet splits, realtime interleaving, bounded SysEx recovery, collector capacity, signed IDs, and clocks with different epochs.
+
+Enable the separately registered macOS suite with `-DDUSKSTUDIO_TEST_COREMIDI_VIRTUAL=ON`; the default test run does not create virtual endpoints. The virtual-endpoint suite exercises native enumeration, input/output, source timestamps, fragmented SysEx, scheduling, independent destinations, route cancellation, callback teardown/restart, compound identifier migration, ambiguity refusal, and endpoint notifications. It creates only its own virtual sources/destinations and does not change global MIDI setup or open hardware endpoints.
+
+Validation uses exact-commit macOS app compilation and the native virtual tests, Linux app/test build and CTest, the isolated Linux selftest, source review, the JUCE gate and diff check. The macOS validation configuration disables LV2; no GUI or audio app runtime is part of this evidence. Virtual endpoints have no external device/entity hierarchy, so the two external identifier forms are checked against the actual framework sources and portable synthetic cases. They have not been exercised against physical external devices. SDK-only builds and virtual fixtures do not establish hardware timing or full application behavior.
+
+The implementation deliberately uses CoreMIDI's deprecated MIDI 1 byte-packet APIs and suppresses those deprecation diagnostics in its native translation unit. An independent strict-warning build with AddressSanitizer and UndefinedBehaviorSanitizer exercises the portable and virtual suites. A separate scratch probe compiles the fallback against the actual macOS JUCE 8.0.4 source and checks signed, compound, missing and ambiguous routes through both backends' migration methods, using only its own virtual endpoints. Unrelated dependency warnings are compared with the parent revision, including a single-file parent build that reproduces sfizz's existing `std::result_of` warnings after CMake cache reuse changes its language standard.
+
+Owed to Marc's bench: physical MIDI input/output, MTC and MIDI Clock jitter, physical disconnect/reconnect, driver-specific naming/identity, sleep/wake, and real CoreAudio/device integration. This phase does not complete issue #298 or globally unlink a JUCE module.
+
+## API evidence
+
+- [MIDITimeStamp](https://developer.apple.com/documentation/coremidi/miditimestamp): host time comes from `mach_absolute_time()`.
+- [MIDIPacket.timeStamp](https://developer.apple.com/documentation/coremidi/midipacket/timestamp): timestamps describe occurrence/playback time; zero means now.
+- [MIDIClientDispose](https://developer.apple.com/documentation/coremidi/midiclientdispose(_:)): disposing the last client can prevent later client creation.
+- [MIDIClientCreate](https://developer.apple.com/documentation/coremidi/midiclientcreate(_:_:_:_:)): notifications use the creating run loop.
+- [MIDIInputPortCreateWithBlock](https://developer.apple.com/documentation/coremidi/midiinputportcreatewithblock(_:_:_:_:)): input blocks run on a CoreMIDI-owned high-priority thread.
+- [MIDIPacketListAdd](https://developer.apple.com/documentation/coremidi/midipacketlistadd(_:_:_:_:_:_:)): a packet may contain partial SysEx; packet lists are limited to 65,536 bytes.
+- [MIDIFlushOutput](https://developer.apple.com/documentation/coremidi/midiflushoutput(_:)): cancellation applies to the destination, so backend teardown avoids it.

--- a/docs/dejuce-native-midi-plan.md
+++ b/docs/dejuce-native-midi-plan.md
@@ -1,13 +1,15 @@
 # Native ALSA-seq MIDI backend — executable spec (M1 → M3)
 
-**Status: TOWER COMPLETE.** M1 (PR #93) primitives + backend interface, M2
-(PR #94) `AlsaSeqMidi`, M3 (PR #98) the seam flip — all merged to main. Gate
-194, suite 417/417, Xvfb self-test 15/15, ALSA loopback + migration suites
-green on merged main.
+**Linux tower status: COMPLETE.** M1 (PR #93) primitives + backend interface, M2
+(PR #94) `AlsaSeqMidi`, M3 (PR #98) the seam flip — all merged to main. At the
+Linux tower's completion, gate 194, suite 417/417, Xvfb self-test 15/15, and
+ALSA loopback + migration suites passed.
 
 What shipped: the seam runs on `IMidiInput/OutputBackend` (per-input
 `dusk::MidiCollector`, SPSC slot queue + `std::thread` pump, `std::string`
-device info); Linux uses `AlsaSeqMidi`, everything else `JuceMidiBackend`; both
+device info); Linux uses `AlsaSeqMidi`, macOS has an opt-in
+[CoreMIDI backend](dejuce-coremidi-plan.md), and the default macOS/Windows path
+uses `JuceMidiBackend`; both
 device-API leaks outside the seam are routed through it; `juceManager()` is
 compiled out on Linux; legacy JUCE identifiers migrate by re-resolving the old
 `<client>-<port>` address.
@@ -17,16 +19,17 @@ Three things this tower did NOT do, which the next planner must not assume:
 - **`juce_audio_devices` did not unlink.** Dual-gated with Phase-3-audio, so
   the gate stayed flat at 194 and the module count at 12. The metric moving is
   Phase-3-audio's job.
-- **The mac/win `JuceMidiBackend` has never been executed.** It is not compiled
-  on Linux; it was syntax-checked against real JUCE headers and reviewed, and
-  its first genuine run is mac/win CI.
+- **Platform sign-off remains separate.** The macOS CoreMIDI work includes
+  exact-commit builds and virtual-endpoint checks, including migration through
+  the actual JUCE fallback. That does not establish physical-device timing,
+  Windows MIDI coverage, or CoreAudio parity.
 - **Hardware sign-off is still owed**: real-keyboard smoke, and MTC / MIDI-clock
   timing against external gear.
 
-Known follow-on, designed but not built: MIDI hot-plug auto-detect. Nothing
-calls `refreshMidiInputs()` automatically (only the Audio Settings Rescan
-button), which predates this tower. Plan is to subscribe the input port to the
-ALSA System Announce port and refresh when the transport is stopped.
+Native MIDI hot-plug detection now exists: ALSA subscribes to System Announce,
+and the opt-in CoreMIDI backend receives endpoint notifications. The engine
+coalesces changes and defers a bank rebuild until transport/recording state
+allows it. The JUCE fallback retains manual rescan.
 
 The phase-by-phase spec below is kept as the record of what was built and why.
 

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -20,7 +20,7 @@
 #if DUSKSTUDIO_HAS_NATIVE_AU
  #include "au/AuBundle.h"
 #endif
-#if ! defined(__linux__)
+#if ! defined(__linux__) && ! DUSKSTUDIO_HAS_NATIVE_COREMIDI
  #include "midi/JuceMidiBackend.h"
 #endif
 #include "../foundation/Decibels.h"
@@ -753,16 +753,14 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
             opened, savedDevice, liveDevice);
     }
 
-   #if ! defined(__linux__)
+   #if ! defined(__linux__) && ! DUSKSTUDIO_HAS_NATIVE_COREMIDI
     // The JUCE MIDI fallback drives its input enable/callback lifecycle through
-    // the device manager. Linux runs the native ALSA-sequencer backend, which
-    // owns its own connections, and compiles this out entirely.
+    // the device manager. Native MIDI backends own their connections.
     duskstudio::midi::setJuceMidiDeviceManager (deviceManager.juceManager());
    #endif
 
-    // Hot-plug. Set before the backend starts: the handler runs on its MIDI
-    // thread, so it only hops to the message thread and lets that side decide
-    // when a rebuild is safe.
+    // Defer hot-plug handling to a fresh message-thread turn so a backend
+    // notification never re-enters its own stop/rebuild lifecycle.
     midiIn.setDeviceChangeHandler ([this, alive = midiHotplugAlive]
     {
         dusk::callAsync ([this, alive]

--- a/src/engine/midi/CoreMidiBackend.h
+++ b/src/engine/midi/CoreMidiBackend.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "MidiBackend.h"
+
+#include <memory>
+
+namespace duskstudio::midi
+{
+// Construct/control on the message thread; CoreMIDI notifications use its run
+// loop. stop() fences input delivery and must not be called by the receiver.
+std::unique_ptr<IMidiInputBackend> makeCoreMidiInputBackend();
+std::unique_ptr<IMidiOutputBackend> makeCoreMidiOutputBackend();
+std::string coreMidiLegacyInputIdentifier (const std::string& identifier);
+std::string coreMidiLegacyOutputIdentifier (const std::string& identifier);
+} // namespace duskstudio::midi

--- a/src/engine/midi/CoreMidiBackend.h
+++ b/src/engine/midi/CoreMidiBackend.h
@@ -10,6 +10,10 @@ namespace duskstudio::midi
 // loop. stop() fences input delivery and must not be called by the receiver.
 std::unique_ptr<IMidiInputBackend> makeCoreMidiInputBackend();
 std::unique_ptr<IMidiOutputBackend> makeCoreMidiOutputBackend();
-std::string coreMidiLegacyInputIdentifier (const std::string& identifier);
-std::string coreMidiLegacyOutputIdentifier (const std::string& identifier);
+// Resolve against the fallback's actual enumeration, since its external-device
+// identifier representation differs between supported framework versions.
+std::string coreMidiLegacyInputIdentifier (const std::string& identifier,
+                                          const std::vector<BackendDeviceInfo>& available);
+std::string coreMidiLegacyOutputIdentifier (const std::string& identifier,
+                                           const std::vector<BackendDeviceInfo>& available);
 } // namespace duskstudio::midi

--- a/src/engine/midi/CoreMidiBackend.mm
+++ b/src/engine/midi/CoreMidiBackend.mm
@@ -152,9 +152,15 @@ bool startsWithDeviceName (const std::string& name, const std::string& prefix)
     if (prefix.empty()) return true;
     const auto value = CFStringCreateWithCString (nullptr, name.c_str(), kCFStringEncodingUTF8);
     const auto start = CFStringCreateWithCString (nullptr, prefix.c_str(), kCFStringEncodingUTF8);
+    const auto characters = [] (CFStringRef text)
+    {
+        std::u16string result (static_cast<std::size_t> (CFStringGetLength (text)), u'\0');
+        for (std::size_t i = 0; i < result.size(); ++i)
+            result[i] = CFStringGetCharacterAtIndex (text, static_cast<CFIndex> (i));
+        return result;
+    };
     const bool result = value != nullptr && start != nullptr
-        && CFStringFindWithOptions (value, start, CFRangeMake (0, CFStringGetLength (value)),
-                                   kCFCompareAnchored | kCFCompareCaseInsensitive, nullptr);
+        && coremidi::legacyNameStartsWith (characters (value), characters (start));
     if (start != nullptr) CFRelease (start);
     if (value != nullptr) CFRelease (value);
     return result;

--- a/src/engine/midi/CoreMidiBackend.mm
+++ b/src/engine/midi/CoreMidiBackend.mm
@@ -496,7 +496,11 @@ public:
         const auto now = backendClockMs();
         bool sent = true;
         while (! pending.empty() && pending.begin()->first <= now)
-            sent = sendFirstPending() && sent;
+        {
+            const auto destination = pending.begin()->second.destination;
+            const bool delivered = sendFirstPending();
+            if (destination == found->second) sent = sent && delivered;
+        }
         wake.notify_all();
         return sent;
     }

--- a/src/engine/midi/CoreMidiBackend.mm
+++ b/src/engine/midi/CoreMidiBackend.mm
@@ -160,32 +160,39 @@ bool startsWithDeviceName (const std::string& name, const std::string& prefix)
     return result;
 }
 
-BackendDeviceInfo legacyEndpointInfo (MIDIEndpointRef endpoint, bool external)
+struct LegacyInfo
+{
+    BackendDeviceInfo deviceForm;
+    BackendDeviceInfo endpointForm;
+};
+
+LegacyInfo legacyEndpointInfo (MIDIEndpointRef endpoint, bool external)
 {
     auto info = objectInfo (endpoint);
     MIDIEntityRef entity = 0;
     MIDIEndpointGetEntity (endpoint, &entity);
-    if (entity == 0) return info;
+    if (entity == 0) return { info, info };
     if (info.name.empty() && info.identifier.empty()) info = objectInfo (entity);
     MIDIDeviceRef device = 0;
     MIDIEntityGetDevice (entity, &device);
-    if (device == 0) return info;
+    if (device == 0) return { info, info };
     const auto deviceInfo = objectInfo (device);
-    if (deviceInfo.name.empty() && deviceInfo.identifier.empty()) return info;
+    if (deviceInfo.name.empty() && deviceInfo.identifier.empty()) return { info, info };
     if (external && MIDIDeviceGetNumberOfEntities (device) < 2)
-        info.name = deviceInfo.name;
-    else if (! startsWithDeviceName (info.name, deviceInfo.name))
+        return { coremidi::externalEndpointInfo (info, deviceInfo, coremidi::ExternalIdentifier::Device),
+                 coremidi::externalEndpointInfo (info, deviceInfo, coremidi::ExternalIdentifier::Endpoint) };
+    if (! startsWithDeviceName (info.name, deviceInfo.name))
     {
         info.name = deviceInfo.name + " " + info.name;
         while (! info.name.empty() && static_cast<unsigned char> (info.name.back()) <= ' ') info.name.pop_back();
         info.identifier = deviceInfo.identifier + " " + info.identifier;
     }
-    return info;
+    return { info, info };
 }
 
-BackendDeviceInfo connectedEndpointInfo (MIDIEndpointRef endpoint)
+LegacyInfo connectedEndpointInfo (MIDIEndpointRef endpoint)
 {
-    BackendDeviceInfo info;
+    LegacyInfo info;
     CFDataRef connections = nullptr;
     MIDIObjectGetDataProperty (endpoint, kMIDIPropertyConnectionUniqueID, &connections);
     if (connections != nullptr)
@@ -199,24 +206,28 @@ BackendDeviceInfo connectedEndpointInfo (MIDIEndpointRef endpoint)
             MIDIObjectRef object = 0;
             MIDIObjectType type = kMIDIObjectType_Other;
             if (MIDIObjectFindByUniqueID (static_cast<MIDIUniqueID> (id), &object, &type) != noErr) continue;
-            const auto connected = type == kMIDIObjectType_ExternalSource || type == kMIDIObjectType_ExternalDestination
-                                 ? legacyEndpointInfo (static_cast<MIDIEndpointRef> (object), true) : objectInfo (object);
-            if (! connected.name.empty() || ! connected.identifier.empty())
+            LegacyInfo connected;
+            if (type == kMIDIObjectType_ExternalSource || type == kMIDIObjectType_ExternalDestination)
+                connected = legacyEndpointInfo (static_cast<MIDIEndpointRef> (object), true);
+            else
             {
-                info.name += (info.name.empty() ? "" : ", ") + connected.name;
-                info.identifier += (info.identifier.empty() ? "" : ", ") + connected.identifier;
+                const auto objectDetails = objectInfo (object);
+                connected = { objectDetails, objectDetails };
             }
+            coremidi::appendConnectedInfo (info.deviceForm, connected.deviceForm);
+            coremidi::appendConnectedInfo (info.endpointForm, connected.endpointForm);
         }
         CFRelease (connections);
     }
-    return info.name.empty() && info.identifier.empty() ? legacyEndpointInfo (endpoint, false) : info;
+    return info.deviceForm.name.empty() && info.deviceForm.identifier.empty() ? legacyEndpointInfo (endpoint, false) : info;
 }
 
 struct Endpoint
 {
     MIDIEndpointRef endpoint;
     BackendDeviceInfo info;
-    std::string legacyIdentifier;
+    std::string deviceLegacyIdentifier;
+    std::string endpointLegacyIdentifier;
 };
 
 std::vector<Endpoint> endpoints (bool input)
@@ -231,7 +242,8 @@ std::vector<Endpoint> endpoints (bool input)
         if (endpoint == 0 || MIDIObjectGetIntegerProperty (endpoint, kMIDIPropertyUniqueID, &id) != noErr || id == 0) continue;
         if (MIDIObjectGetIntegerProperty (endpoint, kMIDIPropertyOffline, &offline) == noErr && offline != 0) continue;
         const auto legacy = connectedEndpointInfo (endpoint);
-        result.push_back ({ endpoint, { legacy.name, coremidi::identifier (id) }, legacy.identifier });
+        result.push_back ({ endpoint, { legacy.deviceForm.name, coremidi::identifier (id) },
+                            legacy.deviceForm.identifier, legacy.endpointForm.identifier });
     }
     return result;
 }
@@ -243,17 +255,17 @@ std::vector<BackendDeviceInfo> enumerate (bool input)
     return result;
 }
 
+std::vector<coremidi::EndpointIdentity> identitySnapshot (bool input)
+{
+    std::vector<coremidi::EndpointIdentity> result;
+    for (const auto& endpoint : endpoints (input))
+        result.push_back ({ endpoint.info.identifier, endpoint.deviceLegacyIdentifier, endpoint.endpointLegacyIdentifier });
+    return result;
+}
+
 std::string migrate (bool input, const std::string& legacy)
 {
-    if (legacy.empty()) return {};
-    std::string result;
-    for (const auto& endpoint : endpoints (input))
-        if (endpoint.legacyIdentifier == legacy)
-        {
-            if (! result.empty()) return {};
-            result = endpoint.info.identifier;
-        }
-    return result;
+    return coremidi::migrateIdentifier (identitySnapshot (input), legacy);
 }
 
 coremidi::ClockAnchor clockAnchor (double millisecondsPerTick)
@@ -264,16 +276,9 @@ coremidi::ClockAnchor clockAnchor (double millisecondsPerTick)
     return { before + (after - before) / 2, milliseconds, millisecondsPerTick };
 }
 
-std::string legacyIdentifier (bool input, const std::string& identifier)
+std::string legacyIdentifier (bool input, const std::string& identifier, const std::vector<BackendDeviceInfo>& available)
 {
-    if (identifier.rfind ("coremidi:", 0) != 0) return {};
-    const auto ports = endpoints (input);
-    const auto found = std::find_if (ports.begin(), ports.end(), [&] (const auto& port)
-                                   { return port.info.identifier == identifier; });
-    if (found == ports.end() || found->legacyIdentifier.empty()) return {};
-    if (std::count_if (ports.begin(), ports.end(), [&] (const auto& port)
-                      { return port.legacyIdentifier == found->legacyIdentifier; }) != 1) return {};
-    return found->legacyIdentifier;
+    return coremidi::legacyIdentifier (identitySnapshot (input), identifier, available);
 }
 
 double tickDuration()
@@ -538,8 +543,10 @@ private:
 
 std::unique_ptr<IMidiInputBackend> makeCoreMidiInputBackend() { return std::make_unique<CoreMidiInput>(); }
 std::unique_ptr<IMidiOutputBackend> makeCoreMidiOutputBackend() { return std::make_unique<CoreMidiOutput>(); }
-std::string coreMidiLegacyInputIdentifier (const std::string& identifier) { return legacyIdentifier (true, identifier); }
-std::string coreMidiLegacyOutputIdentifier (const std::string& identifier) { return legacyIdentifier (false, identifier); }
+std::string coreMidiLegacyInputIdentifier (const std::string& identifier, const std::vector<BackendDeviceInfo>& available)
+{ return legacyIdentifier (true, identifier, available); }
+std::string coreMidiLegacyOutputIdentifier (const std::string& identifier, const std::vector<BackendDeviceInfo>& available)
+{ return legacyIdentifier (false, identifier, available); }
 } // namespace duskstudio::midi
 
 #pragma clang diagnostic pop

--- a/src/engine/midi/CoreMidiBackend.mm
+++ b/src/engine/midi/CoreMidiBackend.mm
@@ -1,0 +1,545 @@
+#include "CoreMidiBackend.h"
+#include "CoreMidiProtocol.h"
+
+#include <CoreMIDI/CoreMIDI.h>
+#include <mach/mach_time.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <condition_variable>
+#include <map>
+#include <mutex>
+#include <set>
+#include <thread>
+#include <utility>
+#include <vector>
+
+// The device seam carries MIDI 1 bytes, including fragmented SysEx. Keep the
+// byte-packet API here until the content model has a UMP representation.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+namespace duskstudio::midi
+{
+namespace
+{
+class CallbackGate
+{
+public:
+    // CoreMIDI serialises input on its receive thread. Admit at most one anyway
+    // so a concurrent delivery cannot turn a source collector into MPSC.
+    bool enter() noexcept
+    {
+        std::uint32_t idle = 0;
+        return users.compare_exchange_strong (idle, 1, std::memory_order_acquire, std::memory_order_relaxed);
+    }
+    void leave() noexcept { users.fetch_sub (1, std::memory_order_release); }
+    void open() noexcept { users.store (0, std::memory_order_release); }
+    void close() noexcept { users.fetch_or (kClosed, std::memory_order_acq_rel); }
+    void wait() const noexcept
+    {
+        while ((users.load (std::memory_order_acquire) & ~kClosed) != 0)
+            std::this_thread::yield();
+    }
+private:
+    static constexpr std::uint32_t kClosed = 1u << 31;
+    std::atomic<std::uint32_t> users { kClosed };
+};
+
+struct AdmittedCallback
+{
+    CallbackGate& gate;
+    ~AdmittedCallback() { gate.leave(); }
+};
+
+struct ChangeSubscription
+{
+    CallbackGate gate;
+    IMidiInputBackend::DeviceChangeHandler handler;
+};
+
+bool changesEndpoints (const MIDINotification* notification)
+{
+    if (notification->messageID == kMIDIMsgObjectAdded || notification->messageID == kMIDIMsgObjectRemoved)
+    {
+        const auto type = reinterpret_cast<const MIDIObjectAddRemoveNotification*> (notification)->childType;
+        return type == kMIDIObjectType_Source || type == kMIDIObjectType_Destination
+            || type == kMIDIObjectType_ExternalSource || type == kMIDIObjectType_ExternalDestination;
+    }
+    if (notification->messageID != kMIDIMsgPropertyChanged) return false;
+    const auto* change = reinterpret_cast<const MIDIObjectPropertyChangeNotification*> (notification);
+    if (change->objectType == kMIDIObjectType_Other) return false;
+    return CFEqual (change->propertyName, kMIDIPropertyName)
+        || CFEqual (change->propertyName, kMIDIPropertyOffline)
+        || CFEqual (change->propertyName, kMIDIPropertyUniqueID)
+        || CFEqual (change->propertyName, kMIDIPropertyConnectionUniqueID);
+}
+
+struct ProcessClient
+{
+    MIDIClientRef client = 0;
+    std::mutex mutex;
+    std::vector<std::weak_ptr<ChangeSubscription>> subscribers;
+
+    ProcessClient()
+    {
+        MIDIClientCreate (CFSTR ("Dusk Studio"), [] (const MIDINotification* n, void* context)
+        {
+            if (! changesEndpoints (n)) return;
+            auto& self = *static_cast<ProcessClient*> (context);
+            std::vector<std::shared_ptr<ChangeSubscription>> current;
+            {
+                const std::lock_guard<std::mutex> lock (self.mutex);
+                for (auto it = self.subscribers.begin(); it != self.subscribers.end();)
+                    if (auto subscriber = it->lock())
+                    {
+                        current.push_back (std::move (subscriber));
+                        ++it;
+                    }
+                    else it = self.subscribers.erase (it);
+            }
+            for (const auto& subscriber : current)
+                if (subscriber->gate.enter())
+                {
+                    const AdmittedCallback admitted { subscriber->gate };
+                    if (subscriber->handler) subscriber->handler();
+                }
+        }, this, &client);
+    }
+
+    void subscribe (const std::shared_ptr<ChangeSubscription>& subscriber)
+    {
+        const std::lock_guard<std::mutex> lock (mutex);
+        subscribers.erase (std::remove_if (subscribers.begin(), subscribers.end(),
+                                          [] (const auto& item) { return item.expired(); }), subscribers.end());
+        subscribers.push_back (subscriber);
+    }
+};
+
+ProcessClient& processClient()
+{
+    // Apple warns that disposing the last client can make later creation fail.
+    // The framework releases this one process client at process termination.
+    static auto* client = new ProcessClient;
+    return *client;
+}
+
+std::string stringProperty (MIDIObjectRef object, CFStringRef property)
+{
+    CFStringRef value = nullptr;
+    if (MIDIObjectGetStringProperty (object, property, &value) != noErr || value == nullptr) return {};
+    const auto capacity = CFStringGetMaximumSizeForEncoding (CFStringGetLength (value), kCFStringEncodingUTF8) + 1;
+    std::string result (static_cast<std::size_t> (capacity), '\0');
+    if (! CFStringGetCString (value, result.data(), capacity, kCFStringEncodingUTF8)) result.clear();
+    else result.resize (std::char_traits<char>::length (result.c_str()));
+    CFRelease (value);
+    return result;
+}
+
+BackendDeviceInfo objectInfo (MIDIObjectRef object)
+{
+    SInt32 id = 0;
+    return { stringProperty (object, kMIDIPropertyName),
+             MIDIObjectGetIntegerProperty (object, kMIDIPropertyUniqueID, &id) == noErr
+                 ? std::to_string (id) : stringProperty (object, kMIDIPropertyUniqueID) };
+}
+
+bool startsWithDeviceName (const std::string& name, const std::string& prefix)
+{
+    if (prefix.empty()) return true;
+    const auto value = CFStringCreateWithCString (nullptr, name.c_str(), kCFStringEncodingUTF8);
+    const auto start = CFStringCreateWithCString (nullptr, prefix.c_str(), kCFStringEncodingUTF8);
+    const bool result = value != nullptr && start != nullptr
+        && CFStringFindWithOptions (value, start, CFRangeMake (0, CFStringGetLength (value)),
+                                   kCFCompareAnchored | kCFCompareCaseInsensitive, nullptr);
+    if (start != nullptr) CFRelease (start);
+    if (value != nullptr) CFRelease (value);
+    return result;
+}
+
+BackendDeviceInfo legacyEndpointInfo (MIDIEndpointRef endpoint, bool external)
+{
+    auto info = objectInfo (endpoint);
+    MIDIEntityRef entity = 0;
+    MIDIEndpointGetEntity (endpoint, &entity);
+    if (entity == 0) return info;
+    if (info.name.empty() && info.identifier.empty()) info = objectInfo (entity);
+    MIDIDeviceRef device = 0;
+    MIDIEntityGetDevice (entity, &device);
+    if (device == 0) return info;
+    const auto deviceInfo = objectInfo (device);
+    if (deviceInfo.name.empty() && deviceInfo.identifier.empty()) return info;
+    if (external && MIDIDeviceGetNumberOfEntities (device) < 2)
+        info.name = deviceInfo.name;
+    else if (! startsWithDeviceName (info.name, deviceInfo.name))
+    {
+        info.name = deviceInfo.name + " " + info.name;
+        while (! info.name.empty() && static_cast<unsigned char> (info.name.back()) <= ' ') info.name.pop_back();
+        info.identifier = deviceInfo.identifier + " " + info.identifier;
+    }
+    return info;
+}
+
+BackendDeviceInfo connectedEndpointInfo (MIDIEndpointRef endpoint)
+{
+    BackendDeviceInfo info;
+    CFDataRef connections = nullptr;
+    MIDIObjectGetDataProperty (endpoint, kMIDIPropertyConnectionUniqueID, &connections);
+    if (connections != nullptr)
+    {
+        const auto* data = CFDataGetBytePtr (connections);
+        const auto length = CFDataGetLength (connections);
+        for (CFIndex offset = 0; offset + 4 <= length; offset += 4)
+        {
+            const std::uint32_t id = (std::uint32_t (data[offset]) << 24) | (std::uint32_t (data[offset + 1]) << 16)
+                                  | (std::uint32_t (data[offset + 2]) << 8) | data[offset + 3];
+            MIDIObjectRef object = 0;
+            MIDIObjectType type = kMIDIObjectType_Other;
+            if (MIDIObjectFindByUniqueID (static_cast<MIDIUniqueID> (id), &object, &type) != noErr) continue;
+            const auto connected = type == kMIDIObjectType_ExternalSource || type == kMIDIObjectType_ExternalDestination
+                                 ? legacyEndpointInfo (static_cast<MIDIEndpointRef> (object), true) : objectInfo (object);
+            if (! connected.name.empty() || ! connected.identifier.empty())
+            {
+                info.name += (info.name.empty() ? "" : ", ") + connected.name;
+                info.identifier += (info.identifier.empty() ? "" : ", ") + connected.identifier;
+            }
+        }
+        CFRelease (connections);
+    }
+    return info.name.empty() && info.identifier.empty() ? legacyEndpointInfo (endpoint, false) : info;
+}
+
+struct Endpoint
+{
+    MIDIEndpointRef endpoint;
+    BackendDeviceInfo info;
+    std::string legacyIdentifier;
+};
+
+std::vector<Endpoint> endpoints (bool input)
+{
+    std::vector<Endpoint> result;
+    if (processClient().client == 0) return result;
+    const auto count = input ? MIDIGetNumberOfSources() : MIDIGetNumberOfDestinations();
+    for (ItemCount i = 0; i < count; ++i)
+    {
+        const auto endpoint = input ? MIDIGetSource (i) : MIDIGetDestination (i);
+        SInt32 id = 0, offline = 0;
+        if (endpoint == 0 || MIDIObjectGetIntegerProperty (endpoint, kMIDIPropertyUniqueID, &id) != noErr || id == 0) continue;
+        if (MIDIObjectGetIntegerProperty (endpoint, kMIDIPropertyOffline, &offline) == noErr && offline != 0) continue;
+        const auto legacy = connectedEndpointInfo (endpoint);
+        result.push_back ({ endpoint, { legacy.name, coremidi::identifier (id) }, legacy.identifier });
+    }
+    return result;
+}
+
+std::vector<BackendDeviceInfo> enumerate (bool input)
+{
+    std::vector<BackendDeviceInfo> result;
+    for (const auto& endpoint : endpoints (input)) result.push_back (endpoint.info);
+    return result;
+}
+
+std::string migrate (bool input, const std::string& legacy)
+{
+    if (legacy.empty()) return {};
+    std::string result;
+    for (const auto& endpoint : endpoints (input))
+        if (endpoint.legacyIdentifier == legacy)
+        {
+            if (! result.empty()) return {};
+            result = endpoint.info.identifier;
+        }
+    return result;
+}
+
+coremidi::ClockAnchor clockAnchor (double millisecondsPerTick)
+{
+    const auto before = mach_absolute_time();
+    const double milliseconds = backendClockMs();
+    const auto after = mach_absolute_time();
+    return { before + (after - before) / 2, milliseconds, millisecondsPerTick };
+}
+
+std::string legacyIdentifier (bool input, const std::string& identifier)
+{
+    if (identifier.rfind ("coremidi:", 0) != 0) return {};
+    const auto ports = endpoints (input);
+    const auto found = std::find_if (ports.begin(), ports.end(), [&] (const auto& port)
+                                   { return port.info.identifier == identifier; });
+    if (found == ports.end() || found->legacyIdentifier.empty()) return {};
+    if (std::count_if (ports.begin(), ports.end(), [&] (const auto& port)
+                      { return port.legacyIdentifier == found->legacyIdentifier; }) != 1) return {};
+    return found->legacyIdentifier;
+}
+
+double tickDuration()
+{
+    mach_timebase_info_data_t timebase {};
+    if (mach_timebase_info (&timebase) != KERN_SUCCESS || timebase.denom == 0) return 0.0;
+    return static_cast<double> (timebase.numer) / static_cast<double> (timebase.denom) / 1000000.0;
+}
+
+struct InputConnection
+{
+    CallbackGate gate;
+    coremidi::PacketDecoder decoder;
+    IMidiInputBackend::Receiver receiver;
+    std::string identifier;
+    double millisecondsPerTick = tickDuration();
+};
+
+struct InputPort
+{
+    MIDIPortRef port = 0;
+    std::shared_ptr<InputConnection> connection;
+};
+
+class CoreMidiInput final : public IMidiInputBackend
+{
+public:
+    ~CoreMidiInput() override { stop(); }
+    std::vector<BackendDeviceInfo> enumerate() override { return midi::enumerate (true); }
+    std::string migrateIdentifier (const std::string& legacy) override { return migrate (true, legacy); }
+    void setReceiver (Receiver value) override { receiver = std::move (value); }
+    void setDeviceChangeHandler (DeviceChangeHandler value) override { changeHandler = std::move (value); }
+
+    bool enable (const std::string& identifier) override
+    {
+        if (ports.count (identifier) != 0) return true;
+        for (const auto& endpoint : endpoints (true))
+            if (endpoint.info.identifier == identifier && connect (identifier, endpoint.endpoint))
+            {
+                enabled.insert (identifier);
+                return true;
+            }
+        return false;
+    }
+
+    void disableAll() override { stop(); enabled.clear(); }
+
+    void start() override
+    {
+        if (running) return;
+        for (const auto& endpoint : endpoints (true))
+            if (enabled.count (endpoint.info.identifier) != 0 && ports.count (endpoint.info.identifier) == 0)
+                connect (endpoint.info.identifier, endpoint.endpoint);
+        changes = std::make_shared<ChangeSubscription>();
+        changes->handler = changeHandler;
+        processClient().subscribe (changes);
+        changes->gate.open();
+        for (const auto& entry : ports)
+        {
+            entry.second.connection->receiver = receiver;
+            entry.second.connection->gate.open();
+        }
+        running = true;
+    }
+
+    void stop() override
+    {
+        if (changes != nullptr) changes->gate.close();
+        for (const auto& entry : ports) entry.second.connection->gate.close();
+        if (changes != nullptr) changes->gate.wait();
+        for (const auto& entry : ports) entry.second.connection->gate.wait();
+        for (const auto& entry : ports) MIDIPortDispose (entry.second.port);
+        ports.clear();
+        changes.reset();
+        running = false;
+    }
+
+private:
+    bool connect (const std::string& identifier, MIDIEndpointRef endpoint)
+    {
+        const auto state = std::make_shared<InputConnection>();
+        if (! (state->millisecondsPerTick > 0.0)) return false;
+        state->receiver = receiver;
+        state->identifier = identifier;
+        MIDIPortRef port = 0;
+        if (MIDIInputPortCreateWithBlock (processClient().client, CFSTR ("Dusk MIDI Input"), &port,
+            ^(const MIDIPacketList* packets, void*)
+            {
+                if (! state->gate.enter()) return;
+                const AdmittedCallback admitted { state->gate };
+                const auto anchor = clockAnchor (state->millisecondsPerTick);
+                auto* packet = &packets->packet[0];
+                for (UInt32 i = 0; i < packets->numPackets; ++i)
+                {
+                    state->decoder.push (packet->data, packet->length, anchor.toMilliseconds (packet->timeStamp),
+                        [&] (const std::uint8_t* bytes, int count, double timeMs)
+                        { if (state->receiver) state->receiver (state->identifier, bytes, count, timeMs); });
+                    packet = MIDIPacketNext (packet);
+                }
+            }) != noErr) return false;
+        if (MIDIPortConnectSource (port, endpoint, nullptr) != noErr)
+        {
+            MIDIPortDispose (port);
+            return false;
+        }
+        ports.emplace (identifier, InputPort { port, state });
+        if (running) state->gate.open();
+        return true;
+    }
+
+    Receiver receiver;
+    DeviceChangeHandler changeHandler;
+    std::set<std::string> enabled;
+    std::map<std::string, InputPort> ports;
+    std::shared_ptr<ChangeSubscription> changes;
+    bool running = false;
+};
+
+class CoreMidiOutput final : public IMidiOutputBackend
+{
+public:
+    CoreMidiOutput()
+    {
+        if (MIDIOutputPortCreate (processClient().client, CFSTR ("Dusk MIDI Output"), &port) == noErr)
+            worker = std::thread ([this] { run(); });
+    }
+
+    ~CoreMidiOutput() override
+    {
+        {
+            const std::lock_guard<std::mutex> lock (mutex);
+            running = false;
+            pending.clear();
+        }
+        wake.notify_all();
+        if (worker.joinable()) worker.join();
+        if (port != 0) MIDIPortDispose (port);
+    }
+
+    std::vector<BackendDeviceInfo> enumerate() override { return midi::enumerate (false); }
+    std::string migrateIdentifier (const std::string& legacy) override { return migrate (false, legacy); }
+
+    bool open (const std::string& identifier) override
+    {
+        const std::lock_guard<std::mutex> lock (mutex);
+        if (port == 0) return false;
+        if (outputs.count (identifier) != 0) return true;
+        for (const auto& endpoint : endpoints (false))
+            if (endpoint.info.identifier == identifier)
+            {
+                outputs.emplace (identifier, endpoint.endpoint);
+                return true;
+            }
+        return false;
+    }
+
+    void closeAll() override
+    {
+        const std::lock_guard<std::mutex> lock (mutex);
+        outputs.clear();
+        pending.clear();
+        queuedBytes = 0;
+        wake.notify_all();
+    }
+
+    bool isOpen (const std::string& identifier) const override
+    {
+        const std::lock_guard<std::mutex> lock (mutex);
+        return outputs.count (identifier) != 0;
+    }
+
+    bool send (const std::string& identifier, const dusk::MidiBuffer& events, double baseTimeMs, double sampleRate) override
+    {
+        const std::lock_guard<std::mutex> lock (mutex);
+        const auto found = outputs.find (identifier);
+        if (found == outputs.end() || ! std::isfinite (baseTimeMs)) return false;
+        const double rate = std::isfinite (sampleRate) && sampleRate > 0.0 ? sampleRate : 48000.0;
+        std::size_t bytes = 0;
+        for (const auto event : events)
+        {
+            const double due = baseTimeMs + static_cast<double> (event.samplePosition) * 1000.0 / rate;
+            if (! std::isfinite (due)) return false;
+            bytes += sizeof (PendingMessage) + static_cast<std::size_t> (event.numBytes);
+            if (bytes > kMaxQueuedBytes - queuedBytes) return false;
+        }
+        for (const auto event : events)
+        {
+            const double due = baseTimeMs + static_cast<double> (event.samplePosition) * 1000.0 / rate;
+            pending.emplace (due, PendingMessage { found->second, { event.data, event.data + event.numBytes } });
+        }
+        queuedBytes += bytes;
+        // Direct panic/control sends are due now and must reach CoreMIDI before
+        // a caller immediately closes routes. Future events remain cancellable.
+        const auto now = backendClockMs();
+        bool sent = true;
+        while (! pending.empty() && pending.begin()->first <= now)
+            sent = sendFirstPending() && sent;
+        wake.notify_all();
+        return sent;
+    }
+
+private:
+    struct PendingMessage
+    {
+        MIDIEndpointRef destination;
+        std::vector<std::uint8_t> bytes;
+    };
+
+    void run()
+    {
+        std::unique_lock<std::mutex> lock (mutex);
+        while (running)
+        {
+            if (pending.empty())
+            {
+                wake.wait (lock, [this] { return ! running || ! pending.empty(); });
+                continue;
+            }
+            const double delayMs = pending.begin()->first - backendClockMs();
+            if (delayMs > 0.0)
+            {
+                wake.wait_for (lock, std::chrono::duration<double, std::milli> (std::min (delayMs, 1000.0)));
+                continue;
+            }
+            sendFirstPending();
+        }
+    }
+
+    bool sendFirstPending()
+    {
+        auto item = pending.extract (pending.begin());
+        const auto& message = item.mapped();
+        queuedBytes -= sizeof (PendingMessage) + message.bytes.size();
+        // Only due events enter CoreMIDI. Route closure can discard this
+        // client's queue without flushing another client's destination.
+        std::size_t offset = 0;
+        while (offset < message.bytes.size())
+        {
+            auto* list = reinterpret_cast<MIDIPacketList*> (packetStorage.data());
+            auto* packet = MIDIPacketListInit (list);
+            const auto count = std::min<std::size_t> (message.bytes.size() - offset, 65500);
+            if (MIDIPacketListAdd (list, packetStorage.size(), packet, 0, count, message.bytes.data() + offset) == nullptr
+                || MIDISend (port, message.destination, list) != noErr) return false;
+            offset += count;
+        }
+        return true;
+    }
+
+    static constexpr std::size_t kMaxQueuedBytes = 64 * dusk::kMidiRoutingBlockBytes;
+    MIDIPortRef port = 0;
+    mutable std::mutex mutex;
+    std::condition_variable wake;
+    std::thread worker;
+    bool running = true;
+    std::map<std::string, MIDIEndpointRef> outputs;
+    std::multimap<double, PendingMessage> pending;
+    std::size_t queuedBytes = 0;
+    alignas(MIDIPacketList) std::array<std::uint8_t, 65536> packetStorage {};
+};
+
+} // namespace
+
+std::unique_ptr<IMidiInputBackend> makeCoreMidiInputBackend() { return std::make_unique<CoreMidiInput>(); }
+std::unique_ptr<IMidiOutputBackend> makeCoreMidiOutputBackend() { return std::make_unique<CoreMidiOutput>(); }
+std::string coreMidiLegacyInputIdentifier (const std::string& identifier) { return legacyIdentifier (true, identifier); }
+std::string coreMidiLegacyOutputIdentifier (const std::string& identifier) { return legacyIdentifier (false, identifier); }
+} // namespace duskstudio::midi
+
+#pragma clang diagnostic pop

--- a/src/engine/midi/CoreMidiBackend.mm
+++ b/src/engine/midi/CoreMidiBackend.mm
@@ -330,7 +330,12 @@ public:
         return false;
     }
 
-    void disableAll() override { stop(); enabled.clear(); }
+    void disableAll() override
+    {
+        closeInputGates();
+        disposeInputs();
+        enabled.clear();
+    }
 
     void start() override
     {
@@ -353,16 +358,26 @@ public:
     void stop() override
     {
         if (changes != nullptr) changes->gate.close();
-        for (const auto& entry : ports) entry.second.connection->gate.close();
+        closeInputGates();
         if (changes != nullptr) changes->gate.wait();
-        for (const auto& entry : ports) entry.second.connection->gate.wait();
-        for (const auto& entry : ports) MIDIPortDispose (entry.second.port);
-        ports.clear();
+        disposeInputs();
         changes.reset();
         running = false;
     }
 
 private:
+    void closeInputGates()
+    {
+        for (const auto& entry : ports) entry.second.connection->gate.close();
+    }
+
+    void disposeInputs()
+    {
+        for (const auto& entry : ports) entry.second.connection->gate.wait();
+        for (const auto& entry : ports) MIDIPortDispose (entry.second.port);
+        ports.clear();
+    }
+
     bool connect (const std::string& identifier, MIDIEndpointRef endpoint)
     {
         const auto state = std::make_shared<InputConnection>();

--- a/src/engine/midi/CoreMidiProtocol.h
+++ b/src/engine/midi/CoreMidiProtocol.h
@@ -5,7 +5,10 @@
 
 #include <array>
 #include <cstdint>
+#include <cwctype>
+#include <limits>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace duskstudio::midi::coremidi
@@ -16,6 +19,37 @@ inline std::string identifier (std::int32_t uniqueId)
 }
 
 enum class ExternalIdentifier { Device, Endpoint };
+
+// Legacy identifiers depend on this name-prefix test. Match the fallback's
+// per-codepoint, current-locale casing; Unicode folding expands some letters.
+inline bool legacyNameStartsWith (std::u16string_view name, std::u16string_view prefix) noexcept
+{
+    const auto next = [] (std::u16string_view& text)
+    {
+        char32_t value = text.front();
+        text.remove_prefix (1);
+        if (value >= 0xd800 && value <= 0xdbff && ! text.empty()
+            && text.front() >= 0xdc00 && text.front() <= 0xdfff)
+        {
+            value = 0x10000 + ((value - 0xd800) << 10) + (text.front() - 0xdc00);
+            text.remove_prefix (1);
+        }
+        return value;
+    };
+    const auto upper = [] (char32_t value)
+    {
+        if constexpr (sizeof (std::wint_t) < sizeof (char32_t))
+            if (value > std::numeric_limits<std::wint_t>::max()) return value;
+        return static_cast<char32_t> (std::towupper (static_cast<std::wint_t> (value)));
+    };
+    while (! prefix.empty())
+    {
+        if (name.empty()) return false;
+        const auto left = next (name), right = next (prefix);
+        if (left != right && upper (left) != upper (right)) return false;
+    }
+    return true;
+}
 
 inline BackendDeviceInfo externalEndpointInfo (const BackendDeviceInfo& endpoint,
                                                const BackendDeviceInfo& device, ExternalIdentifier form)

--- a/src/engine/midi/CoreMidiProtocol.h
+++ b/src/engine/midi/CoreMidiProtocol.h
@@ -1,16 +1,69 @@
 #pragma once
 
+#include "MidiBackend.h"
 #include "../../foundation/MidiBuffer.h"
 
 #include <array>
 #include <cstdint>
 #include <string>
+#include <vector>
 
 namespace duskstudio::midi::coremidi
 {
 inline std::string identifier (std::int32_t uniqueId)
 {
     return "coremidi:" + std::to_string (uniqueId);
+}
+
+enum class ExternalIdentifier { Device, Endpoint };
+
+inline BackendDeviceInfo externalEndpointInfo (const BackendDeviceInfo& endpoint,
+                                               const BackendDeviceInfo& device, ExternalIdentifier form)
+{
+    return { device.name, form == ExternalIdentifier::Device ? device.identifier : endpoint.identifier };
+}
+
+inline void appendConnectedInfo (BackendDeviceInfo& result, const BackendDeviceInfo& connected)
+{
+    if (connected.name.empty() && connected.identifier.empty()) return;
+    result.name += (result.name.empty() ? "" : ", ") + connected.name;
+    result.identifier += (result.identifier.empty() ? "" : ", ") + connected.identifier;
+}
+
+// Older macOS backends used the device UID for a single-entity external
+// connection; newer ones retain the endpoint UID. Both forms exist in sessions.
+struct EndpointIdentity
+{
+    std::string identifier;
+    std::string deviceLegacyIdentifier;
+    std::string endpointLegacyIdentifier;
+};
+
+inline std::string migrateIdentifier (const std::vector<EndpointIdentity>& endpoints, const std::string& legacy)
+{
+    if (legacy.empty()) return {};
+    std::string result;
+    for (const auto& endpoint : endpoints)
+        if (endpoint.deviceLegacyIdentifier == legacy || endpoint.endpointLegacyIdentifier == legacy)
+        {
+            if (! result.empty()) return {};
+            result = endpoint.identifier;
+        }
+    return result;
+}
+
+inline std::string legacyIdentifier (const std::vector<EndpointIdentity>& endpoints,
+                                     const std::string& identifier, const std::vector<BackendDeviceInfo>& available)
+{
+    if (identifier.rfind ("coremidi:", 0) != 0) return {};
+    std::string result;
+    for (const auto& device : available)
+        if (migrateIdentifier (endpoints, device.identifier) == identifier)
+        {
+            if (! result.empty()) return {};
+            result = device.identifier;
+        }
+    return result;
 }
 
 // Capture afresh for every input callback: the two clocks may

--- a/src/engine/midi/CoreMidiProtocol.h
+++ b/src/engine/midi/CoreMidiProtocol.h
@@ -1,0 +1,134 @@
+#pragma once
+
+#include "../../foundation/MidiBuffer.h"
+
+#include <array>
+#include <cstdint>
+#include <string>
+
+namespace duskstudio::midi::coremidi
+{
+inline std::string identifier (std::int32_t uniqueId)
+{
+    return "coremidi:" + std::to_string (uniqueId);
+}
+
+// Capture afresh for every input callback: the two clocks may
+// advance differently across sleep. Subtract ticks before converting so a long
+// uptime does not lose sub-millisecond timing in floating point.
+struct ClockAnchor
+{
+    std::uint64_t hostTicks;
+    double nowMs;
+    double millisecondsPerTick;
+
+    double toMilliseconds (std::uint64_t ticks) const noexcept
+    {
+        if (ticks == 0) return nowMs;
+        const double delta = ticks >= hostTicks ? static_cast<double> (ticks - hostTicks)
+                                               : -static_cast<double> (hostTicks - ticks);
+        return nowMs + delta * millisecondsPerTick;
+    }
+};
+
+// One parser per source. Storage is bounded by what the input collector can
+// carry; an oversized SysEx is discarded whole, through its terminating F7.
+// Messages emit on completion: realtime can precede a fragmented message whose
+// first-byte timestamp is older. Never hold clock ticks behind incomplete SysEx.
+class PacketDecoder
+{
+public:
+    void reset() noexcept
+    {
+        size = 0;
+        expected = 0;
+        runningStatus = 0;
+        inSysex = false;
+        overflow = false;
+    }
+
+    template <class Receiver>
+    void push (const std::uint8_t* bytes, int count, double timeMs, Receiver&& receive)
+    {
+        for (int i = 0; bytes != nullptr && i < count; ++i)
+        {
+            const auto byte = bytes[i];
+            if (byte >= 0xf8)
+            {
+                receive (&bytes[i], 1, timeMs);
+                continue;
+            }
+
+            if (inSysex)
+            {
+                if (byte < 0x80 || byte == 0xf7)
+                {
+                    if (size < data.size()) data[size++] = byte;
+                    else overflow = true;
+                    if (byte == 0xf7)
+                    {
+                        if (! overflow) receive (data.data(), static_cast<int> (size), startMs);
+                        reset();
+                    }
+                    continue;
+                }
+                reset();
+            }
+
+            if (byte >= 0x80)
+            {
+                size = 0;
+                expected = 0;
+                runningStatus = byte < 0xf0 ? byte : 0;
+                if (byte == 0xf7) continue;
+                startMs = timeMs;
+                data[size++] = byte;
+                if (byte == 0xf0)
+                {
+                    inSysex = true;
+                    continue;
+                }
+                expected = messageSize (byte);
+                if (expected == 1)
+                {
+                    receive (data.data(), 1, startMs);
+                    size = 0;
+                }
+                continue;
+            }
+
+            if (size == 0)
+            {
+                if (runningStatus == 0) continue;
+                data[size++] = runningStatus;
+                expected = messageSize (runningStatus);
+                startMs = timeMs;
+            }
+            data[size++] = byte;
+            if (size == expected)
+            {
+                receive (data.data(), static_cast<int> (size), startMs);
+                size = 0;
+            }
+        }
+    }
+
+private:
+    static std::size_t messageSize (std::uint8_t status) noexcept
+    {
+        if (status < 0xf0) return (status & 0xe0) == 0xc0 ? 2 : 3;
+        if (status == 0xf1 || status == 0xf3) return 2;
+        if (status == 0xf2) return 3;
+        return 1;
+    }
+
+    static constexpr std::size_t kMaxMessageBytes = dusk::kMidiBlockBytes - sizeof (double) - sizeof (std::int32_t);
+    std::array<std::uint8_t, kMaxMessageBytes> data {};
+    std::size_t size = 0;
+    std::size_t expected = 0;
+    std::uint8_t runningStatus = 0;
+    double startMs = 0.0;
+    bool inSysex = false;
+    bool overflow = false;
+};
+} // namespace duskstudio::midi::coremidi

--- a/src/engine/midi/JuceMidiBackend.cpp
+++ b/src/engine/midi/JuceMidiBackend.cpp
@@ -1,5 +1,9 @@
 #include "JuceMidiBackend.h"
 
+#if defined(__APPLE__)
+ #include "CoreMidiBackend.h"
+#endif
+
 #include <map>
 #include <mutex>
 #include <utility>
@@ -27,9 +31,12 @@ public:
 
     void setReceiver (Receiver r) override { receiver = std::move (r); }
 
-    // JUCE's identifiers are what earlier sessions already hold on the platforms
-    // this backend serves, so there is nothing to migrate.
+   #if defined(__APPLE__)
+    std::string migrateIdentifier (const std::string& identifier) override
+    { return coreMidiLegacyInputIdentifier (identifier, enumerate()); }
+   #else
     std::string migrateIdentifier (const std::string&) override { return {}; }
+   #endif
 
     bool enable (const std::string& identifier) override
     {
@@ -92,7 +99,12 @@ public:
         return out;
     }
 
+   #if defined(__APPLE__)
+    std::string migrateIdentifier (const std::string& identifier) override
+    { return coreMidiLegacyOutputIdentifier (identifier, enumerate()); }
+   #else
     std::string migrateIdentifier (const std::string&) override { return {}; }
+   #endif
 
     bool open (const std::string& identifier) override
     {

--- a/src/engine/midi/MidiBackend.h
+++ b/src/engine/midi/MidiBackend.h
@@ -9,7 +9,7 @@
 #include <vector>
 
 // JUCE-free backend interfaces behind the MIDI device seam. A platform backend
-// (native ALSA sequencer on Linux; a JUCE-backed fallback on mac/win)
+// (native ALSA on Linux; opt-in CoreMIDI on macOS; JUCE fallback on mac/win)
 // implements these; the seam (MidiInputClient / MidiOutputBank) owns the
 // index->identifier mapping and the per-input retiming collectors, so backends
 // stay identifier-keyed and never see seam-order indices.
@@ -47,13 +47,11 @@ public:
 
     virtual void setReceiver (Receiver r) = 0;          // set once, before start
 
-    // Fires on the backend's MIDI thread when the OS reports that the set of
-    // MIDI ports moved. A bare signal, not a diff: the only useful response is
-    // a full re-enumeration. One plug raises several, so the consumer coalesces.
-    // The handler must not re-enter the backend - the rebuild that follows a
-    // change calls stop(), which joins the thread the handler runs on.
-    // Default no-op: only the ALSA sequencer has an announce port, so the JUCE
-    // fallback leaves mac/win on the manual rescan path.
+    // Port-change notifications run on the ALSA dispatch thread or CoreMIDI's
+    // creating run loop. A bare signal, not a diff: consumers re-enumerate and
+    // coalesce bursts. Defer handling to a fresh message-thread turn; it must
+    // not re-enter the backend's stop/rebuild lifecycle from a notification.
+    // Default no-op keeps the JUCE fallback on manual rescan.
     using DeviceChangeHandler = std::function<void()>;
     virtual void setDeviceChangeHandler (DeviceChangeHandler) {}   // set once, before start
 
@@ -63,10 +61,12 @@ public:
     // Message thread.
     [[nodiscard]] virtual std::string migrateIdentifier (const std::string& legacy) = 0;
 
+    // Input controls run on the message thread, never from either callback:
+    // a backend may wait for admitted callback delivery.
     [[nodiscard]] virtual bool enable (const std::string& identifier) = 0;
-    virtual void disableAll() = 0;
+    virtual void disableAll() = 0;                      // disconnect inputs; keep attach/notifications
     virtual void start() = 0;                            // attach fence
-    // Detach fence: joins the dispatch side before returning, so no receiver
+    // Detach fence: waits for admitted delivery before returning, so no receiver
     // callback is in flight once stop() returns (the contract the seam's
     // detach/rebuild/attach sequence relies on).
     virtual void stop() = 0;

--- a/src/engine/midi/MidiDevices.cpp
+++ b/src/engine/midi/MidiDevices.cpp
@@ -2,6 +2,8 @@
 
 #if defined(__linux__)
  #include "AlsaSeqMidi.h"
+#elif defined(__APPLE__) && DUSKSTUDIO_HAS_NATIVE_COREMIDI
+ #include "CoreMidiBackend.h"
 #else
  #include "JuceMidiBackend.h"
 #endif
@@ -28,6 +30,8 @@ std::unique_ptr<IMidiInputBackend> makeInputBackend()
 {
    #if defined(__linux__)
     return std::make_unique<AlsaSeqMidiInput>();
+   #elif defined(__APPLE__) && DUSKSTUDIO_HAS_NATIVE_COREMIDI
+    return makeCoreMidiInputBackend();
    #else
     return makeJuceMidiInputBackend();
    #endif
@@ -37,6 +41,8 @@ std::unique_ptr<IMidiOutputBackend> makeOutputBackend()
 {
    #if defined(__linux__)
     return std::make_unique<AlsaSeqMidiOutput>();
+   #elif defined(__APPLE__) && DUSKSTUDIO_HAS_NATIVE_COREMIDI
+    return makeCoreMidiOutputBackend();
    #else
     return makeJuceMidiOutputBackend();
    #endif

--- a/src/engine/midi/MidiDevices.h
+++ b/src/engine/midi/MidiDevices.h
@@ -65,14 +65,14 @@ public:
     // bytes under the dead identifier.
     void rebuild (double sampleRate);
 
-    // Message thread, before the first attachCallback. Forwarded to the backend,
-    // whose MIDI thread fires it when the OS port set moves. Bursty and raised
-    // off the message thread, so the consumer owns the thread hop and the
-    // coalescing; backends without an OS notification never fire it.
+    // Message thread, before the first attachCallback. Delivery context is
+    // backend-defined; defer handling to a fresh message-thread turn to avoid
+    // re-entering backend callbacks. The consumer coalesces notification bursts;
+    // backends without an OS notification never fire it.
     void setDeviceChangeHandler (std::function<void()> h);
 
-    // Detach half of the fence: stop the backend's dispatch (its stop() joins
-    // that side before returning) and release the OS handles before a rebuild.
+    // Detach half of the fence: stop backend dispatch and wait for admitted
+    // callbacks before returning, so a rebuild can safely change the routes.
     void detachCallback();
     void disableAllDevices();
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -235,11 +235,9 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         alsa_thread_teardown.cpp
         ${CMAKE_SOURCE_DIR}/src/engine/alsa/AlsaAudioIODevice.cpp)
     target_link_libraries(dusk-studio-tests PRIVATE asound)
+elseif(APPLE AND DUSKSTUDIO_NATIVE_COREMIDI)
+    target_compile_definitions(dusk-studio-tests PRIVATE DUSKSTUDIO_HAS_NATIVE_COREMIDI=1)
 else()
-    # The seam picks its backend on __linux__, so off Linux the JUCE fallback is
-    # what MidiDevices.cpp links against. It is the only remaining user of the
-    # JUCE MIDI device API in the test binary, so the module is linked here
-    # rather than for every platform.
     target_sources(dusk-studio-tests PRIVATE
         ${CMAKE_SOURCE_DIR}/src/engine/midi/JuceMidiBackend.cpp)
     target_link_libraries(dusk-studio-tests PRIVATE juce::juce_audio_devices)
@@ -710,6 +708,7 @@ catch_discover_tests(dusk-studio-tests
     TEST_SPEC "~[alsa]")
 
 if(APPLE)
+    target_link_libraries(dusk-studio-tests PRIVATE dusk-coremidi)
     add_executable(dusk-coremidi-tests core_midi_backend.mm)
     set_target_properties(dusk-coremidi-tests PROPERTIES OBJCXX_STANDARD 17 OBJCXX_STANDARD_REQUIRED ON)
     target_compile_options(dusk-coremidi-tests PRIVATE -Wall -Wextra -Wpedantic -fblocks)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -99,6 +99,7 @@ add_executable(dusk-studio-tests
     recording_byte_accuracy.cpp
     midi_fifo_overflow.cpp
     midi_device_layer.cpp
+    core_midi_protocol.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/midi/MidiDevices.cpp
     midi_time_code_decode.cpp
     midi_time_code_emit.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -709,6 +709,20 @@ catch_discover_tests(dusk-studio-tests
 catch_discover_tests(dusk-studio-tests
     TEST_SPEC "~[alsa]")
 
+if(APPLE)
+    add_executable(dusk-coremidi-tests core_midi_backend.mm)
+    set_target_properties(dusk-coremidi-tests PROPERTIES OBJCXX_STANDARD 17 OBJCXX_STANDARD_REQUIRED ON)
+    target_compile_options(dusk-coremidi-tests PRIVATE -Wall -Wextra -Wpedantic -fblocks)
+    target_link_libraries(dusk-coremidi-tests PRIVATE dusk-coremidi Catch2::Catch2WithMain)
+    add_dependencies(dusk-studio-tests dusk-coremidi-tests)
+
+    option(DUSKSTUDIO_TEST_COREMIDI_VIRTUAL "Run CoreMIDI tests that create temporary virtual endpoints" OFF)
+    if(DUSKSTUDIO_TEST_COREMIDI_VIRTUAL)
+        add_test(NAME coremidi-virtual-endpoints COMMAND dusk-coremidi-tests)
+        set_tests_properties(coremidi-virtual-endpoints PROPERTIES TIMEOUT 45 RUN_SERIAL TRUE)
+    endif()
+endif()
+
 # Exercise the real release-version insertion script against an isolated fixture,
 # and pin the private-release fan-in and single-publisher contract. The release
 # script is Unix-only.

--- a/tests/core_midi_backend.mm
+++ b/tests/core_midi_backend.mm
@@ -317,6 +317,8 @@ TEST_CASE ("CoreMIDI reports endpoint hotplug without reporting its own input po
     REQUIRE (input->enable (findId (input->enumerate(), fixture->sourceName)));
     fixture->emit ({ 0x90, 61, 100 });
     CFRunLoopRunInMode (kCFRunLoopDefaultMode, 0.05, false);
+    // Retire this connection so delayed packets cannot enter the next start.
+    input->stop();
     REQUIRE (changes.load() == afterStop);
     {
         const std::lock_guard<std::mutex> lock (sink.mutex);

--- a/tests/core_midi_backend.mm
+++ b/tests/core_midi_backend.mm
@@ -12,7 +12,9 @@
 #include <array>
 #include <chrono>
 #include <condition_variable>
+#include <functional>
 #include <future>
+#include <memory>
 #include <mutex>
 #include <thread>
 #include <vector>

--- a/tests/core_midi_backend.mm
+++ b/tests/core_midi_backend.mm
@@ -287,25 +287,46 @@ TEST_CASE ("CoreMIDI migrates signed and connected IDs and rejects ambiguous ali
 
 TEST_CASE ("CoreMIDI reports endpoint hotplug without reporting its own input ports", "[coremidi-native][issue-298]")
 {
+    Sink sink;
     auto input = makeCoreMidiInputBackend();
     std::atomic<int> changes { 0 };
+    input->setReceiver (sink.receiver());
     input->setDeviceChangeHandler ([&] { changes.fetch_add (1); });
     input->start();
     auto fixture = std::make_unique<Fixture>();
     REQUIRE (pumpUntil ([&] { return changes.load() > 0; }));
     CFRunLoopRunInMode (kCFRunLoopDefaultMode, 0.05, false);
     const auto beforePort = changes.load();
-    REQUIRE (input->enable (findId (input->enumerate(), fixture->sourceName)));
+    const auto identifier = findId (input->enumerate(), fixture->sourceName);
+    REQUIRE (input->enable (identifier));
     CFRunLoopRunInMode (kCFRunLoopDefaultMode, 0.05, false);
     REQUIRE (changes.load() == beforePort);
+    fixture->emit ({ 0x90, 60, 100 });
+    REQUIRE (sink.wait (1));
+    input->disableAll();
+    REQUIRE (input->enable (identifier));
+    fixture->emit ({ 0x80, 60, 0 });
+    REQUIRE (sink.wait (2));
+    input->disableAll();
     const auto beforeRemoval = changes.load();
     fixture.reset();
     REQUIRE (pumpUntil ([&] { return changes.load() > beforeRemoval; }));
     input->stop();
     const auto afterStop = changes.load();
     fixture = std::make_unique<Fixture>();
+    REQUIRE (input->enable (findId (input->enumerate(), fixture->sourceName)));
+    fixture->emit ({ 0x90, 61, 100 });
     CFRunLoopRunInMode (kCFRunLoopDefaultMode, 0.05, false);
     REQUIRE (changes.load() == afterStop);
+    {
+        const std::lock_guard<std::mutex> lock (sink.mutex);
+        REQUIRE (sink.events.size() == 2);
+    }
+    input->start();
+    fixture->emit ({ 0x80, 61, 0 });
+    REQUIRE (sink.wait (3));
+    input->stop();
+    REQUIRE (sink.events.size() == 3);
 }
 
 TEST_CASE ("CoreMIDI future output does not delay a different destination", "[coremidi-native][issue-298]")

--- a/tests/core_midi_backend.mm
+++ b/tests/core_midi_backend.mm
@@ -1,0 +1,399 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "engine/midi/CoreMidiBackend.h"
+#include "engine/midi/CoreMidiProtocol.h"
+
+#include <CoreMIDI/CoreMIDI.h>
+#include <mach/mach_time.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <array>
+#include <chrono>
+#include <condition_variable>
+#include <future>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+using namespace duskstudio::midi;
+using Catch::Matchers::WithinAbs;
+
+namespace
+{
+MIDIClientRef testClient()
+{
+    static const auto client = []
+    {
+        MIDIClientRef value = 0;
+        MIDIClientCreate (CFSTR ("Dusk CoreMIDI Tests"), nullptr, nullptr, &value);
+        return value;
+    }();
+    return client;
+}
+
+struct Fixture
+{
+    MIDIEndpointRef source = 0;
+    MIDIEndpointRef destination = 0;
+    std::string sourceName;
+    std::string destinationName;
+
+    Fixture()
+    {
+        static int sequence = 0;
+        const auto suffix = std::to_string (getpid()) + " " + std::to_string (++sequence);
+        sourceName = "Dusk CoreMIDI Test Source " + suffix;
+        destinationName = "Dusk CoreMIDI Test Destination " + suffix;
+        const auto sourceString = CFStringCreateWithCString (nullptr, sourceName.c_str(), kCFStringEncodingUTF8);
+        const auto sourceStatus = MIDISourceCreate (testClient(), sourceString, &source);
+        CFRelease (sourceString);
+        REQUIRE (sourceStatus == noErr);
+        const auto destinationString = CFStringCreateWithCString (nullptr, destinationName.c_str(), kCFStringEncodingUTF8);
+        const auto target = source;
+        const auto destinationStatus = MIDIDestinationCreateWithBlock (testClient(), destinationString, &destination,
+            ^(const MIDIPacketList* packets, void*) { MIDIReceived (target, packets); });
+        CFRelease (destinationString);
+        REQUIRE (destinationStatus == noErr);
+    }
+
+    ~Fixture()
+    {
+        if (destination != 0) MIDIEndpointDispose (destination);
+        if (source != 0) MIDIEndpointDispose (source);
+    }
+
+    void emit (const std::vector<std::uint8_t>& bytes, MIDITimeStamp ticks = 0)
+    {
+        alignas(MIDIPacketList) std::array<std::uint8_t, 2048> storage {};
+        auto* list = reinterpret_cast<MIDIPacketList*> (storage.data());
+        REQUIRE (MIDIPacketListAdd (list, storage.size(), MIDIPacketListInit (list), ticks, bytes.size(), bytes.data()) != nullptr);
+        REQUIRE (MIDIReceived (source, list) == noErr);
+    }
+};
+
+std::string findId (const std::vector<BackendDeviceInfo>& devices, const std::string& name)
+{
+    for (const auto& device : devices)
+        if (device.name == name) return device.identifier;
+    return {};
+}
+
+struct Sink
+{
+    struct Event { std::vector<std::uint8_t> bytes; double timeMs; std::string id; };
+    std::mutex mutex;
+    std::condition_variable changed;
+    std::vector<Event> events;
+
+    IMidiInputBackend::Receiver receiver()
+    {
+        return [this] (const std::string& id, const std::uint8_t* bytes, int count, double timeMs)
+        {
+            const std::lock_guard<std::mutex> lock (mutex);
+            events.push_back ({ { bytes, bytes + count }, timeMs, id });
+            changed.notify_all();
+        };
+    }
+
+    bool wait (std::size_t count)
+    {
+        std::unique_lock<std::mutex> lock (mutex);
+        return changed.wait_for (lock, std::chrono::seconds (3), [&] { return events.size() >= count; });
+    }
+};
+
+bool pumpUntil (const std::function<bool()>& ready)
+{
+    const auto end = std::chrono::steady_clock::now() + std::chrono::seconds (3);
+    while (! ready() && std::chrono::steady_clock::now() < end)
+        CFRunLoopRunInMode (kCFRunLoopDefaultMode, 0.005, false);
+    return ready();
+}
+
+SInt32 negativeId (MIDIEndpointRef endpoint)
+{
+    static SInt32 next = -1000000000 - getpid();
+    MIDIObjectRef existing = 0;
+    MIDIObjectType type = kMIDIObjectType_Other;
+    while (MIDIObjectFindByUniqueID (--next, &existing, &type) == noErr) {}
+    REQUIRE (MIDIObjectSetIntegerProperty (endpoint, kMIDIPropertyUniqueID, next) == noErr);
+    return next;
+}
+
+void setConnections (MIDIEndpointRef endpoint, const std::vector<SInt32>& ids)
+{
+    std::vector<std::uint8_t> bytes;
+    for (const auto id : ids)
+        for (int shift = 24; shift >= 0; shift -= 8)
+            bytes.push_back (static_cast<std::uint8_t> (static_cast<std::uint32_t> (id) >> shift));
+    const auto data = CFDataCreate (nullptr, bytes.data(), static_cast<CFIndex> (bytes.size()));
+    const auto status = MIDIObjectSetDataProperty (endpoint, kMIDIPropertyConnectionUniqueID, data);
+    CFRelease (data);
+    REQUIRE (status == noErr);
+}
+}
+
+TEST_CASE ("CoreMIDI virtual endpoints carry channel system and SysEx messages", "[coremidi-native][issue-298]")
+{
+    Fixture fixture;
+    Sink sink;
+    auto input = makeCoreMidiInputBackend();
+    auto output = makeCoreMidiOutputBackend();
+    const auto inputId = findId (input->enumerate(), fixture.sourceName);
+    const auto outputId = findId (output->enumerate(), fixture.destinationName);
+    REQUIRE_FALSE (inputId.empty());
+    REQUIRE_FALSE (outputId.empty());
+    REQUIRE (input->enable (inputId));
+    input->setReceiver (sink.receiver());
+    REQUIRE (output->open (outputId));
+    input->start();
+    const std::vector<std::vector<std::uint8_t>> expected {
+        { 0x90, 60, 100 }, { 0x80, 60, 0 }, { 0xb0, 1, 64 }, { 0xc0, 2 }, { 0xd0, 33 }, { 0xe0, 0, 64 },
+        { 0xf1, 0x17 }, { 0xf2, 1, 2 }, { 0xf3, 3 }, { 0xf6 }, { 0xf8 }, { 0xfa }, { 0xfb }, { 0xfc }, { 0xfe }, { 0xff },
+        { 0xf0, 0x7f, 1, 1, 1, 0x60, 0, 0, 0, 0xf7 }
+    };
+    dusk::MidiBuffer events;
+    for (const auto& bytes : expected) REQUIRE (events.addEvent (bytes.data(), static_cast<int> (bytes.size()), 0));
+    REQUIRE (output->send (outputId, events, backendClockMs(), 48000.0));
+    REQUIRE (sink.wait (expected.size()));
+    input->stop();
+    REQUIRE (sink.events.size() == expected.size());
+    for (std::size_t i = 0; i < expected.size(); ++i)
+    {
+        REQUIRE (sink.events[i].bytes == expected[i]);
+        REQUIRE (sink.events[i].id == inputId);
+    }
+    output->closeAll();
+    REQUIRE_FALSE (output->isOpen (outputId));
+    REQUIRE_FALSE (output->send (outputId, events, backendClockMs(), 48000.0));
+}
+
+TEST_CASE ("CoreMIDI preserves packet time and reassembles SysEx across packets", "[coremidi-native][issue-298]")
+{
+    Fixture fixture;
+    Sink sink;
+    auto input = makeCoreMidiInputBackend();
+    input->setReceiver (sink.receiver());
+    REQUIRE (input->enable (findId (input->enumerate(), fixture.sourceName)));
+    input->start();
+    mach_timebase_info_data_t timebase {};
+    REQUIRE (mach_timebase_info (&timebase) == KERN_SUCCESS);
+    const auto tenMilliseconds = static_cast<std::uint64_t> (10000000.0 * timebase.denom / timebase.numer);
+    const auto timestamp = mach_absolute_time() - tenMilliseconds;
+    const double expectedMs = backendClockMs() - 10.0;
+    fixture.emit ({ 0x90, 60, 100 }, timestamp);
+    fixture.emit ({ 0xf0, 0x7f, 1, 1 }, timestamp);
+    fixture.emit ({ 1, 0x60, 0, 0, 0, 0xf7 });
+    REQUIRE (sink.wait (2));
+    input->stop();
+    REQUIRE_THAT (sink.events[0].timeMs, WithinAbs (expectedMs, 2.0));
+    REQUIRE_THAT (sink.events[1].timeMs, WithinAbs (expectedMs, 2.0));
+    REQUIRE (sink.events[1].bytes == std::vector<std::uint8_t> { 0xf0, 0x7f, 1, 1, 1, 0x60, 0, 0, 0, 0xf7 });
+}
+
+TEST_CASE ("CoreMIDI schedules queued sample offsets in time order", "[coremidi-native][issue-298]")
+{
+    Fixture fixture;
+    Sink sink;
+    auto input = makeCoreMidiInputBackend();
+    auto output = makeCoreMidiOutputBackend();
+    input->setReceiver (sink.receiver());
+    REQUIRE (input->enable (findId (input->enumerate(), fixture.sourceName)));
+    const auto outputId = findId (output->enumerate(), fixture.destinationName);
+    REQUIRE (output->open (outputId));
+    input->start();
+    dusk::MidiBuffer events;
+    const std::uint8_t note[] { 0x90, 60, 100 };
+    REQUIRE (events.addEvent (note, 3, 960));
+    const std::uint8_t off[] { 0x80, 60, 0 };
+    REQUIRE (events.addEvent (off, 3, 0));
+    const double baseMs = backendClockMs() - 10.0;
+    REQUIRE (output->send (outputId, events, baseMs, 48000.0));
+    REQUIRE (sink.wait (2));
+    input->stop();
+    REQUIRE (sink.events[0].bytes == std::vector<std::uint8_t> { 0x80, 60, 0 });
+    REQUIRE (sink.events[1].bytes == std::vector<std::uint8_t> { 0x90, 60, 100 });
+    REQUIRE (sink.events[1].timeMs >= baseMs + 19.0);
+    REQUIRE (sink.events[1].timeMs < baseMs + 100.0);
+}
+
+TEST_CASE ("CoreMIDI stop fences an admitted callback and restart clears partial messages", "[coremidi-native][issue-298]")
+{
+    Fixture fixture;
+    std::promise<void> entered, release;
+    auto released = release.get_future().share();
+    auto input = makeCoreMidiInputBackend();
+    input->setReceiver ([&] (const std::string&, const std::uint8_t*, int, double)
+    {
+        entered.set_value();
+        released.wait();
+    });
+    REQUIRE (input->enable (findId (input->enumerate(), fixture.sourceName)));
+    input->start();
+    fixture.emit ({ 0x90, 60, 100 });
+    REQUIRE (entered.get_future().wait_for (std::chrono::seconds (3)) == std::future_status::ready);
+    auto stopped = std::async (std::launch::async, [&] { input->stop(); });
+    const auto status = stopped.wait_for (std::chrono::milliseconds (20));
+    release.set_value();
+    REQUIRE (status == std::future_status::timeout);
+    REQUIRE (stopped.wait_for (std::chrono::seconds (3)) == std::future_status::ready);
+
+    Sink sink;
+    input->setReceiver (sink.receiver());
+    input->start();
+    fixture.emit ({ 0xf0, 1, 2 });
+    input->stop();
+    fixture.emit ({ 3, 0xf7 });
+    input->start();
+    fixture.emit ({ 0x80, 60, 0 });
+    REQUIRE (sink.wait (1));
+    input->stop();
+    REQUIRE (sink.events.size() == 1);
+    REQUIRE (sink.events[0].bytes == std::vector<std::uint8_t> { 0x80, 60, 0 });
+}
+
+TEST_CASE ("CoreMIDI migrates signed and connected IDs and rejects ambiguous aliases", "[coremidi-native][issue-298]")
+{
+    Fixture first, second, connected, duplicate;
+    const auto firstId = negativeId (first.source);
+    const auto secondId = negativeId (second.source);
+    auto input = makeCoreMidiInputBackend();
+    REQUIRE (input->migrateIdentifier (std::to_string (firstId)) == coremidi::identifier (firstId));
+    REQUIRE (coreMidiLegacyInputIdentifier (coremidi::identifier (firstId)) == std::to_string (firstId));
+    const auto outputId = negativeId (first.destination);
+    auto output = makeCoreMidiOutputBackend();
+    REQUIRE (output->migrateIdentifier (std::to_string (outputId)) == coremidi::identifier (outputId));
+    REQUIRE (coreMidiLegacyOutputIdentifier (coremidi::identifier (outputId)) == std::to_string (outputId));
+    REQUIRE (input->migrateIdentifier ("missing").empty());
+    setConnections (connected.source, { firstId, secondId });
+    SInt32 connectedId = 0;
+    REQUIRE (MIDIObjectGetIntegerProperty (connected.source, kMIDIPropertyUniqueID, &connectedId) == noErr);
+    const auto legacy = std::to_string (firstId) + ", " + std::to_string (secondId);
+    REQUIRE (input->migrateIdentifier (legacy) == coremidi::identifier (connectedId));
+    REQUIRE (coreMidiLegacyInputIdentifier (coremidi::identifier (connectedId)) == legacy);
+    setConnections (duplicate.source, { firstId, secondId });
+    REQUIRE (input->migrateIdentifier (legacy).empty());
+    REQUIRE (coreMidiLegacyInputIdentifier (coremidi::identifier (connectedId)).empty());
+}
+
+TEST_CASE ("CoreMIDI reports endpoint hotplug without reporting its own input ports", "[coremidi-native][issue-298]")
+{
+    auto input = makeCoreMidiInputBackend();
+    std::atomic<int> changes { 0 };
+    input->setDeviceChangeHandler ([&] { changes.fetch_add (1); });
+    input->start();
+    auto fixture = std::make_unique<Fixture>();
+    REQUIRE (pumpUntil ([&] { return changes.load() > 0; }));
+    CFRunLoopRunInMode (kCFRunLoopDefaultMode, 0.05, false);
+    const auto beforePort = changes.load();
+    REQUIRE (input->enable (findId (input->enumerate(), fixture->sourceName)));
+    CFRunLoopRunInMode (kCFRunLoopDefaultMode, 0.05, false);
+    REQUIRE (changes.load() == beforePort);
+    const auto beforeRemoval = changes.load();
+    fixture.reset();
+    REQUIRE (pumpUntil ([&] { return changes.load() > beforeRemoval; }));
+    input->stop();
+    const auto afterStop = changes.load();
+    fixture = std::make_unique<Fixture>();
+    CFRunLoopRunInMode (kCFRunLoopDefaultMode, 0.05, false);
+    REQUIRE (changes.load() == afterStop);
+}
+
+TEST_CASE ("CoreMIDI future output does not delay a different destination", "[coremidi-native][issue-298]")
+{
+    Fixture first, second;
+    Sink sink;
+    auto input = makeCoreMidiInputBackend();
+    auto output = makeCoreMidiOutputBackend();
+    input->setReceiver (sink.receiver());
+    const auto firstInput = findId (input->enumerate(), first.sourceName);
+    const auto secondInput = findId (input->enumerate(), second.sourceName);
+    REQUIRE (input->enable (firstInput));
+    REQUIRE (input->enable (secondInput));
+    const auto firstOutput = findId (output->enumerate(), first.destinationName);
+    const auto secondOutput = findId (output->enumerate(), second.destinationName);
+    REQUIRE (output->open (firstOutput));
+    REQUIRE (output->open (secondOutput));
+    input->start();
+    dusk::MidiBuffer events;
+    const std::uint8_t note[] { 0x90, 60, 100 };
+    REQUIRE (events.addEvent (note, 3, 0));
+    REQUIRE (output->send (firstOutput, events, backendClockMs() + 500.0, 48000.0));
+    REQUIRE (output->send (secondOutput, events, backendClockMs(), 48000.0));
+    REQUIRE (sink.wait (2));
+    input->stop();
+    REQUIRE (sink.events[0].id == secondInput);
+    REQUIRE (sink.events[1].id == firstInput);
+}
+
+TEST_CASE ("CoreMIDI close cancels owned pending output and preserves another sender", "[coremidi-native][issue-298]")
+{
+    Fixture fixture;
+    Sink sink;
+    auto input = makeCoreMidiInputBackend();
+    auto first = makeCoreMidiOutputBackend();
+    auto second = makeCoreMidiOutputBackend();
+    input->setReceiver (sink.receiver());
+    REQUIRE (input->enable (findId (input->enumerate(), fixture.sourceName)));
+    const auto outputId = findId (first->enumerate(), fixture.destinationName);
+    REQUIRE (first->open (outputId));
+    REQUIRE (second->open (outputId));
+    input->start();
+    dusk::MidiBuffer cancelled, retained;
+    const std::uint8_t note[] { 0x90, 60, 100 }, off[] { 0x80, 60, 0 };
+    REQUIRE (cancelled.addEvent (note, 3, 0));
+    REQUIRE (retained.addEvent (off, 3, 0));
+    const auto now = backendClockMs();
+    REQUIRE (first->send (outputId, cancelled, now + 200.0, 48000.0));
+    REQUIRE (second->send (outputId, retained, now + 250.0, 48000.0));
+    first->closeAll();
+    REQUIRE (first->open (outputId));
+    REQUIRE (sink.wait (1));
+    input->stop();
+    REQUIRE (sink.events.size() == 1);
+    REQUIRE (sink.events[0].bytes == std::vector<std::uint8_t> { 0x80, 60, 0 });
+}
+
+TEST_CASE ("CoreMIDI direct output survives immediate close or destruction", "[coremidi-native][issue-298]")
+{
+    Fixture fixture;
+    Sink sink;
+    auto input = makeCoreMidiInputBackend();
+    auto output = makeCoreMidiOutputBackend();
+    input->setReceiver (sink.receiver());
+    REQUIRE (input->enable (findId (input->enumerate(), fixture.sourceName)));
+    const auto outputId = findId (output->enumerate(), fixture.destinationName);
+    REQUIRE (output->open (outputId));
+    input->start();
+    dusk::MidiBuffer events;
+    const std::uint8_t off[] { 0x80, 60, 0 }, note[] { 0x90, 60, 100 };
+    REQUIRE (events.addEvent (off, 3, 0));
+    REQUIRE (events.addEvent (note, 3, 48000));
+    REQUIRE (output->send (outputId, events, backendClockMs(), 48000.0));
+    SECTION ("closeAll") { output->closeAll(); }
+    SECTION ("destruction") { output.reset(); }
+    REQUIRE (sink.wait (1));
+    input->stop();
+    REQUIRE (sink.events.size() == 1);
+    REQUIRE (sink.events[0].bytes == std::vector<std::uint8_t> { 0x80, 60, 0 });
+}
+
+TEST_CASE ("CoreMIDI refresh cannot reopen a removed destination", "[coremidi-native][issue-298]")
+{
+    Fixture fixture;
+    auto output = makeCoreMidiOutputBackend();
+    const auto outputId = findId (output->enumerate(), fixture.destinationName);
+    REQUIRE (output->open (outputId));
+    REQUIRE (MIDIEndpointDispose (fixture.destination) == noErr);
+    fixture.destination = 0;
+    output->closeAll();
+    REQUIRE (findId (output->enumerate(), fixture.destinationName).empty());
+    REQUIRE_FALSE (output->open (outputId));
+}
+
+#pragma clang diagnostic pop

--- a/tests/core_midi_backend.mm
+++ b/tests/core_midi_backend.mm
@@ -264,21 +264,25 @@ TEST_CASE ("CoreMIDI migrates signed and connected IDs and rejects ambiguous ali
     const auto secondId = negativeId (second.source);
     auto input = makeCoreMidiInputBackend();
     REQUIRE (input->migrateIdentifier (std::to_string (firstId)) == coremidi::identifier (firstId));
-    REQUIRE (coreMidiLegacyInputIdentifier (coremidi::identifier (firstId)) == std::to_string (firstId));
+    const std::vector<BackendDeviceInfo> inputs { { first.sourceName, std::to_string (firstId) } };
+    REQUIRE (coreMidiLegacyInputIdentifier (coremidi::identifier (firstId), inputs) == std::to_string (firstId));
+    REQUIRE (coreMidiLegacyInputIdentifier (coremidi::identifier (firstId), {}).empty());
     const auto outputId = negativeId (first.destination);
     auto output = makeCoreMidiOutputBackend();
     REQUIRE (output->migrateIdentifier (std::to_string (outputId)) == coremidi::identifier (outputId));
-    REQUIRE (coreMidiLegacyOutputIdentifier (coremidi::identifier (outputId)) == std::to_string (outputId));
+    const std::vector<BackendDeviceInfo> outputs { { first.destinationName, std::to_string (outputId) } };
+    REQUIRE (coreMidiLegacyOutputIdentifier (coremidi::identifier (outputId), outputs) == std::to_string (outputId));
     REQUIRE (input->migrateIdentifier ("missing").empty());
     setConnections (connected.source, { firstId, secondId });
     SInt32 connectedId = 0;
     REQUIRE (MIDIObjectGetIntegerProperty (connected.source, kMIDIPropertyUniqueID, &connectedId) == noErr);
     const auto legacy = std::to_string (firstId) + ", " + std::to_string (secondId);
     REQUIRE (input->migrateIdentifier (legacy) == coremidi::identifier (connectedId));
-    REQUIRE (coreMidiLegacyInputIdentifier (coremidi::identifier (connectedId)) == legacy);
+    const std::vector<BackendDeviceInfo> connectedInputs { { connected.sourceName, legacy } };
+    REQUIRE (coreMidiLegacyInputIdentifier (coremidi::identifier (connectedId), connectedInputs) == legacy);
     setConnections (duplicate.source, { firstId, secondId });
     REQUIRE (input->migrateIdentifier (legacy).empty());
-    REQUIRE (coreMidiLegacyInputIdentifier (coremidi::identifier (connectedId)).empty());
+    REQUIRE (coreMidiLegacyInputIdentifier (coremidi::identifier (connectedId), connectedInputs).empty());
 }
 
 TEST_CASE ("CoreMIDI reports endpoint hotplug without reporting its own input ports", "[coremidi-native][issue-298]")

--- a/tests/core_midi_protocol.cpp
+++ b/tests/core_midi_protocol.cpp
@@ -43,11 +43,36 @@ TEST_CASE ("CoreMIDI clocks retain source timestamps across different epochs", "
     REQUIRE_THAT (afterSleep.toMilliseconds (0), WithinAbs (62001.0, 1e-9));
 }
 
-TEST_CASE ("CoreMIDI endpoint identifiers retain signed unique IDs", "[midi][coremidi][issue-298]")
+TEST_CASE ("CoreMIDI endpoint identities preserve signed and compound legacy routes", "[midi][coremidi][issue-298]")
 {
     REQUIRE (identifier (42) == "coremidi:42");
     REQUIRE (identifier (-42) == "coremidi:-42");
     REQUIRE (identifier (std::numeric_limits<std::int32_t>::min()) == "coremidi:-2147483648");
+
+    const duskstudio::midi::BackendDeviceInfo endpoint { "Port", "-21" }, device { "Interface", "-20" };
+    auto oldInfo = externalEndpointInfo (endpoint, device, ExternalIdentifier::Device);
+    auto newInfo = externalEndpointInfo (endpoint, device, ExternalIdentifier::Endpoint);
+    REQUIRE (oldInfo.name == "Interface");
+    REQUIRE (oldInfo.identifier == "-20");
+    REQUIRE (newInfo.name == "Interface");
+    REQUIRE (newInfo.identifier == "-21");
+    appendConnectedInfo (oldInfo, { "Bridge", "-30 -31" });
+    appendConnectedInfo (newInfo, { "Bridge", "-30 -31" });
+    REQUIRE (oldInfo.identifier == "-20, -30 -31");
+    REQUIRE (newInfo.identifier == "-21, -30 -31");
+
+    std::vector<EndpointIdentity> identities { { "coremidi:1", oldInfo.identifier, newInfo.identifier } };
+    REQUIRE (migrateIdentifier (identities, oldInfo.identifier) == "coremidi:1");
+    REQUIRE (migrateIdentifier (identities, newInfo.identifier) == "coremidi:1");
+    REQUIRE (migrateIdentifier (identities, "missing").empty());
+    REQUIRE (legacyIdentifier (identities, "coremidi:1", { oldInfo }) == oldInfo.identifier);
+    REQUIRE (legacyIdentifier (identities, "coremidi:1", { newInfo }) == newInfo.identifier);
+    REQUIRE (legacyIdentifier (identities, "coremidi:1", { oldInfo, newInfo }).empty());
+    REQUIRE (legacyIdentifier (identities, "coremidi:1", { oldInfo, oldInfo }).empty());
+    identities.push_back ({ "coremidi:2", newInfo.identifier, "2" });
+    REQUIRE (migrateIdentifier (identities, newInfo.identifier).empty());
+    REQUIRE (legacyIdentifier (identities, "coremidi:1", { newInfo }).empty());
+    REQUIRE (migrateIdentifier (identities, oldInfo.identifier) == "coremidi:1");
 }
 
 TEST_CASE ("CoreMIDI packets separate channel and system messages", "[midi][coremidi][issue-298]")

--- a/tests/core_midi_protocol.cpp
+++ b/tests/core_midi_protocol.cpp
@@ -1,0 +1,152 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "engine/midi/CoreMidiProtocol.h"
+#include "foundation/MidiRing.h"
+
+#include <limits>
+#include <vector>
+
+using namespace duskstudio::midi::coremidi;
+using Catch::Matchers::WithinAbs;
+
+namespace
+{
+struct Received
+{
+    std::vector<std::uint8_t> bytes;
+    double timeMs;
+};
+
+struct DecoderProbe
+{
+    PacketDecoder decoder;
+    std::vector<Received> messages;
+
+    void push (const std::vector<std::uint8_t>& bytes, double timeMs = 100.0)
+    {
+        decoder.push (bytes.data(), static_cast<int> (bytes.size()), timeMs,
+                      [this] (const std::uint8_t* b, int n, double t)
+                      { messages.push_back ({ { b, b + n }, t }); });
+    }
+};
+}
+
+TEST_CASE ("CoreMIDI clocks retain source timestamps across different epochs", "[midi][coremidi][issue-298]")
+{
+    const ClockAnchor clock { 9000000000000000000ull, 2000.0, 1.0 / 24000.0 };
+    REQUIRE_THAT (clock.toMilliseconds (clock.hostTicks - 12000), WithinAbs (1999.5, 1e-9));
+    REQUIRE_THAT (clock.toMilliseconds (clock.hostTicks + 48000), WithinAbs (2002.0, 1e-9));
+    REQUIRE_THAT (clock.toMilliseconds (0), WithinAbs (2000.0, 1e-9));
+    const ClockAnchor afterSleep { clock.hostTicks + 24000, 62001.0, clock.millisecondsPerTick };
+    REQUIRE_THAT (afterSleep.toMilliseconds (afterSleep.hostTicks - 12000), WithinAbs (62000.5, 1e-9));
+    REQUIRE_THAT (afterSleep.toMilliseconds (0), WithinAbs (62001.0, 1e-9));
+}
+
+TEST_CASE ("CoreMIDI endpoint identifiers retain signed unique IDs", "[midi][coremidi][issue-298]")
+{
+    REQUIRE (identifier (42) == "coremidi:42");
+    REQUIRE (identifier (-42) == "coremidi:-42");
+    REQUIRE (identifier (std::numeric_limits<std::int32_t>::min()) == "coremidi:-2147483648");
+}
+
+TEST_CASE ("CoreMIDI packets separate channel and system messages", "[midi][coremidi][issue-298]")
+{
+    DecoderProbe probe;
+    probe.push ({ 0x90, 60 }, 100.0);
+    probe.push ({ 0xf8, 100, 61, 110, 0xc2, 9, 0xd2, 70, 0xe2, 0, 64 }, 101.0);
+    probe.push ({ 0xf1, 0x17, 0xf2, 0x01, 0x02, 0xf3, 0x03, 0xf6, 0xfa, 0xfb, 0xfc, 0xfe, 0xff });
+    REQUIRE (probe.messages.size() == 15);
+    REQUIRE (probe.messages[0].bytes == std::vector<std::uint8_t> { 0xf8 });
+    REQUIRE (probe.messages[1].bytes == std::vector<std::uint8_t> { 0x90, 60, 100 });
+    REQUIRE_THAT (probe.messages[1].timeMs, WithinAbs (100.0, 1e-9));
+    REQUIRE (probe.messages[2].bytes == std::vector<std::uint8_t> { 0x90, 61, 110 });
+    REQUIRE (probe.messages[3].bytes == std::vector<std::uint8_t> { 0xc2, 9 });
+    REQUIRE (probe.messages[4].bytes == std::vector<std::uint8_t> { 0xd2, 70 });
+    REQUIRE (probe.messages[5].bytes == std::vector<std::uint8_t> { 0xe2, 0, 64 });
+    REQUIRE (probe.messages[6].bytes == std::vector<std::uint8_t> { 0xf1, 0x17 });
+    REQUIRE (probe.messages[7].bytes == std::vector<std::uint8_t> { 0xf2, 1, 2 });
+    REQUIRE (probe.messages[8].bytes == std::vector<std::uint8_t> { 0xf3, 3 });
+    REQUIRE (probe.messages[9].bytes == std::vector<std::uint8_t> { 0xf6 });
+    REQUIRE (probe.messages[10].bytes == std::vector<std::uint8_t> { 0xfa });
+    REQUIRE (probe.messages[11].bytes == std::vector<std::uint8_t> { 0xfb });
+    REQUIRE (probe.messages[12].bytes == std::vector<std::uint8_t> { 0xfc });
+    REQUIRE (probe.messages[13].bytes == std::vector<std::uint8_t> { 0xfe });
+    REQUIRE (probe.messages[14].bytes == std::vector<std::uint8_t> { 0xff });
+}
+
+TEST_CASE ("CoreMIDI SysEx spans packets and permits interleaved realtime", "[midi][coremidi][issue-298]")
+{
+    DecoderProbe probe;
+    probe.push ({ 0xf0, 0x7f, 0x01 }, 10.0);
+    probe.push ({ 0xf8, 0x01, 0x01, 0x60 }, 20.0);
+    probe.push ({ 0x00, 0x00, 0x00, 0xf7 }, 30.0);
+    REQUIRE (probe.messages.size() == 2);
+    REQUIRE (probe.messages[0].bytes == std::vector<std::uint8_t> { 0xf8 });
+    REQUIRE (probe.messages[1].bytes == std::vector<std::uint8_t> { 0xf0, 0x7f, 1, 1, 1, 0x60, 0, 0, 0, 0xf7 });
+    REQUIRE_THAT (probe.messages[0].timeMs, WithinAbs (20.0, 1e-9));
+    REQUIRE_THAT (probe.messages[1].timeMs, WithinAbs (10.0, 1e-9));
+}
+
+TEST_CASE ("CoreMIDI drops oversized SysEx whole and recovers at the next message", "[midi][coremidi][issue-298]")
+{
+    DecoderProbe probe;
+    probe.push ({ 0xf0 });
+    probe.push (std::vector<std::uint8_t> (dusk::kMidiBlockBytes, 1));
+    probe.push ({ 0xf8, 0xf7, 0x90, 60, 100 });
+    REQUIRE (probe.messages.size() == 2);
+    REQUIRE (probe.messages[0].bytes == std::vector<std::uint8_t> { 0xf8 });
+    REQUIRE (probe.messages[1].bytes == std::vector<std::uint8_t> { 0x90, 60, 100 });
+}
+
+TEST_CASE ("CoreMIDI largest accepted SysEx fits the collector ring", "[midi][coremidi][issue-298]")
+{
+    DecoderProbe probe;
+    std::vector<std::uint8_t> sysex (dusk::kMidiBlockBytes - sizeof (double) - sizeof (std::int32_t), 1);
+    sysex.front() = 0xf0;
+    sysex.back() = 0xf7;
+    probe.push (sysex);
+    REQUIRE (probe.messages.size() == 1);
+    dusk::MidiRing ring (dusk::kMidiBlockBytes);
+    REQUIRE (ring.push (probe.messages[0].bytes.data(), static_cast<int> (probe.messages[0].bytes.size()), 100.0));
+    std::vector<std::uint8_t> received;
+    const auto count = ring.drain ([&] (const std::uint8_t* bytes, int size, double)
+                                 { received.assign (bytes, bytes + size); });
+    REQUIRE (count == 1);
+    REQUIRE (received == sysex);
+
+    probe.messages.clear();
+    sysex.insert (sysex.end() - 1, 1);
+    probe.push (sysex);
+    REQUIRE (probe.messages.empty());
+    probe.push ({ 0x90, 60, 100 });
+    REQUIRE (probe.messages.size() == 1);
+    REQUIRE (probe.messages[0].bytes == std::vector<std::uint8_t> { 0x90, 60, 100 });
+}
+
+TEST_CASE ("CoreMIDI ignores orphan data and discards interrupted messages", "[midi][coremidi][issue-298]")
+{
+    DecoderProbe probe;
+    probe.push ({ 1, 2, 0x90, 60, 0xc0, 10, 0xf1, 1, 60, 100, 0xf0, 1, 0x80, 60, 0 });
+    REQUIRE (probe.messages.size() == 3);
+    REQUIRE (probe.messages[0].bytes == std::vector<std::uint8_t> { 0xc0, 10 });
+    REQUIRE (probe.messages[1].bytes == std::vector<std::uint8_t> { 0xf1, 1 });
+    REQUIRE (probe.messages[2].bytes == std::vector<std::uint8_t> { 0x80, 60, 0 });
+    probe.push ({ 0x90, 61 });
+    probe.decoder.reset();
+    probe.push ({ 100 });
+    REQUIRE (probe.messages.size() == 3);
+}
+
+TEST_CASE ("CoreMIDI orphan end of SysEx cancels running status without becoming a message", "[midi][coremidi][issue-298]")
+{
+    DecoderProbe probe;
+    probe.push ({ 0x90, 60, 100, 0xf7, 61, 100, 0xf0, 0xf7 });
+    REQUIRE (probe.messages.size() == 2);
+    REQUIRE (probe.messages[0].bytes == std::vector<std::uint8_t> { 0x90, 60, 100 });
+    REQUIRE (probe.messages[1].bytes == std::vector<std::uint8_t> { 0xf0, 0xf7 });
+    probe.push ({ 0xf4, 0xf5 });
+    REQUIRE (probe.messages.size() == 4);
+    REQUIRE (probe.messages[2].bytes == std::vector<std::uint8_t> { 0xf4 });
+    REQUIRE (probe.messages[3].bytes == std::vector<std::uint8_t> { 0xf5 });
+}

--- a/tests/core_midi_protocol.cpp
+++ b/tests/core_midi_protocol.cpp
@@ -48,6 +48,17 @@ TEST_CASE ("CoreMIDI endpoint identities preserve signed and compound legacy rou
     REQUIRE (identifier (42) == "coremidi:42");
     REQUIRE (identifier (-42) == "coremidi:-42");
     REQUIRE (identifier (std::numeric_limits<std::int32_t>::min()) == "coremidi:-2147483648");
+    REQUIRE (legacyNameStartsWith (u"", u""));
+    REQUIRE (legacyNameStartsWith (u"Device", u""));
+    REQUIRE_FALSE (legacyNameStartsWith (u"", u"Device"));
+    REQUIRE (legacyNameStartsWith (u"abc Port", u"ABC"));
+    REQUIRE_FALSE (legacyNameStartsWith (u"AB", u"ABC"));
+    REQUIRE_FALSE (legacyNameStartsWith (u"Stra\u00dfe", u"STRASSE"));
+    REQUIRE_FALSE (legacyNameStartsWith (u"\u00e9cho", u"e\u0301cho"));
+    REQUIRE (legacyNameStartsWith (u"\U0001f3b9 Port", u"\U0001f3b9"));
+    REQUIRE_FALSE (legacyNameStartsWith (u"\U0001f3b9 A", u"\U0001f3b9 B"));
+    REQUIRE_FALSE (legacyNameStartsWith (u"\U00010400", u"\U00020400"));
+    REQUIRE_FALSE (legacyNameStartsWith (u"\U0001f3b9", u"\xd83c"));
 
     const duskstudio::midi::BackendDeviceInfo endpoint { "Port", "-21" }, device { "Interface", "-20" };
     auto oldInfo = externalEndpointInfo (endpoint, device, ExternalIdentifier::Device);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional native CoreMIDI backend for macOS, with MIDI device discovery, input/output handling, identifier migration, timestamped events, SysEx support, and hot-plug notifications.
  * Retained existing ALSA and JUCE MIDI backend options on supported platforms.

* **Bug Fixes**
  * Improved MIDI device-change notification handling and callback shutdown safety.

* **Tests**
  * Expanded MIDI protocol, backend, virtual endpoint, and Windows regression test coverage.

* **Documentation**
  * Updated MIDI platform status, planning details, and test-suite counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->