### PR TITLE
fix(pipewire): wait for the graph's first cycle past a device waking up

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ GPL source on this repo, so building it yourself costs you nothing but compile t
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 1034 Catch2 test cases across 193 test source files. Linux
+The C++ suite declares 1038 Catch2 test cases across 193 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -124,7 +124,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # Native log storage + CrashHandler signal reports
-tests/         # 1034 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 1038 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ GPL source on this repo, so building it yourself costs you nothing but compile t
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 1038 Catch2 test cases across 193 test source files. Linux
+The C++ suite declares 1039 Catch2 test cases across 193 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -124,7 +124,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # Native log storage + CrashHandler signal reports
-tests/         # 1038 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 1039 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -624,10 +624,20 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
     if (const auto stateFile = audioDeviceStateFile(); stateFile.existsAsFile())
         savedDeviceState = stateFile.loadFileAsString().toStdString();
 
+    // The order the backends were registered in IS the preference order, so the
+    // first one is what the app uses when it has the choice. Captured before
+    // initialise because a failed open moves the current type off it.
+    std::string preferredBackend;
+    if (const auto types = deviceManager.getAvailableDeviceTypes(); ! types.empty())
+        if (types.front() != nullptr)
+            preferredBackend = types.front()->getTypeName();
+
+    std::string deviceInitError;
     if (const auto err = deviceManager.initialise (16, 2, savedDeviceState,
                                                    /*selectDefaultOnFailure*/ true);
         ! err.empty())
     {
+        deviceInitError = err;
         std::fprintf (stderr,
                       "[Dusk Studio/AudioEngine] device-manager init reported: %s\n",
                       err.c_str());
@@ -752,6 +762,15 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
         }
         startupDeviceMessage_ = duskstudio::startupDeviceMessage (
             opened, savedDevice, liveDevice);
+
+        // Falling back across backends is invisible otherwise: the session works,
+        // so nothing alerts, and the only record is a line on stderr the user
+        // never sees. The bar carries it until they pick a device.
+        backendFallbackNotice_ = duskstudio::backendFallbackNotice (
+            deviceInitError, preferredBackend, liveDevice.backendName);
+        if (! backendFallbackNotice_.empty())
+            std::fprintf (stderr, "[Dusk Studio/AudioEngine] %s\n",
+                          backendFallbackNotice_.c_str());
     }
 
     // First launch only. The default pick, and the cross-backend fallback above

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -767,7 +767,8 @@ AudioEngine::AudioEngine (Session& sessionToBindTo, int initialWorkers)
         // so nothing alerts, and the only record is a line on stderr the user
         // never sees. The bar carries it until they pick a device.
         backendFallbackNotice_ = duskstudio::backendFallbackNotice (
-            deviceInitError, preferredBackend, liveDevice.backendName);
+            ! savedDeviceState.empty(), deviceInitError, preferredBackend,
+            liveDevice.backendName);
         if (! backendFallbackNotice_.empty())
             std::fprintf (stderr, "[Dusk Studio/AudioEngine] %s\n",
                           backendFallbackNotice_.c_str());

--- a/src/engine/AudioEngine.h
+++ b/src/engine/AudioEngine.h
@@ -295,6 +295,16 @@ public:
     // startup fallback and immediately persists the user's explicit choice.
     void clearDeviceFallbackHold();
 
+    // One line for the transport bar when the startup open could not use the
+    // preferred backend. Empty when it did. Unlike consumeStartupDeviceMessage
+    // this is not drained by reading: the bar polls it, and it stands until the
+    // user picks a device, because the fallback stands until then too.
+    const std::string& backendFallbackNotice() const noexcept
+    {
+        return backendFallbackNotice_;
+    }
+    void clearBackendFallbackNotice() noexcept { backendFallbackNotice_.clear(); }
+
     // Marker jumps clamp to known points - no overshoot past zero or
     // past the last marker. Message-thread only.
     void jumpToPrevMarker();
@@ -964,6 +974,11 @@ private:
     // Set once in the constructor by the busy-device fallback; drained by
     // consumeStartupDeviceMessage() after construction. Message-thread only.
     juce::String        startupDeviceMessage_;
