### PR TITLE
test(session): cover native-insert clone and undo in the self-test

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -186,6 +186,23 @@ jobs:
                 DUSKSTUDIO_CLAP_STATE_FIXTURE="$PWD/build-tests/dusk-studio-multi-bus-clap-fixture.clap" \
             build-linux/DuskStudio_artefacts/Release/DuskStudio
 
+      - name: Self-test with the CLAP fixture (xvfb)
+        # The full self-test again, this time with the fixture the previous
+        # step builds, so the clone/undo leg runs instead of skipping. It has
+        # to come after the test build: the fixture does not exist earlier in
+        # the job, which is why the first self-test step cannot cover it.
+        # 90 s for the same reason the plain run gets 60: no audio device, so
+        # the device-readiness wait burns its budget before the synthetic
+        # tests start.
+        run: |
+          timeout 90 xvfb-run --auto-servernum \
+            env DUSKSTUDIO_RUN_SELFTEST=1 \
+                DUSKSTUDIO_CLAP_STATE_FIXTURE="$PWD/build-tests/dusk-studio-multi-bus-clap-fixture.clap" \
+            build-linux/DuskStudio_artefacts/Release/DuskStudio \
+            | tee self-test-clap-fixture.log
+          grep -q '^\[OK\] Clone track native insert' self-test-clap-fixture.log \
+            || { echo "::error::clone/undo leg did not run with the fixture set" >&2; exit 1; }
+
       - name: ccache stats
         if: always()
         run: ccache -s

--- a/src/engine/AudioPipelineSelfTest.cpp
+++ b/src/engine/AudioPipelineSelfTest.cpp
@@ -2,6 +2,7 @@
 #include "../foundation/Fs.h"
 #include "../foundation/Text.h"
 #include "audiofile/FileReader.h"
+#include "../session/RegionEditActions.h"
 #if defined(__linux__)
  #include "alsa/AlsaAudioIODevice.h"
 #endif
@@ -960,6 +961,122 @@ std::string AudioPipelineSelfTest::probeUMC1820AlsaFormat()
     return out;
 }
 
