### PR TITLE
build(packaging): define and verify the 1.0 package contents

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -673,8 +673,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          msi="$(ls *.msi build/*.msi 2>/dev/null | head -1)"
-          [[ -n "$msi" ]] || { echo "::error::no MSI to verify" >&2; exit 1; }
+          # The repo root only, and exactly one: that is where the packaging
+          # step leaves the MSI and what the upload path publishes, so checking
+          # a copy under build/ could verify a file nobody ships.
+          shopt -s nullglob
+          msis=(*.msi)
+          (( ${#msis[@]} == 1 )) || {
+            echo "::error::expected exactly one MSI at the repo root, found ${#msis[@]}" >&2
+            exit 1; }
+          msi="${msis[0]}"
           work="$(mktemp -d)"
           7z x -y -o"$work" "$msi" > /dev/null
           scripts/verify-package-contents.sh windows "$work"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -892,8 +892,18 @@ jobs:
           set -euo pipefail
           dmg="$(ls *.dmg | head -1)"
           mnt="$(mktemp -d)"
+          # The DMG carries a licence agreement, so hdiutil blocks for an
+          # answer, and it closes stdin once it has one. Read hdiutil's own
+          # status rather than the pipeline's, which pipefail would otherwise
+          # take from the SIGPIPEd yes. Same pattern as the launch check below.
+          set +o pipefail
           yes | hdiutil attach -nobrowse -readonly -noverify -noautoopen \
                         -mountpoint "$mnt" "$dmg" > /dev/null
+          mount_rc=${PIPESTATUS[1]}
+          set -o pipefail
+          [[ $mount_rc -eq 0 ]] || {
+              echo "::error::could not mount $dmg to verify its contents" >&2
+              exit 1; }
           trap 'hdiutil detach "$mnt" >/dev/null 2>&1 || true' EXIT
           scripts/verify-package-contents.sh macos "$mnt"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -336,6 +336,15 @@ jobs:
         # integration.
         run: BUILD_DIR=build-linux scripts/package-tarball.sh
 
+      - name: Verify tarball contents
+        # packaging/contents.txt is the contract; a packager that stops shipping
+        # a file fails here rather than on the user's first launch.
+        run: |
+          set -euo pipefail
+          work="$(mktemp -d)"
+          tar -xf dusk-studio-*-Linux-${{ matrix.arch }}.tar.xz -C "$work"
+          root="$(find "$work" -mindepth 1 -maxdepth 1 -type d -print -quit)"
+          scripts/verify-package-contents.sh linux "$root"
 
       - name: Stage Linux payload
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -658,6 +667,17 @@ jobs:
           Get-ChildItem build\*.msi
           Get-ChildItem *.msi -ErrorAction SilentlyContinue
 
+      - name: Verify MSI contents
+        # 7z flattens an MSI, so the checker matches file names rather than
+        # paths on this platform. See packaging/contents.txt.
+        shell: bash
+        run: |
+          set -euo pipefail
+          msi="$(ls *.msi build/*.msi 2>/dev/null | head -1)"
+          [[ -n "$msi" ]] || { echo "::error::no MSI to verify" >&2; exit 1; }
+          work="$(mktemp -d)"
+          7z x -y -o"$work" "$msi" > /dev/null
+          scripts/verify-package-contents.sh windows "$work"
 
       - name: Stage Windows payload
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -864,6 +884,18 @@ jobs:
           base="$(basename "$DMG" .dmg)"
           mv "$DMG" "./${base}.dmg"
           echo "Unsigned DMG: ${base}.dmg"
+
+      - name: Verify DMG contents
+        # Mounts the image the user downloads and checks it against
+        # packaging/contents.txt before anything is staged for publication.
+        run: |
+          set -euo pipefail
+          dmg="$(ls *.dmg | head -1)"
+          mnt="$(mktemp -d)"
+          yes | hdiutil attach -nobrowse -readonly -noverify -noautoopen \
+                        -mountpoint "$mnt" "$dmg" > /dev/null
+          trap 'hdiutil detach "$mnt" >/dev/null 2>&1 || true' EXIT
+          scripts/verify-package-contents.sh macos "$mnt"
 
       - name: Verify the packaged app launches
         # The build and the test suite both run against the Homebrew prefix,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1703,9 +1703,15 @@ if(UNIX AND NOT APPLE)
             DESTINATION share/doc/dusk-studio)
     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/packaging/copyright"
             DESTINATION share/doc/dusk-studio)
