### PR TITLE
feat(ui): open the shipped quickstart from the Settings menu

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -530,6 +530,8 @@ Only one stage is visible at a time, but the same engine drives all four. Switch
 - **MASTERING** swaps the console view for the mastering chain, including a file picker for loading a finished mix.
 - **AUX** swaps the console view for the four aux return lanes, with a full-width view of each lane's plugin chain.
 
+**Settings → Quickstart** opens the one-page quickstart that ships with the app, in whatever your system uses for text; it is greyed out and says so when that file is not installed.
+
 Press **Cmd/Ctrl+1 / 2 / 3 / 4** to jump straight to RECORDING / MIXING / MASTERING / AUX. The bank selector has the plain number keys **1 through 8**, so a modified digit changes stage and a plain digit changes the visible page of strips. Hovering any tab or bank button shows its shortcut, and **?** opens a full keyboard-shortcut list (also under **Settings → Keyboard Shortcuts**).
 
 Switching into or out of MASTERING force-stops the transport. The mix engine and the mastering engine cannot run at the same time. Changing stage also closes the notepad, saving it — the two cannot share the window.

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -5346,8 +5346,17 @@ void MainComponent::menuItemSelected (int menuItemID, int /*topLevelMenuIndex*/)
         case kMenuSettingsQuickstart:
         {
             const auto quickstart = locateQuickstartDocument();
-            if (! quickstart.empty())
-                duskstudio::platform::openPathInDefaultApp (quickstart);
+            if (quickstart.empty()) break;
+
+            if (! duskstudio::platform::openPathInDefaultApp (quickstart))
+            {
+                // Nothing was launched, so say where the file is rather than
+                // leaving a menu click that silently did nothing.
+                const auto message = "Dusk Studio could not hand this file to a "
+                                     "default application: " + quickstart.string()
+                                   + ". Open it from there by hand.";
+                showDuskAlert (*this, "Could not open the quickstart", message.c_str());
+            }
             break;
         }
         case kMenuSettingsAbout:

--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -60,6 +60,7 @@
 #include "../foundation/PlanarBuffer.h"
 #include "../foundation/Text.h"
 #include <algorithm>
+#include <filesystem>
 
 namespace duskstudio
 {
@@ -5068,7 +5069,35 @@ enum MenuItemId
     kMenuSettingsAbout = 2002,
     kMenuSettingsShortcuts = 2003,
     kMenuSettingsSupporters = 2004,
+    kMenuSettingsQuickstart = 2005,
 };
+
+// The quickstart document as the packagers place it: at the install root, one
+// level above the executable on Linux and Windows, and three above it inside a
+// macOS bundle, which is also where the repo's own copy sits relative to a
+// build run out of the tree. packaging/contents.txt names it .md on all three
+// platforms; .txt is accepted so a packager renaming it does not silently turn
+// the menu entry off.
+std::filesystem::path locateQuickstartDocument()
+{
+    const auto exeDir = duskstudio::platform::executableDirectory();
+    if (exeDir.empty()) return {};
+
+    const std::filesystem::path roots[] = {
+        exeDir.parent_path(),
+        exeDir,
+        exeDir.parent_path() / "Resources",
+        exeDir.parent_path().parent_path().parent_path(),
+    };
+
+    std::error_code ec;
+    for (const auto& root : roots)
+        for (const char* name : { "QUICKSTART.md", "QUICKSTART.txt" })
+            if (std::filesystem::is_regular_file (root / name, ec))
+                return root / name;
+
+    return {};
+}
 }
 
 juce::StringArray MainComponent::getMenuBarNames()
