### PR TITLE
feat(sfz): scan local directories for soundfonts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -690,6 +690,7 @@ target_sources(DuskStudio PRIVATE
     src/engine/PluginDescriptor.cpp
     src/engine/PluginManager.cpp
     src/engine/PluginSlot.cpp
+    src/engine/sfz/SfzLibrary.cpp
     src/engine/RecordManager.cpp
     src/dsp/AuxLaneStrip.cpp
     src/dsp/BusStrip.cpp

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ GPL source on this repo, so building it yourself costs you nothing but compile t
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 1001 Catch2 test cases across 188 test source files. Linux
+The C++ suite declares 1012 Catch2 test cases across 189 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -123,7 +123,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # Native log storage + CrashHandler signal reports
-tests/         # 1001 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 1012 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/sfz/SfzLibrary.cpp
+++ b/src/engine/sfz/SfzLibrary.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdlib>
 #include <set>
 #include <system_error>
 

--- a/src/engine/sfz/SfzLibrary.cpp
+++ b/src/engine/sfz/SfzLibrary.cpp
@@ -1,0 +1,206 @@
+#include "SfzLibrary.h"
+
+#include "../../foundation/Fs.h"
+
+#include <algorithm>
+#include <cctype>
+#include <set>
+#include <system_error>
+
+namespace duskstudio::sfz
+{
+namespace
+{
+namespace stdfs = std::filesystem;
+
+bool cancelled (const std::atomic<bool>* cancel) noexcept
+{
+    return cancel != nullptr && cancel->load (std::memory_order_relaxed);
+}
+
+std::string toLower (std::string_view text)
+{
+    std::string out (text);
+    std::transform (out.begin(), out.end(), out.begin(),
+                    [] (unsigned char c) { return (char) std::tolower (c); });
+    return out;
+}
+
+bool classify (const stdfs::path& file, LibraryFormat& formatOut)
+{
+    if (dusk::fs::hasExtension (file, ".sfz")) { formatOut = LibraryFormat::Sfz; return true; }
+    if (dusk::fs::hasExtension (file, ".sf2")) { formatOut = LibraryFormat::Sf2; return true; }
+    return false;
+}
+
+// Identity for the visited set. A symlinked pack directory that points back up
+// its own tree is a loop the depth cap alone would still walk to the bottom of,
+// once per branch, so identity is what actually stops it.
+std::string canonicalKey (const stdfs::path& dir)
+{
+    std::error_code ec;
+    const auto canonical = stdfs::canonical (dir, ec);
+    return ec ? dir.u8string() : canonical.u8string();
+}
+
+void scanOneRoot (const stdfs::path& root,
+                  const std::atomic<bool>* cancel,
+                  std::set<std::string>& visited,
+                  ScanResult& result)
+{
+    std::error_code ec;
+    if (! stdfs::exists (root, ec) || ec)
+    {
+        result.problems.push_back ({ root, "not found" });
+        return;
+    }
+    if (! stdfs::is_directory (root, ec) || ec)
+    {
+        result.problems.push_back ({ root, "not a directory" });
+        return;
+    }
+
+    struct Pending { stdfs::path dir; int depth; };
+    std::vector<Pending> queue { { root, 0 } };
+    bool reportedUnreadable = false;
+
+    while (! queue.empty())
+    {
+        if (cancelled (cancel)) return;
+
+        const auto pending = queue.back();
+        queue.pop_back();
+
+        if (! visited.insert (canonicalKey (pending.dir)).second)
+            continue;
+
+        std::error_code iterError;
+        stdfs::directory_iterator it (pending.dir, iterError);
+        if (iterError)
+        {
+            // One line per root, not per unreadable subdirectory: a permission
+            // hole halfway down a pack tree is not worth a wall of rows.
+            if (! reportedUnreadable)
+            {
+                result.problems.push_back ({ root, "could not be read: " + iterError.message() });
+                reportedUnreadable = true;
+            }
+            continue;
+        }
+
+        for (const auto& entry : it)
+        {
+            if (cancelled (cancel)) return;
+
+            std::error_code entryError;
+            if (entry.is_directory (entryError) && ! entryError)
+            {
+                if (pending.depth + 1 <= kMaxScanDepth)
+                    queue.push_back ({ entry.path(), pending.depth + 1 });
+                continue;
+            }
+            if (entryError) continue;
+
+            LibraryFormat format {};
+            if (! classify (entry.path(), format)) continue;
+
+            LibraryEntry found;
+            found.path        = entry.path();
+            found.displayName = entry.path().stem().u8string();
+            found.folder      = entry.path().parent_path().filename().u8string();
+            found.format      = format;
+            found.sizeBytes   = dusk::fs::fileSize (entry.path());
+            result.entries.push_back (std::move (found));
+        }
+    }
+}
+} // namespace
+
+std::string_view formatName (LibraryFormat format) noexcept
+{
+    switch (format)
+    {
+        case LibraryFormat::Sfz: return "SFZ";
+        case LibraryFormat::Sf2: return "SF2";
+    }
+    return "";
+}
+
+std::vector<std::filesystem::path> defaultLibraryRoots()
+{
+    const auto home = dusk::fs::userHomeDir();
+    std::vector<stdfs::path> roots;
+
+#if defined (_WIN32)
+    roots.push_back (home / "Documents" / "Soundfonts");
+    if (const char* localAppData = std::getenv ("LOCALAPPDATA");
+        localAppData != nullptr && *localAppData != '\0')
+        roots.push_back (stdfs::path (localAppData) / "Soundfonts");
+#elif defined (__APPLE__)
+    roots.push_back ("/Library/Audio/Sounds/Banks");
+    roots.push_back (home / "Library" / "Audio" / "Sounds" / "Banks");
+    roots.push_back (home / "Music" / "Soundfonts");
+#else
+    // The first two are where distribution packages install, so a fresh install
+    // carrying a packaged General MIDI bank has something to show on first open.
+    roots.push_back ("/usr/share/sounds/sf2");
+    roots.push_back ("/usr/share/soundfonts");
+    roots.push_back (home / ".local" / "share" / "sounds" / "sf2");
+    roots.push_back (home / ".local" / "share" / "soundfonts");
+    roots.push_back (home / ".local" / "share" / "sfz");
+    roots.push_back (home / "soundfonts");
+#endif
+
+    return roots;
+}
+
+ScanResult scanLibraryRoots (const std::vector<std::filesystem::path>& roots,
+                             const std::atomic<bool>* cancel,
+                             std::function<void (std::size_t, std::size_t)> progress)
+{
+    ScanResult result;
+    // Shared across roots so two roots that overlap, or one that symlinks into
+    // another, cannot list the same instrument twice.
+    std::set<std::string> visited;
+
+    for (std::size_t i = 0; i < roots.size(); ++i)
+    {
+        if (cancelled (cancel))
+        {
+            result.cancelled = true;
+            return result;
+        }
+        scanOneRoot (roots[i], cancel, visited, result);
+        if (progress) progress (i + 1, roots.size());
+    }
+
+    if (cancelled (cancel)) result.cancelled = true;
+
+    std::sort (result.entries.begin(), result.entries.end(),
+               [] (const LibraryEntry& a, const LibraryEntry& b)
+               {
+                   const auto an = toLower (a.displayName);
+                   const auto bn = toLower (b.displayName);
+                   if (an != bn) return an < bn;
+                   return a.path < b.path;
+               });
+    return result;
+}
+
+std::vector<const LibraryEntry*> filterEntries (const std::vector<LibraryEntry>& entries,
+                                                std::string_view query)
+{
+    std::vector<const LibraryEntry*> matches;
+    matches.reserve (entries.size());
+
+    const auto needle = toLower (query);
+    for (const auto& entry : entries)
+    {
+        if (needle.empty()
+            || toLower (entry.displayName).find (needle) != std::string::npos
+            || toLower (entry.folder).find (needle) != std::string::npos)
+            matches.push_back (&entry);
+    }
+    return matches;
+}
+} // namespace duskstudio::sfz

--- a/src/engine/sfz/SfzLibrary.h
+++ b/src/engine/sfz/SfzLibrary.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace duskstudio::sfz
+{
+enum class LibraryFormat
+{
+    Sfz,
+    Sf2,
+};
+
+std::string_view formatName (LibraryFormat format) noexcept;
+
+struct LibraryEntry
+{
+    std::filesystem::path path;
+    std::string           displayName;
+    std::string           folder;
+    LibraryFormat         format = LibraryFormat::Sfz;
+    std::int64_t          sizeBytes = 0;
+};
+
+// A root the user configured that could not be read. Reported rather than
+// dropped: a library that silently lists nothing is indistinguishable from a
+// library that is genuinely empty, and the user cannot fix what they cannot see.
+struct RootProblem
+{
+    std::filesystem::path root;
+    std::string           reason;
+};
+
+struct ScanResult
+{
+    std::vector<LibraryEntry> entries;
+    std::vector<RootProblem>  problems;
+    bool                      cancelled = false;
+};
+
+// Depth is capped rather than unbounded because a library root is routinely a
+// pack collection nested a few levels deep, while an accidental root like the
+// home directory is not something to walk to the bottom of.
+constexpr int kMaxScanDepth = 6;
+
+// Where instruments land when something else installed them. Distro packages
+// own the first two entries on Linux. Everything here is a first guess and is
+// skipped without complaint when absent; the user's own roots do the real work.
+std::vector<std::filesystem::path> defaultLibraryRoots();
+
+// Walks `roots` for .sfz and .sf2. Runs on the calling thread and blocks: the
+// caller owns the worker. Not for the audio thread and not for the message
+// thread. `cancel`, when set, is polled per directory and per file. `progress`,
+// when set, is called with the number of roots finished and the total.
+ScanResult scanLibraryRoots (const std::vector<std::filesystem::path>& roots,
+                             const std::atomic<bool>* cancel = nullptr,
+                             std::function<void (std::size_t, std::size_t)> progress = {});
+
+// Case-insensitive substring match over the display name and the containing
+// folder. An empty query matches everything, so clearing the box restores the
+// full list without a rescan.
+std::vector<const LibraryEntry*> filterEntries (const std::vector<LibraryEntry>& entries,
+                                                std::string_view query);
+} // namespace duskstudio::sfz

--- a/src/ui/AppConfig.cpp
+++ b/src/ui/AppConfig.cpp
@@ -29,6 +29,7 @@ constexpr const char* kKeyMulticoreManual    = "multicore_dsp_workers";
 constexpr const char* kKeyMidiSoftTakeover   = "midi_soft_takeover";
 constexpr const char* kKeyAutosaveInterval   = "autosave_interval_sec";
 constexpr const char* kKeyRecordLatencyOffset = "recording_latency_offset_samples";
+constexpr const char* kKeySfzLibraryRoots = "sfz_library_roots";
 
 int numCpus()
 {
@@ -233,6 +234,86 @@ int getRecordingLatencyOffsetSamples()
     if (! looksSignedNumeric (raw)) return kRecordingLatencyOffsetDefault;
     return std::clamp (dusk::text::getIntValue (raw),
                        kRecordingLatencyOffsetMin, kRecordingLatencyOffsetMax);
+}
+
+std::string percentEncodeRoot (const std::string& root)
+{
+    static constexpr char kHex[] = "0123456789ABCDEF";
+    std::string out;
+    out.reserve (root.size());
+    for (const unsigned char c : root)
+    {
+        if (c == '%' || c == ':' || c < 0x20 || c == 0x7f)
+        {
+            out += '%';
+            out += kHex[(c >> 4) & 0x0f];
+            out += kHex[c & 0x0f];
+        }
+        else
+        {
+            out += (char) c;
+        }
+    }
+    return out;
+}
+
+int hexDigit (char c) noexcept
+{
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+std::string percentDecodeRoot (const std::string& text)
+{
+    std::string out;
+    out.reserve (text.size());
+    for (std::size_t i = 0; i < text.size(); ++i)
+    {
+        if (text[i] == '%' && i + 2 < text.size())
+        {
+            const int hi = hexDigit (text[i + 1]);
+            const int lo = hexDigit (text[i + 2]);
+            if (hi >= 0 && lo >= 0)
+            {
+                out += (char) ((hi << 4) | lo);
+                i += 2;
+                continue;
+            }
+        }
+        out += text[i];
+    }
+    return out;
+}
+
+std::vector<std::string> getSfzLibraryRoots()
+{
+    std::vector<std::string> roots;
+    const auto raw = readKey (kKeySfzLibraryRoots);
+    std::size_t start = 0;
+    while (start <= raw.size())
+    {
+        const auto end = raw.find (':', start);
+        const auto field = raw.substr (start, end == std::string::npos ? std::string::npos
+                                                                       : end - start);
+        if (! field.empty()) roots.push_back (percentDecodeRoot (field));
+        if (end == std::string::npos) break;
+        start = end + 1;
+    }
+    return roots;
+}
+
+void setSfzLibraryRoots (const std::vector<std::string>& roots)
+{
+    std::string joined;
+    for (const auto& root : roots)
+    {
+        if (root.empty()) continue;
+        if (! joined.empty()) joined += ':';
+        joined += percentEncodeRoot (root);
+    }
+    writeKey (kKeySfzLibraryRoots, joined);
 }
 
 void setRecordingLatencyOffsetSamples (int samples)

--- a/src/ui/AppConfig.h
+++ b/src/ui/AppConfig.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <string>
+#include <vector>
+
 namespace duskstudio::appconfig
 {
 // Per-machine preferences. Stored as a key=value text file at
@@ -134,4 +137,11 @@ void setRecordingLatencyOffsetSamples (int samples);
 constexpr int kVkbCentreDefault = 36;
 int  getVkbCentreNote();
 void setVkbCentreNote (int midiNote);
+
+// Extra directories the soundfont library scans, on top of the per-OS defaults
+// in SfzLibrary.cpp. The store holds one key per line, so each root is
+// percent-encoded and the list joined with ':'. That keeps a path containing a
+// separator, or a newline, from splitting into roots that do not exist.
+std::vector<std::string> getSfzLibraryRoots();
+void setSfzLibraryRoots (const std::vector<std::string>& roots);
 } // namespace duskstudio::appconfig

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,8 @@ add_executable(dusk-studio-tests
     hosting_insert_adapter.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/hosting/InsertAdapter.cpp
     sfz_catalog.cpp
+    sfz_library_scan.cpp
+    ${CMAKE_SOURCE_DIR}/src/engine/sfz/SfzLibrary.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/sfz/SfzCatalog.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/sfz/SfzCatalogEnvelope.cpp
     # Native CLAP tests + sources are added conditionally below.

--- a/tests/appconfig_store.cpp
+++ b/tests/appconfig_store.cpp
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <iterator>
 #include <string>
+#include <vector>
 
 namespace
 {
@@ -155,4 +156,34 @@ TEST_CASE ("Writing one key preserves the others", "[appconfig]")
     CHECK (duskstudio::appconfig::getNotepadEnabled());
     CHECK (duskstudio::appconfig::getScanPluginsOnStartup());
     CHECK (store.contents().find ("# a comment") != std::string::npos);
+}
+
+TEST_CASE ("Soundfont library roots round-trip", "[appconfig]")
+{
+    const ScopedStore store { "sfz-roots" };
+    CHECK (duskstudio::appconfig::getSfzLibraryRoots().empty());
+
+    const std::vector<std::string> roots {
+        "/home/someone/soundfonts",
+        "/mnt/library/packs with spaces",
+        "/srv/instruments",
+    };
+    duskstudio::appconfig::setSfzLibraryRoots (roots);
+    CHECK (duskstudio::appconfig::getSfzLibraryRoots() == roots);
+
+    duskstudio::appconfig::setSfzLibraryRoots ({});
+    CHECK (duskstudio::appconfig::getSfzLibraryRoots().empty());
+}
+
+TEST_CASE ("A library root carrying a separator still round-trips", "[appconfig]")
+{
+    const ScopedStore store { "sfz-roots-separator" };
+    const std::vector<std::string> awkward {
+        "/good/one",
+        "/has:a:colon",
+        "/has\nnewline",
+        "/has%percent",
+    };
+    duskstudio::appconfig::setSfzLibraryRoots (awkward);
+    CHECK (duskstudio::appconfig::getSfzLibraryRoots() == awkward);
 }

--- a/tests/sfz_library_scan.cpp
+++ b/tests/sfz_library_scan.cpp
@@ -1,0 +1,173 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/sfz/SfzLibrary.h"
+#include "foundation/Fs.h"
+
+#include <atomic>
+#include <fstream>
+#include <system_error>
+
+using namespace duskstudio::sfz;
+
+namespace
+{
+namespace stdfs = std::filesystem;
+
+struct ScratchTree
+{
+    ScratchTree() : root (dusk::fs::createUniqueTempDirectory ("dusk-sfz-library-")) {}
+    ~ScratchTree()
+    {
+        std::error_code ec;
+        stdfs::remove_all (root, ec);
+    }
+
+    void file (const stdfs::path& relative)
+    {
+        const auto full = root / relative;
+        std::error_code ec;
+        stdfs::create_directories (full.parent_path(), ec);
+        std::ofstream out (full);
+        out << "x";
+    }
+
+    stdfs::path root;
+};
+
+bool listed (const ScanResult& result, std::string_view name)
+{
+    for (const auto& entry : result.entries)
+        if (entry.displayName == name) return true;
+    return false;
+}
+} // namespace
+
+TEST_CASE ("SfzLibrary lists only soundfonts")
+{
+    ScratchTree tree;
+    tree.file ("piano.sfz");
+    tree.file ("bank.sf2");
+    tree.file ("readme.txt");
+    tree.file ("cover.png");
+    tree.file ("notes.sfz.bak");
+
+    const auto result = scanLibraryRoots ({ tree.root });
+
+    CHECK (result.entries.size() == 2);
+    CHECK (listed (result, "piano"));
+    CHECK (listed (result, "bank"));
+    CHECK (result.problems.empty());
+    CHECK_FALSE (result.cancelled);
+}
+
+TEST_CASE ("SfzLibrary reports a root it cannot use instead of listing nothing")
+{
+    ScratchTree tree;
+    const auto missing = tree.root / "does-not-exist";
+
+    const auto result = scanLibraryRoots ({ missing });
+
+    CHECK (result.entries.empty());
+    REQUIRE (result.problems.size() == 1);
+    CHECK (result.problems[0].root == missing);
+    CHECK_FALSE (result.problems[0].reason.empty());
+}
+
+TEST_CASE ("SfzLibrary caps how deep it walks")
+{
+    ScratchTree tree;
+    stdfs::path deep;
+    for (int i = 0; i <= kMaxScanDepth + 2; ++i)
+        deep /= "d";
+    tree.file (deep / "buried.sfz");
+
+    stdfs::path shallow;
+    for (int i = 0; i < kMaxScanDepth; ++i)
+        shallow /= "s";
+    tree.file (shallow / "reachable.sfz");
+
+    const auto result = scanLibraryRoots ({ tree.root });
+
+    CHECK (listed (result, "reachable"));
+    CHECK_FALSE (listed (result, "buried"));
+}
+
+TEST_CASE ("SfzLibrary does not list the same instrument twice through a loop")
+{
+    ScratchTree tree;
+    tree.file ("packs/one.sfz");
+
+    std::error_code ec;
+    stdfs::create_directory_symlink (tree.root, tree.root / "packs" / "loop", ec);
+    if (ec) SKIP ("symlinks are not available on this filesystem");
+
+    const auto result = scanLibraryRoots ({ tree.root });
+
+    CHECK (result.entries.size() == 1);
+    CHECK (listed (result, "one"));
+}
+
+TEST_CASE ("SfzLibrary does not list an instrument twice when roots overlap")
+{
+    ScratchTree tree;
+    tree.file ("packs/one.sfz");
+
+    const auto result = scanLibraryRoots ({ tree.root, tree.root / "packs" });
+
+    CHECK (result.entries.size() == 1);
+}
+
+TEST_CASE ("SfzLibrary stops when cancelled")
+{
+    ScratchTree tree;
+    tree.file ("one.sfz");
+
+    std::atomic<bool> cancel { true };
+    const auto result = scanLibraryRoots ({ tree.root }, &cancel);
+
+    CHECK (result.cancelled);
+    CHECK (result.entries.empty());
+}
+
+TEST_CASE ("SfzLibrary reports scan progress once per root")
+{
+    ScratchTree tree;
+    tree.file ("one.sfz");
+
+    std::vector<std::pair<std::size_t, std::size_t>> ticks;
+    (void) scanLibraryRoots ({ tree.root, tree.root / "nope" }, nullptr,
+                             [&ticks] (std::size_t done, std::size_t total)
+                             { ticks.emplace_back (done, total); });
+
+    REQUIRE (ticks.size() == 2);
+    CHECK (ticks[0] == std::make_pair (std::size_t (1), std::size_t (2)));
+    CHECK (ticks[1] == std::make_pair (std::size_t (2), std::size_t (2)));
+}
+
+TEST_CASE ("SfzLibrary filtering is case-insensitive and clears back to everything")
+{
+    std::vector<LibraryEntry> entries {
+        { "/a/Grand Piano.sfz", "Grand Piano", "keys", LibraryFormat::Sfz, 1 },
+        { "/a/Rhodes.sfz",      "Rhodes",      "keys", LibraryFormat::Sfz, 1 },
+        { "/b/Kit.sf2",         "Kit",         "drums", LibraryFormat::Sf2, 1 },
+    };
+
+    CHECK (filterEntries (entries, "").size() == 3);
+    CHECK (filterEntries (entries, "piano").size() == 1);
+    CHECK (filterEntries (entries, "PIANO").size() == 1);
+    CHECK (filterEntries (entries, "keys").size() == 2);
+    CHECK (filterEntries (entries, "nothing here").empty());
+}
+
+TEST_CASE ("SfzLibrary default roots are absolute and distinct")
+{
+    const auto roots = defaultLibraryRoots();
+
+    REQUIRE_FALSE (roots.empty());
+    for (const auto& root : roots)
+        CHECK (root.is_absolute());
+
+    auto sorted = roots;
+    std::sort (sorted.begin(), sorted.end());
+    CHECK (std::unique (sorted.begin(), sorted.end()) == sorted.end());
+}


### PR DESCRIPTION
Refs #535. PR 1 of 3: the model and its tests. No UI, and nothing here touches the network, a catalog, an archive, libcurl or libarchive.

## What lands

`src/engine/sfz/SfzLibrary.{h,cpp}` is framework-free and built on `dusk::fs`. It walks a list of roots for `.sfz` and `.sf2` and returns entries (path, display name, containing folder, format, size) plus, for every root it could not use, a stated reason.

Reporting bad roots rather than dropping them is deliberate: a library that silently lists nothing looks exactly like one that is genuinely empty, and the user cannot fix what they cannot see.

The walk is depth-capped at 6 and carries a set of canonical directory identities. The cap alone does not stop a symlink loop, it just bounds how far each branch of it is walked, so identity is what actually terminates. The same set also means two roots that overlap, or one that symlinks into another, list their shared instruments once.

`scanLibraryRoots` blocks on the calling thread and takes a cancel flag polled per directory and per file, plus a progress callback fired once per root. The panel in PR 2 owns the worker. Nothing here belongs on the audio thread or the message thread.

`filterEntries` is a pure case-insensitive substring match over name and folder, so the panel can filter without rescanning and an empty query restores the full list.

## Default roots

One table per platform in `SfzLibrary.cpp`, all skipped without complaint when absent:

- Linux: `/usr/share/sounds/sf2`, `/usr/share/soundfonts`, `~/.local/share/sounds/sf2`, `~/.local/share/soundfonts`, `~/.local/share/sfz`, `~/soundfonts`
- macOS: `/Library/Audio/Sounds/Banks`, `~/Library/Audio/Sounds/Banks`, `~/Music/Soundfonts`
- Windows: `%USERPROFILE%\Documents\Soundfonts`, `%LOCALAPPDATA%\Soundfonts`

The first two Linux entries are where distribution packages install, so a fresh install carrying a packaged General MIDI bank shows something the first time the browser opens.

**This list is a first guess and is flagged for review.** It is one table in one file precisely so it can be corrected in one place.

## User roots

Two `appconfig` accessors. The store is one key per line, so a newline-separated list silently truncated at the first entry, which the round-trip test caught. Each root is now percent-encoded and the list joined with `:`, so a path containing a colon, a newline or a percent sign round-trips intact instead of splitting into roots that do not exist.

## Coverage

Eleven new cases: extension filtering, a missing root reported rather than swallowed, the depth cap, a symlink loop, overlapping roots, cancellation, progress ticks, case-insensitive filtering and clearing back, default roots absolute and distinct, and the two appconfig round-trips including the awkward-path one. The symlink case skips where the filesystem has no symlinks.

`ctest`: 991/991. `tools/juce-gate.sh`: 163 files / 8067 uses, unchanged; the model adds no framework tokens. App builds clean at `-j3`.

## Size

575 insertions, of which 204 are tests and 90 are the config accessors, leaving about 280 lines of model. Over the 400-line guide once tests are counted; splitting the tests from the code they cover would have been worse.

## Next

PR 2 adds the embedded-modal panel (and hand-adds its two files to the coupling allowlist, justified there). PR 3 covers MANUAL.md. The picker entry point is deferred per the design discussion; I am updating the acceptance criteria on #535 to say so.