+
+    // Non-empty while the startup open landed on a backend other than the
+    // platform's preferred one. Read by the transport bar every timer tick and
+    // cleared when the user picks a device. Message-thread only.
+    std::string         backendFallbackNotice_;
 
     DeviceLostAlertSink onDeviceLostAlert_;
     RecordBlockedSink   onRecordBlocked_;

--- a/src/engine/DeviceFallbackMessage.h
+++ b/src/engine/DeviceFallbackMessage.h
@@ -76,14 +76,20 @@ inline std::string startupDeviceMessage (bool opened,
 // silently landing on a fallback is how someone ends up wondering why their
 // interface is missing from a list that never had it.
 //
+//   hadSavedIntent   : the launch restored a persisted setup. startupDeviceMessage
+//                      above owns that case, and a user who chose ALSA on purpose
+//                      must not be told it is a fallback on every launch.
 //   initError        : what the device-manager init reported (empty = clean).
 //   preferredBackend : the first backend the platform registers (the one the
 //                      app uses when it has the choice).
 //   actualBackend    : the backend that ended up open (empty = none did).
-inline std::string backendFallbackNotice (const std::string& initError,
+inline std::string backendFallbackNotice (bool hadSavedIntent,
+                                          const std::string& initError,
                                           const std::string& preferredBackend,
                                           const std::string& actualBackend)
 {
+    if (hadSavedIntent)
+        return {};
     if (initError.empty() || preferredBackend.empty() || actualBackend.empty())
         return {};
     if (preferredBackend == actualBackend)

--- a/src/engine/DeviceFallbackMessage.h
+++ b/src/engine/DeviceFallbackMessage.h
@@ -68,4 +68,27 @@ inline std::string startupDeviceMessage (bool opened,
            "device in the other app, then open Audio Settings and select one.";
     return msg;
 }
+
+// One-line transport-bar notice for a startup open that could not use the
+// preferred backend. Empty string = nothing to say. Separate from
+// startupDeviceMessage above because this one is not an alert: the session is
+// working, and the user is only being told which backend it is working on -
+// silently landing on a fallback is how someone ends up wondering why their
+// interface is missing from a list that never had it.
+//
+//   initError        : what the device-manager init reported (empty = clean).
+//   preferredBackend : the first backend the platform registers (the one the
+//                      app uses when it has the choice).
+//   actualBackend    : the backend that ended up open (empty = none did).
+inline std::string backendFallbackNotice (const std::string& initError,
+                                          const std::string& preferredBackend,
+                                          const std::string& actualBackend)
+{
+    if (initError.empty() || preferredBackend.empty() || actualBackend.empty())
+        return {};
+    if (preferredBackend == actualBackend)
+        return {};
+    return preferredBackend + " unavailable - using " + actualBackend
+         + ". Change it in Settings > Audio.";
+}
 } // namespace duskstudio

--- a/src/engine/pipewire/PipeWireAudioIODevice.cpp
+++ b/src/engine/pipewire/PipeWireAudioIODevice.cpp
@@ -37,6 +37,10 @@ namespace
 // the data thread allocation-free across any legal quantum.
 constexpr int kMaxQuantum = 8192;
 
+// How long open() waits for the graph to run its first cycle after the filter
+// reaches STREAMING. See the wait in open() for the measurement behind it.
+constexpr int kQuantumWaitMs = 2000;
+
 // pw_init refcounts internally; the once-flag just keeps a first-use race
 // between the type ctor, a device open and a bare runSelfTest() off the global.
 void ensurePipeWireInit()
@@ -533,12 +537,26 @@ std::string PipeWireAudioIODevice::open (const device::ChannelSet& inputChannels
     // every block to silence. A quantum above maxQuantum is itself dropped by
     // onProcess, so treat "no usable quantum" as a failed open rather than
     // silently keeping the requested size.
-    for (int t = 0; t < 100 && negotiatedQuantum.load (std::memory_order_relaxed) == 0; ++t)
-        std::this_thread::sleep_for (std::chrono::milliseconds (2));
-    const int nq = negotiatedQuantum.load (std::memory_order_relaxed);
+    //
+    // STREAMING says our node was started, not that the graph has run a cycle:
+    // the elected driver may still be a device node waking from suspend, which
+    // WirePlumber only resumes once our links go active. On PipeWire 1.4.6 the
+    // first cycle lands 1-10 ms after STREAMING against a device that is already
+    // running and 267-270 ms against one resuming from suspend, which is the
+    // case on a launch with no saved device to reopen. A budget between those
+    // two fails only there. The deadline is generous because it costs time only
+    // when the graph really is not running, and the connect handshake above
+    // already allows longer.
+    const auto quantumDeadline = std::chrono::steady_clock::now()
+                               + std::chrono::milliseconds (kQuantumWaitMs);
+    while (negotiatedQuantum.load (std::memory_order_acquire) == 0
+           && std::chrono::steady_clock::now() < quantumDeadline)
+        std::this_thread::sleep_for (std::chrono::milliseconds (1));
+    const int nq = negotiatedQuantum.load (std::memory_order_acquire);
     if (nq <= 0 || nq > maxQuantum)
     {
-        lastError = "PipeWire delivered no usable quantum (" + std::to_string (nq) + ")";
+        lastError = "PipeWire delivered no usable quantum (" + std::to_string (nq)
+                  + ") in " + std::to_string (kQuantumWaitMs) + "ms";
         close();
         return lastError;
     }
@@ -735,7 +753,9 @@ void PipeWireAudioIODevice::onProcess (struct spa_io_position* position) noexcep
     if (n == 0)
         return;
 
-    negotiatedQuantum.store ((int) n, std::memory_order_relaxed);
+    // Release: open() reads this to size the block the engine prepares for, so
+    // the cycle's port setup must be visible to it once the value is.
+    negotiatedQuantum.store ((int) n, std::memory_order_release);
 
     // Count one xrun per recovery episode: increment on the rising edge of the
     // XRUN_RECOVER flag, not on every cycle it stays set (a recovery can span

--- a/src/ui/ScreenshotCapture.cpp
+++ b/src/ui/ScreenshotCapture.cpp
@@ -224,7 +224,7 @@ void MainComponent::captureScreenshots (const juce::File& outDir)
         const auto savedCapture = session.deviceCaptureChannels.load (
             std::memory_order_relaxed);
         session.deviceCaptureChannels.store (0, std::memory_order_relaxed);
-        transportBar->refreshInputNotice();
+        transportBar->refreshDeviceNotice();
         snapshotComponent (transportBar.get(), outDir, "rec-02-no-input-notice.png", 250);
         session.deviceCaptureChannels.store (savedCapture, std::memory_order_relaxed);
     }

--- a/src/ui/TransportBar.cpp
+++ b/src/ui/TransportBar.cpp
@@ -691,20 +691,24 @@ void TransportBar::forwardTap()
         engine.jumpToNextMarker();
 }
 
-void TransportBar::refreshInputNotice()
+void TransportBar::refreshDeviceNotice()
 {
     // Exactly zero, not "unknown": before a device has started there is no
     // evidence either way and the bar should stay quiet.
     const bool noInput = engine.getSession().deviceCaptureChannels.load (
                              std::memory_order_relaxed) == 0;
-    if (noInput == noCaptureInput) return;
-    noCaptureInput = noInput;
+    // No input is the one that stops the next thing the user tries, so it wins
+    // when a backend fallback is also standing.
+    auto wanted = noInput ? std::string ("No input device. Choose one in Settings > Audio.")
+                          : engine.backendFallbackNotice();
+    if (wanted == deviceNotice) return;
+    deviceNotice = std::move (wanted);
     repaint();
 }
 
 void TransportBar::timerCallback()
 {
-    refreshInputNotice();
+    refreshDeviceNotice();
 
     // 10x scrub. Once a REW / FFWD button has been held past
     // kHoldThresholdMs, advance the playhead by (sr * kScrubMultiplier *
@@ -1083,19 +1087,19 @@ void TransportBar::paint (juce::Graphics& g)
     g.setColour (juce::Colour (0xff2a2a32));
     g.drawRect (getLocalBounds(), 1);
 
-    if (! noCaptureInput) return;
+    if (deviceNotice.empty()) return;
 
     // The bar's own row is full, so the notice takes the gap the transport
-    // leaves in the middle rather than overlapping a control.
-    static constexpr int kNoticeW = 330;
+    // leaves in the middle rather than overlapping a control. Wide enough for
+    // the longest line either notice produces; a narrow window clamps it.
+    static constexpr int kNoticeW = 380;
     auto notice = getLocalBounds().withSizeKeepingCentre (
         std::min (kNoticeW, getWidth()), std::min (20, getHeight() - 6));
     g.setColour (kNoInputBackground);
     g.fillRoundedRectangle (notice.toFloat(), 3.0f);
     g.setColour (kNoInputText);
     g.setFont (kNoticeFont);
-    g.drawText ("No input device. Choose one in Settings > Audio.",
-                notice, kNoticeJustification, false);
+    g.drawText (deviceNotice.c_str(), notice, kNoticeJustification, false);
 }
 
 void TransportBar::resized()

--- a/src/ui/TransportBar.cpp
+++ b/src/ui/TransportBar.cpp
@@ -698,11 +698,13 @@ void TransportBar::refreshDeviceNotice()
     const bool noInput = engine.getSession().deviceCaptureChannels.load (
                              std::memory_order_relaxed) == 0;
     // No input is the one that stops the next thing the user tries, so it wins
-    // when a backend fallback is also standing.
-    auto wanted = noInput ? std::string ("No input device. Choose one in Settings > Audio.")
-                          : engine.backendFallbackNotice();
+    // when a backend fallback is also standing. Views, not strings: this runs
+    // at the timer rate and the notice changes almost never.
+    const std::string_view wanted =
+        noInput ? std::string_view ("No input device. Choose one in Settings > Audio.")
+                : std::string_view (engine.backendFallbackNotice());
     if (wanted == deviceNotice) return;
-    deviceNotice = std::move (wanted);
+    deviceNotice.assign (wanted.data(), wanted.size());
     repaint();
 }
 
