### PR TITLE
fix(app): route termination signals through the staged shutdown

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2286,7 +2286,7 @@ The format for each entry:
 
 ### Save changes before quitting?
 
-- **When**: You quit with unsaved changes.
+- **When**: You quit with unsaved changes. Logging out, shutting the machine down, or stopping the app from a terminal counts as quitting: the prompt appears then too, and the session waits on your answer.
 - **Text**: "Your session has unsaved changes since the last manual save. If you don't save, the autosave will still be available the next time you open this session."
 - **Buttons**: **Save** / **Don't Save** / **Cancel**.
 - **Action**: Save unless you specifically want to discard. The autosave file remains as a safety net regardless.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ GPL source on this repo, so building it yourself costs you nothing but compile t
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 1001 Catch2 test cases across 188 test source files. Linux
+The C++ suite declares 1002 Catch2 test cases across 188 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -123,7 +123,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # Native log storage + CrashHandler signal reports
-tests/         # 1001 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 1002 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -2606,6 +2606,13 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
 
     mainWindow = std::make_unique<MainWindow> (getApplicationName());
 
+    // A desktop logout, a `systemctl --user stop`, or any supervisor asks for
+    // an exit with SIGTERM. Without a handler the process dies where it stands:
+    // no unsaved-changes prompt, plugin editors torn down after the instances
+    // they belong to, sandbox children left to the reaper.
+    quitSignalHandler = std::make_unique<dusk::QuitSignalHandler> (
+        [this] { systemRequestedQuit(); });
+
     // Open a session passed on the command line (file-manager "open with",
     // `DuskStudio path/to/session.json`, or a session directory). Deferred so
     // it runs after MainComponent's own startup (recovery prompt / scan) has
