### PR TITLE
feat(builtin): built-in insert rung, Utility unit, picker section and session state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,16 @@ that will carry a signed 1.0.
 - **Releases carry a signed checksum file.** `SHA256SUMS` now ships with a
   detached OpenPGP signature beside it, and the manual documents the verify
   command. A tag cannot publish without it.
+- **Built-in insert units.** Dusk Studio now ships its own insert units, listed
+  in a **Built-In** section pinned to the top of the plugin picker. They are
+  compiled into the application, so they need no scan and are available on a
+  fresh install with no third-party plugins on the machine. A built-in unit
+  loads onto a channel insert or an aux lane slot exactly like a scanned
+  plugin, replaces whatever the slot held, reports its latency to delay
+  compensation, and saves and restores its settings with the session and
+  through Clone Track and its undo. The first unit is **Utility**: gain,
+  polarity invert, stereo width and mono sum, all smoothed over 20 ms and
+  transparent at their defaults. Per-unit editor panels follow.
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -681,15 +681,15 @@ target_sources(DuskStudio PRIVATE
     src/engine/McuReceiver.cpp
     src/engine/McuController.cpp
     src/engine/MidiTimeCodeEmitter.cpp
+    src/engine/builtin/BuiltinInstance.cpp
+    src/engine/builtin/BuiltinRegistry.cpp
+    src/engine/builtin/UtilityUnit.cpp
     # DeviceManager: native orchestrator on Linux (DeviceManager.cpp), JUCE-wrapped
     # fallback off Linux (DeviceManagerJuce.cpp). Gated below the target_sources().
     src/engine/midi/MidiDevices.cpp
     src/engine/midi/MidiFileReader.cpp
     src/engine/NativePluginCache.cpp
     src/engine/PlaybackEngine.cpp
-    src/engine/builtin/BuiltinInstance.cpp
-    src/engine/builtin/BuiltinRegistry.cpp
-    src/engine/builtin/UtilityUnit.cpp
     src/engine/PluginDescriptor.cpp
     src/engine/PluginManager.cpp
     src/engine/PluginSlot.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -687,6 +687,9 @@ target_sources(DuskStudio PRIVATE
     src/engine/midi/MidiFileReader.cpp
     src/engine/NativePluginCache.cpp
     src/engine/PlaybackEngine.cpp
+    src/engine/builtin/BuiltinInstance.cpp
+    src/engine/builtin/BuiltinRegistry.cpp
+    src/engine/builtin/UtilityUnit.cpp
     src/engine/PluginDescriptor.cpp
     src/engine/PluginManager.cpp
     src/engine/PluginSlot.cpp
@@ -986,15 +989,10 @@ if(UNIX AND NOT APPLE AND PIPEWIRE_FOUND)
     target_compile_definitions(DuskStudio PRIVATE DUSKSTUDIO_HAS_PIPEWIRE=1)
 endif()
 
-# Shared native-host layer (format-agnostic) — compiled whenever any native host
-# or the multisample instrument rung is on, so it isn't double-added by the
-# per-format blocks below. The sfizz test mirrors the multisample gate further
-# down: that rung is platform-independent, so mac/win link it too.
-if(DUSKSTUDIO_NATIVE_CLAP OR DUSKSTUDIO_NATIVE_LV2 OR DUSKSTUDIO_NATIVE_VST3
-   OR DUSKSTUDIO_NATIVE_AU
-   OR EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/sfizz/src/sfizz.h")
-    target_sources(DuskStudio PRIVATE src/engine/hosting/InsertAdapter.cpp)
-endif()
+# Shared native-host layer (format-agnostic). Unconditional: the built-in unit
+# rung is always compiled in, so every platform reaches the insert adapter
+# whether or not a third-party host format is enabled.
+target_sources(DuskStudio PRIVATE src/engine/hosting/InsertAdapter.cpp)
 
 # Native macOS Audio Unit host. Registry discovery is metadata-only (no child
 # scanner needed); instantiation, rendering, state, and Cocoa views use the

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1564,12 +1564,14 @@ In the **plugin picker** modal:
 
 - Use the filter field at the top to narrow by name.
 - The list is grouped by manufacturer. Click a manufacturer to expand or collapse.
-- Each row shows the plugin name and its format (VST3 / LV2 / AudioUnit / CLAP / LV2-Native / VST3-Native).
+- Each row shows the plugin name and its format (VST3 / LV2 / AudioUnit / CLAP / LV2-Native / VST3-Native / Built-In).
 - Click a row to load and dismiss.
 
 Both the effect and instrument pickers list VST3 plugins as **VST3-Native** rows on every OS, and LV2 plugins as **LV2-Native** rows on Linux and macOS — the same plugins, hosted by Dusk Studio's native hosts instead of the standard one. On macOS, Audio Units appear once as native **AudioUnit** rows. There are no duplicate standard-host rows for these formats.
 
 The picker filters by intent: only effect plugins appear when you're loading onto a channel insert or aux lane; only instruments appear when you're loading onto a MIDI track.
+
+A **Built-In** section sits at the top of the list, above the manufacturer groups, and stays there whichever grouping you pick. Those rows are Dusk Studio's own units. They are compiled into the application, so they need no scan, they are present on a fresh install with nothing else on the machine, and they are identical on Linux, macOS and Windows. See *Built-in insert units* below.
 
 The insert chooser and the bottom of the picker also provide these actions where applicable:
 
@@ -1577,6 +1579,27 @@ The insert chooser and the bottom of the picker also provide these actions where
 - **Soundfont (.sfz / .sf2 / .bank.xml)**: open a soundfont directly. Choosing this on an audio track converts the track to MIDI; see *Multi-sample instruments*.
 - **Browse file…**: load a plugin by file path (useful for plugins not yet in the scan cache).
 - **Scan plugins**: re-scan.
+
+## Built-in insert units
+
+Dusk Studio ships its own insert units. They load into a channel insert slot or an aux lane slot exactly like a scanned plugin: the same picker, the same Replace and Remove actions, the same bypass, and the same delay compensation. Only one insert host runs per slot, so loading a built-in unit replaces whatever the slot held, and loading a plugin replaces the built-in unit.
+
+Settings are saved with the session and restored when you reopen it, and they travel with **Clone Track** and its undo. A built-in unit needs nothing installed and cannot go offline the way a missing plugin does.
+
+### Utility
+
+A clean gain and stereo-image tool. Reach for it to trim a level without touching the fader, to flip an out-of-phase mic, to check a mix in mono, or to narrow a stereo source that is fighting the centre.
+
+| Control | Range | Default | What it does |
+|---|---|---|---|
+| Gain | −60 dB to +24 dB | 0 dB | Output level. At the bottom of the range the unit is silent rather than very quiet. |
+| Polarity | Off / On | Off | Inverts both channels. Useful on a mic that is out of phase with another. |
+| Width | 0% to 200% | 100% | Stereo width. 100% passes left and right through untouched, 0% collapses to the centre, and above 100% pushes the sides wider. |
+| Mono | Off / On | Off | Sums left and right to the centre. Width has no effect once Mono is on, because the sum has already removed the sides. |
+
+The controls are applied in the order polarity, width, mono, gain. Every one of them is smoothed over 20 milliseconds, so moving a control never clicks. At its defaults the unit passes audio through unchanged and adds no latency.
+
+Utility has no editor window yet, so its controls are not adjustable from the interface in this release. It loads, processes, saves and reloads; the panel follows.
 
 ## Opening the editor
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ GPL source on this repo, so building it yourself costs you nothing but compile t
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 1050 Catch2 test cases across 195 test source files. Linux
+The C++ suite declares 1051 Catch2 test cases across 196 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -124,7 +124,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # Native log storage + CrashHandler signal reports
-tests/         # 1050 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 1051 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ GPL source on this repo, so building it yourself costs you nothing but compile t
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 1051 Catch2 test cases across 196 test source files. Linux
+The C++ suite declares 1052 Catch2 test cases across 196 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -124,7 +124,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # Native log storage + CrashHandler signal reports
-tests/         # 1051 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 1052 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ GPL source on this repo, so building it yourself costs you nothing but compile t
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 1043 Catch2 test cases across 194 test source files. Linux
+The C++ suite declares 1050 Catch2 test cases across 195 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -124,7 +124,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # Native log storage + CrashHandler signal reports
-tests/         # 1043 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 1050 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/src/dsp/AuxLaneStrip.cpp
+++ b/src/dsp/AuxLaneStrip.cpp
@@ -208,6 +208,46 @@ void AuxLaneStrip::prepare (double sampleRate, int blockSize)
     }
 #endif
 
+    for (int s = 0; s < kMaxPlugins; ++s)
+    {
+        auto& bs = builtinSlots[(size_t) s];
+        if (bs.isLoaded())
+        {
+            const auto unitName = bs.displayName();
+            std::string err;
+            const bool loaded = bs.reactivate (preparedSampleRate, preparedBlockSize, err);
+            const auto reason = hosting::enforceReactivationPolicy (
+                loaded, err, [&] { bs.quarantineAfterFailedReactivation(); });
+            const bool wasFailed = builtinRestoreFailed[(size_t) s].exchange (
+                ! reason.empty(), std::memory_order_relaxed);
+            if (! reason.empty() && ! wasFailed)
+                nativeRestoreFailures.push_back ({ "built-in", unitName, reason, s });
+        }
+        else if (! pendingBuiltinId[(size_t) s].empty())
+        {
+            if (! isNativeClapLoaded (s) && ! isNativeLv2Loaded (s)
+                && ! isNativeVst3Loaded (s) && ! isNativeAuLoaded (s))
+            {
+                const auto& unitId = pendingBuiltinId[(size_t) s];
+                const bool stateWasSupplied = ! pendingBuiltinState[(size_t) s].empty();
+                std::string err;
+                const bool loaded = bs.loadUnit (
+                    unitId, preparedSampleRate, preparedBlockSize, err);
+                const bool stateAccepted = ! stateWasSupplied
+                    || (loaded && bs.loadState (pendingBuiltinState[(size_t) s]));
+                const auto reason = hosting::enforceRestorePolicy (
+                    loaded, stateWasSupplied, stateAccepted, err,
+                    pendingBuiltinState[(size_t) s].size(), [&] { bs.unload(); });
+                builtinRestoreFailed[(size_t) s].store (! reason.empty(),
+                                                        std::memory_order_relaxed);
+                if (! reason.empty())
+                    nativeRestoreFailures.push_back ({ "built-in", unitId, reason, s });
+            }
+            pendingBuiltinId[(size_t) s].clear();
+            pendingBuiltinState[(size_t) s].clear();
+        }
+    }
+
     constexpr double rampSeconds = 0.020;
     returnGain.reset (sampleRate, rampSeconds);
     returnGain.setCurrentAndTargetValue (1.0f);
@@ -260,6 +300,7 @@ bool AuxLaneStrip::loadNativeClap (int slotIdx, const juce::File& path, std::str
     unloadNativeLv2 (slotIdx);
     unloadNativeVst3 (slotIdx);
     unloadNativeAu (slotIdx);
+    unloadBuiltin (slotIdx);
     slots[(size_t) slotIdx].unload();
     const bool ok = nativeClapSlots[(size_t) slotIdx].load (std::filesystem::u8path (path.getFullPathName().toStdString()),
                                                             preparedSampleRate, preparedBlockSize, errorOut, pluginId.toStdString());
@@ -301,6 +342,7 @@ bool AuxLaneStrip::loadNativeLv2 (int slotIdx, const juce::File& path, std::stri
     unloadNativeClap (slotIdx);
     unloadNativeVst3 (slotIdx);
     unloadNativeAu (slotIdx);
+    unloadBuiltin (slotIdx);
     slots[(size_t) slotIdx].unload();
     const bool ok = nativeLv2Slots[(size_t) slotIdx].load (std::filesystem::u8path (path.getFullPathName().toStdString()),
                                                            preparedSampleRate, preparedBlockSize, errorOut, pluginId.toStdString());
@@ -342,6 +384,7 @@ bool AuxLaneStrip::loadNativeVst3 (int slotIdx, const juce::File& path, std::str
     unloadNativeClap (slotIdx);
     unloadNativeLv2 (slotIdx);
     unloadNativeAu (slotIdx);
+    unloadBuiltin (slotIdx);
     slots[(size_t) slotIdx].unload();
     const bool ok = nativeVst3Slots[(size_t) slotIdx].load (std::filesystem::u8path (path.getFullPathName().toStdString()),
                                                             preparedSampleRate, preparedBlockSize, errorOut, pluginId.toStdString());
@@ -380,6 +423,7 @@ bool AuxLaneStrip::loadNativeAu (int slotIdx, const juce::String& identifier,
     unloadNativeClap (slotIdx);
     unloadNativeLv2 (slotIdx);
     unloadNativeVst3 (slotIdx);
+    unloadBuiltin (slotIdx);
     slots[(size_t) slotIdx].unload();
     const auto stableId = identifier.toStdString();
     const bool ok = nativeAuSlots[(size_t) slotIdx].load (
@@ -407,6 +451,41 @@ void AuxLaneStrip::setPendingNativeAu (int slotIdx,
     pendingAuState[(size_t) slotIdx] = std::move (state);
 }
 #endif
+
+bool AuxLaneStrip::loadBuiltin (int slotIdx, const std::string& unitId,
+                                std::string& errorOut)
+{
+    jassert (slotIdx >= 0 && slotIdx < kMaxPlugins);
+    if (preparedSampleRate <= 0.0 || preparedBlockSize <= 0)
+    { errorOut = "aux lane not prepared"; return false; }
+    // One host per slot - see loadNativeClap.
+    unloadNativeClap (slotIdx);
+    unloadNativeLv2 (slotIdx);
+    unloadNativeVst3 (slotIdx);
+    unloadNativeAu (slotIdx);
+    slots[(size_t) slotIdx].unload();
+    const bool ok = builtinSlots[(size_t) slotIdx].loadUnit (
+        unitId, preparedSampleRate, preparedBlockSize, errorOut);
+    builtinRestoreFailed[(size_t) slotIdx].store (false, std::memory_order_relaxed);
+    return ok;
+}
+
+void AuxLaneStrip::unloadBuiltin (int slotIdx) noexcept
+{
+    jassert (slotIdx >= 0 && slotIdx < kMaxPlugins);
+    builtinSlots[(size_t) slotIdx].unload();
+    builtinRestoreFailed[(size_t) slotIdx].store (false, std::memory_order_relaxed);
+    pendingBuiltinId[(size_t) slotIdx].clear();
+    pendingBuiltinState[(size_t) slotIdx].clear();
+}
+
+void AuxLaneStrip::setPendingBuiltin (int slotIdx, std::string unitId,
+                                      std::vector<uint8_t> state) noexcept
+{
+    jassert (slotIdx >= 0 && slotIdx < kMaxPlugins);
+    pendingBuiltinId[(size_t) slotIdx]    = std::move (unitId);
+    pendingBuiltinState[(size_t) slotIdx] = std::move (state);
+}
 
 void AuxLaneStrip::updateGainTarget() noexcept
 {
@@ -522,6 +601,9 @@ void AuxLaneStrip::processStereoBlock (float* L, float* R, int numSamples,
                 nativeAuSlots[sIdx].processStereo (L, R, L, R, numSamples);
             else
 #endif
+            if (builtinSlots[sIdx].isLoaded())
+                builtinSlots[sIdx].processStereo (L, R, L, R, numSamples);
+            else
                 slots[sIdx].processStereoBlock (L, R, numSamples, pluginMidiScratch);
         }
         else if (activeInsertMode[sIdx] == kInsertHardware)

--- a/src/dsp/AuxLaneStrip.cpp
+++ b/src/dsp/AuxLaneStrip.cpp
@@ -241,7 +241,11 @@ void AuxLaneStrip::prepare (double sampleRate, int blockSize)
                 builtinRestoreFailed[(size_t) s].store (! reason.empty(),
                                                         std::memory_order_relaxed);
                 if (! reason.empty())
-                    nativeRestoreFailures.push_back ({ "built-in", unitId, reason, s });
+                {
+                    const auto* info = builtin::findUnit (unitId);
+                    nativeRestoreFailures.push_back (
+                        { "built-in", info != nullptr ? info->name : unitId, reason, s });
+                }
             }
             pendingBuiltinId[(size_t) s].clear();
             pendingBuiltinState[(size_t) s].clear();

--- a/src/dsp/AuxLaneStrip.h
+++ b/src/dsp/AuxLaneStrip.h
@@ -9,6 +9,7 @@
 #include "../session/Session.h"
 #include "../engine/PluginSlot.h"
 #include "../engine/hosting/NativeRestorePolicy.h"
+#include "../engine/builtin/NativeBuiltinSlot.h"
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
   #include "../engine/clap/NativeClapSlot.h"   // Linux-only native CLAP host
 #endif
@@ -161,10 +162,28 @@ public:
     bool nativeVst3ReloadFailed (int) const noexcept { return false; }
 #endif
 
+    // Built-in unit rung - same contract as the CLAP block above, with a
+    // registry id in place of a bundle path. Never compile-gated.
+    bool loadBuiltin (int slotIdx, const std::string& unitId, std::string& errorOut);
+    void unloadBuiltin (int slotIdx) noexcept;
+    bool isBuiltinLoaded (int slotIdx) const noexcept
+        { jassert (slotIdx >= 0 && slotIdx < kMaxPlugins); return builtinSlots[(size_t) slotIdx].isLoaded(); }
+    builtin::NativeBuiltinSlot& getBuiltinSlot (int idx) noexcept
+        { jassert (idx >= 0 && idx < kMaxPlugins); return builtinSlots[(size_t) idx]; }
+    const builtin::NativeBuiltinSlot& getBuiltinSlot (int idx) const noexcept
+        { jassert (idx >= 0 && idx < kMaxPlugins); return builtinSlots[(size_t) idx]; }
+    void setPendingBuiltin (int slotIdx, std::string unitId,
+                            std::vector<uint8_t> state) noexcept;
+    bool builtinReloadFailed (int slotIdx) const noexcept
+        { jassert (slotIdx >= 0 && slotIdx < kMaxPlugins); return builtinRestoreFailed[(size_t) slotIdx].load (std::memory_order_relaxed); }
+    void markBuiltinRestoreFailed (int slotIdx) noexcept
+        { jassert (slotIdx >= 0 && slotIdx < kMaxPlugins); builtinRestoreFailed[(size_t) slotIdx].store (true, std::memory_order_relaxed); }
+
     bool nativeInsertRestoreFailed (int slotIdx) const noexcept
     {
         return nativeClapReloadFailed (slotIdx) || nativeLv2ReloadFailed (slotIdx)
-            || nativeVst3ReloadFailed (slotIdx) || nativeAuReloadFailed (slotIdx);
+            || nativeVst3ReloadFailed (slotIdx) || nativeAuReloadFailed (slotIdx)
+            || builtinReloadFailed (slotIdx);
     }
 
     // MIDI Learn: last-touched parameter of whichever host owns the slot
@@ -210,6 +229,10 @@ private:
 
     std::array<PluginSlot, kMaxPlugins> slots;
     std::array<HardwareInsertSlot, kMaxPlugins> hardwareSlots;
+    std::array<builtin::NativeBuiltinSlot, kMaxPlugins> builtinSlots;
+    std::array<std::atomic<bool>,          kMaxPlugins> builtinRestoreFailed {};
+    std::array<std::string,                kMaxPlugins> pendingBuiltinId;
+    std::array<std::vector<uint8_t>,       kMaxPlugins> pendingBuiltinState;
     std::vector<hosting::NativeRestoreFailure> nativeRestoreFailures;
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
     std::array<clap::NativeClapSlot, kMaxPlugins> nativeClapSlots;

--- a/src/dsp/ChannelStrip.cpp
+++ b/src/dsp/ChannelStrip.cpp
@@ -315,6 +315,42 @@ void ChannelStrip::prepare (double sampleRate, int blockSize, int oversamplingFa
     }
 #endif
 
+    if (builtinSlot.isLoaded())
+    {
+        const auto unitName = builtinSlot.displayName();
+        std::string err;
+        const bool loaded = builtinSlot.reactivate (
+            preparedSampleRate, preparedBlockSize, err);
+        const auto reason = hosting::enforceReactivationPolicy (
+            loaded, err, [&] { builtinSlot.quarantineAfterFailedReactivation(); });
+        const bool wasFailed = builtinRestoreFailed.exchange (
+            ! reason.empty(), std::memory_order_relaxed);
+        if (! reason.empty() && ! wasFailed)
+            nativeRestoreFailures.push_back ({ "built-in", unitName, reason });
+    }
+    else if (! pendingBuiltinId.empty())
+    {
+        if (! isNativeClapLoaded() && ! isNativeLv2Loaded() && ! isNativeVst3Loaded()
+            && ! isNativeAuLoaded() && ! isNativeMultisampleLoaded())
+        {
+            const auto& unitId = pendingBuiltinId;
+            const bool stateWasSupplied = ! pendingBuiltinState.empty();
+            std::string err;
+            const bool loaded = builtinSlot.loadUnit (
+                unitId, preparedSampleRate, preparedBlockSize, err);
+            const bool stateAccepted = ! stateWasSupplied
+                || (loaded && builtinSlot.loadState (pendingBuiltinState));
+            const auto reason = hosting::enforceRestorePolicy (
+                loaded, stateWasSupplied, stateAccepted, err, pendingBuiltinState.size(),
+                [&] { builtinSlot.unload(); });
+            builtinRestoreFailed.store (! reason.empty(), std::memory_order_relaxed);
+            if (! reason.empty())
+                nativeRestoreFailures.push_back ({ "built-in", unitId, reason });
+        }
+        pendingBuiltinId.clear();
+        pendingBuiltinState.clear();
+    }
+
     // Oversampling: wrap (EQ + Comp) in a Dusk Studio-side oversampler when the
     // user picks 2× / 4× in Audio Settings. The EQ's always-on console
     // saturation and the comp's saturation alias hard at native rate; the wrap
@@ -604,6 +640,7 @@ bool ChannelStrip::loadNativeClap (const juce::File& path, std::string& errorOut
     unloadNativeVst3();
     unloadNativeAu();
     unloadNativeMultisample();
+    unloadBuiltin();
     pluginSlot.unload();
     const bool ok = nativeClapSlot.load (std::filesystem::u8path (path.getFullPathName().toStdString()),
                                          preparedSampleRate, preparedBlockSize, errorOut, pluginId.toStdString());
@@ -643,6 +680,7 @@ bool ChannelStrip::loadNativeLv2 (const juce::File& path, std::string& errorOut,
     unloadNativeVst3();
     unloadNativeAu();
     unloadNativeMultisample();
+    unloadBuiltin();
     pluginSlot.unload();
     const bool ok = nativeLv2Slot.load (std::filesystem::u8path (path.getFullPathName().toStdString()),
                                         preparedSampleRate, preparedBlockSize, errorOut, pluginId.toStdString());
@@ -682,6 +720,7 @@ bool ChannelStrip::loadNativeVst3 (const juce::File& path, std::string& errorOut
     unloadNativeLv2();
     unloadNativeAu();
     unloadNativeMultisample();
+    unloadBuiltin();
     pluginSlot.unload();
     const bool ok = nativeVst3Slot.load (std::filesystem::u8path (path.getFullPathName().toStdString()),
                                          preparedSampleRate, preparedBlockSize, errorOut, pluginId.toStdString());
@@ -717,6 +756,7 @@ bool ChannelStrip::loadNativeAu (const juce::String& identifier, std::string& er
     unloadNativeLv2();
     unloadNativeVst3();
     unloadNativeMultisample();
+    unloadBuiltin();
     pluginSlot.unload();
     const auto stableId = identifier.toStdString();
     const bool ok = nativeAuSlot.load (std::filesystem::u8path (stableId),
@@ -755,6 +795,7 @@ bool ChannelStrip::loadNativeMultisample (const juce::File& soundfont, std::stri
     unloadNativeLv2();
     unloadNativeVst3();
     unloadNativeAu();
+    unloadBuiltin();
     pluginSlot.unload();
     const bool ok = nativeMultisampleSlot.load (
         std::filesystem::u8path (soundfont.getFullPathName().toStdString()),
@@ -791,6 +832,7 @@ bool ChannelStrip::commitNativeMultisample (NativeMultisampleSlot::PrimedLoad pr
     unloadNativeLv2();
     unloadNativeVst3();
     unloadNativeAu();
+    unloadBuiltin();
     pluginSlot.unload();
     const bool ok = nativeMultisampleSlot.commit (std::move (primed), preparedBlockSize);
     // A user-initiated load always ends any "failed restore" state (see loadNativeClap).
@@ -805,6 +847,39 @@ void ChannelStrip::setPendingNativeMultisample (const juce::File& soundfont,
     pendingMultisampleState = std::move (state);
 }
 #endif
+
+bool ChannelStrip::loadBuiltin (const std::string& unitId, std::string& errorOut)
+{
+    if (preparedSampleRate <= 0.0 || preparedBlockSize <= 0)
+    { errorOut = "channel strip not prepared"; return false; }
+    // One host per insert - see loadNativeClap.
+    unloadNativeClap();
+    unloadNativeLv2();
+    unloadNativeVst3();
+    unloadNativeAu();
+    unloadNativeMultisample();
+    pluginSlot.unload();
+    const bool ok = builtinSlot.loadUnit (unitId, preparedSampleRate,
+                                          preparedBlockSize, errorOut);
+    // A user-initiated load always ends any "failed restore" state (see loadNativeClap).
+    builtinRestoreFailed.store (false, std::memory_order_relaxed);
+    return ok;
+}
+
+void ChannelStrip::unloadBuiltin() noexcept
+{
+    builtinSlot.unload();
+    builtinRestoreFailed.store (false, std::memory_order_relaxed);
+    pendingBuiltinId.clear();
+    pendingBuiltinState.clear();
+}
+
+void ChannelStrip::setPendingBuiltin (std::string unitId,
+                                      std::vector<uint8_t> state) noexcept
+{
+    pendingBuiltinId    = std::move (unitId);
+    pendingBuiltinState = std::move (state);
+}
 
 void ChannelStrip::relatchPdcIfDrained (float blockPeakAbs, int numSamples) noexcept
 {
@@ -876,6 +951,7 @@ bool ChannelStrip::hasLoadedMidiConsumer() const noexcept
 #if DUSKSTUDIO_HAS_MULTISAMPLE
     if (nativeMultisampleSlot.isLoaded()) return true;
 #endif
+    if (builtinSlot.isLoaded()) return true;
     return pluginSlot.isLoaded();
 }
 
@@ -1186,6 +1262,17 @@ void ChannelStrip::processAndAccumulate (const float* inL,
             }
             else
 #endif
+            if (builtinSlot.isLoaded())
+            {
+                // Same stereo-only mono fold as the CLAP branch above.
+                std::memcpy (insertScratchR.data(), tempMono.data(), sizeof (float) * (size_t) numSamples);
+                builtinSlot.processStereo (tempMono.data(), insertScratchR.data(),
+                                           tempMono.data(), insertScratchR.data(), numSamples);
+                for (int i = 0; i < numSamples; ++i)
+                    tempMono[(size_t) i] = 0.5f
+                        * (tempMono[(size_t) i] + insertScratchR[(size_t) i]);
+            }
+            else
             {
                 pluginMidiScratch.clear();
                 pluginSlot.processMonoBlock (tempMono.data(), numSamples, pluginMidiScratch);
@@ -1360,14 +1447,10 @@ void ChannelStrip::processAndAccumulate (const float* inL,
             // tick the smoother to keep its state in sync in case the
             // track later flips to audio mode. A native host owns the slot
             // when loaded - same precedence as the effect-insert path.
-#if DUSKSTUDIO_HAS_NATIVE_CLAP || DUSKSTUDIO_HAS_NATIVE_LV2 || DUSKSTUDIO_HAS_NATIVE_VST3 \
-    || DUSKSTUDIO_HAS_NATIVE_AU \
-    || DUSKSTUDIO_HAS_MULTISAMPLE
             // Bridge the block's MIDI into dusk once for whichever native host
             // runs. This is the last hop before the instrument, so a torn copy
             // here is a hung note: the bridge is whole-block-or-nothing.
             dusk::copyEventsWhole (trackMidi, nativeMidiScratch);
-#endif
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
             if (nativeClapSlot.isLoaded())
                 nativeClapSlot.processStereo (L, R, L, R, numSamples, &nativeMidiScratch);
@@ -1393,6 +1476,9 @@ void ChannelStrip::processAndAccumulate (const float* inL,
                 nativeMultisampleSlot.processStereo (L, R, L, R, numSamples, &nativeMidiScratch);
             else
 #endif
+            if (builtinSlot.isLoaded())
+                builtinSlot.processStereo (L, R, L, R, numSamples, &nativeMidiScratch);
+            else
             pluginSlot.processStereoBlock (L, R, numSamples, trackMidi);
             for (int i = 0; i < numSamples; ++i)
                 activeInsertGain.getNextValue();
@@ -1439,6 +1525,9 @@ void ChannelStrip::processAndAccumulate (const float* inL,
                     nativeAuSlot.processStereo (L, R, L, R, numSamples);
                 else
 #endif
+                if (builtinSlot.isLoaded())
+                    builtinSlot.processStereo (L, R, L, R, numSamples);
+                else
                 {
                     pluginMidiScratch.clear();
                     pluginSlot.processStereoBlock (L, R, numSamples, pluginMidiScratch);

--- a/src/dsp/ChannelStrip.cpp
+++ b/src/dsp/ChannelStrip.cpp
@@ -345,7 +345,11 @@ void ChannelStrip::prepare (double sampleRate, int blockSize, int oversamplingFa
                 [&] { builtinSlot.unload(); });
             builtinRestoreFailed.store (! reason.empty(), std::memory_order_relaxed);
             if (! reason.empty())
-                nativeRestoreFailures.push_back ({ "built-in", unitId, reason });
+            {
+                const auto* info = builtin::findUnit (unitId);
+                nativeRestoreFailures.push_back (
+                    { "built-in", info != nullptr ? info->name : unitId, reason });
+            }
         }
         pendingBuiltinId.clear();
         pendingBuiltinState.clear();

--- a/src/dsp/ChannelStrip.h
+++ b/src/dsp/ChannelStrip.h
@@ -14,6 +14,7 @@
 #include "../session/Session.h"
 #include "../engine/PluginSlot.h"
 #include "../engine/hosting/NativeRestorePolicy.h"
+#include "../engine/builtin/NativeBuiltinSlot.h"
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
   #include "../engine/clap/NativeClapSlot.h"   // Linux-only native CLAP host
 #endif
@@ -186,11 +187,25 @@ public:
     bool nativeMultisampleReloadFailed() const noexcept { return false; }
 #endif
 
+    // Built-in unit rung - same contract as the CLAP block above, with a
+    // registry id in place of a bundle path. Never compile-gated: the suite
+    // ships with the app on every platform.
+    bool loadBuiltin (const std::string& unitId, std::string& errorOut);
+    void unloadBuiltin() noexcept;
+    bool isBuiltinLoaded() const noexcept { return builtinSlot.isLoaded(); }
+    builtin::NativeBuiltinSlot&       getBuiltinSlot()       noexcept { return builtinSlot; }
+    const builtin::NativeBuiltinSlot& getBuiltinSlot() const noexcept { return builtinSlot; }
+    void setPendingBuiltin (std::string unitId, std::vector<uint8_t> state) noexcept;
+    bool builtinReloadFailed() const noexcept
+        { return builtinRestoreFailed.load (std::memory_order_relaxed); }
+    void markBuiltinRestoreFailed() noexcept
+        { builtinRestoreFailed.store (true, std::memory_order_relaxed); }
+
     bool nativeInsertRestoreFailed() const noexcept
     {
         return nativeClapReloadFailed() || nativeLv2ReloadFailed()
             || nativeVst3ReloadFailed() || nativeAuReloadFailed()
-            || nativeMultisampleReloadFailed();
+            || nativeMultisampleReloadFailed() || builtinReloadFailed();
     }
 
     // Whether a native host owns the insert with an instrument loaded (no main
@@ -212,6 +227,7 @@ public:
 #if DUSKSTUDIO_HAS_MULTISAMPLE
         if (isNativeMultisampleLoaded()) return nativeMultisampleSlot.isLoadedInstrument();
 #endif
+        if (isBuiltinLoaded()) return builtinSlot.isLoadedInstrument();
         return false;
     }
 
@@ -373,6 +389,8 @@ private:
     NativeMultisampleSlot nativeMultisampleSlot;
     std::atomic<bool>     multisampleReloadFailed { false };
 #endif
+    builtin::NativeBuiltinSlot builtinSlot;
+    std::atomic<bool>          builtinRestoreFailed { false };
     HardwareInsertSlot hardwareSlot;
     std::vector<hosting::NativeRestoreFailure> nativeRestoreFailures;
 
@@ -403,6 +421,8 @@ private:
     juce::String         pendingMultisamplePath;
     std::vector<uint8_t> pendingMultisampleState;
 #endif
+    std::string          pendingBuiltinId;
+    std::vector<uint8_t> pendingBuiltinState;
 
     // activeInsertMode = what we're currently running; insertMode = what
     // the UI wants. Mismatch triggers ramp-out / swap / ramp-in.

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -2388,6 +2388,7 @@ void AudioEngine::consumePluginStateAfterLoad()
                 strip.unloadNativeVst3();
                 strip.unloadNativeAu();
                 strip.unloadNativeMultisample();
+                strip.unloadBuiltin();
                 strip.setPendingNativeClap (clapFile, std::move (blob), track.nativeClapPluginId);
             }
             continue;
@@ -2440,6 +2441,7 @@ void AudioEngine::consumePluginStateAfterLoad()
                 strip.unloadNativeVst3();
                 strip.unloadNativeAu();
                 strip.unloadNativeMultisample();
+                strip.unloadBuiltin();
                 strip.setPendingNativeLv2 (lv2File, std::move (blob), track.nativeLv2PluginId,
                                            lv2StateDirFor (session,
                                                "track" + juce::String (t + 1).paddedLeft ('0', 2)));
@@ -2492,6 +2494,7 @@ void AudioEngine::consumePluginStateAfterLoad()
                 strip.unloadNativeLv2();
                 strip.unloadNativeAu();
                 strip.unloadNativeMultisample();
+                strip.unloadBuiltin();
                 strip.setPendingNativeVst3 (vst3File, std::move (blob), track.nativeVst3PluginId);
             }
             continue;
@@ -2539,6 +2542,7 @@ void AudioEngine::consumePluginStateAfterLoad()
                 strip.unloadNativeLv2();
                 strip.unloadNativeVst3();
                 strip.unloadNativeMultisample();
+                strip.unloadBuiltin();
                 strip.setPendingNativeAu (track.nativeAuIdentifier, std::move (blob));
             }
             continue;
@@ -2603,6 +2607,7 @@ void AudioEngine::consumePluginStateAfterLoad()
                 strip.unloadNativeLv2();
                 strip.unloadNativeVst3();
                 strip.unloadNativeAu();
+                strip.unloadBuiltin();
                 strip.setPendingNativeMultisample (soundfont, std::move (blob));
             }
             continue;
@@ -2795,6 +2800,7 @@ void AudioEngine::consumePluginStateAfterLoad()
                     strip.unloadNativeLv2 (s);
                     strip.unloadNativeVst3 (s);
                     strip.unloadNativeAu (s);
+                    strip.unloadBuiltin (s);
                     strip.setPendingNativeClap (s, clapFile, std::move (blob),
                                                 lane.nativeClapPluginId[(size_t) s]);
                 }
@@ -2851,6 +2857,7 @@ void AudioEngine::consumePluginStateAfterLoad()
                     strip.unloadNativeClap (s);   // see the CLAP pending branch above
                     strip.unloadNativeVst3 (s);
                     strip.unloadNativeAu (s);
+                    strip.unloadBuiltin (s);
                     strip.setPendingNativeLv2 (s, lv2File, std::move (blob),
                                                lane.nativeLv2PluginId[(size_t) s],
                                                lv2StateDirFor (session,
@@ -2907,6 +2914,7 @@ void AudioEngine::consumePluginStateAfterLoad()
                     strip.unloadNativeClap (s);   // see the CLAP pending branch above
                     strip.unloadNativeLv2 (s);
                     strip.unloadNativeAu (s);
+                    strip.unloadBuiltin (s);
                     strip.setPendingNativeVst3 (s, vst3File, std::move (blob),
                                                 lane.nativeVst3PluginId[(size_t) s]);
                 }
@@ -2959,6 +2967,7 @@ void AudioEngine::consumePluginStateAfterLoad()
                     strip.unloadNativeClap (s);
                     strip.unloadNativeLv2 (s);
                     strip.unloadNativeVst3 (s);
+                    strip.unloadBuiltin (s);
                     strip.setPendingNativeAu (s, identifier, std::move (blob));
                 }
                 continue;

--- a/src/engine/AudioEngine.cpp
+++ b/src/engine/AudioEngine.cpp
@@ -220,8 +220,6 @@ static std::filesystem::path lv2StateDirFor (Session& session, const juce::Strin
 }
 #endif
 
-#if DUSKSTUDIO_HAS_NATIVE_CLAP || DUSKSTUDIO_HAS_NATIVE_LV2 || DUSKSTUDIO_HAS_NATIVE_VST3 \
-    || DUSKSTUDIO_HAS_NATIVE_AU || DUSKSTUDIO_HAS_MULTISAMPLE
 static DecodedStateBlob decodeBase64Blob (const juce::String& s, const char* slotKind)
 {
     auto decoded = decodeStoredStateBase64 (s.toStdString());
@@ -254,6 +252,34 @@ static void captureNativeState (SlotType& slot, juce::String& stateOut,
                   stateOut.isEmpty() ? "no matching stored copy retained"
                                      : "keeping the matching stored copy");
     std::fflush (stderr);
+}
+
+// Built-in twin of the two helpers above. The session carries a built-in unit's
+// identity and state as std::string, so neither the JUCE-string template nor the
+// JUCE base64 encoder applies.
+static void captureBuiltinState (builtin::NativeBuiltinSlot& slot, std::string& stateOut,
+                                 const char* slotKind, int index)
+{
+    std::vector<uint8_t> blob;
+    if (slot.saveState (blob) && ! blob.empty())
+    {
+        stateOut = dusk::base64::encode (blob.data(), blob.size());
+        return;
+    }
+    std::fprintf (stderr, "[Dusk Studio/session] %s %d saved no state; %s\n",
+                  slotKind, index + 1,
+                  stateOut.empty() ? "no matching stored copy retained"
+                                   : "keeping the matching stored copy");
+    std::fflush (stderr);
+}
+
+static void bindBuiltinStateToLoadedIdentity (std::string& carriedId,
+                                              std::string& carriedState,
+                                              const std::string& liveId)
+{
+    hosting::retainStateForLiveIdentity ({ "builtin", carriedId, {} },
+                                         { "builtin", liveId, {} }, carriedState);
+    carriedId = liveId;
 }
 
 // Publish a live native identity and first invalidate any carried fallback that
@@ -298,7 +324,6 @@ static void noteStateRejected (const char* slotKind, int index, std::size_t byte
     std::fputc ('\n', stderr);
     std::fflush (stderr);
 }
-#endif
 
 #if DUSKSTUDIO_HAS_NATIVE_AU
 // JUCE's AU descriptor already carries the platform-stable component triple.
@@ -1048,6 +1073,8 @@ void AudioEngine::recomputePdc() noexcept
                 if (strip.isNativeAuLoaded())
                     lat = strip.getNativeAuSlot().getLatencySamples();
 #endif
+                if (strip.isBuiltinLoaded())
+                    lat = strip.getBuiltinSlot().getLatencySamples();
             }
         }
         latency[t] = std::clamp (lat, 0, ChannelStrip::kMaxPdcSamples);
@@ -1092,6 +1119,8 @@ void AudioEngine::recomputePdc() noexcept
                 if (lane.isNativeAuLoaded (p))
                     slotLat = lane.getNativeAuSlot (p).getLatencySamples();
 #endif
+                if (lane.isBuiltinLoaded (p))
+                    slotLat = lane.getBuiltinSlot (p).getLatencySamples();
                 laneLat += std::max (0, slotLat);
             }
             else if (mode == AuxLaneStrip::kInsertHardware)
@@ -1954,6 +1983,20 @@ void AudioEngine::publishPluginStateForSave (bool audioCallbackDetached)
             track.nativeMultisampleStateBase64.clear();
         }
 #endif
+        if (strip.isBuiltinLoaded())
+        {
+            auto& builtinSlot = strip.getBuiltinSlot();
+            bindBuiltinStateToLoadedIdentity (
+                track.builtinUnitId, track.builtinStateBase64, builtinSlot.getPluginId());
+            if (! strip.builtinReloadFailed())
+                captureBuiltinState (builtinSlot, track.builtinStateBase64,
+                                     "track built-in", t);
+        }
+        else if (! strip.builtinReloadFailed())
+        {
+            track.builtinUnitId.clear();
+            track.builtinStateBase64.clear();
+        }
     }
     for (int a = 0; a < Session::kNumAuxLanes; ++a)
     {
@@ -2059,6 +2102,23 @@ void AudioEngine::publishPluginStateForSave (bool audioCallbackDetached)
                 lane.nativeAuStateBase64[(size_t) s].clear();
             }
 #endif
+            if (strip.isBuiltinLoaded (s))
+            {
+                auto& builtinSlot = strip.getBuiltinSlot (s);
+                bindBuiltinStateToLoadedIdentity (
+                    lane.builtinUnitId[(size_t) s],
+                    lane.builtinStateBase64[(size_t) s],
+                    builtinSlot.getPluginId());
+                if (! strip.builtinReloadFailed (s))
+                    captureBuiltinState (builtinSlot,
+                                         lane.builtinStateBase64[(size_t) s],
+                                         "aux built-in", s);
+            }
+            else if (! strip.builtinReloadFailed (s))
+            {
+                lane.builtinUnitId[(size_t) s].clear();
+                lane.builtinStateBase64[(size_t) s].clear();
+            }
         }
     }
 }
@@ -2187,8 +2247,12 @@ void AudioEngine::consumePluginStateAfterLoad()
     };
 #endif
 
-#if DUSKSTUDIO_HAS_NATIVE_CLAP || DUSKSTUDIO_HAS_NATIVE_LV2 || DUSKSTUDIO_HAS_NATIVE_VST3 \
-    || DUSKSTUDIO_HAS_NATIVE_AU || DUSKSTUDIO_HAS_MULTISAMPLE
+    auto builtinName = [] (const std::string& unitId)
+    {
+        const auto* unit = builtin::findUnit (unitId);
+        return unit != nullptr ? std::string (unit->name) : unitId;
+    };
+
     auto rejectUnreadableTrackState = [&] (
         const DecodedStateBlob& state, ChannelStrip& strip,
         auto&& markRestoreFailed, const std::string& location,
@@ -2211,6 +2275,7 @@ void AudioEngine::consumePluginStateAfterLoad()
                 strip.unloadNativeVst3();
                 strip.unloadNativeAu();
                 strip.unloadNativeMultisample();
+                strip.unloadBuiltin();
             });
         if (prepared) resumeProcessing();
         markRestoreFailed();
@@ -2223,8 +2288,6 @@ void AudioEngine::consumePluginStateAfterLoad()
         return true;
     };
 
-#if DUSKSTUDIO_HAS_NATIVE_CLAP || DUSKSTUDIO_HAS_NATIVE_LV2 \
-    || DUSKSTUDIO_HAS_NATIVE_VST3 || DUSKSTUDIO_HAS_NATIVE_AU
     auto rejectUnreadableAuxState = [&] (
         const DecodedStateBlob& state, AuxLaneStrip& strip, int slotIndex,
         auto&& markRestoreFailed, const std::string& location,
@@ -2243,6 +2306,7 @@ void AudioEngine::consumePluginStateAfterLoad()
                 strip.unloadNativeLv2 (slotIndex);
                 strip.unloadNativeVst3 (slotIndex);
                 strip.unloadNativeAu (slotIndex);
+                strip.unloadBuiltin (slotIndex);
             });
         if (prepared) resumeProcessing();
         markRestoreFailed();
@@ -2254,8 +2318,6 @@ void AudioEngine::consumePluginStateAfterLoad()
         lastPluginLoadFailures.push_back (std::move (failure));
         return true;
     };