@@ -1090,16 +1092,17 @@ void TransportBar::paint (juce::Graphics& g)
     if (deviceNotice.empty()) return;
 
     // The bar's own row is full, so the notice takes the gap the transport
-    // leaves in the middle rather than overlapping a control. Wide enough for
-    // the longest line either notice produces; a narrow window clamps it.
-    static constexpr int kNoticeW = 380;
+    // leaves in the middle rather than overlapping a control. Fitted rather than
+    // clipped: the backend line's length depends on two backend names, so no
+    // fixed width is right for every pair.
+    static constexpr int kNoticeW = 330;
     auto notice = getLocalBounds().withSizeKeepingCentre (
         std::min (kNoticeW, getWidth()), std::min (20, getHeight() - 6));
     g.setColour (kNoInputBackground);
     g.fillRoundedRectangle (notice.toFloat(), 3.0f);
     g.setColour (kNoInputText);
     g.setFont (kNoticeFont);
-    g.drawText (deviceNotice.c_str(), notice, kNoticeJustification, false);
+    g.drawFittedText (deviceNotice.c_str(), notice, kNoticeJustification, 1);
 }
 
 void TransportBar::resized()

--- a/src/ui/TransportBar.h
+++ b/src/ui/TransportBar.h
@@ -3,6 +3,8 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 #include "../engine/AudioEngine.h"
 #include "../foundation/MessageThread.h"
