### PR TITLE
ci(release): sign the Windows MSI and its executables

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -657,15 +657,159 @@ jobs:
           $wixBin                     | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
           Write-Host "WiX ready: $wixBin"
 
-      - name: Package MSI via CPack WIX (unsigned)
+      - name: Decide the Windows signing route
+        # Two credential shapes. A PFX is the simple one and works with any
+        # certificate you hold; Azure Trusted Signing is the CI-friendly one,
+        # because since June 2023 OV and EV certificates are issued on hardware
+        # tokens that a hosted runner cannot reach. Either is enough; neither on
+        # a tag is not.
+        id: winsign
+        shell: bash
+        env:
+          WINDOWS_CERT_PFX_BASE64: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
+          WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          TRUSTED_SIGNING_ENDPOINT: ${{ secrets.TRUSTED_SIGNING_ENDPOINT }}
+          TRUSTED_SIGNING_ACCOUNT: ${{ secrets.TRUSTED_SIGNING_ACCOUNT }}
+          TRUSTED_SIGNING_PROFILE: ${{ secrets.TRUSTED_SIGNING_PROFILE }}
+          IS_TAG: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+        run: |
+          set -euo pipefail
+          route=none
+          if [[ -n "${WINDOWS_CERT_PFX_BASE64:-}" && -n "${WINDOWS_CERT_PASSWORD:-}" ]]; then
+            route=pfx
+          elif [[ -n "${AZURE_TENANT_ID:-}" && -n "${AZURE_CLIENT_ID:-}" \
+               && -n "${AZURE_CLIENT_SECRET:-}" && -n "${TRUSTED_SIGNING_ENDPOINT:-}" \
+               && -n "${TRUSTED_SIGNING_ACCOUNT:-}" && -n "${TRUSTED_SIGNING_PROFILE:-}" ]]; then
+            route=azure
+          fi
+
+          if [[ "$route" == "none" ]]; then
+            if [[ "$IS_TAG" == "true" ]]; then
+              echo "::error::cannot publish a signed Windows build; set either the PFX secrets or the full Azure Trusted Signing set" >&2
+              exit 1
+            fi
+            echo "::notice::Windows signing secrets absent; the MSI stays unsigned (dispatch publishes nothing)"
+          fi
+          echo "route=$route" >> "$GITHUB_OUTPUT"
+
+      - name: Sign the executables (PFX)
+        # Before the MSI is built: signing only the installer would leave the
+        # binaries it lays down unsigned, which is what the user actually runs.
+        if: ${{ steps.winsign.outputs.route == 'pfx' }}
         shell: pwsh
-        # Delegates the cpack run to the cross-platform packaging script.
-        # No signing args: the MSI ships unsigned by design.
+        env:
+          WINDOWS_CERT_PFX_BASE64: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
+          WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $pfx = Join-Path $env:RUNNER_TEMP 'code-signing.pfx'
+          try {
+              [IO.File]::WriteAllBytes($pfx,
+                  [Convert]::FromBase64String($env:WINDOWS_CERT_PFX_BASE64))
+              $targets = Get-ChildItem build -Recurse -File -Include `
+                  'DuskStudio.exe','dusk-studio-plugin-host.exe'
+              if (-not $targets) { throw 'no executables to sign under build' }
+              foreach ($t in $targets) {
+                  # RFC 3161 timestamp: without one every signature expires with
+                  # the certificate and old downloads stop validating.
+                  & signtool sign /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 `
+                      /f $pfx /p $env:WINDOWS_CERT_PASSWORD $t.FullName
+                  if ($LASTEXITCODE -ne 0) { throw "signtool failed for $($t.FullName)" }
+              }
+          }
+          finally {
+              if (Test-Path $pfx) { Remove-Item $pfx -Force }
+          }
+
+      - name: Sign the executables (Azure Trusted Signing)
+        if: ${{ steps.winsign.outputs.route == 'azure' }}
+        uses: azure/trusted-signing-action@v0
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: ${{ secrets.TRUSTED_SIGNING_ENDPOINT }}
+          trusted-signing-account-name: ${{ secrets.TRUSTED_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ secrets.TRUSTED_SIGNING_PROFILE }}
+          files-folder: build
+          files-folder-filter: exe
+          files-folder-recurse: true
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Package MSI via CPack WIX
+        shell: pwsh
+        # Delegates the cpack run to the cross-platform packaging script. The
+        # executables it packages are already signed on a tag.
         run: |
           .\scripts\package-windows.ps1 -BuildDir build
           if ($LASTEXITCODE -ne 0) { throw "package-windows.ps1 failed" }
           Get-ChildItem build\*.msi
           Get-ChildItem *.msi -ErrorAction SilentlyContinue
