### PR TITLE
fix(single-instance): mark the slot with an owner lock instead of trusting a refusal

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ GPL source on this repo, so building it yourself costs you nothing but compile t
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 1033 Catch2 test cases across 193 test source files. Linux
+The C++ suite declares 1034 Catch2 test cases across 193 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -124,7 +124,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # Native log storage + CrashHandler signal reports
-tests/         # 1033 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 1034 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/util/SingleInstance.cpp
+++ b/src/util/SingleInstance.cpp
@@ -68,6 +68,7 @@ struct Listener
 {
     std::thread thread;
     std::atomic<int> listenFd { -1 };
+    std::atomic<int> ownerFd { -1 };
     std::atomic<bool> unlinked { false };
     int wakeFds[2] = { -1, -1 };
     std::string socketPath;
@@ -235,6 +236,47 @@ int acceptPeer (int fd)
 #endif
 }
 
+// Liveness has to be something a launch can observe directly, because a connect
+// result cannot carry it: macOS answers ECONNREFUSED both for a primary that
+// died and for one whose listen backlog is momentarily full, and acting on the
+// second as though it were the first deletes a live primary's socket and elects
+// a second one over the same session directory. The owner lock is held by the
+// primary for its whole life, so the kernel drops it on a crash and no stale
+// file can outlive the process the way the socket entry does.
+//
+// This is deliberately not the SlotLock: that one is a short critical section
+// every launch takes and releases around mutations of the slot entry, and a
+// launch waiting on it would block forever if it doubled as the liveness mark.
+// Like that lock's file, this one is never unlinked: removing it while a launch
+// holds it open leaves that launch locking an unlinked inode while another
+// locks a fresh one at the same name, and both then read the slot as theirs.
+std::string ownerLockPath (const std::string& socketPath)
+{
+    return socketPath + ".owner";
+}
+
+int takeOwnerLock (const std::string& socketPath)
+{
+    const int fd = ::open (ownerLockPath (socketPath).c_str(),
+                           O_RDWR | O_CREAT | O_CLOEXEC, 0600);
+    if (fd < 0) return -1;
+    if (::flock (fd, LOCK_EX | LOCK_NB) == 0) return fd;
+    ::close (fd);
+    return -1;
+}
+
+// Fails closed: a lock we cannot open or cannot reason about reads as owned, so
+// the caller leaves the slot entry alone rather than clearing one that may
+// still be serving.
+bool ownerLockIsFree (const std::string& socketPath)
+{
+    const int fd = takeOwnerLock (socketPath);
+    if (fd < 0) return false;
+    ::flock (fd, LOCK_UN);
+    ::close (fd);
+    return true;
+}
+
 // The invariant every launch relies on: the directory entry at the slot path is
 // created, made listenable, and removed only under this lock. A stat before the
 // unlink cannot stand in for it, because the entry can be replaced between the
@@ -286,14 +328,8 @@ private:
     int fd = -1;
 };
 
-// Closing the listening fd is what makes a later launch fall back to acting as
-// primary; leaving it bound but unserviced would strand every launch after it.
-// Both exchanges keep this safe to call from the listener thread and from
-// release() without double-closing.
-void teardown (Listener& l)
+void unlinkOwnSocket (Listener& l)
 {
-    const int fd = l.listenFd.exchange (-1);
-    if (fd >= 0) ::close (fd);
     if (l.unlinked.exchange (true) || ! l.socketIdentified) return;
 
     const SlotLock lock (l.socketPath);
@@ -309,6 +345,25 @@ void teardown (Listener& l)
     if (named.st_dev == l.socketDev && named.st_ino == l.socketIno)
         ::unlink (l.socketPath.c_str());
 }