+std::string AudioPipelineSelfTest::testCloneTrackNativeInsert()
+{
+#if ! DUSKSTUDIO_HAS_NATIVE_CLAP
+    return "[SKIP] Clone track native insert: no native CLAP support in this build";
+#else
+    const char* fixturePath = std::getenv ("DUSKSTUDIO_CLAP_STATE_FIXTURE");
+    if (fixturePath == nullptr || *fixturePath == '\0')
+        return "[SKIP] Clone track native insert: DUSKSTUDIO_CLAP_STATE_FIXTURE unset";
+
+    constexpr double sr = 48000.0;
+    constexpr int blockSize = 64;
+    constexpr int srcIdx = 6;
+    constexpr int dstIdx = 7;
+    constexpr const char* fixtureId = "studio.dusk.test.multi-bus";
+
+    prepareCleanState();
+    engine.prepareForSelfTest (sr, blockSize);
+
+    auto& srcTrack = session.track (srcIdx);
+    auto& dstTrack = session.track (dstIdx);
+    auto& srcStrip = engine.getChannelStrip (srcIdx);
+    auto& dstStrip = engine.getChannelStrip (dstIdx);
+
+    const auto savedSrcName = srcTrack.name;
+    const auto savedDstName = dstTrack.name;
+    const auto savedSrcPath = srcTrack.nativeClapPath;
+    const auto savedDstPath = dstTrack.nativeClapPath;
+    const auto savedSrcId = srcTrack.nativeClapPluginId;
+    const auto savedDstId = dstTrack.nativeClapPluginId;
+    const auto savedSrcState = srcTrack.nativeClapStateBase64;
+    const auto savedDstState = dstTrack.nativeClapStateBase64;
+
+    auto restore = [&]
+    {
+        srcStrip.unloadNativeClap();
+        dstStrip.unloadNativeClap();
+        srcTrack.name = savedSrcName;
+        dstTrack.name = savedDstName;
+        srcTrack.nativeClapPath = savedSrcPath;
+        dstTrack.nativeClapPath = savedDstPath;
+        srcTrack.nativeClapPluginId = savedSrcId;
+        dstTrack.nativeClapPluginId = savedDstId;
+        srcTrack.nativeClapStateBase64 = savedSrcState;
+        dstTrack.nativeClapStateBase64 = savedDstState;
+    };
+
+    std::vector<std::string> failures;
+    auto expect = [&failures] (bool condition, const char* message)
+    {
+        if (! condition) failures.emplace_back (message);
+        return condition;
+    };
+
+    const auto fixture = std::filesystem::u8path (fixturePath);
+    std::string error;
+    if (! srcStrip.getNativeClapSlot().load (fixture, sr, blockSize, error, fixtureId))
+    {
+        restore();
+        return "[FAIL] Clone track native insert: could not load the fixture (" + error + ")";
+    }
+
+    // Drive the plug-in so its state diverges from the one it loads with,
+    // otherwise a clone that dropped the blob entirely would still compare
+    // equal to a freshly constructed destination.
+    std::array<float, blockSize> left {};
+    std::array<float, blockSize> right {};
+    for (int i = 0; i < 4; ++i)
+        srcStrip.getNativeClapSlot().processStereo (
+            left.data(), right.data(), left.data(), right.data(), blockSize);
+
+    engine.publishPluginStateForSave (true);
+    const auto sourceState = srcTrack.nativeClapStateBase64;
+    expect (srcTrack.nativeClapPath.toStdString() == fixture.u8string(),
+            "source path was not published");
+    expect (sourceState.isNotEmpty(), "source state was empty before the clone");
+
+    CloneTrackAction clone (session, engine, srcIdx, dstIdx);
+    if (! expect (clone.perform(), "perform() refused the clone"))
+    {
+        restore();
+        return "[FAIL] Clone track native insert: " + failures.front();
+    }
+
+    expect (dstTrack.nativeClapPath.toStdString() == fixture.u8string(),
+            "clone did not carry the plug-in path");
+    expect (dstTrack.nativeClapPluginId == fixtureId,
+            "clone did not carry the plug-in ID");
+    expect (dstTrack.nativeClapStateBase64 == sourceState,
+            "clone did not carry the plug-in state");
+    expect (dstStrip.isNativeClapLoaded(), "clone left the destination slot offline");
+    expect (dstTrack.name == savedSrcName + " (copy)", "clone did not tag the name");
+    expect (srcTrack.nativeClapStateBase64 == sourceState,
+            "clone disturbed the source state");
+
+    expect (clone.undo(), "undo() refused");
+    expect (dstTrack.nativeClapPath == savedDstPath,
+            "undo did not restore the destination path");
+    expect (dstTrack.nativeClapPluginId == savedDstId,
+            "undo did not restore the destination plug-in ID");
+    expect (dstTrack.nativeClapStateBase64 == savedDstState,
+            "undo did not restore the destination state");
+    expect (! dstStrip.isNativeClapLoaded(),
+            "undo left a plug-in on the destination slot");
+    expect (dstTrack.name == savedDstName, "undo did not restore the destination name");
+    expect (srcTrack.nativeClapStateBase64 == sourceState,
+            "undo disturbed the source state");
+
+    restore();
+
+    if (failures.empty())
+        return "[OK] Clone track native insert: CLAP identity and state clone and undo";
+    return "[FAIL] Clone track native insert: "
+             + dusk::text::joinIntoString (failures, "; ");
+#endif
+}
+
 std::string AudioPipelineSelfTest::testBackendsOpenCleanly()
 {
     std::string out;
@@ -1717,6 +1834,7 @@ std::string AudioPipelineSelfTest::runAll()
     report.push_back (testMidiPlayAlongMonitor());
     report.push_back (testAudioPlayAlongSends());
     report.push_back (testLoopRecordTakeStacking());
+    report.push_back (testCloneTrackNativeInsert());
     report.push_back ("");
 
    #if defined(__linux__)

--- a/src/engine/AudioPipelineSelfTest.h
+++ b/src/engine/AudioPipelineSelfTest.h
@@ -124,6 +124,7 @@ private:
     std::string testMidiPlayAlongMonitor();   // armed+IN MIDI track sounds live notes in Stopped AND Playing
     std::string testAudioPlayAlongSends();    // IN audio track feeds its aux send in Stopped AND Playing
     std::string testLoopRecordTakeStacking(); // one callback crosses loop seam into a second audio+MIDI take
+    std::string testCloneTrackNativeInsert(); // clone + undo carry a native CLAP insert's identity and state
     std::string testBackendsOpenCleanly();
     std::string probeUMC1820AlsaFormat();   // explicitly open UMC1820 ALSA & report format
 


### PR DESCRIPTION
Closes #500.

## Why a self-test leg and not a Catch2 case

`CloneTrackAction` takes `Session&` and `AudioEngine&`, and `captureTrack` reaches through `engine.getStrip(idx).getPluginSlot()`, `.getNativeMultisampleSlot()` and `engine.getSession()`. Neither `AudioEngine.cpp` nor `RegionEditActions.cpp` is in the test target, and adding them would pull the whole DSP chain plus donor sources into the narrow-link test binary, which is exactly what the testing section of CLAUDE.md rules out. The issue asks for a self-test leg for this reason and it is the right call.

## The leg

`AudioPipelineSelfTest::testCloneTrackNativeInsert()`, called from `runAll()` beside the other synthetic legs. It loads the in-repo multi-bus CLAP fixture onto track 6, drives four blocks through it so its state diverges from the blob it loads with, publishes, then clones to track 7 and asserts:

- path, plug-in ID and state blob all carried to the destination
- the destination slot is actually live, not just described in the session
- the name is tagged `(copy)`
- the source state is undisturbed

Then `undo()` and asserts the destination's path, ID, state, name and slot liveness are all back as they were, and the source is still untouched.

Save/restore discipline matches `testLoopRecordTakeStacking`: every field it touches is snapshotted up front and restored on every exit path, including the early return when the fixture fails to load.

It skips with `[SKIP] Clone track native insert: DUSKSTUDIO_CLAP_STATE_FIXTURE unset` when the fixture is not supplied, so local runs and the two existing CI self-test steps stay green and unchanged.

**Verified non-vacuous.** Replacing the state copy in `applyTrack` with an empty string turns the leg red with "clone did not carry the plug-in state", then green again when restored. A test that cannot fail is not coverage.

## The CI step

Neither existing step could ever run this leg: the plain self-test at `linux-build.yml:148` runs before the fixture exists, and the CLAP round-trip step sets `DUSKSTUDIO_CLAP_STATE_TEST_ONLY=1`, which skips `runAll()` entirely. Both are left exactly as they are.

The new step runs after the test build with the fixture set, and greps its own output for the leg's pass line, failing the job if the leg is missing or skipped. That keeps the coverage from quietly reverting to a skip if the fixture path or the env gate ever moves.

Timeout is 90 s. The full run takes about 6 s locally; the margin follows the same reasoning the existing 60 s carries, namely that a runner with no audio device burns the device-readiness wait before the synthetic tests start.

## Verification

- Self-test with the fixture: exit 0, `[OK] Clone track native insert`.
- Self-test without the fixture: exit 0, explicit SKIP line.
- Negative check as described above.
- `tools/juce-gate.sh`: pass, 163 files / 8067 uses, unchanged. The leg adds no framework tokens.
- App builds clean at `-j3`, no new warnings.

No README test-count change: this is a self-test leg, not a Catch2 case, so it does not collide with #538 or #541 on that line.
