### PR TITLE
refactor: replace region thumbnails with native waveform details

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 981 Catch2 test cases across 186 test source files. Linux
+The C++ suite declares 990 Catch2 test cases across 187 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # Native log storage + CrashHandler signal reports
-tests/         # 981 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 990 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/docs/dejuce-campaign.md
+++ b/docs/dejuce-campaign.md
@@ -109,8 +109,10 @@ reimplemented.
   `IFileWriteSink` + externally-drained `ThreadedFileWriter` +
   `WriterDrainPool` (one disk thread per subsystem, as before). LameMp3Writer
   is JUCE-free (allowlist −2, gate 182 — the "zero movement" honest-yield
-  prediction missed this). `juce_audio_formats` stays linked only for
-  `juce_audio_utils`/AudioThumbnail; it unlinks globally with the GUI tower.
+  prediction missed this). Mastering and region waveforms now use the native
+  `WaveformSource`; no production AudioThumbnail consumer remains.
+  `juce_audio_formats` and `juce_audio_utils` still link pending a transitive
+  include and cross-platform module-unlink audit.
   Bench debts at spec §Owed. Spec:
   [dejuce-audiofile-plan.md](dejuce-audiofile-plan.md).
 
@@ -124,8 +126,9 @@ reimplemented.
    hosting path (PluginSlot/PluginManager JUCE half/PluginHostMain loop) and
    both remaining in-app JUCE donor processors (TapeMachine -> TapeMachineDSP,
    Multiband UniversalCompressor -> framework-free donor port) are deleted. Unlinks
-   `juce_audio_processors` globally; `juce_audio_utils` and
-   `juce_audio_formats` stay for AudioThumbnail — GUI tower unlinks those.
+   `juce_audio_processors` globally. AudioThumbnail consumers have migrated;
+   the remaining `juce_audio_utils` and `juce_audio_formats` links need their
+   own transitive-dependency audit before removal.
    Multi-PR tower, phases H1-H6 in
    [dejuce-hosting-plan.md](dejuce-hosting-plan.md).
 2. **GUI tower (finale)** — framework decision (Marc, 2026-07-27): build on

--- a/docs/dejuce-gui-plan.md
+++ b/docs/dejuce-gui-plan.md
@@ -725,9 +725,19 @@ Owns: `MainComponent.{h,cpp}` (6,000 lines), `DuskStudioApp.{h,cpp}`,
 ### G6 — Residue
 
 What is left once no UI is JUCE: `MessageThread.cpp` rewritten on the pugl
-world's timers and event loop, `juce_data_structures`, `AudioThumbnail` off
-`juce_audio_utils`, and the last `juce::String`/`File`/`Colour` holdouts in
+world's timers and event loop, `juce_data_structures`, the remaining
+`juce_audio_utils`/`juce_audio_formats` links, and the last `juce::String`/`File`/`Colour` holdouts in
 `src/session` and `src/engine` that were anchored by UI types.
+
+Mastering and region waveforms already use native `WaveformSource` snapshots.
+The region editor requests bounded, exact visible-column details for sample-level
+zoom and same-file slices; metadata and audio reads run on the source worker.
+Paint uses one immutable snapshot so the waveform and ruler share a native sample
+rate. Until metadata arrives, existing engine-rate fallback behavior applies.
+AudioThumbnail has no production consumers. Module unlink still needs a separate
+audit of transitive includes and all platform builds. Persistent waveform caches
+and broader tape-view waveforms remain separate work; native GUI and accessibility
+gates are unchanged.
 
 Module unlink order, each step its own commit so a bisect lands on one module:
 

--- a/docs/dejuce-remaining-phase-prompts.md
+++ b/docs/dejuce-remaining-phase-prompts.md
@@ -248,9 +248,10 @@ PluginHostMain's JUCE message loop + MessageManagerLock sites (the OOP child
 shrinks to the native scan sandbox — shm/futex layer is already
 tri-platform), JUCE_PLUGINHOST_* defines, and every JUCE-host fallback rung in
 the slot ladders (ladder becomes CLAP > LV2 > VST3 > MS [> AU on mac]).
-Unlink juce_audio_processors from CMake on ALL THREE platforms (module count
-12 → 11 — the campaign's first global unlink; juce_audio_utils and
-juce_audio_formats stay for AudioThumbnail until the GUI tower). Retire
+Unlink juce_audio_processors from CMake on ALL THREE platforms. Recount the
+current links before recording module totals: AudioThumbnail consumers have
+already migrated, while juce_audio_utils and juce_audio_formats still need a
+separate transitive-include and cross-platform unlink audit. Retire
 tools/tsan_suppressions.txt entries tied to deleted primitives in the SAME PR.
 Update tools/juce-allowlist.txt — expect a large ratchet drop; record
 before/after. Sweep per CLAUDE.md rule 10: grep for every deleted symbol

--- a/src/engine/audiofile/WaveformPeaks.cpp
+++ b/src/engine/audiofile/WaveformPeaks.cpp
@@ -16,20 +16,45 @@ WaveformPeaks::Peak merge (WaveformPeaks::Peak a, WaveformPeaks::Peak b) noexcep
 }
 
 float finiteSample (float value) noexcept { return std::isfinite (value) ? value : 0.0f; }