-#endif
-#endif
 
     for (int t = 0; t < Session::kNumTracks; ++t)
     {
@@ -2547,12 +2609,62 @@ void AudioEngine::consumePluginStateAfterLoad()
         }
 #endif
 
+        if (! track.builtinUnitId.empty())
+        {
+            slot.unload();
+            strip.insertMode.store (ChannelStrip::kInsertPlugin, std::memory_order_release);
+
+            auto decoded = decodeBase64Blob (track.builtinStateBase64, "track built-in");
+            const auto unitId = track.builtinUnitId;
+            if (rejectUnreadableTrackState (
+                    decoded, strip, [&] { strip.markBuiltinRestoreFailed(); },
+                    dusk::text::format ("Track %d", t + 1),
+                    builtinName (unitId), "built-in"))
+                continue;
+            auto& blob = decoded.bytes;
+            if (strip.isPrepared())
+            {
+                suspendProcessing();
+                std::string err;
+                const bool stateWasSupplied = ! blob.empty();
+                const bool loaded = strip.loadBuiltin (unitId, err);
+                bool stateAccepted = ! stateWasSupplied;
+                if (loaded && stateWasSupplied)
+                {
+                    stateAccepted = strip.getBuiltinSlot().loadState (blob);
+                    if (! stateAccepted) noteStateRejected ("track built-in", t, blob.size());
+                }
+                const auto reason = hosting::enforceRestorePolicy (
+                    loaded, stateWasSupplied, stateAccepted, err, blob.size(),
+                    [&] { strip.unloadBuiltin(); });
+                resumeProcessing();
+                if (! reason.empty())
+                {
+                    strip.markBuiltinRestoreFailed();   // keep refs - see the CLAP twin
+                    lastPluginLoadFailures.push_back ({
+                        dusk::text::format ("Track %d", t + 1),
+                        builtinName (unitId), "built-in", reason });
+                }
+            }
+            else
+            {
+                strip.unloadNativeClap();   // see the CLAP pending branch above
+                strip.unloadNativeLv2();
+                strip.unloadNativeVst3();
+                strip.unloadNativeAu();
+                strip.unloadNativeMultisample();
+                strip.setPendingBuiltin (unitId, std::move (blob));
+            }
+            continue;
+        }
+
         // No native host in this session for this strip - tear down any native
         // instance carried over from the previously-loaded session before the JUCE
         // restore below (unload destroys the instance, so fence it when live).
         if (strip.isNativeClapLoaded() || strip.isNativeLv2Loaded() || strip.isNativeVst3Loaded()
             || strip.isNativeAuLoaded()
-            || strip.isNativeMultisampleLoaded())
+            || strip.isNativeMultisampleLoaded()
+            || strip.isBuiltinLoaded())
         {
 #if DUSKSTUDIO_HAS_MULTISAMPLE
             // Join the soundfont loader BEFORE the gate parks the audio thread -
@@ -2565,6 +2677,7 @@ void AudioEngine::consumePluginStateAfterLoad()
             strip.unloadNativeVst3();
             strip.unloadNativeAu();
             strip.unloadNativeMultisample();
+            strip.unloadBuiltin();
             resumeProcessing();
         }
         else