+
+#include <string>
 #include <array>
 
 namespace duskstudio
@@ -42,10 +44,10 @@ public:
     explicit TransportBar (AudioEngine& engineRef);
     ~TransportBar() override;
 
-    // Re-reads the device's capture width and repaints if it changed. The
-    // timer calls this; the capture harness calls it directly, because it
-    // sleeps between frames rather than pumping the message loop.
-    void refreshInputNotice();
+    // Re-reads what the bar should say about the audio device and repaints if
+    // it changed. The timer calls this; the capture harness calls it directly,
+    // because it sleeps between frames rather than pumping the message loop.
+    void refreshDeviceNotice();
 
     void paint (juce::Graphics&) override;
     void resized() override;
@@ -112,11 +114,12 @@ private:
 
     AudioEngine& engine;
 
-    // Set from the timer when the open device reports no capture channels, so
-    // the bar can say why arming does nothing instead of leaving the user to
-    // discover it by recording silence. Not a modal: it also appears when a
-    // device change takes the inputs away, where there is no click to answer.
-    bool noCaptureInput = false;
+    // Set from the timer: what the bar should say about the audio device, or
+    // empty for nothing. Covers an open device with no capture channels (why
+    // arming does nothing) and a startup that fell back off the preferred
+    // backend. Not a modal: both also arrive on a device change, where there is
+    // no click to answer.
+    std::string deviceNotice;
     TransportIconButton stopButton   { "Stop",     TransportIconButton::Icon::Stop,
                                         juce::Colour (0xffd0d0d0) };
     TransportIconButton rewButton    { "Rewind",   TransportIconButton::Icon::Rewind,

--- a/src/ui/TransportBar.h
+++ b/src/ui/TransportBar.h
@@ -5,6 +5,7 @@
 #include "../foundation/MessageThread.h"
 
 #include <string>
+#include <string_view>
 #include <array>
 
 namespace duskstudio

--- a/src/ui/imgui/AudioSettingsView.cpp
+++ b/src/ui/imgui/AudioSettingsView.cpp
@@ -120,6 +120,9 @@ public:
             [this]
             {
                 engine.clearDeviceFallbackHold();
+                // An explicit pick settles the backend question, so the bar's
+                // startup fallback notice has said all it has to say.
+                engine.clearBackendFallbackNotice();
                 populateMainOutput();
             });
 

