### PR TITLE
fix(oop): spawn sandbox children from a thread that outlives them

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ GPL source on this repo, so building it yourself costs you nothing but compile t
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 1001 Catch2 test cases across 188 test source files. Linux
+The C++ suite declares 1002 Catch2 test cases across 188 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -123,7 +123,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # Native log storage + CrashHandler signal reports
-tests/         # 1001 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 1002 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/PluginSlot.cpp
+++ b/src/engine/PluginSlot.cpp
@@ -349,15 +349,29 @@ void PluginSlot::beginRemoteLoad (PluginDescriptor descriptor,
     auto finished = std::make_shared<std::atomic<bool>> (false);
     auto cancel   = std::make_shared<std::atomic<bool>> (false);
 
+    // The spawn stays here, on the message thread, because the child dies with
+    // the thread that spawned it (see RemotePluginConnection::spawnChild). Only
+    // the handshake and the load - the parts that can block for seconds - move
+    // to the worker.
+    auto remote = std::make_unique<duskstudio::ipc::RemotePluginConnection>();
+    remote->setCancelFlag (cancel);
+    std::string spawnError;
+    const bool spawned = remote->spawnChild (hostPath, modeArg, spawnError);
+
     std::thread worker (
-        [this, life, epoch, onDone, descriptor, hostPath, modeArg, descriptionXml,
-         sampleRate, blockSize, finished, cancel]
+        [this, life, epoch, onDone, descriptor, modeArg, descriptionXml,
+         sampleRate, blockSize, finished, cancel, spawned, spawnError,
+         remote = std::move (remote)]
+        () mutable
     {
         auto outcome = std::make_shared<Outcome>();
-        auto remote = std::make_unique<duskstudio::ipc::RemotePluginConnection>();
-        remote->setCancelFlag (cancel);
 
-        if (! remote->connect (hostPath, modeArg, outcome->error))
+        if (! spawned)
+        {
+            outcome->error = spawnError;
+            remote.reset();
+        }
+        else if (! remote->completeConnect (modeArg, outcome->error))
             remote.reset();
         else if (! remote->loadPlugin (descriptionXml, sampleRate, blockSize,
                                         outcome->numIn, outcome->numOut,

--- a/src/engine/ipc/PluginHostMain.cpp
+++ b/src/engine/ipc/PluginHostMain.cpp
@@ -19,6 +19,8 @@
 //                 validation regression child.
 //   --ipc-load-reply-stub: answers LoadPlugin with a fixed stereo layout so the
 //                 parent's sandboxed load path can be driven without a plugin.
+//   --ipc-load-audio-stub: the same child plus the worker topology, so it also
+//                 answers block commands and can be driven by a live callback.
 //   --ipc-mute-handshake-stub: the same child with the ready byte withheld,
 //                 leaving the parent inside its handshake wait.
 //   --ipc-host  : full Phase-2 host. Loads a juce::AudioPluginInstance
@@ -525,7 +527,8 @@ int runIpcControlReplyStub (int argc, const char* const* argv) noexcept
 // plugin in the loop. With ackHandshake false the ready byte is withheld
 // instead, leaving the parent inside its handshake wait - the shape a load
 // cancelled from the slot's destructor has to unwind from.
-int runIpcLoadStub (int argc, const char* const* argv, bool ackHandshake) noexcept
+int runIpcLoadStub (int argc, const char* const* argv, bool ackHandshake,
+                    bool withAudioWorker) noexcept
 {
     ipcp::NativeHandle channel = ipcp::locateInheritedChannel (argc, argv);
     if (! ipcp::isValid (channel)) return 1;
@@ -558,6 +561,57 @@ int runIpcLoadStub (int argc, const char* const* argv, bool ackHandshake) noexce
     char ready = 'k';
     if (! ipcp::writeExact (channel, &ready, 1)) return 1;
 
+    // The control-only shape answers no block command, so a parent whose device
+    // callback is running times out every block and bypasses the slot whatever
+    // the child does. Pairing the control loop with the worker topology is what
+    // makes a live-callback test measure the slot rather than the stub.
+    std::atomic<bool> workerQuit { false };
+    std::thread worker;
+    if (withAudioWorker)
+        worker = std::thread ([&]
+        {
+            std::uint32_t lastSeq = 0;
+            while (! workerQuit.load (std::memory_order_acquire))
+            {
+                if (block->state.load (std::memory_order_acquire) == kStateTeardown)
+                    break;
+
+                const auto cmd = block->cmdSeq.load (std::memory_order_acquire);
+                if (cmd == lastSeq)
+                {
+                    (void) commandSignal.wait (&block->cmdSeq, cmd, nullptr);
+                    continue;
+                }
+
+                int n  = (int) block->numSamples;
+                int ci = (int) block->numInChans;
+                int co = (int) block->numOutChans;
+                n  = std::clamp (n,  0, kMaxBlock);
+                ci = std::clamp (ci, 0, kMaxChans);
+                co = std::clamp (co, 0, kMaxChans);
+
+                for (int c = 0; c < co; ++c)
+                {
+                    float* outCh = audioOutChannel (shm.data(), c);
+                    if (c < ci)
+                        std::memcpy (outCh, audioInChannel (shm.data(), c),
+                                     (std::size_t) n * sizeof (float));
+                    else
+                        std::memset (outCh, 0, (std::size_t) n * sizeof (float));
+                }
+
+                const auto midiInBytes = block->midiInBytes <= kMidiBytes
+                                           ? block->midiInBytes : 0u;
+                block->midiOutBytes = midiInBytes;
+                if (midiInBytes > 0)
+                    std::memcpy (midiOut (shm.data()), midiIn (shm.data()), midiInBytes);
+
+                lastSeq = cmd;
+                block->replySeq.store (cmd, std::memory_order_release);
+                replySignal.wake (&block->replySeq);
+            }
+        });
+
     for (;;)
     {
         ControlMsgHeader request {};
@@ -587,6 +641,12 @@ int runIpcLoadStub (int argc, const char* const* argv, bool ackHandshake) noexce
         }
     }
 
+    if (worker.joinable())
+    {
+        workerQuit.store (true, std::memory_order_release);
+        commandSignal.wake (&block->cmdSeq);
+        worker.join();
+    }
     return 0;
 }
 
@@ -1825,6 +1885,7 @@ int main (int argc, char** argv)
     bool ipcControlReplyStub = false;
     bool ipcParkTimeoutStub = false;
     bool ipcLoadReplyStub = false;
+    bool ipcLoadAudioStub = false;
     bool ipcMuteHandshakeStub = false;
     bool ipcHost = false;
     bool scan    = false;
@@ -1847,6 +1908,7 @@ int main (int argc, char** argv)
         if (std::strcmp (args[i], "--ipc-control-reply-stub") == 0) ipcControlReplyStub = true;
         if (std::strcmp (args[i], "--ipc-park-timeout-stub") == 0) ipcParkTimeoutStub = true;
         if (std::strcmp (args[i], "--ipc-load-reply-stub") == 0) ipcLoadReplyStub = true;
+        if (std::strcmp (args[i], "--ipc-load-audio-stub") == 0) ipcLoadAudioStub = true;
         if (std::strcmp (args[i], "--ipc-mute-handshake-stub") == 0)
             ipcMuteHandshakeStub = true;
         if (std::strcmp (args[i], "--ipc-host") == 0) ipcHost = true;
@@ -1871,8 +1933,9 @@ int main (int argc, char** argv)
                                               : StubReplyMode::Normal);
     if (ipcControlReplyStub) return runIpcControlReplyStub (argc, args);
     if (ipcParkTimeoutStub) return runIpcParkTimeoutStub (argc, args);
-    if (ipcLoadReplyStub || ipcMuteHandshakeStub)
-        return runIpcLoadStub (argc, args, ipcLoadReplyStub);
+    if (ipcLoadReplyStub || ipcLoadAudioStub || ipcMuteHandshakeStub)
+        return runIpcLoadStub (argc, args, ipcLoadReplyStub || ipcLoadAudioStub,
+                               ipcLoadAudioStub);
     if (ipcHost) return runIpcHost (argc, args);
 
     std::fprintf (stderr,

--- a/src/engine/ipc/RemotePluginConnection.cpp
+++ b/src/engine/ipc/RemotePluginConnection.cpp
@@ -87,6 +87,18 @@ bool RemotePluginConnection::connect (const std::string& hostExecutablePath,
                                         const std::string& extraArg,
                                         std::string& errorOut)
 {
+    return spawnChild (hostExecutablePath, extraArg, errorOut)
+             && completeConnect (extraArg, errorOut);
+}
+
+// Must run on a thread that outlives the child. The child arms
+// prctl(PR_SET_PDEATHSIG, SIGTERM), and on Linux that signal is delivered when
+// the spawning THREAD exits, not when the process does - so spawning from a
+// short-lived worker kills the child as soon as that worker returns.
+bool RemotePluginConnection::spawnChild (const std::string& hostExecutablePath,
+                                            const std::string& extraArg,
+                                            std::string& errorOut)
+{
     if (child.isAlive())
         return true;
 
@@ -126,7 +138,12 @@ bool RemotePluginConnection::connect (const std::string& hostExecutablePath,
     }
 
     controlChannel = pair.parentEnd;
+    return true;
+}
 
+bool RemotePluginConnection::completeConnect (const std::string& extraArg,
+                                                 std::string& errorOut)
+{
     if (! platform::sendHandle (controlChannel, shm.handle()))
     {
         errorOut = std::string ("sendHandle failed: ") + std::strerror (errno);
@@ -199,6 +216,7 @@ bool RemotePluginConnection::connect (const std::string& hostExecutablePath,
         || extraArg == "--ipc-control-reply-stub"
         || extraArg == "--ipc-park-timeout-stub"
         || extraArg == "--ipc-load-reply-stub"
+        || extraArg == "--ipc-load-audio-stub"
         || extraArg == "--ipc-stub-sudden-death")
         startReaderThread();
 

--- a/src/engine/ipc/RemotePluginConnection.h
+++ b/src/engine/ipc/RemotePluginConnection.h
@@ -56,6 +56,15 @@ public:
                    const std::string& extraArg,
                    std::string& errorOut);
 
+    // connect() split in two so a caller can keep the spawn on a long-lived
+    // thread and move only the waiting off it. spawnChild must run on a thread
+    // that outlives the child (see its definition); completeConnect may run
+    // anywhere. Calling connect() is equivalent to calling both in order.
+    bool spawnChild (const std::string& hostExecutablePath,
+                      const std::string& extraArg,
+                      std::string& errorOut);
+    bool completeConnect (const std::string& extraArg, std::string& errorOut);
+
     // --- Control plane (Phase 2 - message-thread only) -------------------
     // Each of these does a synchronous request/reply over the control
     // socket. Not RT-safe; not callable from the audio thread.

--- a/tests/plugin_slot_lifecycle.cpp
+++ b/tests/plugin_slot_lifecycle.cpp
@@ -177,6 +177,73 @@ TEST_CASE ("PluginSlot completes an out-of-process load off the message thread")
     CHECK (succeeded);
     CHECK (slot.isRemote());
 }
+
+// The same async load, with the device callback already running across it. A
+// child spawned from the load worker dies with that worker, which the startup
+// restore never sees because it spawns from the message thread. Needs the stub
+// that answers block commands as well as control RPCs; the control-only one
+// cannot keep any slot alive under a live callback.
+TEST_CASE ("PluginSlot keeps its sandbox child when the graph is live across the load")
+{
+    using namespace std::chrono_literals;
+
+    juce::ScopedJuceInitialiser_GUI juceInit;
+
+    PluginManager manager;
+    useSandboxStub (manager, "--ipc-load-audio-stub");
+
+    PluginSlot slot;
+    slot.setManager (manager);
+    slot.prepareToPlay (48000.0, 64);
+
+    std::atomic<bool> stopAudio { false };
+    std::atomic<int>  blocksRun { 0 };
+
+    std::thread audioThread ([&]
+    {
+        float left[64] {};
+        float right[64] {};
+        juce::MidiBuffer midi;
+        while (! stopAudio.load (std::memory_order_acquire))
+        {
+            slot.processStereoBlock (left, right, 64, midi);
+            blocksRun.fetch_add (1, std::memory_order_relaxed);
+            std::this_thread::sleep_for (1333us);
+        }
+    });
+
+    while (blocksRun.load (std::memory_order_relaxed) < 8)
+        std::this_thread::yield();
+
+    std::atomic<bool> completed { false };
+    std::atomic<bool> succeeded { false };
+    slot.loadFromDescriptorAsync (sandboxTestDescriptor(),
+                                  [&] (bool ok, juce::String)
+    {
+        succeeded.store (ok, std::memory_order_release);
+        completed.store (true, std::memory_order_release);
+    });
+
+    // Keeps pumping past the completion: the child is lost about 200 ms after a
+    // load that reported success, so stopping at the completion would pass.
+    std::chrono::steady_clock::time_point settleUntil {};
+    pumpUntil ([&]
+    {
+        if (! completed.load (std::memory_order_acquire)) return false;
+        if (settleUntil.time_since_epoch().count() == 0)
+            settleUntil = std::chrono::steady_clock::now() + 1500ms;
+        return std::chrono::steady_clock::now() >= settleUntil;
+    }, std::chrono::seconds (20));
+
+    stopAudio.store (true, std::memory_order_release);
+    audioThread.join();
+
+    REQUIRE (completed.load (std::memory_order_acquire));
+    REQUIRE (succeeded.load (std::memory_order_acquire));
+    CHECK_FALSE (slot.wasCrashed());
+    CHECK_FALSE (slot.wasAutoBypassed());
+    CHECK (slot.isRemote());
+}
 #endif
 
 // Quitting while a child stalls used to cost the destructor the whole handshake


### PR DESCRIPTION
Closes #508.

## Cause

Not the park timeout the issue nominates. The child arms `prctl(PR_SET_PDEATHSIG, SIGTERM)` (`PluginHostMain.cpp:142`). On Linux that signal fires when the **spawning thread** exits, not when the parent process does. `PluginSlot::beginRemoteLoad` spawned the child from its detached load worker, and that worker exits as soon as it has posted the completion, so the kernel SIGTERMed the child roughly 200 ms after a load that had already reported success.

The synchronous restore branch spawns on the message thread, which never exits, which is exactly why that path keeps its child and the runtime enable does not.

Evidence: `waitpid` on the child returned `WIFSIGNALED`, `WTERMSIG` 15. `RemotePluginConnection::disconnect()` was entered only at teardown with `child.isAlive()` already false, and `retireRemoteConnection()` only before the load with a null connection, so no parent path killed it. The child's own clean-exit paths never ran.

## Fix

`connect()` splits into `spawnChild` and `completeConnect`. The spawn stays on the message thread beside the synchronous path; the handshake and `loadPlugin`, which are the parts that can block for seconds, still run on the worker. `connect()` keeps its signature and calls both in order, so the synchronous path is unchanged.

Spawn cost measured on the message thread over three runs: 0.220, 0.236, 0.177 ms. That is fork/exec plus the socketpair and handle passing; no fallback spawner thread is needed.

## Test infrastructure

Neither existing stub can model a working sandboxed plugin, which is why this had no coverage:

- `--ipc-stub` runs the audio loop with no control thread.
- `--ipc-load-reply-stub` runs the control loop with no audio worker, so a live callback times out every block and bypasses the slot whatever the child does.

`--ipc-load-audio-stub` runs both, and is added to the parent's reader-thread list in `RemotePluginConnection.cpp`. The new case drives an async load with the device callback already running and asserts the slot still holds its child 1.5 s later. It fails on `main` (3 assertions) and passes with the fix; verified both directions by reverting only `PluginSlot.cpp`.

## Verification

- `ctest`: 981/981 pass.
- `tools/juce-gate.sh`: pass, 163 files / 8067 uses, no count raised.
- App builds clean at `-j3`, no new warnings.
- `scripts/run-selftest-xvfb.sh`: exit 0, 15/15 checks passed. Never run on the live session.

README's declared test-case count moves 1001 -> 1002 because `release-mechanics-contract` asserts it against the source tree. That is the only reason this PR touches README.

## Platforms

The cause is Linux-only; Windows uses a job object and macOS has no PDEATHSIG. The spawn-site move is a reordering of the same calls with no runtime behaviour change on either, so Windows compile plus ctest from `windows-tests.yml` is the intended check here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when loading sandboxed plugins asynchronously while audio is already running.
  - Prevented valid remote plugin loads from timing out or being incorrectly marked as crashed or bypassed.

- **Documentation**
  - Updated the documented Catch2 test count from 1,001 to 1,002.

- **Tests**
  - Added coverage for remote plugin loading during active audio processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->