@@ -2574,6 +2687,7 @@ void AudioEngine::consumePluginStateAfterLoad()
             strip.unloadNativeVst3();
             strip.unloadNativeAu();
             strip.unloadNativeMultisample();
+            strip.unloadBuiltin();
         }
 
         if (! track.pluginDescriptor.has_value()
@@ -2851,16 +2965,69 @@ void AudioEngine::consumePluginStateAfterLoad()
             }
 #endif
 
+            if (! lane.builtinUnitId[(size_t) s].empty())
+            {
+                slot.unload();
+                strip.insertMode[(size_t) s].store (
+                    AuxLaneStrip::kInsertPlugin, std::memory_order_release);
+                auto decoded = decodeBase64Blob (
+                    lane.builtinStateBase64[(size_t) s], "aux built-in");
+                const auto unitId = lane.builtinUnitId[(size_t) s];
+                if (rejectUnreadableAuxState (
+                        decoded, strip, s,
+                        [&] { strip.markBuiltinRestoreFailed (s); },
+                        dusk::text::format ("Aux %d slot %d", a + 1, s + 1),
+                        builtinName (unitId), "built-in"))
+                    continue;
+                auto& blob = decoded.bytes;
+                if (strip.isPrepared())
+                {
+                    suspendProcessing();
+                    std::string err;
+                    const bool stateWasSupplied = ! blob.empty();
+                    const bool loaded = strip.loadBuiltin (s, unitId, err);
+                    bool stateAccepted = ! stateWasSupplied;
+                    if (loaded && stateWasSupplied)
+                    {
+                        stateAccepted = strip.getBuiltinSlot (s).loadState (blob);
+                        if (! stateAccepted)
+                            noteStateRejected ("aux built-in", s, blob.size(), a);
+                    }
+                    const auto reason = hosting::enforceRestorePolicy (
+                        loaded, stateWasSupplied, stateAccepted, err, blob.size(),
+                        [&] { strip.unloadBuiltin (s); });
+                    resumeProcessing();
+                    if (! reason.empty())
+                    {
+                        strip.markBuiltinRestoreFailed (s);
+                        lastPluginLoadFailures.push_back ({
+                            dusk::text::format ("Aux %d slot %d", a + 1, s + 1),
+                            builtinName (unitId), "built-in", reason });
+                    }
+                }
+                else
+                {
+                    strip.unloadNativeClap (s);
+                    strip.unloadNativeLv2 (s);
+                    strip.unloadNativeVst3 (s);
+                    strip.unloadNativeAu (s);
+                    strip.setPendingBuiltin (s, unitId, std::move (blob));
+                }
+                continue;
+            }
+
             // No native host for this slot - tear down any instance carried over from
             // the previous session before the JUCE restore (fence when live).
             if (strip.isNativeClapLoaded (s) || strip.isNativeLv2Loaded (s)
-                || strip.isNativeVst3Loaded (s) || strip.isNativeAuLoaded (s))
+                || strip.isNativeVst3Loaded (s) || strip.isNativeAuLoaded (s)
+                || strip.isBuiltinLoaded (s))
             {
                 suspendProcessing();
                 strip.unloadNativeClap (s);
                 strip.unloadNativeLv2 (s);
                 strip.unloadNativeVst3 (s);
                 strip.unloadNativeAu (s);
+                strip.unloadBuiltin (s);
                 resumeProcessing();
             }
             else
@@ -2869,6 +3036,7 @@ void AudioEngine::consumePluginStateAfterLoad()
                 strip.unloadNativeLv2 (s);
                 strip.unloadNativeVst3 (s);
                 strip.unloadNativeAu (s);
+                strip.unloadBuiltin (s);
             }
 
             auto& descriptor = lane.pluginDescriptor[(size_t) s];

--- a/src/engine/builtin/BuiltinBundle.h
+++ b/src/engine/builtin/BuiltinBundle.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "BuiltinRegistry.h"
+
+#include <string>
+
+namespace duskstudio::builtin
+{
+// The "bundle" of a built-in unit is its registry entry, so load() is a lookup
+// and touches no disk. It exists so the built-in rung satisfies the same
+// NativeInsertSlot traits contract as the CLAP / LV2 / VST3 rungs.
+class BuiltinBundle
+{
+public:
+    bool load (const std::string& id, std::string& errorOut)
+    {
+        info = findUnit (id);
+        if (info == nullptr)
+        {
+            errorOut = "no built-in unit with id '" + id + "'";
+            return false;
+        }
+        return true;
+    }
+
+    const UnitInfo* unit() const noexcept { return info; }
+
+private:
+    const UnitInfo* info = nullptr;
+};
+} // namespace duskstudio::builtin

--- a/src/engine/builtin/BuiltinInstance.cpp
+++ b/src/engine/builtin/BuiltinInstance.cpp
@@ -1,0 +1,185 @@
+#include "BuiltinInstance.h"
+
+#include "../../foundation/Json.h"
+
+#include <algorithm>
+#include <cstring>
+
+namespace duskstudio::builtin
+{
+namespace
+{
+constexpr int kStateVersion = 1;
+
+hosting::PortLayout makeLayout (bool isInstrument)
+{
+    hosting::PortLayout layout;
+    if (! isInstrument)
+    {
+        hosting::BusInfo in;
+        in.dir = hosting::BusInfo::Direction::Input;
+        in.channelCount = 2;
+        in.active = true;
+        in.name = "Input";
+        layout.inputs.push_back (std::move (in));
+        layout.mainInIndex = 0;
+    }
+    else
+    {
+        hosting::BusInfo events;
+        events.kind = hosting::BusInfo::Kind::Event;
+        events.dir = hosting::BusInfo::Direction::Input;
+        events.carriesMidi = true;
+        events.active = true;
+        events.name = "MIDI In";
+        layout.inputs.push_back (std::move (events));
+        layout.eventInIndex = 0;
+    }
+
+    hosting::BusInfo out;
+    out.dir = hosting::BusInfo::Direction::Output;
+    out.channelCount = 2;
+    out.active = true;
+    out.name = "Output";
+    layout.outputs.push_back (std::move (out));
+    layout.mainOutIndex = 0;
+    layout.isInstrument = isInstrument;
+    return layout;
+}
+} // namespace
+
+bool BuiltinInstance::create (const BuiltinBundle& bundle, const std::string& pluginId,
+                              std::string& errorOut)
+{
+    info = bundle.unit();
+    if (info == nullptr)
+    {
+        errorOut = "bundle carries no unit";
+        return false;
+    }
+    if (! pluginId.empty() && pluginId != info->id)
+    {
+        errorOut = "requested unit '" + pluginId + "' is not '" + info->id + "'";
+        return false;
+    }
+
+    unit = createUnit (info->id);
+    if (unit == nullptr)
+    {
+        errorOut = "no factory for built-in unit '" + std::string (info->id) + "'";
+        return false;
+    }
+
+    id = info->id;
+    layout = makeLayout (info->isInstrument);
+    return true;
+}
+
+bool BuiltinInstance::activate (double sampleRate, int maxBlockFrames, std::string& errorOut)
+{
+    if (unit == nullptr)
+    {
+        errorOut = "no unit";
+        return false;
+    }
+    if (sampleRate <= 0.0 || maxBlockFrames <= 0)
+    {
+        errorOut = "invalid audio spec";
+        return false;
+    }
+    unit->prepare (sampleRate, maxBlockFrames);
+    preparedBlockFrames = maxBlockFrames;
+    active.store (true, std::memory_order_release);
+    return true;
+}
+
+void BuiltinInstance::deactivate()
+{
+    active.store (false, std::memory_order_release);
+    preparedBlockFrames = 0;
+}
+
+bool BuiltinInstance::reactivate (double sampleRate, int maxBlockFrames, std::string& errorOut)
+{
+    // The unit keeps its parameters across a re-prepare, so a rate change costs
+    // nothing but the smoother re-seed inside prepare().
+    active.store (false, std::memory_order_release);
+    return activate (sampleRate, maxBlockFrames, errorOut);
+}
+
+void BuiltinInstance::processBlock (const hosting::PortBuffers& io) noexcept
+{
+    if (! active.load (std::memory_order_acquire) || unit == nullptr)
+        return;
+    if (io.numFrames <= 0 || io.numFrames > preparedBlockFrames)
+        return;
+    if (io.mainOut == nullptr || io.mainOutChannels < 2)
+        return;
+
+    float* outL = io.mainOut[0];
+    float* outR = io.mainOut[1];
+    if (outL == nullptr || outR == nullptr)
+        return;
+
+    const auto bytes = sizeof (float) * (size_t) io.numFrames;
+    if (io.mainIn != nullptr && io.mainInChannels >= 2)
+    {
+        std::memcpy (outL, io.mainIn[0], bytes);
+        std::memcpy (outR, io.mainIn[1], bytes);
+    }
+
+    unit->process (outL, outR, io.numFrames);
+}
+
+bool BuiltinInstance::saveState (std::vector<std::uint8_t>& out) const
+{
+    out.clear();
+    if (unit == nullptr) return false;
+
+    dusk::json::Json params = dusk::json::Json::object();
+    for (int i = 0; i < unit->paramCount(); ++i)
+        params[unit->paramInfo (i).id] = unit->getParam (i);
+
+    dusk::json::Json root = dusk::json::Json::object();
+    root["id"] = id;
+    root["version"] = kStateVersion;
+    root["params"] = std::move (params);
+
+    const auto text = root.dump();
+    out.assign (text.begin(), text.end());
+    return true;
+}
+
+bool BuiltinInstance::loadState (const std::vector<std::uint8_t>& in)
+{
+    if (unit == nullptr || in.empty()) return false;
+
+    const auto root = dusk::json::Json::parse (
+        std::string (in.begin(), in.end()), nullptr, /*allow_exceptions*/ false);
+    if (! root.is_object()) return false;
+    // A blob belongs to exactly one unit; applying another unit's parameter set
+    // by name would restore a plausible-looking wrong patch.
+    if (dusk::json::getString (root, "id") != id) return false;
+
+    const auto& params = dusk::json::child (root, "params");
+    for (int i = 0; i < unit->paramCount(); ++i)
+    {
+        const auto& info = unit->paramInfo (i);
+        unit->setParam (i, (float) dusk::json::getDouble (params, info.id,
+                                                          (double) info.defaultValue));
+    }
+    return true;
+}
+
+int BuiltinInstance::getLatencySamples() const noexcept
+{
+    if (! active.load (std::memory_order_acquire) || unit == nullptr) return 0;
+    return std::max (0, unit->latencySamples());
+}
+
+const ParamInfo* BuiltinInstance::paramInfo (int index) const noexcept
+{
+    if (unit == nullptr || index < 0 || index >= unit->paramCount()) return nullptr;
+    return &unit->paramInfo (index);
+}
+} // namespace duskstudio::builtin

--- a/src/engine/builtin/BuiltinInstance.cpp
+++ b/src/engine/builtin/BuiltinInstance.cpp
@@ -164,9 +164,9 @@ bool BuiltinInstance::loadState (const std::vector<std::uint8_t>& in)
     const auto& params = dusk::json::child (root, "params");
     for (int i = 0; i < unit->paramCount(); ++i)
     {
-        const auto& info = unit->paramInfo (i);
-        unit->setParam (i, (float) dusk::json::getDouble (params, info.id,
-                                                          (double) info.defaultValue));
+        const auto& p = unit->paramInfo (i);
+        unit->setParam (i, (float) dusk::json::getDouble (params, p.id,
+                                                          (double) p.defaultValue));
     }
     return true;
 }

--- a/src/engine/builtin/BuiltinInstance.h
+++ b/src/engine/builtin/BuiltinInstance.h
@@ -15,8 +15,7 @@ namespace duskstudio::builtin
 // A built-in unit presented to the mixer as a native plug-in instance, so an
 // insert slot drives it through exactly the path a scanned CLAP / LV2 / VST3
 // takes. There is no shared library and no negotiation: the port layout is the