+
+bool validInfo (const FileInfo& info) noexcept
+{
+    return std::isfinite (info.sampleRate) && info.sampleRate > 0.0
+        && info.numChannels > 0 && info.numChannels <= 256 && info.numFrames >= 0;
+}
+
+bool validWindow (const WaveformDetails::Window& window) noexcept
+{
+    return window.sourceStart >= 0 && window.sourceLength > 0 && window.fullWidth > 0
+        && window.firstColumn >= 0 && window.firstColumn < window.fullWidth
+        && window.numColumns > 0 && window.numColumns <= window.fullWidth - window.firstColumn;
+}
+
+int64_t columnBoundary (const WaveformDetails::Window& window, int column,
+                        bool roundUp, int64_t fileFrames) noexcept
+{
+    if (window.sourceStart >= fileFrames) return fileFrames;
+    const auto remainder = (window.sourceLength % window.fullWidth) * column;
+    const auto delta = (window.sourceLength / window.fullWidth) * column
+        + remainder / window.fullWidth + (roundUp && remainder % window.fullWidth != 0);
+    return window.sourceStart + std::min (delta, fileFrames - window.sourceStart);
+}
 }
 
 std::shared_ptr<const WaveformPeaks> WaveformPeaks::generate (
     const std::filesystem::path& path, const CancelCheck& cancelled)
 {
-    const auto shouldCancel = [&] { return cancelled && cancelled(); };
-    if (shouldCancel()) return {};
-
+    if (cancelled && cancelled()) return {};
     auto reader = FileReader::open (path);
-    if (reader == nullptr) return {};
-    const auto info = reader->info();
-    if (! std::isfinite (info.sampleRate) || info.sampleRate <= 0.0
-        || info.numChannels <= 0 || info.numChannels > 256 || info.numFrames < 0)
-        return {};
+    return reader ? generate (*reader, cancelled) : nullptr;
+}
+
+std::shared_ptr<const WaveformPeaks> WaveformPeaks::generate (
+    FileReader& reader, const CancelCheck& cancelled)
+{
+    const auto shouldCancel = [&] { return cancelled && cancelled(); };
+    const auto info = reader.info();
+    if (! validInfo (info)) return {};
 
     int framesPerBin = 1;
     constexpr int64_t kDetailedPeakCount = 65536;
@@ -62,7 +87,7 @@ std::shared_ptr<const WaveformPeaks> WaveformPeaks::generate (
         {
             if (shouldCancel()) return {};
             const auto count = std::min<int64_t> (kReadFrames, info.numFrames - first);
-            if (reader->read (scratch.data(), info.numChannels, first, count) != count)
+            if (reader.read (scratch.data(), info.numChannels, first, count) != count)
                 return {};
             for (int offset = 0; offset < count; offset += framesPerBin)
             {
@@ -137,6 +162,118 @@ std::optional<WaveformPeaks::Peak> WaveformPeaks::query (
     return peak;
 }
 
+std::optional<std::pair<int64_t, int64_t>> WaveformDetails::Window::columnRange (
+    int column, int64_t fileFrames) const noexcept
+{
+    if (! validWindow (*this) || column < 0 || column >= numColumns || fileFrames < 0) return {};
+    return std::pair<int64_t, int64_t> { columnBoundary (*this, firstColumn + column, false, fileFrames),
+                                       columnBoundary (*this, firstColumn + column + 1, true, fileFrames) };
+}
+
+bool WaveformDetails::validRequest (const std::vector<Window>& windows, int channels) noexcept
+{
+    if (channels <= 0 || channels > 256 || windows.size() > kMaxColumns) return false;
+    std::size_t columns = 0;
+    for (const auto& window : windows)
+    {
+        if (! validWindow (window)
+            || window.sourceLength > (int64_t) window.fullWidth * WaveformPeaks::kMaxFramesPerPeak
+            || (std::size_t) window.numColumns > kMaxColumns - columns)
+            return false;
+        columns += (std::size_t) window.numColumns;
+    }
+    const auto bookkeeping = sizeof (WaveformDetails) + 2 * sizeof (std::vector<Window>)
+        + windows.size() * (3 * sizeof (Window) + sizeof (std::size_t));
+    return bookkeeping <= kMaxBytes
+        && columns <= (kMaxBytes - bookkeeping) / sizeof (WaveformPeaks::Peak) / (std::size_t) channels;
+}
+
+std::shared_ptr<const WaveformDetails> WaveformDetails::generate (
+    FileReader& reader, const std::vector<Window>& windows, const WaveformPeaks::CancelCheck& cancelled)
+{
+    const auto shouldCancel = [&] { return cancelled && cancelled(); };
+    const auto info = reader.info();
+    if (shouldCancel() || ! validInfo (info) || ! validRequest (windows, info.numChannels)) return {};
+    try
+    {
+        auto result = std::shared_ptr<WaveformDetails> (new WaveformDetails);
+        result->fileInfo = info;
+        result->viewWindows = windows;
+        result->offsets.reserve (windows.size());
+        std::size_t entries = 0;
+        for (const auto& window : windows)
+        {
+            result->offsets.push_back (entries);
+            entries += (std::size_t) window.numColumns * (std::size_t) info.numChannels;
+        }
+        result->peaks.resize (entries);
+        constexpr int kReadFrames = 8192;
+        PlanarBuffer scratch;
+        if (! scratch.setSize (info.numChannels, kReadFrames)) return {};
+        for (std::size_t index = 0; index < windows.size(); ++index)
+        {
+            if (shouldCancel()) return {};
+            const auto& window = windows[index];
+            const auto windowEnd = window.columnRange (window.numColumns - 1, info.numFrames)->second;
+            int64_t bufferFirst = -1;
+            int bufferCount = 0;
+            for (int column = 0; column < window.numColumns; ++column)
+            {
+                if (column % 256 == 0 && shouldCancel()) return {};
+                const auto range = *window.columnRange (column, info.numFrames);
+                auto position = range.first;
+                const auto end = range.second;
+                auto* destination = result->peaks.data() + result->offsets[index]
+                    + (std::size_t) column * (std::size_t) info.numChannels;
+                bool initialized = false;
+                while (position < end)
+                {
+                    if (position < bufferFirst || position - bufferFirst >= bufferCount)
+                    {
+                        if (shouldCancel()) return {};
+                        bufferFirst = position;
+                        bufferCount = (int) std::min<int64_t> (kReadFrames, windowEnd - position);
+                        if (reader.read (scratch.data(), info.numChannels, position, bufferCount) != bufferCount)
+                            return {};
+                    }
+                    const int offset = (int) (position - bufferFirst);
+                    const int count = (int) std::min<int64_t> (end - position, bufferCount - offset);
+                    for (int channel = 0; channel < info.numChannels; ++channel)
+                    {
+                        const auto* samples = scratch.channel (channel) + offset;
+                        if (! initialized)
+                        {
+                            const auto value = finiteSample (samples[0]);
+                            destination[channel] = { value, value };
+                        }
+                        for (int frame = 0; frame < count; ++frame)
+                        {
+                            const auto value = finiteSample (samples[frame]);
+                            destination[channel] = merge (destination[channel], { value, value });
+                        }
+                    }
+                    initialized = true;
+                    position += count;
+                }
+            }
+        }
+        if (shouldCancel()) return {};
+        return result;
+    }
+    catch (const std::bad_alloc&) { return {}; }
+    catch (const std::length_error&) { return {}; }
+}
+
+std::optional<WaveformPeaks::Peak> WaveformDetails::column (
+    std::size_t window, int channel, int columnIndex) const noexcept
+{
+    if (window >= viewWindows.size() || channel < 0 || channel >= fileInfo.numChannels
+        || columnIndex < 0 || columnIndex >= viewWindows[window].numColumns)
+        return {};
+    return peaks[offsets[window] + (std::size_t) columnIndex * (std::size_t) fileInfo.numChannels
+                 + (std::size_t) channel];
+}
+
 WaveformSource::WaveformSource() : worker ([this] { run(); }) {}
 
 WaveformSource::~WaveformSource()
@@ -152,12 +289,47 @@ WaveformSource::~WaveformSource()
 
 void WaveformSource::setFile (const std::filesystem::path& file)
 {
+    auto path = file.empty() ? std::shared_ptr<const std::filesystem::path>()
+                            : std::make_shared<const std::filesystem::path> (file);
     std::lock_guard<std::mutex> lock (mutex);
-    pendingFile = file;
+    pendingFile = std::move (path);
+    ++fileGeneration;
     generation.fetch_add (1, std::memory_order_release);
+    filePending = true;
     pending = ! file.empty();
-    current = { pending ? State::Loading : State::Empty, {} };
+    detailsPending = false;
+    requestedWindows.clear();
+    current = {};
+    current.state = pending ? State::Loading : State::Empty;
     wake.notify_one();
+}
+
+bool WaveformSource::setDetailWindows (const std::vector<WaveformDetails::Window>& windows)
+{
+    std::lock_guard<std::mutex> lock (mutex);
+    if (windows == requestedWindows && (! windows.empty() || current.detailState == State::Empty))
+        return current.detailState != State::Failed;
+    generation.fetch_add (1, std::memory_order_release);
+    current.details.reset();
+    current.detailState = windows.empty() ? State::Empty : State::Failed;
+    detailsPending = false;
+    requestedWindows.clear();
+    bool valid = windows.empty() || (current.state != State::Empty
+        && WaveformDetails::validRequest (windows, current.info ? current.info->numChannels : 1));
+    if (valid && ! windows.empty())
+    {
+        try
+        {
+            auto replacement = windows;
+            requestedWindows.swap (replacement);
+            detailsPending = true;
+            current.detailState = State::Loading;
+        }
+        catch (const std::bad_alloc&) { valid = false; }
+        catch (const std::length_error&) { valid = false; }
+    }
+    wake.notify_one();
+    return valid;
 }
 
 WaveformSource::Snapshot WaveformSource::snapshot() const
@@ -169,26 +341,78 @@ WaveformSource::Snapshot WaveformSource::snapshot() const
 void WaveformSource::run()
 {
     std::unique_lock<std::mutex> lock (mutex);
+    std::unique_ptr<FileReader> reader;
     while (true)
     {
-        wake.wait (lock, [this] { return stopping || pending; });
+        wake.wait (lock, [this] { return stopping || filePending || pending || detailsPending; });
         if (stopping) return;
-        const auto file = std::move (pendingFile);
+        if (filePending)
+        {
+            const auto file = pendingFile;
+            const auto fileRequest = fileGeneration;
+            filePending = false;
+            lock.unlock();
+            reader.reset();
+            try
+            {
+                if (file) reader = FileReader::open (*file);
+                if (reader && ! validInfo (reader->info())) reader.reset();
+            }
+            catch (const std::exception&) { reader.reset(); }
+            lock.lock();
+            if (fileRequest != fileGeneration) continue;
+            if (reader) current.info = reader->info();
+            else
+            {
+                pending = false;
+                detailsPending = false;
+                current.state = file ? State::Failed : State::Empty;
+                current.detailState = requestedWindows.empty() ? State::Empty : State::Failed;
+            }
+        }
+        if (! reader)
+        {
+            detailsPending = false;
+            if (! requestedWindows.empty()) current.detailState = State::Failed;
+            continue;
+        }
+        const bool detail = detailsPending;
+        std::vector<WaveformDetails::Window> windows;
+        if (detail)
+        {
+            detailsPending = false;
+            try { windows = requestedWindows; }
+            catch (const std::exception&) { current.detailState = State::Failed; continue; }
+        }
+        const auto fileRequest = fileGeneration;
         const auto request = generation.load (std::memory_order_acquire);
-        pending = false;
         lock.unlock();
         std::shared_ptr<const WaveformPeaks> peaks;
+        std::shared_ptr<const WaveformDetails> details;
         try
         {
-            peaks = WaveformPeaks::generate (file, [this, request]
+            const auto cancelled = [this, request]
             {
                 return generation.load (std::memory_order_acquire) != request;
-            });
+            };
+            if (detail) details = WaveformDetails::generate (*reader, windows, cancelled);
+            else peaks = WaveformPeaks::generate (*reader, cancelled);
         }
         catch (const std::exception&) {}
         lock.lock();
-        if (generation.load (std::memory_order_acquire) == request)
-            current = { peaks ? State::Ready : State::Failed, std::move (peaks) };
+        if (fileRequest != fileGeneration || generation.load (std::memory_order_acquire) != request)
+            continue;
+        if (detail)
+        {
+            current.detailState = details ? State::Ready : State::Failed;
+            current.details = std::move (details);
+        }
+        else
+        {
+            pending = false;
+            current.state = peaks ? State::Ready : State::Failed;
+            current.peaks = std::move (peaks);
+        }
     }
 }
 } // namespace dusk::audio

--- a/src/engine/audiofile/WaveformPeaks.h
+++ b/src/engine/audiofile/WaveformPeaks.h
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <optional>
 #include <thread>
+#include <utility>
 
 namespace dusk::audio
 {
@@ -25,6 +26,7 @@ public:
     // Cancellation is checked between bounded reads and pyramid reductions.
     static std::shared_ptr<const WaveformPeaks> generate (
         const std::filesystem::path&, const CancelCheck& cancelled = {});
+    static std::shared_ptr<const WaveformPeaks> generate (FileReader&, const CancelCheck& cancelled = {});
 
     const FileInfo& info() const noexcept { return fileInfo; }
     double durationSeconds() const noexcept { return (double) fileInfo.numFrames / fileInfo.sampleRate; }
@@ -43,6 +45,50 @@ private:
     std::vector<std::vector<Peak>> levels;
 };
 
+// Exact sample extrema for the visible columns of one or more source slices.
+class WaveformDetails final
+{
+public:
+    struct Window
+    {
+        int64_t sourceStart = 0, sourceLength = 0;
+        int fullWidth = 0, firstColumn = 0, numColumns = 0;
+
+        // Shared by detail and overview rendering. Invalid geometry returns no
+        // range; an off-file column returns an empty clipped range.
+        std::optional<std::pair<int64_t, int64_t>> columnRange (int column, int64_t fileFrames) const noexcept;
+
+        bool operator== (const Window& other) const noexcept
+        {
+            return sourceStart == other.sourceStart && sourceLength == other.sourceLength
+                && fullWidth == other.fullWidth && firstColumn == other.firstColumn
+                && numColumns == other.numColumns;
+        }
+    };
+    static constexpr std::size_t kMaxColumns = 65536;
+    static constexpr std::size_t kMaxBytes = 16u * 1024u * 1024u;
+
+    // Includes pending/worker window copies and result indexing in the budget.
+    // Windows retain the full slice mapping, even when only a clipped subset
+    // of its columns is visible. Coarser than 512 frames/column uses overview.
+    static bool validRequest (const std::vector<Window>&, int channels) noexcept;
+    static std::shared_ptr<const WaveformDetails> generate (
+        FileReader&, const std::vector<Window>&, const WaveformPeaks::CancelCheck& cancelled = {});
+
+    const std::vector<Window>& windows() const noexcept { return viewWindows; }
+    const FileInfo& info() const noexcept { return fileInfo; }
+    // Column is relative to firstColumn. Samples outside the file are clipped;
+    // a column wholly outside the file has a zero peak.
+    std::optional<WaveformPeaks::Peak> column (std::size_t window, int channel, int column) const noexcept;
+
+private:
+    WaveformDetails() = default;
+    FileInfo fileInfo;
+    std::vector<Window> viewWindows;
+    std::vector<std::size_t> offsets;
+    std::vector<WaveformPeaks::Peak> peaks;
+};
+
 // One replaceable source for a view. Calls and destruction are non-RT. The worker
 // never invokes UI callbacks; a view polls snapshot() using its existing timer.
 class WaveformSource final
@@ -53,6 +99,9 @@ public:
     {
         State state = State::Empty;
         std::shared_ptr<const WaveformPeaks> peaks;
+        std::optional<FileInfo> info;
+        State detailState = State::Empty;
+        std::shared_ptr<const WaveformDetails> details;
     };
 
     WaveformSource();
@@ -63,6 +112,13 @@ public:
     // Each call invalidates even the same path, so callers request only on load
     // or explicit reload, not on every repaint/refresh. Empty clears it.
     void setFile (const std::filesystem::path&);
+    // Set after setFile. True accepts async validation: geometry and known-channel
+    // budgets are checked immediately, unknown channels after opening the file.
+    // A changed request clears prior detail. Identical requests (including Failed)
+    // are deduplicated; clear detail or change file/windows to retry.
+    // Visible detail preempts an unfinished overview, which restarts after requests
+    // settle. Completed overview survives. Empty clears only detail.
+    bool setDetailWindows (const std::vector<WaveformDetails::Window>&);
     Snapshot snapshot() const;
 
 private:
@@ -71,9 +127,13 @@ private:
     mutable std::mutex mutex;
     std::condition_variable wake;
     std::atomic<uint64_t> generation { 0 };
-    std::filesystem::path pendingFile;
+    uint64_t fileGeneration = 0;
+    std::shared_ptr<const std::filesystem::path> pendingFile;
+    std::vector<WaveformDetails::Window> requestedWindows;
     Snapshot current;
+    bool filePending = false;
     bool pending = false;
+    bool detailsPending = false;
     bool stopping = false;
     std::thread worker;
 };

--- a/src/ui/AudioRegionEditor.cpp
+++ b/src/ui/AudioRegionEditor.cpp
@@ -320,8 +320,6 @@ AudioRegionEditor::AudioRegionEditor (Session& s, AudioEngine& e, int t, int r)
 AudioRegionEditor::~AudioRegionEditor()
 {
     stopTimer();
-    // ChangeListener removal is handled by AudioThumbnail's destructor
-    // (it removes its listeners on the broadcast list it owns).
     if (thumb != nullptr) thumb->removeChangeListener (this);
 }
 

--- a/src/ui/AudioRegionEditor.cpp
+++ b/src/ui/AudioRegionEditor.cpp
@@ -15,6 +15,7 @@
 #include "../foundation/PlanarBuffer.h"
 #include <algorithm>
 #include <cmath>
+#include <iterator>
 #include <limits>
 
 namespace duskstudio
@@ -24,6 +25,14 @@ namespace
 // clamp with jlimit's argument order (lo, hi, value).
 template <typename T>
 inline T jlimit (T lo, T hi, T value) noexcept { return std::clamp (value, lo, std::max (lo, hi)); }
+
+dusk::audio::WaveformDetails::Window waveformWindow (
+    const AudioRegion& region, int xa, int xb, juce::Rectangle<int> clip)
+{
+    const int first = std::max (xa, clip.getX());
+    return { region.sourceOffset, region.lengthInSamples, xb - xa,
+             first - xa, std::min (xb, clip.getRight()) - first };
+}
 } // namespace
 namespace
 {
@@ -59,7 +68,6 @@ AudioRegionEditor::AudioRegionEditor (Session& s, AudioEngine& e, int t, int r)
 {
     setOpaque (true);
     setWantsKeyboardFocus (true);
-    formatManager.registerBasicFormats();
 
     // Top icon row.
     auto wireIcon = [this] (IconButton& b, const juce::String& tip,
@@ -303,6 +311,8 @@ AudioRegionEditor::AudioRegionEditor (Session& s, AudioEngine& e, int t, int r)
 
     refreshStatusBarReadouts();
 
+    refreshWaveform();
+
     // 30 Hz playhead poll - matches the meter cadence elsewhere. The
     // tick is cheap when transport is stopped (no repaint) so leaving
     // it running unconditionally keeps the start-of-playback latency
@@ -320,7 +330,6 @@ AudioRegionEditor::AudioRegionEditor (Session& s, AudioEngine& e, int t, int r)
 AudioRegionEditor::~AudioRegionEditor()
 {
     stopTimer();
-    if (thumb != nullptr) thumb->removeChangeListener (this);
 }
 
 AudioRegion* AudioRegionEditor::region()
@@ -339,38 +348,60 @@ const AudioRegion* AudioRegionEditor::region() const
     return &v[(size_t) regionIdx];
 }
 
-void AudioRegionEditor::rebuildThumbIfNeeded()
+void AudioRegionEditor::refreshWaveform()
 {
     const auto* r = region();
-    if (r == nullptr) return;
-    if (thumb != nullptr && r->file == loadedFile) return;
-
-    if (thumb != nullptr) thumb->removeChangeListener (this);
-    thumb = std::make_unique<juce::AudioThumbnail> (512, formatManager, thumbCache);
-    if (r->file.existsAsFile())
-        thumb->setSource (new juce::FileInputSource (r->file));
-    else
-        thumb->setSource (nullptr);
-    thumb->addChangeListener (this);
-    loadedFile = r->file;
-
-    // Cache the WAV's native sample rate so the bar grid + thumbnail
-    // time-domain agree. One-shot reader open just to read the metadata
-    // header (no audio data read); destructor closes it before we leave.
-    loadedFileSampleRate = 0.0;
-    if (r->file.existsAsFile())
+    const auto file = r != nullptr ? r->file : juce::File();
+    if (file != loadedFile)
     {
-        std::unique_ptr<juce::AudioFormatReader> reader (
-            formatManager.createReaderFor (r->file));
-        if (reader != nullptr)
-            loadedFileSampleRate = reader->sampleRate;
+        loadedFile = file;
+        loadedFileSampleRate = 0.0;
+        waveformSource.setFile (std::filesystem::u8path (file.getFullPathName().toStdString()));
     }
-}
 
-void AudioRegionEditor::changeListenerCallback (juce::ChangeBroadcaster*)
-{
-    refreshStatusBarReadouts();
-    repaint();
+    auto next = waveformSource.snapshot();
+    std::vector<dusk::audio::WaveformDetails::Window> windows;
+    if (r != nullptr && getWidth() > 8 && pixelsPerSample > 0.0f)
+    {
+        const auto area = juce::Rectangle<int> (0, kIconRowHeight + kRulerHeight, getWidth(),
+            getHeight() - kIconRowHeight - kRulerHeight - kStatusBarH - kScrollBarH);
+        const auto inset = area.reduced (4, 4);
+        const auto anchorEnd = anchorTimelineStart + anchorTimelineLength;
+        std::size_t columns = 0;
+        for (const auto& reg : session.track (trackIdx).regions)
+        {
+            if (reg.file != loadedFile || reg.lengthInSamples <= 0) continue;
+            const auto regEnd = reg.timelineStart + reg.lengthInSamples;
+            if (regEnd <= anchorTimelineStart || reg.timelineStart >= anchorEnd) continue;
+            const int xa = xForTimelineSample (reg.timelineStart, area);
+            const int xb = xForTimelineSample (regEnd, area);
+            if (xb <= xa) continue;
+            const auto window = waveformWindow (reg, xa, xb, inset);
+            if (window.numColumns <= 0 || window.sourceLength
+                > (std::int64_t) window.fullWidth * dusk::audio::WaveformPeaks::kMaxFramesPerPeak) continue;
+            if ((std::size_t) window.numColumns > dusk::audio::WaveformDetails::kMaxColumns - columns)
+            {
+                windows.clear();
+                break;
+            }
+            columns += (std::size_t) window.numColumns;
+            windows.push_back (window);
+        }
+    }
+    if (! dusk::audio::WaveformDetails::validRequest (windows, next.info ? next.info->numChannels : 1))
+        windows.clear();
+    waveformSource.setDetailWindows (windows);
+    next = waveformSource.snapshot();
+    const bool changed = next.state != waveformSnapshot.state || next.peaks != waveformSnapshot.peaks
+        || next.info.has_value() != waveformSnapshot.info.has_value()
+        || next.detailState != waveformSnapshot.detailState || next.details != waveformSnapshot.details;
+    loadedFileSampleRate = next.info ? next.info->sampleRate : 0.0;
+    waveformSnapshot = std::move (next);
+    if (changed)
+    {
+        refreshStatusBarReadouts();
+        repaint();
+    }
 }
 
 void AudioRegionEditor::resized()
@@ -389,6 +420,7 @@ void AudioRegionEditor::resized()
         getHeight() - kIconRowHeight - kRulerHeight - kStatusBarH - kScrollBarH);
     zoomFitToArea (waveArea);
     syncScrollBarRange();
+    refreshWaveform();
 
     // Re-apply cursor inheritance - covers any child added or relaid out
     // after the ctor (the dynamic IconRow + status-bar widgets all
@@ -416,6 +448,7 @@ void AudioRegionEditor::scrollBarMoved (juce::ScrollBar* bar, double newRangeSta
                                     anchorTimelineLength - viewSamples);
     scrollSamples = jlimit<std::int64_t> (0, maxStart,
                                                   (std::int64_t) newRangeStart);
+    refreshWaveform();
     repaint();
 }
 
