### PR TITLE
fix(session): a never-saved session is not dirty just because it autosaved

### DIFF
--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -3315,8 +3315,23 @@ bool MainComponent::currentSessionDirty()
     // so transient fields don't flip the raw JSON on an otherwise-clean session.
     const auto strippedCurrent = stripVolatileStateForDirtyCompare (SessionSerializer::serialize (session));
     const auto strippedSaved   = stripVolatileStateForDirtyCompare (lastSavedSessionJson);
-    return (! lastSavedSessionJson.isEmpty() && strippedCurrent != strippedSaved)
-         || autosaveIsNewerThan (dir.getChildFile ("session.json"));
+    const bool divergedFromBaseline =
+        ! lastSavedSessionJson.isEmpty() && strippedCurrent != strippedSaved;
+
+    // A session that was never saved has no session.json, only the autosave the
+    // heartbeat wrote from this very state. autosaveIsNewerThan answers "yes"
+    // there because there is nothing for it to be newer than, which on the
+    // bootstrap Untitled session means the first autosave tick makes an
+    // untouched app ask the user to save work they have not done. The baseline
+    // seeded at construction answers the question instead - and if that
+    // baseline is ever missing, the old reading stands rather than reporting an
+    // hour of unsaved work clean.
+    const auto sessionJson = dir.getChildFile ("session.json");
+    if (! sessionJson.existsAsFile())
+        return lastSavedSessionJson.isEmpty() ? autosaveIsNewerThan (sessionJson)
+                                              : divergedFromBaseline;
+
+    return divergedFromBaseline || autosaveIsNewerThan (sessionJson);
 }
 
 void MainComponent::requestQuit()


### PR DESCRIPTION
Closes #549

## Root cause

Reproduced on a clean `HOME` under Xvfb. The bootstrap session directory after 30 seconds of an untouched app:

```
~/Dusk Studio/Untitled/
  audio/
  session.json.autosave
```

No `session.json`. The user has not saved, so there is not one. The autosave heartbeat writes its file into that directory regardless, and `autosaveIsNewerThan` returns true whenever `session.json` is absent, with the comment "autosave is the only state we have". That reading is right for the recovery-offer path at load. It is wrong for the dirty check, where the file it is comparing against was written by us, from the very state being compared.

So from the first autosave tick, an untouched app reads dirty forever, and the first click a new user makes asks them to make a decision about work they have not done.

## Fix

With no `session.json` on disk, the baseline compare (live JSON vs the baseline seeded at construction) is the whole answer. `autosaveIsNewerThan` is untouched, so the recovery path at load still reads a lone autosave as recoverable state.

Genuine edits to a never-saved session still prompt: the baseline is seeded in the constructor, so any divergence is caught.

## Verification

Clean `HOME`, Xvfb, `session.json.autosave` present and no `session.json`, clicking NEW in the startup picker goes straight to "Name your new session". Screenshots before and after the click are in the session scratchpad. Build clean, no new warnings, ctest 981/981, `tools/juce-gate.sh` unchanged at 163 / 8067.

No unit test: the check reads `juce::File` existence and calls into the engine to publish plugin state, so it is not reachable from the session-level test harness. The filesystem repro above is what pins it.

## Not included

#549 also notes that the picker lands on RECENT, which is empty on first run. RECENT is not a tab in the sense the label suggests, it is the only panel the dialog draws, with OPEN and NEW as actions that dismiss it. Changing where the dialog lands is a design decision about the first-run path rather than a bug fix, and #550 is where that path gets its attention.