-// insert's own stereo pair (or a stereo source for an instrument unit), and
-// create() cannot fail once the bundle resolved.
+// insert's own stereo pair, or a stereo source for an instrument unit.
 //
 // Threading matches INativeInstance: create / activate / deactivate /
 // reactivate / saveState / loadState are message-thread, processBlock is the
@@ -40,7 +39,6 @@ public:
     bool loadState (const std::vector<std::uint8_t>& in) override;
     int  getLatencySamples() const noexcept override;
 
-    const std::string& unitId() const noexcept { return id; }
     std::string displayName() const { return info != nullptr ? info->name : std::string(); }
 
     // Message thread. The parameter surface an editor and the session drive.

--- a/src/engine/builtin/BuiltinInstance.h
+++ b/src/engine/builtin/BuiltinInstance.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "BuiltinBundle.h"
+#include "BuiltinUnit.h"
+#include "../hosting/INativeInstance.h"
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace duskstudio::builtin
+{
+// A built-in unit presented to the mixer as a native plug-in instance, so an
+// insert slot drives it through exactly the path a scanned CLAP / LV2 / VST3
+// takes. There is no shared library and no negotiation: the port layout is the
+// insert's own stereo pair (or a stereo source for an instrument unit), and
+// create() cannot fail once the bundle resolved.
+//
+// Threading matches INativeInstance: create / activate / deactivate /
+// reactivate / saveState / loadState are message-thread, processBlock is the
+// sole audio-thread entry, and the slot fences load and unload with the
+// engine's process gate.
+class BuiltinInstance final : public hosting::INativeInstance
+{
+public:
+    // NativeInsertSlot construction hook. pluginId is the unit id and must
+    // match the bundle - the slot's traits resolve it before we are called.
+    bool create (const BuiltinBundle& bundle, const std::string& pluginId,
+                 std::string& errorOut);
+
+    const hosting::PortLayout& portLayout() const noexcept override { return layout; }
+    bool activate (double sampleRate, int maxBlockFrames, std::string& errorOut) override;
+    void deactivate() override;
+    bool reactivate (double sampleRate, int maxBlockFrames, std::string& errorOut) override;
+    bool isActive() const noexcept override { return active.load (std::memory_order_acquire); }
+    void processBlock (const hosting::PortBuffers& io) noexcept override;
+    bool saveState (std::vector<std::uint8_t>& out) const override;
+    bool loadState (const std::vector<std::uint8_t>& in) override;
+    int  getLatencySamples() const noexcept override;
+
+    const std::string& unitId() const noexcept { return id; }
+    std::string displayName() const { return info != nullptr ? info->name : std::string(); }
+
+    // Message thread. The parameter surface an editor and the session drive.
+    int paramCount() const noexcept { return unit != nullptr ? unit->paramCount() : 0; }
+    const ParamInfo* paramInfo (int index) const noexcept;
+    float getParamValue (int index) const noexcept
+        { return unit != nullptr ? unit->getParam (index) : 0.0f; }
+    void setParamValue (int index, float value) noexcept
+        { if (unit != nullptr) unit->setParam (index, value); }
+
+private:
+    const UnitInfo* info = nullptr;
+    std::string id;
+    std::unique_ptr<BuiltinUnit> unit;
+    hosting::PortLayout layout;
+    std::atomic<bool> active { false };
+    int preparedBlockFrames = 0;
+};
+} // namespace duskstudio::builtin

--- a/src/engine/builtin/BuiltinRegistry.cpp
+++ b/src/engine/builtin/BuiltinRegistry.cpp
@@ -1,0 +1,28 @@
+#include "BuiltinRegistry.h"
+
+#include "UtilityUnit.h"
+
+namespace duskstudio::builtin
+{
+const std::vector<UnitInfo>& registry()
+{
+    static const std::vector<UnitInfo> units
+    {
+        { "dusk.builtin.utility", "Utility", "Fx|Utility", false },
+    };
+    return units;
+}
+
+const UnitInfo* findUnit (const std::string& id)
+{
+    for (const auto& unit : registry())
+        if (id == unit.id) return &unit;
+    return nullptr;
+}
+
+std::unique_ptr<BuiltinUnit> createUnit (const std::string& id)
+{
+    if (id == "dusk.builtin.utility") return std::make_unique<UtilityUnit>();
+    return nullptr;
+}
+} // namespace duskstudio::builtin

--- a/src/engine/builtin/BuiltinRegistry.cpp
+++ b/src/engine/builtin/BuiltinRegistry.cpp
@@ -8,7 +8,8 @@ const std::vector<UnitInfo>& registry()
 {
     static const std::vector<UnitInfo> units
     {
-        { "dusk.builtin.utility", "Utility", "Fx|Utility", false },
+        { "dusk.builtin.utility", "Utility", "Fx|Utility", false,
+          [] () -> std::unique_ptr<BuiltinUnit> { return std::make_unique<UtilityUnit>(); } },
     };
     return units;
 }
@@ -22,7 +23,7 @@ const UnitInfo* findUnit (const std::string& id)
 
 std::unique_ptr<BuiltinUnit> createUnit (const std::string& id)
 {
-    if (id == "dusk.builtin.utility") return std::make_unique<UtilityUnit>();
-    return nullptr;
+    const auto* unit = findUnit (id);
+    return unit != nullptr && unit->create != nullptr ? unit->create() : nullptr;
 }
 } // namespace duskstudio::builtin

--- a/src/engine/builtin/BuiltinRegistry.h
+++ b/src/engine/builtin/BuiltinRegistry.h
@@ -9,13 +9,15 @@
 namespace duskstudio::builtin
 {
 // A unit in the built-in suite. `id` is the stable session key and the picker
-// row's location; it never changes once a session can hold it.
+// row's location; it never changes once a session can hold it. The factory
+// lives here so the registry is the only place a new unit is declared.
 struct UnitInfo
 {
     const char* id;
     const char* name;
     const char* category;
     bool isInstrument;
+    std::unique_ptr<BuiltinUnit> (*create)();
 };
 
 // The suite, in picker order. Compiled in, so it is identical on every

--- a/src/engine/builtin/BuiltinRegistry.h
+++ b/src/engine/builtin/BuiltinRegistry.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "BuiltinUnit.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace duskstudio::builtin
+{
+// A unit in the built-in suite. `id` is the stable session key and the picker
+// row's location; it never changes once a session can hold it.
+struct UnitInfo
+{
+    const char* id;
+    const char* name;
+    const char* category;
+    bool isInstrument;
+};
+
+// The suite, in picker order. Compiled in, so it is identical on every
+// platform and needs no scan.
+const std::vector<UnitInfo>& registry();
+
+// nullptr when no unit carries that id (a session written by a newer build).
+const UnitInfo* findUnit (const std::string& id);
+
+// nullptr for an unknown id. Message thread - the unit allocates.
+std::unique_ptr<BuiltinUnit> createUnit (const std::string& id);
+
+// What picker rows and the session's "which plugin is this" surfaces show.
+constexpr const char* kManufacturer = "Dusk Audio";
+constexpr const char* kFormatName   = "Builtin";
+} // namespace duskstudio::builtin

--- a/src/engine/builtin/BuiltinScanRows.h
+++ b/src/engine/builtin/BuiltinScanRows.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "BuiltinRegistry.h"
+#include "../PluginDescriptor.h"
+
+#include <vector>
+
+namespace duskstudio::builtin
+{
+// Picker rows for the built-in suite. There is nothing to scan: the registry is
+// compiled in, so the rows are the same on every machine. `location` carries the
+// unit id, which is what a slot loads and what the session persists.
+inline std::vector<PluginDescriptor> descriptorRows (bool instruments)
+{
+    std::vector<PluginDescriptor> rows;
+    for (const auto& unit : registry())
+    {
+        if (unit.isInstrument != instruments) continue;
+        PluginDescriptor descriptor;
+        descriptor.name = unit.name;
+        descriptor.manufacturer = kManufacturer;
+        descriptor.category = unit.category;
+        descriptor.formatName = kFormatName;
+        descriptor.backend = PluginBackend::Native;
+        descriptor.location = unit.id;
+        descriptor.isInstrument = unit.isInstrument;
+        rows.push_back (std::move (descriptor));
+    }
+    return rows;
+}
+} // namespace duskstudio::builtin

--- a/src/engine/builtin/BuiltinUnit.h
+++ b/src/engine/builtin/BuiltinUnit.h
@@ -2,28 +2,25 @@
 
 #include <algorithm>
 #include <atomic>
-#include <cstring>
 #include <vector>
 
 namespace duskstudio::builtin
 {
 // One control of a built-in unit. The id is the session-persistent key (the
 // index is not: reordering or inserting a parameter must not silently rebind a
-// saved value), the name is what an editor shows.
+// saved value), the name is what a diagnostic or a binding list shows.
 struct ParamInfo
 {
     const char* id;
     const char* name;
-    const char* suffix;
     float minValue;
     float maxValue;
     float defaultValue;
-    bool  isToggle;
 };
 
 // A DSP unit compiled into the app and reachable from an insert slot through
-// BuiltinInstance. Parameter storage lives here so every unit persists and
-// automates the same way; the DSP itself is the subclass's business.
+// BuiltinInstance. Parameter storage lives here so every unit persists the same
+// way; the DSP itself is the subclass's business.
 //
 // Threading: the parameter accessors are the message-thread surface, process()
 // is the sole audio-thread entry, and the two meet only through the relaxed
@@ -33,37 +30,31 @@ class BuiltinUnit
 {
 public:
     BuiltinUnit (const ParamInfo* infos, int count)
-        : infos_ (infos), count_ (count), values_ ((size_t) count)
+        : paramInfos (infos), numParams (count), paramValues ((size_t) count)
     {
-        for (int i = 0; i < count_; ++i)
-            values_[(size_t) i].store (infos_[i].defaultValue, std::memory_order_relaxed);
+        for (int i = 0; i < numParams; ++i)
+            paramValues[(size_t) i].store (paramInfos[i].defaultValue,
+                                           std::memory_order_relaxed);
     }
 
     virtual ~BuiltinUnit() = default;
 
-    int paramCount() const noexcept { return count_; }
+    int paramCount() const noexcept { return numParams; }
 
-    const ParamInfo& paramInfo (int index) const noexcept { return infos_[index]; }
+    const ParamInfo& paramInfo (int index) const noexcept { return paramInfos[index]; }
 
     float getParam (int index) const noexcept
     {
-        if (index < 0 || index >= count_) return 0.0f;
-        return values_[(size_t) index].load (std::memory_order_relaxed);
+        if (index < 0 || index >= numParams) return 0.0f;
+        return paramValues[(size_t) index].load (std::memory_order_relaxed);
     }
 
     void setParam (int index, float value) noexcept
     {
-        if (index < 0 || index >= count_) return;
-        const auto& info = infos_[index];
-        values_[(size_t) index].store (std::clamp (value, info.minValue, info.maxValue),
-                                       std::memory_order_relaxed);
-    }
-
-    int indexOfParam (const char* id) const noexcept
-    {
-        for (int i = 0; i < count_; ++i)
-            if (std::strcmp (infos_[i].id, id) == 0) return i;
-        return -1;
+        if (index < 0 || index >= numParams) return;
+        const auto& info = paramInfos[index];
+        paramValues[(size_t) index].store (std::clamp (value, info.minValue, info.maxValue),
+                                           std::memory_order_relaxed);
     }
 
     // Message thread. Size every scratch buffer and seed every smoother.
@@ -79,12 +70,12 @@ protected:
     // Audio thread.
     float paramValue (int index) const noexcept
     {
-        return values_[(size_t) index].load (std::memory_order_relaxed);
+        return paramValues[(size_t) index].load (std::memory_order_relaxed);
     }
 
 private:
-    const ParamInfo* infos_;
-    int count_;
-    std::vector<std::atomic<float>> values_;
+    const ParamInfo* paramInfos;
+    int numParams;
+    std::vector<std::atomic<float>> paramValues;
 };
 } // namespace duskstudio::builtin

--- a/src/engine/builtin/BuiltinUnit.h
+++ b/src/engine/builtin/BuiltinUnit.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <cstring>
+#include <vector>
+
+namespace duskstudio::builtin
+{
+// One control of a built-in unit. The id is the session-persistent key (the
+// index is not: reordering or inserting a parameter must not silently rebind a
+// saved value), the name is what an editor shows.
+struct ParamInfo
+{
+    const char* id;
+    const char* name;
+    const char* suffix;
+    float minValue;
+    float maxValue;
+    float defaultValue;
+    bool  isToggle;
+};
+
+// A DSP unit compiled into the app and reachable from an insert slot through
+// BuiltinInstance. Parameter storage lives here so every unit persists and
+// automates the same way; the DSP itself is the subclass's business.
+//
+// Threading: the parameter accessors are the message-thread surface, process()
+// is the sole audio-thread entry, and the two meet only through the relaxed
+// atomics behind paramValue(). prepare() sizes everything; process() allocates
+// nothing.
+class BuiltinUnit
+{
+public:
+    BuiltinUnit (const ParamInfo* infos, int count)
+        : infos_ (infos), count_ (count), values_ ((size_t) count)
+    {
+        for (int i = 0; i < count_; ++i)
+            values_[(size_t) i].store (infos_[i].defaultValue, std::memory_order_relaxed);
+    }
+
+    virtual ~BuiltinUnit() = default;
+
+    int paramCount() const noexcept { return count_; }
+
+    const ParamInfo& paramInfo (int index) const noexcept { return infos_[index]; }
+
+    float getParam (int index) const noexcept
+    {
+        if (index < 0 || index >= count_) return 0.0f;
+        return values_[(size_t) index].load (std::memory_order_relaxed);
+    }
+
+    void setParam (int index, float value) noexcept
+    {
+        if (index < 0 || index >= count_) return;
+        const auto& info = infos_[index];
+        values_[(size_t) index].store (std::clamp (value, info.minValue, info.maxValue),
+                                       std::memory_order_relaxed);
+    }
+
+    int indexOfParam (const char* id) const noexcept
+    {
+        for (int i = 0; i < count_; ++i)
+            if (std::strcmp (infos_[i].id, id) == 0) return i;
+        return -1;
+    }
+
+    // Message thread. Size every scratch buffer and seed every smoother.
+    // Idempotent - a device-rate change calls it again on the live unit.
+    virtual void prepare (double sampleRate, int maxBlockFrames) = 0;
+
+    virtual int latencySamples() const noexcept { return 0; }
+
+    // Audio thread. Stereo, in place.
+    virtual void process (float* left, float* right, int numFrames) noexcept = 0;
+
+protected:
+    // Audio thread.
+    float paramValue (int index) const noexcept
+    {
+        return values_[(size_t) index].load (std::memory_order_relaxed);
+    }
+
+private:
+    const ParamInfo* infos_;
+    int count_;
+    std::vector<std::atomic<float>> values_;
+};
+} // namespace duskstudio::builtin

--- a/src/engine/builtin/NativeBuiltinSlot.h
+++ b/src/engine/builtin/NativeBuiltinSlot.h
@@ -33,7 +33,8 @@ struct BuiltinSlotTraits
 };
 
 // Built-in insert slot - the shared NativeInsertSlot plus the unit's parameter
-// surface, which an editor and the MIDI-binding drain both drive.
+// surface (message thread; the audio thread reads it through relaxed atomics
+// inside the unit).
 class NativeBuiltinSlot final : public hosting::NativeInsertSlot<BuiltinSlotTraits>
 {
 public:
@@ -60,14 +61,5 @@ public:
         { return instance != nullptr ? instance->getParamValue (index) : 0.0f; }
     void setParamValue (int index, float value) noexcept
         { if (instance != nullptr) instance->setParamValue (index, value); }
-
-protected:
-    // MIDI binding: 0..1 fraction -> the parameter's own min..max range.
-    void applyParamBinding (uint32_t paramIndex, float frac) override
-    {
-        const auto* p = paramInfo ((int) paramIndex);
-        if (p == nullptr) return;
-        setParamValue ((int) paramIndex, p->minValue + frac * (p->maxValue - p->minValue));
-    }
 };
 } // namespace duskstudio::builtin

--- a/src/engine/builtin/NativeBuiltinSlot.h
+++ b/src/engine/builtin/NativeBuiltinSlot.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "BuiltinBundle.h"
+#include "BuiltinInstance.h"
+#include "../hosting/NativeInsertSlot.h"
+
+#include <string>
+
+namespace duskstudio::builtin
+{
+struct BuiltinSlotTraits
+{
+    using Bundle   = BuiltinBundle;
+    using Instance = BuiltinInstance;
+    static constexpr const char* bundleNoun = "built-in unit";
+
+    // One unit per bundle: the bundle IS the registry entry, so the only
+    // acceptable id is its own.
+    static bool pickPlugin (const BuiltinBundle& bundle, const std::string& requestedId,
+                            std::string& idOut, std::string& errorOut)
+    {
+        const auto* unit = bundle.unit();
+        if (unit == nullptr) { errorOut = "no unit in bundle"; return false; }
+        if (! requestedId.empty() && requestedId != unit->id)
+        {
+            errorOut = "built-in unit '" + std::string (unit->id)
+                     + "' does not provide '" + requestedId + "'";
+            return false;
+        }
+        idOut = unit->id;
+        return true;
+    }
+};
+
+// Built-in insert slot - the shared NativeInsertSlot plus the unit's parameter
+// surface, which an editor and the MIDI-binding drain both drive.
+class NativeBuiltinSlot final : public hosting::NativeInsertSlot<BuiltinSlotTraits>
+{
+public:
+    // Message thread. The unit id is the slot's identity, so the bundle "path"
+    // and the plugin id are the same string.
+    bool loadUnit (const std::string& unitId, double sampleRate, int maxBlock,
+                   std::string& errorOut)
+    {
+        return load (std::filesystem::u8path (unitId), sampleRate, maxBlock,
+                     errorOut, unitId);
+    }
+
+    std::string displayName() const
+    {
+        if (instance != nullptr) return instance->displayName();
+        const auto* unit = findUnit (loadedPluginId);
+        return unit != nullptr ? unit->name : loadedPluginId;
+    }
+
+    int paramCount() const noexcept { return instance != nullptr ? instance->paramCount() : 0; }
+    const ParamInfo* paramInfo (int index) const noexcept
+        { return instance != nullptr ? instance->paramInfo (index) : nullptr; }
+    float getParamValue (int index) const noexcept
+        { return instance != nullptr ? instance->getParamValue (index) : 0.0f; }
+    void setParamValue (int index, float value) noexcept
+        { if (instance != nullptr) instance->setParamValue (index, value); }
+
+protected:
+    // MIDI binding: 0..1 fraction -> the parameter's own min..max range.
+    void applyParamBinding (uint32_t paramIndex, float frac) override
+    {
+        const auto* p = paramInfo ((int) paramIndex);
+        if (p == nullptr) return;
+        setParamValue ((int) paramIndex, p->minValue + frac * (p->maxValue - p->minValue));
+    }
+};
+} // namespace duskstudio::builtin