@@ -535,8 +568,10 @@ int AudioRegionEditor::regionIndexAtX (int x, juce::Rectangle<int> area) const
 
 void AudioRegionEditor::paint (juce::Graphics& g)
 {
-    rebuildThumbIfNeeded();
-
+    const auto snapshot = waveformSource.snapshot();
+    const auto* focused = region();
+    loadedFileSampleRate = focused != nullptr && focused->file == loadedFile && snapshot.info
+        ? snapshot.info->sampleRate : 0.0;
     g.fillAll (kBgDark);
 
     // Top icon row band - flat fill; icons paint themselves.
@@ -564,7 +599,7 @@ void AudioRegionEditor::paint (juce::Graphics& g)
                             (float) statusArea.getX(), (float) statusArea.getRight());
 
     paintRuler         (g, rulerArea);
-    paintWaveform      (g, waveArea);
+    paintWaveform      (g, waveArea, snapshot);
     paintBarGrid       (g, waveArea);
     paintFadeEnvelopes (g, waveArea);
     paintLoopPunchBrackets (g, rulerArea, waveArea);
@@ -722,10 +757,10 @@ void AudioRegionEditor::paintRuler (juce::Graphics& g, juce::Rectangle<int> area
     // The bar grid + the "time" ruler must speak in the WAV's OWN
     // sample-rate domain - region.timelineStart / lengthInSamples were
     // stored at recording-time SR, and the rendered waveform uses the
-    // WAV file's native SR via the thumbnail. Using engine.getCurrentSampleRate()
+    // WAV file's native SR from the source worker. Using engine.getCurrentSampleRate()
     // here drifts the grid against the audio whenever the user hot-swaps
     // to a device at a different rate. Fall back to engine SR when the
-    // WAV's SR hasn't been cached yet (thumb not loaded).
+    // WAV's SR hasn't been cached yet (source still opening).
     const double sr = std::max (1.0,
         loadedFileSampleRate > 0.0 ? loadedFileSampleRate
                                     : engine.getCurrentSampleRate());
@@ -889,25 +924,18 @@ void AudioRegionEditor::paintBarGrid (juce::Graphics& g, juce::Rectangle<int> ar
     }
 }
 
