### PR TITLE
docs: cover the changes merged since 0.13.3 was dated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,81 @@ All notable changes to Dusk Studio. Format loosely follows
 back-filled from `git log`; once tags exist this file is the
 canonical source.
 
+## [Unreleased]
+
+Work towards 1.0: the first five minutes of using Dusk Studio, offline
+instrument browsing, quitting cleanly by any route, and the release pipeline
+that will carry a signed 1.0.
+
+### Added
+
+- **A one-page quickstart, and a menu item that opens it.** `QUICKSTART.md`
+  ships inside every package and **Settings > Quickstart** hands it to whatever
+  your system uses for text. The item greys out and says so when the file is not
+  installed beside the app.
+- **The first session is created from a template.** Choosing **New** in the
+  startup dialog offers Blank, Band, Beats and Singer-Songwriter, the same set
+  as **File > New from template**, instead of always starting blank.
+- **An offline library for installed instruments.** **Library...** in the
+  soundfont editor lists the `.sfz` and `.sf2` files already on the machine, so
+  loading one does not mean remembering where it lives. The scan is
+  depth-capped, survives symlink loops, can be cancelled, and reports roots it
+  could not read rather than dropping them. It never reaches the network.
+- **First launch picks an input device.** With nothing saved yet, a backend that
+  offers a capture device gets one selected alongside the output, so recording
+  works without visiting Settings first. An existing configuration is never
+  touched.
+- **Releases carry a signed checksum file.** `SHA256SUMS` now ships with a
+  detached OpenPGP signature beside it, and the manual documents the verify
+  command. A tag cannot publish without it.
+
+### Changed
+
+- **Arming a track with no input is refused, and says why.** ARM no longer
+  lights on an audio track while the open device offers no capture channels,
+  because the recording that followed wrote nothing and said nothing. The
+  transport bar carries the reason. A device change that takes the inputs away
+  disarms audio tracks and raises the same message.
+- **The bounce dialog keeps the file name readable.** A path too long for the
+  line is shortened in the middle rather than cut off at the right-hand edge,
+  the whole path is on the line's tooltip, and **Copy path** puts it on the
+  clipboard.
+- **Waveforms are drawn from Dusk-owned peak data.** The mastering overview and
+  the region editor both render from peaks generated in the background instead
+  of JUCE's thumbnail cache. Short files keep fine detail, sample-level
+  zoom reads exact column ranges, and the paint path performs no file reads.
+  Clicking to seek works while a file is still loading.
+
+### Fixed
+
+- **Logging out no longer skips the unsaved-changes prompt.** A termination
+  signal, a logout or a shutdown runs the same staged shutdown as **File >
+  Quit**, so the prompt appears and plugin child processes are not left to be
+  reaped.
+- **A session that has never been saved is not dirty because it autosaved.**
+  Creating a session no longer asks whether to save changes that were never
+  made.
+- **Keyboard shortcuts work without clicking the window first.** Any launch that
+  shows no startup dialog left the window with nothing focused, and every
+  shortcut in the manual was dead until the user happened to click the canvas.
+- **A plugin loaded out of process is not killed moments later.** The sandbox
+  child was spawned from a worker thread that exits as soon as the load
+  reports success, and on Linux the child's parent-death signal fires when that
+  thread exits rather than when the application does.
+- **Opening a session while Dusk Studio is running always reaches the running
+  copy.** Simultaneous launches could each conclude they were the only one, and
+  on macOS a launch that could not reach the running copy started a second
+  window and its session was the one that lost work. The slot is claimed with an
+  owner lock rather than inferred from a refusal.
+- **MIDI files whose header over-counts their tracks import again.** A header
+  that includes a vendor chunk in its track count made the reader run past the
+  end of the file and fail the whole import, discarding tracks it had already
+  parsed. It keeps what it read, which is what the previous reader did.
+- **Faders report mute to a screen reader.** A fader could speak a finite gain
+  while the signal was already hard-muted, and text set to `-INF dB` was read
+  back as 0 dB. The manual's Linux screen-reader claims are corrected to match
+  what is implemented.
+
 ## [0.13.3] - 2026-09-05
 
 This release hardens session and plugin recovery, transport MIDI cleanup,

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -344,7 +344,7 @@ Any modern multi-core CPU (Intel, AMD, or Apple Silicon) is sufficient for a 24-
 
 ## Installing Dusk Studio
 
