### PR TITLE
feat(midi): add native WinMM device enumeration queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GPL source on this repo — build from source and the binary costs you nothing b
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 996 Catch2 test cases across 188 test source files. Linux
+The C++ suite declares 1001 Catch2 test cases across 188 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -112,7 +112,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # Native log storage + CrashHandler signal reports
-tests/         # 996 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 1001 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/midi/WinMmDeviceQuery.cpp
+++ b/src/engine/midi/WinMmDeviceQuery.cpp
@@ -1,0 +1,93 @@
+#include "WinMmDeviceQuery.h"
+#include "WinMmProtocol.h"
+
+#include <mmddk.h>
+
+#include <algorithm>
+#include <array>
+#include <utility>
+
+namespace duskstudio::midi::winmm
+{
+namespace
+{
+std::optional<std::string> utf8 (const wchar_t* text, std::size_t capacity)
+{
+    const auto* end = std::find (text, text + capacity, L'\0');
+    if (end == text + capacity) return std::nullopt;
+    if (end == text) return std::string {};
+    const auto length = static_cast<int> (end - text);
+    const auto bytes = WideCharToMultiByte (CP_UTF8, WC_ERR_INVALID_CHARS, text, length,
+                                           nullptr, 0, nullptr, nullptr);
+    if (bytes == 0) return std::nullopt;
+    std::string result (static_cast<std::size_t> (bytes), '\0');
+    if (WideCharToMultiByte (CP_UTF8, WC_ERR_INVALID_CHARS, text, length,
+                             result.data(), bytes, nullptr, nullptr) != bytes)
+        return std::nullopt;
+    return result;
+}
+}
+
+std::vector<Endpoint> enumerateDevices (Direction direction, const DeviceQueryApi& api)
+{
+    const bool input = direction == Direction::Input;
+    const auto count = input ? api.inputCount() : api.outputCount();
+    std::vector<unsigned int> indices;
+    std::vector<BackendDeviceInfo> devices;
+    for (unsigned int index = 0; index < count; ++index)
+    {
+        std::optional<std::string> name;
+        if (input)
+        {
+            MIDIINCAPSW caps {};
+            if (api.inputCaps (index, &caps, sizeof (caps)) != MMSYSERR_NOERROR) continue;
+            name = utf8 (caps.szPname, MAXPNAMELEN);
+        }
+        else
+        {
+            MIDIOUTCAPSW caps {};
+            if (api.outputCaps (index, &caps, sizeof (caps)) != MMSYSERR_NOERROR) continue;
+            name = utf8 (caps.szPname, MAXPNAMELEN);
+        }
+        if (! name) continue;
+
+        const auto query = [&] (UINT command, DWORD_PTR first, DWORD_PTR second)
+        {
+            const auto id = static_cast<UINT_PTR> (index);
+            return input ? api.inputMessage (reinterpret_cast<HMIDIIN> (id), command, first, second)
+                         : api.outputMessage (reinterpret_cast<HMIDIOUT> (id), command, first, second);
+        };
+        std::string identifier;
+        ULONG bytes = 0;
+        std::array<wchar_t, 512> interfaceName {};
+        if (query (DRV_QUERYDEVICEINTERFACESIZE, reinterpret_cast<DWORD_PTR> (&bytes), 0) == MMSYSERR_NOERROR
+            && bytes >= sizeof (wchar_t) && bytes < sizeof (interfaceName) && bytes % sizeof (wchar_t) == 0
+            && query (DRV_QUERYDEVICEINTERFACE, reinterpret_cast<DWORD_PTR> (interfaceName.data()),
+                      sizeof (interfaceName)) == MMSYSERR_NOERROR)
+            if (auto value = utf8 (interfaceName.data(), interfaceName.size()))
+                identifier = std::move (*value);
+        indices.push_back (index);
+        devices.push_back ({ std::move (*name), std::move (identifier) });
+    }
+    finishDeviceEnumeration (devices);
+    std::vector<Endpoint> result;
+    result.reserve (devices.size());
+    for (std::size_t i = 0; i < devices.size(); ++i)
+        result.push_back ({ indices[i], std::move (devices[i]) });
+    return result;
+}
+
+std::optional<unsigned int> deviceIndexForIdentifier (const std::vector<Endpoint>& devices,
+                                                     std::string_view identifier)
+{
+    if (identifier.empty()) return std::nullopt;
+    std::optional<unsigned int> result;
+    for (const auto& device : devices)
+        if (device.info.identifier == identifier)
+        {
+            if (result) return std::nullopt;
+            result = device.deviceIndex;
+        }
+    return result;
+}
+} // namespace duskstudio::midi::winmm

