### PR TITLE
Add portable WinMM device identity and timestamp helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 990 Catch2 test cases across 187 test source files. Linux
+The C++ suite declares 996 Catch2 test cases across 188 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # Native log storage + CrashHandler signal reports
-tests/         # 990 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 996 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/midi/WinMmProtocol.h
+++ b/src/engine/midi/WinMmProtocol.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "MidiBackend.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace duskstudio::midi::winmm
+{
+// Pass the raw snapshot once, before publishing it. Suffixes depend on the
+// current enumeration order and can collide with an earlier literal name;
+// consumers must reject ambiguous identifiers when opening a port.
+inline void finishDeviceEnumeration (std::vector<BackendDeviceInfo>& devices)
+{
+    for (auto& device : devices)
+        if (device.identifier.empty())
+            device.identifier = device.name;
+
+    const auto appendNumbers = [&devices] (std::string BackendDeviceInfo::* field)
+    {
+        for (std::size_t i = 0; i < devices.size(); ++i)
+        {
+            const auto original = devices[i].*field;
+            std::size_t number = 1;
+            for (auto j = i + 1; j < devices.size(); ++j)
+                if (devices[j].*field == original)
+                    devices[j].*field += "-" + std::to_string (++number);
+        }
+    };
+    appendNumbers (&BackendDeviceInfo::name);
+    appendNumbers (&BackendDeviceInfo::identifier);
+}
+
+class InputClock
+{
+public:
+    explicit InputClock (double startTimeMs) noexcept : startMs (startTimeMs) {}
+
+    // Reset only for a new midiInStart epoch, after fencing old callbacks.
+    void reset (double startTimeMs) noexcept { startMs = startTimeMs; }
+
+    // startTimeMs and nowMs use backendClockMs(); one worker owns this clock.
+    // The nearest modulo epoch assumes delivery delay/clock drift < 2^31 ms
+    // (about 24.9 days). A 32-bit timestamp alone cannot resolve longer delays.
+    [[nodiscard]] double toBackendTime (std::uint32_t timestampMs, double nowMs) noexcept
+    {
+        constexpr double wrapMs = 4294967296.0;
+        const auto timestamp = static_cast<double> (timestampMs);
+        const auto epoch = std::floor ((nowMs - startMs - timestamp + wrapMs / 2.0) / wrapMs);
+        const auto elapsed = std::max (0.0, timestamp + epoch * wrapMs);
+        const auto time = startMs + elapsed;
+        if (time > nowMs)
+        {
+            // Preserve the fallback's bounded correction for driver-clock lead.
+            if (time > nowMs + 2.0)
+                startMs -= 1.0;
+            return nowMs;
+        }
+        return time;
+    }
+
+private:
+    double startMs;
+};
+} // namespace duskstudio::midi::winmm

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -101,6 +101,7 @@ add_executable(dusk-studio-tests
     midi_device_layer.cpp
     core_midi_protocol.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/midi/MidiDevices.cpp
+    winmm_midi_protocol.cpp
     midi_time_code_decode.cpp
     midi_time_code_emit.cpp
     midi_clock_drift.cpp

--- a/tests/winmm_midi_protocol.cpp
+++ b/tests/winmm_midi_protocol.cpp
@@ -1,0 +1,120 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <juce_core/juce_core.h>
+
+#include "engine/midi/WinMmProtocol.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+using duskstudio::midi::BackendDeviceInfo;
+using duskstudio::midi::winmm::InputClock;
+using duskstudio::midi::winmm::finishDeviceEnumeration;
+using Catch::Matchers::WithinAbs;
+
+TEST_CASE ("WinMM identifiers preserve interface paths and fallback names", "[midi][winmm][issue-299]")
+{
+    std::vector<BackendDeviceInfo> devices {
+        { "Keys", R"(\\?\midi#vid_1234&pid_5678#{ab-cd})" },
+        { u8"\u00c9cho \U0001f3b9", "" },
+        { "", "port-2, endpoint -123" }
+    };
+    finishDeviceEnumeration (devices);
+    REQUIRE (devices.size() == 3);
+    REQUIRE (devices[0].name == "Keys");
+    REQUIRE (devices[0].identifier == R"(\\?\midi#vid_1234&pid_5678#{ab-cd})");
+    REQUIRE (devices[1].name == u8"\u00c9cho \U0001f3b9");
+    REQUIRE (devices[1].identifier == u8"\u00c9cho \U0001f3b9");
+    REQUIRE (devices[2].name.empty());
+    REQUIRE (devices[2].identifier == "port-2, endpoint -123");
+}
+
+TEST_CASE ("WinMM duplicate names and IDs are decorated independently in enumeration order", "[midi][winmm][issue-299]")
+{
+    std::vector<BackendDeviceInfo> devices {
+        { "Keys", "port" }, { "Keys", "other" }, { "KEYS", "port" },
+        { "Keys-2", "other" }, { "Keys", "port-2" }
+    };
+    finishDeviceEnumeration (devices);
+    const std::vector<std::string> names { "Keys", "Keys-2", "KEYS", "Keys-2-2", "Keys-3" };
+    const std::vector<std::string> ids { "port", "other", "port-2", "other-2", "port-2-2" };
+    for (std::size_t i = 0; i < devices.size(); ++i)
+    {
+        REQUIRE (devices[i].name == names[i]);
+        REQUIRE (devices[i].identifier == ids[i]);
+    }
+
+    std::vector<BackendDeviceInfo> reordered { { "Keys-2", "port-2" }, { "Keys", "port" }, { "Keys", "port" } };
+    finishDeviceEnumeration (reordered);
+    // The existing fallback's suffixes can collide with an earlier literal name.
+    REQUIRE (reordered[0].identifier == "port-2");
+    REQUIRE (reordered[2].identifier == "port-2");
+    REQUIRE (reordered[0].name == "Keys-2");
+    REQUIRE (reordered[2].name == "Keys-2");
+}
+
+TEST_CASE ("WinMM enumeration agrees with JUCE duplicate decoration", "[midi][winmm][issue-299]")
+{
+    const std::vector<std::vector<BackendDeviceInfo>> snapshots {
+        {}, { { "", "" } }, { { "", "" }, { "", "" }, { "-2", "" } },
+        { { "A-2", "id-2" }, { "A", "id" }, { "A", "id" }, { "A-2", "id-2" } },
+        { { "A", "" }, { "A", "A" }, { "A", "A-2" }, { "a", "a" }, { "A-2", "A" } },
+        { { u8"\u00c9cho", "" }, { u8"\u00e9cho", "" }, { u8"\u00c9cho", "" }, { u8"\U0001f3b9", "" }, { u8"\U0001f3b9", "" } }
+    };
+    for (auto devices : snapshots)
+    {
+        juce::StringArray names, ids;
+        for (const auto& device : devices)
+        {
+            names.add (juce::String::fromUTF8 (device.name.c_str()));
+            ids.add (juce::String::fromUTF8 ((device.identifier.empty() ? device.name : device.identifier).c_str()));
+        }
+        names.appendNumbersToDuplicates (false, false, juce::CharPointer_UTF8 ("-"), juce::CharPointer_UTF8 (""));
+        ids.appendNumbersToDuplicates (false, false, juce::CharPointer_UTF8 ("-"), juce::CharPointer_UTF8 (""));
+        finishDeviceEnumeration (devices);
+        REQUIRE (devices.size() == static_cast<std::size_t> (names.size()));
+        for (std::size_t i = 0; i < devices.size(); ++i)
+        {
+            REQUIRE (devices[i].name == names[static_cast<int> (i)].toStdString());
+            REQUIRE (devices[i].identifier == ids[static_cast<int> (i)].toStdString());
+        }
+    }
+}
+
+TEST_CASE ("WinMM input timestamps retain source time and reset on a new start", "[midi][winmm][issue-299]")
+{
+    InputClock clock (1000.25);
+    REQUIRE_THAT (clock.toBackendTime (0, 1001.0), WithinAbs (1000.25, 1.0e-6));
+    REQUIRE_THAT (clock.toBackendTime (100, 1500.0), WithinAbs (1100.25, 1.0e-6));
+    REQUIRE_THAT (clock.toBackendTime (25, 1600.0), WithinAbs (1025.25, 1.0e-6));
+    clock.reset (2000.5);
+    REQUIRE_THAT (clock.toBackendTime (0, 2001.0), WithinAbs (2000.5, 1.0e-6));
+    REQUIRE_THAT (clock.toBackendTime (25, 2100.0), WithinAbs (2025.5, 1.0e-6));
+}
+
+TEST_CASE ("WinMM future timestamps retain the fallback clock correction", "[midi][winmm][issue-299]")
+{
+    InputClock clock (1000.0);
+    REQUIRE_THAT (clock.toBackendTime (10, 1008.0), WithinAbs (1008.0, 1.0e-6));
+    REQUIRE_THAT (clock.toBackendTime (10, 1020.0), WithinAbs (1010.0, 1.0e-6));
+    REQUIRE_THAT (clock.toBackendTime (30, 1020.0), WithinAbs (1020.0, 1.0e-6));
+    REQUIRE_THAT (clock.toBackendTime (40, 1100.0), WithinAbs (1039.0, 1.0e-6));
+    clock.reset (2000.0);
+    REQUIRE_THAT (clock.toBackendTime (40, 2100.0), WithinAbs (2040.0, 1.0e-6));
+}
+
+TEST_CASE ("WinMM input timestamps unwrap across long runs and delayed completion", "[midi][winmm][issue-299]")
+{
+    constexpr double wrap = 4294967296.0;
+    InputClock clock (1000.0);
+    REQUIRE_THAT (clock.toBackendTime (0xfffffff0u, 1000.0 + wrap - 10.0), WithinAbs (1000.0 + wrap - 16.0, 1.0e-6));
+    REQUIRE_THAT (clock.toBackendTime (0, 1000.0 + wrap - 0.5), WithinAbs (1000.0 + wrap - 0.5, 1.0e-6));
+    REQUIRE_THAT (clock.toBackendTime (4, 1000.0 + wrap + 8.0), WithinAbs (1000.0 + wrap + 4.0, 1.0e-6));
+    REQUIRE_THAT (clock.toBackendTime (0xffffffffu, 1000.0 + wrap + 10.0), WithinAbs (1000.0 + wrap - 1.0, 1.0e-6));
+    REQUIRE_THAT (clock.toBackendTime (25, 1000.0 + 3.0 * wrap + 30.0), WithinAbs (1000.0 + 3.0 * wrap + 25.0, 1.0e-6));
+    clock.reset (2000.0);
+    REQUIRE_THAT (clock.toBackendTime (25, 2100.0), WithinAbs (2025.0, 1.0e-6));
+    REQUIRE_THAT (clock.toBackendTime (0xffffffffu, 2100.0), WithinAbs (2000.0, 1.0e-6));
+}


### PR DESCRIPTION
Adds portable identifier and timestamp helpers for a future WinMM MIDI backend. Existing device selection and the Windows JUCE fallback stay unchanged. Partial work, refs #299.

Device names and identifiers preserve the pinned Windows JUCE 8.0.4 suffix behavior, including independent name/ID decoration, Unicode strings, and existing suffix collisions. A future native opener must reject ambiguous identifiers. Input time conversion preserves ordinary start-relative timing and future-clock correction, while adding 32-bit rollover handling. Epoch selection assumes delivery delay and clock drift remain below half a wrap (about 24.9 days).

Validation:

- Linux Release app/test builds; 980/980 CTest (32.64 s), including six new cases. Prior unchanged helper implementation, isolated Xvfb self-test: 37 PASS / 0 FAIL; optional CLAP fixture unavailable. No new warning messages; JUCE gate remains 163 files / 8,067 uses.
- Prior Windows exact commit `d14207ba8b567b2c65d09e5d195c38e3e9cefc20`: Release app/test builds with ASIO enabled, 930/930 CTest (64.41 s), plus six focused cases / 80 assertions against the actual pinned JUCE 8.0.4. This VM configuration lacks optional LAME/libsamplerate support; no application or hardware runtime was launched.
- Current head `61838eb857435046c0cb48a5fee69bb542dcb590` rebased onto merged #523; helper and test code is unchanged from the previously reviewed Windows-validated implementation. Source review against the repository checklist, suffix/Unicode parity, rollover/reset/delay edge cases and registration/count checks completed. No files leave the JUCE allowlist.

This phase does not implement or select a native Windows MIDI backend. Driver callback/buffer lifetime, SysEx delivery, hot-plug and teardown still need their native implementation and tests. No software MIDI loopback fixture has been established, and no physical MIDI, sleep/wake, WASAPI or ASIO runtime sign-off is claimed.

Only README test-count conflicts needed resolution after #523; helper and tests are unchanged. All seven build/test/ratchet CI checks passed on the preceding revision. Fresh CI is pending.
