### PR TITLE
Extract the shared MIDI packet decoder

### DIFF
--- a/src/engine/midi/CoreMidiBackend.mm
+++ b/src/engine/midi/CoreMidiBackend.mm
@@ -1,5 +1,6 @@
 #include "CoreMidiBackend.h"
 #include "CoreMidiProtocol.h"
+#include "MidiPacketDecoder.h"
 
 #include <CoreMIDI/CoreMIDI.h>
 #include <mach/mach_time.h>
@@ -297,7 +298,7 @@ double tickDuration()
 struct InputConnection
 {
     CallbackGate gate;
-    coremidi::PacketDecoder decoder;
+    PacketDecoder decoder;
     IMidiInputBackend::Receiver receiver;
     std::string identifier;
     double millisecondsPerTick = tickDuration();

--- a/src/engine/midi/CoreMidiProtocol.h
+++ b/src/engine/midi/CoreMidiProtocol.h
@@ -1,9 +1,7 @@
 #pragma once
 
 #include "MidiBackend.h"
-#include "../../foundation/MidiBuffer.h"
 
-#include <array>
 #include <cstdint>
 #include <cwctype>
 #include <limits>
@@ -118,104 +116,4 @@ struct ClockAnchor
     }
 };
 
-// One parser per source. Storage is bounded by what the input collector can
-// carry; an oversized SysEx is discarded whole, through its terminating F7.
-// Messages emit on completion: realtime can precede a fragmented message whose
-// first-byte timestamp is older. Never hold clock ticks behind incomplete SysEx.
-class PacketDecoder
-{
-public:
-    void reset() noexcept
-    {
-        size = 0;
-        expected = 0;
-        runningStatus = 0;
-        inSysex = false;
-        overflow = false;
-    }
-
-    template <class Receiver>
-    void push (const std::uint8_t* bytes, int count, double timeMs, Receiver&& receive)
-    {
-        for (int i = 0; bytes != nullptr && i < count; ++i)
-        {
-            const auto byte = bytes[i];
-            if (byte >= 0xf8)
-            {
-                receive (&bytes[i], 1, timeMs);
-                continue;
-            }
-
-            if (inSysex)
-            {
-                if (byte < 0x80 || byte == 0xf7)
-                {
-                    if (size < data.size()) data[size++] = byte;
-                    else overflow = true;
-                    if (byte == 0xf7)
-                    {
-                        if (! overflow) receive (data.data(), static_cast<int> (size), startMs);
-                        reset();
-                    }
-                    continue;
-                }
-                reset();
-            }
-
-            if (byte >= 0x80)
-            {
-                size = 0;
-                expected = 0;
-                runningStatus = byte < 0xf0 ? byte : 0;
-                if (byte == 0xf7) continue;
-                startMs = timeMs;
-                data[size++] = byte;
-                if (byte == 0xf0)
-                {
-                    inSysex = true;
-                    continue;
-                }
-                expected = messageSize (byte);
-                if (expected == 1)
-                {
-                    receive (data.data(), 1, startMs);
-                    size = 0;
-                }
-                continue;
-            }
-
-            if (size == 0)
-            {
-                if (runningStatus == 0) continue;
-                data[size++] = runningStatus;
-                expected = messageSize (runningStatus);
-                startMs = timeMs;
-            }
-            data[size++] = byte;
-            if (size == expected)
-            {
-                receive (data.data(), static_cast<int> (size), startMs);
-                size = 0;
-            }
-        }
-    }
-
-private:
-    static std::size_t messageSize (std::uint8_t status) noexcept
-    {
-        if (status < 0xf0) return (status & 0xe0) == 0xc0 ? 2 : 3;
-        if (status == 0xf1 || status == 0xf3) return 2;
-        if (status == 0xf2) return 3;
-        return 1;
-    }
-
-    static constexpr std::size_t kMaxMessageBytes = dusk::kMidiBlockBytes - sizeof (double) - sizeof (std::int32_t);
-    std::array<std::uint8_t, kMaxMessageBytes> data {};
-    std::size_t size = 0;
-    std::size_t expected = 0;
-    std::uint8_t runningStatus = 0;
-    double startMs = 0.0;
-    bool inSysex = false;
-    bool overflow = false;
-};
 } // namespace duskstudio::midi::coremidi