--- a/src/engine/midi/WinMmDeviceQuery.h
+++ b/src/engine/midi/WinMmDeviceQuery.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#if defined(_WIN32)
+#ifndef NOMINMAX
+ #define NOMINMAX
+#endif
+#include <windows.h>
+#include <mmsystem.h>
+
+#include "MidiBackend.h"
+
+#include <optional>
+#include <string_view>
+
+namespace duskstudio::midi::winmm
+{
+enum class Direction { Input, Output };
+
+struct DeviceQueryApi
+{
+    decltype (&midiInGetNumDevs) inputCount = &midiInGetNumDevs;
+    decltype (&midiOutGetNumDevs) outputCount = &midiOutGetNumDevs;
+    decltype (&midiInGetDevCapsW) inputCaps = &midiInGetDevCapsW;
+    decltype (&midiOutGetDevCapsW) outputCaps = &midiOutGetDevCapsW;
+    decltype (&midiInMessage) inputMessage = &midiInMessage;
+    decltype (&midiOutMessage) outputMessage = &midiOutMessage;
+};
+
+struct Endpoint
+{
+    unsigned int deviceIndex;
+    BackendDeviceInfo info;
+};
+
+// Blocking metadata queries, never callback work. Indices belong to this
+// enumeration snapshot; re-enumerate and resolve immediately before opening.
+std::vector<Endpoint> enumerateDevices (Direction, const DeviceQueryApi& = {});
+std::optional<unsigned int> deviceIndexForIdentifier (const std::vector<Endpoint>&,
+                                                     std::string_view identifier);
+} // namespace duskstudio::midi::winmm
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -192,7 +192,8 @@ if(WIN32)
     # CoTaskMemFree for the returned known-folder path; advapi32: per-user
     # security descriptors and token checks for the single-instance pipe;
     # bcrypt: BCryptGenRandom in the IPC channel backend compiled in below.
-    target_link_libraries(dusk-studio-tests PRIVATE shell32 ole32 advapi32 bcrypt)
+    target_sources(dusk-studio-tests PRIVATE ${CMAKE_SOURCE_DIR}/src/engine/midi/WinMmDeviceQuery.cpp)
+    target_link_libraries(dusk-studio-tests PRIVATE shell32 ole32 advapi32 bcrypt winmm)
 endif()
 
 # pffft backend for dusk::audio::Fft, plus its A/B parity suite. The pffft

--- a/tests/winmm_midi_protocol.cpp
+++ b/tests/winmm_midi_protocol.cpp
@@ -5,6 +5,12 @@
 
 #include "engine/midi/WinMmProtocol.h"
 
+#if defined(_WIN32)
+ #include "engine/midi/WinMmDeviceQuery.h"
+ #include <mmddk.h>
+#endif
+
+#include <algorithm>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -118,3 +124,188 @@ TEST_CASE ("WinMM input timestamps unwrap across long runs and delayed completio
     REQUIRE_THAT (clock.toBackendTime (25, 2100.0), WithinAbs (2025.0, 1.0e-6));
     REQUIRE_THAT (clock.toBackendTime (0xffffffffu, 2100.0), WithinAbs (2000.0, 1.0e-6));
 }
