### PR TITLE
fix(ui): give the canvas keyboard focus when no startup picker opens

### DIFF
--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -1011,28 +1011,33 @@ MainComponent::MainComponent()
     // benchmarking the load path (the [Dusk Studio/Load] timing line ends
     // up in the parent terminal) and for scripted reproductions of
     // user-reported regressions.
-    if (const char* loadPath = std::getenv ("DUSKSTUDIO_LOAD_SESSION");
-        loadPath != nullptr && *loadPath)
+    // startupDialogPending was already set before setSize() above (so the
+    // scan-kicking resized() saw the gate); the routing here just decides what
+    // the first tick does. Capture mode suppresses the picker too - its modal
+    // would overlay the snapshots (mirrors the CAPTURE_DIR guard in the scan
+    // path).
+    //
+    // The last branch is not a no-op: only the picker's dismissal hands
+    // keyboard focus to the canvas, so a route that shows no picker leaves the
+    // window with nothing focused, and every shortcut in the manual is dead
+    // until the user happens to click the canvas.
     {
+        const char* loadPath = std::getenv ("DUSKSTUDIO_LOAD_SESSION");
+        const bool loadsSession = loadPath != nullptr && *loadPath;
+        juce::String pathStr (loadsSession ? loadPath : "");
+        const bool wantsPicker = ! loadsSession
+                              && std::getenv ("DUSKSTUDIO_SKIP_STARTUP_DIALOG") == nullptr
+                              && std::getenv ("DUSKSTUDIO_CAPTURE_DIR") == nullptr;
+
         juce::Component::SafePointer<MainComponent> safeThis (this);
-        juce::String pathStr (loadPath);
-        dusk::callAsync ([safeThis, pathStr]
+        dusk::callAsync ([safeThis, pathStr, loadsSession, wantsPicker]
         {
-            if (safeThis != nullptr)
-                safeThis->loadSessionFromJson (juce::File (pathStr));
-        });
-    }
-    else if (std::getenv ("DUSKSTUDIO_SKIP_STARTUP_DIALOG") == nullptr
-             && std::getenv ("DUSKSTUDIO_CAPTURE_DIR") == nullptr)
-    {
-        // startupDialogPending was already set before setSize() above (so the
-        // scan-kicking resized() saw the gate); just queue the dialog here.
-        // Capture mode suppresses the picker too - its modal would overlay
-        // the snapshots (mirrors the CAPTURE_DIR guard in the scan path).
-        juce::Component::SafePointer<MainComponent> safeThis (this);
-        dusk::callAsync ([safeThis]
-        {
-            if (safeThis != nullptr) safeThis->launchStartupDialog();
+            auto* const self = safeThis.getComponent();
+            if (self == nullptr) return;
+
+            if (loadsSession)      self->loadSessionFromJson (juce::File (pathStr));
+            else if (wantsPicker)  self->launchStartupDialog();
+            else                   self->focusMainCanvas();
         });
     }
 
@@ -2579,6 +2584,7 @@ void MainComponent::launchStartupDialog()
     // Skipping by environment variable never raises the gate at all, which is why
     // only this path needs the call.
     startupDialogPending = false;
+    focusMainCanvas();
     maybeStartStartupPluginScan();
    #else
     if (openStartupPanel (false))
@@ -2587,9 +2593,37 @@ void MainComponent::launchStartupDialog()
     // A display that cannot carry the panel must not leave the app looking wedged
     // behind a dim overlay, so the launch continues as if the dialog was skipped.
     startupDialogPending = false;
+    focusMainCanvas();
     setStatusText ("Startup dialog unavailable on this display; opened the default session");
     maybeStartStartupPluginScan();
    #endif
+}
+
+// The canvas is what MainComponent::keyPressed hangs off, so without this the
+// window has nothing focused and JUCE delivers key events to the peer's
+// component instead, which is this one's parent and never routes back down.
+void MainComponent::focusMainCanvas()
+{
+    // The startup routing runs on the first message-loop tick, before the
+    // window is on screen, and a component that is not showing cannot take
+    // focus. Latch the request; parentHierarchyChanged takes it once it can.
+    canvasFocusPending = true;
+    takePendingCanvasFocus();
+}
+
+void MainComponent::takePendingCanvasFocus()
+{
+    if (! canvasFocusPending || ! isShowing())
+        return;
+    canvasFocusPending = false;
+    grabKeyboardFocus();
+}
+
+// Showing the window walks this down every descendant, and it is the first
+// moment the canvas is allowed to hold focus.
+void MainComponent::parentHierarchyChanged()
+{
+    takePendingCanvasFocus();
 }
 
 void MainComponent::openStartupForCapture (const std::string& capturePath)