+    # Reachable before the app is opened, which is the point: a user who cannot
+    # get a device configured has not got as far as the in-app link. The Linux
+    # tarball is not CPack and stages its own copy in package-tarball.sh.
+    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/packaging/QUICKSTART.txt"
+            DESTINATION share/doc/dusk-studio)
 else()
     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE"
                   "${CMAKE_CURRENT_SOURCE_DIR}/LICENSES.txt"
+                  "${CMAKE_CURRENT_SOURCE_DIR}/packaging/QUICKSTART.txt"
             DESTINATION .)
 endif()
 # The hicolor size the .desktop Icon=DuskStudio key resolves. Committed rather

--- a/docs/MAINTAINER-GUIDE.md
+++ b/docs/MAINTAINER-GUIDE.md
@@ -578,6 +578,22 @@ current tag workflows publish, so nothing a tagged release produces uses it.
 Do not announce the release when the workflow merely turns green; complete the
 acceptance checks below first.
 
+### Package contents
+
+[`packaging/contents.txt`](../packaging/contents.txt) is the contract for what
+every package must contain: one `<platform><TAB><path>` record per required
+file, relative to that package's own install root. Each of the three packaging
+jobs runs
+[`scripts/verify-package-contents.sh`](../scripts/verify-package-contents.sh)
+against the built artifact before staging it, so a packager that stops shipping
+a file fails the release rather than the user's first launch. Windows is matched
+by file name rather than path, because an MSI is a database and 7z flattens it
+on extraction. Adding a file to one package means adding its record here, and
+the `package-contents-checker` ctest case covers the checker itself. Project
+templates are deliberately absent: they ship as code in
+`src/session/SessionTemplates.h` and reach the user through File -> New, so
+there is no file to verify.
+
 ### Tag assets and acceptance
 
 A complete `vX.Y.Z` release has exactly these six assets:

--- a/packaging/QUICKSTART.txt
+++ b/packaging/QUICKSTART.txt
@@ -1,0 +1,7 @@
+Dusk Studio - getting started
+
+The quickstart guide lives at:
+
+    https://github.com/dusk-audio/dusk-studio/blob/main/MANUAL.md#getting-started
+
+The full manual ships with every release as MANUAL.pdf.

