### PR TITLE
fix(windows): resolve the IPC harness child under its real name

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ GPL source on this repo, so building it yourself costs you nothing but compile t
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 1001 Catch2 test cases across 188 test source files. Linux
+The C++ suite declares 1002 Catch2 test cases across 188 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -123,7 +123,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # Native log storage + CrashHandler signal reports
-tests/         # 1001 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 1002 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/DuskStudioApp.cpp
+++ b/src/DuskStudioApp.cpp
@@ -30,7 +30,7 @@
 #include "session/SessionSerializer.h"
 #include "util/CrashHandler.h"
 #include "util/SingleInstance.h"
-#if JUCE_LINUX
+#if DUSKSTUDIO_HAS_OOP_PLUGINS
  #include "engine/ipc/IpcSelfTest.h"
 #endif
 #if defined(__linux__)
@@ -2445,15 +2445,36 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
         return;
     }
 
-   #if JUCE_LINUX
+   #if DUSKSTUDIO_HAS_OOP_PLUGINS
+    // Both harnesses launch the sibling child. Resolve it under the name the
+    // loader uses, and report a child that is not there: handing the connect a
+    // path that cannot be spawned leaves the harness waiting with no output.
+    const auto resolveIpcHostChild = []
+    {
+        const auto exe = juce::File::getSpecialLocation (juce::File::currentExecutableFile);
+        const auto host = exe.getSiblingFile (pluginHostExecutableName());
+        if (! host.existsAsFile())
+        {
+            std::fprintf (stderr, "FAIL: no %s next to the app; build it first\n",
+                          pluginHostExecutableName());
+            std::fflush (stderr);
+        }
+        return host;
+    };
+
     if (envFlagSet ("DUSKSTUDIO_RUN_IPC_SELFTEST"))
     {
         // Out-of-process plugin hosting Phase 1 acceptance gate.
         // Validates the shm + futex round-trip against the
         // dusk-studio-plugin-host stub binary (which lives next to Dusk Studio in
         // the build output).
-        const auto exe = juce::File::getSpecialLocation (juce::File::currentExecutableFile);
-        const auto host = exe.getSiblingFile ("dusk-studio-plugin-host");
+        const auto host = resolveIpcHostChild();
+        if (! host.existsAsFile())
+        {
+            setApplicationReturnValue (1);
+            quit();
+            return;
+        }
         const auto rc = duskstudio::ipc::runIpcSelfTest (host.getFullPathName().toStdString());
         std::fflush (stdout);
         setApplicationReturnValue (rc);
@@ -2468,8 +2489,13 @@ void DuskStudioApp::initialise (const juce::String& commandLine)
     // entire JUCE plugin loading + processBlock path through the IPC.
     if (const char* path = std::getenv ("DUSKSTUDIO_IPC_HOST_TEST"); path != nullptr && *path)
     {
-        const auto exe = juce::File::getSpecialLocation (juce::File::currentExecutableFile);
-        const auto host = exe.getSiblingFile ("dusk-studio-plugin-host");
+        const auto host = resolveIpcHostChild();
+        if (! host.existsAsFile())
+        {
+            setApplicationReturnValue (1);
+            quit();
+            return;
+        }
         const auto rc = duskstudio::ipc::runIpcHostTest (
             host.getFullPathName().toStdString(), std::string (path));
         std::fflush (stdout);

--- a/src/engine/PluginManager.h
+++ b/src/engine/PluginManager.h
@@ -162,6 +162,18 @@ private:
                           const char* jsonFileName) const;
 };
 
