### PR TITLE
docs: park de-JUCE and record the 1.0-on-JUCE decision

### DIFF
--- a/docs/decisions/0001-ship-1.0-on-juce.md
+++ b/docs/decisions/0001-ship-1.0-on-juce.md
@@ -1,0 +1,57 @@
+# 0001: Ship Dusk Studio 1.0 on JUCE
+
+Date: 2026-09-09
+
+Status: accepted
+
+## Decision
+
+Dusk Studio 1.0 ships on JUCE. The migration to the DAF / DAF-Widgets / Dusk
+pugl stack is parked until 1.0 is out. It resumes after 1.0 as the 1.1+
+"H-series" campaign.
+
+## Why
+
+The migration is not release work. The validated baseline on main is about 179
+JUCE-coupled files in `src/` and about 9,200 qualified uses across 12 linked
+modules. Finishing that is a year of work at the pace this project can sustain.
+It does not move the release date closer. It moves it further away.
+
+1.0 is gated on what a user can do with the app and on builds they can run
+without fighting their operating system. It is not gated on framework purity.
+Nobody buys a framework. They buy a recorder that boots, records, mixes and
+bounces, and they buy signed builds that install without a warning dialog.
+
+Every hour spent on the migration before 1.0 is an hour the paid product does
+not ship.
+
+## What stays
+
+Everything already merged to main stays. None of the completed de-JUCE work is
+reverted. The Dusk seams in `src/foundation/`, `src/engine/device/`,
+`src/engine/midi/` and `src/engine/audiofile/` remain the preferred target for
+new code.
+
+`tools/juce-gate.sh` and `tools/juce-allowlist.txt` stay in place and stay
+enforced in CI. The ratchet is what keeps JUCE usage from growing while the
+campaign is parked. New code still uses the seams. A clean file that gains a
+JUCE include still fails the build.
+
+## The rule
+
+No PR that reduces JUCE usage is accepted before 1.0, unless it fixes a
+1.0-blocking user-facing bug.
+
+If a bug fix happens to remove JUCE along the way, that is fine. Removal for
+its own sake is not, however small it looks.
+
+## Tracking
+
+Milestone 3 "Complete JUCE removal" is closed. Its issues #294-#314 stay open
+and now carry the `post-1.0` label. They get re-milestoned when the H-series
+campaign restarts.
+
+The campaign map and the tower order live in
+[docs/dejuce-campaign.md](../dejuce-campaign.md). Every `docs/dejuce-*.md` plan
+carries a PARKED banner pointing back here. Those documents are still accurate.
+They are just not the current work.

--- a/docs/dejuce-accessibility-plan.md
+++ b/docs/dejuce-accessibility-plan.md
@@ -1,3 +1,5 @@
+> **PARKED until 1.0.** See [docs/decisions/0001-ship-1.0-on-juce.md](decisions/0001-ship-1.0-on-juce.md).
+
 # GUI accessibility bridge — issue #305
 
 **Decision, 2026-09-08:** preserve screen-reader support with a platform

