### PR TITLE
fix(device): select an input device on first launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ GPL source on this repo, so building it yourself costs you nothing but compile t
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 1001 Catch2 test cases across 188 test source files. Linux
+The C++ suite declares 1006 Catch2 test cases across 189 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -123,7 +123,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # Native log storage + CrashHandler signal reports
-tests/         # 1001 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 1006 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -5,6 +5,7 @@
 #include "PdcMath.h"
 #include "PluginStateDiagnostics.h"
 #include "RtPriority.h"
+#include "device/DefaultInputChoice.h"
 #include "hosting/NativeStateIdentity.h"
 #include "../dsp/OutputPairRouting.h"
 #include "McuReceiver.h"
@@ -751,6 +752,41 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
         }
         startupDeviceMessage_ = duskstudio::startupDeviceMessage (
             opened, savedDevice, liveDevice);
+    }
+
+    // First launch only. The default pick, and the cross-backend fallback above
+    // (which clears the input name so a busy device cannot block the reopen),
+    // can both settle on an output with no input selected. Recording then rolls
+    // and captures nothing. An existing configuration is never touched: a user
+    // who chose no input keeps it.
+    if (savedDeviceState.empty())
+    {
+        auto setup = deviceManager.getSetup();
+        if (setup.inputDeviceName.empty())
+        {
+            if (auto* type = deviceManager.getCurrentDeviceType())
+            {
+                const auto chosen = device::chooseDefaultInputDevice (
+                    setup.outputDeviceName, type->getDeviceNames (/*wantInputNames*/ true));
+                if (! chosen.empty())
+                {
+                    setup.inputDeviceName = chosen;
+                    setup.useDefaultInputChannels = true;
+                    deviceManager.setSetup (setup, /*treatAsChosen*/ false);
+                    std::fprintf (stderr,
+                                  "[Dusk Studio/AudioEngine] first launch: selected input "
+                                  "device \"%s\" alongside output \"%s\".\n",
+                                  chosen.c_str(), setup.outputDeviceName.c_str());
+                }
+                else
+                {
+                    std::fprintf (stderr,
+                                  "[Dusk Studio/AudioEngine] first launch: backend offers no "
+                                  "capture devices; recording is unavailable until one is "
+                                  "chosen in Settings.\n");
+                }
+            }
+        }
     }
 
    #if ! defined(__linux__) && ! DUSKSTUDIO_HAS_NATIVE_COREMIDI

