### PR TITLE
fix(single-instance): ride out a full handoff backlog instead of running unattached

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ GPL source on this repo, so building it yourself costs you nothing but compile t
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 1032 Catch2 test cases across 193 test source files. Linux
+The C++ suite declares 1033 Catch2 test cases across 193 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -124,7 +124,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # Native log storage + CrashHandler signal reports
-tests/         # 1032 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 1033 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/util/SingleInstance.cpp
+++ b/src/util/SingleInstance.cpp
@@ -529,8 +529,7 @@ Slot probeSlot (const sockaddr_un& addr, socklen_t len)
     if (::connect (fd, (const sockaddr*) &addr, len) != 0)
     {
         result = errno;
-        if (result == EINPROGRESS || result == EALREADY || result == EINTR
-            || result == EAGAIN || result == EWOULDBLOCK)
+        if (result == EINPROGRESS || result == EALREADY || result == EINTR)
         {
             const auto deadline = std::chrono::steady_clock::now()
                                 + std::chrono::milliseconds (kProbeBudgetMs);
@@ -547,6 +546,10 @@ Slot probeSlot (const sockaddr_un& addr, socklen_t len)
     ::close (fd);
 
     if (result == 0) return Slot::Live;
+    // A Unix-domain connect answers EAGAIN when the backlog is full, which only
+    // a listening socket can be, so this is the one refusal-shaped error that
+    // proves the slot is occupied rather than abandoned.
+    if (result == EAGAIN || result == EWOULDBLOCK) return Slot::Live;
     if (result == ECONNREFUSED) return Slot::Orphaned;
     if (result == ENOENT) return Slot::Vacant;
     return Slot::Unknown;
@@ -611,9 +614,14 @@ Handoff handOver (const sockaddr_un& addr, socklen_t len, const std::string& pay
         else
         {
             connectErr = errno;
+            // Only EINPROGRESS and its relatives mean a connect is under way.
+            // EAGAIN from a Unix-domain connect means the backlog is full and
+            // nothing was started: poll() then answers POLLOUT|POLLHUP for a
+            // socket that never connected, SO_ERROR is clear because no error
+            // was ever recorded, and the write that follows fails ENOTCONN -
+            // costing the launch the command line it was carrying.
             if (connectErr == EINPROGRESS || connectErr == EALREADY
-                || connectErr == EINTR || connectErr == EAGAIN
-                || connectErr == EWOULDBLOCK)
+                || connectErr == EINTR)
             {
                 const int revents = pollUntil (fd, POLLOUT, deadline);
                 if ((revents & POLLNVAL) == 0 && revents != 0)
@@ -658,7 +666,8 @@ Handoff handOver (const sockaddr_un& addr, socklen_t len, const std::string& pay
                                           : Handoff::Submitted;
         }
         ::close (fd);
-        if (connectErr != ECONNREFUSED)
+        const bool backlogFull = connectErr == EAGAIN || connectErr == EWOULDBLOCK;
+        if (connectErr != ECONNREFUSED && ! backlogFull)
         {
             failureErrno = connectErr;
             return Handoff::Failed;
@@ -667,8 +676,17 @@ Handoff handOver (const sockaddr_un& addr, socklen_t len, const std::string& pay
         // A simultaneous primary may have bound but not reached listen() yet.
         // Retry refusals only long enough to cover the bind-to-listen race.
         // A dead primary should not add the full delivery timeout to startup.
-        if (std::chrono::steady_clock::now() >= refusalDeadline) break;
-        std::this_thread::sleep_for (std::chrono::milliseconds (25));
+        // A full backlog is the opposite case - it proves someone is listening,
+        // so it is worth the whole delivery budget - and it must never be
+        // reported as a refusal, which is what licenses unlinking the slot.
+        if (std::chrono::steady_clock::now() < (backlogFull ? deadline : refusalDeadline))
+        {
+            std::this_thread::sleep_for (std::chrono::milliseconds (25));
+            continue;
+        }
+        if (! backlogFull) break;
+        failureErrno = connectErr;
+        return Handoff::Failed;
     }
     return Handoff::Refused;
 }

--- a/tests/single_instance_socket_lifecycle.cpp
+++ b/tests/single_instance_socket_lifecycle.cpp
@@ -217,6 +217,28 @@ void sendFrame (int fd, std::uint32_t declaredSize, const std::string& body)
     if (! body.empty()) sendAll (fd, body.data(), body.size());
 }
 
+#if defined (__linux__)
+constexpr std::uint32_t kMaxTestPayloadBytes = 64 * 1024;
+
+void sendAck (int fd)
+{
+    const char ack = '\1';
+    (void) ::send (fd, &ack, 1, MSG_NOSIGNAL);
+}
+
+int acceptWithin (int listenFd, std::chrono::milliseconds budget)
+{
+    const auto deadline = std::chrono::steady_clock::now() + budget;
+    for (;;)
+    {
+        const int peer = ::accept (listenFd, nullptr, nullptr);
+        if (peer >= 0) return peer;
+        if (std::chrono::steady_clock::now() >= deadline) return -1;
+        std::this_thread::sleep_for (std::chrono::milliseconds (2));
+    }
+}
+#endif
+
 // The lock the production code takes around every mutation of the slot entry.
 int holdSlotLock (const fs::path& socketPath)
 {
@@ -408,6 +430,98 @@ TEST_CASE ("a handoff nobody acknowledges leaves the launch unattached",
 
     REQUIRE (runsUnattached);
 }
+
+// Linux answers a full Unix-domain backlog with EAGAIN. macOS answers
+// ECONNREFUSED, which is indistinguishable from a socket whose owner is gone,
+// so the state this covers cannot be built there.
+#if defined (__linux__)
+// A Unix-domain connect answers EAGAIN, not ECONNREFUSED, while the peer's
+// listen backlog is full. Reading that as a connect in progress leaves a socket
+// that never connected: poll reports it writable, SO_ERROR is clear because no
+// error was ever recorded, and the write fails ENOTCONN, which costs the launch
+// the session it was carrying with a live primary a few milliseconds from
+// having room.
+TEST_CASE ("a handoff waits out a full primary backlog",
+           "[single-instance][socket][issue-567]")
+{
+    ScopedSlot slot;
+    REQUIRE (duskstudio::single_instance::acquire ("", noPayload));
+    const auto sock = soleSocketIn (slot.path());
+    REQUIRE_FALSE (sock.empty());
+    duskstudio::single_instance::release();
+    REQUIRE (inodeOf (sock) == 0);
+
+    const int listenFd = bindSocketAt (sock);
+    REQUIRE (::fcntl (listenFd, F_SETFL, O_NONBLOCK) == 0);
+    REQUIRE (::listen (listenFd, 1) == 0);
+
+    // The kernel is free to round the backlog up, so fill until a connect is
+    // actually turned away rather than trusting the number passed to listen.
+    std::vector<int> fillers;
+    for (int i = 0; i < 64 && fillers.size() == (std::size_t) i; ++i)
+    {
+        const int fd = ::socket (AF_UNIX, SOCK_STREAM, 0);
+        REQUIRE (fd >= 0);
+        REQUIRE (::fcntl (fd, F_SETFL, O_NONBLOCK) == 0);
+        sockaddr_un addr {};
+        addr.sun_family = AF_UNIX;
+        const auto name = sock.string();
+        std::memcpy (addr.sun_path, name.c_str(), name.size());
+        if (::connect (fd, (const sockaddr*) &addr, sizeof addr) == 0)
+        {
+            fillers.push_back (fd);
+            continue;
+        }
+        REQUIRE (errno == EAGAIN);
+        ::close (fd);
+    }
+    REQUIRE_FALSE (fillers.empty());
+    REQUIRE (fillers.size() < 64);
+
+    std::string received;
+    std::thread drain ([&]
+    {
+        std::this_thread::sleep_for (std::chrono::milliseconds (150));
+        std::vector<int> accepted;
+        for (std::size_t i = 0; i < fillers.size(); ++i)
+            accepted.push_back (acceptWithin (listenFd, std::chrono::seconds (2)));
+
+        const int peer = acceptWithin (listenFd, std::chrono::seconds (3));
+        if (peer >= 0)
+        {
+            std::uint32_t size = 0;
+            if (::read (peer, &size, sizeof size) == (ssize_t) sizeof size
+                && size <= kMaxTestPayloadBytes)
+            {
+                std::string body (size, '\0');
+                std::size_t got = 0;
+                bool complete = true;
+                while (got < size)
+                {
+                    const ssize_t n = ::read (peer, &body[got], size - got);
+                    if (n < 0 && errno == EINTR) continue;
+                    if (n <= 0) { complete = false; break; }
+                    got += (std::size_t) n;
+                }
+                if (complete) received = std::move (body);
+            }
+            sendAck (peer);
+            ::close (peer);
+        }
+        for (const int fd : accepted)
+            if (fd >= 0) ::close (fd);
+    });
+
+    const std::string session = "/tmp/backlog/take-1.dusksession";
+    const bool ranUnattached = duskstudio::single_instance::acquire (session, noPayload);
+    drain.join();
+    for (const int fd : fillers) ::close (fd);
+    ::close (listenFd);
+
+    REQUIRE_FALSE (ranUnattached);
+    REQUIRE (received == session);
+}
+#endif
 
 TEST_CASE ("release leaves a newer primary socket at the same path",
            "[single-instance][socket][issue-368]")


### PR DESCRIPTION
Closes #567

#567 was filed as a flake: three of eight simultaneous launches returned `true` from `acquire()` where the test requires exactly one. The question was whether the test asserted more than the contract, or whether there was a real double primary.

Neither, exactly. There is one primary every time, and there is a real bug.

## What the instrumentation showed

Every `acquire()` return path on the POSIX arm was tagged and the election test looped. **12 failures in 6205 runs.** In all twelve, exactly one launch bound the socket and started a listener. The `SlotLock`/`flock` election is sound: every extra `true` was a `reportUnattached` return from a thread that had taken the lock, probed the slot as `Live`, correctly declined to bind, and then failed to hand off.

The failing threads all had the identical trace:

```
handover connect errno=11           <- EAGAIN
handover poll revents=20            <- POLLOUT|POLLHUP
handover writeAll failed errno=107  <- ENOTCONN
handover=Failed errno=107
RESULT=UNATTACHED errno=107
```

## Root cause

1. `startListener` calls `::listen (fd, 8)`. Eight racing launches open up to fourteen sockets against it (a `probeSlot` connect plus a `handOver` connect each), so the backlog transiently overflows.
2. On a full Unix-domain backlog, `connect()` returns **EAGAIN**. That is not "in progress" - nothing was started.
3. `handOver` lumped `EAGAIN`/`EWOULDBLOCK` in with `EINPROGRESS` and polled for `POLLOUT`. An unconnected Unix socket answers `POLLOUT|POLLHUP` immediately and `getsockopt(SO_ERROR)` returns 0, because no error was ever recorded, so the code concluded it was connected.
4. The write on that never-connected socket failed **ENOTCONN**, giving `Handoff::Failed`.
5. `Failed` is not `Refused`, so `acquire()` left the retry loop, reported unattached, and returned `true` - **dropping the command line it was carrying**. On the desktop that is a session opened while the app is starting landing in a second window that does not have the file.

`probeSlot` misread the same errno. It happened to land on `Slot::Live`, which is the safe answer, but by accident.

## The change

- Poll for connect completion only on `EINPROGRESS`/`EALREADY`/`EINTR`.
- Retry a full backlog instead. It gets the whole `kDeliveryBudgetMs` rather than the short `kRefusalRetryMs`, because unlike a refusal it proves someone is listening; a dead primary still must not add the full delivery timeout to startup.
- A full backlog is never reported as `Refused`. `Refused` is what licenses unlinking the slot, and unlinking a live primary's socket is how you get two of them.
- `probeSlot` returns `Slot::Live` on EAGAIN deliberately, with the reason recorded.

The `listen` backlog stays at 8. Raising it would only narrow the window and would weaken the regression test.

## Regression test

`a handoff waits out a full primary backlog` binds a socket at the slot path, fills its backlog until a connect is actually turned away (the kernel is free to round the backlog up, so it fills until EAGAIN rather than trusting the number passed to `listen`), and drains it 150 ms later. The handoff must survive the saturation and arrive.

- **Before the fix**: `REQUIRE_FALSE (ranUnattached)` fails with `!true` - the launch gave up and ran unattached.
- **After the fix**: passes, and the payload arrives intact.

The drainer writes a one-byte acknowledgement before closing, which `main` ignores but the POSIX ack path in #570 will read, so the test does not become a silent-listener case when that lands.

## Verification

| | before | after |
|---|---|---|
| `simultaneous single-instance launches elect exactly one owner`, 2500 iterations | **15 failures** | **0 failures** |

- `ctest --test-dir build-tests`: 983/983 pass.
- `tools/juce-gate.sh`: clean, 163 coupled files / 8066 uses, no allowlist change.
- `scripts/run-selftest-xvfb.sh`: 15 passed, 0 failed. (The UMC1820 direct-open probe reports the device held by PipeWire, as it does on `main`.)
- README test-case count updated 1002 -> 1003.

Relabelled #567 `1.0-blocker` and retitled it to describe the handoff bug; the flake history stays in the issue body.