--- a/src/engine/builtin/UtilityUnit.cpp
+++ b/src/engine/builtin/UtilityUnit.cpp
@@ -1,0 +1,80 @@
+#include "UtilityUnit.h"
+
+#include "../../foundation/Decibels.h"
+#include "../../foundation/ScopedNoDenormals.h"
+
+#include <algorithm>
+
+namespace duskstudio::builtin
+{
+namespace
+{
+constexpr float kMinGainDb = -60.0f;
+
+const ParamInfo kUtilityParams[] =
+{
+    { "gain_db",  "Gain",     "dB", kMinGainDb, 24.0f,  0.0f,   false },
+    { "polarity", "Polarity", "",   0.0f,       1.0f,   0.0f,   true  },
+    { "width",    "Width",    "%",  0.0f,       200.0f, 100.0f, false },
+    { "mono",     "Mono",     "",   0.0f,       1.0f,   0.0f,   true  },
+};
+
+constexpr double kRampSeconds = 0.02;
+} // namespace
+
+UtilityUnit::UtilityUnit()
+    : BuiltinUnit (kUtilityParams, kNumParams)
+{
+}
+
+void UtilityUnit::prepare (double sampleRate, int)
+{
+    const double sr = sampleRate > 0.0 ? sampleRate : 48000.0;
+    gain    .reset (sr, kRampSeconds);
+    width   .reset (sr, kRampSeconds);
+    monoSum .reset (sr, kRampSeconds);
+    polarity.reset (sr, kRampSeconds);
+
+    const float db = getParam (kGainDb);
+    gain.setCurrentAndTargetValue (db <= kMinGainDb ? 0.0f : dusk::audio::decibelsToGain (db));
+    width.setCurrentAndTargetValue (getParam (kWidth) * 0.01f);
+    monoSum.setCurrentAndTargetValue (getParam (kMonoSum) >= 0.5f ? 1.0f : 0.0f);
+    polarity.setCurrentAndTargetValue (getParam (kPolarityInvert) >= 0.5f ? -1.0f : 1.0f);
+}
+
+void UtilityUnit::process (float* left, float* right, int numFrames) noexcept
+{
+    dusk::audio::ScopedNoDenormals noDenormals;
+
+    if (left == nullptr || right == nullptr || numFrames <= 0)
+        return;
+
+    const float db = paramValue (kGainDb);
+    gain    .setTargetValue (db <= kMinGainDb ? 0.0f : dusk::audio::decibelsToGain (db));
+    width   .setTargetValue (paramValue (kWidth) * 0.01f);
+    monoSum .setTargetValue (paramValue (kMonoSum) >= 0.5f ? 1.0f : 0.0f);
+    polarity.setTargetValue (paramValue (kPolarityInvert) >= 0.5f ? -1.0f : 1.0f);
+
+    for (int i = 0; i < numFrames; ++i)
+    {
+        const float pol = polarity.getNextValue();
+        const float w   = width.getNextValue();
+        const float m   = monoSum.getNextValue();
+        const float g   = gain.getNextValue();
+
+        const float l = left[i] * pol;
+        const float r = right[i] * pol;
+
+        // Written as a two-tap matrix rather than mid +/- side so unity width
+        // is bit-exact passthrough: the cross coefficient is exactly zero.
+        const float direct = 0.5f * (1.0f + w);
+        const float cross  = 0.5f * (1.0f - w);
+        const float wideL = l * direct + r * cross;
+        const float wideR = r * direct + l * cross;
+        const float mid   = 0.5f * (l + r);
+
+        left[i]  = ((1.0f - m) * wideL + m * mid) * g;
+        right[i] = ((1.0f - m) * wideR + m * mid) * g;
+    }
+}
+} // namespace duskstudio::builtin

--- a/src/engine/builtin/UtilityUnit.cpp
+++ b/src/engine/builtin/UtilityUnit.cpp
@@ -13,10 +13,10 @@ constexpr float kMinGainDb = -60.0f;
 
 const ParamInfo kUtilityParams[] =
 {
-    { "gain_db",  "Gain",     "dB", kMinGainDb, 24.0f,  0.0f,   false },
-    { "polarity", "Polarity", "",   0.0f,       1.0f,   0.0f,   true  },
-    { "width",    "Width",    "%",  0.0f,       200.0f, 100.0f, false },
-    { "mono",     "Mono",     "",   0.0f,       1.0f,   0.0f,   true  },
+    { "gain_db",  "Gain",     kMinGainDb, 24.0f,  0.0f   },
+    { "polarity", "Polarity", 0.0f,       1.0f,   0.0f   },
+    { "width",    "Width",    0.0f,       200.0f, 100.0f },
+    { "mono",     "Mono",     0.0f,       1.0f,   0.0f   },
 };
 
 constexpr double kRampSeconds = 0.02;
@@ -29,11 +29,10 @@ UtilityUnit::UtilityUnit()
 
 void UtilityUnit::prepare (double sampleRate, int)
 {
-    const double sr = sampleRate > 0.0 ? sampleRate : 48000.0;
-    gain    .reset (sr, kRampSeconds);
-    width   .reset (sr, kRampSeconds);
-    monoSum .reset (sr, kRampSeconds);
-    polarity.reset (sr, kRampSeconds);
+    gain    .reset (sampleRate, kRampSeconds);
+    width   .reset (sampleRate, kRampSeconds);
+    monoSum .reset (sampleRate, kRampSeconds);
+    polarity.reset (sampleRate, kRampSeconds);
 
     const float db = getParam (kGainDb);
     gain.setCurrentAndTargetValue (db <= kMinGainDb ? 0.0f : dusk::audio::decibelsToGain (db));

--- a/src/engine/builtin/UtilityUnit.h
+++ b/src/engine/builtin/UtilityUnit.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "BuiltinUnit.h"
+
+#include "../../foundation/SmoothedValue.h"
+
+namespace duskstudio::builtin
+{
+// Gain / polarity / stereo width / mono sum. Signal order is polarity ->
+// width -> mono sum -> gain, so the width control is inert once the sum is on
+// (the sum has already collapsed the side signal).
+//
+// At its defaults the unit is bit-exact unity: 0 dB, polarity off, 100 % width
+// (mid/side reconstructs L and R exactly) and no mono sum.
+class UtilityUnit final : public BuiltinUnit
+{
+public:
+    UtilityUnit();
+
+    void prepare (double sampleRate, int maxBlockFrames) override;
+    void process (float* left, float* right, int numFrames) noexcept override;
+
+private:
+    enum ParamIndex { kGainDb = 0, kPolarityInvert, kWidth, kMonoSum, kNumParams };
+
+    dusk::audio::SmoothedValue<float> gain { 1.0f };
+    dusk::audio::SmoothedValue<float> width { 1.0f };
+    dusk::audio::SmoothedValue<float> monoSum { 0.0f };
+    dusk::audio::SmoothedValue<float> polarity { 1.0f };
+};
+} // namespace duskstudio::builtin

--- a/src/session/RegionEditActions.cpp
+++ b/src/session/RegionEditActions.cpp
@@ -1025,7 +1025,11 @@ void applyTrack (Track& t, AudioEngine& engine, int idx,
                 loaded = strip.getBuiltinSlot().loadState (s.builtinState);
             engine.resumeProcessing();
             if (! loaded)
+            {
                 strip.markBuiltinRestoreFailed();
+                DBG ("CloneTrackAction: built-in restore failed on strip " << idx
+                      << " (" << s.builtinUnitId.c_str() << "): " << builtinErr.c_str());
+            }
             t.builtinUnitId = s.builtinUnitId;
             t.builtinStateBase64 = s.builtinState.empty()
                 ? std::string()

--- a/src/session/RegionEditActions.cpp
+++ b/src/session/RegionEditActions.cpp
@@ -475,6 +475,11 @@ struct CloneTrackAction::Impl
     std::vector<uint8_t> auState;
 #endif
 
+    // Built-in unit id and parameter state. Same offline-preserving contract as
+    // the Audio Unit pair above.
+    std::string          builtinUnitId;
+    std::vector<uint8_t> builtinState;
+
     // Region / MIDI region content.
     std::vector<AudioRegion> regions;
     std::vector<MidiRegion>  midiRegions;
@@ -695,6 +700,8 @@ CloneTrackAction::Impl captureTrack (Track& t, AudioEngine& engine, int idx)
     if (strip.isNativeMultisampleLoaded())
         liveNativeCaptured = true;
 #endif
+    if (strip.isBuiltinLoaded())
+        liveNativeCaptured = true;
 
     // With no live owner, preserve one offline reference using the same
     // precedence as session restore. This is what makes AU clone/undo safe
@@ -738,6 +745,29 @@ CloneTrackAction::Impl captureTrack (Track& t, AudioEngine& engine, int idx)
 #endif
     }
 #endif
+
+    {
+        auto& builtinSlot = engine.getStrip (idx).getBuiltinSlot();
+        if (builtinSlot.isLoaded())
+        {
+            s.builtinUnitId = builtinSlot.getPluginId();
+            if (! builtinSlot.saveState (s.builtinState) || s.builtinState.empty())
+            {
+                s.builtinState = dusk::base64::decode (
+                    t.builtinStateBase64.data(), t.builtinStateBase64.size());
+                hosting::retainStateForLiveIdentity (
+                    { "builtin", t.builtinUnitId, {} },
+                    { "builtin", builtinSlot.getPluginId(), {} },
+                    s.builtinState);
+            }
+        }
+        else if (! t.builtinUnitId.empty())
+        {
+            s.builtinUnitId = t.builtinUnitId;
+            s.builtinState  = dusk::base64::decode (
+                t.builtinStateBase64.data(), t.builtinStateBase64.size());
+        }
+    }
 
 #if DUSKSTUDIO_HAS_MULTISAMPLE
     auto& msSlot = engine.getStrip (idx).getNativeMultisampleSlot();
@@ -981,6 +1011,39 @@ void applyTrack (Track& t, AudioEngine& engine, int idx,
         }
     }
 #endif
+
+    // Same "after the JUCE replay" rule as the multisample block below: a
+    // built-in load evicts every other host on the insert.
+    {
+        auto& strip = engine.getStrip (idx);
+        if (! s.builtinUnitId.empty())
+        {
+            engine.suspendProcessing();
+            std::string builtinErr;
+            bool loaded = strip.loadBuiltin (s.builtinUnitId, builtinErr);
+            if (loaded && ! s.builtinState.empty())
+                loaded = strip.getBuiltinSlot().loadState (s.builtinState);
+            engine.resumeProcessing();
+            if (! loaded)
+                strip.markBuiltinRestoreFailed();
+            t.builtinUnitId = s.builtinUnitId;
+            t.builtinStateBase64 = s.builtinState.empty()
+                ? std::string()
+                : dusk::base64::encode (s.builtinState.data(), s.builtinState.size());
+            t.pluginDescriptor.reset();
+            t.pluginLegacyDescriptionXml.clear();
+            t.pluginStateBase64.clear();
+        }
+        else
+        {
+            const bool wasLoaded = strip.isBuiltinLoaded();
+            if (wasLoaded) engine.suspendProcessing();
+            strip.unloadBuiltin();
+            if (wasLoaded) engine.resumeProcessing();
+            t.builtinUnitId.clear();
+            t.builtinStateBase64.clear();
+        }
+    }
 
 #if DUSKSTUDIO_HAS_MULTISAMPLE
     // After the JUCE replay: a multisample load evicts the JUCE slot, so doing

--- a/src/session/Session.h
+++ b/src/session/Session.h
@@ -875,6 +875,10 @@ struct Track
     // Soundfont path (.sfz / .sf2) - the multisample rung has no plugin id.
     juce::String nativeMultisamplePath;
     juce::String nativeMultisampleStateBase64;
+    // Built-in unit: the registry id is the whole identity, and the state blob
+    // carries its parameter values.
+    std::string builtinUnitId;
+    std::string builtinStateBase64;
 
     // Track freeze (MIDI tracks): the instrument + pre-fader strip is rendered
     // to a WAV, the plugin is bypassed to free CPU, and playback reads the WAV
@@ -1029,10 +1033,10 @@ struct AuxLane
     std::array<juce::String, AuxLaneParams::kMaxLanePlugins> pluginStateBase64;
 
     // Native host alternatives to the JUCE plugin above. A slot is JUCE /
-    // native-CLAP / native-LV2 / native-VST3 / native-AU / hardware / empty -
-    // at most one host per slot (precedence CLAP > LV2 > VST3 > AU if several
-    // native identities are somehow set). Always present so builds without a
-    // given host round-trip its fields untouched.
+    // native-CLAP / native-LV2 / native-VST3 / native-AU / built-in / hardware /
+    // empty - at most one host per slot (precedence CLAP > LV2 > VST3 > AU >
+    // built-in if several native identities are somehow set). Always present so
+    // builds without a given host round-trip its fields untouched.
     std::array<juce::String, AuxLaneParams::kMaxLanePlugins> nativeClapPath;
     std::array<juce::String, AuxLaneParams::kMaxLanePlugins> nativeClapPluginId;
     std::array<juce::String, AuxLaneParams::kMaxLanePlugins> nativeClapStateBase64;
@@ -1044,6 +1048,8 @@ struct AuxLane
     std::array<juce::String, AuxLaneParams::kMaxLanePlugins> nativeVst3StateBase64;
     std::array<juce::String, AuxLaneParams::kMaxLanePlugins> nativeAuIdentifier;
     std::array<juce::String, AuxLaneParams::kMaxLanePlugins> nativeAuStateBase64;
+    std::array<std::string, AuxLaneParams::kMaxLanePlugins> builtinUnitId;
+    std::array<std::string, AuxLaneParams::kMaxLanePlugins> builtinStateBase64;
 
     std::array<HardwareInsertParams, AuxLaneParams::kMaxLanePlugins> hardwareInserts;
 };

--- a/src/session/Session.h
+++ b/src/session/Session.h
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <limits>
 #include <memory>
+#include <string>
 #include <type_traits>
 #include <vector>
 #include "AtomicSnapshot.h"

--- a/src/session/SessionSerializer.cpp
+++ b/src/session/SessionSerializer.cpp
@@ -539,6 +539,11 @@ JObj trackToObject (const Track& t, const juce::File& sessionDir)
         obj["native_multisample_path"]  = toStd (t.nativeMultisamplePath);
         obj["native_multisample_state"] = toStd (t.nativeMultisampleStateBase64);
     }
+    if (! t.builtinUnitId.empty())
+    {
+        obj["builtin_id"]    = t.builtinUnitId;
+        obj["builtin_state"] = t.builtinStateBase64;
+    }
 
     obj["fader_db"]     = t.strip.faderDb.load();
     obj["pan"]          = t.strip.pan.load();
@@ -1068,6 +1073,8 @@ void restoreTrack (Track& t, int trackIndex, const nlohmann::json& v,
     t.nativeAuStateBase64   = json::getString (v, "native_au_state");
     t.nativeMultisamplePath        = json::getString (v, "native_multisample_path");
     t.nativeMultisampleStateBase64 = json::getString (v, "native_multisample_state");
+    t.builtinUnitId      = json::getString (v, "builtin_id");
+    t.builtinStateBase64 = json::getString (v, "builtin_state");
 
     auto setFloat = [&v] (std::atomic<float>& a, const char* key,
                           float fallback, float minimum, float maximum)
@@ -1654,6 +1661,11 @@ juce::String SessionSerializer::serialize (const Session& s)
                 slot["native_au_identifier"] = toStd (lane.nativeAuIdentifier[(size_t) p]);
                 slot["native_au_state"] = toStd (lane.nativeAuStateBase64[(size_t) p]);
             }
+            if (! lane.builtinUnitId[(size_t) p].empty())
+            {
+                slot["builtin_id"]    = lane.builtinUnitId[(size_t) p];
+                slot["builtin_state"] = lane.builtinStateBase64[(size_t) p];
+            }
 
             // Hardware-insert side of this slot. Same shape as the
             // Track::hardwareInsert block above.
@@ -2160,6 +2172,8 @@ bool SessionSerializer::load (Session& s, const File& source)
                     lane.nativeVst3StateBase64[(size_t) p] = json::getString (sv, "native_vst3_state");
                     lane.nativeAuIdentifier[(size_t) p]    = json::getString (sv, "native_au_identifier");
                     lane.nativeAuStateBase64[(size_t) p]   = json::getString (sv, "native_au_state");
+                    lane.builtinUnitId[(size_t) p]         = json::getString (sv, "builtin_id");
+                    lane.builtinStateBase64[(size_t) p]    = json::getString (sv, "builtin_state");
 
                     // Same default-off rationale as the track hardware_insert.
                     lane.hardwareInserts[(size_t) p].enabled.store (

--- a/src/ui/AuxLaneComponent.cpp
+++ b/src/ui/AuxLaneComponent.cpp
@@ -406,6 +406,11 @@ AuxLaneComponent::AuxLaneComponent (AuxLane& l, AuxLaneStrip& s, int idx,
             }
             else
 #endif
+            if (strip.isBuiltinLoaded (i))
+            {
+                strip.getBuiltinSlot (i).setBypassed (on);
+            }
+            else
             {
                 auto& slotRef = strip.getPluginSlot (i);
                 slotRef.setBypassed (on);

--- a/src/ui/AuxLaneComponent.cpp
+++ b/src/ui/AuxLaneComponent.cpp
@@ -813,6 +813,25 @@ void AuxLaneComponent::refreshSlotControls (int i)
     }
 #endif
 
+    if (strip.isBuiltinLoaded (i))
+    {
+        const auto name = strip.getBuiltinSlot (i).displayName();
+        const bool offline = strip.builtinReloadFailed (i);
+        const auto label = nativeLabel (name, offline);
+        setNativeTooltip (offline);
+        if (label != ui.displayedName)
+        {
+            ui.displayedName = label;
+            ui.openOrAddButton.setButtonText (label);
+            resized();
+        }
+        ui.bypassButton.setVisible (true);
+        ui.bypassButton.setToggleState (strip.getBuiltinSlot (i).isBypassed(),
+                                        juce::dontSendNotification);
+        ui.removeButton.setVisible (true);
+        return;
+    }
+
     // A failed load can leave no live instance. Keep the saved native reference
     // visible as an offline row so the user can replace or remove it explicitly.
     if (strip.nativeInsertRestoreFailed (i))
@@ -837,6 +856,8 @@ void AuxLaneComponent::refreshSlotControls (int i)
         if (strip.nativeAuReloadFailed (i))
             name = lane.nativeAuIdentifier[(size_t) i];
 #endif
+        if (strip.builtinReloadFailed (i))
+            name = lane.builtinUnitId[(size_t) i];
         if (name.isEmpty()) name = "native plug-in";
         const auto label = nativeLabel (name, true);
         setNativeTooltip (true);
@@ -945,6 +966,11 @@ void AuxLaneComponent::openPickerForSlot (int slotIdx)
             self->loadNativeAuForSlot (slotIdx, componentId);
     };
 #endif
+    auto onBuiltin = [safe, slotIdx] (const std::string& unitId)
+    {
+        if (auto* self = safe.getComponent())
+            self->loadBuiltinForSlot (slotIdx, unitId);
+    };
     pluginpicker::openPickerMenu (strip.getPluginSlot (slotIdx),
                                     slots[(size_t) slotIdx].openOrAddButton,
                                     [safe, slotIdx]
@@ -962,7 +988,8 @@ void AuxLaneComponent::openPickerForSlot (int slotIdx)
                                                 self->strip.isNativeClapLoaded (slotIdx)
                                                 || self->strip.isNativeLv2Loaded (slotIdx)
                                                 || self->strip.isNativeVst3Loaded (slotIdx)
-                                                || self->strip.isNativeAuLoaded (slotIdx);
+                                                || self->strip.isNativeAuLoaded (slotIdx)
+                                                || self->strip.isBuiltinLoaded (slotIdx);
                                             if (self->strip.getPluginSlot (slotIdx).isLoaded()
                                                 && (hadLiveNative
                                                     || self->strip.nativeInsertRestoreFailed (
@@ -977,6 +1004,7 @@ void AuxLaneComponent::openPickerForSlot (int slotIdx)
                                                 self->strip.unloadNativeLv2 (slotIdx);
                                                 self->strip.unloadNativeVst3 (slotIdx);
                                                 self->strip.unloadNativeAu (slotIdx);
+                                                self->strip.unloadBuiltin (slotIdx);
                                                 if (hadLiveNative) self->engine.resumeProcessing();
                                                 self->lane.nativeClapPath[(size_t) slotIdx].clear();
                                                 self->lane.nativeClapPluginId[(size_t) slotIdx].clear();
@@ -989,6 +1017,8 @@ void AuxLaneComponent::openPickerForSlot (int slotIdx)
                                                 self->lane.nativeVst3StateBase64[(size_t) slotIdx].clear();
                                                 self->lane.nativeAuIdentifier[(size_t) slotIdx].clear();
                                                 self->lane.nativeAuStateBase64[(size_t) slotIdx].clear();
+                                                self->lane.builtinUnitId[(size_t) slotIdx].clear();
+                                                self->lane.builtinStateBase64[(size_t) slotIdx].clear();
                                             }
 
                                             self->refreshSlotControls (slotIdx);
@@ -1007,7 +1037,8 @@ void AuxLaneComponent::openPickerForSlot (int slotIdx)
                                     std::move (onLv2),
                                     std::move (onVst3),
                                     {},
-                                    std::move (onAu));
+                                    std::move (onAu),
+                                    std::move (onBuiltin));
 }
 
 void AuxLaneComponent::openHardwareInsertEditor (int slotIdx)
