### PR TITLE
feat(release): smoke-test a published artifact

### DIFF
--- a/docs/MAINTAINER-GUIDE.md
+++ b/docs/MAINTAINER-GUIDE.md
@@ -578,6 +578,35 @@ current tag workflows publish, so nothing a tagged release produces uses it.
 Do not announce the release when the workflow merely turns green; complete the
 acceptance checks below first.
 
+### Smoke-testing a published artifact
+
+The workflow proves the artifact builds. It does not prove it runs anywhere
+else. Download each asset and run it through
+[`scripts/release-smoke-test.sh`](../scripts/release-smoke-test.sh) (Linux and
+macOS) or
+[`scripts/release-smoke-test.ps1`](../scripts/release-smoke-test.ps1)
+(Windows):
+
+```bash
+scripts/release-smoke-test.sh linux dusk-studio-X.Y.Z-Linux-x86_64.tar.xz
+scripts/release-smoke-test.sh macos dusk-studio-X.Y.Z-macOS-arm64.dmg
+pwsh -NoProfile -File scripts/release-smoke-test.ps1 dusk-studio-X.Y.Z-Windows-x64.msi
+```
+
+Each unpacks or mounts the artifact into a scratch directory, checks it against
+`packaging/contents.txt`, requires `--version` to report the version in the
+artifact's own file name, and on Linux and macOS runs the headless self-test
+against the packaged binary under a bounded wait, which also proves the plugin
+scan terminates. One PASS or FAIL line per check, and every check runs even
+after one fails, so a single invocation reports the whole picture.
+
+Nothing is installed and no system location is touched. On Linux the app is
+launched under a private Xvfb display; never run this against a live session.
+
+Windows coverage is narrower: the MSI is extracted rather than installed, since
+installing needs elevation, and the self-test leg is omitted while
+`DUSKSTUDIO_RUN_IPC_SELFTEST` hangs there (#504).
+
 ### Package contents
 
 [`packaging/contents.txt`](../packaging/contents.txt) is the contract for what

--- a/scripts/release-smoke-test.ps1
+++ b/scripts/release-smoke-test.ps1
@@ -58,6 +58,14 @@ if (-not $ExpectedVersion) {
     exit 2
 }
 
+# Without this the extract below raises CommandNotFoundException, StrictMode
+# turns the $LASTEXITCODE read that follows into a terminating error, and every
+# check is skipped on the way to the success message.
+if (-not (Get-Command 7z -ErrorAction SilentlyContinue)) {
+    Write-Error '7z is required to extract the MSI: install 7-Zip and put it on PATH'
+    exit 2
+}
+
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
 $contentsCheck = Join-Path $repoRoot 'scripts/verify-package-contents.sh'
 $work = Join-Path ([System.IO.Path]::GetTempPath()) ("dusk-smoke-" + [guid]::NewGuid().ToString('N'))
@@ -105,6 +113,11 @@ try {
             Write-Fail "--version reported `"$reported`", expected $ExpectedVersion"
         }
     }
+}
+catch {
+    # A terminating error inside the try would otherwise skip every check and
+    # fall through to the all-passed message with exit 0.
+    Write-Fail "aborted: $($_.Exception.Message)"
 }
 finally {
     Remove-Item -LiteralPath $work -Recurse -Force -ErrorAction SilentlyContinue

--- a/scripts/release-smoke-test.ps1
+++ b/scripts/release-smoke-test.ps1
@@ -1,0 +1,119 @@
+<#
+.SYNOPSIS
+    Prove a published Windows artifact runs on a machine that did not build it.
+
+.DESCRIPTION
+    Extracts the MSI with 7z, checks it against packaging/contents.txt, and runs
+    the app's --version. Read-only with respect to the artifact: everything goes
+    into a scratch directory that is removed on exit, and nothing is installed.
+
+    The MSI is extracted rather than installed on purpose: installing needs
+    elevation, and this has to be runnable on a VM without it. That means the
+    extracted layout is flat and mangled, which is why the contents check
+    matches by file name on this platform.
+
+    Coverage is narrower than the Unix script by design. The headless self-test
+    leg is not run here: DUSKSTUDIO_RUN_IPC_SELFTEST hangs on Windows (#504),
+    and until that is fixed a self-test leg would be a hang rather than a check.
+
+.PARAMETER Artifact
+    Path to dusk-studio-X.Y.Z-Windows-x64.msi.
+
+.PARAMETER ExpectedVersion
+    Defaults to the version in the artifact's file name, so a mismatch between
+    the name and what the binary reports is itself a failure.
+
+.EXAMPLE
+    pwsh -NoProfile -File scripts/release-smoke-test.ps1 dusk-studio-0.13.3-Windows-x64.msi
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string] $Artifact,
+    [string] $ExpectedVersion
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Continue'
+
+$script:Failures = 0
+function Write-Pass { param([string] $What) Write-Host "PASS  $What" }
+function Write-Fail {
+    param([string] $What)
+    Write-Host "FAIL  $What"
+    $script:Failures++
+}
+
+if (-not (Test-Path -LiteralPath $Artifact -PathType Leaf)) {
+    Write-Error "no such artifact: $Artifact"
+    exit 2
+}
+
+if (-not $ExpectedVersion) {
+    # dusk-studio-0.13.3-Windows-x64.msi -> 0.13.3
+    $name = [System.IO.Path]::GetFileName($Artifact)
+    if ($name -match '^dusk-studio-([^-]+)-') { $ExpectedVersion = $Matches[1] }
+}
+if (-not $ExpectedVersion) {
+    Write-Error 'could not derive a version from the artifact name'
+    exit 2
+}
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+$contentsCheck = Join-Path $repoRoot 'scripts/verify-package-contents.sh'
+$work = Join-Path ([System.IO.Path]::GetTempPath()) ("dusk-smoke-" + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $work -Force | Out-Null
+
+try {
+    # --- Extract ---
+    $extract = Join-Path $work 'msi'
+    New-Item -ItemType Directory -Path $extract -Force | Out-Null
+    & 7z x -y "-o$extract" $Artifact | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Pass "extract: $([System.IO.Path]::GetFileName($Artifact))"
+    } else {
+        Write-Fail "extract: 7z returned $LASTEXITCODE"
+    }
+
+    # --- Package contents ---
+    # The checker is bash; the Windows runners have it through Git for Windows.
+    $bash = Get-Command bash -ErrorAction SilentlyContinue
+    if ($bash -and (Test-Path -LiteralPath $contentsCheck)) {
+        $out = & bash $contentsCheck windows $extract 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            Write-Pass 'package contents'
+        } else {
+            Write-Fail "package contents: $($out -join ' ')"
+        }
+    } else {
+        Write-Fail 'package contents: bash or verify-package-contents.sh is unavailable'
+    }
+
+    # --- Version ---
+    # 7z flattens the MSI, so the executable is found by name rather than path.
+    $exe = Get-ChildItem -Path $extract -Recurse -File |
+           Where-Object { $_.Name -like '*DuskStudio.exe' } |
+           Select-Object -First 1
+    if ($null -eq $exe) {
+        Write-Fail 'no DuskStudio.exe in the extracted MSI'
+    } else {
+        $reported = (& $exe.FullName --version 2>&1 | Out-String).Trim()
+        if ($LASTEXITCODE -ne 0) {
+            Write-Fail "--version exited $LASTEXITCODE"
+        } elseif ($reported -like "*$ExpectedVersion*") {
+            Write-Pass "--version reports $ExpectedVersion"
+        } else {
+            Write-Fail "--version reported `"$reported`", expected $ExpectedVersion"
+        }
+    }
+}
+finally {
+    Remove-Item -LiteralPath $work -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host ''
+if ($script:Failures -eq 0) {
+    Write-Host "release smoke test: all checks passed (windows, $ExpectedVersion)"
+    exit 0
+}
+Write-Host "release smoke test: $script:Failures check(s) failed (windows, $ExpectedVersion)"
+exit 1

--- a/scripts/release-smoke-test.sh
+++ b/scripts/release-smoke-test.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Prove a published artifact runs on a machine that did not build it.
+#
+#   scripts/release-smoke-test.sh <linux|macos> <artifact> [expected-version]
+#
+#     linux   <dusk-studio-X.Y.Z-Linux-<arch>.tar.xz>
+#     macos   <dusk-studio-X.Y.Z-macOS-arm64.dmg>
+#
+# The expected version defaults to the one in the artifact's file name, so a
+# mismatch between the name and what the binary reports is itself a failure.
+#
+# Read-only with respect to the artifact: everything is unpacked or mounted
+# into a scratch directory that is removed on exit. Nothing is installed for
+# the user, and no system location is touched.
+#
+# On Linux the app is launched under a private Xvfb display with
+# WAYLAND_DISPLAY cleared. Never run this against a live session: the binary
+# takes an audio device and a GL context.
+#
+# Each check prints one PASS or FAIL line. A single FAIL fails the run, and
+# every check still runs, so one invocation reports the whole picture.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONTENTS_CHECK="${REPO_ROOT}/scripts/verify-package-contents.sh"
+
+usage() {
+    echo "usage: $0 <linux|macos> <artifact> [expected-version]" >&2
+    exit 2
+}
+
+[[ $# -ge 2 && $# -le 3 ]] || usage
+PLATFORM="$1"
+ARTIFACT="$2"
+case "$PLATFORM" in linux|macos) ;; *) usage ;; esac
+[[ -f "$ARTIFACT" ]] || { echo "error: no such artifact: $ARTIFACT" >&2; exit 2; }
+
+# dusk-studio-0.13.3-Linux-x86_64.tar.xz -> 0.13.3
+derive_version() {
+    local base
+    base="$(basename "$1")"
+    base="${base#dusk-studio-}"
+    printf '%s' "${base%%-*}"
+}
+EXPECTED_VERSION="${3:-$(derive_version "$ARTIFACT")}"
+[[ -n "$EXPECTED_VERSION" ]] || { echo "error: could not derive a version" >&2; exit 2; }
+
+failures=0
+pass() { printf 'PASS  %s\n' "$1"; }
+fail() { printf 'FAIL  %s\n' "$1"; failures=$((failures + 1)); }
+
+WORK="$(mktemp -d)"
+MOUNT=""
+cleanup() {
+    [[ -n "$MOUNT" ]] && hdiutil detach "$MOUNT" >/dev/null 2>&1
+    [[ -n "${XVFB_PID:-}" ]] && kill "$XVFB_PID" >/dev/null 2>&1
+    rm -rf "$WORK"
+    return 0
+}
+trap cleanup EXIT
+
+# --- Unpack -----------------------------------------------------------------
+ROOT=""
+APP=""
+if [[ "$PLATFORM" == "linux" ]]; then
+    if tar -xf "$ARTIFACT" -C "$WORK" 2>"$WORK/untar.err"; then
+        ROOT="$(find "$WORK" -mindepth 1 -maxdepth 1 -type d -print -quit)"
+        APP="$ROOT/DuskStudio/DuskStudio"
+        pass "unpack: $(basename "$ARTIFACT")"
+    else
+        fail "unpack: $(cat "$WORK/untar.err")"
+    fi
+else
+    MOUNT="$WORK/mnt"
+    mkdir -p "$MOUNT"
+    # The image carries a licence agreement, so hdiutil blocks for an answer and
+    # closes stdin once it has one. Read hdiutil's status, not the pipeline's,
+    # which would come from the SIGPIPEd yes.
+    set +o pipefail
+    yes | hdiutil attach -nobrowse -readonly -noverify -noautoopen \
+                  -mountpoint "$MOUNT" "$ARTIFACT" >/dev/null 2>&1
+    mount_rc=${PIPESTATUS[1]}
+    set -o pipefail
+    if [[ $mount_rc -eq 0 ]]; then
+        ROOT="$MOUNT"
+        APP="$MOUNT/DuskStudio.app/Contents/MacOS/DuskStudio"
+        pass "mount: $(basename "$ARTIFACT")"
+    else
+        MOUNT=""
+        fail "mount: hdiutil returned $mount_rc"
+    fi
+fi
+
+# --- Package contents -------------------------------------------------------
+if [[ -n "$ROOT" ]]; then
+    if [[ -x "$CONTENTS_CHECK" ]]; then
+        if out="$("$CONTENTS_CHECK" "$PLATFORM" "$ROOT" 2>&1)"; then
+            pass "package contents"
+        else
+            fail "package contents: $(printf '%s' "$out" | tr '\n' ' ')"
+        fi
+    else
+        fail "package contents: $CONTENTS_CHECK is missing"
+    fi
+else
+    fail "package contents: nothing was unpacked"
+fi
+
+# --- Launch under a private display where one is needed ---------------------
+run_app() {
+    if [[ "$PLATFORM" == "linux" ]]; then
+        env -u WAYLAND_DISPLAY DISPLAY="$DISPLAY_NUM" "$@"
+    else
+        "$@"
+    fi
+}
+
+if [[ "$PLATFORM" == "linux" && -n "$ROOT" ]]; then
+    if command -v Xvfb >/dev/null 2>&1; then
+        DISPLAY_NUM=":$(( 90 + RANDOM % 8 ))"
+        Xvfb "$DISPLAY_NUM" -screen 0 1280x800x24 >/dev/null 2>&1 &
+        XVFB_PID=$!
+        sleep 3
+    else
+        fail "Xvfb is required to launch the app headlessly"
+        ROOT=""
+    fi
+fi
+
+# --- Version ----------------------------------------------------------------
+if [[ -n "$ROOT" && -x "$APP" ]]; then
+    reported="$(run_app "$APP" --version 2>&1 | tr -d '\r')"
+    version_rc=$?
+    if [[ $version_rc -ne 0 ]]; then
+        fail "--version exited $version_rc"
+    elif [[ "$reported" == *"$EXPECTED_VERSION"* ]]; then
+        pass "--version reports $EXPECTED_VERSION"
+    else
+        fail "--version reported \"$reported\", expected $EXPECTED_VERSION"
+    fi
+elif [[ -n "$ROOT" ]]; then
+    fail "--version: no executable at $APP"
+fi
+
+# --- Headless self-test, bounded ---------------------------------------------
+# Drives the full AudioPipelineSelfTest against the PACKAGED binary, not the
+# build tree, which is the point of this script. The run also covers the plugin
+# scan: a scan that hangs is the failure worth catching, and this is the run it
+# would hang. One invocation, two verdicts.
+#
+# Bounded with a wait loop rather than `timeout`: macOS has no GNU timeout, and
+# a check that cannot run on one of the two platforms is not much of a check.
+wait_bounded() {
+    local pid="$1" limit="$2" waited=0
+    while kill -0 "$pid" 2>/dev/null; do
+        if [[ $waited -ge $limit ]]; then
+            kill -9 "$pid" 2>/dev/null
+            wait "$pid" 2>/dev/null
+            return 124
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+    wait "$pid"
+}
+
+if [[ -n "$ROOT" && -x "$APP" ]]; then
+    selftest_log="$WORK/selftest.log"
+    run_app env DUSKSTUDIO_RUN_SELFTEST=1 "$APP" >"$selftest_log" 2>&1 &
+    app_pid=$!
+    wait_bounded "$app_pid" 180
+    selftest_rc=$?
+
+    if [[ $selftest_rc -eq 124 ]]; then
+        fail "self-test did not terminate within 180s (a hung plugin scan looks like this)"
+        fail "plugin scan terminates"
+    else
+        pass "plugin scan terminates"
+        if [[ $selftest_rc -ne 0 ]]; then
+            fail "self-test exited $selftest_rc (see the log above)"
+        elif grep -q '^\[FAIL\]' "$selftest_log"; then
+            fail "self-test reported: $(grep -m3 '^\[FAIL\]' "$selftest_log" | tr '\n' ' ')"
+        else
+            pass "headless self-test"
+        fi
+    fi
+fi
+
+echo
+if [[ $failures -eq 0 ]]; then
+    echo "release smoke test: all checks passed ($PLATFORM, $EXPECTED_VERSION)"
+    exit 0
+fi
+echo "release smoke test: $failures check(s) failed ($PLATFORM, $EXPECTED_VERSION)" >&2
+exit 1


### PR DESCRIPTION
Closes #532. Stacked on #546, whose `verify-package-contents.sh` is one of the checks; review that first.

Not wired into `release.yml`, per the brief. That is the follow-up once the signing steps exist.

## The checks

`scripts/release-smoke-test.sh <linux|macos> <artifact> [version]` and `scripts/release-smoke-test.ps1`. Each unpacks or mounts into a scratch directory removed on exit; nothing is installed and no system location is touched.

1. **Unpack / mount.**
2. **Package contents**, through #546's checker.
3. **`--version`**, required to match the version in the artifact's own file name, so a mismatch between the name and the binary is itself a failure.
4. **Headless self-test** against the packaged binary rather than the build tree, which is the point of the script.
5. **Plugin scan terminates.**

One PASS or FAIL line per leg. Every leg runs even after one fails, so one invocation reports the whole picture.

## Two things the runs changed

**The scan leg started as a second `timeout`-bounded run and both parts were wrong.** macOS ships no GNU `timeout`, so the leg failed outright on the Mac; and re-running the self-test to prove the scan terminates does the same expensive work twice. It is now one bounded run yielding both verdicts, bounded by a wait loop that works on either platform. A check that cannot run on one of the two platforms is not much of a check.

**Linux launches under a private Xvfb display** with `WAYLAND_DISPLAY` cleared, never a live session.

## Exercised, not assumed

Linux, against a tarball I built:

```
PASS  unpack: dusk-studio-0.13.3-Linux-x86_64.tar.xz
PASS  package contents
PASS  --version reports 0.13.3
PASS  plugin scan terminates
PASS  headless self-test
release smoke test: all checks passed (linux, 0.13.3)
```

macOS, on the build Mac against a DMG built there with no sudo:

```
PASS  mount: dusk-studio-0.13.3-macOS-arm64.dmg
PASS  package contents
PASS  --version reports 0.13.3
PASS  plugin scan terminates
PASS  headless self-test
release smoke test: all checks passed (macos, 0.13.3)
```

**Proven non-vacuous**, twice. A wrong expected version gives `FAIL --version reported "Dusk Studio 0.13.3"` and exit 1, with the other legs still running. A tarball rebuilt without `LICENSES.txt` gives `FAIL package contents: ... missing 1 required path(s): LICENSES.txt`.

## Windows

**Not run.** `pwsh` is not on this box, so the PowerShell script is reviewed but not machine-checked, not even for syntax. Worker A can run it on the VM.

Its coverage is deliberately narrower and the script says so: the MSI is extracted rather than installed, because installing needs elevation and this has to work on a VM without it, and the self-test leg is omitted while `DUSKSTUDIO_RUN_IPC_SELFTEST` hangs on Windows (#504). An omitted leg beats a leg that hangs.

## One gap against the original criteria

The acceptance criteria on #532 also ask for a record-to-bounce leg and for corrupting the bounce output to fail the run. That is not here: it needs GUI driving, and it would take this well past the size guide. The contents and version legs are proven non-vacuous by other means above. Worth either amending the criteria or filing the bounce leg as a follow-up; I did not want to quietly drop it.

## Verification

MAINTAINER-GUIDE Part 10 gains a "Smoke-testing a published artifact" section before the acceptance list, per the brief, with the rest of the document untouched. 344 insertions, no source changes, so nothing to build or gate beyond CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release packages now include a `QUICKSTART.txt` guide, with a link to online instructions and information about the bundled manual.

- **Bug Fixes**
  - Added automated checks to verify that Linux, macOS, and Windows release packages contain all required files before publication.
  - Added smoke tests that validate package contents and reported application versions across supported platforms.

- **Documentation**
  - Expanded release documentation with package contents and published-artifact testing guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->