--- a/tests/device_fallback_message.cpp
+++ b/tests/device_fallback_message.cpp
@@ -5,6 +5,7 @@
 
 #include <string>
 
+using duskstudio::backendFallbackNotice;
 using duskstudio::startupDeviceMessage;
 using duskstudio::device::DeviceIdentity;
 using dusk::text::contains;
@@ -104,4 +105,41 @@ TEST_CASE ("startupDeviceMessage: nothing opened -> silent-session warning", "[a
         REQUIRE (containsIgnoreCase (m, "soundfonts cannot be loaded"));
         REQUIRE_FALSE (contains (m, "\"\""));   // no empty-quoted device name
     }
+}
+
+// The backend-fallback notice is the transport bar's one line when the startup
+// open could not use the preferred backend. Same reason for testing the pure
+// seam: choosing a backend needs a real graph, deciding what to say does not.
+
+TEST_CASE ("backendFallbackNotice: a clean init says nothing", "[audio][device]")
+{
+    REQUIRE (backendFallbackNotice ("", "PipeWire", "ALSA").empty());
+}
+
+TEST_CASE ("backendFallbackNotice: the preferred backend opening says nothing",
+           "[audio][device]")
+{
+    // An error that did not cost the preferred backend is not the user's problem.
+    REQUIRE (backendFallbackNotice ("device \"HDMI 0\" is busy", "PipeWire", "PipeWire").empty());
+}
+
+TEST_CASE ("backendFallbackNotice: a fallback names both backends", "[audio][device]")
+{
+    const auto m = backendFallbackNotice ("PipeWire delivered no usable quantum (0)",
+                                          "PipeWire", "ALSA");
+    REQUIRE_FALSE (m.empty());
+    REQUIRE (contains (m, "PipeWire"));
+    REQUIRE (contains (m, "ALSA"));
+    REQUIRE (containsIgnoreCase (m, "Settings"));
+    // The bar has one line to spend.
+    REQUIRE (m.find ('\n') == std::string::npos);
+}
+
+TEST_CASE ("backendFallbackNotice: an unknown backend on either side says nothing",
+           "[audio][device]")
+{
+    // Nothing opened, or the platform registered no types: the silent-session
+    // alert covers that case and the bar would only be guessing.
+    REQUIRE (backendFallbackNotice ("no device", "PipeWire", "").empty());
+    REQUIRE (backendFallbackNotice ("no device", "", "ALSA").empty());
 }