--- a/packaging/contents.txt
+++ b/packaging/contents.txt
@@ -1,0 +1,59 @@
+# What a 1.0 package must contain.
+#
+# One record per line: <platform><TAB><path>, where <path> is relative to the
+# package's own install root. Blank lines and lines starting with # are ignored.
+# scripts/verify-package-contents.sh reads this and the three release.yml
+# packaging jobs run it before anything is uploaded, so a packager that stops
+# shipping a file fails the release rather than the user's first launch.
+#
+# Install roots, per platform:
+#   linux    the directory inside the tarball (dusk-studio-<version>-Linux-<arch>)
+#   macos    the mounted DMG
+#   windows  matched by file name, not path: an MSI is a database, and 7z
+#            extraction flattens it, so the paths below are informational and
+#            only the final component is checked.
+#
+# Project templates are NOT here. They ship as code in
+# src/session/SessionTemplates.h and reach the user through File -> New, so
+# there is no file to verify.
+
+# --- Application ---
+linux	DuskStudio/DuskStudio
+macos	DuskStudio.app
+windows	bin/DuskStudio.exe
+
+# --- Out-of-process plugin host ---
+# On macOS the helper lives inside DuskStudio.app/Contents/MacOS because its
+# runtime output is directed beside the app executable, so the bundle carries it.
+linux	DuskStudio/dusk-studio-plugin-host
+macos	DuskStudio.app/Contents/MacOS/dusk-studio-plugin-host
+windows	bin/dusk-studio-plugin-host.exe
+
+# --- Licences (GPL section 4: not optional in a binary distribution) ---
+linux	LICENSE
+linux	LICENSES.txt
+macos	LICENSE
+macos	LICENSES.txt
+windows	LICENSE
+windows	LICENSES.txt
+
+# --- Getting started ---
+linux	QUICKSTART.txt
+macos	QUICKSTART.txt
+windows	QUICKSTART.txt
+
+# --- Linux desktop integration ---
+linux	install.sh
+linux	README-linux.txt
+linux	DuskStudio/share/applications/audio.dusk.studio.desktop
+linux	DuskStudio/share/metainfo/DuskStudio.appdata.xml
+linux	DuskStudio/share/mime/packages/DuskStudio.mime.xml
+linux	DuskStudio/share/icons/hicolor/256x256/apps/DuskStudio.png
+
+# --- Built-in plugin suite (#75) ---
+# Uncomment with the real paths when the suite ships. The slot is here so the
+# contract records that every package is expected to carry it, rather than the
+# omission being discovered on one platform after release.
+#linux	DuskStudio/plugins
+#macos	DuskStudio.app/Contents/Resources/plugins
+#windows	bin/plugins

--- a/scripts/package-tarball.sh
+++ b/scripts/package-tarball.sh
@@ -43,7 +43,7 @@ for f in "$BINARY" "$HOST"; do
     [[ -x "$f" ]] || { echo "error: $f missing - build $BUILD_DIR (Release) first" >&2; exit 1; }
 done
 [[ -f "$ICON_SRC" ]] || { echo "error: $ICON_SRC missing (256x256 hicolor icon)" >&2; exit 1; }
-for f in LICENSE LICENSES.txt; do
+for f in LICENSE LICENSES.txt packaging/QUICKSTART.txt; do
     [[ -f "$f" ]] || { echo "error: $f missing - GPL section 4 requires it in the tarball" >&2; exit 1; }
 done
 
@@ -74,6 +74,7 @@ install -m 0644 "$ICON_SRC"                         "$APPDIR/share/icons/hicolor
 # them part of any binary distribution.
 install -m 0755 scripts/install-linux.sh "$STAGE/$TOPDIR/install.sh"
 install -m 0644 packaging/README-linux.txt "$STAGE/$TOPDIR/README-linux.txt"
+install -m 0644 packaging/QUICKSTART.txt   "$STAGE/$TOPDIR/QUICKSTART.txt"
 install -m 0644 LICENSE                    "$STAGE/$TOPDIR/LICENSE"
 install -m 0644 LICENSES.txt               "$STAGE/$TOPDIR/LICENSES.txt"
 

--- a/scripts/verify-package-contents.sh
+++ b/scripts/verify-package-contents.sh
@@ -68,6 +68,12 @@ while IFS= read -r line || [[ -n "$line" ]]; do
     fi
     recordPlatform="${line%%$'\t'*}"
     recordPath="${line#*$'\t'}"
+    # An empty path would pass vacuously: "$ROOT/" is a directory and so always
+    # exists, which turns a mistyped record into a check that cannot fail.
+    if [[ -z "${recordPath//[[:space:]]/}" ]]; then
+        echo "error: ${CONTRACT}:${lineNo}: record has an empty path" >&2
+        exit 2
+    fi
     case "$recordPlatform" in
         linux|macos|windows) ;;
         *) echo "error: ${CONTRACT}:${lineNo}: unknown platform '$recordPlatform'" >&2; exit 2 ;;

--- a/scripts/verify-package-contents.sh
+++ b/scripts/verify-package-contents.sh
@@ -34,10 +34,11 @@ usage() {
 }
 
 # Lowercase and fold the separator WiX rewrites, so a contract path and an
