### PR TITLE
fix(pipewire): follow PipeWire's own default sink and source

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ GPL source on this repo, so building it yourself costs you nothing but compile t
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 1034 Catch2 test cases across 193 test source files. Linux
+The C++ suite declares 1038 Catch2 test cases across 194 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -124,7 +124,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # Native log storage + CrashHandler signal reports
-tests/         # 1034 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 1038 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/engine/pipewire/PipeWireAudioIODeviceType.cpp
+++ b/src/engine/pipewire/PipeWireAudioIODeviceType.cpp
@@ -1,9 +1,11 @@
 #include "PipeWireAudioIODeviceType.h"
 #include "PipeWireAudioIODevice.h"
+#include "PipeWireDefaultDevice.h"
 
 #include "../../foundation/Text.h"
 
 #include <pipewire/pipewire.h>
+#include <pipewire/extensions/metadata.h>
 #include <spa/utils/dict.h>
 
 #include <cassert>
@@ -81,11 +83,48 @@ struct ScanResult
     std::vector<std::string> inNames, outNames, inIds, outIds;
     std::vector<int>  inChans, outChans;
 
+    // The desktop's chosen devices, as the raw metadata values (JSON objects).
+    // Empty when the graph has no "default" metadata, which is a bare pipewire
+    // with no session manager.
+    std::string defaultSink, defaultSource;
+
     pw_main_loop* loop = nullptr;
+    pw_core*      core = nullptr;
+    pw_registry*  registry = nullptr;
+    pw_proxy*     metadata = nullptr;
+    spa_hook      metadataHook {};
     int  syncSeq = 0;
     bool haveSync = false;
+    // Property events for a metadata object only start after it is bound, which
+    // happens while the first roundtrip is still delivering globals. A second
+    // sync gives them a roundtrip of their own to arrive in.
+    int  metadataSyncSeq = 0;
+    bool haveMetadataSync = false;
     bool completed = false;   // the matching core.done arrived (scan is complete)
 };
+
+int onMetadataProperty (void* data, std::uint32_t subject, const char* key,
+                        const char* /*type*/, const char* value)
+{
+    auto& r = *static_cast<ScanResult*> (data);
+    if (subject != PW_ID_CORE || key == nullptr || value == nullptr)
+        return 0;
+    if (std::strcmp (key, "default.audio.sink") == 0)
+        r.defaultSink = value;
+    else if (std::strcmp (key, "default.audio.source") == 0)
+        r.defaultSource = value;
+    return 0;
+}
+
+pw_metadata_events makeMetadataEvents()
+{
+    pw_metadata_events e {};
+    e.version  = PW_VERSION_METADATA_EVENTS;
+    e.property = onMetadataProperty;
+    return e;
+}
+
+const pw_metadata_events kMetadataEvents = makeMetadataEvents();
 
 void onRegistryGlobal (void* data, uint32_t id, uint32_t /*permissions*/,
                         const char* type, uint32_t /*version*/,
@@ -114,6 +153,22 @@ void onRegistryGlobal (void* data, uint32_t id, uint32_t /*permissions*/,
         n.isSink   = isSink   || isDuplex;
         n.isSource = isSource || isDuplex;
         r.nodes.push_back (n);
+    }
+    else if (std::strcmp (type, PW_TYPE_INTERFACE_Metadata) == 0)
+    {
+        // Only the object the session manager calls "default" carries the
+        // desktop's device choice; others (route settings, per-node state) do not.
+        const char* metaName = spa_dict_lookup (props, PW_KEY_METADATA_NAME);
+        if (metaName == nullptr || std::strcmp (metaName, "default") != 0
+            || r.metadata != nullptr || r.registry == nullptr)
+            return;
+        auto* bound = (pw_proxy*) pw_registry_bind (r.registry, id, type,
+                                                    PW_VERSION_METADATA, 0);
+        if (bound == nullptr)
+            return;
+        r.metadata = bound;
+        pw_metadata_add_listener ((pw_metadata*) bound, &r.metadataHook,
+                                  &kMetadataEvents, &r);
     }
     else if (std::strcmp (type, PW_TYPE_INTERFACE_Port) == 0)
     {
@@ -150,9 +205,24 @@ void onCoreDone (void* data, uint32_t id, int seq)
     auto& r = *static_cast<ScanResult*> (data);
     // The graph delivers every existing registry global BEFORE answering our
     // sync, so once this matching done arrives the enumeration is complete.
-    if (id == PW_ID_CORE && r.haveSync && seq == r.syncSeq)
+    if (id != PW_ID_CORE)
+        return;
+    if (r.haveSync && seq == r.syncSeq)
     {
+        // The node list is whole at this point. Marking it so before waiting on
+        // the metadata keeps a second roundtrip that never answers costing only
+        // the default hint, which has a fallback, rather than the whole scan.
         r.completed = true;
+        if (r.metadata != nullptr && r.core != nullptr && ! r.haveMetadataSync)
+        {
+            r.metadataSyncSeq  = pw_core_sync (r.core, PW_ID_CORE, 0);
+            r.haveMetadataSync = true;
+            return;
+        }
+        pw_main_loop_quit (r.loop);
+    }
+    else if (r.haveMetadataSync && seq == r.metadataSyncSeq)
+    {
         pw_main_loop_quit (r.loop);
     }
 }
@@ -224,6 +294,10 @@ void enumerateNodes (ScanResult& result)
         return;
     }
 