--- a/src/ui/MainComponent.h
+++ b/src/ui/MainComponent.h
@@ -35,6 +35,7 @@ public:
     void paint (juce::Graphics&) override;
     void resized() override;
     bool keyPressed (const juce::KeyPress&) override;
+    void parentHierarchyChanged() override;
 
     // Capture tail for the views that render into a framework child, which the
     // snapshot path cannot reach. Runs from the live message loop and quits when
@@ -144,6 +145,11 @@ private:
     // reading a session that is missing the take still being recorded.
     void guardSessionSwitchThen (const char* title, const char* message,
                                    std::function<void()> proceed);
+    // Give the canvas keyboard focus. Every route that opens without the
+    // startup picker has to call this; the picker's dismissal does it itself.
+    void focusMainCanvas();
+    void takePendingCanvasFocus();
+    bool canvasFocusPending = false;
     void newSessionPrompt();
     // The folder-pick + create half of newSessionPrompt - runs only once any
     // unsaved-changes prompt has been resolved.


### PR DESCRIPTION
Refs #558. It does **not** close it; see the correction at the end.

## Cause

`MainComponent::keyPressed` is where every shortcut in the manual lives, and JUCE only calls it when the canvas holds keyboard focus. Exactly one place granted that focus, on the startup picker's dismissal, and its comment says why:

```cpp
// main canvas so transport / edit shortcuts work without a stray click
// first (StartupDialog isn't an EmbeddedModal, so there's no
// focusRestoreTarget hand-back to lean on).
if (! safeThis->startupQuitRequested && safeThis->isShowing())
    safeThis->grabKeyboardFocus();
```

Every route that shows no picker skipped it: `DUSKSTUDIO_LOAD_SESSION`, `DUSKSTUDIO_SKIP_STARTUP_DIALOG`, `DUSKSTUDIO_CAPTURE_DIR`, and the one that matters to users, a display that cannot carry the panel. On that last one the app prints `Startup dialog unavailable on this display; opened the default session` and carries on with nothing focused, so JUCE hands key events to the peer's component, which is the window rather than the canvas, and they never route back down.

That is the shape of the Windows report in #558, and it is a real gap on its own account: any of those routes leaves a user with no working shortcut until they click the canvas.

## Evidence

I instrumented `keyPressed` on a scratch build and ran both routes under Xvfb.

Picker shown and dismissed: `b`, `t`, `ctrl+s`, `space` and `ctrl+q` all arrive, `ctrl+s` opens Save As, `space` rolls the transport, `t` toggles the timeline.

`DUSKSTUDIO_SKIP_STARTUP_DIALOG=1`, the same no-picker path Windows takes: **zero** key events reach `keyPressed`.

With this change on that path, the latched grab now runs and succeeds:

```
[FP] pending=1 showing=0     <- startup routing, too early to focus
[FP] pending=1 showing=1     <- parentHierarchyChanged, window on screen
[FP] grabbed self=1
```

Before it, `showing` was never true again at any point the code looked, because `resized()` does not fire a second time once the window is up.

## The fix

Latch the request in `focusMainCanvas()` and take it in `parentHierarchyChanged()`, which is what JUCE walks down every descendant when the window becomes visible. The startup routing in the constructor also collapses into one queued lambda with three outcomes rather than two branches and a silent third, which is what let the gap hide.

No new JUCE: the gate goes from 8067 to 8066 uses, and `MainComponent.cpp` sits one under its recorded ceiling.

## This is not the Windows fix

Retested on the installed MSI build on the VM, which draws the picker normally. With the picker shown and dismissed, `Space` does nothing and `T` leaves the screen pixel-identical, while the Windows key opens the Start menu on the same injection path. So Windows ignores keys even when the canvas has been given focus, and #558 stays open with that evidence recorded. What this PR fixes is the no-picker routes, which are reachable on every platform.

## What is not verified, and why

The user-visible half is not confirmed end to end. This box has no window manager, so on a WM-less Xvfb the JUCE window never receives X input focus on the no-picker route, and key events do not reach the process at all even with `xdotool windowfocus`. The picker route works there only because the panel is a separate native window that takes X focus and hands it back. So Linux can show that the focus grant now happens where it never did, and cannot show the keystroke arriving.

That check belongs on the VM, and needs a Windows build of this branch, which needs #552 (the artifact upload) merged first. I will run it and report on this PR as soon as that lands.

## Separately

`Ctrl+Q` reaches `keyPressed` and dispatches Quit correctly, and the app still does not exit. It behaves the same from **File > Quit**, so it is a quit defect rather than a shortcut one and is not touched here. I will file it separately rather than fold it in.
