### PR TITLE
test(single-instance): serialise concurrent deliveries in the harness

### DIFF
--- a/tests/single_instance_socket_lifecycle.cpp
+++ b/tests/single_instance_socket_lifecycle.cpp
@@ -15,6 +15,7 @@
 #include <iterator>
 #include <string>
 #include <system_error>
+#include <mutex>
 #include <thread>
 #include <vector>
 
@@ -114,8 +115,13 @@ private:
 
 struct Deliveries
 {
+    // accept runs on whichever thread delivered the handoff, and the test that
+    // starts eight launches at once gets several at a time. The atomic below
+    // publishes the contents to a waiter but does not serialise two push_backs
+    // against each other, nor one against this object going out of scope.
     void accept (std::string payload)
     {
+        const std::lock_guard<std::mutex> lock (mutex);
         payloads.push_back (std::move (payload));
         published.store (payloads.size(), std::memory_order_release);
     }
@@ -129,8 +135,15 @@ struct Deliveries
         return published.load (std::memory_order_acquire) >= count;
     }
 
-    const std::vector<std::string>& copy() const noexcept { return payloads; }
+    // By value, under the lock: handing back a reference let a caller read the
+    // vector while a delivery was still appending to it.
+    std::vector<std::string> copy() const
+    {
+        const std::lock_guard<std::mutex> lock (mutex);
+        return payloads;
+    }
 
+    mutable std::mutex mutex;
     std::vector<std::string> payloads;
     std::atomic<std::size_t> published { 0 };
 };


### PR DESCRIPTION
Closes #565. Harness only, nothing in `src/`.

## The race

`Deliveries::accept` appended from whichever thread delivered a handoff:

```cpp
payloads.push_back (std::move (payload));
published.store (payloads.size(), std::memory_order_release);
```

The atomic publishes the vector's contents to a waiter. It does not serialise two `accept` calls against each other, nor one against the object going out of scope, and the test that starts eight launches at once is built to produce concurrent delivery. TSan caught it in `~vector()`.

A mutex around the vector, held in `accept` and `copy`. `copy` now returns by value as its name always implied: handing back a `const&` let a caller read the vector while a delivery was still appending to it, which is the same hole from the other side.

Pre-existing on `main`; it surfaced on #557 only because that branch happened to be running when the scheduler cooperated.

## What this does not fix

Running the affected test in a loop, **one run in 42 failed for a different and more interesting reason**:

```
REQUIRE( std::count (primary.begin(), primary.end(), 1) == 1 )
with expansion:  3 == 1
```

Three of eight simultaneous launches each decided to run. That is not the vector race and this PR does not address it. It reproduced once and then passed 37 consecutive runs, so it is rare rather than systematic.

It may not even be a defect: `acquire()` returns true for "run unattached" as well as "you are the primary", so several launches legitimately returning true under contention is within what the function promises, and the test asserts a stronger invariant than that. Or the handoff really is failing under load. I have not established which, and I would rather say so than guess.

Flagging it here rather than filing blind, because it bears directly on **#541**, which changes exactly this path: a launch that cannot confirm delivery now runs unattached instead of quitting, which is a case that returns true. If #541 lands and this test flakes, it will look like #541 caused it. It did not; this predates it.

## Verification

`[single-instance]` tag: 13 cases, 141 assertions, passing. 42 runs of the affected case with one unrelated failure as described. TSan is exercised by CI rather than locally: a sanitizer configure is a full rebuild of the test target, which is not a quick check on this box.
