### PR TITLE
feat(dsp): 4K EQ 2 core for the channel strips and buses

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -107,7 +107,7 @@ jobs:
         # clone breaks configure. Bump every workflow's DONOR_REV together.
         env:
           DONOR_REPO: https://github.com/dusk-audio/dusk-audio-plugins.git
-          DONOR_REV: a08bba29f81bfcb123f47045d2ca9cc2e0a0b075
+          DONOR_REV: 9024271a848426c692da3cc38e3f2f1451c579af
         run: |
           set -euo pipefail
           git init -q "${RUNNER_TEMP}/plugins-main"

--- a/.github/workflows/linux-sanitizer.yml
+++ b/.github/workflows/linux-sanitizer.yml
@@ -23,7 +23,7 @@ concurrency:
 
 env:
   # Both sanitizer jobs must compile the same donor snapshot.
-  DONOR_REV: a08bba29f81bfcb123f47045d2ca9cc2e0a0b075
+  DONOR_REV: 9024271a848426c692da3cc38e3f2f1451c579af
 
 jobs:
   tsan-tests:

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -94,7 +94,7 @@ jobs:
         # clone breaks configure. Bump every workflow's DONOR_REV together.
         env:
           DONOR_REPO: https://github.com/dusk-audio/dusk-audio-plugins.git
-          DONOR_REV: a08bba29f81bfcb123f47045d2ca9cc2e0a0b075
+          DONOR_REV: 9024271a848426c692da3cc38e3f2f1451c579af
         run: |
           set -euo pipefail
           git init -q "${RUNNER_TEMP}/plugins-main"

--- a/.github/workflows/raspberry-pi-build.yml
+++ b/.github/workflows/raspberry-pi-build.yml
@@ -117,7 +117,7 @@ jobs:
         # clone breaks configure. Bump every workflow's DONOR_REV together.
         env:
           DONOR_REPO: https://github.com/dusk-audio/dusk-audio-plugins.git
-          DONOR_REV: a08bba29f81bfcb123f47045d2ca9cc2e0a0b075
+          DONOR_REV: 9024271a848426c692da3cc38e3f2f1451c579af
         run: |
           set -euo pipefail
           git init -q "${RUNNER_TEMP}/plugins-main"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ concurrency:
 
 env:
   RELEASES_REPO: dusk-audio/dusk-studio-releases
-  DONOR_REV: a08bba29f81bfcb123f47045d2ca9cc2e0a0b075
+  DONOR_REV: 9024271a848426c692da3cc38e3f2f1451c579af
   SODIUM_VERSION: 1.0.22
   SODIUM_SHA256: adbdd8f16149e81ac6078a03aca6fc03b592b89ef7b5ed83841c086191be3349
 

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -62,7 +62,7 @@ jobs:
         shell: bash
         env:
           DONOR_REPO: https://github.com/dusk-audio/dusk-audio-plugins.git
-          DONOR_REV: a08bba29f81bfcb123f47045d2ca9cc2e0a0b075
+          DONOR_REV: 9024271a848426c692da3cc38e3f2f1451c579af
         run: |
           set -euo pipefail
           git init -q "${RUNNER_TEMP}/plugins"

--- a/BUILDING-LINUX.md
+++ b/BUILDING-LINUX.md
@@ -80,9 +80,9 @@ cd ~/projects
 git clone --recurse-submodules https://github.com/dusk-audio/dusk-studio.git
 git clone --branch wayland-juce8 https://github.com/plugdata-team/JUCE.git JUCE-wayland
 git clone https://github.com/dusk-audio/dusk-audio-plugins.git plugins
-git -C plugins fetch --depth 1 origin a08bba29f81bfcb123f47045d2ca9cc2e0a0b075
+git -C plugins fetch --depth 1 origin 9024271a848426c692da3cc38e3f2f1451c579af
 git -C plugins checkout --detach FETCH_HEAD