-# extracted MSI name can be compared at all.
+# extracted MSI name can be compared at all. tr rather than ${x,,}: macOS ships
+# bash 3.2, where that expansion is a syntax error at expansion time, which is
+# why it survived a macOS run that only exercised the literal-path branch.
 normalise() {
-    local text="${1//-/_}"
-    printf '%s' "${text,,}"
+    printf '%s' "$1" | tr '\-' '_' | tr '[:upper:]' '[:lower:]'
 }
 
 [[ $# -eq 2 ]] || usage

--- a/scripts/verify-package-contents.sh
+++ b/scripts/verify-package-contents.sh
@@ -11,6 +11,17 @@
 # Windows is matched by file name rather than path: an MSI is a database and 7z
 # flattens it on extraction, so the layout the contract records cannot be
 # checked there. The other two are checked as literal paths.
+#
+# A real extraction of our MSI produces names like
+#
+#   CM_FP_bin.DuskStudio.exe
+#   CM_FP_bin.dusk_studio_plugin_host.exe
+#   CM_FP_LICENSES.txt
+#
+# so the component name is a suffix of the extracted name, WiX has replaced the
+# hyphens with underscores, and case is not guaranteed. Matching therefore
+# lowercases, folds '-' to '_', and requires the expected name to sit at a '.'
+# or '_' boundary, which keeps LICENSE from matching LICENSES.txt.
 
 set -euo pipefail
 
@@ -20,6 +31,13 @@ CONTRACT="${DUSKSTUDIO_CONTENTS_CONTRACT:-${REPO_ROOT}/packaging/contents.txt}"
 usage() {
     echo "usage: $0 <linux|macos|windows> <package-root>" >&2
     exit 2
+}
+
+# Lowercase and fold the separator WiX rewrites, so a contract path and an
+# extracted MSI name can be compared at all.
+normalise() {
+    local text="${1//-/_}"
+    printf '%s' "${text,,}"
 }
 
 [[ $# -eq 2 ]] || usage
@@ -64,11 +82,17 @@ fi
 missing=()
 for path in "${expected[@]}"; do
     if [[ "$PLATFORM" == "windows" ]]; then
-        # Basename match, anywhere under the extraction.
-        name="${path##*/}"
-        if ! find "$ROOT" -name "$name" -print -quit | grep -q .; then
-            missing+=("$path")
-        fi
+        name="$(normalise "${path##*/}")"
+        found=0
+        while IFS= read -r candidate; do
+            candidate="$(normalise "${candidate##*/}")"
+            if [[ "$candidate" == "$name" || "$candidate" == *".${name}" \
+                  || "$candidate" == *"_${name}" ]]; then
+                found=1
+                break
+            fi
+        done < <(find "$ROOT" -type f)
+        [[ $found -eq 1 ]] || missing+=("$path")
     elif [[ ! -e "$ROOT/$path" ]]; then
         missing+=("$path")
     fi

--- a/scripts/verify-package-contents.sh
+++ b/scripts/verify-package-contents.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Check one built package against packaging/contents.txt.
+#
+#   scripts/verify-package-contents.sh linux   <unpacked tarball dir>
+#   scripts/verify-package-contents.sh macos   <mounted DMG>
+#   scripts/verify-package-contents.sh windows <7z extraction of the MSI>
+#
+# Read-only. Exits non-zero listing every missing path, so one run reports the
+# whole gap rather than the first hole in it.
+#
+# Windows is matched by file name rather than path: an MSI is a database and 7z
+# flattens it on extraction, so the layout the contract records cannot be
+# checked there. The other two are checked as literal paths.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONTRACT="${DUSKSTUDIO_CONTENTS_CONTRACT:-${REPO_ROOT}/packaging/contents.txt}"
+
+usage() {
+    echo "usage: $0 <linux|macos|windows> <package-root>" >&2
+    exit 2
+}
+
+[[ $# -eq 2 ]] || usage
+PLATFORM="$1"
+ROOT="$2"
+
+case "$PLATFORM" in
+    linux|macos|windows) ;;
+    *) usage ;;
+esac
+
+[[ -d "$ROOT" ]] || { echo "error: package root is not a directory: $ROOT" >&2; exit 2; }
+[[ -f "$CONTRACT" ]] || { echo "error: contract not found: $CONTRACT" >&2; exit 2; }
+
+expected=()
+lineNo=0
+while IFS= read -r line || [[ -n "$line" ]]; do
+    lineNo=$((lineNo + 1))
+    [[ -z "${line//[[:space:]]/}" ]] && continue
+    [[ "$line" == \#* ]] && continue
+    # Fail closed: a record that is not exactly <platform><TAB><path> means the
+    # contract was edited into a shape this cannot read, and silently skipping
+    # it would drop whatever it required.
+    if [[ "$line" != *$'\t'* ]] || [[ "$(awk -F'\t' '{print NF}' <<< "$line")" != "2" ]]; then
+        echo "error: ${CONTRACT}:${lineNo}: expected <platform><TAB><path>, got: $line" >&2
+        exit 2
+    fi
+    recordPlatform="${line%%$'\t'*}"
+    recordPath="${line#*$'\t'}"
+    case "$recordPlatform" in
+        linux|macos|windows) ;;
+        *) echo "error: ${CONTRACT}:${lineNo}: unknown platform '$recordPlatform'" >&2; exit 2 ;;
+    esac
+    [[ "$recordPlatform" == "$PLATFORM" ]] && expected+=("$recordPath")
+done < "$CONTRACT"
+
+if [[ ${#expected[@]} -eq 0 ]]; then
+    echo "error: contract lists nothing for platform '$PLATFORM'" >&2
+    exit 2
+fi
+
+missing=()
+for path in "${expected[@]}"; do
+    if [[ "$PLATFORM" == "windows" ]]; then
+        # Basename match, anywhere under the extraction.
+        name="${path##*/}"
+        if ! find "$ROOT" -name "$name" -print -quit | grep -q .; then
+            missing+=("$path")
+        fi
+    elif [[ ! -e "$ROOT/$path" ]]; then
+        missing+=("$path")
+    fi
+done
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "error: ${PLATFORM} package is missing ${#missing[@]} required path(s):" >&2
+    for path in "${missing[@]}"; do
+        echo "  $path" >&2
+    done
+    echo "see packaging/contents.txt" >&2
+    exit 1
+fi
+
+echo "${PLATFORM} package contents OK (${#expected[@]} paths checked)"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -738,6 +738,10 @@ if(UNIX)
     find_program(DUSKSTUDIO_BASH_EXECUTABLE bash)
     find_package(Python3 COMPONENTS Interpreter QUIET)
     if(DUSKSTUDIO_BASH_EXECUTABLE AND Python3_Interpreter_FOUND)
+        add_test(NAME package-contents-checker
+            COMMAND "${DUSKSTUDIO_BASH_EXECUTABLE}"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/package_contents.sh"
+                    "${CMAKE_SOURCE_DIR}")
         add_test(NAME release-mechanics-contract
             COMMAND "${DUSKSTUDIO_BASH_EXECUTABLE}"
                     "${CMAKE_CURRENT_SOURCE_DIR}/release_mechanics.sh"

--- a/tests/package_contents.sh
+++ b/tests/package_contents.sh
@@ -78,6 +78,15 @@ printf 'linux only-one-field\n' > "$WORK/bad.txt"
 DUSKSTUDIO_CONTENTS_CONTRACT="$WORK/bad.txt" "$SCRIPT" linux "$WORK/good" >/dev/null 2>&1 \
     && fail "a malformed contract was accepted"
 
+# An empty path used to pass vacuously: "$ROOT/" always exists.
+printf 'linux\t\n' > "$WORK/emptypath.txt"
+if DUSKSTUDIO_CONTENTS_CONTRACT="$WORK/emptypath.txt" "$SCRIPT" linux "$WORK/good" \
+       >/dev/null 2>"$WORK/err4"; then
+    fail "a record with an empty path was accepted"
+fi
+grep -q "emptypath.txt:1: record has an empty path" "$WORK/err4" \
+    || fail "the empty-path record was not reported with its contract line"
+
 printf 'solaris\tApp\n' > "$WORK/unknown.txt"
 DUSKSTUDIO_CONTENTS_CONTRACT="$WORK/unknown.txt" "$SCRIPT" linux "$WORK/good" >/dev/null 2>&1 \
     && fail "an unknown platform tag was accepted"

--- a/tests/package_contents.sh
+++ b/tests/package_contents.sh
@@ -46,6 +46,33 @@ mkdir -p "$WORK/win/some/nested/dir"
 touch "$WORK/win/some/nested/dir/Binary.exe"
 "$SCRIPT" windows "$WORK/win" >/dev/null || fail "a flattened Windows extraction was rejected"
 
+# The shapes a real `7z x` of our MSI actually produces: a CM_FP_ prefix, the
+# install directory folded into the name with a dot, hyphens rewritten as
+# underscores, and root files carrying no directory token at all.
+REALISTIC="$WORK/realistic.txt"
+cat > "$REALISTIC" <<'REAL_EOF'
+windows	bin/DuskStudio.exe
+windows	bin/dusk-studio-plugin-host.exe
+windows	LICENSE
+windows	LICENSES.txt
+REAL_EOF
+mkdir -p "$WORK/msi"
+touch "$WORK/msi/CM_FP_bin.DuskStudio.exe" \
+      "$WORK/msi/CM_FP_bin.dusk_studio_plugin_host.exe" \
+      "$WORK/msi/CM_FP_LICENSE" \
+      "$WORK/msi/CM_FP_LICENSES.txt"
+DUSKSTUDIO_CONTENTS_CONTRACT="$REALISTIC" "$SCRIPT" windows "$WORK/msi" >/dev/null \
+    || fail "a realistic MSI extraction was rejected"
+
+# LICENSE must not be satisfied by LICENSES.txt: the boundary rule is what
+# stops one required file standing in for another.
+rm "$WORK/msi/CM_FP_LICENSE"
+if DUSKSTUDIO_CONTENTS_CONTRACT="$REALISTIC" "$SCRIPT" windows "$WORK/msi" \
+       >/dev/null 2>"$WORK/err3"; then
+    fail "LICENSES.txt was accepted in place of LICENSE"
+fi
+grep -q "LICENSE$" "$WORK/err3" || fail "the missing LICENSE was not named"
+
 # A contract this cannot read must stop the release, not skip the record.
 printf 'linux only-one-field\n' > "$WORK/bad.txt"
 DUSKSTUDIO_CONTENTS_CONTRACT="$WORK/bad.txt" "$SCRIPT" linux "$WORK/good" >/dev/null 2>&1 \

--- a/tests/package_contents.sh
+++ b/tests/package_contents.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Exercises scripts/verify-package-contents.sh against synthetic trees. A
+# checker that cannot fail is not a check, so every case here proves one way it
+# reports a problem, and the happy path proves it still passes when it should.
+
+set -euo pipefail
+
+REPO_ROOT="${1:?usage: package_contents.sh <repo-root>}"
+SCRIPT="${REPO_ROOT}/scripts/verify-package-contents.sh"
+[[ -x "$SCRIPT" ]] || { echo "not executable: $SCRIPT" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+CONTRACT="$WORK/contract.txt"
+cat > "$CONTRACT" <<'CONTRACT_EOF'
+# comment line
+linux	App/Binary
+linux	LICENSE
+
+macos	Bundle.app
+windows	bin/Binary.exe
+CONTRACT_EOF
+export DUSKSTUDIO_CONTENTS_CONTRACT="$CONTRACT"
+
+mkdir -p "$WORK/good/App"
+touch "$WORK/good/App/Binary" "$WORK/good/LICENSE"
+"$SCRIPT" linux "$WORK/good" >/dev/null || fail "a complete package was rejected"
+
+mkdir -p "$WORK/short/App"
+touch "$WORK/short/App/Binary"
+if "$SCRIPT" linux "$WORK/short" >/dev/null 2>"$WORK/err"; then
+    fail "a package missing LICENSE was accepted"
+fi
+grep -q "LICENSE" "$WORK/err" || fail "the missing path was not named"
+
+# Every gap in one run, not just the first.
+mkdir -p "$WORK/empty"
+"$SCRIPT" linux "$WORK/empty" >/dev/null 2>"$WORK/err2" && fail "an empty package was accepted"
+grep -q "missing 2 required" "$WORK/err2" || fail "did not report both gaps at once"
+
+# Windows matches by name anywhere, because 7z flattens an MSI.
+mkdir -p "$WORK/win/some/nested/dir"
+touch "$WORK/win/some/nested/dir/Binary.exe"
+"$SCRIPT" windows "$WORK/win" >/dev/null || fail "a flattened Windows extraction was rejected"
+
+# A contract this cannot read must stop the release, not skip the record.
+printf 'linux only-one-field\n' > "$WORK/bad.txt"
+DUSKSTUDIO_CONTENTS_CONTRACT="$WORK/bad.txt" "$SCRIPT" linux "$WORK/good" >/dev/null 2>&1 \
+    && fail "a malformed contract was accepted"
+
+printf 'solaris\tApp\n' > "$WORK/unknown.txt"
+DUSKSTUDIO_CONTENTS_CONTRACT="$WORK/unknown.txt" "$SCRIPT" linux "$WORK/good" >/dev/null 2>&1 \
+    && fail "an unknown platform tag was accepted"
+
+# The real contract must parse and cover all three platforms.
+unset DUSKSTUDIO_CONTENTS_CONTRACT
+for platform in linux macos windows; do
+    out="$("$SCRIPT" "$platform" "$WORK/empty" 2>&1 || true)"
+    grep -q "required path" <<< "$out" \
+        || fail "the shipped contract lists nothing for $platform: $out"
+done
+
+echo "package-contents checker OK"


### PR DESCRIPTION
Closes #534.

## The contract

`packaging/contents.txt`: one `<platform><TAB><path>` record per required file, relative to that package's own install root. 11 paths for Linux, 5 each for macOS and Windows. Comments carry the reasoning, including where each install root is and why Windows is different.

Two deliberate absences, both recorded in the file:

- **Project templates.** My own acceptance criteria on #534 asked for template files. There are none: Blank, Band, Beats and Singer-Songwriter ship as code in `src/session/SessionTemplates.h` and reach the user through File -> New. Nothing to verify, so the contract says so rather than leaving a reader to wonder.
- **The built-in plugin suite** has a commented-out slot per platform. #75 uncomments three lines instead of remembering that three packagers each need a new entry, which is exactly the failure mode this issue exists to prevent.

## The checker

`scripts/verify-package-contents.sh <platform> <root>`, read-only, exits non-zero listing **every** missing path so one run reports the whole gap. It fails closed on a contract line it cannot parse or a platform tag it does not know: silently skipping a malformed record would drop whatever that record required, which is the same class of bug as shipping without the file.

Windows matches by file name anywhere under the extraction rather than by path. An MSI is a database and 7z flattens it, so the recorded layout is informational there. Documented in the contract, the script and the guide.

## Wiring

Each of the three packaging jobs runs it after packaging and before staging: Linux untars, macOS mounts the DMG it just built and detaches on exit, Windows extracts the MSI with 7z. Nothing about publication changes and no tag is pushed.

## Verification

- Built a real tarball with `scripts/package-tarball.sh` and checked it: **11 paths OK**.
- Deleted `LICENSES.txt` and the AppStream file from the unpacked tree and re-ran: **exit 1, both named in one run**. The checker is not vacuous.
- `tests/package_contents.sh`, wired in as the `package-contents-checker` ctest case, covers the happy path, a single missing file, two missing files reported together, the Windows name-matching mode, a malformed contract, an unknown platform tag, and that the shipped contract lists something for all three platforms.
- `ctest` 981/981. App builds clean at `-j3`.
- No README test-count change: this adds a ctest shell case, not a Catch2 `TEST_CASE`.

`QUICKSTART.txt` now ships in all three packages as a one-line pointer for #533 to replace, so the contract has a real slot rather than a promise.

MAINTAINER-GUIDE Part 10 gains a paragraph before "Tag assets and acceptance".

## All three legs proven, without spending an Actions run

### Windows, against a real MSI

`gh release download v0.13.2 -R dusk-audio/dusk-studio-releases`, extracted with `7z x`. The names are mangled exactly as feared:

```
CM_FP_bin.DuskStudio.exe
CM_FP_bin.dusk_studio_plugin_host.exe
CM_FP_bin.libgallium_wgl.dll
CM_FP_bin.opengl32.dll
CM_FP_LICENSE
CM_FP_LICENSES.txt
```

WiX prefixes the component, folds the install directory into the name with a dot, and **rewrites hyphens as underscores**. The bare-final-component matching I first wrote found none of them, so the Windows release job would have failed on the next tag. Matching now lowercases, folds `-` to `_`, and requires the expected name at a `.` or `_` boundary so `LICENSE` cannot be satisfied by `LICENSES.txt`.

Against that real extraction:

```
error: windows package is missing 1 required path(s):
  QUICKSTART.txt
```

Correct: the four paths 0.13.2 contains all match through the mangling, and only `QUICKSTART.txt` is missing because that release predates it. Adding a `CM_FP_QUICKSTART.txt` to the extraction gives `windows package contents OK (5 paths checked)`, and removing the mangled plugin host again names `bin/dusk-studio-plugin-host.exe`. The real name shapes and the LICENSE-vs-LICENSES substitution are now cases in `tests/package_contents.sh`.

### macOS, against a real DMG

Built on the build Mac and packaged with `cpack -G DragNDrop`, then mounted and checked exactly as the workflow step does:

```
--- mounted contents ---
DuskStudio.app
LICENSE
LICENSES.txt
QUICKSTART.txt
--- checker ---
macos package contents OK (5 paths checked)
```

That includes the helper inside `DuskStudio.app/Contents/MacOS/`, which the contract records because the bundle carries it rather than it sitting beside the app.

Reproducing the step also caught a second bug in my own workflow code. The DMG carries a licence agreement, so `hdiutil` blocks for an answer and closes stdin, SIGPIPEing the `yes` feeding it; under `pipefail` the pipeline reports 141 and the step fails on a mount that worked. It now reads `PIPESTATUS` for hdiutil, the same pattern the launch check below it already uses. Two bugs found by running the thing rather than reasoning about it.

### Linux

Real tarball from `scripts/package-tarball.sh`: 11 paths OK, and 1 with `LICENSES.txt` plus the AppStream file deleted, both named in a single run.

## Still unexercised

The `release.yml` steps themselves run only on the next tag or a manual dispatch. The checker and its inputs are proven on all three platforms, but the YAML around them is not. Dispatch once before merge if you want that proof; I have not spent it.

Unrelated finding while using the Mac: `cpack` is not on that machine's PATH, only `cmake`, `ctest` and `ninja` are symlinked into `~/bin`. I used the absolute path rather than changing Marc's environment. It does not affect CI, which uses GitHub-hosted runners, but it would matter if #320 ever routes macOS packaging to the Air.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Quickstart guide to packaged releases, alongside the full user manual and license files.
  - Standardized the expected contents of Linux, macOS, and Windows packages.

- **Bug Fixes**
  - Release builds now verify packaged files and platform-specific packaging steps before upload, helping prevent incomplete or inconsistent downloads.

- **Documentation**
  - Added maintainer documentation describing package contents and verification requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