@@ -1022,7 +1053,8 @@ void AuxLaneComponent::openHardwareInsertEditor (int slotIdx)
         const bool hadLiveNative = strip.isNativeClapLoaded (slotIdx)
                                 || strip.isNativeLv2Loaded (slotIdx)
                                 || strip.isNativeVst3Loaded (slotIdx)
-                                || strip.isNativeAuLoaded (slotIdx);
+                                || strip.isNativeAuLoaded (slotIdx)
+                                || strip.isBuiltinLoaded (slotIdx);
         if (hadLiveNative) engine.suspendProcessing();
         detachClapEditorForSlot (slotIdx);
         detachLv2EditorForSlot (slotIdx);
@@ -1032,6 +1064,7 @@ void AuxLaneComponent::openHardwareInsertEditor (int slotIdx)
         strip.unloadNativeLv2 (slotIdx);
         strip.unloadNativeVst3 (slotIdx);
         strip.unloadNativeAu (slotIdx);
+        strip.unloadBuiltin (slotIdx);
         if (hadLiveNative) engine.resumeProcessing();
         lane.nativeClapPath[(size_t) slotIdx].clear();
         lane.nativeClapPluginId[(size_t) slotIdx].clear();
@@ -1044,6 +1077,8 @@ void AuxLaneComponent::openHardwareInsertEditor (int slotIdx)
         lane.nativeVst3StateBase64[(size_t) slotIdx].clear();
         lane.nativeAuIdentifier[(size_t) slotIdx].clear();
         lane.nativeAuStateBase64[(size_t) slotIdx].clear();
+        lane.builtinUnitId[(size_t) slotIdx].clear();
+        lane.builtinStateBase64[(size_t) slotIdx].clear();
     }
 
     // Flip the lane's slot to Hardware mode immediately so the audio
@@ -1079,7 +1114,8 @@ void AuxLaneComponent::unloadSlot (int slotIdx)
         const bool hadLiveNative = self->strip.isNativeClapLoaded (slotIdx)
                                 || self->strip.isNativeLv2Loaded (slotIdx)
                                 || self->strip.isNativeVst3Loaded (slotIdx)
-                                || self->strip.isNativeAuLoaded (slotIdx);
+                                || self->strip.isNativeAuLoaded (slotIdx)
+                                || self->strip.isBuiltinLoaded (slotIdx);
         const bool hadNativeReference = hadLiveNative
                                      || self->strip.nativeInsertRestoreFailed (slotIdx);
         if (hadLiveNative) self->engine.suspendProcessing();
@@ -1096,6 +1132,7 @@ void AuxLaneComponent::unloadSlot (int slotIdx)
             self->strip.unloadNativeLv2 (slotIdx);
             self->strip.unloadNativeVst3 (slotIdx);
             self->strip.unloadNativeAu (slotIdx);
+            self->strip.unloadBuiltin (slotIdx);
             if (hadLiveNative) self->engine.resumeProcessing();
             self->lane.nativeClapPath[(size_t) slotIdx].clear();
             self->lane.nativeClapPluginId[(size_t) slotIdx].clear();
@@ -1108,6 +1145,8 @@ void AuxLaneComponent::unloadSlot (int slotIdx)
             self->lane.nativeVst3StateBase64[(size_t) slotIdx].clear();
             self->lane.nativeAuIdentifier[(size_t) slotIdx].clear();
             self->lane.nativeAuStateBase64[(size_t) slotIdx].clear();
+            self->lane.builtinUnitId[(size_t) slotIdx].clear();
+            self->lane.builtinStateBase64[(size_t) slotIdx].clear();
         }
         // Clear the model's enabled flag so any consumer that polls
         // lane.hardwareInserts[slotIdx].enabled sees a disabled slot
@@ -1392,6 +1431,58 @@ void AuxLaneComponent::loadNativeAuForSlot (int slotIdx, const juce::String& com
 }
 #endif // DUSKSTUDIO_HAS_NATIVE_AU
 
+void AuxLaneComponent::loadBuiltinForSlot (int slotIdx, const std::string& unitId)
+{
+    if (slotIdx < 0 || slotIdx >= AuxLaneParams::kMaxLanePlugins) return;
+
+    detachEditorForSlot (slotIdx);
+    detachHardwareInsertForSlot (slotIdx);
+    detachClapEditorForSlot (slotIdx);
+    detachLv2EditorForSlot (slotIdx);
+    detachVst3EditorForSlot (slotIdx);
+    detachAuEditorForSlot (slotIdx);
+
+    std::string err;
+    engine.suspendProcessing();
+    const bool ok = strip.loadBuiltin (slotIdx, unitId, err);
+    if (ok)
+        strip.insertMode[(size_t) slotIdx].store (AuxLaneStrip::kInsertPlugin,
+                                                  std::memory_order_release);
+    engine.resumeProcessing();
+
+    // loadBuiltin evicts every other host on the slot before it can fail, so
+    // clear all of them either way (matches loadNativeAuForSlot).
+    lane.pluginDescriptor[(size_t) slotIdx].reset();
+    lane.pluginLegacyDescriptionXml[(size_t) slotIdx].clear();
+    lane.pluginStateBase64[(size_t) slotIdx].clear();
+    lane.nativeClapPath[(size_t) slotIdx].clear();
+    lane.nativeClapPluginId[(size_t) slotIdx].clear();
+    lane.nativeClapStateBase64[(size_t) slotIdx].clear();
+    lane.nativeLv2Path[(size_t) slotIdx].clear();
+    lane.nativeLv2PluginId[(size_t) slotIdx].clear();
+    lane.nativeLv2StateBase64[(size_t) slotIdx].clear();
+    lane.nativeVst3Path[(size_t) slotIdx].clear();
+    lane.nativeVst3PluginId[(size_t) slotIdx].clear();
+    lane.nativeVst3StateBase64[(size_t) slotIdx].clear();
+    lane.nativeAuIdentifier[(size_t) slotIdx].clear();
+    lane.nativeAuStateBase64[(size_t) slotIdx].clear();
+    lane.builtinUnitId[(size_t) slotIdx].clear();
+    lane.builtinStateBase64[(size_t) slotIdx].clear();
+
+    if (! ok)
+    {
+        std::fprintf (stderr, "[aux builtin] load failed: %s\n", err.c_str());
+        showDuskAlert (*this, "Couldn't load built-in unit", unitId + ":\n" + err);
+        refreshSlotControls (slotIdx);
+        rebuildSlots();
+        return;
+    }
+
+    lane.builtinUnitId[(size_t) slotIdx] = strip.getBuiltinSlot (slotIdx).getPluginId();
+    refreshSlotControls (slotIdx);
+    rebuildSlots();
+}
+
 void AuxLaneComponent::detachClapEditorForSlot (int slotIdx)
 {
 #if DUSKSTUDIO_HAS_NATIVE_CLAP
@@ -1400,7 +1491,7 @@ void AuxLaneComponent::detachClapEditorForSlot (int slotIdx)
     removeChildComponent (ui.clapEditor.get());
     ui.clapEditor.reset();
 #else
-    juce::ignoreUnused (slotIdx);
+    (void) slotIdx;
 #endif
 }
 
@@ -1412,7 +1503,7 @@ void AuxLaneComponent::detachLv2EditorForSlot (int slotIdx)
     removeChildComponent (ui.lv2Editor.get());
     ui.lv2Editor.reset();
 #else
-    juce::ignoreUnused (slotIdx);
+    (void) slotIdx;
 #endif
 }
 
@@ -1424,7 +1515,7 @@ void AuxLaneComponent::detachVst3EditorForSlot (int slotIdx)
     removeChildComponent (ui.vst3Editor.get());
     ui.vst3Editor.reset();
 #else
-    juce::ignoreUnused (slotIdx);
+    (void) slotIdx;
 #endif
 }
 
@@ -1436,7 +1527,7 @@ void AuxLaneComponent::detachAuEditorForSlot (int slotIdx)
     removeChildComponent (ui.auEditor.get());
     ui.auEditor.reset();
 #else
-    juce::ignoreUnused (slotIdx);
+    (void) slotIdx;
 #endif
 }
 
@@ -1584,7 +1675,8 @@ void AuxLaneComponent::layoutEditorForSlot (int slotIdx)
     const int mode = strip.insertMode[(size_t) slotIdx].load (std::memory_order_relaxed);
     if (slot.isLoaded() || slot.isOffline() || mode == AuxLaneStrip::kInsertHardware
         || strip.isNativeClapLoaded (slotIdx) || strip.isNativeLv2Loaded (slotIdx)
-        || strip.isNativeVst3Loaded (slotIdx) || strip.isNativeAuLoaded (slotIdx))
+        || strip.isNativeVst3Loaded (slotIdx) || strip.isNativeAuLoaded (slotIdx)
+        || strip.isBuiltinLoaded (slotIdx))
         center.removeFromTop (kSlotHeaderH + 4);
 
     if (center.isEmpty()) return;

--- a/src/ui/AuxLaneComponent.cpp
+++ b/src/ui/AuxLaneComponent.cpp
@@ -2043,7 +2043,8 @@ void AuxLaneComponent::resized()
     // mode - would never get bounds and the user couldn't dismiss
     // the HW insert.
     const bool nativeLoaded = strip.isNativeClapLoaded (0) || strip.isNativeLv2Loaded (0)
-                           || strip.isNativeVst3Loaded (0) || strip.isNativeAuLoaded (0);
+                           || strip.isNativeVst3Loaded (0) || strip.isNativeAuLoaded (0)
+                           || strip.isBuiltinLoaded (0);
     if (slot0.isLoaded() || slot0.isOffline() || hardware || nativeLoaded
         || strip.nativeInsertRestoreFailed (0))
     {

--- a/src/ui/AuxLaneComponent.h
+++ b/src/ui/AuxLaneComponent.h
@@ -5,6 +5,7 @@
 #include "../foundation/MessageThread.h"
 #include <array>
 #include <memory>
+#include <string>
 #include "../session/Session.h"
 #include "DuskComboBox.h"
 #include "NativeEditorOwner.h"
@@ -84,6 +85,9 @@ private:
 #if DUSKSTUDIO_HAS_NATIVE_AU
     void loadNativeAuForSlot (int slotIdx, const juce::String& componentId);
 #endif
+    // Built-in unit rung. No editor yet, so the slot header and the picker are
+    // the whole UI surface.
+    void loadBuiltinForSlot (int slotIdx, const std::string& unitId);
     // Stubbed (no-op body) off Linux so the many callers don't each need a guard.
     void detachClapEditorForSlot (int slotIdx);
     void detachLv2EditorForSlot (int slotIdx);

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -1352,6 +1352,10 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
             togglePluginEditor();
             return;
         }
+        // A built-in unit has no editor yet, so a click on its occupied slot
+        // does nothing rather than reopening the picker over a loaded insert.
+        if (engine.getChannelStrip (trackIndex).isBuiltinLoaded())
+            return;
         // Empty slot may already be in Hardware mode (user picked HW
         // earlier, then clicked the slot again to revisit routing).
         // Route straight to the HW editor instead of showing the
@@ -1734,7 +1738,8 @@ void ChannelStripComponent::openPluginPicker()
                                             || chStrip.isNativeLv2Loaded()
                                             || chStrip.isNativeVst3Loaded()
                                             || chStrip.isNativeAuLoaded()
-                                            || chStrip.isNativeMultisampleLoaded();
+                                            || chStrip.isNativeMultisampleLoaded()
+                                            || chStrip.isBuiltinLoaded();
                                         if (self->pluginSlot.isLoaded()
                                             && (hadLiveNative
                                                 || chStrip.nativeInsertRestoreFailed()))
@@ -1762,6 +1767,7 @@ void ChannelStripComponent::openPluginPicker()
                                             chStrip.unloadNativeVst3();
                                             chStrip.unloadNativeAu();
                                             chStrip.unloadNativeMultisample();
+                                            chStrip.unloadBuiltin();
                                             if (hadLiveNative) self->engine.resumeProcessing();
                                             self->track.nativeClapPath = {};
                                             self->track.nativeClapPluginId = {};
@@ -1776,6 +1782,8 @@ void ChannelStripComponent::openPluginPicker()
                                             self->track.nativeAuStateBase64 = {};
                                             self->track.nativeMultisamplePath = {};
                                             self->track.nativeMultisampleStateBase64 = {};
+                                            self->track.builtinUnitId.clear();
+                                            self->track.builtinStateBase64.clear();
                                         }
 
                                         // Loading an instrument (soundfont or VST/LV2 synth) on a
@@ -1879,6 +1887,12 @@ void ChannelStripComponent::openPluginPicker()
     };
 #endif
 
+    auto onBuiltin = [safe] (const std::string& unitId)
+    {
+        if (auto* self = safe.getComponent())
+            self->loadBuiltinForChannel (unitId);
+    };
+
     pluginpicker::openInsertChooser (pluginSlot,
                                       pluginSlotButton,
                                       std::move (onChange),
@@ -1888,7 +1902,8 @@ void ChannelStripComponent::openPluginPicker()
                                       std::move (onLv2),
                                       std::move (onVst3),
                                       std::move (onSoundfont),
-                                      std::move (onAu));
+                                      std::move (onAu),
+                                      std::move (onBuiltin));
 }
 
 void ChannelStripComponent::openHardwareInsertEditor()
@@ -2040,6 +2055,22 @@ void ChannelStripComponent::unloadPluginSlot()
     }
 #endif
 
+    {
+        auto& builtinStrip = engine.getChannelStrip (trackIndex);
+        if (builtinStrip.isBuiltinLoaded())
+        {
+            engine.suspendProcessing();
+            builtinStrip.unloadBuiltin();
+            builtinStrip.insertMode.store (ChannelStrip::kInsertPlugin,
+                                           std::memory_order_release);
+            engine.resumeProcessing();
+            track.builtinUnitId.clear();
+            track.builtinStateBase64.clear();
+            refreshPluginSlotButton();
+            return;
+        }
+    }
+
     // A failed load can leave only the preserved session reference, with no
     // native instance for the format-specific branches above to match.
     auto& failedStrip = engine.getChannelStrip (trackIndex);
@@ -2050,6 +2081,7 @@ void ChannelStripComponent::unloadPluginSlot()
         failedStrip.unloadNativeVst3();
         failedStrip.unloadNativeAu();
         failedStrip.unloadNativeMultisample();
+        failedStrip.unloadBuiltin();
         track.nativeClapPath = {};
         track.nativeClapPluginId = {};
         track.nativeClapStateBase64 = {};
@@ -2063,6 +2095,8 @@ void ChannelStripComponent::unloadPluginSlot()
         track.nativeAuStateBase64 = {};
         track.nativeMultisamplePath = {};
         track.nativeMultisampleStateBase64 = {};
+        track.builtinUnitId.clear();
+        track.builtinStateBase64.clear();
         refreshPluginSlotButton();
         return;
     }
@@ -2078,7 +2112,8 @@ void ChannelStripComponent::showPluginSlotMenu()
                            || engine.getChannelStrip (trackIndex).isNativeLv2Loaded()
                            || engine.getChannelStrip (trackIndex).isNativeVst3Loaded()
                            || engine.getChannelStrip (trackIndex).isNativeAuLoaded()
-                           || engine.getChannelStrip (trackIndex).isNativeMultisampleLoaded();
+                           || engine.getChannelStrip (trackIndex).isNativeMultisampleLoaded()
+                           || engine.getChannelStrip (trackIndex).isBuiltinLoaded();
     if (pluginSlot.isLoaded() || nativeLoaded)
     {
         // Editor toggle headline so right-click ALSO becomes a way to open
@@ -2177,7 +2212,8 @@ bool ChannelStripComponent::insertSlotOccupied() const
     auto& st = engine.getChannelStrip (trackIndex);
     if (st.isNativeClapLoaded() || st.isNativeLv2Loaded() || st.isNativeVst3Loaded()
         || st.isNativeAuLoaded()
-        || st.isNativeMultisampleLoaded())
+        || st.isNativeMultisampleLoaded()
+        || st.isBuiltinLoaded())
         return true;
     if (pluginSlot.isLoaded())
         return true;
@@ -2294,6 +2330,18 @@ void ChannelStripComponent::refreshPluginSlotButton()
     }
 #endif
 
+    if (engine.getChannelStrip (trackIndex).isBuiltinLoaded())
+    {
+        const auto nm = engine.getChannelStrip (trackIndex).getBuiltinSlot().displayName();
+        const bool offline = engine.getChannelStrip (trackIndex).builtinReloadFailed();
+        const auto label = nativeLabel (nm, offline);
+        setNativeTooltip (offline);
+        if (label == lastSlotName) return;
+        lastSlotName = label;
+        pluginSlotButton.setButtonText (label);
+        return;
+    }
+
     // A failed session restore may have unloaded the instance completely. The
     // saved path/state still belong to this slot, so keep an explicit offline
     // placeholder instead of making it look empty and healthy.
@@ -2320,6 +2368,8 @@ void ChannelStripComponent::refreshPluginSlotButton()
         if (engine.getChannelStrip (trackIndex).nativeMultisampleReloadFailed())
             name = juce::File (track.nativeMultisamplePath).getFileNameWithoutExtension();
 #endif
+        if (engine.getChannelStrip (trackIndex).builtinReloadFailed())
+            name = track.builtinUnitId;
         if (name.isEmpty()) name = "native plug-in";
 
         // A clone / undo replay can empty the JUCE slot while marking the native
@@ -3342,6 +3392,80 @@ void ChannelStripComponent::loadNativeAuForChannel (const juce::String& componen
     openPluginEditor();
 }
 #endif // DUSKSTUDIO_HAS_NATIVE_AU
