### PR TITLE
ci(windows): upload the built app and plugin host as a short-lived artifact

### DIFF
--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -144,6 +144,17 @@ jobs:
         shell: bash
         run: cmake --build build-tests --config Release --target DuskStudio dusk-studio-tests -j4
 
+      - name: Upload the built app
+        # Windows has no other route to a runnable build from a branch: the
+        # MSI is tag-driven. Short retention because this is for walking a
+        # branch on a test machine, not for distribution.
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: duskstudio-windows-x64
+          path: build-tests/DuskStudio_artefacts/Release/
+          retention-days: 3
+          if-no-files-found: error
+
       - name: Run tests
         # Full Catch2 suite on MSVC. FileImporter fixtures close their writers
         # before import/readback, while a deterministic unit covers the bounded


### PR DESCRIPTION
The Windows job already builds the `DuskStudio` target, then throws the output away. The MSI is tag-driven, so there is no route to a runnable Windows build from a branch, which is what walking the demo path on the test VM needs.

Uploads `build-tests/DuskStudio_artefacts/Release/` (the app, `dusk-studio-plugin-host.exe`, and the runtime files beside them) as `duskstudio-windows-x64`, 3-day retention, `if-no-files-found: error` so a layout change fails loudly instead of producing an empty download. Pinned to the same upload-artifact SHA `release.yml` uses.

The step sits after the build and before the tests, so a red test still leaves a binary to investigate with.

Nothing else in the workflow changes.