+
+#if defined(_WIN32)
+namespace
+{
+namespace winmm = duskstudio::midi::winmm;
+
+struct QueryDevice
+{
+    std::wstring name, identifier;
+    MMRESULT capsResult = MMSYSERR_NOERROR, sizeResult = MMSYSERR_NOERROR, idResult = MMSYSERR_NOERROR;
+    std::optional<ULONG> reportedBytes;
+    bool unterminatedName = false, unterminatedId = false;
+};
+
+struct QueryFixture
+{
+    static inline thread_local QueryFixture* current = nullptr;
+    QueryFixture* previous = current;
+    std::vector<QueryDevice> inputs, outputs;
+    bool invalidCall = false;
+
+    QueryFixture() { current = this; }
+    ~QueryFixture() { current = previous; }
+
+    static UINT WINAPI inputCount() { return static_cast<UINT> (current->inputs.size()); }
+    static UINT WINAPI outputCount() { return static_cast<UINT> (current->outputs.size()); }
+
+    template <class Caps>
+    static MMRESULT caps (const std::vector<QueryDevice>& devices, UINT_PTR index, Caps* result, UINT bytes)
+    {
+        if (index >= devices.size() || result == nullptr || bytes != sizeof (Caps))
+        {
+            current->invalidCall = true;
+            return MMSYSERR_INVALPARAM;
+        }
+        const auto& device = devices[index];
+        *result = {};
+        if (device.unterminatedName)
+            std::fill_n (result->szPname, MAXPNAMELEN, L'X');
+        else
+            std::copy_n (device.name.data(), std::min<std::size_t> (device.name.size(), MAXPNAMELEN - 1),
+                         result->szPname);
+        return device.capsResult;
+    }
+
+    static MMRESULT WINAPI inputCaps (UINT_PTR index, LPMIDIINCAPSW result, UINT bytes)
+    { return caps (current->inputs, index, result, bytes); }
+    static MMRESULT WINAPI outputCaps (UINT_PTR index, LPMIDIOUTCAPSW result, UINT bytes)
+    { return caps (current->outputs, index, result, bytes); }
+
+    static MMRESULT message (const std::vector<QueryDevice>& devices, UINT_PTR index,
+                             UINT command, DWORD_PTR first, DWORD_PTR second)
+    {
+        if (index >= devices.size() || first == 0)
+        {
+            current->invalidCall = true;
+            return MMSYSERR_INVALPARAM;
+        }
+        const auto& device = devices[index];
+        if (command == DRV_QUERYDEVICEINTERFACESIZE && second == 0)
+        {
+            *reinterpret_cast<ULONG*> (first) = device.reportedBytes.value_or (
+                static_cast<ULONG> ((device.identifier.size() + 1) * sizeof (wchar_t)));
+            return device.sizeResult;
+        }
+        if (command == DRV_QUERYDEVICEINTERFACE && second == 512 * sizeof (wchar_t))
+        {
+            auto* destination = reinterpret_cast<wchar_t*> (first);
+            if (device.unterminatedId)
+                std::fill_n (destination, 512, L'X');
+            else
+            {
+                std::fill_n (destination, 512, L'\0');
+                std::copy_n (device.identifier.data(), std::min<std::size_t> (device.identifier.size(), 511),
+                             destination);
+            }
+            return device.idResult;
+        }
+        current->invalidCall = true;
+        return MMSYSERR_INVALPARAM;
+    }
+
+    static MMRESULT WINAPI inputMessage (HMIDIIN index, UINT command, DWORD_PTR first, DWORD_PTR second)
+    { return message (current->inputs, reinterpret_cast<UINT_PTR> (index), command, first, second); }
+    static MMRESULT WINAPI outputMessage (HMIDIOUT index, UINT command, DWORD_PTR first, DWORD_PTR second)
+    { return message (current->outputs, reinterpret_cast<UINT_PTR> (index), command, first, second); }
+
+    winmm::DeviceQueryApi api() const
+    { return { inputCount, outputCount, inputCaps, outputCaps, inputMessage, outputMessage }; }
+};
+}
+
+TEST_CASE ("WinMM native enumeration preserves Windows indices across capability failures", "[midi][winmm][issue-299]")
+{
+    QueryFixture fixture;
+    fixture.inputs = { { L"In 0", L"input-0" }, { L"missing", L"input-1", MMSYSERR_NODRIVER },
+                       { L"In 2", L"input-2" } };
+    fixture.outputs = { { L"Out 0", L"output-0" }, { L"missing", L"output-1", MMSYSERR_BADDEVICEID },
+                        { L"Out 2", L"output-2" } };
+    for (auto direction : { winmm::Direction::Input, winmm::Direction::Output })
+    {
+        const auto devices = winmm::enumerateDevices (direction, fixture.api());
+        REQUIRE (devices.size() == 2);
+        REQUIRE (devices[0].deviceIndex == 0);
+        REQUIRE (devices[1].deviceIndex == 2);
+        REQUIRE (devices[1].info.identifier == (direction == winmm::Direction::Input ? "input-2" : "output-2"));
+        REQUIRE (winmm::deviceIndexForIdentifier (devices, devices[1].info.identifier) == 2);
+    }
+    REQUIRE_FALSE (fixture.invalidCall);
+}
+
+TEST_CASE ("WinMM native enumeration applies fallback identifiers before duplicate decoration", "[midi][winmm][issue-299]")
+{
+    QueryFixture fixture;
+    fixture.inputs = { { L"Keys", L"" }, { L"Keys", L"Keys" }, { L"Keys", L"Keys-2" } };
+    const auto devices = winmm::enumerateDevices (winmm::Direction::Input, fixture.api());
+    REQUIRE (devices.size() == 3);
+    REQUIRE (devices[0].info.identifier == "Keys");
+    REQUIRE (devices[1].info.identifier == "Keys-2");
+    REQUIRE (devices[2].info.identifier == "Keys-2-2");
+    REQUIRE (devices[0].info.name == "Keys");
+    REQUIRE (devices[1].info.name == "Keys-2");
+    REQUIRE (devices[2].info.name == "Keys-3");
+    REQUIRE_FALSE (fixture.invalidCall);
+}
+
+TEST_CASE ("WinMM native queries convert bounded Unicode metadata", "[midi][winmm][issue-299]")
+{
+    QueryFixture fixture;
+    fixture.outputs = { { L"\u00c9cho \U0001f3b9", L"\\\\?\\midi#\u00e9#\U0001f3b9" }, { L"", L"nameless" },
+                        { L"bad", L"bad" } };
+    fixture.outputs[2].unterminatedName = true;
+    const auto devices = winmm::enumerateDevices (winmm::Direction::Output, fixture.api());
+    REQUIRE (devices.size() == 2);
+    REQUIRE (devices[0].info.name == u8"\u00c9cho \U0001f3b9");
+    REQUIRE (devices[0].info.identifier == u8"\\\\?\\midi#\u00e9#\U0001f3b9");
+    REQUIRE (devices[1].info.name.empty());
+    REQUIRE (devices[1].info.identifier == "nameless");
+    REQUIRE_FALSE (fixture.invalidCall);
+}
+
+TEST_CASE ("WinMM native queries bound unavailable or malformed interface metadata", "[midi][winmm][issue-299]")
+{
+    QueryFixture fixture;
+    fixture.inputs = { { L"Keys", L"interface" } };
+    auto& device = fixture.inputs.front();
+    SECTION ("size query fails") { device.sizeResult = MMSYSERR_NOTSUPPORTED; }
+    SECTION ("identifier query fails") { device.idResult = MMSYSERR_NOTSUPPORTED; }
+    SECTION ("no interface") { device.reportedBytes = 0; }
+    SECTION ("incomplete wide character") { device.reportedBytes = 1; }
+    SECTION ("odd byte size") { device.reportedBytes = 3; }
+    SECTION ("legacy size ceiling") { device.reportedBytes = 1024; }
+    SECTION ("oversize metadata") { device.reportedBytes = 0xffffffffu; }
+    SECTION ("missing terminator") { device.unterminatedId = true; }
+    SECTION ("invalid UTF16") { device.identifier.assign (1, static_cast<wchar_t> (0xd800)); }
+    SECTION ("largest accepted interface")
+    {
+        device.identifier.assign (510, L'x');
+        const auto devices = winmm::enumerateDevices (winmm::Direction::Input, fixture.api());
+        REQUIRE (devices.size() == 1);
+        REQUIRE (devices[0].info.identifier == std::string (510, 'x'));
+        REQUIRE_FALSE (fixture.invalidCall);
+        return;
+    }
+    const auto devices = winmm::enumerateDevices (winmm::Direction::Input, fixture.api());
+    REQUIRE (devices.size() == 1);
+    REQUIRE (devices[0].info.identifier == "Keys");
+    REQUIRE_FALSE (fixture.invalidCall);
+}
+
+TEST_CASE ("WinMM device lookup refuses missing or ambiguous identifiers", "[midi][winmm][issue-299]")
+{
+    QueryFixture fixture;
+    REQUIRE (winmm::enumerateDevices (winmm::Direction::Input, fixture.api()).empty());
+    fixture.inputs = { { L"Keys-2", L"" }, { L"Keys", L"" }, { L"Keys", L"" } };
+    const auto devices = winmm::enumerateDevices (winmm::Direction::Input, fixture.api());
+    REQUIRE (devices.size() == 3);
+    REQUIRE (winmm::deviceIndexForIdentifier (devices, "Keys") == 1);
+    REQUIRE_FALSE (winmm::deviceIndexForIdentifier (devices, "Keys-2").has_value());
+    REQUIRE_FALSE (winmm::deviceIndexForIdentifier (devices, "keys").has_value());
+    REQUIRE_FALSE (winmm::deviceIndexForIdentifier (devices, "absent").has_value());
+    REQUIRE_FALSE (winmm::deviceIndexForIdentifier (devices, "").has_value());
+    REQUIRE_FALSE (fixture.invalidCall);
+}
+#endif