-test "$(git -C plugins rev-parse HEAD)" = a08bba29f81bfcb123f47045d2ca9cc2e0a0b075 || {
+test "$(git -C plugins rev-parse HEAD)" = 9024271a848426c692da3cc38e3f2f1451c579af || {
   echo "ERROR: donor checkout did not reach the pinned revision" >&2
   false
 }

--- a/BUILDING-WINDOWS.md
+++ b/BUILDING-WINDOWS.md
@@ -43,9 +43,9 @@ cd C:\dev
 git clone --recurse-submodules https://github.com/dusk-audio/dusk-studio.git
 git clone --branch 8.0.4 https://github.com/juce-framework/JUCE.git
 git clone https://github.com/dusk-audio/dusk-audio-plugins.git plugins
-git -C plugins fetch --depth 1 origin a08bba29f81bfcb123f47045d2ca9cc2e0a0b075
+git -C plugins fetch --depth 1 origin 9024271a848426c692da3cc38e3f2f1451c579af
 git -C plugins checkout --detach FETCH_HEAD
-git -C plugins rev-parse HEAD | findstr /x /c:"a08bba29f81bfcb123f47045d2ca9cc2e0a0b075" >nul || (echo ERROR: donor checkout did not reach the pinned revision & exit /b 1)
+git -C plugins rev-parse HEAD | findstr /x /c:"9024271a848426c692da3cc38e3f2f1451c579af" >nul || (echo ERROR: donor checkout did not reach the pinned revision & exit /b 1)
 ```
 
 `--recurse-submodules` matters: `external/sfizz` carries the SF2 / multisample instrument engine, and CMake gates it purely on the header being present ([CMakeLists.txt:1164](CMakeLists.txt#L1164)) — clone without it and the feature is gone with no diagnostic. If you already cloned flat, run `git submodule update --init --recursive`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,9 +60,12 @@ that will carry a signed 1.0.
   other oversampled stage. The tape stage now reports a constant 56 samples of
   latency, which delay compensation covers, where it previously reported none
   at 1x.
-
-### Changed
-
+- **The channel strips and the buses run the 4K EQ 2 engine** (#341). Its band
+  curves, filter slopes and console character are calibrated against
+  measurements of the hardware at each marked position, so it is voiced
+  differently from the engine it replaces while the controls, their ranges and
+  their defaults are unchanged. The console character stage no longer adds a
+  noise floor, so a silent channel stays silent through it.
 - **Arming a track with no input is refused, and says why.** ARM no longer
   lights on an audio track while the open device offers no capture channels,
   because the recording that followed wrote nothing and said nothing. The

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -771,6 +771,8 @@ Each knob is a rotary slider. Drag up to increase, down to decrease. Use a verti
 
 EQ in Dusk Studio does **not cramp** near Nyquist; the British EQ does its own internal pre-warping and benefits further when the global oversampling is raised.
 
+The band curves, the filter slopes and the console character are calibrated against measurements of the hardware at each marked position, so a setting reads as the console's own rather than as a textbook filter at the same frequency. The console character is always on, at a fixed light amount, whether the EQ section is engaged or not; a silent channel stays silent through it.
+
 ## Compressor
 
 ![The channel compressor editor in VCA mode.](docs/images/fx-02-comp.png)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ GPL source on this repo, so building it yourself costs you nothing but compile t
 | macOS DMG (unsigned, ad-hoc) | Working (CI publishes to private releases repo on tag) |
 | Deeper a11y (full screen-reader labels + keyboard-only mixer nav) | Floor only |
 
-The C++ suite declares 1081 Catch2 test cases across 202 test source files. Linux
+The C++ suite declares 1085 Catch2 test cases across 203 test source files. Linux
 (amd64 + arm64) and macOS builds run on every push; Windows tests run on every
 push + PR; Linux ThreadSanitizer runs on every PR + push.
 
@@ -124,7 +124,7 @@ src/
   session/     # Session model + JSON serialisation
   ui/          # MainComponent, ConsoleView, channel/aux/master strips, mastering view
   util/        # Native log storage + CrashHandler signal reports
-tests/         # 1081 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
+tests/         # 1085 Catch2 test cases declared in C++ (session, recording, MIDI, IPC, DSP)
 packaging/     # .desktop, AppStream, MIME, macOS bundle — for tarball + DMG builds
 DuskStudio.md  # authoritative product spec
 MANUAL.md      # end-user manual (Pandoc-buildable to PDF via docs/build-pdf.sh)

--- a/docs/RELEASE-1.0.md
+++ b/docs/RELEASE-1.0.md
@@ -96,8 +96,8 @@ Every open issue, one bucket each.
 | 314 | [Final gate] Remove the framework from CMake, CI, packaging, tests, docs | post-1.0 | Framework-removal campaign. |
 | 320 | Route macOS builds to the dusk-mac-air self-hosted runner | post-1.0 | Cost optimisation with no user-visible effect, and the runner is offline. |
 | 340 | Change Tape Machine to use the Tape Machine 2 plugin | 1.0 | The built-in colour insert (#75) runs this core, and the master bus cannot run a different one from the same donor path. Landed with a tone regression pinning the new voicing. |
-| 341 | Change EQ DSP to 4K-EQ-2 DSP | post-1.0 | Same. Also a tone change to a shipped signal path, which is not a 1.0 risk to take. |
-| 342 | Change compressors to use Multi-Comp-2 DSP | post-1.0 | Same. |
+| 341 | Change EQ DSP to 4K-EQ-2 DSP | 1.0 | Marc's call, 1.0 ships the current EQ. Landed with a tone regression pinning the new voicing. |
+| 342 | Change compressors to use Multi-Comp-2 DSP | 1.0 | Marc's call, 1.0 ships on the Multi-Comp 2 core; blocked on the donor core, prerequisites in #586. |
 | 442 | ASan+UBSan and Raspberry Pi jobs are not required checks | 1.0 | Two jobs can go red without blocking a merge. A 1.0 tag needs both gating. |
 | 500 | CloneTrackAction native-insert clone and undo has no coverage | 1.0 | A shipped clone and undo path with no automated test. |
 | 501 | Inline non-modal editor status in the aux slot area | post-1.0 | The unprompted modal was already removed by #459; the remaining alerts are click-initiated. What is left is additive inline status, absorbed by the aux GUI port. |
@@ -113,6 +113,7 @@ Every open issue, one bucket each.
 | 534 | Define the 1.0 package contents and verify all three packagers | 1.0 | Three packagers grown separately, no shared contract. Matters once the plugin suite ships. |
 | 535 | Local instrument browser for soundfonts on disk | 1.0 | The offline half of the SFZ work, with no network, catalog or archive code. |
 | 536 | Walk the demo path on packaged builds and file what it snags on | 1.0 | Individual demo-path bugs have been fixed one at a time. Nobody has walked the whole path on a shipped build. |
+| 586 | Multi-Comp 2 donor prerequisites | 1.0 | What the donor core needs before #342 can be built against it. |
 
 Nothing was bucketed `wontfix`.
 
@@ -167,6 +168,8 @@ the follow-ups are known before the schedule is committed.
 | CloneTrackAction coverage | 500 | 3-4 | `tests/`, self-test leg |
 | Milestone-6 audit residues | 503 | 4-6 | `src/util/SingleInstance.cpp`, `src/engine/PluginSlot.cpp`, `src/ui/ChannelStripComponent.cpp` |
 | Windows self-test harness child resolution | 504 | 2-3 | `src/DuskStudioApp.cpp`, `src/engine/PluginManager.h` |
+| Channel and bus EQ on the 4K EQ 2 core | 341 | 4-6 | donor shared DSP, `src/dsp/ChannelStrip.*`, `src/dsp/BusStrip.*`, `tests/` |
+| Compressors on the Multi-Comp 2 core (blocked on #586) | 342 | - | donor shared DSP, `src/dsp/`, `tests/` |
 
 The two 75 items are sequential. The rest of stage 3 is independent of both.
 
@@ -306,11 +309,13 @@ release.
 ## Out of scope for 1.0
 
 - Anything whose main effect is reducing framework coupling. The whole
-  H-series (#294 through #314) is deferred. So are #341 and #342, because
-  swapping donor DSP for DAF-ported V2 DSP reduces coupling and changes the
-  tone of shipped signal paths at the same time. #340 is the exception and is
-  in: the built-in colour insert needs the Tape Machine 2 core, and the master
-  bus cannot run a different core from the same donor path.
+  H-series (#294 through #314) is deferred. The three donor-core moves are not
+  in that class and are all in 1.0: #340 because the built-in colour insert
+  needs the Tape Machine 2 core and the master bus cannot run a different core
+  from the same donor path, and #341 and #342 because 1.0 ships the V2 tone
+  rather than shipping one voicing and replacing it in the first point release.
+  Each lands with a tone regression pinning the new voicing. #342 waits on the
+  donor prerequisites in #586.
 - The DAF, DAF-Widgets, pugl and DPF-Widgets repositories are consumed, not
   reworked. Consuming them is how the native notepad UI and the built-in unit
   editors are built. A change to one of them lands only when a 1.0 feature

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -650,6 +650,7 @@ if(DUSK_PLUGINS_PATH)
         $<$<BOOL:${DUSKSTUDIO_DAF_WIDGETS_SOURCE_DIR}>:${CMAKE_SOURCE_DIR}/src/ui/imgui/MasteringLimiterView.cpp>
         dsp_stereo_oversampler.cpp
         eq_british_ab.cpp
+        eq_core_regression.cpp
         tube_multiq_ab.cpp
         comp_core_ab.cpp
         smoke_brickwall_limiter.cpp

--- a/tests/eq_core_regression.cpp
+++ b/tests/eq_core_regression.cpp
@@ -1,0 +1,284 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <FourKEQDSP.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+// Tone regression for duskaudio::FourKEQDSP, the console EQ every channel strip
+// and every bus runs.
+//
+// The A/B against the JUCE BritishEQProcessor next door is a sanity bound, not a
+// null: the two are different revisions of the same design and their difference
+// is measured in tenths of a dB, so it cannot tell a deliberate re-voicing from
+// an accident. This file is the drift guard. The expectations were measured from
+// this core at the revision that was listened to and accepted, so they do not
+// prove it is right; they prove it has not moved since.
+//
+// Aggregate measures rather than a checksum: a float checksum does not survive a
+// different compiler, libm or architecture, and this suite runs on GCC, Clang,
+// MSVC, x86_64 and arm64.
+
+namespace
+{
+constexpr double kSampleRate = 48000.0;
+constexpr int    kBlock      = 256;
+constexpr int    kWarmupBlocks = 32;
+constexpr int    kSignalBlocks = 24;
+
+// The always-on console drive the channel strip pushes into every EQ instance.
+constexpr float kConsoleSaturationDrive = 22.0f;
+
+struct Rng
+{
+    std::uint32_t s;
+    float next() noexcept
+    {
+        s = s * 1664525u + 1013904223u;
+        return (float) ((s >> 8) & 0xFFFFFF) / (float) 0x1000000 * 2.0f - 1.0f;
+    }
+};
+
+// Deterministic stereo program: sustained partials across the band the EQ
+// shapes, level steps, and periodic transients so the saturator sees real
+// movement rather than a steady sine.
+void makeSignal (std::vector<float>& L, std::vector<float>& R, int total)
+{
+    L.assign ((size_t) total, 0.0f);
+    R.assign ((size_t) total, 0.0f);
+    Rng rng { 0x1234567u };
+
+    constexpr double kTwoPi = 6.28318530717958647692;
+    double p1 = 0.0, p2 = 0.0, p3 = 0.0, p4 = 0.0;
+    const int clickPeriod = std::max (1, (int) (kSampleRate * 0.09));
+    const int clickLen    = std::max (1, (int) (kSampleRate * 0.0008));
+    const float segAmp[5] = { 0.12f, 0.5f, 0.25f, 0.7f, 0.05f };
+
+    for (int i = 0; i < total; ++i)
+    {
+        const double t = (double) i / kSampleRate;
+        const float a = segAmp[(int) (t / 0.11) % 5];
+
+        const float sL = 0.5f * (float) std::sin (p1) + 0.3f * (float) std::sin (p2)
+                       + 0.2f * (float) std::sin (p3) + 0.1f * (float) std::sin (p4);
+        const float sR = 0.46f * (float) std::sin (p1 + 0.7) + 0.32f * (float) std::sin (p2 * 1.01)
+                       + 0.18f * (float) std::sin (p3) + 0.09f * (float) std::sin (p4 * 0.99);
+        p1 += kTwoPi * 55.0 / kSampleRate;
+        p2 += kTwoPi * 420.0 / kSampleRate;
+        p3 += kTwoPi * 3100.0 / kSampleRate;
+        p4 += kTwoPi * 9500.0 / kSampleRate;
+
+        float clk = 0.0f;
+        if ((i % clickPeriod) < clickLen)
+            clk = rng.next() > 0.0f ? 0.55f : -0.55f;
+
+        L[(size_t) i] = 0.7f * (a * sL + clk);
+        R[(size_t) i] = 0.7f * (a * sR + clk * 0.8f);
+    }
+}
+
+void makeInput (std::vector<float>& L, std::vector<float>& R)
+{
+    const int warmup = kWarmupBlocks * kBlock;
+    const int total  = warmup + kSignalBlocks * kBlock;
+    std::vector<float> sigL, sigR;
+    makeSignal (sigL, sigR, total - warmup);
+    L.assign ((size_t) total, 0.0f);
+    R.assign ((size_t) total, 0.0f);
+    std::copy (sigL.begin(), sigL.end(), L.begin() + warmup);
+    std::copy (sigR.begin(), sigR.end(), R.begin() + warmup);
+}
+
+// One dialled-in strip: filters in, both mids cut and lifted, both shelves up.
+void applyToCore (duskaudio::FourKEQDSP& eq, bool black)
+{
+    eq.setOversampling (0);
+    eq.setMsMode (false);
+    eq.setAutoGain (false);
+    eq.setBypass (false);
+    eq.setEqType (black ? 1 : 0);
+    eq.setHpfEnabled (true);   eq.setHpfFreq (80.0f);
+    eq.setLpfEnabled (true);   eq.setLpfFreq (16000.0f);
+    eq.setLfGain (4.0f);   eq.setLfFreq (100.0f);   eq.setLfBell (false);
+    eq.setLmGain (-3.0f);  eq.setLmFreq (400.0f);   eq.setLmQ (1.2f);
+    eq.setHmGain (2.5f);   eq.setHmFreq (3000.0f);  eq.setHmQ (0.8f);
+    eq.setHfGain (3.0f);   eq.setHfFreq (10000.0f); eq.setHfBell (false);
+    eq.setInputGainDb (0.0f);
+    eq.setOutputGainDb (0.0f);
+    eq.setSaturation (kConsoleSaturationDrive);
+}
+
+struct Render
+{
+    std::vector<float> L, R;
+    int latency = 0;
+};
+
+Render renderCore (bool black, const std::vector<float>& inL, const std::vector<float>& inR)
+{
+    duskaudio::FourKEQDSP eq;
+    applyToCore (eq, black);
+    eq.prepare (kSampleRate, kBlock);
+    eq.reset();
+
+    Render out;
+    out.L = inL;
+    out.R = inR;
+    out.latency = eq.getLatencySamples();
+
+    for (int off = 0; off < (int) inL.size(); off += kBlock)
+    {
+        const int n = std::min (kBlock, (int) inL.size() - off);
+        float* lr[2] = { out.L.data() + off, out.R.data() + off };
+        eq.processBlock (lr, lr, 2, n);
+    }
+    return out;
+}
+
+struct Measure
+{
+    double peak = 0.0;
+    double rms = 0.0;
+};
+
+Measure measure (const Render& r)
+{
+    const int first = kWarmupBlocks * kBlock + r.latency;
+    Measure m;
+    double sum = 0.0;
+    int n = 0;
+    for (int i = first; i < (int) r.L.size(); ++i)
+    {
+        const double a = std::abs ((double) r.L[(size_t) i]);
+        const double b = std::abs ((double) r.R[(size_t) i]);
+        m.peak = std::max (m.peak, std::max (a, b));
+        sum += a * a + b * b;
+        n += 2;
+    }
+    m.rms = n > 0 ? std::sqrt (sum / (double) n) : 0.0;
+    return m;
+}
+} // namespace
+
+TEST_CASE ("FourKEQDSP reports no latency at the rate the strips run it", "[eq][regression]")
+{
+    // The strips drive the core at 1x and do their own oversampling around it,
+    // so it must add nothing for delay compensation to carry.
+    duskaudio::FourKEQDSP eq;
+    applyToCore (eq, false);
+    eq.prepare (kSampleRate, kBlock);
+    REQUIRE (eq.getLatencySamples() == 0);
+}
+
+TEST_CASE ("FourKEQDSP holds its tone across a fixed render", "[eq][regression]")
+{
+    std::vector<float> inL, inR;
+    makeInput (inL, inR);
+
+    // Measured from this core. A failure is a tone change: either it was
+    // intended, and these move with it in the same commit, or it was not.
+    //
+    // RMS is the sensitive one and carries the tighter bound: it moves with the
+    // band gains and with the saturator's drive, so a tenth of a percent trips
+    // on about 0.01 dB of shift anywhere in the curve. Peak at two tenths is
+    // the guard on gross scaling and on clipping the transients, which is what
+    // RMS alone would miss. Neither is tight enough to trip on the
+    // fused-multiply-add and libm differences between the compilers and
+    // architectures this suite runs on.
+    SECTION ("brown")
+    {
+        const auto m = measure (renderCore (false, inL, inR));
+        INFO ("peak " << m.peak << " rms " << m.rms);
+        REQUIRE_THAT (m.peak, Catch::Matchers::WithinRel (0.704084, 0.002));
+        REQUIRE_THAT (m.rms,  Catch::Matchers::WithinRel (0.0847519, 0.001));
+    }
+
+    SECTION ("black")
+    {
+        const auto m = measure (renderCore (true, inL, inR));
+        INFO ("peak " << m.peak << " rms " << m.rms);
+        REQUIRE_THAT (m.peak, Catch::Matchers::WithinRel (0.783426, 0.002));
+        REQUIRE_THAT (m.rms,  Catch::Matchers::WithinRel (0.0882388, 0.001));
+    }
+}
+
+TEST_CASE ("the flat image a bypassed strip pushes is safe", "[eq][regression]")
+{
+    // A strip with its EQ section off leaves every band and filter at the
+    // value-init zeros and keeps running the core for its always-on console
+    // character, so zero frequencies and a zero Q reach the designers. The
+    // output has to stay finite and stay at level: the tone shaping is what
+    // bypasses, not the strip.
+    std::vector<float> inL, inR;
+    makeInput (inL, inR);
+
+    duskaudio::FourKEQDSP eq;
+    eq.setOversampling (0);
+    eq.setMsMode (false);
+    eq.setAutoGain (false);
+    eq.setBypass (false);
+    eq.setHpfEnabled (false); eq.setHpfFreq (0.0f);
+    eq.setLpfEnabled (false); eq.setLpfFreq (0.0f);
+    eq.setLfGain (0.0f); eq.setLfFreq (0.0f); eq.setLfBell (false);
+    eq.setLmGain (0.0f); eq.setLmFreq (0.0f); eq.setLmQ (0.0f);
+    eq.setHmGain (0.0f); eq.setHmFreq (0.0f); eq.setHmQ (0.0f);
+    eq.setHfGain (0.0f); eq.setHfFreq (0.0f); eq.setHfBell (false);
+    eq.setEqType (0);
+    eq.setSaturation (kConsoleSaturationDrive);
+    eq.setInputGainDb (0.0f);
+    eq.setOutputGainDb (0.0f);
+    eq.prepare (kSampleRate, kBlock);
+    eq.reset();
+
+    Render out;
+    out.L = inL;
+    out.R = inR;
+    for (int off = 0; off < (int) inL.size(); off += kBlock)
+    {
+        const int n = std::min (kBlock, (int) inL.size() - off);
+        float* lr[2] = { out.L.data() + off, out.R.data() + off };
+        eq.processBlock (lr, lr, 2, n);
+    }
+    bool finite = true;
+    for (float v : out.L)
+        finite = finite && std::isfinite (v);
+    REQUIRE (finite);
+
+    Render dry;
+    dry.L = inL;
+    dry.R = inR;
+    const auto wet = measure (out);
+    const auto in  = measure (dry);
+    INFO ("in rms " << in.rms << " out rms " << wet.rms);
+    REQUIRE (wet.rms > in.rms * 0.5);    // no collapse
+    REQUIRE (wet.rms < in.rms * 1.5);    // no runaway
+}
+
+TEST_CASE ("FourKEQDSP passes silence through as silence", "[eq]")
+{
+    // The console saturator's noise floor is switched off in the core's prepare,
+    // so a silent strip stays digitally silent through an always-on saturation
+    // stage. The revision before 4K EQ 2 dithered a floor in unconditionally.
+    duskaudio::FourKEQDSP eq;
+    applyToCore (eq, false);
+    eq.prepare (kSampleRate, kBlock);
+    eq.reset();
+
+    std::vector<float> l ((size_t) kBlock, 0.0f), r ((size_t) kBlock, 0.0f);
+    for (int b = 0; b < 64; ++b)
+    {
+        std::fill (l.begin(), l.end(), 0.0f);
+        std::fill (r.begin(), r.end(), 0.0f);
+        float* lr[2] = { l.data(), r.data() };
+        eq.processBlock (lr, lr, 2, kBlock);
+        for (int i = 0; i < kBlock; ++i)
+        {
+            REQUIRE (std::isfinite (l[(size_t) i]));
+            REQUIRE_THAT (l[(size_t) i], Catch::Matchers::WithinAbs (0.0, 1e-9));
+            REQUIRE_THAT (r[(size_t) i], Catch::Matchers::WithinAbs (0.0, 1e-9));
+        }
+    }
+}


### PR DESCRIPTION
Closes #341. Stacked on #585; merge that first.

The channel strips and buses ship 1.0 on the 4K EQ 2 core.

## What moved

`dusk-1.0-pin` gains two donor commits on top of a08bba29: the 4K EQ 2 core (`FourKEQDSP.hpp`, `FourKEQDSP.cpp` and its two calibration includes, whole from donor main) and a noise-enable switch on the console saturator that the new core calls to keep a measured EQ path at digital silence. That switch is the only shared change: seven lines, default on, and the saturator has exactly one consumer in the pin tree, so nothing else can see it. No filter-designer changes, no SVF clamp, no rename: the new core clamps every design frequency at the call site, so it compiles and runs against the pin's shared headers without them.

`DONOR_REV` moves to 9024271a in the six workflows and both build guides.

## Dusk Studio side

No source change. The core's public surface is identical between the two revisions: the sorted setter, prepare, reset, process and latency symbol sets match, setter bodies are byte-identical, units unchanged, latency still 0 at 1x. The strips still call `setOversampling(0)` and own their own wrap.

Two behaviours checked rather than assumed: the flat image a bypassed EQ section pushes (zero frequencies and Q into the calibrated designers) stays finite on both cores, and the bus path at zero saturation is unchanged because the old noise floor was already blended out at drive 0. Only channels, which run the console character at 22 %, were carrying that floor.

## Tone change, on record

The calibration remaps each marked position independently, so a given dial value is no longer the same filter. Left-channel renders, 400 blocks at 48 kHz, in the review branch's scratchpad:

| render | old | new | delta |
|---|---|---|---|
| channel strip, HPF 80, LF +4 / LM -3 / HM +2.5 / HF +3, drive 22 | peak 0.6838, RMS 0.3045 | peak 0.6607, RMS 0.2877 | peak -0.30 dB, RMS -0.49 dB |
| bus strip, LF +3 / LM -2 / HF +2, drive 0 | peak 0.7125, RMS 0.3283 | peak 0.6479, RMS 0.2902 | peak -0.83 dB, RMS -1.07 dB |

New `tests/eq_core_regression.cpp` pins the new core's voicing with the same fixed program and asymmetric tolerances as the tape regression (RMS 0.1 % as the detector, peak 0.2 % as the scaling guard), both console characters, plus zero latency, the flat bypassed image, and silence in gives silence out at 1e-9, which the old core could not pass. Verified failing against the old core: RMS off by 2.9 to 3.6 dB, peak by up to 1.2 dB.

## Docs

RELEASE-1.0.md: #341 to 1.0 on Marc's call; #342 to 1.0 blocked on #586, with a #586 row and Stage 3 rows for both; out-of-scope paragraph no longer defers them. MANUAL: one paragraph on the measured calibration and on a silent channel staying silent. CHANGELOG: Changed entry.

## Verification

Build clean, zero warnings. ctest 1065/1065. `tools/juce-gate.sh` 165 files / 8106 uses, allowlist untouched. Headless self-test 15/15. `release-mechanics-contract` passes on the guides.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Channel strips and buses now use the 4K EQ 2 engine, with hardware-calibrated curves, filter slopes, and console character.
  - Silent channels remain digitally silent, including through the console character stage.

- **Documentation**
  - Updated channel EQ guidance and release planning information.
  - Refreshed reported test-suite totals.

- **Tests**
  - Added regression coverage for EQ latency, tone stability, bypass behavior, signal levels, and silence handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->