+
+      - name: Sign the MSI (PFX)
+        if: ${{ steps.winsign.outputs.route == 'pfx' }}
+        shell: pwsh
+        env:
+          WINDOWS_CERT_PFX_BASE64: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
+          WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $pfx = Join-Path $env:RUNNER_TEMP 'code-signing.pfx'
+          try {
+              [IO.File]::WriteAllBytes($pfx,
+                  [Convert]::FromBase64String($env:WINDOWS_CERT_PFX_BASE64))
+              $msi = Get-ChildItem *.msi, build\*.msi -ErrorAction SilentlyContinue |
+                     Select-Object -First 1
+              if (-not $msi) { throw 'no MSI to sign' }
+              & signtool sign /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 `
+                  /f $pfx /p $env:WINDOWS_CERT_PASSWORD $msi.FullName
+              if ($LASTEXITCODE -ne 0) { throw 'signtool failed for the MSI' }
+          }
+          finally {
+              if (Test-Path $pfx) { Remove-Item $pfx -Force }
+          }
+
+      - name: Sign the MSI (Azure Trusted Signing)
+        if: ${{ steps.winsign.outputs.route == 'azure' }}
+        uses: azure/trusted-signing-action@v0
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: ${{ secrets.TRUSTED_SIGNING_ENDPOINT }}
+          trusted-signing-account-name: ${{ secrets.TRUSTED_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ secrets.TRUSTED_SIGNING_PROFILE }}
+          files-folder: ${{ github.workspace }}
+          files-folder-filter: msi
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Verify the Authenticode signatures
+        # The acceptance test: all three files a user ends up with, verified the
+        # way Windows will, including that each carries a countersignature so
+        # the signature outlives the certificate.
+        if: ${{ steps.winsign.outputs.route != 'none' }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $msi = Get-ChildItem *.msi, build\*.msi -ErrorAction SilentlyContinue |
+                 Select-Object -First 1
+          $exes = Get-ChildItem build -Recurse -File -Include `
+              'DuskStudio.exe','dusk-studio-plugin-host.exe'
+          foreach ($f in @($msi) + @($exes)) {
+              $out = & signtool verify /pa /v $f.FullName 2>&1 | Out-String
+              Write-Host $out
+              if ($LASTEXITCODE -ne 0) { throw "signtool verify failed for $($f.FullName)" }
+              if ($out -notmatch 'Timestamp') {
+                  throw "no countersignature timestamp on $($f.FullName)"
+              }
+          }
 
       - name: Verify MSI contents
         # 7z flattens an MSI, so the checker matches file names rather than

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -726,7 +726,7 @@ jobs:
 
       - name: Sign the executables (Azure Trusted Signing)
         if: ${{ steps.winsign.outputs.route == 'azure' }}
-        uses: azure/trusted-signing-action@v0
+        uses: azure/trusted-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -776,7 +776,7 @@ jobs:
 
       - name: Sign the MSI (Azure Trusted Signing)
         if: ${{ steps.winsign.outputs.route == 'azure' }}
-        uses: azure/trusted-signing-action@v0
+        uses: azure/trusted-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -878,9 +878,94 @@ jobs:
           cmake --build build-tests --target dusk-studio-tests -j5
           ctest --test-dir build-tests --output-on-failure
 
-      - name: Package unsigned DMG
-        # CMake already ad-hoc-signed the .app via identity "-"; just wrap
-        # it in a DMG. Not notarized, so users right-click -> Open once.
+      - name: Import the Developer ID certificate
+        # A tag must not ship unsigned: Gatekeeper refuses an unnotarized DMG
+        # and the user is told the app is damaged. A dispatch publishes nothing,
+        # so it keeps the ad-hoc signature CMake already applied and says so.
+        id: signing
+        env:
+          MACOS_CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
+          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+          MACOS_TEAM_ID: ${{ secrets.MACOS_TEAM_ID }}
+          NOTARY_KEY_ID: ${{ secrets.NOTARY_KEY_ID }}
+          NOTARY_ISSUER_ID: ${{ secrets.NOTARY_ISSUER_ID }}
+          NOTARY_KEY_P8_BASE64: ${{ secrets.NOTARY_KEY_P8_BASE64 }}
+          IS_TAG: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in MACOS_CERT_P12_BASE64 MACOS_CERT_PASSWORD MACOS_TEAM_ID \
+                      NOTARY_KEY_ID NOTARY_ISSUER_ID NOTARY_KEY_P8_BASE64; do
+            [[ -n "${!name:-}" ]] || missing+=("$name")
+          done
+          if [[ ${#missing[@]} -gt 0 ]]; then
+            if [[ "$IS_TAG" == "true" ]]; then
+              echo "::error::cannot publish a signed macOS build; missing: ${missing[*]}" >&2
+              exit 1
+            fi
+            echo "::notice::macOS signing secrets absent; keeping the ad-hoc signature (dispatch publishes nothing)"
+            echo "signed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # A keychain of our own, unlocked for this job and deleted after it.
+          # The login keychain is never touched.
+          KEYCHAIN="${RUNNER_TEMP}/dusk-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 3600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+
+          cert="${RUNNER_TEMP}/cert.p12"
+          printf '%s' "$MACOS_CERT_P12_BASE64" | base64 -d > "$cert"
+          security import "$cert" -k "$KEYCHAIN" -P "$MACOS_CERT_PASSWORD" \
+                   -T /usr/bin/codesign -T /usr/bin/security
+          rm -f "$cert"
+          # Without this codesign prompts for the keychain on first use, which
+          # on a runner means hanging until the job times out.
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+                   -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" >/dev/null
+
+          identity="$(security find-identity -v -p codesigning "$KEYCHAIN" \
+                        | awk '/Developer ID Application/ { print $2; exit }')"
+          [[ -n "$identity" ]] || {
+            echo "::error::no Developer ID Application identity in the imported certificate" >&2
+            exit 1; }
+
+          echo "signed=true" >> "$GITHUB_OUTPUT"
+          echo "identity=$identity" >> "$GITHUB_OUTPUT"
+          echo "keychain=$KEYCHAIN" >> "$GITHUB_OUTPUT"
+          echo "::add-mask::$identity"
+          echo "imported a Developer ID Application identity"
+
+      - name: Sign the app bundle
+        if: ${{ steps.signing.outputs.signed == 'true' }}
+        env:
+          IDENTITY: ${{ steps.signing.outputs.identity }}
+          KEYCHAIN: ${{ steps.signing.outputs.keychain }}
+        run: |
+          set -euo pipefail
+          APP="build/DuskStudio_artefacts/Release/DuskStudio.app"
+          [[ -d "$APP" ]] || { echo "::error::no app bundle at $APP" >&2; exit 1; }
+          ENTITLEMENTS="build/DuskStudio_artefacts/JuceLibraryCode/DuskStudio.entitlements"
+
+          # Inside out: the helper carries its own signature, and signing the
+          # bundle afterwards would not cover a nested binary signed later.
+          HELPER="$APP/Contents/MacOS/dusk-studio-plugin-host"
+          if [[ -f "$HELPER" ]]; then
+            codesign --force --timestamp --options runtime \
+                     --keychain "$KEYCHAIN" --sign "$IDENTITY" "$HELPER"
+          fi
+
+          codesign --force --deep --timestamp --options runtime \
+                   ${ENTITLEMENTS:+--entitlements "$ENTITLEMENTS"} \
+                   --keychain "$KEYCHAIN" --sign "$IDENTITY" "$APP"
+          codesign --verify --deep --strict --verbose=2 "$APP"
+
+      - name: Package DMG
+        # CMake ad-hoc-signs the .app via identity "-" for a dispatch run; a tag
+        # has replaced that with a Developer ID signature by now.
         run: |
           set -euo pipefail
           ( cd build && cpack -G DragNDrop -C Release )
@@ -890,7 +975,65 @@ jobs:
           [[ -n "$DMG" ]] || { echo "::error::cpack produced no .dmg" >&2; exit 1; }
           base="$(basename "$DMG" .dmg)"
           mv "$DMG" "./${base}.dmg"
-          echo "Unsigned DMG: ${base}.dmg"
+          echo "DMG: ${base}.dmg"
+
+      - name: Sign, notarize and staple the DMG
+        if: ${{ steps.signing.outputs.signed == 'true' }}
+        env:
+          IDENTITY: ${{ steps.signing.outputs.identity }}
+          KEYCHAIN: ${{ steps.signing.outputs.keychain }}
+          MACOS_TEAM_ID: ${{ secrets.MACOS_TEAM_ID }}
+          NOTARY_KEY_ID: ${{ secrets.NOTARY_KEY_ID }}
+          NOTARY_ISSUER_ID: ${{ secrets.NOTARY_ISSUER_ID }}
+          NOTARY_KEY_P8_BASE64: ${{ secrets.NOTARY_KEY_P8_BASE64 }}
+        run: |
+          set -euo pipefail
+          dmg="$(ls *.dmg | head -1)"
+
+          codesign --force --timestamp --keychain "$KEYCHAIN" \
+                   --sign "$IDENTITY" "$dmg"
+
+          key="${RUNNER_TEMP}/notary.p8"
+          printf '%s' "$NOTARY_KEY_P8_BASE64" | base64 -d > "$key"
+          # --wait rather than polling: the submission is the gate, and a build
+          # that publishes before Apple answers would publish an unstapled DMG.
+          xcrun notarytool submit "$dmg" \
+                --key "$key" --key-id "$NOTARY_KEY_ID" \
+                --issuer "$NOTARY_ISSUER_ID" --team-id "$MACOS_TEAM_ID" \
+                --wait --timeout 45m
+          rm -f "$key"
+
+          # Stapling is what lets a first launch succeed offline; without it
+          # Gatekeeper has to reach Apple and a user with no network is refused.
+          xcrun stapler staple "$dmg"
+          xcrun stapler validate "$dmg"
+
+      - name: Assess the DMG the way Gatekeeper will
+        if: ${{ steps.signing.outputs.signed == 'true' }}
+        run: |
+          set -euo pipefail
+          dmg="$(ls *.dmg | head -1)"
+          mnt="$(mktemp -d)"
+          set +o pipefail
+          yes | hdiutil attach -nobrowse -readonly -noverify -noautoopen \
+                        -mountpoint "$mnt" "$dmg" >/dev/null
+          mount_rc=${PIPESTATUS[1]}
+          set -o pipefail
+          [[ $mount_rc -eq 0 ]] || { echo "::error::could not mount $dmg to assess it" >&2; exit 1; }
+          trap 'hdiutil detach "$mnt" >/dev/null 2>&1 || true' EXIT
+
+          # The acceptance test: what a downloader's machine decides, not what
+          # our own signing thinks it did.
+          assessment="$(spctl --assess --type execute --verbose=4 "$mnt/DuskStudio.app" 2>&1)"
+          printf '%s\n' "$assessment"
+          grep -q 'accepted' <<< "$assessment" || {
+            echo "::error::spctl refused the notarized app" >&2; exit 1; }
+          grep -q 'source=Notarized Developer ID' <<< "$assessment" || {
+            echo "::error::app is accepted but not as a notarized Developer ID build" >&2; exit 1; }
+
+      - name: Remove the signing keychain
+        if: ${{ always() && steps.signing.outputs.keychain != '' }}
+        run: security delete-keychain "${{ steps.signing.outputs.keychain }}" || true
 
       - name: Verify DMG contents
         # Mounts the image the user downloads and checks it against

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -981,7 +981,7 @@ jobs:
           retention-days: 1
 
   publish:
-    name: Assemble + publish six release assets
+    name: Assemble + publish the release assets
     needs: [linux, macos, windows, manual]
     runs-on: ubuntu-22.04
     steps:
@@ -1036,10 +1036,67 @@ jobs:
             fi
             sha256sum --check SHA256SUMS
             [[ $(find . -maxdepth 1 -type f | wc -l) -eq 6 ]] || {
-              echo "::error::release directory must contain exactly six assets" >&2
+              echo "::error::release directory must hold the six payloads before signing" >&2
               exit 1
             }
           )
+
+      - name: Sign SHA256SUMS
+        # A checksum published next to the artifact proves the download is
+        # intact, not that it came from us. The signature is what a user can
+        # check against a key they obtained separately.
+        #
+        # A tag must not publish unsigned: fail before anything reaches the
+        # releases repo. A manual dispatch has no secrets to spend and is not
+        # published either, so it says so and carries on.
+        env:
+          RELEASE_SIGNING_KEY: ${{ secrets.RELEASE_SIGNING_KEY }}
+          RELEASE_SIGNING_KEY_PASSWORD: ${{ secrets.RELEASE_SIGNING_KEY_PASSWORD }}
+          IS_TAG: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${RELEASE_SIGNING_KEY:-}" || -z "${RELEASE_SIGNING_KEY_PASSWORD:-}" ]]; then
+            if [[ "$IS_TAG" == "true" ]]; then
+              echo "::error::RELEASE_SIGNING_KEY and RELEASE_SIGNING_KEY_PASSWORD are required to publish a tag" >&2
+              exit 1
+            fi
+            echo "::notice::signing secrets absent; skipping the signature (dispatch runs publish nothing)"
+            exit 0
+          fi
+
+          # Private to the job: a keyring under the workspace, removed with it,
+          # never the runner's default home.
+          export GNUPGHOME="${RUNNER_TEMP}/release-gnupg"
+          mkdir -p "$GNUPGHOME"
+          chmod 700 "$GNUPGHOME"
+          printf '%s' "$RELEASE_SIGNING_KEY" | base64 -d | \
+            gpg --batch --quiet --import
+          key="$(gpg --batch --with-colons --list-secret-keys \
+                   | awk -F: '$1 == "sec" { print $5; exit }')"
+          [[ -n "$key" ]] || { echo "::error::no secret key after import" >&2; exit 1; }
+
+          printf '%s' "$RELEASE_SIGNING_KEY_PASSWORD" > "$GNUPGHOME/pass"
+          gpg --batch --yes --pinentry-mode loopback \
+              --passphrase-file "$GNUPGHOME/pass" \
+              --local-user "$key" \
+              --armor --detach-sign --output dist/SHA256SUMS.asc dist/SHA256SUMS
+          shred -u "$GNUPGHOME/pass" 2>/dev/null || rm -f "$GNUPGHOME/pass"
+
+          # Verified here rather than trusted: a signature the committed public
+          # key cannot check is worse than none, because it looks like proof.
+          # Until the real key is committed the file is a placeholder, which
+          # warns rather than blocks; once it holds a key this is a hard check.
+          if grep -q 'BEGIN PGP PUBLIC KEY BLOCK' packaging/release-signing.pub; then
+            verify="${RUNNER_TEMP}/verify-gnupg"
+            mkdir -p "$verify"
+            chmod 700 "$verify"
+            GNUPGHOME="$verify" gpg --batch --quiet --import packaging/release-signing.pub
+            GNUPGHOME="$verify" gpg --batch --verify dist/SHA256SUMS.asc dist/SHA256SUMS
+            echo "signed SHA256SUMS with $key and verified against packaging/release-signing.pub"
+          else
+            echo "::warning::packaging/release-signing.pub holds no key yet, so the signature was not verified against it; see MAINTAINER-GUIDE Part 10"
+            echo "signed SHA256SUMS with $key"
+          fi
 
       - name: Publish complete asset set to the PRIVATE releases repo
         if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}

--- a/docs/MAINTAINER-GUIDE.md
+++ b/docs/MAINTAINER-GUIDE.md
@@ -578,6 +578,61 @@ current tag workflows publish, so nothing a tagged release produces uses it.
 Do not announce the release when the workflow merely turns green; complete the
 acceptance checks below first.
 
+### Release signing key
+
+`SHA256SUMS` is signed, and the signature ships as a seventh asset. A checksum
+published next to the artifact proves a download is intact; the signature is
+what a user can check against a key obtained separately.
+
+The key pair is generated once. Do this on a machine you trust, not a runner:
+
+```bash
+gpg --batch --quiet --gen-key <<'EOF'
+%echo generating the Dusk Studio release signing key
+Key-Type: eddsa
+Key-Curve: ed25519
+Key-Usage: sign
+Name-Real: Dusk Audio Release Signing
+Name-Email: releases@duskaudio.com
+Expire-Date: 0
+Passphrase: <a long random passphrase>
+%commit
+EOF
+
+KEY=$(gpg --batch --with-colons --list-secret-keys releases@duskaudio.com \
+        | awk -F: '$1 == "sec" { print $5; exit }')
+gpg --armor --export "$KEY" > packaging/release-signing.pub
+gpg --armor --export-secret-keys "$KEY" | base64 -w0 > release-secret.b64
+```
+
+Commit `packaging/release-signing.pub`, replacing the placeholder text. Until
+that file holds a key the workflow signs but warns that it could not verify the
+signature against a committed key; once it does, a signature the key cannot
+verify fails the release.
+
+Upload the two secrets to the repository, then destroy the exported copy:
+
+```bash
+gh secret set RELEASE_SIGNING_KEY --repo dusk-audio/dusk-studio < release-secret.b64
+gh secret set RELEASE_SIGNING_KEY_PASSWORD --repo dusk-audio/dusk-studio
+shred -u release-secret.b64
+```
+
+Keep an offline backup of the secret key. Losing it means a new key, and every
+user who pinned the old one has to be told.
+
+A `v*` tag fails before publishing anything when either secret is missing, so a
+release cannot go out unsigned. A `workflow_dispatch` run skips signing with a
+notice, since it publishes nothing.
+
+To verify a published release by hand:
+
+```bash
+gpg --import packaging/release-signing.pub
+gpg --verify SHA256SUMS.asc SHA256SUMS
+sha256sum --check SHA256SUMS
+```
+
 ### Smoke-testing a published artifact
 
 The workflow proves the artifact builds. It does not prove it runs anywhere
@@ -625,7 +680,7 @@ there is no file to verify.
 
 ### Tag assets and acceptance
 
-A complete `vX.Y.Z` release has exactly these six assets:
+A complete `vX.Y.Z` release has exactly these seven assets:
 
 - `dusk-studio-X.Y.Z-Linux-x86_64.tar.xz`
 - `dusk-studio-X.Y.Z-Linux-aarch64.tar.xz`
@@ -633,6 +688,7 @@ A complete `vX.Y.Z` release has exactly these six assets:
 - `dusk-studio-X.Y.Z-Windows-x64.msi`
 - `MANUAL.pdf`
 - `SHA256SUMS`
+- `SHA256SUMS.asc`
 
 The publisher downloads all five payloads into one job and refuses to publish
 unless their exact filenames are present. It writes a sorted, lowercase

--- a/docs/MAINTAINER-GUIDE.md
+++ b/docs/MAINTAINER-GUIDE.md
@@ -578,6 +578,63 @@ current tag workflows publish, so nothing a tagged release produces uses it.
 Do not announce the release when the workflow merely turns green; complete the
 acceptance checks below first.
 
+### Windows code signing
+
+An unsigned MSI raises SmartScreen's "Windows protected your PC" on every
+download, and the user has to choose More info and then Run anyway. Most people
+do not.
+
+**The certificate.** Since June 2023 both OV and EV code-signing certificates
+are issued on hardware tokens or through a cloud signing service; a `.pfx` file
+you can hand a hosted runner is no longer something a CA will sell you. That
+leaves two practical routes:
+
+- **Azure Trusted Signing**, roughly 10 USD a month, is the CI-friendly one.
+  Microsoft holds the key and the runner authenticates to it, so there is no
+  token and no secret certificate. This is the recommended route.
+- **A hardware token** with an OV or EV certificate, which a hosted runner
+  cannot reach. It needs a self-hosted Windows runner with the token attached,
+  or signing by hand before upload.
+
+The workflow supports a PFX as well, because an existing certificate, an
+internal CA, or a test certificate is still worth being able to use. It is not
+the route to plan a release around.
+
+**OV against EV.** EV carries SmartScreen reputation immediately. OV starts
+from nothing and accrues reputation as downloads accumulate, so the first users
+of a fresh OV certificate may still see the warning. Azure Trusted Signing
+behaves like OV in this respect.
+
+Uploading the Azure Trusted Signing secrets, after creating the account,
+certificate profile, and an app registration with the Trusted Signing Certificate
+Profile Signer role:
+
+```bash
+gh secret set AZURE_TENANT_ID --repo dusk-audio/dusk-studio
+gh secret set AZURE_CLIENT_ID --repo dusk-audio/dusk-studio
+gh secret set AZURE_CLIENT_SECRET --repo dusk-audio/dusk-studio
+gh secret set TRUSTED_SIGNING_ENDPOINT --repo dusk-audio/dusk-studio   # https://<region>.codesigning.azure.net
+gh secret set TRUSTED_SIGNING_ACCOUNT --repo dusk-audio/dusk-studio
+gh secret set TRUSTED_SIGNING_PROFILE --repo dusk-audio/dusk-studio
+```
+
+Or, for the PFX route:
+
+```bash
+base64 -w0 code-signing.pfx | gh secret set WINDOWS_CERT_PFX_BASE64 --repo dusk-audio/dusk-studio
+gh secret set WINDOWS_CERT_PASSWORD --repo dusk-audio/dusk-studio
+```
+
+The job takes the PFX route when both of those are set, otherwise Azure when
+all six are, and fails a `v*` tag when neither set is complete. A
+`workflow_dispatch` run skips signing with a notice.
+
+Both executables are signed before the MSI is built, then the MSI itself:
+signing only the installer would leave the binaries it lays down unsigned, and
+those are what the user runs. Every signature carries an RFC 3161 timestamp, so
+it outlives the certificate. `signtool verify /pa /v` on all three files, plus a
+check that each carries a countersignature, is the acceptance step.
+
 ### macOS signing and notarization
 
 Gatekeeper refuses an unnotarized DMG, and the user is told the app is damaged

--- a/docs/MAINTAINER-GUIDE.md
+++ b/docs/MAINTAINER-GUIDE.md
@@ -578,6 +578,51 @@ current tag workflows publish, so nothing a tagged release produces uses it.
 Do not announce the release when the workflow merely turns green; complete the
 acceptance checks below first.
 
+### macOS signing and notarization
+
+Gatekeeper refuses an unnotarized DMG, and the user is told the app is damaged
+rather than unsigned, so this is not optional for a release people install.
+
+Procuring the credentials, once:
+
+1. **Apple Developer Program membership**, 99 USD a year, for the Dusk Audio
+   entity. Notarization is not available without it.
+2. **A Developer ID Application certificate.** In Xcode, Settings, Accounts,
+   Manage Certificates, then add a Developer ID Application certificate. Export
+   it from Keychain Access as a `.p12` with a password. Developer ID
+   Application is the right type: Mac App Distribution is for the App Store and
+   Gatekeeper will not accept it for a direct download.
+3. **An App Store Connect API key** for notarization, from App Store Connect,
+   Users and Access, Integrations, keys. Give it the Developer role and
+   download the `.p8` once; it cannot be downloaded again. Note the key ID and
+   the issuer ID shown beside it.
+
+An API key is used rather than an Apple ID and app-specific password because
+the key does not expire when a password changes and carries no second factor.
+
+Uploading the six secrets:
+
+```bash
+base64 -i DeveloperID.p12 | gh secret set MACOS_CERT_P12_BASE64 --repo dusk-audio/dusk-studio
+gh secret set MACOS_CERT_PASSWORD --repo dusk-audio/dusk-studio
+gh secret set MACOS_TEAM_ID --repo dusk-audio/dusk-studio          # the 10-character team ID
+gh secret set NOTARY_KEY_ID --repo dusk-audio/dusk-studio          # the API key ID
+gh secret set NOTARY_ISSUER_ID --repo dusk-audio/dusk-studio       # the issuer UUID
+base64 -i AuthKey_XXXXXXXX.p8 | gh secret set NOTARY_KEY_P8_BASE64 --repo dusk-audio/dusk-studio
+```
+
+Keep the `.p12` and the `.p8` somewhere safe offline. The `.p8` in particular
+cannot be re-downloaded.
+
+What the macOS job then does on a `v*` tag: imports the certificate into a
+keychain of its own, signs the plugin host and then the bundle with
+`--options runtime` and a secure timestamp, packages the DMG, signs that,
+submits it to the notary service and waits, staples the ticket, and requires
+`spctl --assess` to report `accepted` with `source=Notarized Developer ID`
+before anything is published. Any missing secret fails the job before
+publication. A `workflow_dispatch` run keeps the ad-hoc signature and says so,
+since it publishes nothing.
+
 ### Release signing key
 
 `SHA256SUMS` is signed, and the signature ships as a seventh asset. A checksum

--- a/docs/MAINTAINER-GUIDE.md
+++ b/docs/MAINTAINER-GUIDE.md
@@ -578,6 +578,35 @@ current tag workflows publish, so nothing a tagged release produces uses it.
 Do not announce the release when the workflow merely turns green; complete the
 acceptance checks below first.
 
+### Smoke-testing a published artifact
+
+The workflow proves the artifact builds. It does not prove it runs anywhere
+else. Download each asset and run it through
+[`scripts/release-smoke-test.sh`](../scripts/release-smoke-test.sh) (Linux and
+macOS) or
+[`scripts/release-smoke-test.ps1`](../scripts/release-smoke-test.ps1)
+(Windows):
+
+```bash
+scripts/release-smoke-test.sh linux dusk-studio-X.Y.Z-Linux-x86_64.tar.xz
+scripts/release-smoke-test.sh macos dusk-studio-X.Y.Z-macOS-arm64.dmg
+pwsh -NoProfile -File scripts/release-smoke-test.ps1 dusk-studio-X.Y.Z-Windows-x64.msi
+```
+
+Each unpacks or mounts the artifact into a scratch directory, checks it against
+`packaging/contents.txt`, requires `--version` to report the version in the
+artifact's own file name, and on Linux and macOS runs the headless self-test
+against the packaged binary under a bounded wait, which also proves the plugin
+scan terminates. One PASS or FAIL line per check, and every check runs even
+after one fails, so a single invocation reports the whole picture.
+
+Nothing is installed and no system location is touched. On Linux the app is
+launched under a private Xvfb display; never run this against a live session.
+
+Windows coverage is narrower: the MSI is extracted rather than installed, since
+installing needs elevation, and the self-test leg is omitted while
+`DUSKSTUDIO_RUN_IPC_SELFTEST` hangs there (#504).
+
 ### Package contents
 
 [`packaging/contents.txt`](../packaging/contents.txt) is the contract for what

--- a/packaging/release-signing.pub
+++ b/packaging/release-signing.pub
@@ -1,0 +1,19 @@
+Dusk Studio release signing key
+===============================
+
+This file will hold the ASCII-armored OpenPGP public key that signs SHA256SUMS
+for every tagged release. It is a placeholder: no release has been signed yet.
+
+Until the real key is committed here, the release workflow signs SHA256SUMS and
+warns that it could not verify the signature against a committed key. Once this
+file contains the key, that verification becomes a hard check and a signature
+the key cannot verify fails the release.
+
+To verify a download:
+
+    gpg --import packaging/release-signing.pub
+    gpg --verify SHA256SUMS.asc SHA256SUMS
+    sha256sum --check SHA256SUMS
+
+Generating the key pair and uploading the secrets is documented in
+docs/MAINTAINER-GUIDE.md, Part 10, under "Release signing key".

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -383,5 +383,5 @@ echo "     Prove landing:     git merge-base --is-ancestor \"\${RELEASE_COMMIT:?
 echo "     PR squash:         re-record RELEASE_COMMIT as the landed commit, then rerun step 6 (see MAINTAINER-GUIDE Part 10)"
 echo "  7) Tag landed commit: git tag -a v$NEW_VERSION -m \"Dusk Studio $NEW_VERSION\" \"\${RELEASE_COMMIT:?record RELEASE_COMMIT after committing metadata}\""
 echo "  8) Push tag:          git push origin \"refs/tags/v$NEW_VERSION\""
-echo "  9) Wait for CI assets: Dusk Studio release (all 6 assets)"
+echo "  9) Wait for CI assets: Dusk Studio release (all 7 assets)"
 echo " 10) Verify assets:     scripts/verify-release-assets.sh v$NEW_VERSION"

--- a/scripts/release-smoke-test.ps1
+++ b/scripts/release-smoke-test.ps1
@@ -58,6 +58,14 @@ if (-not $ExpectedVersion) {
     exit 2
 }
 
+# Without this the extract below raises CommandNotFoundException, StrictMode
+# turns the $LASTEXITCODE read that follows into a terminating error, and every
+# check is skipped on the way to the success message.
+if (-not (Get-Command 7z -ErrorAction SilentlyContinue)) {
+    Write-Error '7z is required to extract the MSI: install 7-Zip and put it on PATH'
+    exit 2
+}
+
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
 $contentsCheck = Join-Path $repoRoot 'scripts/verify-package-contents.sh'
 $work = Join-Path ([System.IO.Path]::GetTempPath()) ("dusk-smoke-" + [guid]::NewGuid().ToString('N'))
@@ -105,6 +113,11 @@ try {
             Write-Fail "--version reported `"$reported`", expected $ExpectedVersion"
         }
     }
+}
+catch {
+    # A terminating error inside the try would otherwise skip every check and
+    # fall through to the all-passed message with exit 0.
+    Write-Fail "aborted: $($_.Exception.Message)"
 }
 finally {
     Remove-Item -LiteralPath $work -Recurse -Force -ErrorAction SilentlyContinue

--- a/scripts/release-smoke-test.ps1
+++ b/scripts/release-smoke-test.ps1
@@ -1,0 +1,119 @@
+<#
+.SYNOPSIS
+    Prove a published Windows artifact runs on a machine that did not build it.
+
+.DESCRIPTION
+    Extracts the MSI with 7z, checks it against packaging/contents.txt, and runs
+    the app's --version. Read-only with respect to the artifact: everything goes
+    into a scratch directory that is removed on exit, and nothing is installed.
+
+    The MSI is extracted rather than installed on purpose: installing needs
+    elevation, and this has to be runnable on a VM without it. That means the
+    extracted layout is flat and mangled, which is why the contents check
+    matches by file name on this platform.
+
+    Coverage is narrower than the Unix script by design. The headless self-test
+    leg is not run here: DUSKSTUDIO_RUN_IPC_SELFTEST hangs on Windows (#504),
+    and until that is fixed a self-test leg would be a hang rather than a check.
+
+.PARAMETER Artifact
+    Path to dusk-studio-X.Y.Z-Windows-x64.msi.
+
+.PARAMETER ExpectedVersion
+    Defaults to the version in the artifact's file name, so a mismatch between
+    the name and what the binary reports is itself a failure.
+
+.EXAMPLE
+    pwsh -NoProfile -File scripts/release-smoke-test.ps1 dusk-studio-0.13.3-Windows-x64.msi
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string] $Artifact,
+    [string] $ExpectedVersion
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Continue'
+
+$script:Failures = 0
+function Write-Pass { param([string] $What) Write-Host "PASS  $What" }
+function Write-Fail {
+    param([string] $What)
+    Write-Host "FAIL  $What"
+    $script:Failures++
+}
+
+if (-not (Test-Path -LiteralPath $Artifact -PathType Leaf)) {
+    Write-Error "no such artifact: $Artifact"
+    exit 2
+}
+
+if (-not $ExpectedVersion) {
+    # dusk-studio-0.13.3-Windows-x64.msi -> 0.13.3
+    $name = [System.IO.Path]::GetFileName($Artifact)
+    if ($name -match '^dusk-studio-([^-]+)-') { $ExpectedVersion = $Matches[1] }
+}
+if (-not $ExpectedVersion) {
+    Write-Error 'could not derive a version from the artifact name'
+    exit 2
+}
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+$contentsCheck = Join-Path $repoRoot 'scripts/verify-package-contents.sh'
+$work = Join-Path ([System.IO.Path]::GetTempPath()) ("dusk-smoke-" + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $work -Force | Out-Null
+
+try {
+    # --- Extract ---
+    $extract = Join-Path $work 'msi'
+    New-Item -ItemType Directory -Path $extract -Force | Out-Null
+    & 7z x -y "-o$extract" $Artifact | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Pass "extract: $([System.IO.Path]::GetFileName($Artifact))"
+    } else {
+        Write-Fail "extract: 7z returned $LASTEXITCODE"
+    }
+
+    # --- Package contents ---
+    # The checker is bash; the Windows runners have it through Git for Windows.
+    $bash = Get-Command bash -ErrorAction SilentlyContinue
+    if ($bash -and (Test-Path -LiteralPath $contentsCheck)) {
+        $out = & bash $contentsCheck windows $extract 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            Write-Pass 'package contents'
+        } else {
+            Write-Fail "package contents: $($out -join ' ')"
+        }
+    } else {
+        Write-Fail 'package contents: bash or verify-package-contents.sh is unavailable'
+    }
+
+    # --- Version ---
+    # 7z flattens the MSI, so the executable is found by name rather than path.
+    $exe = Get-ChildItem -Path $extract -Recurse -File |
+           Where-Object { $_.Name -like '*DuskStudio.exe' } |
+           Select-Object -First 1
+    if ($null -eq $exe) {
+        Write-Fail 'no DuskStudio.exe in the extracted MSI'
+    } else {
+        $reported = (& $exe.FullName --version 2>&1 | Out-String).Trim()
+        if ($LASTEXITCODE -ne 0) {
+            Write-Fail "--version exited $LASTEXITCODE"
+        } elseif ($reported -like "*$ExpectedVersion*") {
+            Write-Pass "--version reports $ExpectedVersion"
+        } else {
+            Write-Fail "--version reported `"$reported`", expected $ExpectedVersion"
+        }
+    }
+}
+finally {
+    Remove-Item -LiteralPath $work -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host ''
+if ($script:Failures -eq 0) {
+    Write-Host "release smoke test: all checks passed (windows, $ExpectedVersion)"
+    exit 0
+}
+Write-Host "release smoke test: $script:Failures check(s) failed (windows, $ExpectedVersion)"
+exit 1

--- a/scripts/release-smoke-test.sh
+++ b/scripts/release-smoke-test.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Prove a published artifact runs on a machine that did not build it.
+#
+#   scripts/release-smoke-test.sh <linux|macos> <artifact> [expected-version]
+#
+#     linux   <dusk-studio-X.Y.Z-Linux-<arch>.tar.xz>
+#     macos   <dusk-studio-X.Y.Z-macOS-arm64.dmg>
+#
+# The expected version defaults to the one in the artifact's file name, so a
+# mismatch between the name and what the binary reports is itself a failure.
+#
+# Read-only with respect to the artifact: everything is unpacked or mounted
+# into a scratch directory that is removed on exit. Nothing is installed for
+# the user, and no system location is touched.
+#
+# On Linux the app is launched under a private Xvfb display with
+# WAYLAND_DISPLAY cleared. Never run this against a live session: the binary
+# takes an audio device and a GL context.
+#
+# Each check prints one PASS or FAIL line. A single FAIL fails the run, and
+# every check still runs, so one invocation reports the whole picture.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONTENTS_CHECK="${REPO_ROOT}/scripts/verify-package-contents.sh"
+
+usage() {
+    echo "usage: $0 <linux|macos> <artifact> [expected-version]" >&2
+    exit 2
+}
+
+[[ $# -ge 2 && $# -le 3 ]] || usage
+PLATFORM="$1"
+ARTIFACT="$2"
+case "$PLATFORM" in linux|macos) ;; *) usage ;; esac
+[[ -f "$ARTIFACT" ]] || { echo "error: no such artifact: $ARTIFACT" >&2; exit 2; }
+
+# dusk-studio-0.13.3-Linux-x86_64.tar.xz -> 0.13.3
+derive_version() {
+    local base
+    base="$(basename "$1")"
+    base="${base#dusk-studio-}"
+    printf '%s' "${base%%-*}"
+}
+EXPECTED_VERSION="${3:-$(derive_version "$ARTIFACT")}"
+[[ -n "$EXPECTED_VERSION" ]] || { echo "error: could not derive a version" >&2; exit 2; }
+
+failures=0
+pass() { printf 'PASS  %s\n' "$1"; }
+fail() { printf 'FAIL  %s\n' "$1"; failures=$((failures + 1)); }
+
+WORK="$(mktemp -d)"
+MOUNT=""
+cleanup() {
+    [[ -n "$MOUNT" ]] && hdiutil detach "$MOUNT" >/dev/null 2>&1
+    [[ -n "${XVFB_PID:-}" ]] && kill "$XVFB_PID" >/dev/null 2>&1
+    rm -rf "$WORK"
+    return 0
+}
+trap cleanup EXIT
+
+# --- Unpack -----------------------------------------------------------------
+ROOT=""
+APP=""
+if [[ "$PLATFORM" == "linux" ]]; then
+    if tar -xf "$ARTIFACT" -C "$WORK" 2>"$WORK/untar.err"; then
+        ROOT="$(find "$WORK" -mindepth 1 -maxdepth 1 -type d -print -quit)"
+        APP="$ROOT/DuskStudio/DuskStudio"
+        pass "unpack: $(basename "$ARTIFACT")"
+    else
+        fail "unpack: $(cat "$WORK/untar.err")"
+    fi
+else
+    MOUNT="$WORK/mnt"
+    mkdir -p "$MOUNT"
+    # The image carries a licence agreement, so hdiutil blocks for an answer and
+    # closes stdin once it has one. Read hdiutil's status, not the pipeline's,
+    # which would come from the SIGPIPEd yes.
+    set +o pipefail
+    yes | hdiutil attach -nobrowse -readonly -noverify -noautoopen \
+                  -mountpoint "$MOUNT" "$ARTIFACT" >/dev/null 2>&1
+    mount_rc=${PIPESTATUS[1]}
+    set -o pipefail
+    if [[ $mount_rc -eq 0 ]]; then
+        ROOT="$MOUNT"
+        APP="$MOUNT/DuskStudio.app/Contents/MacOS/DuskStudio"
+        pass "mount: $(basename "$ARTIFACT")"
+    else
+        MOUNT=""
+        fail "mount: hdiutil returned $mount_rc"
+    fi
+fi
+
+# --- Package contents -------------------------------------------------------
+if [[ -n "$ROOT" ]]; then
+    if [[ -x "$CONTENTS_CHECK" ]]; then
+        if out="$("$CONTENTS_CHECK" "$PLATFORM" "$ROOT" 2>&1)"; then
+            pass "package contents"
+        else
+            fail "package contents: $(printf '%s' "$out" | tr '\n' ' ')"
+        fi
+    else
+        fail "package contents: $CONTENTS_CHECK is missing"
+    fi
+else
+    fail "package contents: nothing was unpacked"
+fi
+
+# --- Launch under a private display where one is needed ---------------------
+run_app() {
+    if [[ "$PLATFORM" == "linux" ]]; then
+        env -u WAYLAND_DISPLAY DISPLAY="$DISPLAY_NUM" "$@"
+    else
+        "$@"
+    fi
+}
+
+if [[ "$PLATFORM" == "linux" && -n "$ROOT" ]]; then
+    if command -v Xvfb >/dev/null 2>&1; then
+        DISPLAY_NUM=":$(( 90 + RANDOM % 8 ))"
+        Xvfb "$DISPLAY_NUM" -screen 0 1280x800x24 >/dev/null 2>&1 &
+        XVFB_PID=$!
+        sleep 3
+    else
+        fail "Xvfb is required to launch the app headlessly"
+        ROOT=""
+    fi
+fi
+
+# --- Version ----------------------------------------------------------------
+if [[ -n "$ROOT" && -x "$APP" ]]; then
+    reported="$(run_app "$APP" --version 2>&1 | tr -d '\r')"
+    version_rc=$?
+    if [[ $version_rc -ne 0 ]]; then
+        fail "--version exited $version_rc"
+    elif [[ "$reported" == *"$EXPECTED_VERSION"* ]]; then
+        pass "--version reports $EXPECTED_VERSION"
+    else
+        fail "--version reported \"$reported\", expected $EXPECTED_VERSION"
+    fi
+elif [[ -n "$ROOT" ]]; then
+    fail "--version: no executable at $APP"
+fi
+
+# --- Headless self-test, bounded ---------------------------------------------
+# Drives the full AudioPipelineSelfTest against the PACKAGED binary, not the
+# build tree, which is the point of this script. The run also covers the plugin
+# scan: a scan that hangs is the failure worth catching, and this is the run it
+# would hang. One invocation, two verdicts.
+#
+# Bounded with a wait loop rather than `timeout`: macOS has no GNU timeout, and
+# a check that cannot run on one of the two platforms is not much of a check.
+wait_bounded() {
+    local pid="$1" limit="$2" waited=0
+    while kill -0 "$pid" 2>/dev/null; do
+        if [[ $waited -ge $limit ]]; then
+            kill -9 "$pid" 2>/dev/null
+            wait "$pid" 2>/dev/null
+            return 124
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+    wait "$pid"
+}
+
+if [[ -n "$ROOT" && -x "$APP" ]]; then
+    selftest_log="$WORK/selftest.log"
+    run_app env DUSKSTUDIO_RUN_SELFTEST=1 "$APP" >"$selftest_log" 2>&1 &
+    app_pid=$!
+    wait_bounded "$app_pid" 180
+    selftest_rc=$?
+
+    if [[ $selftest_rc -eq 124 ]]; then
+        fail "self-test did not terminate within 180s (a hung plugin scan looks like this)"
+        fail "plugin scan terminates"
+    else
+        pass "plugin scan terminates"
+        if [[ $selftest_rc -ne 0 ]]; then
+            fail "self-test exited $selftest_rc (see the log above)"
+        elif grep -q '^\[FAIL\]' "$selftest_log"; then
+            fail "self-test reported: $(grep -m3 '^\[FAIL\]' "$selftest_log" | tr '\n' ' ')"
+        else
+            pass "headless self-test"
+        fi
+    fi
+fi
+
+echo
+if [[ $failures -eq 0 ]]; then
+    echo "release smoke test: all checks passed ($PLATFORM, $EXPECTED_VERSION)"
+    exit 0
+fi
+echo "release smoke test: $failures check(s) failed ($PLATFORM, $EXPECTED_VERSION)" >&2
+exit 1

--- a/scripts/release-smoke-test.sh
+++ b/scripts/release-smoke-test.sh
@@ -107,6 +107,40 @@ else
     fail "package contents: nothing was unpacked"
 fi
 
+# --- Checksum signature -----------------------------------------------------
+# Only when the artifact was downloaded beside its checksum file: the smoke test
+# takes one artifact, so this is skipped rather than failed when the release's
+# SHA256SUMS and signature are not next to it.
+ART_DIR="$(cd "$(dirname "$ARTIFACT")" && pwd)"
+PUBKEY="${REPO_ROOT}/packaging/release-signing.pub"
+if [[ -f "$ART_DIR/SHA256SUMS" && -f "$ART_DIR/SHA256SUMS.asc" ]]; then
+    if ! grep -q 'BEGIN PGP PUBLIC KEY BLOCK' "$PUBKEY" 2>/dev/null; then
+        echo "SKIP  checksum signature: no release key in packaging/release-signing.pub yet"
+    elif ! command -v gpg >/dev/null 2>&1; then
+        echo "SKIP  checksum signature: gpg is not installed"
+    else
+        keyring="$WORK/gnupg"
+        mkdir -p "$keyring"
+        chmod 700 "$keyring"
+        if GNUPGHOME="$keyring" gpg --batch --quiet --import "$PUBKEY" 2>/dev/null \
+           && GNUPGHOME="$keyring" gpg --batch --verify \
+                "$ART_DIR/SHA256SUMS.asc" "$ART_DIR/SHA256SUMS" >/dev/null 2>&1; then
+            pass "checksum signature"
+        else
+            fail "checksum signature does not verify against packaging/release-signing.pub"
+        fi
+        # The signature covers the checksum file; this is what ties the artifact
+        # in hand to it.
+        if ( cd "$ART_DIR" && sha256sum --ignore-missing --check SHA256SUMS >/dev/null 2>&1 ); then
+            pass "checksum matches the artifact"
+        else
+            fail "the artifact's checksum is not the one SHA256SUMS records"
+        fi
+    fi
+else
+    echo "SKIP  checksum signature: SHA256SUMS and SHA256SUMS.asc are not beside the artifact"
+fi
+
 # --- Launch under a private display where one is needed ---------------------
 run_app() {
     if [[ "$PLATFORM" == "linux" ]]; then

--- a/scripts/verify-release-assets.sh
+++ b/scripts/verify-release-assets.sh
@@ -6,7 +6,7 @@
 #   scripts/verify-release-assets.sh v0.13.0
 #
 # The release workflow fans in five platform payloads, creates one canonical
-# checksum file, and publishes all six assets together. This read-only verifier
+# checksum file, signs it, and publishes all seven assets together. This read-only verifier
 # independently checks that contract plus the populated release-summary slot.
 # It exits nonzero if anything is missing, duplicated, or unexpected.
 
@@ -74,6 +74,7 @@ EXPECTED=(
     "Windows MSI|dusk-studio-${VER}-Windows-x64.msi"
     "User manual|MANUAL.pdf"
     "Checksums|SHA256SUMS"
+    "Checksum signature|SHA256SUMS.asc"
 )
 
 GH_ERROR=$(mktemp "${TMPDIR:-/tmp}/duskstudio-release-verify.XXXXXX")

--- a/tests/release_mechanics.sh
+++ b/tests/release_mechanics.sh
@@ -286,7 +286,8 @@ case " $* " in
                 'dusk-studio-9.9.9-macOS-arm64.dmg' \
                 'dusk-studio-9.9.9-Windows-x64.msi' \
                 'MANUAL.pdf' \
-                'SHA256SUMS'
+                'SHA256SUMS' \
+                'SHA256SUMS.asc'
         fi
         ;;
     *)
@@ -1239,7 +1240,7 @@ assert "--jq '.body // \"\"'" in verifier_text, (
     "verifier must normalize a null release body to empty"
 )
 expected_assets = re.findall(r'^\s+"[^"\n]+\|[^"\n]+"$', verifier_text, re.MULTILINE)
-expected_asset_count = 6
+expected_asset_count = 7   # six payloads plus the SHA256SUMS signature
 assert len(expected_assets) == expected_asset_count, (
     "release verifier asset count changed; update the release contract explicitly"
 )
@@ -1388,7 +1389,8 @@ for required in (
     "release fan-in must contain exactly the five expected payloads",
     "SHA256SUMS must contain exactly five entries",
     "sha256sum --check SHA256SUMS",
-    "release directory must contain exactly six assets",
+    "release directory must hold the six payloads before signing",
+    "dist/SHA256SUMS.asc",
     "if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}",
     notes_marker,
     'gh release upload "$TAG" --repo "$RELEASES_REPO" --clobber dist/*',
@@ -1420,8 +1422,11 @@ assert publish_job[:upload_at].count("--draft") == 2, (
 assert upload_at < verify_at < publish_at, (
     "the release must remain draft until the uploaded six-asset set verifies"
 )
-assert "SHA256SUMS." not in release_workflow, (
-    "per-job checksum fragments must not return"
+# The guard is against per-job checksum fragments (SHA256SUMS.linux and the
+# like) coming back. The detached signature is the one legitimate suffix.
+_suffixes = {m for m in re.findall(r"SHA256SUMS\.(\w+)", release_workflow)}
+assert _suffixes <= {"asc"}, (
+    f"per-job checksum fragments must not return (found: {sorted(_suffixes)})"
 )
 assert "if: ${{ github.ref_type == 'tag' }}" not in publish_job, (
     "a workflow_dispatch targeting a tag must not publish"


### PR DESCRIPTION
Refs #530, not Closes: it closes when a signed MSI is verified end to end.

Stacked on #562, so on the #560 / #557 / #546 lineage. Review in that order.

## Order matters

Both executables are signed **before** the MSI is built, then the MSI itself. Signing only the installer would leave `DuskStudio.exe` and `dusk-studio-plugin-host.exe` unsigned once laid down, and those are what the user actually runs. Every signature carries `/tr http://timestamp.digicert.com /td SHA256`, so it outlives the certificate.

## Two credential shapes, and why

Since June 2023 both OV and EV code-signing certificates are issued on hardware tokens or through a cloud service. A `.pfx` you can hand a hosted runner is no longer something a CA will sell, so a PFX-only design would be scaffolding for a route that cannot be taken.

- **Azure Trusted Signing** is the route to plan around: Microsoft holds the key, the runner authenticates to it, no token and no secret certificate. Selected when all six of its secrets are present.
- **A PFX** is still supported for an existing certificate, an internal CA, or a test certificate, and takes precedence when set.
- **Neither complete on a `v*` tag fails the job** before publication. A dispatch skips with a notice.

Worth knowing for the release notes: EV carries SmartScreen reputation immediately, OV and Trusted Signing accrue it as downloads accumulate, so the first users of a fresh certificate may still see the warning.

## Acceptance

`signtool verify /pa /v` on all three files, plus a check that each carries a countersignature timestamp. A signature with no countersignature verifies today and stops verifying when the certificate expires, which is the failure worth catching early.

## Hygiene

The PFX is written under `RUNNER_TEMP` and removed in a `finally` block, so a signing run that throws leaves no certificate on disk. Same discipline as the keychain deletion in #562.

## What is verified: nothing

There is no Windows machine in reach from here and no credentials to exercise it with. `signtool` ships with the Windows SDK on `windows-2022`, which the job already relies on for the WiX toolset, but I have not run any of this. **The whole path is unverified until credentials exist**, and the first tag after that is the real test. If something is wrong it will be in the credential handling or the `signtool` invocation, since those are the parts I could not run.

That is why this is Refs and not Closes.

## Documentation

MAINTAINER-GUIDE gains a "Windows code signing" section: the token-versus-cloud problem, OV against EV and what each means for SmartScreen, Azure Trusted Signing as the recommended route with the app-registration role it needs, and the `gh secret set` commands for both shapes.

## Verification

YAML parses. `release-mechanics-contract` passes. No source changes.