+
+// Closing the listening fd is what makes a later launch fall back to acting as
+// primary; leaving it bound but unserviced would strand every launch after it.
+// The exchanges keep this safe to call from the listener thread and from
+// release() without double-closing.
+void teardown (Listener& l)
+{
+    const int fd = l.listenFd.exchange (-1);
+    if (fd >= 0) ::close (fd);
+    unlinkOwnSocket (l);
+
+    // Dropping the advisory lock is what tells the next launch the slot is
+    // free, so it happens after the entry this process bound is gone. The
+    // reverse order offers a window where the slot reads as owned by nobody
+    // while a socket nothing is listening on is still sitting at the path.
+    const int owner = l.ownerFd.exchange (-1);
+    if (owner >= 0) ::close (owner);
+}
+
 
 bool peerIsThisUser (int fd)
 {
@@ -495,12 +550,21 @@ bool startListener (int fd, const std::string& path,
 {
     if (::listen (fd, 8) != 0) return false;
 
+    // Taken before the slot is served and held for the life of the process. A
+    // launch that cannot mark itself the owner must not become one: the mark is
+    // the only thing that stops the next launch reading a refused connect as an
+    // abandoned slot and clearing this one.
+    const int owner = takeOwnerLock (path);
+    if (owner < 0) return false;
+
     auto* l = new Listener();
     if (! makeWakePipe (l->wakeFds))
     {
+        ::close (owner);
         delete l;
         return false;
     }
+    l->ownerFd.store (owner);
     l->listenFd.store (fd);
     l->socketPath = path;
     struct stat bound {};
@@ -520,7 +584,7 @@ bool startListener (int fd, const std::string& path,
 // cannot change under us: Orphaned is the only state that permits an unlink.
 enum class Slot { Vacant, Live, Orphaned, Unknown };
 
-Slot probeSlot (const sockaddr_un& addr, socklen_t len)
+Slot probeSlot (const std::string& path, const sockaddr_un& addr, socklen_t len)
 {
     const int fd = openSocket (true);
     if (fd < 0) return Slot::Unknown;
@@ -548,11 +612,13 @@ Slot probeSlot (const sockaddr_un& addr, socklen_t len)
     if (result == 0) return Slot::Live;
     // A Unix-domain connect answers EAGAIN when the backlog is full, which only
     // a listening socket can be, so this is the one refusal-shaped error that
-    // proves the slot is occupied rather than abandoned.
+    // proves the slot is occupied rather than abandoned. Linux reports it that
+    // way; macOS reports a full backlog as ECONNREFUSED, which is why a refusal
+    // is never enough on its own to call the slot abandoned.
     if (result == EAGAIN || result == EWOULDBLOCK) return Slot::Live;
-    if (result == ECONNREFUSED) return Slot::Orphaned;
     if (result == ENOENT) return Slot::Vacant;
-    return Slot::Unknown;
+    if (result != ECONNREFUSED) return Slot::Unknown;
+    return ownerLockIsFree (path) ? Slot::Orphaned : Slot::Live;
 }
 
 // An unattached instance is otherwise indistinguishable from a normal launch
@@ -712,10 +778,12 @@ bool acquire (const std::string& payload, std::function<void (std::string)> onCo
             const SlotLock lock (path);
             if (lock.isHeld())
             {
-                // A refusal seen here is final: a live primary completed
-                // listen() before it released the lock, and nothing can create
-                // or remove the entry while we hold it.
-                const Slot state = probeSlot (addr, len);
+                // Nothing can create or remove the entry while we hold the
+                // lock, so this verdict holds for as long as the branch below
+                // acts on it. A refusal alone is not one of the answers that
+                // licenses acting: only the owner lock separates a slot whose
+                // process is gone from one that is merely refusing.
+                const Slot state = probeSlot (path, addr, len);
                 if (state == Slot::Orphaned && ::unlink (path.c_str()) != 0 && errno != ENOENT)
                 {
                     reportUnattached ("the socket a crashed instance left behind could not "

--- a/tests/single_instance_socket_lifecycle.cpp
+++ b/tests/single_instance_socket_lifecycle.cpp
@@ -239,6 +239,18 @@ int acceptWithin (int listenFd, std::chrono::milliseconds budget)
 }
 #endif
 
+// The mark the production code leaves on the slot for as long as it is serving
+// it, which is what separates a dead primary from a live one that is refusing
+// connects.
+int holdOwnerLock (const fs::path& socketPath)
+{
+    const int fd = ::open ((socketPath.string() + ".owner").c_str(),
+                           O_RDWR | O_CREAT | O_CLOEXEC, 0600);
+    REQUIRE (fd >= 0);
+    REQUIRE (::flock (fd, LOCK_EX | LOCK_NB) == 0);
+    return fd;
+}
+
 // The lock the production code takes around every mutation of the slot entry.
 int holdSlotLock (const fs::path& socketPath)
 {
@@ -429,6 +441,39 @@ TEST_CASE ("a handoff nobody acknowledges leaves the launch unattached",
     ::close (deafFd);
 
     REQUIRE (runsUnattached);
+}
+
+// A refused connect does not mean the owner is gone. macOS reports a live
+// primary whose listen backlog is full exactly the way it reports a dead one,
+// so reading a refusal as an abandoned slot deleted a running instance's socket
+// and elected a second primary over the same session directory.
+TEST_CASE ("a refusal from an owned slot leaves the socket alone",
+           "[single-instance][socket][issue-573]")
+{
+    ScopedSlot slot;
+    REQUIRE (duskstudio::single_instance::acquire ("", noPayload));
+    const auto sock = soleSocketIn (slot.path());
+    REQUIRE_FALSE (sock.empty());
+    duskstudio::single_instance::release();
+    REQUIRE (inodeOf (sock) == 0);
+
+    // Bound but never listening, so every connect is refused, with the slot
+    // still marked as owned.
+    const int boundFd = bindSocketAt (sock);
+    const auto ownedInode = inodeOf (sock);
+    REQUIRE (ownedInode != 0);
+    const int ownerFd = holdOwnerLock (sock);
+
+    const bool ranUnattached =
+        duskstudio::single_instance::acquire ("/tmp/owned/session.json", noPayload);
+    const auto afterInode = inodeOf (sock);
+
+    ::flock (ownerFd, LOCK_UN);
+    ::close (ownerFd);
+    ::close (boundFd);
+
+    REQUIRE (ranUnattached);
+    REQUIRE (afterInode == ownedInode);
 }
 
 // Linux answers a full Unix-domain backlog with EAGAIN. macOS answers


### PR DESCRIPTION
Closes #573

Found while fixing #567. That bug was Linux-only; this is the same family on macOS, and worse, because what is lost is the session rather than the command line.

**Stacked on #572** - it touches the same function and I did not want to hand-resolve a conflict in this particular code. The first commit here is #572's; review only `14a0564c`. I will rebase to a single commit once #572 merges.

## The platform difference

A standalone probe on both hosts: bind, `listen (fd, 1)`, then nonblocking `connect()` until one is turned away.

| platform | queued before refusal | errno when the backlog is full |
|---|---|---|
| Linux 6.12 amd64 | 2 | **EAGAIN (11)** |
| macOS 14 arm64 | 1 | **ECONNREFUSED (61)** |

Linux distinguishes "backlog full" from "nobody is listening". macOS does not.

## Why that elected a second primary

`probeSlot` decided liveness purely from the connect result, and `ECONNREFUSED` mapped to `Slot::Orphaned` - the one state that licenses removing the slot entry. On macOS, with a live primary whose backlog was momentarily full, all of this ran under `SlotLock` so nothing could intervene:

1. `probeSlot` gets `ECONNREFUSED` from the full backlog and answers `Orphaned`.
2. `::unlink (path)` removes the **live primary's** socket.
3. `state != Slot::Live`, so the launch binds - which now succeeds, because the entry it would have collided with was just deleted.
4. `startListener` succeeds, `acquire()` returns `true`.

Two primaries, each with its own engine and autosave loop over one session directory. The original is still listening, on a path no launch can reach.

`SlotLock`'s own comment names this outcome as the thing it exists to prevent. It does prevent the race it describes; it could not help here, because the answer `probeSlot` returned from inside the lock was wrong.

## The change

Liveness is now observable rather than inferred. The primary takes an advisory lock on `<slot>.owner` after it binds and holds it for its whole life, so the kernel drops it on a crash and no stale file can outlive the process the way the socket entry does.

- `startListener` takes the lock after `listen` and stores the descriptor on the `Listener`. A launch that cannot take it does **not** become primary - the mark is the only thing stopping the next launch from clearing this one.
- `probeSlot` answers `Orphaned` only when the connect is refused **and** the owner lock can be taken. Everything else that is refusal-shaped reads as `Live`. It fails closed: a lock that cannot be opened reads as owned.
- `teardown` drops the lock last, after the entry this process bound is gone, so no launch sees the slot unowned while a dead socket is still at the path. The socket unlink moved into `unlinkOwnSocket` so the lock is released on every teardown path, including the ones that return early.
- The owner file is never unlinked, for the reason the slot lock file is not (same residue-1 reasoning).

This is deliberately not the `SlotLock`: that is a short critical section every launch takes and releases around mutations of the slot entry, and a launch waiting on it would block forever if it doubled as the liveness mark.

Windows has its own contract and is untouched.

## Regression test

`a refusal from an owned slot leaves the socket alone` binds a socket that never listens (so every connect is refused) while holding the owner lock, then calls `acquire()` and asserts the entry is still the same inode. No Linux-only mechanics, so it runs on both platforms.

Proven on **macOS arm64** with a standalone harness linking only `SingleInstance.cpp`, run against this commit and its parent:

| | inode before | inode after | verdict |
|---|---|---|---|
| without the fix | 1785181 | 1785183 | **the live socket was replaced** |
| with the fix | 1785165 | 1785165 | unchanged, launch runs unattached |

On Linux the same test fails before the fix with `1094519 == 1094517` and passes after.

## Verification

- `ctest --test-dir build-tests`: 1014/1014.
- `tools/juce-gate.sh`: clean, no allowlist change.
- `scripts/run-selftest-xvfb.sh`: 15 passed, 0 failed.
- `cmake --build build -j3`: clean.
- README test-case count 1033 -> 1034.
- macOS full build + ctest running on the build node; CI's `Build + tests (clang Release, macOS arm64)` covers the same ground on the gate.

One aside for the record: two `DpAligner` cases failed once each under `ctest -j3` mid-run. Not related to this change - the box's 4 GB `/tmp` was at 100%, and those cases write ~23 MB WAVs. After clearing space, 1014/1014 twice.