--- a/src/engine/midi/MidiPacketDecoder.h
+++ b/src/engine/midi/MidiPacketDecoder.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include "../../foundation/MidiBuffer.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace duskstudio::midi
+{
+// One parser per source. Storage is bounded by what the input collector can
+// carry; an oversized SysEx is discarded whole, through its terminating F7.
+// Messages emit on completion: realtime can precede a fragmented message whose
+// first-byte timestamp is older. Never hold clock ticks behind incomplete SysEx.
+class PacketDecoder
+{
+public:
+    void reset() noexcept
+    {
+        size = 0;
+        expected = 0;
+        runningStatus = 0;
+        inSysex = false;
+        overflow = false;
+    }
+
+    template <class Receiver>
+    void push (const std::uint8_t* bytes, int count, double timeMs, Receiver&& receive)
+    {
+        for (int i = 0; bytes != nullptr && i < count; ++i)
+        {
+            const auto byte = bytes[i];
+            if (byte >= 0xf8)
+            {
+                receive (&bytes[i], 1, timeMs);
+                continue;
+            }
+
+            if (inSysex)
+            {
+                if (byte < 0x80 || byte == 0xf7)
+                {
+                    if (size < data.size()) data[size++] = byte;
+                    else overflow = true;
+                    if (byte == 0xf7)
+                    {
+                        if (! overflow) receive (data.data(), static_cast<int> (size), startMs);
+                        reset();
+                    }
+                    continue;
+                }
+                reset();
+            }
+
+            if (byte >= 0x80)
+            {
+                size = 0;
+                expected = 0;
+                runningStatus = byte < 0xf0 ? byte : 0;
+                if (byte == 0xf7) continue;
+                startMs = timeMs;
+                data[size++] = byte;
+                if (byte == 0xf0)
+                {
+                    inSysex = true;
+                    continue;
+                }
+                expected = messageSize (byte);
+                if (expected == 1)
+                {
+                    receive (data.data(), 1, startMs);
+                    size = 0;
+                }
+                continue;
+            }
+
+            if (size == 0)
+            {
+                if (runningStatus == 0) continue;
+                data[size++] = runningStatus;
+                expected = messageSize (runningStatus);
+                startMs = timeMs;
+            }
+            data[size++] = byte;
+            if (size == expected)
+            {
+                receive (data.data(), static_cast<int> (size), startMs);
+                size = 0;
+            }
+        }
+    }
+
+private:
+    static std::size_t messageSize (std::uint8_t status) noexcept
+    {
+        if (status < 0xf0) return (status & 0xe0) == 0xc0 ? 2 : 3;
+        if (status == 0xf1 || status == 0xf3) return 2;
+        if (status == 0xf2) return 3;
+        return 1;
+    }
+
+    static constexpr std::size_t kMaxMessageBytes = dusk::kMidiBlockBytes - sizeof (double) - sizeof (std::int32_t);
+    std::array<std::uint8_t, kMaxMessageBytes> data {};
+    std::size_t size = 0;
+    std::size_t expected = 0;
+    std::uint8_t runningStatus = 0;
+    double startMs = 0.0;
+    bool inSysex = false;
+    bool overflow = false;
+};
+} // namespace duskstudio::midi

--- a/tests/core_midi_protocol.cpp
+++ b/tests/core_midi_protocol.cpp
@@ -2,11 +2,13 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include "engine/midi/CoreMidiProtocol.h"
+#include "engine/midi/MidiPacketDecoder.h"
 #include "foundation/MidiRing.h"
 
 #include <limits>
 #include <vector>
 
+using duskstudio::midi::PacketDecoder;
 using namespace duskstudio::midi::coremidi;
 using Catch::Matchers::WithinAbs;
 


### PR DESCRIPTION
Moves the existing bounded MIDI byte decoder from the CoreMIDI-specific protocol header into `MidiPacketDecoder.h` under the common MIDI namespace. CoreMIDI uses that same decoder through an explicit include, preparing reuse by the Windows MIDI backend. Partial work, refs #298 and #299.

The decoder class body is copied byte-for-byte. Running status, fragmented SysEx, overflow discard, realtime-message interleaving, first-byte timestamps and completion ordering are preserved. CoreMIDI identity/clock helpers remain in their existing header. There is no compatibility alias or backend selection change.

Rebased onto merged #524 at `8c9015d849bdfa7c607e75f577183f607b1aa43f`; all four implementation/test files are unchanged from the previous reviewed head `5b6a67b08052ec9e0e2ae815608b97adba11137f`. Validation:

- Linux Release app/test builds with `-j4`; 980/980 CTests (32.20 s), zero new warning messages. The same eight portable cases / 78 assertions passed before and after extraction.
- Prior unchanged implementation, isolated Xvfb self-test: 37 PASS / 0 FAIL. Physical devices were unavailable inside the sandbox; the optional CLAP fixture was unavailable.
- Prior unchanged implementation at `5b6a67b`, macOS native CoreMIDI ON: exact app/test build, 950/950 CTests (24.70 s), including the virtual-endpoint suite (2.49 s), plus eight focused cases / 78 assertions. No new warning messages. The pre-extraction virtual suite also passed. Native LV2 is disabled in the Mac validation configuration; no application or physical-device runtime was launched.
- New header compiles standalone as C++17 under `-Wall -Wextra -Wpedantic -Werror`. Source-block comparison confirms the decoder body is unchanged. Reference/include searches and the repository review checklist found no remaining migration issue.
- JUCE gate stays at 163 files / 8,067 uses. No allowlist departures, new coupling, module-link changes or synchronization-primitive changes.

Four-file mechanical phase. The cleanup audit found no dead code to remove before the backend's include/type-qualification update. Windows callback/buffer lifetime, scheduling, hot-plug, native selection and loopback validation remain separate work. Fresh CI is pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MIDI input handling for realtime messages, SysEx data, and channel messages.
  - MIDI messages are now assembled more reliably, including streams that use running status.
  - Message timing is preserved using the timestamp of each message’s first byte.
  - Oversized SysEx messages are safely discarded instead of producing incomplete data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->