@@ -2640,6 +2647,8 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
 
 void DuskStudioApp::shutdown()
 {
+    quitSignalHandler.reset();
+
     // Stop the single-instance listener first: a handoff arriving mid-teardown
     // would target a window that is about to go away.
     single_instance::release();
@@ -2698,6 +2707,18 @@ void DuskStudioApp::shutdown()
 
 void DuskStudioApp::systemRequestedQuit()
 {
+    // Three callers: the desktop session's logout, a termination signal, and
+    // phase 7 of the staged shutdown itself. The first two have to run the
+    // same sequence the titlebar X does, unsaved-changes prompt included. The
+    // third is that sequence asking to finish, so it must not re-enter it.
+    if (mainWindow != nullptr)
+        if (auto* main = dynamic_cast<MainComponent*> (mainWindow->getContentComponent()))
+            if (! main->isShuttingDown())
+            {
+                main->requestQuit();
+                return;
+            }
+
     quit();
 }
 

--- a/src/DuskStudioApp.h
+++ b/src/DuskStudioApp.h
@@ -2,6 +2,8 @@
 
 #include <juce_gui_basics/juce_gui_basics.h>
 
+#include "foundation/MessageThread.h"
+
 namespace duskstudio
 {
 class DuskStudioApp final : public juce::JUCEApplication
@@ -30,6 +32,7 @@ public:
 private:
     class MainWindow;
     std::unique_ptr<MainWindow> mainWindow;
+    std::unique_ptr<dusk::QuitSignalHandler> quitSignalHandler;
     // DUSKSTUDIO_CLAP_EDITOR_TEST standalone window (native CLAP editor embed).
     std::unique_ptr<juce::DocumentWindow> clapEditorTestWindow;
 #if DUSKSTUDIO_HAS_NATIVE_LV2

--- a/src/foundation/MessageThread.cpp
+++ b/src/foundation/MessageThread.cpp
@@ -2,6 +2,9 @@
 
 #include <juce_events/juce_events.h>
 
+#include <csignal>
+#include <utility>
+
 namespace dusk
 {
 // The backend timer. Nested so it can reach Timer's protected timerCallback()
@@ -37,4 +40,78 @@ bool callAsync (std::function<void()> fn)
 {
     return juce::MessageManager::callAsync (std::move (fn));
 }
+
+namespace
+{
+volatile std::sig_atomic_t quitRequestPending = 0;
+
+extern "C" {
+static void latchQuitRequest (int) { quitRequestPending = 1; }
+}
+
+constexpr int quitSignals[] =
+{
+    SIGINT,
+    SIGTERM,
+   #if defined (SIGHUP)
+    SIGHUP,
+   #endif
+};
+
+bool setQuitDisposition (void (*handler) (int)) noexcept
+{
+    bool ok = true;
+
+   #if defined (_WIN32)
+    for (const int sig : quitSignals)
+        ok = (std::signal (sig, handler) != SIG_ERR) && ok;
+   #else
+    // SA_RESTART so a trapped signal does not turn every blocking read in the
+    // process into a spurious EINTR; the handler does no work of its own.
+    struct sigaction action {};
+    action.sa_handler = handler;
+    sigemptyset (&action.sa_mask);
+    action.sa_flags = SA_RESTART;
+
+    for (const int sig : quitSignals)
+        ok = (::sigaction (sig, &action, nullptr) == 0) && ok;
+   #endif
+
+    return ok;
+}
+} // namespace
+
+struct QuitSignalHandler::Impl final : private Timer
+{
+    explicit Impl (std::function<void()> fn) : onQuitRequested (std::move (fn))
+    {
+        quitRequestPending = 0;
+        installed = setQuitDisposition (latchQuitRequest);
+        if (installed)
+            startTimer (50);
+    }
+
+    ~Impl() override
+    {
+        if (installed)
+            setQuitDisposition (SIG_DFL);
+        quitRequestPending = 0;
+    }
+
+    void timerCallback() override
+    {
+        if (quitRequestPending == 0) return;
+        quitRequestPending = 0;
+        if (onQuitRequested) onQuitRequested();
+    }
+
+    std::function<void()> onQuitRequested;
+    bool installed = false;
+};
+
+QuitSignalHandler::QuitSignalHandler (std::function<void()> onQuitRequested)
+    : impl (std::make_unique<Impl> (std::move (onQuitRequested))) {}
+QuitSignalHandler::~QuitSignalHandler() = default;
+
+bool QuitSignalHandler::isInstalled() const noexcept { return impl->installed; }
 } // namespace dusk

--- a/src/foundation/MessageThread.h
+++ b/src/foundation/MessageThread.h
@@ -43,4 +43,30 @@ private:
 // Post fn to run once on the message thread. Returns false if the message loop
 // is gone (shutdown) and the call could not be queued.
 bool callAsync (std::function<void()> fn);
+
+// Traps the signals a desktop session or a supervisor uses to ask a process to
+// exit (SIGTERM, plus SIGINT and SIGHUP where the platform defines them) and
+// runs onQuitRequested on the message thread. The signal handler itself only
+// latches a flag: callAsync allocates and takes the message-manager lock, and
+// neither is safe from a signal handler, so a message-thread watcher polls the
+// latch instead. Construct and destroy on the message thread. The dispositions
+// are process-wide, so only one of these may exist at a time; the destructor
+// restores the defaults. isInstalled() is false when the platform refused the
+// handlers, in which case the default disposition stands and the callback
+// never runs.
+class QuitSignalHandler
+{
+public:
+    explicit QuitSignalHandler (std::function<void()> onQuitRequested);
+    ~QuitSignalHandler();
+
+    bool isInstalled() const noexcept;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl;
+
+    QuitSignalHandler (const QuitSignalHandler&) = delete;
+    QuitSignalHandler& operator= (const QuitSignalHandler&) = delete;
+};
 } // namespace dusk

--- a/src/ui/MainComponent.h
+++ b/src/ui/MainComponent.h
@@ -71,6 +71,10 @@ public:
     // windowing -> hide main window -> sync again -> post quit.
     void beginSafeShutdown();
 
+    // True once beginSafeShutdown has been entered. The sequence posts a quit
+    // of its own at the end, and that must not be mistaken for a new request.
+    bool isShuttingDown() const noexcept { return shutdownInProgress; }
+
     // Process-shutdown only. Drops plugin instance ownership without
     // destructing. See AudioEngine::leakAllPluginInstancesForShutdown.
     void leakAllPluginInstancesForShutdown();

--- a/tests/foundation_message_thread.cpp
+++ b/tests/foundation_message_thread.cpp
@@ -6,6 +6,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <csignal>
 #include <functional>
 
 // The event seam is a thin wrapper over the platform message loop.
@@ -100,5 +101,22 @@ TEST_CASE ("dusk::callAsync defers and dispatches on the message thread", "[foun
 #if ! defined (__APPLE__)
     pumpUntil ([&ran] { return ran.load(); }, std::chrono::seconds (5));
     REQUIRE (ran.load());
+#endif
+}
+
+TEST_CASE ("a termination signal routes a quit request to the message thread", "[foundation][events]")
+{
+    juce::ScopedJuceInitialiser_GUI juceInit;
+
+    std::atomic<bool> asked { false };
+    dusk::QuitSignalHandler handler ([&asked] { asked.store (true, std::memory_order_relaxed); });
+    REQUIRE (handler.isInstalled());
+
+    REQUIRE (std::raise (SIGTERM) == 0);
+    REQUIRE_FALSE (asked.load());   // latched in the handler, not called back from signal context
+
+#if ! defined (__APPLE__)
+    pumpUntil ([&asked] { return asked.load(); }, std::chrono::seconds (5));
+    REQUIRE (asked.load());
 #endif
 }


### PR DESCRIPTION
Closes #507

## The bug

Nothing in `src/` set a disposition for SIGTERM, and JUCE's Linux loop installs a handler for SIGINT only (`juce_Messaging_linux.cpp:304`). `DuskStudioApp::systemRequestedQuit()` was a bare `quit()` that never reached `MainComponent::requestQuit`.

Reproduced against `origin/main` under a private Xvfb display: SIGTERM to the GUI process exits **143 with zero `[Dusk Studio/shutdown]` markers**. No unsaved-changes prompt, plugin editors dropped after the instances they belong to, sandbox children left to the reaper.

## The fix

`dusk::QuitSignalHandler` in the message-thread seam (`src/foundation/MessageThread.h/.cpp`):

- Traps SIGTERM, SIGINT and SIGHUP. The handler is async-signal-safe: it writes a `volatile sig_atomic_t` and nothing else. `dusk::callAsync` allocates and takes the message-manager lock, so it cannot be called from signal context.
- A 50 ms message-thread watcher consumes the latch and runs the callback.
- RAII. The destructor restores the default dispositions. `DuskStudioApp` owns one for the window's lifetime and resets it first thing in `shutdown()`.

`systemRequestedQuit()` now routes into `MainComponent::requestQuit` unless the staged shutdown is already running. That guard matters: `beginSafeShutdown` phase 7 posts a `systemRequestedQuit` of its own, and without the check the app would re-enter `requestQuit`, hit the `shutdownInProgress` latch, and never quit. `MainComponent::isShuttingDown()` exposes the latch for it.

Same phase sequence as the titlebar X, unsaved-changes prompt included.

## Verification

Linux (this box):

- SIGTERM under Xvfb before: `EXIT=143`, 0 shutdown markers. After: `EXIT=0`, all 8 phases printed.
- `cmake --build build -j3` clean, zero new warnings.
- `ctest --test-dir build-tests` 981/981 pass.
- `tools/juce-gate.sh` unchanged at 163 files / 8067 uses. The new code adds no JUCE.

macOS (M3 Air, arm64, clang):

- `cmake --build build -j5` succeeds, zero warnings from the touched files. The first Mac run surfaced two clang-only warnings in the new code (`-Wmissing-prototypes` on the signal handler, `-Winconsistent-missing-destructor-override`); both are fixed in this branch.
- `ctest --test-dir build-tests` 956/956 pass, new case included.
- No end-to-end SIGTERM run on the Mac: GUI launches from ssh abort in MainWindow on that box, and the handler is only installed on the GUI path, so the headless self-test would not exercise it. The unit test covers install plus latch there; the dispatch half runs on Linux and Windows.

## Test

`tests/foundation_message_thread.cpp` gains a case that installs the handler, raises a real SIGTERM, asserts the callback did **not** run from signal context, then pumps the loop and asserts it did. README's test-case count contract is bumped 1001 to 1002 to match.

## Manual

`MANUAL.md` "Save changes before quitting?" now says a logout, a machine shutdown, or stopping the app from a terminal counts as quitting and raises the same prompt.