@@ -5185,6 +5214,13 @@ juce::PopupMenu MainComponent::getMenuForIndex (int topLevelMenuIndex,
     {
         menu.addItem (kMenuSettingsAudio, "Settings...");
         menu.addItem (kMenuSettingsShortcuts, "Keyboard Shortcuts  (?)");
+        // Disabled rather than hidden when the document is not installed, and
+        // it says why in the label: a menu item has nowhere to put a tooltip,
+        // and an alert for a missing help file is worse than the gap.
+        const bool quickstartInstalled = ! locateQuickstartDocument().empty();
+        menu.addItem (kMenuSettingsQuickstart,
+                      quickstartInstalled ? "Quickstart" : "Quickstart  (not installed)",
+                      quickstartInstalled);
         menu.addSeparator();
        #if DUSKSTUDIO_HAS_PATREON_CREDITS
         menu.addItem (kMenuSettingsSupporters, "Supporters");
@@ -5307,6 +5343,13 @@ void MainComponent::menuItemSelected (int menuItemID, int /*topLevelMenuIndex*/)
             break;
         }
        #endif
+        case kMenuSettingsQuickstart:
+        {
+            const auto quickstart = locateQuickstartDocument();
+            if (! quickstart.empty())
+                duskstudio::platform::openPathInDefaultApp (quickstart);
+            break;
+        }
         case kMenuSettingsAbout:
         {
             // Pull the version string from the JUCE_APPLICATION_VERSION_STRING

--- a/src/ui/PlatformWindowing.h
+++ b/src/ui/PlatformWindowing.h
@@ -2,6 +2,7 @@
 
 #include <juce_gui_basics/juce_gui_basics.h>
 
+#include <filesystem>
 #include <functional>
 
 // Forward-decl in the juce namespace so createInProcessEditorHost's
@@ -18,6 +19,16 @@ class AudioProcessorEditor;
 
 namespace duskstudio::platform
 {
+// The directory the running executable sits in. Package layouts arrange the
+// user-facing documents around it, so a caller resolves those from here rather
+// than from the working directory, which is wherever the launcher happened to
+// be. Empty if the platform would not say.
+std::filesystem::path executableDirectory();
+
+// Hand a path to the desktop's default handler for its type. False when
+// nothing could be launched; the caller decides what to say about it.
+bool openPathInDefaultApp (const std::filesystem::path& path);
+
 // Cross-platform window-management primitives. Per-platform
 // implementations live in PlatformWindowing_{Linux,Mac,Windows}.{cpp,mm}.
 // Callsites stay platform-agnostic; only this header is included.

--- a/src/ui/PlatformWindowing_Linux.cpp
+++ b/src/ui/PlatformWindowing_Linux.cpp
@@ -10,13 +10,46 @@
 
 #include <X11/Xproto.h>
 
+#include <sys/wait.h>
+#include <unistd.h>
+
 #include <atomic>
 #include <cstdio>
 #include <cstdlib>
 #include <mutex>
+#include <system_error>
 
 namespace duskstudio::platform
 {
+std::filesystem::path executableDirectory()
+{
+    std::error_code ec;
+    const auto exe = std::filesystem::read_symlink ("/proc/self/exe", ec);
+    if (ec) return {};
+    return exe.parent_path();
+}
+
+bool openPathInDefaultApp (const std::filesystem::path& path)
+{
+    // Double fork so the viewer is reparented to init: the app never waits on
+    // it, and a single fork would leave a zombie for the life of the session.
+    const auto outer = ::fork();
+    if (outer < 0) return false;
+
+    if (outer == 0)
+    {
+        if (::fork() == 0)
+        {
+            ::setsid();
+            ::execlp ("xdg-open", "xdg-open", path.c_str(), (char*) nullptr);
+        }
+        ::_exit (0);
+    }
+
+    int status = 0;
+    return ::waitpid (outer, &status, 0) == outer;
+}
+
 #if DUSKSTUDIO_JUCE_HAS_WAYLAND
 using juce::WaylandSymbols;
 using juce::WaylandWindowSystem;

--- a/src/ui/PlatformWindowing_Linux.cpp
+++ b/src/ui/PlatformWindowing_Linux.cpp
@@ -10,8 +10,11 @@
 
 #include <X11/Xproto.h>
 
+#include <fcntl.h>
 #include <sys/wait.h>
 #include <unistd.h>
+
+#include <cerrno>
 
 #include <atomic>
 #include <cstdio>
@@ -31,23 +34,62 @@ std::filesystem::path executableDirectory()
 
 bool openPathInDefaultApp (const std::filesystem::path& path)
 {
+    // The grandchild has no other way to report a failed exec, and the caller
+    // needs to tell "no handler" from "launched". CLOEXEC closes this pipe when
+    // the exec takes, so an empty read is success and any bytes are the errno
+    // that stopped it.
+    int fds[2] {};
+    if (::pipe2 (fds, O_CLOEXEC) != 0)
+        return false;
+
     // Double fork so the viewer is reparented to init: the app never waits on
     // it, and a single fork would leave a zombie for the life of the session.
-    const auto outer = ::fork();
-    if (outer < 0) return false;
-
-    if (outer == 0)
+    const auto middle = ::fork();
+    if (middle < 0)
     {
-        if (::fork() == 0)
+        ::close (fds[0]);
+        ::close (fds[1]);
+        return false;
+    }
+
+    if (middle == 0)
+    {
+        // Async-signal-safe calls only from here to the exec.
+        ::close (fds[0]);
+        const auto grandchild = ::fork();
+
+        if (grandchild == 0)
         {
             ::setsid();
             ::execlp ("xdg-open", "xdg-open", path.c_str(), (char*) nullptr);
+            const int failure = errno;
+            (void) ::write (fds[1], &failure, sizeof (failure));
+            ::_exit (127);
         }
+
+        if (grandchild < 0)
+        {
+            const int failure = errno;
+            (void) ::write (fds[1], &failure, sizeof (failure));
+        }
+
+        ::close (fds[1]);
         ::_exit (0);
     }
 
+    // The grandchild owns the only remaining write end once this closes, so the
+    // read below cannot block on our own copy.
+    ::close (fds[1]);
+
     int status = 0;
-    return ::waitpid (outer, &status, 0) == outer;
+    while (::waitpid (middle, &status, 0) < 0 && errno == EINTR)
+        continue;
+
+    int failure = 0;
+    const auto reported = ::read (fds[0], &failure, sizeof (failure));
+    ::close (fds[0]);
+
+    return reported == 0;
 }
 
 #if DUSKSTUDIO_JUCE_HAS_WAYLAND

--- a/src/ui/PlatformWindowing_Mac.mm
+++ b/src/ui/PlatformWindowing_Mac.mm
@@ -2,6 +2,10 @@
 #include <juce_audio_processors/juce_audio_processors.h>
 #import <AppKit/AppKit.h>   // NSCursor (hide/unhide) - not pulled in transitively
 
+#include <mach-o/dyld.h>
+
+#include <string>
+
 // Native counterparts to the Linux windowing operations. A peer's native
 // handle is its NSView; the containing NSWindow owns activation and ordering.
 // The remaining operations are intentionally small platform hooks:
@@ -11,6 +15,25 @@
 
 namespace duskstudio::platform
 {
+std::filesystem::path executableDirectory()
+{
+    std::uint32_t size = 0;
+    _NSGetExecutablePath (nullptr, &size);   // sets the size it needs
+    if (size == 0) return {};
+
+    std::string buffer (size, '\0');
+    if (_NSGetExecutablePath (buffer.data(), &size) != 0) return {};
+
+    return std::filesystem::path (buffer.c_str()).parent_path();
+}
+
+bool openPathInDefaultApp (const std::filesystem::path& path)
+{
+    NSString* const native = [NSString stringWithUTF8String: path.c_str()];
+    if (native == nil) return false;
+    return [[NSWorkspace sharedWorkspace] openURL: [NSURL fileURLWithPath: native]] == YES;
+}
+
 namespace
 {
 // Wraps a parent-process juce::AudioProcessorEditor (created from

--- a/src/ui/PlatformWindowing_Windows.cpp
+++ b/src/ui/PlatformWindowing_Windows.cpp
@@ -4,6 +4,7 @@
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #include <windows.h>
+#include <shellapi.h>
 
 // Native counterparts to the Linux windowing operations. A peer's native
 // handle is its HWND; Win32 owns restoration, activation and taskbar notice.
@@ -13,6 +14,32 @@
 
 namespace duskstudio::platform
 {
+std::filesystem::path executableDirectory()
+{
+    std::wstring buffer (MAX_PATH, L'\0');
+    for (;;)
+    {
+        const auto written = ::GetModuleFileNameW (nullptr, buffer.data(),
+                                                   (DWORD) buffer.size());
+        if (written == 0) return {};
+        if (written < buffer.size())
+        {
+            buffer.resize (written);
+            return std::filesystem::path (buffer).parent_path();
+        }
+        // Truncated: the documented signal is a full buffer, so grow and retry.
+        buffer.resize (buffer.size() * 2);
+    }
+}
+
+bool openPathInDefaultApp (const std::filesystem::path& path)
+{
+    const auto result = ::ShellExecuteW (nullptr, L"open", path.c_str(),
+                                         nullptr, nullptr, SW_SHOWNORMAL);
+    // ShellExecuteW returns a fake HINSTANCE; anything above 32 is success.
+    return (INT_PTR) result > 32;
+}
+
 namespace
 {
 bool setWindowParent (HWND child, HWND parent) noexcept


### PR DESCRIPTION
Closes #533
Refs #561, which adds the document this points at.

## What it does

**Settings > Quickstart** hands the shipped quickstart to the desktop's default handler. That is the same menu as Keyboard Shortcuts, Supporters and About, so no new menu surface.

## Finding the file

Resolved from the executable, not the working directory, because the working directory is wherever the launcher happened to be. The candidates, in order:

| Path | Covers |
|---|---|
| `<exe>/../QUICKSTART.txt` | Linux tarball (`DuskStudio/DuskStudio` under the root) and the Windows MSI (`bin/DuskStudio.exe`) |
| `<exe>/QUICKSTART.txt` | a flat layout |
| `<exe>/../Resources/QUICKSTART.txt` | inside a macOS bundle, if packaging later puts it there |
| `<exe>/../../../QUICKSTART.md` | the repo copy, so a build run out of the tree finds it |

These match `packaging/contents.txt` on #561's branch, which places `QUICKSTART.txt` at the install root on all three platforms.

macOS is worth calling out: the DMG carries the file next to `DuskStudio.app`, and dragging the app to Applications leaves it behind. Until packaging puts a copy in the bundle, a macOS user who installs the normal way gets the disabled entry. The Resources candidate is there so that becomes a packaging change rather than a code change.

## Missing file

The entry is disabled and reads `Quickstart  (not installed)`. No modal. A `PopupMenu` item has nowhere to hang a tooltip, so the label carries the reason.

## Platform seam

`executableDirectory()` and `openPathInDefaultApp()` join `duskstudio::platform` alongside the existing windowing primitives, one implementation per OS: `/proc/self/exe` and `xdg-open` (double-forked so the viewer reparents to init and leaves no zombie), `GetModuleFileNameW` and `ShellExecuteW`, `_NSGetExecutablePath` and `NSWorkspace`. No JUCE in any of them, and the gate is unchanged at 163 files / 8067 uses.

## Verification

Xvfb, all three states, screenshots in the session scratchpad:

- Document present: the entry is enabled and reads `Quickstart`.
- Document absent: greyed out, reads `Quickstart  (not installed)`.
- Clicking it with a stub `xdg-open` first on `PATH`: the stub records `/home/marc/projects/DuskStudio-worker-a/QUICKSTART.md`, so the resolution and the handoff both work end to end.

Build clean, no new warnings, ctest 980/980.

Windows and macOS are compile-only here. The Windows leg is the MSVC job; I have no way to click the menu on the VM until #558 is understood, and macOS is not mine to touch this round.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added **Settings → Quickstart** to open the bundled one-page quickstart guide in the system’s default text viewer.
  - The menu entry locates the guide across supported installations and platforms.
  - When the guide is unavailable, the entry is disabled with an explanatory label.
  - Displays an alert if the guide cannot be opened by the system’s default application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->