+    // The registry callback binds the "default" metadata object off these.
+    result.core     = core;
+    result.registry = registry;
+
     spa_hook registryHook {};
     spa_hook coreHook {};
     pw_registry_add_listener (registry, &registryHook, &kRegistryEvents, &result);
@@ -241,6 +315,12 @@ void enumerateNodes (ScanResult& result)
     pw_main_loop_run (result.loop);
 
     pw_loop_destroy_source (pwLoop, timer);
+    if (result.metadata != nullptr)
+    {
+        spa_hook_remove (&result.metadataHook);
+        pw_proxy_destroy (result.metadata);
+        result.metadata = nullptr;
+    }
     spa_hook_remove (&registryHook);
     spa_hook_remove (&coreHook);
     pw_proxy_destroy ((pw_proxy*) registry);
@@ -248,6 +328,8 @@ void enumerateNodes (ScanResult& result)
     pw_context_destroy (context);
     pw_main_loop_destroy (result.loop);
     result.loop = nullptr;
+    result.core = nullptr;
+    result.registry = nullptr;
 
     // Only publish devices from a complete scan; a core error or the timeout
     // quits the loop early with partial data, which would list wrong counts.
@@ -272,6 +354,8 @@ void PipeWireAudioIODeviceType::scanForDevices()
     outputIds   = r.outIds;
     inputChans  = r.inChans;
     outputChans = r.outChans;
+    defaultSinkValue   = r.defaultSink;
+    defaultSourceValue = r.defaultSource;
 
     appendNumbersToDuplicates (inputNames);
     appendNumbersToDuplicates (outputNames);