--- a/src/engine/device/DefaultInputChoice.h
+++ b/src/engine/device/DefaultInputChoice.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+#include <vector>
+
+namespace duskstudio::device
+{
+// Picks the capture device a first launch should open, given the output device
+// already chosen and the capture devices the backend offers.
+//
+// Preference order:
+//   1. The entry whose name matches the output device's, exactly and then
+//      case-insensitively. Most interfaces expose both directions under one
+//      name, so this keeps a first launch on one piece of hardware rather than
+//      pairing an interface's output with a webcam's microphone.
+//   2. The first capture device the backend lists.
+//
+// Empty when the backend offers no capture devices, which the caller must read
+// as "leave the input unset" rather than "open the empty-named default".
+inline std::string chooseDefaultInputDevice (const std::string& outputDeviceName,
+                                             const std::vector<std::string>& inputDeviceNames)
+{
+    if (inputDeviceNames.empty()) return {};
+
+    if (! outputDeviceName.empty())
+    {
+        for (const auto& name : inputDeviceNames)
+            if (name == outputDeviceName) return name;
+
+        const auto fold = [] (std::string text)
+        {
+            std::transform (text.begin(), text.end(), text.begin(),
+                            [] (unsigned char c) { return (char) std::tolower (c); });
+            return text;
+        };
+        const auto wanted = fold (outputDeviceName);
+        for (const auto& name : inputDeviceNames)
+            if (fold (name) == wanted) return name;
+    }
+
+    return inputDeviceNames.front();
+}
+} // namespace duskstudio::device

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(dusk-studio-tests
     ${CMAKE_SOURCE_DIR}/src/engine/NativePluginCache.cpp
     plugin_scan_protocol.cpp
     plugin_backing_check.cpp
+    default_input_choice.cpp
     session_tick_conversion.cpp
     tempo_map_conversion.cpp
     output_pair_routing.cpp

--- a/tests/default_input_choice.cpp
+++ b/tests/default_input_choice.cpp
@@ -1,0 +1,47 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/device/DefaultInputChoice.h"
+
+using duskstudio::device::chooseDefaultInputDevice;
+
+TEST_CASE ("No capture devices means the input stays unset")
+{
+    CHECK (chooseDefaultInputDevice ("Some Output", {}).empty());
+    CHECK (chooseDefaultInputDevice ("", {}).empty());
+}
+
+// Most interfaces expose both directions under one name, so a first launch
+// should stay on one piece of hardware.
+TEST_CASE ("The capture device matching the output is preferred")
+{
+    const std::vector<std::string> inputs {
+        "HD Pro Webcam C920, USB Audio",
+        "HDA Intel PCH, ALC700 Analog",
+        "UMC1820, USB Audio",
+    };
+
+    CHECK (chooseDefaultInputDevice ("HDA Intel PCH, ALC700 Analog", inputs)
+             == "HDA Intel PCH, ALC700 Analog");
+    CHECK (chooseDefaultInputDevice ("UMC1820, USB Audio", inputs)
+             == "UMC1820, USB Audio");
+}
+
+TEST_CASE ("The match ignores case")
+{
+    const std::vector<std::string> inputs { "Webcam", "Scarlett 2i2 USB" };
+    CHECK (chooseDefaultInputDevice ("scarlett 2i2 usb", inputs) == "Scarlett 2i2 USB");
+}
+
+TEST_CASE ("With no matching name the first capture device is taken")
+{
+    const std::vector<std::string> inputs { "First Input", "Second Input" };
+    CHECK (chooseDefaultInputDevice ("Unrelated Output", inputs) == "First Input");
+    CHECK (chooseDefaultInputDevice ("", inputs) == "First Input");
+}
+
+// An exact match must win even when a case-insensitive one comes earlier.
+TEST_CASE ("An exact match outranks a case-insensitive one")
+{
+    const std::vector<std::string> inputs { "device", "Device" };
+    CHECK (chooseDefaultInputDevice ("Device", inputs) == "Device");
+}


### PR DESCRIPTION
Closes #548. Found walking the demo path (#536); this is why the input was never selected, and #554 is what stops the silence when it is not.

Branched from `origin/main`, not from #554: the selection is independent of the capture-width publish. The two are only related through the bug they jointly produced.

## What was wrong

A fresh install opened an output device and left `Input device: (None)` on a machine with three capture devices available. Both routes to a device can land there: the default pick, and the cross-backend fallback, which does `s.inputDeviceName.clear()` so a busy device cannot block the reopen and never puts one back. In the walk it was the fallback, after PipeWire reported no usable quantum.

## The rule

`chooseDefaultInputDevice(outputDeviceName, inputDeviceNames)` in `src/engine/device/DefaultInputChoice.h`: framework-free, header-only, no device required.

1. The entry matching the chosen output, exactly and then case-insensitively. Most interfaces expose both directions under one name, so this keeps a first launch on one piece of hardware rather than pairing an interface's output with a webcam's microphone.
2. Otherwise the first capture device.
3. Empty when there are none, which the caller reads as "leave it unset" rather than "open the empty-named default".

`AudioEngine` applies it after the device settles, on first launch only, and logs either the choice or the fact that the backend has no capture device.

**An existing configuration is never touched.** The guard is a non-empty saved device blob, so a user who deliberately chose no input keeps it.

## Verified on a real fresh config

Fresh `HOME`, headless:

```
[ALSA] opened "HDA Intel PCH, HDMI 0" ... out=8ch in=0ch (active out=2 in=0)
[ALSA] opened "HDA Intel PCH, HDMI 0" ... out=8ch in=2ch (active out=2 in=2)
[AudioEngine] first launch: selected input device "HDA Intel PCH, ALC700 Analog"
              alongside output "HDA Intel PCH, HDMI 0".
```

The device reopens with inputs. The output here is HDMI and the input analog, so the name match did not apply and the first-capture-device fallback took it, which is the rule working rather than luck.

Then with a saved blob pinning an empty input: **0 first-launch lines**, device stays `in=0`. The user's choice survives.

One honest gap: I could not produce a saved blob by quitting normally, because SIGTERM bypasses the staged shutdown so persistence never runs. That is #507, Worker A's, not this change. I planted the blob by hand instead, which exercises the actual guard condition.

## Coverage

Five Catch2 cases over the rule: no capture devices, exact match preferred, case-insensitive match, first-device fallback with and without an output name, and an exact match outranking a case-insensitive one. The enumeration is mockable in the sense that matters here: the rule takes the list, so the test supplies it and no device or seam mock is needed.

## Verification

`ctest` 985/985. `tools/juce-gate.sh` green, 163 files / 8067 uses, unchanged; the new header is framework-free. `scripts/run-selftest-xvfb.sh` exit 0, 15/15. App clean at `-j3`. README count 1001 -> 1006.

I will re-walk the record step of the demo path with #554 and this together and note the result on #536.