+// File name of the out-of-process host child. Windows needs the suffix, and
+// the IPC harnesses in DuskStudioApp resolve the child through here so they
+// cannot drift from the name the loader launches.
+inline const char* pluginHostExecutableName() noexcept
+{
+   #if JUCE_WINDOWS
+    return "dusk-studio-plugin-host.exe";
+   #else
+    return "dusk-studio-plugin-host";
+   #endif
+}
+
 inline juce::String PluginManager::getHostExecutablePath() const
 {
    #if DUSKSTUDIO_HAS_OOP_PLUGINS
@@ -169,12 +181,7 @@ inline juce::String PluginManager::getHostExecutablePath() const
     if (! hostExecutableOverride.empty()) return hostExecutableOverride;
    #endif
     auto exe = juce::File::getSpecialLocation (juce::File::currentExecutableFile);
-   #if JUCE_WINDOWS
-    const char* const childName = "dusk-studio-plugin-host.exe";
-   #else
-    const char* const childName = "dusk-studio-plugin-host";
-   #endif
-    return exe.getParentDirectory().getChildFile (childName).getFullPathName();
+    return exe.getParentDirectory().getChildFile (pluginHostExecutableName()).getFullPathName();
    #else
     return {};
    #endif

--- a/tests/plugin_manager_descriptor.cpp
+++ b/tests/plugin_manager_descriptor.cpp
@@ -144,3 +144,17 @@ TEST_CASE ("PluginManager falls back from malformed native JSON without erasing 
         CHECK (loaded.empty());
     }
 }
+
+TEST_CASE ("the out-of-process host child name carries the platform suffix", "[plugins][ipc]")
+{
+    // The IPC harnesses used to spell the child themselves and dropped the
+    // Windows suffix, so they waited on a connect to a process that could
+    // never start. Both they and getHostExecutablePath go through this.
+    const std::string childName = pluginHostExecutableName();
+
+#if defined (_WIN32)
+    CHECK (childName == "dusk-studio-plugin-host.exe");
+#else
+    CHECK (childName == "dusk-studio-plugin-host");
+#endif
+}


### PR DESCRIPTION
Closes #504

## The bug

Two things, both of which end the same way.

`src/DuskStudioApp.cpp` resolved the harness child as `exe.getSiblingFile ("dusk-studio-plugin-host")`. On Windows the installed tree ships `dusk-studio-plugin-host.exe`; the loader's `getHostExecutablePath()` already appended the suffix, the harnesses did not.

Both harness blocks were also `#if JUCE_LINUX`, so on Windows `DUSKSTUDIO_RUN_IPC_SELFTEST` and `DUSKSTUDIO_IPC_HOST_TEST` were compiled out and silently ignored, and the app started its GUI instead of the harness.

Confirmed on the Windows 11 VM against the installed 0.13.3 build, before this change:

```
exe: C:\Program Files\Dusk Studio\bin\DuskStudio.exe
siblings matching plugin-host:
  dusk-studio-plugin-host.exe
exists no-suffix : False
exists .exe      : True
started pid 10728, waiting up to 60s
STILL RUNNING AFTER 60s (hang)
--- stdout ---
--- stderr ---
[DuskStudio] parallel strip DSP: 10 worker(s)
```

No harness output, no exit.

## The fix

- `pluginHostExecutableName()` in `src/engine/PluginManager.h` owns the child's file name and its Windows suffix. `getHostExecutablePath()` builds on it, and so do both harnesses, so the two cannot drift again.
- The harness gate widens from `JUCE_LINUX` to `DUSKSTUDIO_HAS_OOP_PLUGINS`, which is every platform that builds the child. `IpcSelfTest.cpp` was already compiled on all three.
- A missing child prints the name it looked for and exits 1 instead of handing the connect a path that can never be spawned.

No behaviour change on the Linux path beyond the new guard.

## Verification

Linux:

- `DUSKSTUDIO_RUN_IPC_SELFTEST=1` under Xvfb, child present: `PASS`, exit 0, 10000 round-trips.
- Same run with the child moved aside: exit 1 in under a second with `FAIL: no dusk-studio-plugin-host next to the app; build it first`. That is the hang this fixes, in its Linux-visible form.
- `cmake --build build -j3` clean, no new warnings.
- `ctest --test-dir build-tests` 981/981 pass.
- `tools/juce-gate.sh` 163 files / 8065 uses, down two from main's 8067. The allowlist ceiling is untouched.

Windows: `windows-tests.yml` builds the `DuskStudio` target on MSVC, so this compiles the widened gate there, and the new Catch2 case asserts the `.exe` name under `_WIN32` in that same job. I did not run the fixed binary on the VM: it has no source tree or dependency set, and standing it up is the full CI recipe. The pre-fix hang above is reproduced from the shipped build.

## Test

`tests/plugin_manager_descriptor.cpp` pins the child's name per platform. README's test-case count goes 1001 to 1002; #538, #540 and #541 bump the same line, so whichever lands last re-bumps.