@@ -288,9 +372,20 @@ std::vector<std::string> PipeWireAudioIODeviceType::getDeviceNames (bool wantInp
 int PipeWireAudioIODeviceType::getDefaultDeviceIndex (bool forInput) const
 {
     assert (hasScanned);
-    // Skip monitor sources and HDMI sinks - the same "don't default to the
-    // thing the user didn't mean" heuristic the ALSA backend uses. A saved
-    // selection, once resolved, always takes precedence over this.
+    // What the rest of the desktop plays through and records from, when the
+    // graph says. Ahead of the heuristic below because it is the user's actual
+    // answer rather than a guess at it.
+    if (const int fromMetadata = pipewire::indexOfMetadataDefault (
+            forInput ? defaultSourceValue : defaultSinkValue,
+            forInput ? inputIds : outputIds,
+            forInput ? inputNames : outputNames);
+        fromMetadata >= 0)
+        return fromMetadata;
+
+    // No session manager, or it names something this scan did not see: skip
+    // monitor sources and HDMI sinks, the same "don't default to the thing the
+    // user didn't mean" heuristic the ALSA backend uses. A saved selection,
+    // once resolved, always takes precedence over either.
     const auto& names = forInput ? inputNames : outputNames;
     for (int i = 0; i < (int) names.size(); ++i)
     {

--- a/src/engine/pipewire/PipeWireAudioIODeviceType.h
+++ b/src/engine/pipewire/PipeWireAudioIODeviceType.h
@@ -43,6 +43,10 @@ private:
     std::vector<std::string> inputNames, outputNames;
     std::vector<std::string> inputIds, outputIds;   // PW_KEY_NODE_NAME, index-aligned with the *Names arrays
     std::vector<int>         inputChans, outputChans; // audio.channels, index-aligned with the *Names arrays
+    // Raw "default" metadata values from the last scan, as the graph publishes
+    // them (JSON objects naming a node). Empty when there is no session manager.
+    std::string defaultSinkValue, defaultSourceValue;
+
     bool hasScanned = false;
 
     PipeWireAudioIODeviceType (const PipeWireAudioIODeviceType&) = delete;

--- a/src/engine/pipewire/PipeWireDefaultDevice.h
+++ b/src/engine/pipewire/PipeWireDefaultDevice.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "../../foundation/Json.h"
+#include "../../foundation/Text.h"
+
+#include <string>
+#include <vector>
+
+namespace duskstudio::pipewire
+{
+// The graph publishes the desktop's audio devices in its "default" metadata
+// object, as JSON of the form {"name":"<node.name>"}. Resolve one of those
+// values against a scan's node names.
+//
+// default.audio.sink / .source are the pair in force. The parallel
+// default.configured.audio.* keys record what the user last asked for, which
+// can name a device that is not present right now (a switched-off Bluetooth
+// sink, say), so they are not what to open.
+//
+// Returns the index into ids, or -1 when the value is absent, malformed, names
+// a node this scan did not see, or names a monitor. A monitor is a real choice
+// for the desktop and a bad one for a DAW: defaulting the record input to the
+// loopback of your own output produces takes full of whatever else was playing,
+// and nothing on screen says why. Those fall back to the caller's own order.
+inline int indexOfMetadataDefault (const std::string& metadataValue,
+                                   const std::vector<std::string>& ids,
+                                   const std::vector<std::string>& names)
+{
+    if (metadataValue.empty())
+        return -1;
+
+    const auto parsed = dusk::json::Json::parse (metadataValue, nullptr,
+                                                 /*allow_exceptions*/ false);
+    const auto wanted = dusk::json::getString (parsed, "name");
+    if (wanted.empty())
+        return -1;
+
+    for (int i = 0; i < (int) ids.size(); ++i)
+    {
+        if (ids[(size_t) i] != wanted)
+            continue;
+        if (dusk::text::containsIgnoreCase (ids[(size_t) i], "monitor"))
+            return -1;
+        if (i < (int) names.size()
+            && dusk::text::containsIgnoreCase (names[(size_t) i], "monitor"))
+            return -1;
+        return i;
+    }
+    return -1;
+}
+} // namespace duskstudio::pipewire

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,6 +83,7 @@ add_executable(dusk-studio-tests
     session_portable_paths.cpp
     session_track_shrink.cpp
     device_fallback_message.cpp
+    pipewire_default_device.cpp
     imgui_gl_loader_win32.cpp
     device_interfaces.cpp
     device_state_blob.cpp

--- a/tests/pipewire_default_device.cpp
+++ b/tests/pipewire_default_device.cpp
@@ -1,0 +1,66 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/pipewire/PipeWireDefaultDevice.h"
+
+#include <string>
+#include <vector>
+
+using duskstudio::pipewire::indexOfMetadataDefault;
+
+// PipeWire publishes the desktop's chosen devices as JSON in its "default"
+// metadata object. Resolving one of those values against a scan is pure, so it
+// carries the coverage; binding the metadata object needs a live graph.
+
+namespace
+{
+const std::vector<std::string> kIds {
+    "alsa_output.usb-BEHRINGER_UMC1820-00.multichannel-output",
+    "alsa_output.pci-0000_00_1f.3.analog-stereo",
+    "alsa_output.pci-0000_00_1f.3.analog-stereo.monitor",
+};
+const std::vector<std::string> kNames {
+    "UMC1820 Multichannel",
+    "Built-in Audio Analog Stereo",
+    "Monitor of Built-in Audio Analog Stereo",
+};
+} // namespace
+
+TEST_CASE ("indexOfMetadataDefault: names a device the scan saw", "[audio][pipewire]")
+{
+    REQUIRE (indexOfMetadataDefault (
+                 R"({"name":"alsa_output.pci-0000_00_1f.3.analog-stereo"})", kIds, kNames)
+             == 1);
+}
+
+TEST_CASE ("indexOfMetadataDefault: names a device the scan did not see",
+           "[audio][pipewire]")
+{
+    // A default that is configured but absent, such as a Bluetooth sink that is
+    // switched off. The caller's own order decides instead.
+    REQUIRE (indexOfMetadataDefault (
+                 R"({"name":"bluez_output.41_42_3E_4D_61_3B.1"})", kIds, kNames)
+             == -1);
+}
+
+TEST_CASE ("indexOfMetadataDefault: a monitor default falls through", "[audio][pipewire]")
+{
+    // Recording the loopback of your own output by default produces takes full
+    // of whatever else was playing, with nothing on screen to say why.
+    REQUIRE (indexOfMetadataDefault (
+                 R"({"name":"alsa_output.pci-0000_00_1f.3.analog-stereo.monitor"})",
+                 kIds, kNames)
+             == -1);
+}
+
+TEST_CASE ("indexOfMetadataDefault: no metadata, or metadata that is not usable",
+           "[audio][pipewire]")
+{
+    SECTION ("absent")        { REQUIRE (indexOfMetadataDefault ("", kIds, kNames) == -1); }
+    SECTION ("not json")      { REQUIRE (indexOfMetadataDefault ("alsa_output.x", kIds, kNames) == -1); }
+    SECTION ("truncated")     { REQUIRE (indexOfMetadataDefault (R"({"name":)", kIds, kNames) == -1); }
+    SECTION ("no name key")   { REQUIRE (indexOfMetadataDefault (R"({"id":7})", kIds, kNames) == -1); }
+    SECTION ("empty name")    { REQUIRE (indexOfMetadataDefault (R"({"name":""})", kIds, kNames) == -1); }
+    SECTION ("name not text") { REQUIRE (indexOfMetadataDefault (R"({"name":7})", kIds, kNames) == -1); }
+    SECTION ("json null")     { REQUIRE (indexOfMetadataDefault ("null", kIds, kNames) == -1); }
+    SECTION ("empty scan")    { REQUIRE (indexOfMetadataDefault (R"({"name":"x"})", {}, {}) == -1); }
+}


### PR DESCRIPTION
Closes #577
Found on #536 step 1.

`PipeWireAudioIODeviceType::getDefaultDeviceIndex` took the first non-Monitor non-HDMI node in registry order and ignored PipeWire's own defaults. On the dev box that put the UMC1820 in front of the built-in analog output the desktop uses.

## Change

- During the existing scan roundtrip the registry callback binds the `default` metadata object and listens for `default.audio.sink` and `default.audio.source`. A second `pw_core_sync` gives the property events a roundtrip. The scan is marked complete before the metadata wait, so a lost second roundtrip only loses the hint, never the node list.
- `indexOfMetadataDefault` in the new `PipeWireDefaultDevice.h` is pure: parses the `{"name":...}` value, resolves against the scanned nodes, returns -1 for absent, malformed, unknown or monitor.
- The effective `default.audio.sink` is used, not `default.configured.audio.sink`. On the dev box the configured key names a Bluetooth sink that is not in the graph.
- Monitors stay excluded even when named as the default. A DAW whose record input defaults to the loopback of its own output produces takes full of whatever else was playing, with nothing on screen to say why.
- Fallback is the previous order when the metadata is absent.

## Verification

Four Catch2 cases, 12 assertions. Build clean, ctest 1018/1018, gate unchanged with all three PipeWire files at 0, headless self-test passes. Fresh-HOME launch on Xvfb now opens `Built-in Audio Analog Stereo` where it opened `UMC1820 Multichannel` before.