--- a/tests/device_fallback_message.cpp
+++ b/tests/device_fallback_message.cpp
@@ -113,19 +113,19 @@ TEST_CASE ("startupDeviceMessage: nothing opened -> silent-session warning", "[a
 
 TEST_CASE ("backendFallbackNotice: a clean init says nothing", "[audio][device]")
 {
-    REQUIRE (backendFallbackNotice ("", "PipeWire", "ALSA").empty());
+    REQUIRE (backendFallbackNotice (false, "", "PipeWire", "ALSA").empty());
 }
 
 TEST_CASE ("backendFallbackNotice: the preferred backend opening says nothing",
            "[audio][device]")
 {
     // An error that did not cost the preferred backend is not the user's problem.
-    REQUIRE (backendFallbackNotice ("device \"HDMI 0\" is busy", "PipeWire", "PipeWire").empty());
+    REQUIRE (backendFallbackNotice (false, "device \"HDMI 0\" is busy", "PipeWire", "PipeWire").empty());
 }
 
 TEST_CASE ("backendFallbackNotice: a fallback names both backends", "[audio][device]")
 {
-    const auto m = backendFallbackNotice ("PipeWire delivered no usable quantum (0)",
+    const auto m = backendFallbackNotice (false, "PipeWire delivered no usable quantum (0)",
                                           "PipeWire", "ALSA");
     REQUIRE_FALSE (m.empty());
     REQUIRE (contains (m, "PipeWire"));
@@ -140,6 +140,15 @@ TEST_CASE ("backendFallbackNotice: an unknown backend on either side says nothin
 {
     // Nothing opened, or the platform registered no types: the silent-session
     // alert covers that case and the bar would only be guessing.
-    REQUIRE (backendFallbackNotice ("no device", "PipeWire", "").empty());
-    REQUIRE (backendFallbackNotice ("no device", "", "ALSA").empty());
+    REQUIRE (backendFallbackNotice (false, "no device", "PipeWire", "").empty());
+    REQUIRE (backendFallbackNotice (false, "no device", "", "ALSA").empty());
+}
+
+TEST_CASE ("backendFallbackNotice: a restored setup is startupDeviceMessage's to report",
+           "[audio][device]")
+{
+    // Someone who chose ALSA on purpose would otherwise be told it was a
+    // fallback every single launch.
+    REQUIRE (backendFallbackNotice (true, "PipeWire delivered no usable quantum (0)",
+                                    "PipeWire", "ALSA").empty());
 }


### PR DESCRIPTION
Closes #576

## Cause

`PipeWireAudioIODevice::open` waited 100 x 2 ms for `onProcess` to report the graph's real quantum and failed the open with `no usable quantum (0)` when no cycle arrived. `PW_FILTER_STATE_STREAMING` says our node was started, not that the graph has run. `pw-dump --monitor` during a failing open showed all four links active, the target sink running, and the elected driver still suspended. WirePlumber only resumes a suspended device node after the links go active, and the wait was racing that resume.

Measured with a temporary timestamp in the wait, first cycle after STREAMING on PipeWire 1.4.6:

| target device before launch | first cycle |
|---|---|
| already running (4 runs) | 1, 3, 6, 10 ms |
| resuming from suspend (4 runs) | 268, 270, 267, 270 ms |

Every device node is suspended on a launch with no saved device to reopen, which is why this only ever showed on a first launch. Once `audio-device.xml` recorded the ALSA fallback the message never appeared again.

## Change

- The wait is a 2 s deadline polled at 1 ms. The comment carries the measurement. The connect handshake above it already allows longer on the same thread, so this is not a new block.
- The quantum store/load pair is release/acquire.
- A one-line transport-bar notice when the app fell back off the preferred backend on a launch with no saved device state. `startupDeviceMessage` keeps the saved-intent case, so a user who deliberately saved ALSA never sees it. Pure helper with four Catch2 cases.

## Verification

Four cold launches on Xvfb with both target nodes confirmed suspended before each: 4/4 opened PipeWire, 0 fell back. Before: 0/4. Build clean, ctest 1019/1019, gate unchanged at 165 / 8135 with the PipeWire backend at 0, headless self-test passes.

The notice paints correctly but sits under the bank selector in a banked session until #578 lands. That is pre-existing and also hides the no-input line from #554. #578 has the fix; whichever of the two merges second needs a small rebase in `TransportBar.cpp`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a transport-bar notice when startup cannot use the preferred audio backend and falls back to another available backend.
  * The notice identifies both the unavailable and active backends and clears after selecting a device.
* **Bug Fixes**
  * Improved PipeWire startup reliability by waiting for the audio graph to report its active quantum.
  * Updated the displayed test count from 1034 to 1039.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->