-void AudioRegionEditor::paintWaveform (juce::Graphics& g, juce::Rectangle<int> area)
+void AudioRegionEditor::paintWaveform (juce::Graphics& g, juce::Rectangle<int> area,
+                                      const dusk::audio::WaveformSource::Snapshot& snapshot)
 {
     const auto* focused = region();
-    if (focused == nullptr || thumb == nullptr) return;
-
-    // Waveform thumbnail expects seconds in the FILE'S native SR domain.
-    // Use the cached WAV SR so a hot-swap of the audio device doesn't
-    // stretch the waveform vs the bar grid above. Fall back to engine
-    // SR before the thumb has loaded its metadata.
-    const double sr = std::max (1.0,
-        loadedFileSampleRate > 0.0 ? loadedFileSampleRate
-                                    : engine.getCurrentSampleRate());
+    if (focused == nullptr) return;
     auto inset = area.reduced (4, 4);
     g.setColour (juce::Colours::black.withAlpha (0.25f));
     g.fillRect (inset);
 
     // Neighborhood view: iterate every region on this track and paint
     // any whose timeline span intersects the anchor range. Slices
-    // sharing the focused file render via the cached thumbnail at
+    // sharing the focused file render via the cached peaks at
     // their own sourceOffset / length. The focused slice gets full
     // brightness; the others are dimmed so the user can still see
     // them but knows what edits apply to.
@@ -945,28 +973,47 @@ void AudioRegionEditor::paintWaveform (juce::Graphics& g, juce::Rectangle<int> a
                                       ? kWaveformFill
                                       : reg.customColour);
 
-        if (reg.file == loadedFile && (thumb->isFullyLoaded() || thumb->getNumChannels() > 0))
+        if (reg.file == focused->file && focused->file == loadedFile && snapshot.info)
         {
-            // Shares the focused region's audio file -> render its slice of the
-            // cached thumbnail at the region's own sourceOffset / length.
             g.setColour (sliceColour.withMultipliedBrightness (isFocused ? 1.05f : 0.55f)
                                       .withAlpha (isFocused ? 1.0f : 0.85f));
-            const double t0 = (double) reg.sourceOffset / sr;
-            const double t1 = t0 + (double) reg.lengthInSamples / sr;
-            // Clip so we only draw inside the slice's x-range even when
-            // it overflows the inset (e.g. region partially outside the
-            // anchor window).
+            const auto window = waveformWindow (reg, xa, xb, inset);
+            std::size_t detailIndex = 0;
+            if (snapshot.details)
+            {
+                const auto& cached = snapshot.details->windows();
+                detailIndex = (std::size_t) std::distance (cached.begin(), std::find (cached.begin(), cached.end(), window));
+            }
             juce::Graphics::ScopedSaveState saved (g);
             g.reduceClipRegion (slice);
-            thumb->drawChannels (g,
-                                  juce::Rectangle<int> (xa, inset.getY(),
-                                                          xb - xa, inset.getHeight()),
-                                  t0, t1, 0.95f);
+            const auto clip = g.getClipBounds();
+            const int firstColumn = std::max (0, clip.getX() - slice.getX());
+            const int endColumn = std::min (window.numColumns, clip.getRight() - slice.getX());
+            const int channels = snapshot.info->numChannels;
+            for (int channel = 0; channel < channels; ++channel)
+            {
+                const float top = (float) (inset.getY() + channel * inset.getHeight() / channels);
+                const float bottom = (float) (inset.getY() + (channel + 1) * inset.getHeight() / channels);
+                const float centre = (top + bottom) * 0.5f;
+                const float scale = (bottom - top) * 0.475f;
+                for (int column = firstColumn; column < endColumn; ++column)
+                {
+                    auto peak = snapshot.details ? snapshot.details->column (detailIndex, channel, column)
+                                                 : std::optional<dusk::audio::WaveformPeaks::Peak>();
+                    if (! peak && snapshot.peaks)
+                        if (const auto range = window.columnRange (column, snapshot.info->numFrames))
+                            peak = snapshot.peaks->query (channel, range->first, range->second);
+                    if (! peak || (peak->minimum >= 0.0f && peak->maximum <= 0.0f)) continue;
+                    const float y1 = std::clamp (centre - std::clamp (peak->maximum, -1.0f, 1.0f) * scale - 0.3f, top, bottom);
+                    const float y2 = std::clamp (centre - std::clamp (peak->minimum, -1.0f, 1.0f) * scale + 0.3f, top, bottom);
+                    g.drawVerticalLine (slice.getX() + column, y1, y2);
+                }
+            }
         }
-        else if (reg.file != loadedFile)
+        else if (reg.file != focused->file)
         {
             // Different audio source than the focused region: the editor caches
-            // one thumbnail, so we can't draw this region's waveform. Paint a
+            // one source, so we can't draw this region's waveform. Paint a
             // flat colour block so it's still visible on the track when zoomed
             // out (double-click it to focus + see its waveform).
             g.setColour (sliceColour.withMultipliedBrightness (0.5f).withAlpha (0.7f));
@@ -3011,6 +3058,7 @@ void AudioRegionEditor::zoomByFactor (float factor)
     scrollSamples += (editCursorSample - anchorSampleAfterRaw);
     scrollSamples = jlimit<std::int64_t> (0,
         std::max<std::int64_t> (0, anchorTimelineLength - 1), scrollSamples);
+    refreshWaveform();
     repaint();
 }
 
@@ -3511,6 +3559,7 @@ void AudioRegionEditor::zoomFit()
                                                    getWidth(),
                                                    getHeight() - kIconRowHeight - kRulerHeight - kStatusBarH - kScrollBarH);
     zoomFitToArea (waveArea);