-The binaries shipped via Patreon and GitHub Sponsors are **unsigned by design** — Dusk Studio uses no Apple Developer ID and no Windows Authenticode certificate, and neither is planned. The result: macOS Gatekeeper and Windows SmartScreen will warn you on first launch. The warning is expected and the bypass is quick — under 30 seconds per OS — but it is required the first time.
+The binaries shipped via Patreon and GitHub Sponsors before 1.0 are **unsigned** - they carry no Apple Developer ID and no Windows Authenticode certificate. Signing both is part of 1.0. Until a signed release lands, the result is unchanged: macOS Gatekeeper and Windows SmartScreen will warn you on first launch. The warning is expected and the bypass is quick — under 30 seconds per OS — but it is required the first time.
 
 The source on GitHub is GPL-3.0; anyone who prefers to skip the warning can build from source.
 
@@ -421,7 +421,15 @@ Get-FileHash -Algorithm SHA256 dusk-studio-*-Windows-x64.msi
 # Compare against that file's line in the published SHA256SUMS.
 ```
 
-Verification protects against a bit-flipped download or a man-in-the-middle attack on the release attachment. It does NOT verify authorship; that's what the (currently absent) code-signing certificate would do.
+From 1.0 on, `SHA256SUMS` ships with a detached OpenPGP signature, `SHA256SUMS.asc`, and the public key that made it is published with the release. Import that key once, then check the signature before you check the hashes:
+
+```bash
+gpg --verify SHA256SUMS.asc SHA256SUMS
+```
+
+The checksums tell you the download arrived intact. The signature is what tells you the checksums came from us, so a signature that does not verify matters more than a hash that does.
+
+Verification protects against a bit-flipped download or a man-in-the-middle attack on the release attachment.
 
 ## First launch
 
@@ -449,6 +457,7 @@ Open **Settings → Audio…** to choose your audio device. The panel is divided
 - **Active output channels**: the master mix uses outputs 1-2. If your interface has more outputs, tick the extra pairs here to open them — each pair then becomes selectable as an aux lane's **Output** (a headphone / cue feed). Off by default; the master stays stereo until you enable more.
 - **Main output**: which physical pair the master mix goes to. **1-2 (default)** in most rigs; move it to another pair (e.g. when you want outputs 1-2 free for a control-room or cue feed). Only pairs the device currently has open are listed. If an aux lane is routed to the same pair as the master, the two sum on that pair.
 - **Rescan devices**: re-enumerates every backend and every MIDI port, useful if you plugged in a USB interface after launch. MIDI controllers on Linux do not need it — see [MIDI hot-plug](#midi-hot-plug).
+- **First launch only**: with nothing saved yet, Dusk Studio picks an input device alongside the output when the backend offers one, so recording works without a trip to this panel first. It never touches a configuration you have already made: if you chose no input on purpose, it stays that way.
 
 ### Control surface
 


### PR DESCRIPTION
Refs the Docs section of docs/RELEASE-1.0.md.

CHANGELOG.md had no `[Unreleased]` section: 33 PRs merged since `[0.13.3]` was dated and none were recorded. Every merged PR was checked against MANUAL.md and CHANGELOG.md.

## CHANGELOG

New `## [Unreleased]` with Added / Changed / Fixed in the file's existing style, covering the fourteen user-visible items: first-launch input pick, template choice on first session, ARM refusal with the reason in the bar, staged shutdown on logout and SIGTERM, offline SFZ/SF2 library, Settings > Quickstart and QUICKSTART.md in every package, readable bounce dialog with Copy path, shortcuts without a first click, session handoff to the running copy, screen-reader mute state, waveform detail on short files and at sample zoom, MIDI header over-count import, out-of-process plugin no longer killed after load, signed SHA256SUMS.

## MANUAL

Three additions, no existing prose rewritten except one correction:

- Audio settings: first launch picks an input device alongside the output; an existing configuration is never touched.
- Verifying your download: `SHA256SUMS.asc`, the `gpg --verify` command, and why a bad signature matters more than a good hash.
- Installing: the sentence saying no Developer ID or Authenticode signing "and neither is planned" contradicted RELEASE-1.0.md and #571. Now says signing is 1.0 work and the OS warnings stand until a signed release lands.

Internal, CI, packaging-mechanics and build-time-only PRs got no entry; the reasons are in the audit table on the branch report.

`scripts/release-metadata-check.sh` exit 0. `release-mechanics-contract` and `package-contents-checker` pass. No em dashes, no emulated-hardware names.