### PR DESCRIPTION
Adds native WinMM device enumeration and identifier lookup for the Windows MIDI replacement. Successful entries retain their actual Windows device index when another capability query fails, preventing later entries from shifting onto a different port. Missing or ambiguous identifiers fail lookup. Partial work, refs #299.

Queries use the Windows SDK metadata APIs without opening ports. Bounded UTF-16 conversion handles Unicode names and interface paths, with the existing raw-name fallback and independent duplicate suffix rules. A narrow injected API table exercises query failures and malformed metadata using the real SDK types and calling conventions.

This five-file phase adds the query implementation, tests, Windows narrow-link registration and README test counts. Only the Windows test target consumes the query code so far. Production integration, callback/SysEx ownership, scheduling, hot-plug and native backend selection follow separately; no selector or shipping behavior changes here.

Validation at `4691e8ffe35afcb2e5e2fc1965b0b012816bbeaf`:

- Linux Release app/test builds with `-j4`; 980/980 CTests (31.62 s), no new warnings.
- Isolated private-Xvfb/bwrap self-test: 37 PASS / 0 FAIL. Physical devices were unavailable inside the sandbox; optional CLAP fixture skipped.
- Windows exact-commit Release app/test build with ASIO enabled; 944/944 CTests (60.74 s), plus 11 focused cases / 143 assertions, no new warning messages. The VM lacks optional LAME/libsamplerate. No GUI launch, port opens or driver installation.
- JUCE gate unchanged: 163 files / 8,067 uses; no allowlist departures or synchronization suppression changes.
- Root full-diff and repository-checklist review covered platform gates, SDK calling conventions and pointer widths, buffer boundaries, native indices, duplicate collisions and error handling. Compared compatibility behavior with the actual Windows-pinned JUCE 8.0.4 implementation and checked Microsoft SDK contracts. No extra review agents or paid review processes.

No structural refactor of an existing file over 300 lines; CMake changes only register the native test source/library. Real MIDI loopback, reconnect and hardware timing remain unverified and do not gain coverage from the injected tests. CI is pending; Marc owns review and merge.