+    refreshWaveform();
     repaint();
 }
 
@@ -3872,6 +3921,7 @@ void AudioRegionEditor::timerCallback()
         }
     }
 
+    refreshWaveform();
     if (x == lastPlayheadX) return;
     // Repaint just the strip the playhead vacated AND the strip it
     // entered - 4 px wide each so the line + a tiny halo redraws

--- a/src/ui/AudioRegionEditor.h
+++ b/src/ui/AudioRegionEditor.h
@@ -58,7 +58,6 @@ public:
     juce::ScrollBar horizontalScrollBar { false };
     void scrollBarMoved (juce::ScrollBar* bar, double newRangeStart) override;
     void syncScrollBarRange();
-    static constexpr int kKeyboardWidth = 0;
 
 private:
     Session& session;

--- a/src/ui/AudioRegionEditor.h
+++ b/src/ui/AudioRegionEditor.h
@@ -1,12 +1,7 @@
 #pragma once
 
 #include <juce_gui_basics/juce_gui_basics.h>
-#include <juce_audio_formats/juce_audio_formats.h>
-// juce_dsp must precede juce_audio_utils so SIMDNativeOps<int64> is
-// visible before juce_audio_processors (transitively pulled by
-// juce_audio_utils) instantiates SIMDRegister<int64>.
-#include <juce_dsp/juce_dsp.h>
-#include <juce_audio_utils/juce_audio_utils.h>
+#include "../engine/audiofile/WaveformPeaks.h"
 #include "../foundation/MessageThread.h"
 #include <functional>
 #include "../session/Session.h"
@@ -17,14 +12,13 @@ class AudioEngine;
 class EditModeToolbar;
 
 // Modal editor for one AudioRegion. Sister to PianoRollComponent.
-// AudioThumbnail waveform + fade envelopes + edit cursor.
+// Cached waveform + fade envelopes + edit cursor.
 //
 // Owned by MainComponent. Constructed on the message thread; the
 // underlying AudioRegion may be mutated by other UI / RecordManager
 // while open. region() validates indices on every access - a stale
 // view paints nothing rather than crashing.
 class AudioRegionEditor final : public juce::Component,
