### PR TITLE
fix(oop): refuse PrepareToPlay with no plug-in and acknowledge the POSIX handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ GPL source on this repo, so building it yourself costs you nothing but compile t
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 1002 Catch2 test cases across 188 test source files. Linux
+The C++ suite declares 1004 Catch2 test cases across 189 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -123,7 +123,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # Native log storage + CrashHandler signal reports
-tests/         # 1002 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 1004 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/ipc/PluginHostMain.cpp
+++ b/src/engine/ipc/PluginHostMain.cpp
@@ -1231,7 +1231,7 @@ std::uint32_t handlePrepareToPlay (HostState& host,
     if (payload.size() < sizeof (PrepareToPlayPayload)) return 1;
     PrepareToPlayPayload p {};
     std::memcpy (&p, payload.data(), sizeof (p));
-    if (host.ownedInstance == nullptr) return 0;
+    if (host.ownedInstance == nullptr) return kControlStatusNoPluginLoaded;
     return withParkedHostWorker (host, [&]
     {
         host.ownedInstance->prepareToPlay (p.sampleRate, p.blockSize);

--- a/src/engine/ipc/PluginIpc.h
+++ b/src/engine/ipc/PluginIpc.h
@@ -47,6 +47,12 @@ constexpr std::uint32_t kControlStatusWorkerParkTimeout = 100;
 // inside its own RPC deadline instead of burning it.
 constexpr std::uint32_t kControlStatusMessageThreadTimeout = 101;
 
+// Non-terminal control-RPC status: PrepareToPlay arrived with no plug-in
+// loaded. Answering 0 would let the parent republish the connection and route
+// audio to a child that has nothing to process, which is silence the parent
+// cannot tell from a working slot.
+constexpr std::uint32_t kControlStatusNoPluginLoaded = 102;
+
 // State values for `BlockHeader::state`.
 constexpr std::uint32_t kStateReady    = 0;
 constexpr std::uint32_t kStateCrashed  = 1;

--- a/src/util/SingleInstance.cpp
+++ b/src/util/SingleInstance.cpp
@@ -264,6 +264,12 @@ public:
         fd = -1;
     }
 
+    // The lock file is deliberately never unlinked. Removing it while another
+    // launch holds it open would leave that launch holding flock on an
+    // unlinked inode while a third creates and locks a fresh one at the same
+    // name, so both would believe they own the slot - the double-primary the
+    // lock exists to prevent. It costs one empty file per runtime directory,
+    // which the session clears on logout.
     ~SlotLock()
     {
         if (fd < 0) return;
@@ -463,13 +469,19 @@ void listenLoop (Listener* l)
         {
             std::string payload;
             const Receive outcome = readPayload (peer, l->wakeFds[0], payload);
-            ::close (peer);
-            if (outcome == Receive::Stopping) return;
             if (outcome == Receive::Complete)
             {
                 auto fn = l->onCommandLine;
                 dispatch ([fn, payload] { fn (payload); });
+                // Only once the payload is queued on the message thread: the
+                // sender quits on this byte, so it has to mean the path is
+                // this process's responsibility now.
+                const auto ackDeadline = std::chrono::steady_clock::now()
+                                       + std::chrono::milliseconds (kDeliveryBudgetMs);
+                (void) writeAll (peer, std::string (1, '\1'), ackDeadline);
             }
+            ::close (peer);
+            if (outcome == Receive::Stopping) return;
         }
         else
         {
@@ -557,7 +569,11 @@ void reportUnattached (const char* what, int failure)
 // that made it. Failed covers a peer we could not reach for any other reason -
 // no permission, a wedged primary, a backlog with no room - all of which leave
 // a socket whose owner may still be running.
-enum class Handoff { Delivered, Refused, Failed };
+// Submitted mirrors the Windows shape: the payload reached the socket but the
+// primary never acknowledged taking it. A launch racing a kill -9 gets its
+// connect accepted into the dying backlog and its write completed, so a
+// completed write alone is not proof anyone will act on the path.
+enum class Handoff { Delivered, Submitted, Refused, Failed };
 
 // A fresh socket per attempt: a connect that failed leaves the fd unusable for
 // a second try. failureErrno carries what went wrong on Failed, for the log
@@ -615,10 +631,31 @@ Handoff handOver (const sockaddr_un& addr, socklen_t len, const std::string& pay
         if (connected)
         {
             const bool sent = writeAll (fd, framed, deadline);
-            if (sent) ::shutdown (fd, SHUT_WR);
-            else      failureErrno = errno;   // before close(), which clobbers it
+            if (! sent)
+            {
+                failureErrno = errno;   // before close(), which clobbers it
+                ::close (fd);
+                return Handoff::Failed;
+            }
+            ::shutdown (fd, SHUT_WR);
+
+            unsigned char accepted = 0;
+            const int revents = pollUntil (fd, POLLIN, deadline);
+            bool acked = false;
+            if ((revents & POLLIN) == 0)
+            {
+                failureErrno = ETIMEDOUT;   // no reader answered; errno is stale
+            }
+            else
+            {
+                errno = 0;
+                acked = ::read (fd, &accepted, sizeof accepted)
+                          == (ssize_t) sizeof accepted;
+                if (! acked) failureErrno = errno;
+            }
             ::close (fd);
-            return sent ? Handoff::Delivered : Handoff::Failed;
+            return acked && accepted == 1 ? Handoff::Delivered
+                                          : Handoff::Submitted;
         }
         ::close (fd);
         if (connectErr != ECONNREFUSED)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -571,6 +571,7 @@ endif()
 if (_duskstudio_ipc_test_enabled)
     target_sources(dusk-studio-tests PRIVATE
         ipc_stub_round_trip.cpp
+        ipc_prepare_without_plugin.cpp
         ${CMAKE_SOURCE_DIR}/src/engine/ipc/RemotePluginConnection.cpp
         ${_duskstudio_ipc_test_sources})
     # The parent pipe endpoint uses overlapped I/O on Windows, so the reader's

--- a/tests/ipc_prepare_without_plugin.cpp
+++ b/tests/ipc_prepare_without_plugin.cpp
@@ -1,0 +1,21 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/ipc/PluginIpc.h"
+#include "engine/ipc/RemotePluginConnection.h"
+
+#include <string>
+
+// A Release leaves the child alive with no instance. Answering the next
+// PrepareToPlay with success let the parent republish the connection and route
+// audio into a child with nothing to process, which reads as a working slot
+// that is simply silent.
+TEST_CASE ("PrepareToPlay is refused when the child holds no plug-in")
+{
+    duskstudio::ipc::RemotePluginConnection connection;
+
+    std::string error;
+    REQUIRE (connection.connect (DUSKSTUDIO_PLUGIN_HOST_PATH, "--ipc-host", error));
+
+    CHECK_FALSE (connection.prepareToPlay (48000.0, 64, error));
+    CHECK_FALSE (error.empty());
+}

--- a/tests/single_instance_socket_lifecycle.cpp
+++ b/tests/single_instance_socket_lifecycle.cpp
@@ -382,6 +382,33 @@ TEST_CASE ("a refused handoff reclaims a dead primary socket",
     REQUIRE (reclaimedInode != staleInode);
 }
 
+// A primary killed between accept and read leaves a listening socket whose
+// backlog still completes the connect and swallows the write. Treating a
+// completed write as delivery made the second launch quit and take the session
+// path with it, so the path has to be acknowledged, not just written.
+TEST_CASE ("a handoff nobody acknowledges leaves the launch unattached",
+           "[single-instance][socket][issue-503]")
+{
+    ScopedSlot slot;
+    REQUIRE (duskstudio::single_instance::acquire ("", noPayload));
+    const auto sock = soleSocketIn (slot.path());
+    REQUIRE_FALSE (sock.empty());
+
+    duskstudio::single_instance::release();
+    REQUIRE (inodeOf (sock) == 0);
+
+    // Listening but never accepting: the kernel completes the connect from the
+    // backlog and buffers the payload, and no reader ever answers.
+    const int deafFd = bindSocketAt (sock);
+    REQUIRE (::listen (deafFd, 8) == 0);
+
+    const bool runsUnattached =
+        duskstudio::single_instance::acquire ("/tmp/handoff/session.json", noPayload);
+    ::close (deafFd);
+
+    REQUIRE (runsUnattached);
+}
+
 TEST_CASE ("release leaves a newer primary socket at the same path",
            "[single-instance][socket][issue-368]")
 {


### PR DESCRIPTION
Closes #503. Covers residues 1, 2 and 3 of the four; residue 4 needs no change (verdict and reasoning on the issue: a failed hide means the child is wedged, crashed or gone, bailing never removes the stuck window and only withholds the working shell editor).

## Residue 3 - PrepareToPlay succeeded with no plug-in

`handlePrepareToPlay` returned status 0 when `host.ownedInstance` was null, so after a Release the parent's success path republished `currentRemote` and routed audio into a child with nothing to process. The slot reads as live and is silent, with no error anywhere.

Latent today because only shutdown calls `releaseResources`, exactly as the issue says; wiring release into a device change would surface it. PrepareToPlay with no instance now returns `kControlStatusNoPluginLoaded`, so the parent's existing failure path nulls `currentRemote` and leaves the slot bypassed.

Test connects to a real `--ipc-host` child and calls `prepareToPlay` without loading anything. No plug-in fixture needed, since the defect is precisely the empty-child case. Fails on main, passes here.

## Residue 2 - POSIX handoff had no acknowledgement

`handOver` treated a completed `writeAll` as delivery. A launch racing a `kill -9` on the primary gets its connect accepted out of the dying process's backlog and its write buffered, reports Delivered, and quits, taking the session path with it.

The listener now writes a one-byte acknowledgement after the payload is queued on its message thread, and the sender waits for it. An unacknowledged handoff returns the new `Handoff::Submitted`, which the existing caller already treats as "run unattached" rather than quitting. This is the shape Windows already had, including the `Submitted` state.

Test binds a listening socket that never accepts, so the kernel completes the connect and buffers the payload with no reader. Before: the launch quits. After: it runs unattached. Fails on main, passes here.

## Residue 1 - slot lock file - wontfix

The `<slot>.lock` companion is deliberately never unlinked, and this PR records why at the destructor rather than changing behaviour. Unlinking it while another launch holds it open leaves that launch holding `flock` on an unlinked inode while a third creates and locks a fresh inode at the same name, so both believe they own the slot. That is the double-primary the lock exists to prevent, and it is the same class of bug as residue 2. The cost of leaving it is one empty file per runtime directory, in `/run/user/<uid>`, which the session clears at logout.

## Residue 4 - no change needed

`ChannelStripComponent.cpp:2661` and `:2725` (the issue's `:2748`/`:2809` have drifted). The audit finding does not hold up. `hideRemoteEditor` returns false for four different reasons, only one of which is "a child window may still be up", and the child answers HideEditor successfully when it has no editor window (`destroyEditorOnMessageThread` no-ops on a null `editorWindow`). So a failure means the child is wedged, crashed or gone. A crashed child's window died with it; a wedged child's window stays up whether or not we present the shell. Bailing never removes the stuck window, it only withholds the working editor, so the existing comment is right on the merits. Full reasoning on the issue.

## Verification

- `ctest`: 982/982 pass. Both new tests verified failing on main and passing here.
- `tools/juce-gate.sh`: pass, 163 files / 8067 uses, unchanged.
- App builds clean at `-j3`, no new warnings.
- `scripts/run-selftest-xvfb.sh`: exit 0, 15/15. Never run on the live session.

README's declared test count moves to 1003 across 189 files because `release-mechanics-contract` asserts it. **This collides with PR #538, which moves it to 1002 across 188.** Whichever merges second needs a rebase and a recount; after #538 this becomes 1004 across 189.

No overlap with #538 otherwise: residue 3's fix is entirely child-side, so `PluginSlot.cpp` is untouched here.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin preparation now reports an error when no plug-in is loaded, instead of indicating success.
  * Single-instance command handoffs now confirm delivery; launches proceed independently when confirmation is unavailable.

* **Tests**
  * Added coverage for preparing without a loaded plug-in and unacknowledged single-instance handoffs.

* **Documentation**
  * Updated README test suite statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->