--- a/docs/dejuce-audiofile-plan.md
+++ b/docs/dejuce-audiofile-plan.md
@@ -1,3 +1,5 @@
+> **PARKED until 1.0.** See [docs/decisions/0001-ship-1.0-on-juce.md](decisions/0001-ship-1.0-on-juce.md).
+
 # De-JUCE tower spec — Audio-file call-site sweep (juce_audio_formats consumers → dusk libsndfile seam)
 
 **STATUS: TOWER COMPLETE. PR-1 MERGED (#107, main @ 8c7859e); PR-2 =

--- a/docs/dejuce-campaign.md
+++ b/docs/dejuce-campaign.md
@@ -1,3 +1,5 @@
+> **PARKED until 1.0.** See [docs/decisions/0001-ship-1.0-on-juce.md](decisions/0001-ship-1.0-on-juce.md).
+
 # De-JUCE campaign — map and working agreement
 
 Read this first among the de-JUCE docs in any session doing de-JUCE work. It is

--- a/docs/dejuce-coremidi-plan.md
+++ b/docs/dejuce-coremidi-plan.md
@@ -1,3 +1,5 @@
+> **PARKED until 1.0.** See [docs/decisions/0001-ship-1.0-on-juce.md](decisions/0001-ship-1.0-on-juce.md).
+
 # Native CoreMIDI — first macOS device phase
 
 Partial work for issue #298. CoreAudio, the JUCE audio-device module, Windows MIDI, and hardware sign-off remain separate work.

--- a/docs/dejuce-device-phase3-audio-plan.md
+++ b/docs/dejuce-device-phase3-audio-plan.md
@@ -1,3 +1,5 @@
+> **PARKED until 1.0.** See [docs/decisions/0001-ship-1.0-on-juce.md](decisions/0001-ship-1.0-on-juce.md).
+
 # De-JUCE tower spec — Device Phase-3-audio
 
 **STATUS: TOWER COMPLETE — all phases merged to main. P0-P2 = #103, P3 = #104,

--- a/docs/dejuce-events-plan.md
+++ b/docs/dejuce-events-plan.md
@@ -1,3 +1,5 @@
+> **PARKED until 1.0.** See [docs/decisions/0001-ship-1.0-on-juce.md](decisions/0001-ship-1.0-on-juce.md).
+
 # De-JUCE — events-remainder tower (executable spec)
 
 Status: **E0–E3 DONE 2026-07-25, committed on `dejuce/events-remainder`,

--- a/docs/dejuce-fft-plan.md
+++ b/docs/dejuce-fft-plan.md
@@ -1,3 +1,5 @@
+> **PARKED until 1.0.** See [docs/decisions/0001-ship-1.0-on-juce.md](decisions/0001-ship-1.0-on-juce.md).
+
 # De-JUCE — FFT tower (executable spec)
 
 Status: **F0–F2 DONE 2026-07-25, committed on `dejuce/fft`, awaiting Marc's

--- a/docs/dejuce-gui-plan.md
+++ b/docs/dejuce-gui-plan.md
@@ -1,3 +1,5 @@
+> **PARKED until 1.0.** See [docs/decisions/0001-ship-1.0-on-juce.md](decisions/0001-ship-1.0-on-juce.md).
+
 # De-JUCE — GUI tower (campaign plan)
 
 The last tower. It removes `src/ui/` as a JUCE surface and, with it, every

--- a/docs/dejuce-hosting-h1-tape.md
+++ b/docs/dejuce-hosting-h1-tape.md
@@ -1,3 +1,5 @@
+> **PARKED until 1.0.** See [docs/decisions/0001-ship-1.0-on-juce.md](decisions/0001-ship-1.0-on-juce.md).
+
 # Hosting tower H1 — TapeMachine2 swap (executable spec)
 
 Status: **H1a–H1c implemented; H1d pending donor consolidation.** Branch

--- a/docs/dejuce-hosting-h3-multisample.md
+++ b/docs/dejuce-hosting-h3-multisample.md
@@ -1,3 +1,5 @@
+> **PARKED until 1.0.** See [docs/decisions/0001-ship-1.0-on-juce.md](decisions/0001-ship-1.0-on-juce.md).
+
 # Hosting tower H3 — DuskMultisample re-home (executable spec)
 
 Status: **IMPLEMENTED 2026-07-27, committed on `dejuce/hosting-h3`,

--- a/docs/dejuce-hosting-h4-descriptors.md
+++ b/docs/dejuce-hosting-h4-descriptors.md
@@ -1,3 +1,5 @@
+> **PARKED until 1.0.** See [docs/decisions/0001-ship-1.0-on-juce.md](decisions/0001-ship-1.0-on-juce.md).
+
 # Hosting tower H4 — descriptor/plumbing de-JUCE (executable spec)
 
 Status: **IMPLEMENTED AND VALIDATED 2026-07-29 on

--- a/docs/dejuce-hosting-h5-platform.md
+++ b/docs/dejuce-hosting-h5-platform.md
@@ -1,3 +1,5 @@
+> **PARKED until 1.0.** See [docs/decisions/0001-ship-1.0-on-juce.md](decisions/0001-ship-1.0-on-juce.md).
+
 # Hosting tower H5 — native platform ports + AU (executable spec)
 
 Status: **H5a MERGED (PRs #120/#121/#122). H5b MERGED (PR #154). H5c IS OPEN

--- a/docs/dejuce-hosting-plan.md
+++ b/docs/dejuce-hosting-plan.md
@@ -1,3 +1,5 @@
+> **PARKED until 1.0.** See [docs/decisions/0001-ship-1.0-on-juce.md](decisions/0001-ship-1.0-on-juce.md).
+
 # De-JUCE — plugin-hosting tower (campaign plan)
 
 Status: **H1a-c merged (PR #114); H3 merged (PR #118); H4 merged (PR #119,

--- a/docs/dejuce-native-midi-plan.md
+++ b/docs/dejuce-native-midi-plan.md
@@ -1,3 +1,5 @@
+> **PARKED until 1.0.** See [docs/decisions/0001-ship-1.0-on-juce.md](decisions/0001-ship-1.0-on-juce.md).
+
 # Native ALSA-seq MIDI backend — executable spec (M1 → M3)
 
 **Linux tower status: COMPLETE.** M1 (PR #93) primitives + backend interface, M2

--- a/docs/dejuce-remaining-phase-prompts.md
+++ b/docs/dejuce-remaining-phase-prompts.md
@@ -1,3 +1,5 @@
+> **PARKED until 1.0.** See [docs/decisions/0001-ship-1.0-on-juce.md](decisions/0001-ship-1.0-on-juce.md).
+
 # De-JUCE campaign — handoff prompts for remaining phases
 
 One prompt per remaining phase, each written for a fresh context window


### PR DESCRIPTION
Records the decision to ship 1.0 on JUCE and parks the de-JUCE campaign until after the release.

- New `docs/decisions/0001-ship-1.0-on-juce.md`: the decision, the reasoning, what stays, and the rule that no JUCE-reducing PR lands before 1.0 unless it fixes a 1.0-blocking user-facing bug.
- PARKED banner on all 15 `docs/dejuce-*.md` plans pointing at the decision record.

Repo state that goes with this:

- Milestone 3 "Complete JUCE removal" is closed, with the parked note prepended to its description.
- Its 20 open issues (#294-#300, #302-#314) stay open, are off the milestone, and now carry the new `post-1.0` label.
- The gate (`tools/juce-gate.sh` + allowlist) is untouched and stays enforced, so JUCE usage still cannot grow.

Docs only. No code, CI, or build changes.