+
+void ChannelStripComponent::loadBuiltinForChannel (const std::string& unitId)
+{
+    auto& strip = engine.getChannelStrip (trackIndex);
+
+    closePluginEditor();
+#if DUSKSTUDIO_HAS_NATIVE_CLAP
+    clapEditor.reset();
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_LV2
+    lv2Editor.reset();
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_VST3
+    vst3Editor.reset();
+#endif
+#if DUSKSTUDIO_HAS_NATIVE_AU
+    auEditor.reset();
+#endif
+#if DUSKSTUDIO_HAS_MULTISAMPLE
+    multisampleEditor.reset();
+    multisampleEditorOwner = nullptr;
+    drainMultisampleLoads();
+#endif
+    pluginEditor.reset();
+    pluginEditorOwner = nullptr;
+   #if JUCE_LINUX && DUSKSTUDIO_HAS_OOP_PLUGINS
+    resetRemoteEditorEmbed();
+   #endif
+   #if DUSKSTUDIO_HAS_OOP_PLUGINS && ! JUCE_LINUX
+    remoteForeignEmbed.reset();
+   #endif
+
+    std::string err;
+    engine.suspendProcessing();
+    const bool ok = strip.loadBuiltin (unitId, err);
+    if (ok)
+        strip.insertMode.store (ChannelStrip::kInsertPlugin, std::memory_order_release);
+    engine.resumeProcessing();
+
+    // loadBuiltin evicts every other host before it can fail, so a failure
+    // leaves the whole insert empty - drop every persisted reference, not just
+    // the built-in pair (matches loadNativeAuForChannel).
+    track.pluginDescriptor.reset();
+    track.pluginLegacyDescriptionXml.clear();
+    track.pluginStateBase64.clear();
+    track.nativeClapPath = {};
+    track.nativeClapPluginId = {};
+    track.nativeClapStateBase64 = {};
+    track.nativeLv2Path = {};
+    track.nativeLv2PluginId = {};
+    track.nativeLv2StateBase64 = {};
+    track.nativeVst3Path = {};
+    track.nativeVst3PluginId = {};
+    track.nativeVst3StateBase64 = {};
+    track.nativeAuIdentifier = {};
+    track.nativeAuStateBase64 = {};
+    track.nativeMultisamplePath = {};
+    track.nativeMultisampleStateBase64 = {};
+    track.builtinUnitId.clear();
+    track.builtinStateBase64.clear();
+
+    if (! ok)
+    {
+        std::fprintf (stderr, "[chan builtin] load failed: %s\n", err.c_str());
+        showDuskAlert (*this, "Couldn't load built-in unit", unitId + ":\n" + err);
+        refreshPluginSlotButton();
+        return;
+    }
+
+    if (strip.getBuiltinSlot().isLoadedInstrument())
+        adoptInstrumentTrackDefaults();
+    track.builtinUnitId = strip.getBuiltinSlot().getPluginId();
+    refreshPluginSlotButton();
+}
 
 void ChannelStripComponent::syncNativeEditorOwners()
 {
@@ -5193,7 +5317,8 @@ void ChannelStripComponent::onTrackModeChanged()
               || engine.getChannelStrip (trackIndex).isNativeLv2Loaded()
               || engine.getChannelStrip (trackIndex).isNativeVst3Loaded()
               || engine.getChannelStrip (trackIndex).isNativeAuLoaded()
-              || engine.getChannelStrip (trackIndex).isNativeMultisampleLoaded())
+              || engine.getChannelStrip (trackIndex).isNativeMultisampleLoaded()
+              || engine.getChannelStrip (trackIndex).isBuiltinLoaded())
     {
         // Same mode/kind matching as the JUCE slot above: a native EFFECT can't
         // ride a MIDI strip, a native INSTRUMENT can't ride an audio strip.

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -1336,10 +1336,11 @@ ChannelStripComponent::ChannelStripComponent (int idx, Track& t, Session& s,
     pluginSlotButton.setColour (juce::TextButton::textColourOffId,  juce::Colour (0xff9080c0));
     pluginSlotButton.setColour (juce::TextButton::textColourOnId,   juce::Colour (0xffd0c0e0));
     pluginSlotButton.setTooltip (juce::CharPointer_UTF8 (
-        "Empty: click to pick a plugin (VST3 / CLAP / LV2 / AU) or an External "
-        "Hardware Insert. Loaded plugin: click to toggle the editor; "
-        "right-click for Replace / Remove. Hardware insert: click to "
-        "open the routing editor."));
+        "Empty: click to pick a built-in unit or a plugin (VST3 / CLAP / LV2 / AU), "
+        "or an External Hardware Insert. Loaded plugin: click to toggle the "
+        "editor; right-click for Replace / Remove. Loaded built-in unit: no "
+        "editor yet; right-click for Replace / Remove. Hardware insert: click "
+        "to open the routing editor."));
     pluginSlotButton.onClick = [this]
     {
         if (pluginSlot.isLoaded()

--- a/src/ui/ChannelStripComponent.cpp
+++ b/src/ui/ChannelStripComponent.cpp
@@ -2118,9 +2118,13 @@ void ChannelStripComponent::showPluginSlotMenu()
     {
         // Editor toggle headline so right-click ALSO becomes a way to open
         // the plugin GUI (some users find right-click more discoverable).
-        const bool editorOpen = isPluginEditorOpen();
-        menu.addItem (2001, editorOpen ? "Close editor" : "Open editor");
-        menu.addSeparator();
+        // A built-in unit has no editor, so the item would be inert.
+        if (! engine.getChannelStrip (trackIndex).isBuiltinLoaded())
+        {
+            const bool editorOpen = isPluginEditorOpen();
+            menu.addItem (2001, editorOpen ? "Close editor" : "Open editor");
+            menu.addSeparator();
+        }
         menu.addItem (2002, "Replace insert...");
         menu.addItem (2003, "Remove plugin");
         // Crash/auto-bypass recovery is a JUCE-slot concept (native hosts run

--- a/src/ui/ChannelStripComponent.h
+++ b/src/ui/ChannelStripComponent.h
@@ -376,6 +376,9 @@ private:
     std::unique_ptr<class AuPluginEditorComponent> auEditor;
     void loadNativeAuForChannel (const juce::String& componentId);
 #endif
+    // Built-in unit rung. No editor yet, so the slot label and the picker are
+    // the whole UI surface.
+    void loadBuiltinForChannel (const std::string& unitId);
 #if DUSKSTUDIO_HAS_MULTISAMPLE
     // Multisample instrument editor - in-process Dusk UI over the strip's
     // NativeMultisampleSlot instance, same kept-alive/showBorrowed lifecycle.

--- a/src/ui/PluginPickerHelpers.cpp
+++ b/src/ui/PluginPickerHelpers.cpp
@@ -5,6 +5,7 @@
 #include "PluginPickerPanel.h"
 #include "../engine/PluginManager.h"
 #include "../engine/PluginSlot.h"
+#include "../engine/builtin/BuiltinScanRows.h"
 #include <algorithm>
 #if DUSKSTUDIO_HAS_MULTISAMPLE
  #include "../engine/multisample/AriaBank.h"
@@ -399,7 +400,8 @@ void openPickerMenu (PluginSlot& slot,
                       std::function<void (const juce::File&, const juce::String&)> onPickNativeLv2,
                       std::function<void (const juce::File&, const juce::String&)> onPickNativeVst3,
                       std::function<void (const juce::File&)> onPickSoundfont,
-                      std::function<void (const juce::String&)> onPickNativeAu)
+                      std::function<void (const juce::String&)> onPickNativeAu,
+                      std::function<void (const std::string&)> onPickBuiltin)
 {
     auto& manager = slot.getManagerForUi();
 
@@ -478,6 +480,16 @@ void openPickerMenu (PluginSlot& slot,
                              std::make_move_iterator (native.end()));
     }
 
+    // The built-in suite needs no scan and is never absent, so its rows go in
+    // whenever the surface can host them.
+    if (onPickBuiltin)
+    {
+        auto rows = builtin::descriptorRows (kind == PluginKind::Instruments);
+        descriptions.insert (descriptions.end(),
+                             std::make_move_iterator (rows.begin()),
+                             std::make_move_iterator (rows.end()));
+    }
+
     auto* parent = target.getTopLevelComponent();
     if (parent == nullptr) parent = &target;
 
@@ -498,7 +510,8 @@ void openPickerMenu (PluginSlot& slot,
 
     cb.onScan = [closeModal, slotPtr, safeTarget, safeParent, onChange, kind,
                   onPickHardwareInsert, onPickNativeClap, onPickNativeLv2,
-                  onPickNativeVst3, onPickNativeAu, onPickSoundfont]() mutable
+                  onPickNativeVst3, onPickNativeAu, onPickSoundfont,
+                  onPickBuiltin]() mutable
     {
         closeModal();
 
@@ -509,7 +522,7 @@ void openPickerMenu (PluginSlot& slot,
         // on top), making the result message invisible.
         auto reopenPicker = [slotPtr, safeTarget, onChange, kind, onPickHardwareInsert,
                               onPickNativeClap, onPickNativeLv2, onPickNativeVst3,
-                              onPickNativeAu, onPickSoundfont]() mutable
+                              onPickNativeAu, onPickSoundfont, onPickBuiltin]() mutable
         {
             if (auto* t = safeTarget.getComponent())
                 openPickerMenu (*slotPtr, *t, std::move (onChange), kind, { -1, -1 },
@@ -518,7 +531,8 @@ void openPickerMenu (PluginSlot& slot,
                                   std::move (onPickNativeLv2),
                                   std::move (onPickNativeVst3),
                                   std::move (onPickSoundfont),
-                                  std::move (onPickNativeAu));
+                                  std::move (onPickNativeAu),
+                                  std::move (onPickBuiltin));
         };
         runScanModal (slotPtr->getManagerForUi(), safeParent.getComponent(),
                        std::move (reopenPicker));
@@ -561,7 +575,7 @@ void openPickerMenu (PluginSlot& slot,
 
     cb.onPickPlugin = [closeModal, slotPtr, safeTarget, safeParent, onChange, kind,
                        onPickNativeClap, onPickNativeLv2, onPickNativeVst3,
-                       onPickNativeAu]
+                       onPickNativeAu, onPickBuiltin]
                         (const PluginDescriptor& desc) mutable
     {
         closeModal();
@@ -580,6 +594,12 @@ void openPickerMenu (PluginSlot& slot,
             if (desc.formatName == "AudioUnit")
             {
                 if (onPickNativeAu) onPickNativeAu (juce::String (desc.location));
+                return;
+            }
+            // Built-in rows carry a registry id, not a path, for the same reason.
+            if (desc.formatName == builtin::kFormatName)
+            {
+                if (onPickBuiltin) onPickBuiltin (desc.location);
                 return;
             }
             const juce::File bundle (desc.location);
@@ -778,7 +798,8 @@ void openInsertChooser (PluginSlot& slot,
                          std::function<void (const juce::File&, const juce::String&)> onPickNativeLv2,
                          std::function<void (const juce::File&, const juce::String&)> onPickNativeVst3,
                          std::function<void (const juce::File&)> onPickSoundfont,
-                         std::function<void (const juce::String&)> onPickNativeAu)
+                         std::function<void (const juce::String&)> onPickNativeAu,
+                         std::function<void (const std::string&)> onPickBuiltin)
 {
     auto* parent = target.getTopLevelComponent();
     if (parent == nullptr) parent = &target;
@@ -817,7 +838,7 @@ void openInsertChooser (PluginSlot& slot,
 
     auto onPlugin = [closeChooser, slotPtr, safeTarget, onChange, kind,
                      onPickNativeClap, onPickNativeLv2, onPickNativeVst3,
-                     onPickNativeAu]() mutable
+                     onPickNativeAu, onPickBuiltin]() mutable
     {
         closeChooser();
         if (auto* t = safeTarget.getComponent())
@@ -828,7 +849,8 @@ void openInsertChooser (PluginSlot& slot,
                               std::move (onPickNativeLv2),
                               std::move (onPickNativeVst3),
                               /*onPickSoundfont*/ {},
-                              std::move (onPickNativeAu));
+                              std::move (onPickNativeAu),
+                              std::move (onPickBuiltin));
     };
 
     auto onCancel = closeChooser;

--- a/src/ui/PluginPickerHelpers.h
+++ b/src/ui/PluginPickerHelpers.h
@@ -3,6 +3,7 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <functional>
 #include <memory>
+#include <string>
 
 namespace duskstudio
 {
@@ -60,6 +61,9 @@ enum class PluginKind { Effects, Instruments };
 // duplicates, and routes the stable component identifier here.
 // `onPickSoundfont`, when set, adds the "Soundfont" button to an instrument
 // picker and hands the chosen .sfz / .sf2 to the caller's multisample rung.
+// `onPickBuiltin` routes the built-in suite. Its rows come from the compiled-in
+// registry rather than a scan and always appear (there is nothing to install),
+// so a surface that can host them must always pass this.
 void openPickerMenu (PluginSlot& slot,
                       juce::Component& target,
                       std::function<void()> onChange,
@@ -71,7 +75,8 @@ void openPickerMenu (PluginSlot& slot,
                       std::function<void (const juce::File&, const juce::String&)> onPickNativeLv2 = {},
                       std::function<void (const juce::File&, const juce::String&)> onPickNativeVst3 = {},
                       std::function<void (const juce::File&)> onPickSoundfont = {},
-                      std::function<void (const juce::String&)> onPickNativeAu = {});
+                      std::function<void (const juce::String&)> onPickNativeAu = {},
+                      std::function<void (const std::string&)> onPickBuiltin = {});
 
 // Two-step insert flow. Step 1 shows a small modal with three big
 // buttons - Hardware Insert / Soundfont / Plugin - letting the user
@@ -93,7 +98,8 @@ void openInsertChooser (PluginSlot& slot,
                          std::function<void (const juce::File&, const juce::String&)> onPickNativeLv2 = {},
                          std::function<void (const juce::File&, const juce::String&)> onPickNativeVst3 = {},
                          std::function<void (const juce::File&)> onPickSoundfont = {},
-                         std::function<void (const juce::String&)> onPickNativeAu = {});
+                         std::function<void (const juce::String&)> onPickNativeAu = {},
+                         std::function<void (const std::string&)> onPickBuiltin = {});
 
 // Synchronous scan. Blocks the message thread during scanInstalledPlugins().
 // Shows a Dusk in-window completion alert in `parent` (top-level Component)

--- a/src/ui/PluginPickerPanel.cpp
+++ b/src/ui/PluginPickerPanel.cpp
@@ -14,6 +14,8 @@ class PluginPickerPanel::ListBody final : public juce::Component
 public:
     enum class Group { Manufacturer, Type };
 
+    static constexpr const char* kBuiltinGroup = "Built-In";
+
     ListBody (std::vector<PluginDescriptor> descs,
               std::function<void (const PluginDescriptor&)> picker)
         : rawDescs (std::move (descs)), onPick (std::move (picker))
@@ -31,6 +33,12 @@ public:
     // Header key a description sorts/groups under, per current group mode.
     static juce::String groupKeyFor (const PluginDescriptor& d, Group g)
     {
+        // The built-in suite is its own section under either grouping: it is
+        // what a user with nothing installed reaches for, so it must be findable
+        // without knowing who made it.
+        if (d.backend == PluginBackend::Native && d.formatName == "Builtin")
+            return kBuiltinGroup;
+
         if (g == Group::Manufacturer)
             return d.manufacturer.empty() ? juce::String ("(unknown)")
                                           : juce::String (d.manufacturer);
@@ -55,7 +63,14 @@ public:
             {
                 const auto ka = groupKeyFor (a, g);
                 const auto kb = groupKeyFor (b, g);
-                if (ka != kb) return ka.compareIgnoreCase (kb) < 0;
+                if (ka != kb)
+                {
+                    // Built-In pins to the top rather than sorting by name.
+                    const int ra = ka == kBuiltinGroup ? 0 : 1;
+                    const int rb = kb == kBuiltinGroup ? 0 : 1;
+                    if (ra != rb) return ra < rb;
+                    return ka.compareIgnoreCase (kb) < 0;
+                }
                 return juce::String (a.name).compareIgnoreCase (juce::String (b.name)) < 0;
             });
 
@@ -80,6 +95,8 @@ public:
                     visibleFormat = "LV2-Native";
                 else if (d.backend == PluginBackend::Native && d.formatName == "VST3")
                     visibleFormat = "VST3-Native";
+                else if (d.backend == PluginBackend::Native && d.formatName == "Builtin")
+                    visibleFormat = kBuiltinGroup;
                 label += "  (" + visibleFormat + ")";
             }
             allEntries.push_back ({ false, label, d });

--- a/src/ui/ScreenshotCapture.cpp
+++ b/src/ui/ScreenshotCapture.cpp
@@ -22,6 +22,7 @@
 #include "MidiBindingsPanel.h"
 #include "HardwareInsertEditor.h"
 #include "PluginPickerPanel.h"
+#include "../engine/builtin/BuiltinScanRows.h"
 #include "multisample/SfzLibraryPanel.h"
 #include "BounceDialog.h"
 #include "../engine/BounceEngine.h"
@@ -32,6 +33,7 @@
 #include "../engine/AudioEngine.h"
 
 #include <algorithm>
+#include <iterator>
 
 namespace duskstudio
 {
@@ -422,6 +424,10 @@ void MainComponent::captureScreenshots (const juce::File& outDir)
             mk ("ZamComp",         "Zam Audio",       "Dynamics"),
             mk ("x42 Convolver",   "Robin Gareus",    "Reverb")
         };
+        auto builtinRows = builtin::descriptorRows (/*instruments*/ false);
+        descs.insert (descs.end(),
+                      std::make_move_iterator (builtinRows.begin()),
+                      std::make_move_iterator (builtinRows.end()));
         PluginPickerPanel::Callbacks cb;   // all null - display only
         PluginPickerPanel pp (descs, PluginPickerPanel::Kind::Effects, cb);
         modalShot (pp, 480, 560, "pl-01-plugin-picker.png", 300);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,12 @@ add_executable(dusk-studio-tests
     hosting_port_layout.cpp
     hosting_insert_adapter.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/hosting/InsertAdapter.cpp
+    # Built-in insert rung: registry, the Utility unit and the slot that
+    # presents it to the mixer.
+    builtin_insert_slot.cpp
+    ${CMAKE_SOURCE_DIR}/src/engine/builtin/BuiltinInstance.cpp
+    ${CMAKE_SOURCE_DIR}/src/engine/builtin/BuiltinRegistry.cpp
+    ${CMAKE_SOURCE_DIR}/src/engine/builtin/UtilityUnit.cpp
     sfz_catalog.cpp
     sfz_library_scan.cpp
     ${CMAKE_SOURCE_DIR}/src/engine/sfz/SfzLibrary.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,6 +78,7 @@ add_executable(dusk-studio-tests
     base64_decode.cpp
     legacy_state_base64.cpp
     session_round_trip.cpp
+    session_builtin_insert_roundtrip.cpp
     session_tape_migration.cpp
     session_freeze_roundtrip.cpp
     session_region_bounds.cpp

--- a/tests/builtin_insert_slot.cpp
+++ b/tests/builtin_insert_slot.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
+#include "engine/builtin/BuiltinScanRows.h"
 #include "engine/builtin/NativeBuiltinSlot.h"
 
 #include <cmath>
@@ -52,6 +53,27 @@ TEST_CASE ("built-in registry resolves units by id")
     // that cannot load.
     for (const auto& unit : registry())
         REQUIRE (createUnit (unit.id) != nullptr);
+}
+
+TEST_CASE ("built-in picker rows are filtered by slot kind")
+{
+    const auto effects     = descriptorRows (/*instruments*/ false);
+    const auto instruments = descriptorRows (/*instruments*/ true);
+
+    // An instrument row reaching an effect picker would let the user load a
+    // MIDI-driven unit onto an aux return, where nothing feeds it notes.
+    for (const auto& row : effects)
+    {
+        REQUIRE_FALSE (row.isInstrument);
+        REQUIRE (row.formatName == kFormatName);
+        REQUIRE (row.backend == duskstudio::PluginBackend::Native);
+        REQUIRE (findUnit (row.location) != nullptr);
+    }
+    for (const auto& row : instruments)
+        REQUIRE (row.isInstrument);
+
+    REQUIRE (effects.size() + instruments.size() == registry().size());
+    REQUIRE_FALSE (effects.empty());
 }
 
 TEST_CASE ("built-in slot loads a unit without touching disk")

--- a/tests/builtin_insert_slot.cpp
+++ b/tests/builtin_insert_slot.cpp
@@ -1,0 +1,255 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "engine/builtin/NativeBuiltinSlot.h"
+
+#include <cmath>
+#include <string>
+#include <vector>
+
+// The built-in insert rung: registry lookup, the Utility unit's DSP contract,
+// the opaque state blob a session carries, and the slot that presents all of it
+// to the mixer as a native plug-in.
+
+using namespace duskstudio::builtin;
+using Catch::Matchers::WithinAbs;
+
+namespace
+{
+constexpr double kSampleRate = 48000.0;
+constexpr int    kBlock      = 128;
+
+int paramIndex (const NativeBuiltinSlot& slot, const char* id)
+{
+    for (int i = 0; i < slot.paramCount(); ++i)
+        if (std::string (slot.paramInfo (i)->id) == id) return i;
+    return -1;
+}
+
+// Several blocks so every smoother has reached its target before we measure.
+void runBlocks (NativeBuiltinSlot& slot, std::vector<float>& l, std::vector<float>& r,
+                int blocks)
+{
+    for (int b = 0; b < blocks; ++b)
+        slot.processStereo (l.data(), r.data(), l.data(), r.data(), (int) l.size());
+}
+} // namespace
+
+TEST_CASE ("built-in registry resolves units by id")
+{
+    REQUIRE_FALSE (registry().empty());
+
+    const auto* utility = findUnit ("dusk.builtin.utility");
+    REQUIRE (utility != nullptr);
+    REQUIRE (std::string (utility->name) == "Utility");
+    REQUIRE_FALSE (utility->isInstrument);
+
+    REQUIRE (findUnit ("dusk.builtin.nope") == nullptr);
+    REQUIRE (createUnit ("dusk.builtin.nope") == nullptr);
+    REQUIRE (createUnit ("dusk.builtin.utility") != nullptr);
+
+    // Every registered unit must be constructible, or the picker offers a row
+    // that cannot load.
+    for (const auto& unit : registry())
+        REQUIRE (createUnit (unit.id) != nullptr);
+}
+
+TEST_CASE ("built-in slot loads a unit without touching disk")
+{
+    NativeBuiltinSlot slot;
+    std::string error;
+    REQUIRE (slot.loadUnit ("dusk.builtin.utility", kSampleRate, kBlock, error));
+    REQUIRE (error.empty());
+    REQUIRE (slot.isLoaded());
+    REQUIRE (slot.getPluginId() == "dusk.builtin.utility");
+    REQUIRE (slot.displayName() == "Utility");
+    REQUIRE_FALSE (slot.isLoadedInstrument());
+    REQUIRE (slot.getLatencySamples() == 0);
+
+    SECTION ("an unknown id fails and leaves the slot empty")
+    {
+        std::string err;
+        REQUIRE_FALSE (slot.loadUnit ("dusk.builtin.nope", kSampleRate, kBlock, err));
+        REQUIRE_FALSE (err.empty());
+        REQUIRE_FALSE (slot.isLoaded());
+    }
+
+    SECTION ("unload clears the slot")
+    {
+        slot.unload();
+        REQUIRE_FALSE (slot.isLoaded());
+        REQUIRE (slot.getPluginId().empty());
+    }
+}
+
+TEST_CASE ("utility unit passes silence through as silence")
+{
+    NativeBuiltinSlot slot;
+    std::string error;
+    REQUIRE (slot.loadUnit ("dusk.builtin.utility", kSampleRate, kBlock, error));
+
+    std::vector<float> l ((size_t) kBlock, 0.0f), r ((size_t) kBlock, 0.0f);
+    runBlocks (slot, l, r, 8);
+
+    for (int i = 0; i < kBlock; ++i)
+    {
+        REQUIRE (l[(size_t) i] == 0.0f);
+        REQUIRE (r[(size_t) i] == 0.0f);
+    }
+}
+
+TEST_CASE ("utility unit at its defaults is unity gain")
+{
+    NativeBuiltinSlot slot;
+    std::string error;
+    REQUIRE (slot.loadUnit ("dusk.builtin.utility", kSampleRate, kBlock, error));
+
+    std::vector<float> l ((size_t) kBlock), r ((size_t) kBlock);
+    auto fill = [&]
+    {
+        for (int i = 0; i < kBlock; ++i)
+        {
+            l[(size_t) i] = std::sin (0.05f * (float) i);
+            r[(size_t) i] = std::cos (0.11f * (float) i) * 0.5f;
+        }
+    };
+
+    // Warm the smoothers on throwaway blocks, then measure a fresh one.
+    fill();
+    runBlocks (slot, l, r, 8);
+
+    fill();
+    const auto expectedL = l;
+    const auto expectedR = r;
+    runBlocks (slot, l, r, 1);
+
+    for (int i = 0; i < kBlock; ++i)
+    {
+        REQUIRE_THAT (l[(size_t) i], WithinAbs (expectedL[(size_t) i], 1e-6));
+        REQUIRE_THAT (r[(size_t) i], WithinAbs (expectedR[(size_t) i], 1e-6));
+    }
+}
+
+TEST_CASE ("utility unit applies gain, polarity, width and mono sum")
+{
+    NativeBuiltinSlot slot;
+    std::string error;
+    REQUIRE (slot.loadUnit ("dusk.builtin.utility", kSampleRate, kBlock, error));
+
+    const int gainIdx  = paramIndex (slot, "gain_db");
+    const int polIdx   = paramIndex (slot, "polarity");
+    const int widthIdx = paramIndex (slot, "width");
+    const int monoIdx  = paramIndex (slot, "mono");
+    REQUIRE (gainIdx >= 0);
+    REQUIRE (polIdx >= 0);
+    REQUIRE (widthIdx >= 0);
+    REQUIRE (monoIdx >= 0);
+
+    std::vector<float> l ((size_t) kBlock), r ((size_t) kBlock);
+    auto fillConstant = [&] (float left, float right)
+    {
+        std::fill (l.begin(), l.end(), left);
+        std::fill (r.begin(), r.end(), right);
+    };
+
+    SECTION ("-6 dB halves the signal")
+    {
+        slot.setParamValue (gainIdx, -6.0206f);
+        for (int b = 0; b < 40; ++b) { fillConstant (1.0f, 1.0f); runBlocks (slot, l, r, 1); }
+        REQUIRE_THAT (l.back(), WithinAbs (0.5, 1e-4));
+        REQUIRE_THAT (r.back(), WithinAbs (0.5, 1e-4));
+    }
+
+    SECTION ("polarity inverts both channels")
+    {
+        slot.setParamValue (polIdx, 1.0f);
+        for (int b = 0; b < 40; ++b) { fillConstant (0.25f, -0.75f); runBlocks (slot, l, r, 1); }
+        REQUIRE_THAT (l.back(), WithinAbs (-0.25, 1e-4));
+        REQUIRE_THAT (r.back(), WithinAbs (0.75, 1e-4));
+    }
+
+    SECTION ("zero width collapses to the mid signal")
+    {
+        slot.setParamValue (widthIdx, 0.0f);
+        for (int b = 0; b < 40; ++b) { fillConstant (1.0f, 0.0f); runBlocks (slot, l, r, 1); }
+        REQUIRE_THAT (l.back(), WithinAbs (0.5, 1e-4));
+        REQUIRE_THAT (r.back(), WithinAbs (0.5, 1e-4));
+    }
+
+    SECTION ("mono sum averages the two channels")
+    {
+        slot.setParamValue (monoIdx, 1.0f);
+        for (int b = 0; b < 40; ++b) { fillConstant (0.8f, 0.2f); runBlocks (slot, l, r, 1); }
+        REQUIRE_THAT (l.back(), WithinAbs (0.5, 1e-4));
+        REQUIRE_THAT (r.back(), WithinAbs (0.5, 1e-4));
+    }
+
+    SECTION ("parameters clamp to their declared range")
+    {
+        slot.setParamValue (widthIdx, 9999.0f);
+        REQUIRE_THAT (slot.getParamValue (widthIdx),
+                      WithinAbs (slot.paramInfo (widthIdx)->maxValue, 1e-6));
+        slot.setParamValue (gainIdx, -9999.0f);
+        REQUIRE_THAT (slot.getParamValue (gainIdx),
+                      WithinAbs (slot.paramInfo (gainIdx)->minValue, 1e-6));
+    }
+}
+
+TEST_CASE ("built-in unit state round-trips through the slot")
+{
+    NativeBuiltinSlot saver;
+    std::string error;
+    REQUIRE (saver.loadUnit ("dusk.builtin.utility", kSampleRate, kBlock, error));
+
+    const int gainIdx  = paramIndex (saver, "gain_db");
+    const int widthIdx = paramIndex (saver, "width");
+    saver.setParamValue (gainIdx, -3.5f);
+    saver.setParamValue (widthIdx, 150.0f);
+
+    std::vector<std::uint8_t> blob;
+    REQUIRE (saver.saveState (blob));
+    REQUIRE_FALSE (blob.empty());
+
+    NativeBuiltinSlot loader;
+    REQUIRE (loader.loadUnit ("dusk.builtin.utility", kSampleRate, kBlock, error));
+    REQUIRE (loader.loadState (blob));
+    REQUIRE_THAT (loader.getParamValue (gainIdx), WithinAbs (-3.5, 1e-6));
+    REQUIRE_THAT (loader.getParamValue (widthIdx), WithinAbs (150.0, 1e-6));
+
+    SECTION ("a blob from another unit is refused rather than partly applied")
+    {
+        std::string text (blob.begin(), blob.end());
+        const auto at = text.find ("dusk.builtin.utility");
+        REQUIRE (at != std::string::npos);
+        text.replace (at, std::string ("dusk.builtin.utility").size(), "dusk.builtin.someth");
+        std::vector<std::uint8_t> foreign (text.begin(), text.end());
+
+        NativeBuiltinSlot other;
+        REQUIRE (other.loadUnit ("dusk.builtin.utility", kSampleRate, kBlock, error));
+        REQUIRE_FALSE (other.loadState (foreign));
+        REQUIRE_THAT (other.getParamValue (gainIdx), WithinAbs (0.0, 1e-6));
+    }
+
+    SECTION ("garbage is refused")
+    {
+        NativeBuiltinSlot other;
+        REQUIRE (other.loadUnit ("dusk.builtin.utility", kSampleRate, kBlock, error));
+        REQUIRE_FALSE (other.loadState ({ 0x01, 0x02, 0x03 }));
+    }
+}
+
+TEST_CASE ("a bypassed built-in slot passes dry audio and reports no latency")
+{
+    NativeBuiltinSlot slot;
+    std::string error;
+    REQUIRE (slot.loadUnit ("dusk.builtin.utility", kSampleRate, kBlock, error));
+    slot.setParamValue (paramIndex (slot, "gain_db"), -60.0f);
+    slot.setBypassed (true);
+
+    std::vector<float> l ((size_t) kBlock, 0.4f), r ((size_t) kBlock, -0.2f);
+    runBlocks (slot, l, r, 8);
+
+    REQUIRE_THAT (l.back(), WithinAbs (0.4, 1e-6));
+    REQUIRE_THAT (r.back(), WithinAbs (-0.2, 1e-6));
+    REQUIRE (slot.getLatencySamples() == 0);
+}

--- a/tests/session_builtin_insert_roundtrip.cpp
+++ b/tests/session_builtin_insert_roundtrip.cpp
@@ -1,0 +1,120 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "engine/builtin/BuiltinInstance.h"
+#include "foundation/Base64.h"
+#include "session/Session.h"
+#include "session/SessionSerializer.h"
+
+#include <juce_core/juce_core.h>
+#include <nlohmann/json.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+// A built-in insert is identified by a registry id, not a file path, so the
+// session carries builtin_id plus an opaque builtin_state blob on both the
+// channel-strip and the aux-slot lanes. These pin that round trip and the
+// blob's survival through base64, since a lost blob silently resets a user's
+// unit to its defaults on the next load.
+
+namespace
+{
+juce::File makeTempSessionDir()
+{
+    auto dir = juce::File::getSpecialLocation (juce::File::tempDirectory)
+                  .getChildFile ("dusk-studio-builtin-roundtrip-"
+                                 + juce::String (juce::Random::getSystemRandom().nextInt()));
+    dir.createDirectory();
+    return dir;
+}
+
+// The blob a loaded Utility unit would hand the session.
+std::string encodedUtilityState (float gainDb, float width)
+{
+    duskstudio::builtin::BuiltinBundle bundle;
+    std::string error;
+    REQUIRE (bundle.load ("dusk.builtin.utility", error));
+
+    duskstudio::builtin::BuiltinInstance instance;
+    REQUIRE (instance.create (bundle, "dusk.builtin.utility", error));
+    REQUIRE (instance.activate (48000.0, 128, error));
+
+    for (int i = 0; i < instance.paramCount(); ++i)
+    {
+        const auto* info = instance.paramInfo (i);
+        if (std::string (info->id) == "gain_db") instance.setParamValue (i, gainDb);
+        if (std::string (info->id) == "width")   instance.setParamValue (i, width);
+    }
+
+    std::vector<std::uint8_t> blob;
+    REQUIRE (instance.saveState (blob));
+    return dusk::base64::encode (blob.data(), blob.size());
+}
+} // namespace
+
+TEST_CASE ("SessionSerializer round-trips a built-in insert on a track and an aux slot",
+           "[session][serializer][builtin]")
+{
+    using duskstudio::Session;
+    using duskstudio::SessionSerializer;
+
+    const auto dir = makeTempSessionDir();
+    const auto target = dir.getChildFile ("session.json");
+
+    const auto trackState = encodedUtilityState (-4.5f, 130.0f);
+    const auto auxState   = encodedUtilityState (2.0f, 70.0f);
+
+    auto savedPtr = std::make_unique<Session>();
+    Session& saved = *savedPtr;
+    saved.track (3).builtinUnitId      = "dusk.builtin.utility";
+    saved.track (3).builtinStateBase64 = trackState;
+    saved.auxLane (1).builtinUnitId[0]      = "dusk.builtin.utility";
+    saved.auxLane (1).builtinStateBase64[0] = auxState;
+
+    REQUIRE (SessionSerializer::save (saved, target));
+
+    auto loadedPtr = std::make_unique<Session>();
+    Session& loaded = *loadedPtr;
+    REQUIRE (SessionSerializer::load (loaded, target));
+
+    REQUIRE (loaded.track (3).builtinUnitId == "dusk.builtin.utility");
+    REQUIRE (loaded.track (3).builtinStateBase64 == trackState);
+    REQUIRE (loaded.auxLane (1).builtinUnitId[0] == "dusk.builtin.utility");
+    REQUIRE (loaded.auxLane (1).builtinStateBase64[0] == auxState);
+
+    SECTION ("the restored blob still restores the unit's parameters")
+    {
+        const auto blob = dusk::base64::decode (
+            loaded.track (3).builtinStateBase64.data(),
+            loaded.track (3).builtinStateBase64.size());
+
+        duskstudio::builtin::BuiltinBundle bundle;
+        std::string error;
+        REQUIRE (bundle.load ("dusk.builtin.utility", error));
+        duskstudio::builtin::BuiltinInstance instance;
+        REQUIRE (instance.create (bundle, "dusk.builtin.utility", error));
+        REQUIRE (instance.activate (48000.0, 128, error));
+        REQUIRE (instance.loadState (blob));
+
+        for (int i = 0; i < instance.paramCount(); ++i)
+        {
+            const auto* info = instance.paramInfo (i);
+            if (std::string (info->id) == "gain_db")
+                REQUIRE (instance.getParamValue (i) == -4.5f);
+            if (std::string (info->id) == "width")
+                REQUIRE (instance.getParamValue (i) == 130.0f);
+        }
+    }
+
+    SECTION ("an empty slot writes no built-in keys")
+    {
+        const auto text = target.loadFileAsString();
+        const auto parsed = nlohmann::json::parse (text.toStdString(), nullptr, false);
+        REQUIRE (parsed.is_object());
+        REQUIRE (parsed["tracks"][0].contains ("builtin_id") == false);
+        REQUIRE (parsed["tracks"][3]["builtin_id"] == "dusk.builtin.utility");
+    }
+
+    dir.deleteRecursively();
+}

--- a/tools/juce-allowlist.txt
+++ b/tools/juce-allowlist.txt
@@ -59,7 +59,7 @@ src/ui/AnalogVuMeter.cpp	113
 src/ui/AnalogVuMeter.h	7
 src/ui/AudioRegionEditor.cpp	334
 src/ui/AudioRegionEditor.h	78
-src/ui/AuxLaneComponent.cpp	172
+src/ui/AuxLaneComponent.cpp	169
 src/ui/AuxLaneComponent.h	28
 src/ui/AuxView.cpp	60
 src/ui/AuxView.h	5


### PR DESCRIPTION
Refs #75. Stage 1 of the built-in insert suite: the plumbing, one real unit, no editors yet. Stage 2 (reverb, delay, colour, instrument, editor) follows on a stacked branch.

## Seam

A built-in unit is a `hosting::INativeInstance` whose "bundle" is a lookup in a compiled-in registry keyed by a stable id, sitting on the same `NativeInsertSlot<Traits>` rung the multisample instrument already uses. That buys the process-gate fencing, the mono/stereo fold, bypass and quarantine dry-pass, the latency query and opaque state for free. The per-format ladder in `ChannelStrip`, `AuxLaneStrip` and `AudioEngine` grows by one entry.

Decisions a reviewer should see:

- No compile gate. Every other rung has `DUSKSTUDIO_HAS_NATIVE_*`; this one must ship on all three platforms, so `InsertAdapter.cpp` and the shared state helpers in `AudioEngine.cpp` compile unconditionally.
- `std::string` throughout, not the framework string, because the gate refuses new tokens in `Session.h`, `ChannelStrip`, `AuxLaneStrip` and `AudioEngine.cpp`. Two small builtin-only twins of the existing state-capture templates follow from that; deduplicating them would rewrite the shipped save path for every other format days before a candidate, so they stay.
- Precedence is last: CLAP > LV2 > VST3 > AU > multisample > built-in for load eviction, restore and the corrupt-session tiebreak.
- Not added to the shutdown leak list; a built-in unit destroys cleanly.
- State blob is JSON keyed by parameter id, not index, and refused when the id does not match the live unit.
- `UnitInfo` carries the factory, so a new unit is one registry row plus two CMake lines.

## Utility unit

Gain (-60..+24 dB), polarity, width (0..200 %), mono sum, 20 ms smoothing, `dusk::audio::SmoothedValue`, `ScopedNoDenormals`. Width is a two-tap matrix rather than mid/side so 100 % is bit-exact passthrough.

## Picker, session, clone

A pinned **Built-In** section at the top of the insert picker, rows read `Utility  (Built-In)`. Instruments are filtered by intent, pinned by test. `builtin_unit_id` and `builtin_state` on channel and aux lanes, assigned unconditionally on load so a session written without the keys resets the slot. Clone Track and undo carry the id and blob. Aux bypass and the slot menu were wired for a built-in occupant during review.

## Gate

165 files / 8132 uses, down from 8135. The only allowlist edit lowers `AuxLaneComponent.cpp` 172 to 169; the four `(void)` swaps there are on a parameter that is genuinely unused in the non-Linux branch.

## Verification

Build clean, no new warnings. ctest 1023/1023 (8 new cases across three files plus the picker filter case). `tools/juce-gate.sh` exit 0. Headless self-test 15/15. Picker screenshot reviewed under Xvfb. MANUAL and CHANGELOG cover the section and the unit.

Stage 2 entry points: subclass `BuiltinUnit`, one registry row, both CMake lists; instrument needs `process` to gain a MIDI argument at two call sites; latency is already threaded through `recomputePdc`.

## Review follow-ups

- A loaded unit is now evicted before a pending native identity is stored in the not-prepared restore arm, on tracks and aux lanes, mirroring what the five native rungs already do to each other.
- An aux built-in's bypass and remove buttons get bounds; the header layout guard omitted the built-in case.
- The slot tooltip no longer promises an editor for a loaded built-in.
- Not done: hiding the Built-In picker rows until an editor exists. The editor and MIDI Learn land on the stacked stage 2 branch, and hiding a section in one PR to unhide it in the next serves nobody.
- The hardware-insert teardown finding was checked and does not apply: the built-in is torn down and its session fields cleared under the same fence as the four native formats, and a live insert cannot reach hardware mode from either surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added built-in insert units that are available immediately on fresh installations without plugin scanning.
  - Added the Utility unit with gain, polarity inversion, stereo width, and mono sum controls.
  - Built-in units can be used on channel inserts and aux lanes, with latency compensation and session persistence.
  - Added a dedicated, top-positioned **Built-In** section in the plugin picker.

- **Documentation**
  - Updated the manual and changelog with built-in unit details.
  - Updated test-suite statistics in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->