-                                  private juce::ChangeListener,
                                   private dusk::Timer,
                                   private juce::ScrollBar::Listener
 {
@@ -75,13 +69,10 @@ private:
     void overlapNeighbours (std::int64_t& overlapPrev, std::int64_t& overlapNext,
                              FadeShape& prevOutShape, FadeShape& nextInShape) const;
 
-    juce::AudioFormatManager formatManager;
-    // 8 is plenty - we show one region at a time, but cached entries
-    // keep take cycling snappy.
-    juce::AudioThumbnailCache thumbCache { 8 };
-    std::unique_ptr<juce::AudioThumbnail> thumb;
+    dusk::audio::WaveformSource waveformSource;
+    dusk::audio::WaveformSource::Snapshot waveformSnapshot;
     juce::File loadedFile;
-    // Cached from the AudioFormatReader so the bar/beat grid is
+    // Cached from the source worker so the bar/beat grid is
     // computed in the WAV's own time domain regardless of the device's
     // current SR. Without this, the grid drifts when the user hot-
     // swaps to a different-rate device. 0 = unknown (fall back to
@@ -306,12 +297,12 @@ private:
     void zoomByFactor (float factor);
     void splitAtCursor();
 
-    void rebuildThumbIfNeeded();
-    void changeListenerCallback (juce::ChangeBroadcaster*) override;
+    void refreshWaveform();
 
     void paintRuler         (juce::Graphics&, juce::Rectangle<int> area);
     void paintBarGrid       (juce::Graphics&, juce::Rectangle<int> waveArea);
-    void paintWaveform      (juce::Graphics&, juce::Rectangle<int> area);
+    void paintWaveform      (juce::Graphics&, juce::Rectangle<int> area,
+                             const dusk::audio::WaveformSource::Snapshot&);
     void paintFadeEnvelopes (juce::Graphics&, juce::Rectangle<int> area);
     // Loop (green) + punch (red) brackets over the ruler + waveform, read
     // from the transport. Dimmed when the matching mode is disabled.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -253,6 +253,7 @@ endif()
 target_sources(dusk-studio-tests PRIVATE
     audiofile_roundtrip.cpp
     waveform_peaks.cpp
+    waveform_details.cpp
     audiofile_ab_null.cpp
     audiofile_buffered_reader.cpp
     audiofile_drain_pool.cpp

--- a/tests/waveform_details.cpp
+++ b/tests/waveform_details.cpp
@@ -1,0 +1,341 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "engine/audiofile/WaveformPeaks.h"
+#include "engine/audiofile/FileWriter.h"
+#include "TestTempDirectory.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <limits>
+#include <thread>
+
+using namespace dusk::audio;
+using Catch::Matchers::WithinAbs;
+
+namespace
+{
+void writeDetailFile (const std::filesystem::path& file, const std::vector<std::vector<float>>& samples)
+{
+    WriteSpec spec;
+    spec.sampleRate = 48000.0;
+    spec.numChannels = (int) samples.size();
+    spec.bitsPerSample = 32;
+    auto writer = FileWriter::create (file, spec);
+    REQUIRE (writer != nullptr);
+    std::vector<const float*> channels;
+    for (const auto& samplesForChannel : samples) channels.push_back (samplesForChannel.data());
+    REQUIRE (writer->write (channels.data(), spec.numChannels, (int64_t) samples.front().size()));
+}
+
+void checkDetail (const std::optional<WaveformPeaks::Peak>& peak, float minimum, float maximum)
+{
+    REQUIRE (peak.has_value());
+    REQUIRE_THAT (peak->minimum, WithinAbs (minimum, 1.0e-6));
+    REQUIRE_THAT (peak->maximum, WithinAbs (maximum, 1.0e-6));
+}
+
+WaveformSource::Snapshot waitForDetail (const WaveformSource& source, bool overview = false)
+{
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds (5);
+    auto snapshot = source.snapshot();
+    while ((overview ? snapshot.state : snapshot.detailState) == WaveformSource::State::Loading
+           && std::chrono::steady_clock::now() < deadline)
+    {
+        std::this_thread::yield();
+        snapshot = source.snapshot();
+    }
+    REQUIRE ((overview ? snapshot.state : snapshot.detailState) != WaveformSource::State::Loading);
+    return snapshot;
+}
+}
+
+TEST_CASE ("Waveform details preserve individual samples across read boundaries", "[waveform][detail]")
+{
+    duskstudio::test::TempDirectory dir ("dusk-waveform-detail-samples");
+    const auto file = dir.path() / "samples.wav";
+    std::vector<std::vector<float>> samples (2, std::vector<float> (9000));
+    for (int frame = 0; frame < 9000; ++frame)
+    {
+        samples[0][(size_t) frame] = (float) (frame % 17) * 0.1f;
+        samples[1][(size_t) frame] = -0.75f;
+    }
+    samples[0][8191] = std::numeric_limits<float>::quiet_NaN();
+    samples[0][8192] = 1.75f;
+    writeDetailFile (file, samples);
+    auto reader = FileReader::open (file);
+    REQUIRE (reader != nullptr);
+    const auto detail = WaveformDetails::generate (*reader, { { 0, 9000, 9000, 0, 9000 }, { 31, 1, 10, 0, 10 } });
+    REQUIRE (detail != nullptr);
+    REQUIRE_THAT (detail->info().sampleRate, WithinAbs (48000.0, 1.0e-9));
+    for (int frame = 0; frame < 9000; ++frame)
+    {
+        const float value = frame == 8191 ? 0.0f : samples[0][(size_t) frame];
+        checkDetail (detail->column (0, 0, frame), value, value);
+        checkDetail (detail->column (0, 1, frame), -0.75f, -0.75f);
+    }
+    for (int column = 0; column < 10; ++column)
+        checkDetail (detail->column (1, 0, column), samples[0][31], samples[0][31]);
+    REQUIRE_FALSE (detail->column (2, 0, 0));
+    REQUIRE_FALSE (detail->column (0, -1, 0));
+    REQUIRE_FALSE (detail->column (0, 2, 0));
+    REQUIRE_FALSE (detail->column (0, 0, -1));
+    REQUIRE_FALSE (detail->column (0, 0, 9000));
+
+#ifndef _WIN32
+    SECTION ("An open source stays consistent after atomic path replacement")
+    {
+        const auto replacement = dir.path() / "replacement.wav";
+        writeDetailFile (replacement, { std::vector<float> (500, -0.5f) });
+        std::filesystem::rename (replacement, file);
+        const auto overview = WaveformPeaks::generate (*reader);
+        REQUIRE (overview != nullptr);
+        REQUIRE (overview->info().numFrames == 9000);
+        REQUIRE (overview->info().numChannels == 2);
+        checkDetail (overview->query (1, 0, 9000), -0.75f, -0.75f);
+        const auto retained = WaveformDetails::generate (*reader, { { 8192, 1, 1, 0, 1 } });
+        REQUIRE (retained != nullptr);
+        checkDetail (retained->column (0, 0, 0), 1.75f, 1.75f);
+        const auto reopened = WaveformPeaks::generate (file);
+        REQUIRE (reopened != nullptr);
+        REQUIRE (reopened->info().numFrames == 500);
+        REQUIRE (reopened->info().numChannels == 1);
+        checkDetail (reopened->query (0, 0, 500), -0.5f, -0.5f);
+    }
+#endif
+}
+
+TEST_CASE ("Waveform detail windows retain full mappings and clipped disjoint extrema", "[waveform][detail]")
+{
+    duskstudio::test::TempDirectory dir ("dusk-waveform-detail-windows");
+    const auto file = dir.path() / "windows.wav";
+    std::vector<float> samples (12000);
+    for (size_t frame = 0; frame < samples.size(); ++frame)
+        samples[frame] = std::sin ((float) frame * 0.0321f);
+    writeDetailFile (file, { samples });
+    auto reader = FileReader::open (file);
+    REQUIRE (reader != nullptr);
+    const std::vector<WaveformDetails::Window> windows {
+        { 13, 9327, 1200, 171, 834 }, { 11985, 200, 99, 0, 99 }, { 500, 1000, 77, 0, 77 },
+        { std::numeric_limits<int64_t>::max() - 10, 100, 100, 0, 100 },
+        { 0, (int64_t) std::numeric_limits<int>::max() * 512 - 1,
+          std::numeric_limits<int>::max(), std::numeric_limits<int>::max() - 3, 3 } };
+    const auto detail = WaveformDetails::generate (*reader, windows);
+    REQUIRE (detail != nullptr);
+    REQUIRE (detail->windows() == windows);
+    for (size_t index = 0; index < windows.size(); ++index)
+    {
+        const auto& window = windows[index];
+        for (int column = 0; column < window.numColumns; ++column)
+        {
+            const long double first = (long double) window.sourceStart
+                + std::floor ((long double) window.sourceLength * (window.firstColumn + column) / window.fullWidth);
+            const long double end = (long double) window.sourceStart
+                + std::ceil ((long double) window.sourceLength * (window.firstColumn + column + 1) / window.fullWidth);
+            const auto a = (size_t) std::min (first, (long double) samples.size());
+            const auto b = (size_t) std::min (end, (long double) samples.size());
+            const auto range = window.columnRange (column, (int64_t) samples.size());
+            REQUIRE (range.has_value());
+            REQUIRE (range->first == (int64_t) a);
+            REQUIRE (range->second == (int64_t) b);
+            if (a == b) checkDetail (detail->column (index, 0, column), 0.0f, 0.0f);
+            else
+            {
+                const auto expected = std::minmax_element (samples.begin() + (ptrdiff_t) a,
+                                                           samples.begin() + (ptrdiff_t) b);
+                checkDetail (detail->column (index, 0, column), *expected.first, *expected.second);
+            }
+        }
+    }
+}
+
+TEST_CASE ("Waveform detail admission bounds invalid geometry and complete result memory", "[waveform][detail]")
+{
+    using Window = WaveformDetails::Window;
+    const std::vector<Window> invalid {
+        { -1, 1, 1, 0, 1 }, { 0, 0, 1, 0, 1 }, { 0, 1, 0, 0, 1 }, { 0, 1, 1, -1, 1 },
+        { 0, 1, 1, 0, 0 }, { 0, 1, 1, 0, 2 }, { 0, 513, 1, 0, 1 },
+        { 0, std::numeric_limits<int64_t>::max(), std::numeric_limits<int>::max(), 0, 1 },
+        { 0, 1, std::numeric_limits<int>::max(), std::numeric_limits<int>::max() - 1, 2 },
+        { 0, 65537, 65537, 0, 65537 } };
+    for (const auto& window : invalid) REQUIRE_FALSE (WaveformDetails::validRequest ({ window }, 1));
+    REQUIRE_FALSE (WaveformDetails::validRequest ({ { 0, 1, 1, 0, 1 } }, 0));
+    REQUIRE_FALSE (WaveformDetails::validRequest ({ { 0, 1, 1, 0, 1 } }, 257));
+    REQUIRE (WaveformDetails::validRequest ({ { 0, 65536, 65536, 0, 65536 } }, 1));
+    REQUIRE_FALSE (WaveformDetails::validRequest ({ { 0, 65536, 65536, 0, 65536 } }, 256));
+    std::vector<Window> many (WaveformDetails::kMaxColumns, { 0, 1, 1, 0, 1 });
+    REQUIRE (WaveformDetails::validRequest (many, 1));
+    REQUIRE_FALSE (WaveformDetails::validRequest (many, 32));
+    many.push_back ({ 0, 1, 1, 0, 1 });
+    REQUIRE_FALSE (WaveformDetails::validRequest (many, 1));
+
+    const Window ordinary { 0, 10, 10, 0, 10 };
+    REQUIRE_FALSE (ordinary.columnRange (-1, 10));
+    REQUIRE_FALSE (ordinary.columnRange (10, 10));
+    REQUIRE_FALSE (ordinary.columnRange (0, -1));
+    for (size_t index : { 0u, 1u, 2u, 3u, 4u, 5u, 8u })
+        REQUIRE_FALSE (invalid[index].columnRange (0, 100));
+    const Window extreme { 0, std::numeric_limits<int64_t>::max(),
+        std::numeric_limits<int>::max(), std::numeric_limits<int>::max() - 1, 1 };
+    const auto finalRange = extreme.columnRange (0, std::numeric_limits<int64_t>::max());
+    REQUIRE (finalRange.has_value());
+    REQUIRE (finalRange->first == std::numeric_limits<int64_t>::max() - INT64_C (4294967299));
+    REQUIRE (finalRange->second == std::numeric_limits<int64_t>::max());
+}
+
+TEST_CASE ("Waveform detail cancellation never returns partial batches", "[waveform][detail]")
+{
+    duskstudio::test::TempDirectory dir ("dusk-waveform-detail-cancel");
+    const auto file = dir.path() / "cancel.wav";
+    writeDetailFile (file, { std::vector<float> (50000, 0.625f) });
+    auto reader = FileReader::open (file);
+    REQUIRE (reader != nullptr);
+    const std::vector<WaveformDetails::Window> windows { { 0, 40000, 100, 0, 100 }, { 100, 10000, 1000, 300, 500 } };
+    int checks = 0;
+    const auto complete = WaveformDetails::generate (*reader, windows, [&] { ++checks; return false; });
+    REQUIRE (complete != nullptr);
+    REQUIRE (checks > 6);
+    for (int cancelAt = 1; cancelAt <= checks; ++cancelAt)
+    {
+        int current = 0;
+        REQUIRE_FALSE (WaveformDetails::generate (*reader, windows, [&] { return ++current == cancelAt; }));
+        REQUIRE (current == cancelAt);
+    }
+    checkDetail (complete->column (0, 0, 50), 0.625f, 0.625f);
+    const auto fresh = WaveformDetails::generate (*reader, windows);
+    REQUIRE (fresh != nullptr);
+    checkDetail (fresh->column (1, 0, 499), 0.625f, 0.625f);
+}
+
+TEST_CASE ("Waveform viewport publication preserves completed overview and immutable detail", "[waveform][detail]")
+{
+    duskstudio::test::TempDirectory dir ("dusk-waveform-detail-publish");
+    const auto file = dir.path() / "publish.wav";
+    std::vector<float> samples (100000, 0.25f);
+    samples[123] = -0.75f;
+    writeDetailFile (file, { samples });
+    WaveformSource source;
+    source.setFile (file);
+    const auto original = waitForDetail (source, true);
+    REQUIRE (original.state == WaveformSource::State::Ready);
+    REQUIRE (original.peaks != nullptr);
+    REQUIRE (original.info.has_value());
+    REQUIRE_THAT (original.info->sampleRate, WithinAbs (48000.0, 1.0e-9));
+    const std::vector<WaveformDetails::Window> first { { 120, 10, 10, 0, 10 } };
+    REQUIRE (source.setDetailWindows (first));
+    REQUIRE (source.snapshot().peaks == original.peaks);
+    const auto loaded = waitForDetail (source);
+    REQUIRE (loaded.detailState == WaveformSource::State::Ready);
+    REQUIRE (loaded.details != nullptr);
+    checkDetail (loaded.details->column (0, 0, 3), -0.75f, -0.75f);
+    REQUIRE (source.setDetailWindows (first));
+    REQUIRE (source.snapshot().details == loaded.details);
+    const std::vector<WaveformDetails::Window> second { { 500, 10, 10, 0, 10 } };
+    REQUIRE (source.setDetailWindows (second));
+    REQUIRE (source.snapshot().peaks == original.peaks);
+    const auto changed = waitForDetail (source);
+    REQUIRE (changed.details != nullptr);
+    REQUIRE (changed.details->windows() == second);
+    REQUIRE (changed.state == WaveformSource::State::Ready);
+    checkDetail (changed.details->column (0, 0, 3), 0.25f, 0.25f);
+    checkDetail (loaded.details->column (0, 0, 3), -0.75f, -0.75f);
+}
+
+TEST_CASE ("Invalid waveform viewport clears prior Ready detail and empty clears failure", "[waveform][detail]")
+{
+    duskstudio::test::TempDirectory dir ("dusk-waveform-detail-invalid");
+    const auto file = dir.path() / "valid.wav";
+    writeDetailFile (file, { std::vector<float> (1000, 0.25f) });
+    WaveformSource source;
+    source.setFile (file);
+    REQUIRE (source.setDetailWindows ({ { 0, 1000, 1000, 0, 1000 } }));
+    const auto original = waitForDetail (source);
+    REQUIRE (original.details != nullptr);
+    REQUIRE_FALSE (source.setDetailWindows ({ { 0, 1000, 1, 0, 1 } }));
+    const auto failed = source.snapshot();
+    REQUIRE (failed.detailState == WaveformSource::State::Failed);
+    REQUIRE_FALSE (failed.details);
+    REQUIRE (source.setDetailWindows ({}));
+    REQUIRE (source.snapshot().detailState == WaveformSource::State::Empty);
+    REQUIRE_FALSE (source.snapshot().details);
+    checkDetail (original.details->column (0, 0, 0), 0.25f, 0.25f);
+}
+
+TEST_CASE ("Waveform worker validates early detail requests against actual source channels", "[waveform][detail]")
+{
+    duskstudio::test::TempDirectory dir ("dusk-waveform-detail-channel-budget");
+    const auto file = dir.path() / "many-channels.wav";
+    writeDetailFile (file, std::vector<std::vector<float>> (256, std::vector<float> (1, 0.25f)));
+    const std::vector<WaveformDetails::Window> windows { { 0, 1, 65536, 0, 65536 } };
+    REQUIRE (WaveformDetails::validRequest (windows, 1));
+    REQUIRE_FALSE (WaveformDetails::validRequest (windows, 256));
+    WaveformSource source;
+    source.setFile (file);
+    // Metadata may arrive before admission; both schedules must refuse Ready.
+    source.setDetailWindows (windows);
+    const auto failed = waitForDetail (source);
+    REQUIRE (failed.detailState == WaveformSource::State::Failed);
+    REQUIRE_FALSE (failed.details);
+    const auto loaded = waitForDetail (source, true);
+    REQUIRE (loaded.state == WaveformSource::State::Ready);
+    REQUIRE (loaded.info.has_value());
+    REQUIRE (loaded.info->numChannels == 256);
+    REQUIRE_FALSE (source.setDetailWindows (windows));
+    REQUIRE (source.setDetailWindows ({}));
+    REQUIRE (source.setDetailWindows ({ { 0, 1, 1, 0, 1 } }));
+    const auto valid = waitForDetail (source);
+    REQUIRE (valid.details != nullptr);
+    checkDetail (valid.details->column (0, 255, 0), 0.25f, 0.25f);
+}
+
+TEST_CASE ("Waveform worker rejects superseded viewports and source replacements", "[waveform][detail]")
+{
+    duskstudio::test::TempDirectory dir ("dusk-waveform-detail-replace");
+    const auto first = dir.path() / "first.wav";
+    const auto second = dir.path() / "second.wav";
+    writeDetailFile (first, { std::vector<float> (50000, 0.25f) });
+    writeDetailFile (second, { std::vector<float> (1000, -0.5f) });
+    WaveformSource source;
+    const std::vector<WaveformDetails::Window> latest { { 17, 10, 10, 0, 10 } };
+    for (int attempt = 0; attempt < 20; ++attempt)
+    {
+        source.setFile (first);
+        REQUIRE (source.setDetailWindows ({ { 0, 50000, 100, 0, 100 } }));
+        REQUIRE (source.setDetailWindows (latest));
+        const auto viewport = waitForDetail (source);
+        REQUIRE (viewport.details != nullptr);
+        REQUIRE (viewport.details->windows() == latest);
+        checkDetail (viewport.details->column (0, 0, 0), 0.25f, 0.25f);
+        REQUIRE (source.setDetailWindows ({ { 0, 50000, 100, 0, 100 } }));
+        source.setFile (second);
+        REQUIRE (source.setDetailWindows (latest));
+        const auto replacement = waitForDetail (source);
+        REQUIRE (replacement.details != nullptr);
+        REQUIRE (replacement.info.has_value());
+        REQUIRE (replacement.info->numFrames == 1000);
+        checkDetail (replacement.details->column (0, 0, 0), -0.5f, -0.5f);
+        checkDetail (viewport.details->column (0, 0, 0), 0.25f, 0.25f);
+        source.setFile ({});
+        REQUIRE (source.snapshot().detailState == WaveformSource::State::Empty);
+        REQUIRE_FALSE (source.snapshot().details);
+        REQUIRE_FALSE (source.snapshot().info);
+    }
+}
+
+TEST_CASE ("Waveform detail worker reports unreadable sources without stale metadata", "[waveform][detail]")
+{
+    duskstudio::test::TempDirectory dir ("dusk-waveform-detail-missing");
+    WaveformSource source;
+    source.setFile (dir.path() / "missing.wav");
+    REQUIRE (source.setDetailWindows ({ { 0, 10, 10, 0, 10 } }));
+    const auto failed = waitForDetail (source);
+    REQUIRE (failed.state == WaveformSource::State::Failed);
+    REQUIRE (failed.detailState == WaveformSource::State::Failed);
+    REQUIRE_FALSE (failed.info);
+    REQUIRE_FALSE (failed.details);
+    source.setFile ({});
+    REQUIRE_FALSE (source.setDetailWindows ({ { 0, 1, 1, 0, 1 } }));
+    REQUIRE (source.setDetailWindows ({}));
+    REQUIRE (source.snapshot().detailState == WaveformSource::State::Empty);
+}

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -57,8 +57,8 @@ src/session/SessionSerializer.h	13
 src/session/SessionTemplates.cpp	3
 src/ui/AnalogVuMeter.cpp	113
 src/ui/AnalogVuMeter.h	7
-src/ui/AudioRegionEditor.cpp	336
-src/ui/AudioRegionEditor.h	86
+src/ui/AudioRegionEditor.cpp	334
+src/ui/AudioRegionEditor.h	78
 src/ui/AuxLaneComponent.cpp	172
 src/ui/AuxLaneComponent.h	28
 src/ui/AuxView.cpp	60


### PR DESCRIPTION
Replaces the region editor's remaining AudioThumbnail consumer with native waveform snapshots. A single source worker reads metadata, overview peaks and bounded visible-column details; the paint path performs no file reads. Sample-level zoom, source offsets and same-file split regions use exact column ranges, with overview fallback while details load.

Part of #306. Builds on merged #519 and targets main. The existing editor controls, fades, transport and accessibility surface remain in place.

Validation on `9fbaab0deda4901fdb205618c2090cf742dd2c2e`:
- Release app and test builds with `-j4`; 974/974 CTests (32.61 s), zero new warnings.
- Nine new detail cases cover fractional ranges, 64-bit bounds, admission limits, cancellation, retained-reader consistency, stale requests and source replacement.
- Prior executable revision, unchanged waveform code: isolated Xvfb self-test 37 PASS / 0 FAIL. No physical audio device was exposed; the optional CLAP fixture was unavailable.
- Before/after private-display captures cover fit, one-sample-per-pixel zoom, disjoint split offsets and a 44.1 kHz source against a 48 kHz engine. Fixture hashes match; the single-sample impulse occupies the expected column. Region runtime code is identical to the reviewed capture revision after rebase.
- JUCE gate: 163 files / 8,077 uses to 163 files / 8,067 uses. No files leave the allowlist; both editor files still own existing GUI types. No production AudioThumbnail or AudioThumbnailCache references remain.
- Source review and repository checklist completed; verified first-frame sample-rate and source-change display findings were fixed. Final review found no high/medium defects. New CI is pending.

The worker retains one reader until source replacement or close, so Windows file-handle lifetime can be longer than the previous idle cache. Metadata arrives asynchronously; the existing engine-rate fallback applies until it is available. Persistent waveform caches, broader tape-view waveforms and module unlink remain separate work. The campaign and GUI phase notes now record those boundaries. Native GUI/accessibility gates are unchanged.

Rebased after #518 merged. Only README test-count conflicts required resolution; the reviewed region implementation and tests are unchanged. The preceding revision passed all seven build/test/ratchet CI checks. Current local app/test builds and full CTest passed with no new warnings; fresh CI is pending. Ready for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed waveform rendering for audio regions, providing accurate min/max sample visualization across visible waveform columns.
  * Added asynchronous waveform detail loading for responsive navigation, zooming, and scrolling.
  * Improved handling of waveform updates when files or viewing ranges change.

* **Bug Fixes**
  * Prevented stale waveform data from appearing after source files or viewports are replaced.
  * Improved handling of invalid, unreadable, and cancelled waveform requests.

* **Documentation**
  * Updated test-suite statistics and waveform migration documentation.

* **Tests**
  * Added comprehensive coverage for waveform detail generation, validation, cancellation, and source replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->